### PR TITLE
Move recommended monitor up in the nav

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -4110,12 +4110,12 @@ main:
     url: developers/integrations/create-an-integration-dashboard
     parent: dev_tools_integrations
     weight: 407
-  - name: OAuth for Integrations
-    url: developers/integrations/oauth_for_integrations
-    parent: dev_tools_integrations
-    weight: 408
   - name: Create a Recommended Monitor
     url: developers/integrations/create-an-integration-recommended-monitor
+    parent: dev_tools_integrations
+    weight: 408
+  - name: OAuth for Integrations
+    url: developers/integrations/oauth_for_integrations
     parent: dev_tools_integrations
     weight: 409
   - name: Install Agent Integration Developer Tool


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Move the "Create a Recommended Monitor" up one so that it sits right below "Create a Dashboard" under Developer nav section
Requested by PM

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->