### PR TITLE
[OpenShift Operator] Add security context override to DCA

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -381,6 +381,10 @@ spec:
     clusterAgent:
       image:
         name: gcr.io/datadoghq/cluster-agent:latest
+      containers:
+        cluster-agent:
+          securityContext:
+            readOnlyRootFilesystem: false
     nodeAgent:
       serviceAccountName: datadog-agent-scc
       securityContext:


### PR DESCRIPTION
### What does this PR do?
* Updates the OpenShift documentation to include the SC override for the DCA so it can run `agent ...` commands (thanks to the `auth_token` in `/etc/datadog-agent/`) and use cluster checks from files

### Motivation
* Detailed context is available in : 
    * Github original PR : https://github.com/DataDog/datadog-operator/pull/897
    * Internal slack discussion : https://dd.slack.com/archives/C037CDX0WJV/p1693386280774969

### Additional Notes
* This is a "band-aid" while the DCA is not able to properly run for now with `readOnlyRootFilesystem: true` (not specifically in OpenShift, but this is where notably we can see the consequences)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
