### PR TITLE
[WEB-4021] Fixes regex error and edge cases with mark element in results.

### DIFF
--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -8,22 +8,16 @@ export function getHitData(hit, searchQuery = '') {
     const matchingWordsArray = getFilteredMatchingWords(searchQuery).map(word => replaceSpecialCharacters(word))
     const joinedMatchingWordsFromSearch = matchingWordsArray.join('|');
     const regexQry = new RegExp(`(${joinedMatchingWordsFromSearch})`, 'gi');
-    let highlightedTitle = (hit._highlightResult.title.value || title);
-    let highlightedContent = (hit._highlightResult.content.value || '');
-    
-    // Avoid overwriting <mark> element which sometimes already exists in title/content returned by Algolia.
-    if (searchQuery) {
-      highlightedTitle = highlightedTitle.includes('<mark>') ? highlightedTitle : highlightedTitle.replace(regexQry, '<mark>$1</mark>');
-      highlightedContent = highlightedContent.includes('<mark>') ? highlightedContent : highlightedContent.replace(regexQry, '<mark>$1</mark>');
-    }
+    const highlightedTitle = (hit._highlightResult.title.value || title);
+    const highlightedContent = (hit._highlightResult.content.value || '');
 
     return {
         relpermalink: cleanRelPermalink,
         category: hit.category ? hit.category : 'Documentation',
         subcategory: hit.subcategory ? hit.subcategory : title,
-        title: highlightedTitle,
+        title: handleHighlightingSearchResultContent(highlightedTitle, regexQry),
         section_header: hit.section_header || null,
-        content: highlightedContent,
+        content: handleHighlightingSearchResultContent(highlightedContent, regexQry),
         content_snippet: hit._snippetResult ? hit._snippetResult.content.value : '',
         content_snippet_match_level: hit._snippetResult ? hit._snippetResult.content.matchLevel : ''
     };
@@ -36,4 +30,17 @@ export function getHitData(hit, searchQuery = '') {
 const getFilteredMatchingWords = (searchQuery) => {
     const stopWords = ['the', 'and', 'for']
     return searchQuery.split(' ').filter(word => word.length > 2 && !stopWords.includes(word))
+}
+
+/*
+    Manually add <mark> element when applicable as relevant content isn't always highlighted in title/content.
+ */
+const handleHighlightingSearchResultContent = (string, regex) => {
+    if (string.includes('<mark>')) return string
+
+    if (string.search(regex) > 0) {
+        return string.replace(regex, '<mark>$1</mark>')
+    }
+    
+    return string
 }

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -1,9 +1,13 @@
+import { replace } from "lodash";
+import { replaceSpecialCharacters } from "../../helpers/string";
+
 export function getHitData(hit, searchQuery = '') {
     const title = hit.title ? hit.title : hit.type;
     const cleanRelPermalink =
         hit.language == 'en' ? hit.relpermalink : hit.relpermalink.replace(`/${hit.language}/`, '');
 
-    const joinedMatchingWordsFromSearch = getFilteredMatchingWords(searchQuery).join('|');
+    const matchingWordsArray = getFilteredMatchingWords(searchQuery).map(word => replaceSpecialCharacters(word))
+    const joinedMatchingWordsFromSearch = matchingWordsArray.join('|');
     const regexQry = new RegExp(`(${joinedMatchingWordsFromSearch})`, 'gi');
     let highlightedTitle = (hit._highlightResult.title.value || title);
     let highlightedContent = (hit._highlightResult.content.value || '');

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -1,4 +1,3 @@
-import { replace } from "lodash";
 import { replaceSpecialCharacters } from "../../helpers/string";
 
 export function getHitData(hit, searchQuery = '') {

--- a/assets/scripts/helpers/string.js
+++ b/assets/scripts/helpers/string.js
@@ -15,4 +15,8 @@ const truncateString = (string, characterMax, addEllipsis) => {
   return trimmed;
 };
 
-export { stringToTitleCase, truncateString };
+const replaceSpecialCharacters = (string) => {
+  return string.replace(/[^a-zA-Z0-9 ]/, '')    
+}
+
+export { stringToTitleCase, truncateString, replaceSpecialCharacters };


### PR DESCRIPTION
### What does this PR do?
- Fixes a JS console error when special characters are in the query string (for example try search for `+core`).
- Fixes cases where the search results are still rendering parts of the `<mark>` element in the title and or content.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-4021

### Preview
- Searches with special chars (such as `+`, `-`) should not result in a JS invalid regex console error.  For example: https://docs-staging.datadoghq.com/brian.deutsch/highlight-result-body-html/search/?s=%2Bcore
- Searches should not result in any part of the `<mark>` element being rendered as plain text in the search results.  For example: https://docs-staging.datadoghq.com/brian.deutsch/highlight-result-body-html/search/?s=%2B
- Test some search queries and confirm the search results still behave as intended.  
- Confirm above fixes apply to the other search dropdowns on the site (in the left nav, and on the homepage).

### Additional Notes
there is another, unrelated JS console error present `Refused to execute script from 'https://docs-staging.datadoghq.com/brian.deutsch/highlight-result-body-html/' because its MIME type ('text/html') is not executable, and strict MIME type checking is enabled.`.   That error is also in live and unrelated to these changes.   There is a Jira ticket capturing this already.

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
