### PR TITLE
Add missing context parameter to python extractor code sample

### DIFF
--- a/content/en/serverless/distributed_tracing/_index.md
+++ b/content/en/serverless/distributed_tracing/_index.md
@@ -259,7 +259,7 @@ The following code samples outline sample extractors you might use for propagati
 {{< tabs >}}
 {{% tab "Python" %}}
 ```py
-def extractor(payload):
+def extractor(payload, context):
     trace_headers = json.loads(payload["_datadog"]);
     trace_id = trace_headers["x-datadog-trace-id"];
     parent_id = trace_headers["x-datadog-parent-id"];

--- a/content/fr/serverless/distributed_tracing/_index.md
+++ b/content/fr/serverless/distributed_tracing/_index.md
@@ -259,7 +259,7 @@ Le code suivant comporte des extraits de fonction d'extraction que vous pouvez u
 {{< tabs >}}
 {{% tab "Python" %}}
 ```py
-def extractor(payload):
+def extractor(payload, context):
     trace_headers = json.loads(payload["_datadog"]);
     trace_id = trace_headers["x-datadog-trace-id"];
     parent_id = trace_headers["x-datadog-parent-id"];

--- a/content/ja/serverless/distributed_tracing/_index.md
+++ b/content/ja/serverless/distributed_tracing/_index.md
@@ -259,7 +259,7 @@ exports.handler = async event => {
 {{< tabs >}}
 {{% tab "Python" %}}
 ```py
-def extractor(payload):
+def extractor(payload, context):
     trace_headers = json.loads(payload["_datadog"]);
     trace_id = trace_headers["x-datadog-trace-id"];
     parent_id = trace_headers["x-datadog-parent-id"];

--- a/content/ko/serverless/distributed_tracing/_index.md
+++ b/content/ko/serverless/distributed_tracing/_index.md
@@ -259,7 +259,7 @@ Consumer Lambda 함수에서 위의 트레이스 컨텍스트를 추출하려면
 {{< tabs >}}
 {{% tab "Python" %}}
 ```py
-def extractor(payload):
+def extractor(payload, context):
     trace_headers = json.loads(payload["_datadog"]);
     trace_id = trace_headers["x-datadog-trace-id"];
     parent_id = trace_headers["x-datadog-parent-id"];


### PR DESCRIPTION
### What does this PR do?

Fixes the custom extractor code samples for Python in the serverless distributed tracing section.

### Motivation

I initially wrote an extractor using the existing code sample in the documentation, but found that it wasn't working in production (running on Python 11). When I turned on debug logging for Datadog, I saw the following error: `The trace extractor returned with error extractor() takes 1 positional argument but 2 were given`.

<img width="1394" alt="A screenshot of CloudWatch logs depicting the error" src="https://github.com/DataDog/documentation/assets/4233139/02201c2c-e6ab-46da-a4f2-3efffef25a67">

This PR adds the missing `context` argument to the code sample.

### Additional Notes

This is my first contribution, apologies if I've missed anything in the contribution guidelines, be gentle ;)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
