### PR TITLE
[DOCS-6135] Update Observability Pipelines setup docs

### DIFF
--- a/content/en/observability_pipelines/_index.md
+++ b/content/en/observability_pipelines/_index.md
@@ -46,6 +46,9 @@ The Datadog UI provides a control plane to manage your Observability Pipelines W
 
 1. [Set up the Observability Pipelines Worker][1].
 2. [Create pipelines to collect, transform and route your data][2].
+3. Deep dive into recommendations for deploying and scaling the Observability Pipelines Worker:
+    - See [Deployment Design and Principles][3] for information on what to consider when designing your Observability Pipelines architecture.
+    - See [Best Practices for OPW Aggregator Architecture][4] for details on the recommended Observability Pipelines aggregator architecture, which is optimized for scaling.
 
 ## Explore Observability Pipelines
 
@@ -82,3 +85,5 @@ Get a holistic view of all of your pipelines' topologies and monitor key perform
 
 [1]: /observability_pipelines/setup/
 [2]: /observability_pipelines/configurations/
+[3]: /observability_pipelines/production_deployment_overview/
+[4]: /observability_pipelines/architecture/

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -382,7 +382,7 @@ The Quickstart walked you through how to install the Worker and deploy a sample 
 
 {{< partial name="observability_pipelines/use_cases.html" >}}
 
-For a deeper dive into best practices for deploying and scaling the Observability Pipelines Worker:
+For a deeper dive into recommendations for deploying and scaling the Observability Pipelines Worker:
 
 - See [Deployment Design and Principles][7] for information on what to consider when designing your Observability Pipelines architecture.
 - See [Best Practices for OPW Aggregator Architecture][8] for details on the recommended Observability Pipelines aggregator architecture, which is optimized for scaling.

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -5,8 +5,397 @@ type: multi-code-lang
 aliases:
   - /getting_started/observability_pipelines/
   - /observability_pipelines/installation/
+further_reading:
+  - link: "/observability_pipelines/working_with_data/"
+    tag: "Documentation"
+    text: "Working with data in Observability Pipelines"
+  - link: "/observability_pipelines/production_deployment_overview/"
+    tag: "Documentation"
+    text: "Deployment Design and Principles for the Observability Pipelines Worker"
+  - link: "/observability_pipelines/architecture/"
+    tag: "Documentation"
+    text: "Production deployment design and principles for the Observability Pipelines Worker"
+  - link: "https://dtdg.co/d22op"
+    tag: "Learning Center"
+    text: "Safe and Secure Local Processing with Observability Pipelines"
 ---
 
