### PR TITLE
Document support for Camel-OpenTelemetry 3.12.0+

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -143,7 +143,7 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 
 **JMS Note**: Datadog's JMS integration automatically adds and reads message object properties `x__dash__datadog__dash__trace__dash__id` and `x__dash__datadog__dash__parent__dash__id` to maintain context propagation between consumer and producer services.
 
-**Camel Note**: distributed trace propagation over Camel routes is not currently supported.
+**Camel Note**: Distributed trace propagation over Camel routes is not supported.
 
 Don't see your desired networking framework? Datadog is continually adding additional support. Contact [Datadog support][2] if you need help.
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -119,7 +119,7 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 | Apache HTTP Client       | 4.0+        | Fully Supported | `httpclient`, `apache-httpclient`, `apache-http-client` |
 | Apache HTTP Async Client | 4.0+        | Fully Supported | `httpasyncclient`, `apache-httpasyncclient`    |
 | AWS Java SDK             | 1.11+, 2.2+ | Fully Supported | `aws-sdk`                                      |
-| Camel-OpenTelemetry      | 3.12.0+     | Beta            | [opentelemetry.experimental](../../otel_instrumentation/java/) |
+| Camel-OpenTelemetry      | 3.12.0+     | Beta            | [opentelemetry-1](../../otel_instrumentation/java/) |
 | Commons HTTP Client      | 2.0+        | Fully Supported | `commons-http-client`                          |
 | Google HTTP Client       | 1.19.0+     | Fully Supported | `google-http-client`                           |
 | Grizzly HTTP Client      | 1.9+        | [Beta](#framework-integrations-disabled-by-default) | `grizzly-client`     |

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -119,6 +119,7 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 | Apache HTTP Client       | 4.0+        | Fully Supported | `httpclient`, `apache-httpclient`, `apache-http-client` |
 | Apache HTTP Async Client | 4.0+        | Fully Supported | `httpasyncclient`, `apache-httpasyncclient`    |
 | AWS Java SDK             | 1.11+, 2.2+ | Fully Supported | `aws-sdk`                                      |
+| Camel-OpenTelemetry      | 3.12.0+     | Beta            | [opentelemetry.experimental](../../otel_instrumentation/java/) |
 | Commons HTTP Client      | 2.0+        | Fully Supported | `commons-http-client`                          |
 | Google HTTP Client       | 1.19.0+     | Fully Supported | `google-http-client`                           |
 | Grizzly HTTP Client      | 1.9+        | [Beta](#framework-integrations-disabled-by-default) | `grizzly-client`     |

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -143,6 +143,8 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 
 **JMS Note**: Datadog's JMS integration automatically adds and reads message object properties `x__dash__datadog__dash__trace__dash__id` and `x__dash__datadog__dash__parent__dash__id` to maintain context propagation between consumer and producer services.
 
+**Camel Note**: distributed trace propagation over Camel routes is not currently supported.
+
 Don't see your desired networking framework? Datadog is continually adding additional support. Contact [Datadog support][2] if you need help.
 
 ### Data store compatibility

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -26,10 +26,10 @@ The Java Tracer supports automatic instrumentation for the following Oracle JDK 
 | Java versions | Operating Systems                                                               | Support level                       | Tracer version |
 | -------------| ------------------------------------------------------------------------------- | ----------------------------------- | -------------- |
 | 18 to 19     | Windows (x86, x86-64)<br>Linux (x86, x86-64, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#levels-of-support)               | Latest         |
-| 8 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [GA](#levels-of-support)                   | Latest         |
 | 8 to 17      | Linux (arm64)<br>Mac (arm64)                                                    | [Beta](#levels-of-support)               | Latest         |
-| 7            | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [Maintenance](#levels-of-support) | v0             |
 | 7            | Linux (arm64)<br>Mac (arm64)                                                    | [End-of-life](#levels-of-support)         | v0             |
+| 8 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [GA](#levels-of-support)                   | Latest         |
+| 7            | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [Maintenance](#levels-of-support) | v0             |
 
 Datadog does not officially support any early-access versions of Java.
 
@@ -119,7 +119,7 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 | Apache HTTP Client       | 4.0+        | Fully Supported | `httpclient`, `apache-httpclient`, `apache-http-client` |
 | Apache HTTP Async Client | 4.0+        | Fully Supported | `httpasyncclient`, `apache-httpasyncclient`    |
 | AWS Java SDK             | 1.11+, 2.2+ | Fully Supported | `aws-sdk`                                      |
-| Camel-OpenTelemetry      | 3.12.0+     | Beta            | [opentelemetry-1](../../otel_instrumentation/java/) |
+| Camel-OpenTelemetry      | 3.12.0+     | Beta            | [opentelemetry-1][5]                           |
 | Commons HTTP Client      | 2.0+        | Fully Supported | `commons-http-client`                          |
 | Google HTTP Client       | 1.19.0+     | Fully Supported | `google-http-client`                           |
 | Grizzly HTTP Client      | 1.9+        | [Beta](#framework-integrations-disabled-by-default) | `grizzly-client`     |
@@ -255,3 +255,4 @@ Running the Java tracer in Bitbucket is not supported.
 [2]: https://www.datadoghq.com/support/
 [3]: /tracing/manual_instrumentation/java
 [4]: https://github.com/DataDog/documentation#outside-contributors
+[5]: /tracing/trace_collection/otel_instrumentation/java/


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Documents support for [Camel-OpenTelemetry](https://github.com/apache/camel/tree/main/components/camel-opentelemetry) 3.12.0+ via the Java tracer's beta [OpenTelemetry integration](https://docs.datadoghq.com/tracing/trace_collection/otel_instrumentation/java/)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->