### PR TITLE
Add PHP exception profiling to docs

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -215,6 +215,9 @@ Allocated memory (v0.88+)
 : The amount of heap memory allocated by each function during the profiling period (default: 67s), including allocations which were subsequently freed. Stack allocations are not tracked.<br />
 _Note: Not available when JIT is active_
 
+Thrown Exceptions (v0.92+)
+: The number of caught or uncaught exceptions raised by each method, as well as their type.
+
 [1]: /profiler/enabling/php/#requirements
 {{< /programming-lang >}}
 {{< programming-lang lang="ddprof" >}}

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -134,6 +134,16 @@ Enable the allocation size and allocation bytes profile type. Added in version `
 **Default**: `1`<br>
 Enable the experimental CPU profile type. Added in version `0.69.0`. For version `0.76` and below it defaulted to `0`.
 
+`DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED`
+: **INI**: `datadog.profiling.experimental_exception_enabled`. INI available since `0.92.0`.<br>
+**Default**: `0`<br>
+Enable the experimental exception profile type. Added in version `0.92.0`.
+
+`DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE`
+: **INI**: `datadog.profiling.experimental_exception_sampling_distance`. INI available since `0.92.0`.<br>
+**Default**: `100`<br>
+Configure the sampling distance for exceptions. The higher the sampling distance, the fewer samples are created and the lower the overhead.
+
 `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED`
 : **INI**: `datadog.profiling.experimental_timeline_enabled`. INI available since `0.89.0`.<br>
 **Default**: `0`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

With https://github.com/DataDog/dd-trace-php/pull/2197 we merged exception profiling for PHP into the profiler. This will be released with version `0.92.0`.
Goal is to document the new feature with environment variables and INI settings.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes

Do not merge as long as `0.92.0` is not released.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->