### PR TITLE
Add allowFallbackToLocalStorage init parameter

### DIFF
--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -1569,7 +1569,7 @@ Use a secure cross-site session cookie. This allows the RUM Browser SDK to run w
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**: `false`<br/>
-Allows to use Local Storage when cookies cannot be set. This enables the RUM Browser SDK to run in environments that do not provide cookie support. See [Monitor Electron Applications Using the Browser SDK][23] for a typical use-case.
+Allows the use of Local Storage when cookies cannot be set. This enables the RUM Browser SDK to run in environments that do not provide cookie support. See [Monitor Electron Applications Using the Browser SDK][23] for a typical use-case.
 
 ### Tagging
 

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -1565,6 +1565,12 @@ Use a secure session cookie. This disables RUM events sent on insecure (non-HTTP
 **Default**:`false`<br/>
 Use a secure cross-site session cookie. This allows the RUM Browser SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`.
 
+`allowFallbackToLocalStorage`
+: Optional<br/>
+**Type**: Boolean<br/>
+**Default**: `false`<br/>
+Allows to use Local Storage when cookies cannot be set. This enables the RUM Browser SDK to run in environments that do not provide cookie support. See [Monitor Electron Applications Using the Browser SDK][23] for a typical use-case.
+
 ### Tagging
 
 A service is an independent, deployable code repository that maps to a set of pages.
@@ -1663,3 +1669,4 @@ window.DD_RUM && window.DD_RUM.getInternalContext() // { session_id: "xxxx", app
 [20]: /real_user_monitoring/frustration_signals/
 [21]: /real_user_monitoring/guide/sampling-browser-plans/
 [22]: /integrations/content_security_policy_logs/#use-csp-with-real-user-monitoring-and-session-replay
+[23]: /real_user_monitoring/guide/monitor-electron-applications-using-browser-sdk


### PR DESCRIPTION
### What does this PR do?
Add `allowFallbackToLocalStorage` RUM browser SDK  init parameter.

### Motivation
This parameter has been recently added to the browser SDK. 

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
