### PR TITLE
Remove reviewer checklist and simplify template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,12 +17,3 @@
 
 ### Additional Notes
 <!-- Anything else we should know when reviewing?-->
-
----
-
-### Reviewer checklist
-- [ ] Review the changed files.
-- [ ] Review the URLs listed in the [Preview](#preview) section.
-- [ ] Check images for PII
-- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
-- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,14 @@
 <!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
 
-### What does this PR do?
-<!-- A brief description of the change being made with this pull request.-->
-
-### Motivation
-<!-- What inspired you to submit this pull request?-->
-
-<!-- ### Preview -->
-<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->
+### What does this PR do? What is the motivation?
+<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
 
 ### Merge instructions
-<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations
- that you want us to be aware of, list them below. -->
- 
+<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->
+
 - [ ] Please merge after reviewing
 
-### Additional Notes
+### Additional notes
 <!-- Anything else we should know when reviewing?-->
+
+<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


### PR DESCRIPTION
### What does this PR do?
Removes the reviewer section from the PR template. We have more detailed internal documentation on reviewing, which makes this section redundant, and we wanted to simplify the template as much as possible.

I also combined the "What does it do?" and "Motivation" sections.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->
 
- [x] Please merge after reviewing
