### PR TITLE
Add WordPress tracing configuration options

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -413,6 +413,22 @@ Propagation styles to use when extracting tracing headers. If using multiple sty
   - [B3 single header][8]
   - Datadog
 
+`DD_TRACE_WORDPRESS_ADDITIONAL_ACTIONS`
+: **INI**: `datadog.trace.wordpress_additional_actions`<br>
+**Default**: `null`<br>
+A comma-separated list of WordPress action hooks to be instrumented. This feature is only available when `DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION` is enabled. Added in version `0.91.0`.
+
+`DD_TRACE_WORDPRESS_CALLBACKS`
+: **INI**: `datadog.trace.wordpress_callbacks`<br>
+**Default**: `false`<br>
+Enables WordPress action hook callbacks instrumentation. This feature is only available when `DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION` is enabled. Added in version `0.91.0`.
+
+`DD_TRACE_WORDPRESS_ENHANCED_INTEGRAION`
+: **INI**: `datadog.trace.wordpress_enhanced_integration`<br>
+**Default**: `false`<br>
+Enabled the enhanced WordPress integration. Added in version `0.91.0`.
+
+
 `DD_DBM_PROPAGATION_MODE`
 : **INI**: `datadog.dbm_propagation_mode`<br>
 **Default**: `'disabled'`<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -426,7 +426,7 @@ Enables WordPress action hook callbacks instrumentation. This feature is only av
 `DD_TRACE_WORDPRESS_ENHANCED_INTEGRAION`
 : **INI**: `datadog.trace.wordpress_enhanced_integration`<br>
 **Default**: `false`<br>
-Enabled the enhanced WordPress integration. Added in version `0.91.0`.
+Enables the enhanced WordPress integration. Added in version `0.91.0`.
 
 
 `DD_DBM_PROPAGATION_MODE`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds some doc on the WordPress configuration options introduced with the 0.91.0 release of the PHP tracer 👍 

### Motivation
<!-- What inspired you to submit this pull request?-->

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run, and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
