### PR TITLE
[CWS] fix the security profile enable instructions

### DIFF
--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -94,13 +94,13 @@ Alternatively, use the following examples to enable CSM Enterprise:
           enabled: true
     ```
 2. **Optional**: To enable [Runtime Anomaly Detection][1], add the following to the `values.yaml` file:
-   
+
     ```yaml
     # values.yaml file
     datadog:
       securityAgent:
         runtime:
-          security_profile:
+          securityProfile:
             enabled: true
     ```
 
@@ -126,20 +126,7 @@ Alternatively, use the following examples to enable CSM Enterprise:
           enabled: true
     ```
 
-1. **Optional**: To enable [Runtime Anomaly Detection][1], add the following to the `values.yaml` file:
-   
-    ```yaml
-    # values.yaml file
-    spec:
-      features:
-        cws:
-          security_profile:
-            enabled: true
-    ```
-
-    See the [Datadog Operator documentation][2] for additional configuration options.
-
-3. Restart the Agent.
+2. Restart the Agent.
 
 
 [1]: /security/threats/runtime_anomaly_detection

--- a/content/en/security/cloud_security_management/setup/csm_workload_security.md
+++ b/content/en/security/cloud_security_management/setup/csm_workload_security.md
@@ -58,13 +58,13 @@ Alternatively, use the following examples to enable CSM Workload Security:
           enabled: true
     ```
 2. **Optional**: To enable [Runtime Anomaly Detection][1], add the following to the `values.yaml` file:
-   
+
     ```yaml
     # values.yaml file
     datadog:
       securityAgent:
         runtime:
-          security_profile:
+          securityProfile:
             enabled: true
     ```
 
@@ -88,20 +88,7 @@ Alternatively, use the following examples to enable CSM Workload Security:
           enabled: true
     ```
 
-2. **Optional**: To enable [Runtime Anomaly Detection][1], add the following to the `values.yaml` file:
-   
-    ```yaml
-    # values.yaml file
-    spec:
-      features:
-        cws:
-          security_profile:
-            enabled: true
-    ```
-
-    See the [Datadog Operator documentation][2] for additional configuration options.
-
-3. Restart the Agent.
+2. Restart the Agent.
 
 
 [1]: /security/threats/runtime_anomaly_detection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR fixes the security profiles enable instruction:
- fixing the value in helm charts to match https://github.com/DataDog/helm-charts/pull/1171
- remove the instruction when using the operator since it's not available yet there

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->