### PR TITLE
[Alerting]: fix error-tracking attributes example

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -320,7 +320,7 @@ To include **any** attribute or tag from a log, a trace span, a RUM event, a CI 
 |-----------------|--------------------------------------------------|
 | Log             | `{{log.attributes.key}}` or `{{log.tags.key}}`   |
 | Trace Analytics | `{{span.attributes.key}}` or `{{span.tags.key}}` |
-| Error Tracking  | `{{span.attributes.[error.message]}}`             |
+| Error Tracking  | Traces: `{{span.attributes.[error.message]}}`<br>RUM Events: `{{rum.attributes.[error.message]}}`<br>Logs: `{{log.attributes.[error.message]}}`             |
 | RUM             | `{{rum.attributes.key}}` or `{{rum.tags.key}}`   |
 | CI Pipeline     | `{{cipipeline.attributes.key}}`                  |
 | CI Test         | `{{citest.attributes.key}}`                      |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Customers are complaining they don't know how to access the issue info when writing monitor notification messages.
The example provided in the doc is actually only working for APM traces but error-tracking also works for logs and rum which have different path.

https://github.com/DataDog/documentation/blob/1a9516226543ab745dd1b972b55df264cc5f0a51/content/en/monitors/notify/variables.md#matching-attributetag-variables

### Merge instructions

- [x] Please merge after reviewing

### Additional notes

This isn't super nice formatting to try to put so much info into a table cell.

I thought about creating an Error-Tracking section where I could go into more details but I see no other specific product section.

If I had such section I could document other "error" attributes that can differ per traces/rum/logs.
