### PR TITLE
Update usage_metrics.md

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -43,7 +43,7 @@ Estimated usage metrics are generally available for the following usage types:
 | Parallel Testing Slots        | `datadog.estimated_usage.synthetics.parallel_testing_slots` | Estimated usage for parallel testing slots. |
 | Network Hosts                 | `datadog.estimated_usage.network.hosts` | Unique NPM hosts seen in the last hour. |
 | Network Devices               | `datadog.estimated_usage.network.devices` | Unique NDM devices seen in the last hour. |
-| Profiled Hosts                | `datadog.estimated_usage.profiling.hosts` | Unique profiling containers seen in the last hour. |
+| Profiled Hosts                | `datadog.estimated_usage.profiling.hosts` | Unique profiling hosts seen in the last hour. |
 | Profiled Containers           | `datadog.estimated_usage.profiling.containers` | Unique profiling containers seen in last 5 minutes. |
 | Profiler Fargate Tasks        | `datadog.estimated_usage.profiling.fargate_tasks` | Unique profiling Fargate Tasks seen in the last 5 minutes. |
 | CSPM Hosts                    | `datadog.estimated_usage.cspm.hosts` | Unique CSPM hosts seen in the last hour. |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Profiled Hosts	- datadog.estimated_usage.profiling.hosts should be "Unique profiling "hosts" seen in the last hour" not "containers".

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->