### PR TITLE
Browser RUM: add view.name as updatable property

### DIFF
--- a/content/en/real_user_monitoring/browser/modifying_data_and_context.md
+++ b/content/en/real_user_monitoring/browser/modifying_data_and_context.md
@@ -451,6 +451,7 @@ You can update the following event properties:
 |-----------------------|-----------|-----------------------------------------------------------------------------------------------------|
 |   `view.url`            |   String  |   The URL of the active web page.                            |
 |   `view.referrer`       |   String  |   The URL of the previous web page from which a link to the currently requested page was followed.  |
+|   `view.name`           |   String  |   The name of the current view.                            |
 |   `action.target.name`  |   String  |   The element that the user interacted with. Only for automatically collected actions.              |
 |   `error.message`       |   String  |   A concise, human-readable, one-line message explaining the error.                                 |
 |   `error.stack `        |   String  |   The stack trace or complementary information about the error.                                     |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?

List `view.name` as an updatable property.

### Motivation
<!-- What inspired you to submit this pull request?-->
Customer request: https://github.com/DataDog/browser-sdk/pull/2396
<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