-For setup instructions, select your use case:
+## Overview
+
+The [Observability Pipelines Worker][1] can collect, process, and route logs and metrics from any source to any destination. Using Datadog, you can build and manage all of your Observability Pipelines Worker deployments at scale.
+
+There are several ways to get started with the Observability Pipelines Worker.
+
+- [Quickstart](#quickstart): Install the Worker and test out the functionality of Observability Pipelines with demo data.
+- [Datadog setup guide][2]: Install the Worker and connect it to Datadog.
+- [Splunk setup guide][3]: Install the Worker and connect it to Splunk.
+
+## Prerequisites
+
+To install the Observability Pipelines Worker, you need the following:
+
+- A valid [Datadog API key][4].
+- A pipeline ID.
+
+To generate a new API key and pipeline:
+
+1. Navigate to [Observability Pipelines][5].
+2. Click **New Pipeline**.
+3. Enter a name for your pipeline.
+4. Click **Next**.
+4. Select the template you want and follow the instructions.
+
+## Quickstart
+
+Follow the below instructions to install the Worker and deploy a sample pipeline configuration that uses demo data.
+
+### Install the Observability Pipelines Worker
+
+{{< tabs >}}
+{{% tab "Docker" %}}
+
+The Observability Pipelines Worker Docker image is published to Docker Hub [here][1].
+
+1. Download the [sample pipeline configuration file][2] that uses demo data for this quickstart. See [Configurations][3] for more information about the source, transform, and sink used in the sample configuration.
+
+2. Run the following command to start the Observability Pipelines Worker with Docker:
+    ```
+    docker run -i -e DD_API_KEY=<API_KEY> \
+      -e DD_OP_PIPELINE_ID=<PIPELINE_ID> \
+      -e DD_SITE=<SITE> \
+      -p 8282:8282 \
+      -v ./pipeline.yaml:/etc/observability-pipelines-worker/pipeline.yaml:ro \
+      datadog/observability-pipelines-worker run
+    ```
+
+    Replace `<API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. `./pipeline.yaml` must be the relative or absolute path to the configuration you downloaded in Step 1.
+
+[1]: https://hub.docker.com/r/datadog/observability-pipelines-worker
+[2]: /resources/yaml/observability_pipelines/quickstart/pipeline.yaml
+[3]: /observability_pipelines/configurations/
+{{% /tab %}}
+{{% tab "AWS EKS" %}}
+1. Download the [Helm chart][1] for AWS EKS. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+        opw datadog/observability-pipelines-worker \
+        -f aws_eks.yaml
+    ```
+
+[1]: /resources/yaml/observability_pipelines/quickstart/aws_eks.yaml
+[2]: /observability_pipelines/configurations/
+{{% /tab %}}
+{{% tab "Azure AKS" %}}
+1. Download the [Helm chart][1] for Azure AKS. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+      opw datadog/observability-pipelines-worker \
+      -f azure_aks.yaml
+    ```
+
+[1]: /resources/yaml/observability_pipelines/quickstart/azure_aks.yaml
+[2]: /observability_pipelines/configurations/
+{{% /tab %}}
+{{% tab "Google GKE" %}}
+1. Download the [Helm chart][1] for Google GKE. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+      opw datadog/observability-pipelines-worker \
+      -f google_gke.yaml
+    ```
+
+[1]: /resources/yaml/observability_pipelines/quickstart/google_gke.yaml
+[2]: /observability_pipelines/configurations/
+{{% /tab %}}
+{{% tab "APT-based Linux" %}}
+
+Install the Worker with the one-line install script or manually.
+#### One-line installation script
+
+1. Run the one-line install command to install the Worker. Replace `<DD_API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}.
+
+    ```
+    DD_API_KEY=<DD_API_KEY> DD_OP_PIPELINE_ID=<PIPELINES_ID> DD_SITE=<SITE> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_op_worker1.sh)"
+    ```
+
+2. Download the [sample configuration file][1] to `/etc/observability-pipelines-worker/pipeline.yaml` on the host. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+3. Start the worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+#### Manual installation
+
+1. Run the following commands to set up APT to download through HTTPS:
+
+    ```
+    sudo apt-get update
+    sudo apt-get install apt-transport-https curl gnupg
+    ```
+
+2. Run the following commands to set up the Datadog `deb` repo on your system and create a Datadog archive keyring:
+
+    ```
+    sudo sh -c "echo 'deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable observability-pipelines-worker-1' > /etc/apt/sources.list.d/datadog-observability-pipelines-worker.list"
+    sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+    sudo chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_CURRENT.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    curl https://keys.datadoghq.com/DATADOG_APT_KEY_C0962C7D.public | sudo gpg --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg --import --batch
+    ```
+
+3. Run the following commands to update your local `apt` repo and install the Worker:
+
+    ```
+    sudo apt-get update
+    sudo apt-get install observability-pipelines-worker datadog-signing-keys
+    ```
+
+4. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
+
+    ```
+    sudo cat <<-EOF > /etc/default/observability-pipelines-worker
+    DD_API_KEY=<API_KEY>
+    DD_OP_PIPELINE_ID=<PIPELINE_ID>
+    DD_SITE=<SITE>
+    EOF
+    ```
+
+5. Download the [sample configuration file][1] to `/etc/observability-pipelines-worker/pipeline.yaml` on the host.
+
+6. Start the worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+[1]: /resources/yaml/observability_pipelines/datadog/pipeline.yaml
+[2]: /observability_pipelines/configurations/
+{{% /tab %}}
+{{% tab "RPM-based Linux" %}}
+
+Install the Worker with the one-line install script or manually.
+
+#### One-line installation script
+
+1. Run the one-line install command to install the Worker. Replace `<DD_API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}.
+
+    ```
+    DD_API_KEY=<DD_API_KEY> DD_OP_PIPELINE_ID=<PIPELINES_ID> DD_SITE=<SITE> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_op_worker1.sh)"
+    ```
+
+2. Download the [sample configuration file][1] to `/etc/observability-pipelines-worker/pipeline.yaml` on the host. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+3. Run the following command to start the Worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+#### Manual installation
+
+1. Run the following commands to set up the Datadog `rpm` repo on your system:
+
+    ```
+    cat <<EOF > /etc/yum.repos.d/datadog-observability-pipelines-worker.repo
+    [observability-pipelines-worker]
+    name = Observability Pipelines Worker
+    baseurl = https://yum.datadoghq.com/stable/observability-pipelines-worker-1/\$basearch/
+    enabled=1
+    gpgcheck=1
+    repo_gpgcheck=1
+    gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+           https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+    EOF
+    ```
+
+   **Note:** If you are running RHEL 8.1 or CentOS 8.1, use `repo_gpgcheck=0` instead of `repo_gpgcheck=1` in the configuration above.
+
+2. Update your packages and install the Worker:
+
+    ```
+    sudo yum makecache
+    sudo yum install observability-pipelines-worker
+    ```
+
+3. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
+
+    ```
+    sudo cat <<-EOF > /etc/default/observability-pipelines-worker
+    DD_API_KEY=<API_KEY>
+    DD_OP_PIPELINE_ID=<PIPELINE_ID>
+    DD_SITE=<SITE>
+    EOF
+    ```
+
+4. Download the [sample configuration file][1] to `/etc/observability-pipelines-worker/pipeline.yaml` on the host. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+5. Run the following command to start the Worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+[1]: /resources/yaml/observability_pipelines/quickstart/pipeline.yaml
+[2]: /observability_pipelines/configurations/
+{{% /tab %}}
+{{% tab "Terraform (AWS)" %}}
+Set up the Worker module in your existing Terraform using this sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline.
+
+See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+```
+module "opw" {
+    source     = "https://github.com/DataDog/opw-terraform//aws"
+    vpc-id     = "{VPC ID}"
+    subnet-ids = ["{SUBNET ID 1}", "{SUBNET ID 2}"]
+    region     = "{REGION}"
+
+    datadog-api-key = "{DATADOG API KEY}"
+    pipeline-id = "{OP PIPELINE ID}"
+    pipeline-config = <<EOT
+## SOURCES: Data sources that Observability Pipelines Worker collects data from.
+## For a Datadog use case, we will receive data from the Datadog agent.
+sources:
+  datadog_agent:
+    address: 0.0.0.0:8282
+    type: datadog_agent
+    multiple_outputs: true
+
+transforms:
+  ## The Datadog Agent natively encodes its tags as a comma-separated list
+  ## of values that are stored in the string `.ddtags`. To work with
+  ## and filter off of these tags, you need to parse that string into
+  ## more structured data.
+  logs_parse_ddtags:
+    type: remap
+    inputs:
+      - datadog_agent.logs
+    source: |
+      .ddtags = parse_key_value!(.ddtags, key_value_delimiter: ":", field_delimiter: ",")
+
+  ## The `.status` attribute added by the Datadog Agent needs to be deleted, otherwise
+  ## your logs can be miscategorized at intake.
+  logs_remove_wrong_level:
+    type: remap
+    inputs:
+      - logs_parse_ddtags
+    source: |
+      del(.status)
+
+  ## This is a placeholder for your own remap (or other transform)
+  ## steps with tags set up. Datadog recommends these tag assignments.
+  ## They show which data has been moved over to OP and what still needs
+  ## to be moved.
+  LOGS_YOUR_STEPS:
+    type: remap
+    inputs:
+      - logs_remove_wrong_level
+    source: |
+      .ddtags.sender = "observability_pipelines_worker"
+      .ddtags.opw_aggregator = get_hostname!()
+
+  ## Before sending data to the logs intake, you must re-encode the
+  ## tags into the expected format, so that it appears as if the Agent is
+  ## sending it directly.
+  logs_finish_ddtags:
+    type: remap
+    inputs:
+      - LOGS_YOUR_STEPS
+    source: |
+      .ddtags = encode_key_value(.ddtags, key_value_delimiter: ":", field_delimiter: ",")
+
+  metrics_add_dd_tags:
+    type: remap
+    inputs:
+      - datadog_agent.metrics
+    source: |
+      .tags.sender = "observability_pipelines_worker"
+      .tags.opw_aggregator = get_hostname!()
+
+## This buffer configuration is split into the following, totaling the 288GB
+## provisioned automatically by the Terraform module:
+## - 240GB buffer for logs
+## - 48GB buffer for metrics
+##
+## This should work for the vast majority of OP Worker deployments and should rarely
+## need to be adjusted. If you do change it, be sure to update the `ebs-drive-size-gb`
+## parameter.
+sinks:
+  datadog_logs:
+    type: datadog_logs
+    inputs:
+      - logs_finish_ddtags
+    default_api_key: "$${DD_API_KEY}"
+    compression: gzip
+    buffer:
+       type: disk
+       max_size: 257698037760
+  datadog_metrics:
+    type: datadog_metrics
+    inputs:
+      - metrics_add_dd_tags
+    default_api_key: "$${DD_API_KEY}"
+    buffer:
+      type: disk
+      max_size: 51539607552
+EOT
+}
+```
+
+[2]: /observability_pipelines/configurations/
+{{% /tab %}}
+{{< /tabs >}}
+
+See [Working with Data][6] for more information on transforming your data.
+
+## Next steps
+
+The Quickstart walked you through how to install the Worker and deploy a sample pipeline configuration. For deploying specific use cases, select your use case:
 
 {{< partial name="observability_pipelines/use_cases.html" >}}
