### PR TITLE
[DOCS-6174] Make Configuring the Node.js Tracing Library Header Visible

### DIFF
--- a/content/en/tracing/trace_collection/library_config/nodejs.md
+++ b/content/en/tracing/trace_collection/library_config/nodejs.md
@@ -234,6 +234,8 @@ Remote configuration polling interval in seconds.
 
 ### Headers extraction and injection
 
+For information about valid values and using the following configuration options, see [Propagating Node.js Trace Context][5].
+
 `DD_TRACE_PROPAGATION_STYLE_INJECT`
 : **Configuration**: `tracePropagationStyle.inject`<br>
 **Default**: `Datadog,tracecontext`<br>
@@ -259,4 +261,5 @@ For more examples of how to work with the library see [API documentation][2].
 [2]: https://datadog.github.io/dd-trace-js/
 [3]: /tracing/trace_pipeline/ingestion_mechanisms/
 [4]: /help/
+[5]: /tracing/trace_collection/trace_context_propagation/nodejs
 [13]: /agent/guide/network/#configure-ports

--- a/content/en/tracing/trace_collection/library_config/nodejs.md
+++ b/content/en/tracing/trace_collection/library_config/nodejs.md
@@ -232,7 +232,7 @@ A regex string to redact sensitive data by its value in attack reports.
 **Default**: 5<br>
 Remote configuration polling interval in seconds.
 
-<a id="headers-extraction-and-injection"></a>
+### Headers extraction and injection
 
 `DD_TRACE_PROPAGATION_STYLE_INJECT`
 : **Configuration**: `tracePropagationStyle.inject`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
https://datadoghq.atlassian.net/browse/DOCS-6174
* Originally completed this card by just fixing the underline bug.
* After discussing with Vidur, he suggested not making the header hidden at all.
* Note that this anchor is referenced in several other files.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->