### PR TITLE
[DOCS-6239] removing arm64 references as not supported

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/php.md
+++ b/content/en/security/application_security/enabling/compatibility/php.md
@@ -77,8 +77,6 @@ PHP ASM supports the following architectures:
 | ------------------------------------------|-----------------------|----------------------------------------|
 | Linux GNU amd64 (`x86-64-linux-gnu`)      | GA                    | All                                    |
 | Linux MUSL amd64 (`x86-64-linux-musl`)    | GA                    | All                                    |
-| Linux GNU arm64 (`aarch64-linux-gnu`)     | GA                    | > `0.78.0`                             |
-| Linux MUSL arm64 (`aarch64-linux-musl`)   | GA                    | > `0.78.0`                             |
 
 The Datadog PHP library supports PHP version 7.0 and above on the following architectures:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
[DOCS-6239](https://datadoghq.atlassian.net/browse/DOCS-6239)

Removing Linux GNU arm64 `aarch64-linux-gnu` and Linux MUSL arm64 (`aarch64-linux-musl`) as these are not supported libraries.

### Merge instructions
ok to merge

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6239]: https://datadoghq.atlassian.net/browse/DOCS-6239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