+
+For a deeper dive into best practices for deploying and scaling the Observability Pipelines Worker:
+
+- See [Deployment Design and Principles][7] for information on what to consider when designing your Observability Pipelines architecture.
+- See [Best Practices for OPW Aggregator Architecture][8] for details on the recommended Observability Pipelines aggregator architecture, which is optimized for scaling.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /observability_pipelines/#what-is-observability-pipelines-and-the-observability-pipelines-worker
+[2]: /observability_pipelines/setup/datadog/
+[3]: /observability_pipelines/setup/splunk/
+[4]: https://app.datadoghq.com/observability-pipelines
+[5]: /account_management/api-app-keys/#api-keys
+[6]: /observability_pipelines/working_with_data/
+[7]: /observability_pipelines/production_deployment_overview/
+[8]: /observability_pipelines/architecture/

--- a/content/en/observability_pipelines/setup/datadog.md
+++ b/content/en/observability_pipelines/setup/datadog.md
@@ -52,15 +52,24 @@ To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with
   ```
 * Datadog recommends using Amazon EKS >= 1.16.
 
+See [Best Practices for OPW Aggregator Architecture][2] for production-level requirements.
+
 [1]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
+[2]: /observability_pipelines/architecture/
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments. 
 
+See [Best Practices for OPW Aggregator Architecture][1] for production-level requirements.
+
+[1]: /observability_pipelines/architecture/
 {{% /tab %}}
 {{% tab "Google GKE" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.
 
+See [Best Practices for OPW Aggregator Architecture][1] for production-level requirements.
+
+[1]: /observability_pipelines/architecture/
 {{% /tab %}}
 {{% tab "APT-based Linux" %}}
 There are no provider-specific requirements for APT-based Linux.

--- a/content/en/observability_pipelines/setup/datadog.md
+++ b/content/en/observability_pipelines/setup/datadog.md
@@ -55,10 +55,12 @@ To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with
 [1]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
-To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.
+To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments. 
+
 {{% /tab %}}
 {{% tab "Google GKE" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.
+
 {{% /tab %}}
 {{% tab "APT-based Linux" %}}
 There are no provider-specific requirements for APT-based Linux.
@@ -364,6 +366,7 @@ Use the load balancer URL given to you by Helm when you configure the Datadog Ag
 
 NLBs provisioned by the [AWS Load Balancer Controller][1] are used.
 
+See [Capacity Planning and Scaling][2] for load balancer recommendations when scaling the Worker.
 #### Cross-availability-zone load balancing
 The provided Helm configuration tries to simplify load balancing, but you must take into consideration the potential price implications of cross-AZ traffic. Wherever possible, the samples try to avoid creating situations where multiple cross-AZ hops can happen.
 
@@ -373,10 +376,11 @@ The sample configurations do not enable the cross-zone load balancing feature av
 service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
 ```
 
