### PR TITLE
[RUM][REPLAY] Disclose data-* attributes in mask mode

### DIFF
--- a/content/en/real_user_monitoring/session_replay/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/privacy_options.md
@@ -59,7 +59,7 @@ Masks most form fields such as inputs, text areas, and checkbox values while rec
 
 ### Mask mode
 
-Setting `defaultPrivacyLevel` to `mask` mode will mask all HTML text, user input, images, links and [`data-*` attributes]. Text on your application is replaced with `X`, rendering the page into a wireframe.
+Setting `defaultPrivacyLevel` to `mask` mode will mask all HTML text, user input, images, links and [`data-*` attributes][1]. Text on your application is replaced with `X`, rendering the page into a wireframe.
 
 {{< img src="real_user_monitoring/session_replay/mask-mode-fixed.png" alt="Mask mode" style="width:70%;">}}
 

--- a/content/en/real_user_monitoring/session_replay/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/privacy_options.md
@@ -59,7 +59,7 @@ Masks most form fields such as inputs, text areas, and checkbox values while rec
 
 ### Mask mode
 
-Setting `defaultPrivacyLevel` to `mask` mode will mask all HTML text, user input, images, and links. Text on your application is replaced with `X`, rendering the page into a wireframe.
+Setting `defaultPrivacyLevel` to `mask` mode will mask all HTML text, user input, images, links and [`data-*` attributes]. Text on your application is replaced with `X`, rendering the page into a wireframe.
 
 {{< img src="real_user_monitoring/session_replay/mask-mode-fixed.png" alt="Mask mode" style="width:70%;">}}
 
@@ -134,3 +134,5 @@ Datadog is working to add more privacy features to RUM & Session Replay. Have so
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes

--- a/content/en/real_user_monitoring/session_replay/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/privacy_options.md
@@ -59,7 +59,7 @@ Masks most form fields such as inputs, text areas, and checkbox values while rec
 
 ### Mask mode
 
-Setting `defaultPrivacyLevel` to `mask` mode will mask all HTML text, user input, images, links and [`data-*` attributes][1]. Text on your application is replaced with `X`, rendering the page into a wireframe.
+Setting `defaultPrivacyLevel` to `mask` mode masks all HTML text, user input, images, links and [`data-*` attributes][1]. Text on your application is replaced with `X`, rendering the page into a wireframe.
 
 {{< img src="real_user_monitoring/session_replay/mask-mode-fixed.png" alt="Mask mode" style="width:70%;">}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Disclose that Session Replay will also mask `data-*` attributes when the `mask` mode is used.

### Merge instructions
- [x] Please merge after reviewing

### Additional notes



<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->