### PR TITLE
(DOCS-6224) apt-key is deprecated

### DIFF
--- a/content/en/agent/guide/linux-agent-2022-key-rotation.md
+++ b/content/en/agent/guide/linux-agent-2022-key-rotation.md
@@ -77,12 +77,11 @@ Datadog encourages you to use one of the [install methods](#install-methods-that
 
 Run the following commands on the host:
 
-```bash
-$ curl -o /tmp/DATADOG_APT_KEY_F14F620E https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
-$ sudo apt-key add /tmp/DATADOG_APT_KEY_F14F620E
-$ sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
-$ cat /tmp/DATADOG_APT_KEY_F14F620E | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg
-$ sudo chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg
+```shell
+curl -o /tmp/DATADOG_APT_KEY_F14F620E https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
+sudo touch /usr/share/keyrings/datadog-archive-keyring.gpg
+cat /tmp/DATADOG_APT_KEY_F14F620E | sudo gpg --import --batch --no-default-keyring --keyring /usr/share/keyrings/datadog-archive-keyring.gpg
+sudo chmod a+r /usr/share/keyrings/datadog-archive-keyring.gpg
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The `apt-key` command is deprecated. If I understand this correctly, `apt-key` is a wrapper for the `gpg` command and we're already running `gpg`, so I don't think `apt-key` is needed.

Mimics the manual instructions on the [Ubuntu installation page](https://app.datadoghq.com/account/settings/agent/latest?platform=ubuntu) in the app.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->