-See [AWS Load Balancer Controller][2] for more details.
+See [AWS Load Balancer Controller][3] for more details.
 
 [1]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/
-[2]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/#load-balancer-attributes
+[2]: /observability_pipelines/architecture/capacity_planning_scaling/
+[3]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/#load-balancer-attributes
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
 Use the load balancers provided by your cloud provider.
@@ -385,8 +389,12 @@ so they are only accessible inside your network.
 
 Use the load balancer URL given to you by Helm when you configure the Datadog Agent.
 
+See [Capacity Planning and Scaling][1] for load balancer recommendations when scaling the Worker.
+
 #### Cross-availability-zone load balancing
 The provided Helm configuration tries to simplify load balancing, but you must take into consideration the potential price implications of cross-AZ traffic. Wherever possible, the samples try to avoid creating situations where multiple cross-AZ hops can happen.
+
+[1]: /observability_pipelines/architecture/capacity_planning_scaling/
 {{% /tab %}}
 {{% tab "Google GKE" %}}
 Use the load balancers provided by your cloud provider.
@@ -395,10 +403,14 @@ so they are only accessible inside your network.
 
 Use the load balancer URL given to you by Helm when you configure the Datadog Agent.
 
+See [Capacity Planning and Scaling][1] for load balancer recommendations when scaling the Worker.
+
 #### Cross-availability-zone load balancing
 The provided Helm configuration tries to simplify load balancing, but you must take into consideration the potential price implications of cross-AZ traffic. Wherever possible, the samples try to avoid creating situations where multiple cross-AZ hops can happen.
 
 Global Access is enabled by default since that is likely required for use in a shared tools cluster.
