### PR TITLE
Use literal value for characters ` \`

### DIFF
--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -96,23 +96,23 @@
         {{- end -}}
     {{- end -}}
 {{- end -}}
-<span class="kn">"</span>&nbsp;\
+<span class="kn">"</span>{{ " \\" }}
 <span class="o">-H</span> <span class="s1">"Accept: application/json"</span>
 {{- /* Content-Type header based on "requestBody" */ -}}
 {{- if (or ($body) ($endpoint.action.requestBody)) -}}
 {{- with (index $endpoint.action.responses "204") -}}
 {{- else -}}
-&nbsp;\
+{{ " \\" }}
 <span class="o">-H</span> <span class="s1">"Content-Type: {{ default "application/json" .contentType }}"</span>
 {{- with $parameters.headerParams -}}
 {{- range . -}}
 {{- if eq .name "Content-Encoding" -}}
   {{- if $contentEncoding -}}
-&nbsp;\
+{{ " \\" }}
 <span class="o">-H</span> <span class="s1">"{{ .name }}: {{ $contentEncoding }}"</span>
   {{- end -}}
 {{- else -}}
-&nbsp;\
+{{ " \\" }}
 <span class="o">-H</span> <span class="s1">"{{ .name }}: {{ .example | default .schema.example }}"</span>
 {{- end -}}
 {{- end -}}
@@ -127,14 +127,14 @@
         {{- range $key, $val := . -}}
             {{ $authSchema := (index $securitySchemes $key) }}
             {{- if eq $authSchema.in "header" -}}
-                &nbsp;\
+                {{ " \\" }}
 <span class="o">-H</span> <span class="s1">"{{ $authSchema.name }}: <span class="n">${ {{- index $authSchema "x-env-name" -}} }</span>"</span>
             {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- else -}}
     {{- /* Use global authentication */ -}}
-    &nbsp;\
+    {{ " \\" }}
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span> \
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span>
 {{- end -}}
@@ -142,15 +142,15 @@
 {{- /* Render binary data (usually compressed) */ -}}
 {{- if gt (len $contentEncoding) 0 -}}
 {{- if eq $contentEncoding "gzip" -}}
-&nbsp;\
+{{ " \\" }}
 <span class="o">--data-binary</span> <span class="n">@-</span>
 {{- else if eq $contentEncoding "deflate" -}}
-&nbsp;\
+{{ " \\" }}
 <span class="o">--data-binary</span> <span class="n">@-</span>
 {{- end -}}
 {{ else if (or ($body) ($endpoint.action.requestBody)) }}
 {{- /* Render requestBody example JSON "-d @- << EOF ... EOF" */ -}}
-&nbsp;\
+{{ " \\" }}
 <span class="o">-d</span> <span class="n">@-</span> <span class="o"><<</span> <span class="n">EOF</span>
 <span class="s1">{{ .exampleValue | default $body | default (.dollarScratch.Get "jsonRequestBody") }}</span>
 <span class="n">EOF</span>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Replaces `&nbsp;\` html tags with raw value of ` \`

### Motivation
<!-- What inspired you to submit this pull request?-->
Curl examples are currently broken because `&nbsp` translates to `U+00a0` which breaks the examples when copying them using the `Copy` button.
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
