### PR TITLE
[DOCS-6157] Correct Generated Trace and Span ID Reference

### DIFF
--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -15,8 +15,8 @@ Generally, the libraries generate IDs that are 64-bit unsigned integers. Specifi
 | JavaScript | Unsigned [0, $2^63$]     | Signed or unsigned            |
 | Java       | Unsigned [1, $2^63-1$]   | Unsigned                      |
 | Go         | Unsigned [0, $2^63-1$]   | Signed or unsigned            |
-| Python     | Unsigned [0, $2^63$]     | Unsigned                      |
+| Python     | Unsigned [0, $2^64-1$]   | Unsigned                      |
 | Ruby       | Unsigned [1, $2^62-1$]   | Unsigned                      |
-| .NET       | Unsigned [0, $2^63$]     | Unsigned                      |
-| PHP        | [0, $2^63$]              | Signed                        |
+| .NET       | Unsigned [0, $2^63-1$]   | Unsigned                      |
+| PHP        | [0, $2^64-1$]            | Unsigned                      |
 | C++        | Unsigned [0, $2^63-1$]   | Unsigned                      |

--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -18,5 +18,5 @@ Generally, the libraries generate IDs that are 64-bit unsigned integers. Specifi
 | Python     | Unsigned [0, $2^64-1$]   | Unsigned                      |
 | Ruby       | Unsigned [1, $2^62-1$]   | Unsigned                      |
 | .NET       | Unsigned [0, $2^63-1$]   | Unsigned                      |
-| PHP        | [0, $2^64-1$]            | Unsigned                      |
+| PHP        | Unsigned [1, $2^64-1$]   | Unsigned                      |
 | C++        | Unsigned [0, $2^63-1$]   | Unsigned                      |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Correct generated trace and span IDs based on feedback from all APM language teams.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/jira/software/projects/DOCS/boards/199?assignee=712020%3A0c2a9bb8-dcff-4533-8eb8-9e0bd4696037&selectedIssue=DOCS-6157

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations
 that you want us to be aware of, list them below. -->
 
- [x] Please merge after reviewing

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
