### PR TITLE
Update use_frameworks! docs for React Native

### DIFF
--- a/content/en/real_user_monitoring/reactnative/_index.md
+++ b/content/en/real_user_monitoring/reactnative/_index.md
@@ -387,15 +387,15 @@ If you have `use_frameworks!` enabled in your `Podfile`, running `pod install` a
 The 'Pods-MyApp' target has transitive dependencies that include statically linked binaries: (DatadogSDKBridge, DatadogSDKCrashReporting)
 ```
 
-To prevent that error, you can overwrite `use_frameworks!` and install all pods as static except for the ones that needs to be a framework:
+To prevent that error, edit your `Podfile` to install the React Native SDK pod as a static library:
 
 ```ruby
-dynamic_frameworks = ['DatadogSDKBridge','DatadogSDKCrashReporting']
+static_libraries = ['DatadogSDKReactNative']
 
-# Make all the other frameworks into static frameworks by overriding the static_framework? function to return true
+# Turn pods with static dependencies into static libraries by overriding the static_framework? function to return true
 pre_install do |installer|
   installer.pod_targets.each do |pod|
-    if !dynamic_frameworks.include?(pod.name)
+    if static_libraries.include?(pod.name)
       def pod.static_framework?;
         true
       end


### PR DESCRIPTION
### What does this PR do?

Update the steps for supporting `use_frameworks!` to be easier to maintain

### Motivation
The current suggested fix can require a bit of extra work if a lot of libraries need to be build as dynamic frameworks.
This new solution is easier to maintain and has less impact on the project.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
