### PR TITLE
Add peer service remapping for python

### DIFF
--- a/content/en/tracing/guide/inferred-service-opt-in.md
+++ b/content/en/tracing/guide/inferred-service-opt-in.md
@@ -223,6 +223,22 @@ Add the following environment variables to your tracer settings or system proper
 - `DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED=true`
 - `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED=true`
 
+#### Peer service mapping
+
+Datadog uses a default naming scheme for inferred services. If you prefer, you can map specific values to peer services using the following settings:
+
+| Environment variable | TracerSettings |
+| ---  | ----------- |
+| `DD_TRACE_PEER_SERVICE_MAPPING` | `PeerServiceNameMappings` |
+
+Each setting accepts a comma separated list: `key1:value1,key2:value2`.
+
+For example, if you're using environment variables and you need to rename the peer service `10.0.32.3` to `my-service`, use the following configuration:
+
+```yaml
+DD_TRACE_PEER_SERVICE_MAPPING=10.0.32.3:my-service
+```
+
 As of tracer version `v1.16.0` all libraries are supported except for Boto2.
 
 [1]: https://github.com/DataDog/dd-trace-py/releases/tag/v1.16.0

--- a/content/en/tracing/guide/inferred-service-opt-in.md
+++ b/content/en/tracing/guide/inferred-service-opt-in.md
@@ -231,7 +231,7 @@ Datadog uses a default naming scheme for inferred services. If you prefer, you c
 | ---  | ----------- |
 | `DD_TRACE_PEER_SERVICE_MAPPING` | `PeerServiceNameMappings` |
 
-Each setting accepts a comma separated list: `key1:value1,key2:value2`.
+Each setting accepts a comma-separated list: `key1:value1,key2:value2`.
 
 For example, if you're using environment variables and you need to rename the peer service `10.0.32.3` to `my-service`, use the following configuration:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
This PR updates the "inferred-service-opt-in" tracer guidelines page with Python's support for peer service mapping

### Motivation
The work is done in the Python tracer so the documentation needs to be updated to reflect reality

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
The language is pretty much a copy-paste from the .NET language documentation

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
