### PR TITLE
(DOCS-6205) Add resource exclusion subsections

### DIFF
--- a/content/en/account_management/billing/aws.md
+++ b/content/en/account_management/billing/aws.md
@@ -33,7 +33,7 @@ Hosts with a running Agent still display and are included in billing. Use the li
 
 ### CloudWatch Metric Streams with Kinesis Data Firehose
 
-You can optionally [forward CloudWatch Metric Streams to Datadog with the Kinesis Data Firehose][8]. If you use this method, you must manage all rules for including and excluding namespaces in the streams using the CloudWatch Metric Streams configuration in your AWS accounts. Namespace defaults and account-level settings in the Datadog AWS integration page only apply to the default API polling approach. 
+You can optionally [send CloudWatch metrics to Datadog using CloudWatch Metric Streams and Kinesis Data Firehose][8] instead of using the default API polling method. If your organization uses the CloudWatch Metric Streams with Kinesis method, AWS resource exclusion rules defined in the Datadog AWS integration page do not apply. You must manage all rules for including and excluding metric namespaces or specific metric names in the CloudWatch Metric Streams configuration in your AWS accounts.
 
 ## Troubleshooting
 

--- a/content/en/account_management/billing/aws.md
+++ b/content/en/account_management/billing/aws.md
@@ -25,11 +25,15 @@ You can also limit AWS metrics using the [API][4].
 
 **Note**: Only EC2 (hosts), Lambda (active functions), and CloudWatch Custom Metrics (custom metrics) are billable by Datadog. Metrics integrated for the other services you can filter do not incur Datadog charges.
 
-**Note**: EC2 metrics resource exclusion settings apply to both EC2 and its attached EBS volumes. 
+### EC2
 
-When adding limits to existing AWS accounts within the integration page, the previously discovered instances could stay in the [Infrastructure List][5] up to 2 hours. During the transition period, EC2 instances display a status of `???`. This does not count towards your billing.
+EC2 metrics resource exclusion settings apply to both EC2 instances and any attached EBS volumes. When adding limits to existing AWS accounts within the integration page, the previously discovered instances could stay in the [Infrastructure List][5] for up to two hours. During the transition period, EC2 instances display a status of `???`. This does not count towards your billing.
 
 Hosts with a running Agent still display and are included in billing. Use the limit option to restrict `aws.ec2.*` metrics collection from AWS and restrict the AWS resource EC2 instance hosts.
+
+### CloudWatch Metric Streams with Kinesis Data Firehose
+
+You can optionally [forward CloudWatch Metric Streams to Datadog with the Kinesis Data Firehose][8]. If you use this method, you must manage all rules for including and excluding namespaces in the streams using the CloudWatch Metric Streams configuration in your AWS accounts. Namespace defaults and account-level settings in the Datadog AWS integration page only apply to the default API polling approach. 
 
 ## Troubleshooting
 
@@ -44,3 +48,4 @@ For billing questions, contact your [Customer Success][7] Manager.
 [5]: /infrastructure/
 [6]: /help/
 [7]: mailto:success@datadoghq.com
+[8]: https://docs.datadoghq.com/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/?tab=cloudformation#streaming-vs-polling


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- Add a subsection and information about billing considerations with the [Metric Streaming through Kinesis Data Firehose](https://docs.datadoghq.com/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/?tab=cloudformation#streaming-vs-polling) metric collection approach
- Add an additional subsection for multiple pieces of information related to EC2 billing considerations

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->