### PR TITLE
[APPSEC-10895] Document opting out from automated user activity tracking for ASM

### DIFF
--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -21,6 +21,10 @@ Instrument your services and track user activity to detect and block bad actors.
 
 [Track user logins and activity](#adding-business-logic-information-login-success-login-failure-any-business-logic-to-traces) to detect account takeovers and business logic abuse with out-of-the-box detection rules, and to ultimately block attackers.
 
+<div class="alert alert-info">
+<strong>Note: Automated Detection of User Activity</strong> - when possible, Datadog Tracing Libraries will attempt to detect and report user activity events automatically. For more information, read <a href="/security/application_security/threats/add-user-info/?tab=set_user#disabling-automatic-user-activity-event-tracking">Disabling automatic user activity event tracking</a>.
+</div>
+
 The custom user activity for which out-of-the-box detection rules are available are as follow:
 
 | Built-in event names   | Required metadata                                    | Related rules                                                                                                                                                                                                       |
@@ -678,6 +682,18 @@ track_custom_event(tracer, event_name, metadata)
 {{< /programming-lang >}}
 
 {{< /programming-lang-wrapper >}}
+
+## Disabling automatic user activity event tracking
+
+When ASM is enabled, recent Datadog Tracing Libraries will attempt to detect user activity events automatically.
+
+The events that can be automatically detected are:
+
+- `users.login.success`
+- `users.login.failure`
+- `users.signup`
+
+If you wish to disable the detection of these events, you should set the environment variable <code>DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=disabled</code> (on the application hosting the Datadog Tracing Library, not on the Datadog Agent).
 
 ## Further Reading
 

--- a/content/en/security/application_security/threats/custom_rules.md
+++ b/content/en/security/application_security/threats/custom_rules.md
@@ -33,7 +33,10 @@ Another example is customizing a rule to exclude an internal security scanner. A
 In these situations, a custom detection rule can be created to exclude such events. This guide shows you how to create a custom detection rule for ASM.
 
 ## Business logic abuse detection rule
+
 ASM offers out of the box rules to detect business logic abuse (for example, resetting a password through brute force). Those rules require [adding business logic information to traces][7].
+
+Recent Datadog Tracing Libraries will attempt to detect and send user login and signup events automatically needing to modify the code. If needed, you can [opt-out of the automatic user activity event tracking][8].
 
 You can filter the rules, and identify which business logic to start tracking. Additionally, you can use these rules as a blueprint to create custom rules based on your own business logic. 
 
@@ -114,3 +117,5 @@ Use the **Tag resulting signals** dropdown menu to add tags to your signals. For
 [5]: /security/notifications/variables/
 [6]: /security/notifications/variables/#template-variables
 [7]: /security/application_security/threats/add-user-info/?tab=set_user#adding-business-logic-information-login-success-login-failure-any-business-logic-to-traces
+[8]: /security/application_security/threats/add-user-info/?tab=set_user#disabling-automatic-user-activity-event-tracking
+

--- a/content/en/security/application_security/threats/library_configuration.md
+++ b/content/en/security/application_security/threats/library_configuration.md
@@ -33,7 +33,11 @@ ASM automatically attempts to resolve `http.client_ip` from several well-known h
 
 ## Track authenticated bad actors
 
-Many critical attacks are performed by authenticated users who can access your most sensitive endpoints. To identify bad actors that are generating suspicious security activity, add user information to traces by instrumenting your services with the standardized user tags. You can add custom tags to your root span, or use instrumentation functions. Read [Tracking User Activity][1] for more information.
+Many critical attacks are performed by authenticated users who can access your most sensitive endpoints. To identify bad actors that are generating suspicious security activity, add user information to traces by instrumenting your services with the standardized user tags. You can add custom tags to your root span, or use instrumentation functions.
+
+The Datadog Tracing Library will attempt to auto-detect user login and signup events when it detects compatible authentication frameworks in use.
+
+Read [Tracking User Activity][1] for more information on how to manually track user activity, or if you wish to opt out - [Disabling automatic user activity event tracking][7].
 
 ## Exclude specific parameters from triggering detections
 
@@ -114,3 +118,4 @@ If you need additional help, contact [Datadog support][6].
 [4]: https://app.datadoghq.com/security/appsec/signals
 [5]: https://app.datadoghq.com/security/configuration/asm/passlist
 [6]: /help/
+[7]: /security/application_security/threats/add-user-info/?tab=set_user#disabling-automatic-user-activity-event-tracking


### PR DESCRIPTION
### What does this PR do?

Adds documentation on how to disable ASM automated user activity tracking.

### Motivation

Users currently need to reach out to support to understand how to turn this off. It is also never mentioned that this feature exists.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
