### PR TITLE
Adjust the Oracle setup documentation to the custom release 0.40

### DIFF
--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -53,7 +53,7 @@ The Agent does not need to run on the same server nor the same platform as the m
 
 Datadog recommends you install the version listed in the [Latest Agent version](#latest-agent-version). It contains all the implemented Oracle monitoring features and bug fixes.
 
-If the latest Agent version is an official Datadog Agent release, like `7.46.0`, follow the instructions in [Official release](#official-release). If the latest Agent version is an Oracle DBM build, such as `7.46.0~dbm~oracle~0.34`, follow the instructions in [Oracle DBM build](#oracle-dbm-build).
+If the latest Agent version is an official Datadog Agent release, like `7.47.0`, follow the instructions in [Official release](#official-release). If the latest Agent version is an Oracle DBM build, such as `7.47.0~dbm~oracle~0.40`, follow the instructions in [Oracle DBM build](#oracle-dbm-build).
 
 #### Official release
 
@@ -71,7 +71,7 @@ Set `DD_API_KEY` and run the following commands to install the Oracle DBM releas
 
 ```shell
 export DD_AGENT_DIST_CHANNEL=beta
-export DD_AGENT_MINOR_VERSION="46.0~dbm~oracle~0.34-1"
+export DD_AGENT_MINOR_VERSION="47.0~dbm~oracle~0.40-1"
 
 DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```
@@ -85,7 +85,7 @@ Download the MSI file for the [Oracle DBM build][4].
 Set `APIKEY` and run the following command in the command prompt inside the directory where you downloaded the installer, for example:
 
 ```shell
-start /wait msiexec /qn /i datadog-agent-7.46.0-dbm-oracle-0.34-1.x86_64.msi APIKEY="" SITE="datadoghq.com"
+start /wait msiexec /qn /i datadog-agent-7.47.0-dbm-oracle-0.40-1.x86_64.msi APIKEY="" SITE="datadoghq.com"
 ```
 
 ##### Docker
@@ -95,15 +95,15 @@ The docker Oracle DBM images can be found [here][9].
 Set `DD_API_KEY` and run the following command to install the Oracle DBM release, for example:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY="" -e DD_SITE="datadoghq.com" gcr.io/datadoghq/agent:7.46.0-dbm-oracle-0.34
+docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY="" -e DD_SITE="datadoghq.com" gcr.io/datadoghq/agent:7.47.0-dbm-oracle-0.40
 ```
 
 ##### Latest Agent version
 
 The following Oracle DBM builds contain implemented Oracle DBM features:
-- Linux: `7.46.0~dbm~oracle~0.34-1`
-- Windows: `7.46.0-dbm-oracle-0.34-1`
-- Docker: `7.46.0-dbm-oracle-0.34`
+- Linux: `7.47.0~dbm~oracle~0.40-1`
+- Windows: `7.47.0-dbm-oracle-0.40-1`
+- Docker: `7.47.0-dbm-oracle-0.40`
 
 ### Oracle client
 
@@ -128,7 +128,7 @@ For setup instructions, select your hosting type:
 [1]: https://app.datadoghq.com/integrations
 [2]: https://app.datadoghq.com/integrations/oracle
 [3]: https://app.datadoghq.com/account/settings/agent/latest
-[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.46.0-dbm-oracle-0.34-1.x86_64.msi
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.47.0-dbm-oracle-0.40-1.x86_64.msi
 [5]: https://app.datadoghq.com/dash/integration/30990/dbm-oracle-database-overview
 [6]: https://yum.datadoghq.com/beta/7/x86_64/
 [7]: https://apt.datadoghq.com/dists/beta/7/


### PR DESCRIPTION
### What does this PR do?

Adjusting the setup documentation for the new custom build `7.47.0-dbm-oracle-0.40`.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
