### PR TITLE
[DOCS-6163] Address User Confusion w/ DD_TRACE_HEADER_TAGS

### DIFF
--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -167,8 +167,10 @@ A JSON array of objects. Rules are applied in configured order to determine the 
 
 `DD_TRACE_HEADER_TAGS`
 : **TracerSettings property**:`HeaderTags` <br>
-Accepts a comma-separated list of key-value pairs of case-insensitive header keys to tag names, and automatically applies matching header values as tags on root spans. Also accepts entries without a specified tag name. <br>
-**Example**: `CASE-insensitive-Header:my-tag-name,User-ID:userId,My-Header-And-Tag-Name`<br>
+Accepts a comma-separated list of key-value pairs of case-insensitive header keys to tag names, and automatically applies matching header values as tags on root spans. <br>
+**Example**: `CASE-insensitive-Header:my-tag-name,User-ID:userId`<br>
+Also accepts entries without a specified tag name. <br>
+**Example**: `My-Header-And-Tag-Name`<br>
 Added in version 1.18.3. Response header support and entries without tag names added in version 1.26.0.<br><br>
 **Beta**: Starting in version 2.35.0, if [Agent Remote Configuration][16] is enabled where this service runs, you can set `DD_TRACE_HEADER_TAGS` in the [Service Catalog][17] UI. 
 

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -183,8 +183,10 @@ A JSON array of objects. Rules are applied in configured order to determine the 
 
 `DD_TRACE_HEADER_TAGS`
 : **TracerSettings property**:`HeaderTags` <br>
-Accepts a comma-separated list of key-value pairs of case-insensitive header keys to tag names, and automatically applies matching header values as tags on root spans. Also accepts entries without a specified tag name. <br>
-**Example**: `CASE-insensitive-Header:my-tag-name,User-ID:userId,My-Header-And-Tag-Name`<br>
+Accepts a comma-separated list of key-value pairs of case-insensitive header keys to tag names, and automatically applies matching header values as tags on root spans.<br>
+**Example**: `CASE-insensitive-Header:my-tag-name,User-ID:userId,`<br>
+Also accepts entries without a specified tag name. <br>
+**Example**: `My-Header-And-Tag-Name`<br>
 Added in version 1.18.3. Response header support and entries without tag names added in version 1.26.0.<br><br>
 **Beta**: Starting in version 2.35.0, if [Agent Remote Configuration][16] is enabled where this service runs, you can set `DD_TRACE_HEADER_TAGS` in the [Service Catalog][17] UI. 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
<!-- A brief description of the change being made with this pull request.-->
Splits the example for DD_TRACE_HEADER_TAGS into two: one with key:value pairs and one without.
Chatted with @vidurkhannadatadog about this resolution.

### Motivation
<!-- What inspired you to submit this pull request?-->
https://datadoghq.atlassian.net/browse/DOCS-6163
Hotjar feedback from a user who was confused by this.

<!-- ### Preview -->
<!-- Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations
 that you want us to be aware of, list them below. -->
 
- [ ] Please merge after reviewing

### Additional Notes
<!-- Anything else we should know when reviewing?-->

---

### Reviewer checklist
- [ ] Review the changed files.
- [ ] Review the URLs listed in the [Preview](#preview) section.
- [ ] Check images for PII
- [ ] Review any mentions of "Contact Datadog support" for internal support documentation.
- [ ] Check that `cache_enabled` is set to `true` in the `pull_config_preview.yaml` file
