### PR TITLE
Update FIPS proxy version to 0.5.5

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -237,7 +237,7 @@ To send data to Datadog's GOVCLOUD datacenter, add the `fips-proxy` sidecar cont
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:0.5.4",
+            "image": "datadog/fips-proxy:0.5.5",
             "portMappings": [
                 {
                     "containerPort": 9803,


### PR DESCRIPTION
### What does this PR do?
Update version of the FIPS Proxy

### Motivation
New FIPS Proxy version has been released

### Preview
https://docs-staging.datadoghq.com/dustin.long/fips-docs-0.5.5/ (US1 Fed site only)

### Additional Notes
---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
