### PR TITLE
[WEB-4064] avoid escaping TOC items

### DIFF
--- a/layouts/partials/table-of-contents/scraped-toc.html
+++ b/layouts/partials/table-of-contents/scraped-toc.html
@@ -25,7 +25,7 @@
       {{ end }}
 
       <li>
-          <a href="#{{ $h_id }}">{{ $h_title }}</a>
+          <a href="#{{ $h_id }}">{{ $h_title | safeHTML }}</a>
 
       {{ $prev_h_level = $h_level }}
     {{ end }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Marks the TOC items with safeHTML to avoid being escaped 

https://datadoghq.atlassian.net/browse/WEB-4064

### Merge instructions
- [ x ] Please merge after reviewing

### Additional notes
Review: 
https://docs-staging.datadoghq.com/nsollecito/web-4064/account_management/users/#edit-a-users-roles

HTML entity should no longer be escaped
