### PR TITLE
document patched versions for PHP allocation profiling

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -209,11 +209,11 @@ CPU
 
 Allocations (v0.88+)
 : The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
-_Note: Not available when JIT is active_
+_Note: Not available when JIT is active on PHP 8.0.0 - 8.1.20 and 8.2.0 - 8.2.7_
 
 Allocated memory (v0.88+)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
-_Note: Not available when JIT is active_
+_Note: Not available when JIT is active on PHP 8.0.0 - 8.1.20 and 8.2.0 - 8.2.7_
 
 [1]: /profiler/enabling/php/#requirements
 {{< /programming-lang >}}

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -209,11 +209,11 @@ CPU
 
 Allocations (v0.88+)
 : The number of allocations by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
-_Note: Not available when JIT is active on PHP 8.0.0 - 8.1.20 and 8.2.0 - 8.2.7_
+_Note: Not available when JIT is active on PHP `8.0.0`-`8.1.20` and `8.2.0`-`8.2.7`_
 
 Allocated memory (v0.88+)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
-_Note: Not available when JIT is active on PHP 8.0.0 - 8.1.20 and 8.2.0 - 8.2.7_
+_Note: Not available when JIT is active on PHP `8.0.0`-`8.1.20` and `8.2.0`-`8.2.7`_
 
 [1]: /profiler/enabling/php/#requirements
 {{< /programming-lang >}}

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -126,7 +126,7 @@ Whether to enable the endpoint data collection in profiles. Added in version `0.
 `DD_PROFILING_ALLOCATION_ENABLED`
 : **INI**: `datadog.profiling.allocation_enabled`. INI available since `0.88.0`.<br>
 **Default**: `1`<br>
-Enable the allocation size and allocation bytes profile type. Added in version `0.88.0`. When an active JIT is detected, allocation profiling is turned off due to a limitation of the ZendEngine.<br>
+Enable the allocation size and allocation bytes profile type. Added in version `0.88.0`. When an active JIT is detected, allocation profiling is turned off for PHP version `8.0.0`-`8.1.20` and `8.2.0`-`8.2.7` due to a limitation of the ZendEngine.<br>
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_ALLOCATION_ENABLED` environment variable (`datadog.profiling.experimental_allocation_enabled` INI setting), which was available since `0.84`. If both are set, this one takes precedence.
 
 `DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

With PHP 8.1.21 and 8.2.8 there is now a fix for the JIT vs. allocation profiling topic, so in the PHP Profiler `0.92.0` we'll release an update that allocation profiling will be active despite JIT being enabled for PHP >= 8.1.21 and >= 8.2.8.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes

This PR should only be merged after `dd-trace-php` in version `0.92.0` got released.
Related PR in the profiler is https://github.com/DataDog/dd-trace-php/pull/2246