### PR TITLE
Specify languages for AWS Lambda Profiling public beta.

### DIFF
--- a/content/en/serverless/aws_lambda/profiling.md
+++ b/content/en/serverless/aws_lambda/profiling.md
@@ -15,7 +15,7 @@ further_reading:
 Datadog's [Continuous Profiler][1] for AWS Lambda functions gives you visibility into the exact method name, class name, and line number in your Lambda code that is causing CPU or I/O bottlenecks.
 
 <div class="alert alert-warning">
-Continuous Profiler for AWS Lambda is in public beta. During the beta period, profiling is available at no additional cost.
+Continuous Profiler for AWS Lambda is in public beta. During the beta period, profiling for Node and Python is available at no additional cost.
 </div>
 
 ## Usage


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Specify which languages are currently supported for continuous profiling in aws lambda. 

Motivation: a customer turned on the profiler in a golang lambda function thinking they would not be billed for it.

This change removes any confusion about exactly which languages are running the beta.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->