### PR TITLE
Specify the beta status of the WordPress integration

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -426,7 +426,7 @@ Enables WordPress action hook callbacks instrumentation. This feature is only av
 `DD_TRACE_WORDPRESS_ENHANCED_INTEGRAION`
 : **INI**: `datadog.trace.wordpress_enhanced_integration`<br>
 **Default**: `false`<br>
-Enables the enhanced WordPress integration. Added in version `0.91.0`.
+Enables the enhanced WordPress integration. **This integration is currently in public beta**. Added in version `0.91.0`.
 
 
 `DD_DBM_PROPAGATION_MODE`

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -426,7 +426,7 @@ Enables WordPress action hook callbacks instrumentation. This feature is only av
 `DD_TRACE_WORDPRESS_ENHANCED_INTEGRAION`
 : **INI**: `datadog.trace.wordpress_enhanced_integration`<br>
 **Default**: `false`<br>
-Enables the enhanced WordPress integration. **This integration is currently in public beta**. Added in version `0.91.0`.
+Enables the enhanced WordPress integration. **This integration is in public beta**. Added in version `0.91.0`.
 
 
 `DD_DBM_PROPAGATION_MODE`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Specify the beta status of the WordPress integration.

### Motivation
This integration is in beta. I think that it should be mentioned.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