+
+[1]: /observability_pipelines/architecture/capacity_planning_scaling/
 {{% /tab %}}
 {{% tab "APT-based Linux" %}}
 No built-in support for load-balancing is provided, given the single-machine nature of the installation. You will need to provision your own load balancers using whatever your company's standard is.

--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -399,6 +399,9 @@ Use the load balancer URL given to you by Helm when you configure your existing 
 
 NLBs provisioned by the [AWS Load Balancer Controller][1] are used.
 
+
+See [Capacity Planning and Scaling][2] for load balancer recommendations when scaling the Worker.
+
 #### Cross-availability-zone load balancing
 The provided Helm configuration tries to simplify load balancing, but you must take into consideration the potential price implications of cross-AZ traffic. Wherever possible, the samples try to avoid creating situations where multiple cross-AZ hops can happen.
 
@@ -408,10 +411,11 @@ The sample configurations do not enable the cross-zone load balancing feature av
 service.beta.kubernetes.io/aws-load-balancer-attributes: load_balancing.cross_zone.enabled=true
 ```
 
-See [AWS Load Balancer Controller][2] for more details.
+See [AWS Load Balancer Controller][3] for more details.
 
 [1]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/
-[2]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/#load-balancer-attributes
+[2]: /observability_pipelines/architecture/capacity_planning_scaling/
+[3]: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.4/guide/service/annotations/#load-balancer-attributes
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
 Use the load balancers provided by your cloud provider.
@@ -420,8 +424,12 @@ so they are only accessible inside your network.
 
 Use the load balancer URL given to you by Helm when you configure your existing collectors.
 
+See [Capacity Planning and Scaling][1] for load balancer recommendations when scaling the Worker.
+
 #### Cross-availability-zone load balancing
 The provided Helm configuration tries to simplify load balancing, but you must take into consideration the potential price implications of cross-AZ traffic. Wherever possible, the samples try to avoid creating situations where multiple cross-AZ hops can happen.
+
+[1]: /observability_pipelines/architecture/capacity_planning_scaling/
 {{% /tab %}}
 {{% tab "Google GKE" %}}
 Use the load balancers provided by your cloud provider.
@@ -430,10 +438,14 @@ so they are only accessible inside your network.
 
 Use the load balancer URL given to you by Helm when you configure your existing collectors.
 
+See [Capacity Planning and Scaling][1] for load balancer recommendations when scaling the Worker.
+
 #### Cross-availability-zone load balancing
 The provided Helm configuration tries to simplify load balancing, but you must take into consideration the potential price implications of cross-AZ traffic. Wherever possible, the samples try to avoid creating situations where multiple cross-AZ hops can happen.
 
 Global Access is enabled by default since that is likely required for use in a shared tools cluster.
+
+[1]: /observability_pipelines/architecture/capacity_planning_scaling/
 {{% /tab %}}
 {{% tab "APT-based Linux" %}}
 No built-in support for load-balancing is provided, given the single-machine nature of the installation. You will need to provision your own load balancers using whatever your company's standard is.

--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -56,13 +56,24 @@ To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with
   ```
 * Datadog recommends using Amazon EKS >= 1.16.
 
+See [Best Practices for OPW Aggregator Architecture][2] for production-level requirements.
+
 [1]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
+[2]: /observability_pipelines/architecture/
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.
+
+See [Best Practices for OPW Aggregator Architecture][1] for production-level requirements.
+
+[1]: /observability_pipelines/architecture/
 {{% /tab %}}
 {{% tab "Google GKE" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.
+
+See [Best Practices for OPW Aggregator Architecture][1] for production-level requirements.
+
+[1]: /observability_pipelines/architecture/
 {{% /tab %}}
 {{% tab "APT-based Linux" %}}
 There are no provider-specific requirements for APT-based Linux.


### PR DESCRIPTION
### What does this PR do?

- Updates the OP Setup page to include quickstart instructions and next steps.
- Adds links to Capacity Planning and Scaling doc in the Kubernetes load balancing sections in the Datadog and Splunk guides. 

### Motivation

[DOCS-6135](https://datadoghq.atlassian.net/browse/DOCS-6135)

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file


[DOCS-6135]: https://datadoghq.atlassian.net/browse/DOCS-6135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