### PR TITLE
enable search on parent action - [WEB-3965]

### DIFF
--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -33,26 +33,29 @@
           {{ end }}
         {{ end }}
       </div>
+      {{$groupHeaderText := ""}}
       <div class="font-semibold ms-1 group-header-text">
         {{ if $transformGroupTitle }}
           <!-- If first word/only word is 3 letters long e.g aws or gcp then lets capitalize -->
           {{ $words := (split (humanize $v.Key) " ") }}
           {{ range $index, $word := $words }}
             {{ if (and (eq $index 0) (eq (len $word) 3)) }}
-              {{ $word | upper }}
+              {{ $groupHeaderText = $word | upper }}
             {{ else }}
-              {{ $word | title }}
+              <!-- concatenate -->
+              {{ $groupHeaderText = printf "%s %s" $groupHeaderText ($word | title )}}
             {{ end }}
           {{ end }}
         {{ else }}
-          {{ $v.Key }}
+          {{ $groupHeaderText = $v.Key }}
         {{ end }}
+        {{$groupHeaderText}}
       </div>
       <div class="js-group-header__arrow">></div>
     </div>
     <div class="group-{{ .Key }} mb-2 ms-4 d-none">
       {{ range $v.Pages }}
-        <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ .File.TranslationBaseName }}">
+        <a class="mb-1 font-semibold mix js-single-rule {{ range $i, $e := .Params.rule_category }} cat-{{ replace $e "/" "" | urlize }} {{ end }}" href="{{.Permalink}}" data-name="{{ lower .Title }} {{ lower $groupHeaderText }} {{ .File.TranslationBaseName }}">
           {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}
           {{ if in .Params.scope "." }}
             <!-- e.g gcp.project use source -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
enable search on parent action on action catalog pg

### Motivation
<!-- What inspired you to submit this pull request?-->

https://datadoghq.atlassian.net/browse/WEB-3965

### Preview
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

https://docs-staging.datadoghq.com/stefon.simmons/improve-action-search/service_management/workflows/actions_catalog/

ex:
searching for "aws autosc" returns AWS AutoScaling


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations
 that you want us to be aware of, list them below. -->
 
- [x] Please merge after CorpWeb approves

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
