### PR TITLE
Fix error in Java implementation

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -171,8 +171,7 @@ String traceIdHexString = traceIdValue.substring(traceIdValue.length() - 16 );
 long datadogTraceId = Long.parseUnsignedLong(traceIdHexString, 16);
 String datadogTraceIdString = Long.toUnsignedString(datadogTraceId);
 
-String spanIdValue = Span.current().getSpanContext().getSpanId();
-String spanIdHexString = spanIdValue.substring(spanIdValue.length() - 16 );
+String spanIdHexString = Span.current().getSpanContext().getSpanId();
 long datadogSpanId = Long.parseUnsignedLong(spanIdHexString, 16);
 String datadogSpanIdString = Long.toUnsignedString(datadogSpanId);
 


### PR DESCRIPTION


### What does this PR do? What is the motivation?
It fixes an error in the Java implementation of the OpenTelemetry Id conversion. The spanId is already 16 characters long so there is no need to drop the characters. The current implementation fails when trying to parse the resulting empty string

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
