### PR TITLE
Add note to CSM resource evaluation filters

### DIFF
--- a/content/en/security/cloud_security_management/_index.md
+++ b/content/en/security/cloud_security_management/_index.md
@@ -69,13 +69,13 @@ Remediating security issues can meaningfully improve your organization's securit
 
 Available for [CSM Misconfigurations][2], the [security posture score][5] helps you track your organization's overall health. The score represents the percentage of your environment that satisfies all of your active out-of-the-box cloud and infrastructure compliance rules.
 
-Improve your organization's score by remediating misconfigurations, either by resolving the underlying issue or by muting the misconfiguration.
+Improve your organization's score by remediating findings, either by resolving the underlying issue or by muting the finding.
 
 {{< img src="security/csm/health_scores.png" alt="The posture score on the CSM overview page tracks your organization's overall health" width="100%">}}
 
 ## Explore and remediate issues
 
-Use the [Issues page][7] to review and remediate your organization's detections and misconfigurations. View detailed information about a detection, including guidelines and remediation steps. [Send real-time notifications][6] when a threat is detected in your environment, and use tags to identify the owner of an impacted resource.
+Use the [Issues page][7] to review and remediate your organization's detections and findings. View detailed information about a detection, including guidelines and remediation steps. [Send real-time notifications][6] when a threat is detected in your environment, and use tags to identify the owner of an impacted resource.
 
 {{< img src="security/cws/threats_page.png" alt="CSM Threats page" width="100%">}}
 

--- a/content/en/security/cloud_security_management/_index.md
+++ b/content/en/security/cloud_security_management/_index.md
@@ -69,13 +69,13 @@ Remediating security issues can meaningfully improve your organization's securit
 
 Available for [CSM Misconfigurations][2], the [security posture score][5] helps you track your organization's overall health. The score represents the percentage of your environment that satisfies all of your active out-of-the-box cloud and infrastructure compliance rules.
 
-Improve your organization's score by remediating findings, either by resolving the underlying issue or by muting the finding.
+Improve your organization's score by remediating misconfigurations, either by resolving the underlying issue or by muting the misconfiguration.
 
 {{< img src="security/csm/health_scores.png" alt="The posture score on the CSM overview page tracks your organization's overall health" width="100%">}}
 
 ## Explore and remediate issues
 
-Use the [Issues page][7] to review and remediate your organization's detections and findings. View detailed information about a detection, including guidelines and remediation steps. [Send real-time notifications][6] when a threat is detected in your environment, and use tags to identify the owner of an impacted resource.
+Use the [Issues page][7] to review and remediate your organization's detections and misconfigurations. View detailed information about a detection, including guidelines and remediation steps. [Send real-time notifications][6] when a threat is detected in your environment, and use tags to identify the owner of an impacted resource.
 
 {{< img src="security/cws/threats_page.png" alt="CSM Threats page" width="100%">}}
 

--- a/layouts/shortcodes/csm-setup-aws.md
+++ b/layouts/shortcodes/csm-setup-aws.md
@@ -23,6 +23,8 @@ Use one of the following methods to enable CSM for your AWS accounts:
 
 You can use resource tags to create filters that include or exclude resources from being evaluated by CSM. The filters must be specified as a comma-separated list of `key:value` pairs.
 
+**Note**: Resource evaluation filters can only be used with hosts that are scanned by cloud integrations.
+
 | Format                       | Value        |
 |------------------------------|--------------|
 | Allowlist                    | `key:value`  |

--- a/layouts/shortcodes/csm-setup-azure.md
+++ b/layouts/shortcodes/csm-setup-azure.md
@@ -25,6 +25,8 @@ Use one of the following methods to enable CSM for your Azure subscriptions:
 
 You can use resource tags to create filters that include or exclude resources from being evaluated by CSM. The filters must be specified as a comma-separated list of `key:value` pairs.
 
+**Note**: Resource evaluation filters can only be used with hosts that are scanned by cloud integrations.
+
 | Format                       | Value        |
 |------------------------------|--------------|
 | Allowlist                    | `key:value`  |

--- a/layouts/shortcodes/csm-setup-google-cloud.md
+++ b/layouts/shortcodes/csm-setup-google-cloud.md
@@ -47,6 +47,8 @@ Use one of the following methods to enable CSM for your Google Cloud projects:
 
 You can use resource tags to create filters that include or exclude resources from being evaluated by CSM. The filters must be specified as a comma-separated list of `key:value` pairs.
 
+**Note**: Resource evaluation filters can only be used with hosts that are scanned by cloud integrations.
+
 | Format                       | Value        |
 |------------------------------|--------------|
 | Allowlist                    | `key:value`  |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds a note that the CSM resource evaluation filters only work with hosts that are scanned by cloud integrations. Requested by PM.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->