### PR TITLE
[DOCS-6174] Fix Underline Bug on Configuring the Node.js Tracing Library Page

### DIFF
--- a/content/en/tracing/trace_collection/library_config/nodejs.md
+++ b/content/en/tracing/trace_collection/library_config/nodejs.md
@@ -232,7 +232,7 @@ A regex string to redact sensitive data by its value in attack reports.
 **Default**: 5<br>
 Remote configuration polling interval in seconds.
 
-<a id="headers-extraction-and-injection">
+<a id="headers-extraction-and-injection"></a>
 
 `DD_TRACE_PROPAGATION_STYLE_INJECT`
 : **Configuration**: `tracePropagationStyle.inject`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Fixes bug that was causing line 252 to be underlined.
`For more examples of how to work with the library see [API documentation][2].`

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/DOCS-6174

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations
 that you want us to be aware of, list them below. -->
 
- [X] Please merge after reviewing

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
