### PR TITLE
[php tracing] update url to library releases

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/php.md
+++ b/content/en/tracing/trace_collection/dd_libraries/php.md
@@ -449,7 +449,7 @@ For Apache, run:
 [1]: /tracing/compatibility_requirements/php
 [2]: https://app.datadoghq.com/apm/service-setup
 [3]: /tracing/glossary/
-[5]: https://app.datadoghq.com/apm/services
+[5]: https://github.com/DataDog/dd-trace-php/releases
 [6]: /tracing/trace_collection/library_config/php/
 [7]: /tracing/guide/trace-php-cli-scripts/
 [8]: https://packages.sury.org/php/


### PR DESCRIPTION
[php tracing] update url to library releases


### What does this PR do? What is the motivation?

update url to library releases for php tracing libraries. Old link pointed at service list rather than installation bits.