### PR TITLE
Update integration names

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -449,21 +449,31 @@ Use the name when setting integration-specific configuration such as, `DD_TRACE_
 
 | Integration   | Service Name    |
 | ------------- | --------------- |
+| AMQP          | `amqp`          |
 | CakePHP       | `cakephp`       |
 | CodeIgniter   | `codeigniter`   |
 | cURL          | `curl`          |
 | ElasticSearch | `elasticsearch` |
 | Eloquent      | `eloquent`      |
 | Guzzle        | `guzzle`        |
+| Laminas       | `laminas`       |
 | Laravel       | `laravel`       |
+| Laravel Queue | `laravelqueue`  |
 | Lumen         | `lumen`         |
+| Memcache      | `memcache`      |
 | Memcached     | `memcached`     |
 | Mongo         | `mongo`         |
+| MongoDB       | `mongodb`       |
 | Mysqli        | `mysqli`        |
+| Nette         | `nette`         |
+| PCNTL         | `pcntl`         |
 | PDO           | `pdo`           |
 | PhpRedis      | `phpredis`      |
 | Predis        | `predis`        |
-| Slim          | `slim`          |
+| Psr18         | `psr18`         |
+| Roadrunner    | `roadrunner`    |
+| Roadrunner    | `roadrunner`    |
+| Sql Server    | `sqlsrv`          |
 | Symfony       | `symfony`       |
 | WordPress     | `wordpress`     |
 | Yii           | `yii`           |

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -473,7 +473,7 @@ Use the name when setting integration-specific configuration such as, `DD_TRACE_
 | Psr18         | `psr18`         |
 | Roadrunner    | `roadrunner`    |
 | Roadrunner    | `roadrunner`    |
-| Sql Server    | `sqlsrv`          |
+| Sql Server    | `sqlsrv`        |
 | Symfony       | `symfony`       |
 | WordPress     | `wordpress`     |
 | Yii           | `yii`           |

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -472,7 +472,6 @@ Use the name when setting integration-specific configuration such as, `DD_TRACE_
 | Predis        | `predis`        |
 | Psr18         | `psr18`         |
 | Roadrunner    | `roadrunner`    |
-| Roadrunner    | `roadrunner`    |
 | Sql Server    | `sqlsrv`        |
 | Symfony       | `symfony`       |
 | WordPress     | `wordpress`     |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Update the integration names (see [integrations.h](https://github.com/DataDog/dd-trace-php/blob/master/ext/integrations/integrations.h))

### Motivation
Seems like it is a bit outdated

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
