### PR TITLE
docs: Add WordPress 6 compatibiility

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -109,7 +109,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 | RoadRunner     | 2.x                               | All supported PHP versions | Framework-level instrumentation |
 | Slim           | 2.x, 3.x, 4.x                     | All supported PHP versions | Framework-level instrumentation |
 | Symfony        | 2.x, 3.3, 3.4, 4.x, 5.x, 6.x      | All supported PHP versions | Framework-level instrumentation |
-| WordPress      | 4.x, 5.x                          | PHP 7+                     | Framework-level instrumentation |
+| WordPress      | 4.x, 5.x, 6.x                     | PHP 7+                     | Framework-level instrumentation |
 | Yii            | 1.1, 2.0                          | All supported PHP versions | Framework-level instrumentation |
 | Zend Framework | 1.12, 1.21                        | All supported PHP versions | Framework-level instrumentation |
 | Zend Framework | 2.x                               | All supported PHP versions | Generic web tracing             |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The [0.91.0](https://github.com/DataDog/dd-trace-php/releases/tag/0.91.0) release of the tracer includes an enhanced WordPress integration, which is officially compatible with WordPress 6 as well. 

Currently in public beta, it can be opted-in by customers. _Should it be mentioned here?_

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->