### PR TITLE
ensure the core agent is aware that CWS (runtime-security) is enabled in instructions

### DIFF
--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -232,6 +232,11 @@ remote_configuration:
   ## Set to true to enable remote configuration.
   enabled: true
 
+runtime_security_config:
+  ## @param enabled - boolean - optional - default: false
+  ## Set to true to enable full CSM Threats.
+  enabled: true
+
 compliance_config:
  ## @param enabled - boolean - optional - default: false
  ## Set to true to enable CIS benchmarks for CSPM.

--- a/content/en/security/cloud_security_management/setup/csm_workload_security.md
+++ b/content/en/security/cloud_security_management/setup/csm_workload_security.md
@@ -190,6 +190,11 @@ remote_configuration:
   ## @param enabled - boolean - optional - default: false
   ## Set to true to enable remote configuration.
   enabled: true
+
+runtime_security_config:
+  ## @param enabled - boolean - optional - default: false
+  ## Set to true to enable full CSM Threats.
+  enabled: true
 ```
 
 ```bash


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR fixes the CWS installation instructions by ensuring the core agent is aware CWS is enabled.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->