### PR TITLE
DOCS-6010 add k8s apiserver timeout config

### DIFF
--- a/content/en/containers/kubernetes/configuration.md
+++ b/content/en/containers/kubernetes/configuration.md
@@ -31,6 +31,10 @@ After you have installed the Datadog Agent in your Kubernetes environment, you m
 - [Tag mapping](#configure-tag-mapping)
 - [Secrets](#using-secret-files)
 - [Ignore containers](#ignore-containers)
+- [Kubernetes API server timeout](#kubernetes-api-server-timeout)
+- [Proxy settings](#proxy-settings)
+- [Autodiscovery](#autodiscovery)
+- [Miscellaneous](#miscellaneous)
 
 ## Enable APM and tracing
 
@@ -644,11 +648,11 @@ datadog:
 {{% /tab %}}
 {{< /tabs >}}
 
-### Using secret files
+## Using secret files
 
 Integration credentials can be stored in Docker or Kubernetes secrets and used in Autodiscovery templates. For more information, see [Secrets Management][12].
 
-### Ignore containers
+## Ignore containers
 
 Exclude containers from logs collection, metrics collection, and Autodiscovery. Datadog excludes Kubernetes and OpenShift `pause` containers by default. These allowlists and blocklists apply to Autodiscovery only; traces and DogStatsD are not affected. These environment variables support regular expressions in their values.
 
@@ -656,7 +660,55 @@ See the [Container Discover Management][13] page for examples.
 
 **Note**: The `kubernetes.containers.running`, `kubernetes.pods.running`, `docker.containers.running`, `.stopped`, `.running.total` and `.stopped.total` metrics are not affected by these settings. All containers are counted.
 
-### Proxy settings
+## Kubernetes API server timeout
+
+By default, the [Kubernetes State Metrics Core check][25] waits 10 seconds for a response from the Kubernetes API server. For large clusters, the request may time out, resulting in missing metrics.
+
+You can avoid this by setting the environment variable `DD_KUBERNETES_APISERVER_CLIENT_TIMEOUT` to a higher value than the default 10 seconds.
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+Update your `datadog-agent.yaml` with the following configuration:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    clusterAgent:
+      env:
+        - name: DD_KUBERNETES_APISERVER_CLIENT_TIMEOUT
+          value: <value_greater_than_10>
+```
+
+Then apply the new configuration:
+
+```shell
+kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
+```
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+Update your `datadog-values.yaml` with the following configuration:
+
+```yaml
+clusterAgent:
+  env:
+    - name: DD_KUBERNETES_APISERVER_CLIENT_TIMEOUT
+      value: <value_greater_than_10>
+```
+
+Then upgrade your Helm chart:
+
+```shell
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+## Proxy settings
 
 Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override the Agent proxy settings with the following environment variables:
 
@@ -667,7 +719,7 @@ Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override th
 | `DD_PROXY_NO_PROXY`      | A space-separated list of URLs for which no proxy should be used.      |
 | `DD_SKIP_SSL_VALIDATION` | An option to test if the Agent is having issues connecting to Datadog. |
 
-### Autodiscovery
+## Autodiscovery
 
 | Env Variable                 | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
 |------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -676,7 +728,7 @@ Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override th
 | `DD_CONFIG_PROVIDERS`        | The providers the Agent should call to collect checks configurations. Available providers are: <br>`kubelet` - Handles templates embedded in pod annotations. <br>`docker` - Handles templates embedded in container labels. <br>`clusterchecks` - Retrieves cluster-level check configurations from the Cluster Agent. <br>`kube_services` - Watches Kubernetes services for cluster checks. |
 | `DD_EXTRA_CONFIG_PROVIDERS`  | Additional Autodiscovery configuration providers to use. They are added in addition to the variables defined in the `config_providers` section of the `datadog.yaml` configuration file. |
 
-### Misc
+## Miscellaneous
 
 | Env Variable                        | Description                                                                                                                                                                                                                                                         |
 |-------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -703,3 +755,4 @@ Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override th
 [22]: /containers/guide/cluster_agent_autoscaling_metrics/?tab=helm
 [23]: /infrastructure/process/ 
 [24]: /account_management/api-app-keys/#application-keys
+[25]: /integrations/kubernetes_state_core/

--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -606,6 +606,54 @@ The Kubernetes State Metrics Core check does not include any events.
 
 ## Troubleshooting
 
+### Timeout errors
+
+By default, the Kubernetes State Metrics Core check waits 10 seconds for a response from the Kubernetes API server. For large clusters, the request may time out, resulting in missing metrics.
+
+You can avoid this by setting the environment variable `DD_KUBERNETES_APISERVER_CLIENT_TIMEOUT` to a higher value than the default 10 seconds.
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+Update your `datadog-agent.yaml` with the following configuration:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    clusterAgent:
+      env:
+        - name: DD_KUBERNETES_APISERVER_CLIENT_TIMEOUT
+          value: <value_greater_than_10>
+```
+
+Then apply the new configuration:
+
+```shell
+kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
+```
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+Update your `datadog-values.yaml` with the following configuration:
+
+```yaml
+clusterAgent:
+  env:
+    - name: DD_KUBERNETES_APISERVER_CLIENT_TIMEOUT
+      value: <value_greater_than_10>
+```
+
+Then upgrade your Helm chart:
+
+```shell
+helm upgrade -f datadog-values.yaml <RELEASE_NAME> datadog/datadog
+```
+{{% /tab %}}
+{{< /tabs >}}
+
 Need help? Contact [Datadog support][7].
 
 ## Further Reading


### PR DESCRIPTION
adds config to the troubleshooting section of the Kubernetes State Metrics Core integration (note that this integration lives in the docs repo)

also adds that same config to the kubernetes configuration page

ready to merge