### PR TITLE
[DOCS-5132] Document Experimental Open Telemetry Setting

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -453,6 +453,16 @@ Deprecated since version 1.9.0
 A comma-separated list of header formats from which to attempt to extract distributed tracing propagation data. The first format found with complete and valid headers is used to define the trace to continue.<br>
 Deprecated since version 1.9.0
 
+### Experimental features
+
+The following configuration variables are for features that are available for use but may change in future releases.
+
+`dd.integration.opentelemetry.experimental.enabled`
+: **Environment Variable**: `DD_INTEGRATION_OPENTELEMETRY_EXPERIMENTAL_ENABLED`<br>
+**Default**: `false`<br>
+Enables experimental Open Telemetry features. When you enable this setting, you can use the Open Telemetry tracing API backed by the Datadog Trace Agent.<br>
+Available since version 1.10.0
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -455,7 +455,7 @@ Deprecated since version 1.9.0
 
 ### Experimental features
 
-The following configuration variables are for features that are available for use but may change in future releases.
+The following configuration options are for features that are available for use but may change in future releases.
 
 `dd.integration.opentelemetry.experimental.enabled`
 : **Environment Variable**: `DD_INTEGRATION_OPENTELEMETRY_EXPERIMENTAL_ENABLED`<br>

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -460,7 +460,7 @@ The following configuration variables are for features that are available for us
 `dd.integration.opentelemetry.experimental.enabled`
 : **Environment Variable**: `DD_INTEGRATION_OPENTELEMETRY_EXPERIMENTAL_ENABLED`<br>
 **Default**: `false`<br>
-Enables experimental Open Telemetry features. When you enable this setting, you can use the Open Telemetry tracing API backed by the Datadog Trace Agent.<br>
+Enables experimental OpenTelemetry features. When you enable this setting, you can use the OpenTelemetry tracing API backed by the Datadog Trace Agent.<br>
 Available since version 1.10.0
 
 ## Further Reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/DOCS-5132
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Documents `dd.integration.opentelemetry.experimental.enabled` in Configuring the Java Tracing Library page.
- Adds Experimental features section.
- Per Irene, we want to document experimental settings but not legacy settings.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->