### PR TITLE
rollup: repharse

### DIFF
--- a/content/en/dashboards/functions/rollup.md
+++ b/content/en/dashboards/functions/rollup.md
@@ -5,8 +5,7 @@ aliases:
     - /graphing/functions/rollup/
 ---
 
-`.rollup()`
-The `.rollup()` function is used to aggregate your metrics data inherently in every metrics query. However, appending the `.rollup()` function at the end of a query allows you to perform custom [time aggregation][1] that overrides the defaults. This function enables you to define:
+Every metric query is inherently aggregated. However, appending the `.rollup()` function at the end of a query allows you to perform custom [time aggregation][1] that overrides the defaults. This function enables you to define:
 
 * The rollup `<interval>`: the interval of time your data is aggregated over ([if larger than the query-enforced rollup interval](#rollup-interval-enforced-vs-custom)).
 * The rollup `<aggregator>`: How your data points are aggregated within a given rollup time interval.


### PR DESCRIPTION
I'm not sure if `.rollup()` is somehow used internally, but the previous phrasing is confusing to an end-user (me).