### PR TITLE
Update the Oracle setup document to 7.41.1-oracle-dbm-0.2

### DIFF
--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -70,7 +70,7 @@ Set `DD_API_KEY` and run the following commands to install the Oracle DBM releas
 
 ```shell
 export DD_AGENT_DIST_CHANNEL=beta
-export DD_AGENT_MINOR_VERSION="46.0~dbm~oracle~0.40-1"
+export DD_AGENT_MINOR_VERSION="47.1~dbm~oracle~0.2-1"
 
 DD_API_KEY= DD_SITE="datadoghq.com" bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 ```

--- a/content/en/database_monitoring/setup_oracle/_index.md
+++ b/content/en/database_monitoring/setup_oracle/_index.md
@@ -17,7 +17,7 @@ The features described on this page are in beta. Contact your Customer Success M
 
 - **Versions**: 19c and 21c
 - **Deployment configurations**: Self-managed, RDS, RAC, Exadata, Autonomous Database
-- **Architecture**: Multi-tenant
+- **Architecture**: Multi-tenant, non-CDB, RDS single-tenant
 
 ## Overview
 
@@ -50,11 +50,11 @@ The Agent doesn't require any external Oracle clients.
 
 Datadog recommends the following Oracle DBM builds, because they contain all of the implemented Oracle monitoring features and bug fixes. The basis of an Oracle DBM build is always a stable Agent release.
 
-- Linux: `7.47.0~dbm~oracle~0.40-1`
-- Windows: `7.47.0-dbm-oracle-0.40-1`
-- Docker: `7.47.0-dbm-oracle-0.40`
+- Linux: `7.47.1~dbm~oracle~0.2-1`
+- Windows: `7.47.1-dbm-oracle-0.2-1`
+- Docker: `7.47.1-dbm-oracle-0.2`
 
-If you prefer an official Datadog Agent release, a minimum version of `7.47.0` is recommended.
+If you prefer an official Datadog Agent release, wait at least until the version `7.49.0`.
 
 - To install an Oracle build, see [Oracle DBM build installation](#oracle-dbm-build-installation).
 - To install the latest official release, follow the [instructions for your platform][3]. 
@@ -87,9 +87,9 @@ Download the MSI file for the [Oracle DBM build][4].
 Set `APIKEY` and run the following command in the command prompt inside the directory where you downloaded the installer, for example:
 
 ```shell
-start /wait msiexec /qn /i datadog-agent-7.47.0-dbm-oracle-0.40-1.x86_64.msi APIKEY="" SITE="datadoghq.com"
+start /wait msiexec /qn /i datadog-agent-7.47.1-dbm-oracle-0.2-1.x86_64.msi APIKEY="" SITE="datadoghq.com"
 ```
-[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.47.0-dbm-oracle-0.40-1.x86_64.msi
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-agent-7.47.1-dbm-oracle-0.2-1.x86_64.msi
 [8]: https://ddagent-windows-stable.s3.amazonaws.com/
 
 {{% /tab %}}
@@ -99,7 +99,7 @@ Oracle DBM images can be found in the [Docker builds repository][9].
 Set `DD_API_KEY` and run the following command to install the Oracle DBM release, for example:
 
 ```shell
-docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY="" -e DD_SITE="datadoghq.com" gcr.io/datadoghq/agent:7.47.0-dbm-oracle-0.40
+docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY="" -e DD_SITE="datadoghq.com" gcr.io/datadoghq/agent:7.47.1-dbm-oracle-0.2
 ```
 
 [9]: https://hub.docker.com/r/datadog/agent/tags?page=1&name=oracle

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -27,6 +27,9 @@ Before completing the steps below, verify that you have met <a href="/database_m
 
 The Datadog Agent requires read-only access to the database server to collect samples.
 
+{{< tabs >}}
+{{% tab "Multi-tenant" %}}
+
 ### Create user
 
 If you installed the legacy Oracle integration, skip this step because the user already exists. You must, however, execute the subsequent steps.
@@ -174,6 +177,152 @@ WHERE
 
 GRANT SELECT ON dd_session TO c##datadog ;
 ```
+
+{{% /tab %}}
+
+{{% tab "Non-CDB" %}}
+
+### Create user
+
+If you installed the legacy Oracle integration, skip this step because the user already exists. You must, however, execute the subsequent steps.
+
+Create a read-only login to connect to your server and grant the required permissions:
+
+```SQL
+CREATE USER datadog IDENTIFIED BY &password ;
+```
+
+### Grant permissions
+
+Log on as `sysdba`, and grant the following permissions:
+
+```SQL
+grant create session to datadog ;
+grant select on v_$session to datadog ;
+grant select on v_$database to datadog ;
+grant select on v_$containers to datadog;
+grant select on v_$sqlstats to datadog ;
+grant select on v_$instance to datadog ;
+grant select on dba_feature_usage_statistics to datadog ;
+grant select on V_$SQL_PLAN_STATISTICS_ALL to datadog ;
+grant select on V_$PROCESS to datadog ;
+grant select on V_$SESSION to datadog ;
+grant select on V_$CON_SYSMETRIC to datadog ;
+grant select on CDB_TABLESPACE_USAGE_METRICS to datadog ;
+grant select on CDB_TABLESPACES to datadog ;
+grant select on V_$SQLCOMMAND to datadog ;
+grant select on V_$DATAFILE to datadog ;
+grant select on V_$SYSMETRIC to datadog ;
+grant select on V_$SGAINFO to datadog ;
+grant select on V_$PDBS to datadog ;
+grant select on CDB_SERVICES to datadog ;
+grant select on V_$OSSTAT to datadog ;
+grant select on V_$PARAMETER to datadog ;
+grant select on V_$SQLSTATS to datadog ;
+grant select on V_$CONTAINERS to datadog ;
+grant select on V_$SQL_PLAN_STATISTICS_ALL to datadog ;
+grant select on V_$SQL to datadog ;
+grant select on V_$PGASTAT to datadog ;
+```
+
+### Create view
+
+Log on as `sysdba`, create a new `view` in the `sysdba` schema, and give the Agent user access to it:
+
+```SQL
+CREATE OR REPLACE VIEW dd_session AS
+SELECT
+  s.indx as sid,
+  s.ksuseser as serial#,
+  s.ksuudlna as username,
+  DECODE(BITAND(s.ksuseidl, 9), 1, 'ACTIVE', 0, DECODE(BITAND(s.ksuseflg, 4096), 0, 'INACTIVE', 'CACHED'), 'KILLED') as status,
+  s.ksuseunm as osuser,
+  s.ksusepid as process,
+  s.ksusemnm as machine,
+  s.ksusemnp as port,
+  s.ksusepnm as program,
+  DECODE(BITAND(s.ksuseflg, 19), 17, 'BACKGROUND', 1, 'USER', 2, 'RECURSIVE', '?') as type,
+  s.ksusesqi as sql_id,
+  sq.force_matching_signature as force_matching_signature,
+  s.ksusesph as sql_plan_hash_value,
+  s.ksusesesta as sql_exec_start,
+  s.ksusesql as sql_address,
+  CASE WHEN BITAND(s.ksusstmbv, POWER(2, 04)) = POWER(2, 04) THEN 'Y' ELSE 'N' END as in_parse,
+  CASE WHEN BITAND(s.ksusstmbv, POWER(2, 07)) = POWER(2, 07) THEN 'Y' ELSE 'N' END as in_hard_parse,
+  s.ksusepsi as prev_sql_id,
+  s.ksusepha as prev_sql_plan_hash_value,
+  s.ksusepesta as prev_sql_exec_start,
+  sq_prev.force_matching_signature as prev_force_matching_signature,
+  s.ksusepsq as prev_sql_address,
+  s.ksuseapp as module,
+    s.ksuseact as action,
+    s.ksusecli as client_info,
+    s.ksuseltm as logon_time,
+    s.ksuseclid as client_identifier,
+    s.ksusstmbv as op_flags,
+    decode(s.ksuseblocker,
+        4294967295, 'UNKNOWN', 4294967294, 'UNKNOWN', 4294967293, 'UNKNOWN', 4294967292, 'NO HOLDER', 4294967291, 'NOT IN WAIT',
+        'VALID'
+    ) as blocking_session_status,
+    DECODE(s.ksuseblocker,
+        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL),
+        4294967292, TO_NUMBER(NULL), 4294967291, TO_NUMBER(NULL), BITAND(s.ksuseblocker, 2147418112) / 65536
+    ) as blocking_instance,
+    DECODE(s.ksuseblocker,
+        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL),
+        4294967292, TO_NUMBER(NULL), 4294967291, TO_NUMBER(NULL), BITAND(s.ksuseblocker, 65535)
+    ) as blocking_session,
+    DECODE(s.ksusefblocker,
+        4294967295, 'UNKNOWN', 4294967294, 'UNKNOWN', 4294967293, 'UNKNOWN', 4294967292, 'NO HOLDER', 4294967291, 'NOT IN WAIT', 'VALID'
+    ) as final_blocking_session_status,
+    DECODE(s.ksusefblocker,
+        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL), 4294967292, TO_NUMBER(NULL),
+        4294967291, TO_NUMBER(NULL), BITAND(s.ksusefblocker, 2147418112) / 65536
+    ) as final_blocking_instance,
+    DECODE(s.ksusefblocker,
+        4294967295, TO_NUMBER(NULL), 4294967294, TO_NUMBER(NULL), 4294967293, TO_NUMBER(NULL), 4294967292, TO_NUMBER(NULL),
+        4294967291, TO_NUMBER(NULL), BITAND(s.ksusefblocker, 65535)
+    ) as final_blocking_session,
+    DECODE(w.kslwtinwait,
+        1, 'WAITING', decode(bitand(w.kslwtflags, 256), 0, 'WAITED UNKNOWN TIME',
+        decode(round(w.kslwtstime / 10000), 0, 'WAITED SHORT TIME', 'WAITED KNOWN TIME'))
+    ) as STATE,
+    e.kslednam as event,
+    e.ksledclass as wait_class,
+    w.kslwtstime as wait_time_micro,
+    c.name as pdb_name,
+    sq.sql_text as sql_text,
+    sq.sql_fulltext as sql_fulltext,
+    sq_prev.sql_fulltext as prev_sql_fulltext,
+    comm.command_name
+FROM
+  x$ksuse s,
+  x$kslwt w,
+  x$ksled e,
+  v$sql sq,
+  v$sql sq_prev,
+  v$containers c,
+  v$sqlcommand comm
+WHERE
+  BITAND(s.ksspaflg, 1) != 0
+  AND BITAND(s.ksuseflg, 1) != 0
+  AND s.inst_id = USERENV('Instance')
+  AND s.indx = w.kslwtsid
+  AND w.kslwtevt = e.indx
+  AND s.ksusesqi = sq.sql_id(+)
+  AND s.ksusesph = sq.plan_hash_value(+)
+  AND s.ksusepsi = sq_prev.sql_id(+)
+  AND s.ksusepha = sq_prev.plan_hash_value(+)
+  AND s.con_id = c.con_id(+)
+  AND s.ksuudoct = comm.command_type(+)
+;
+
+GRANT SELECT ON dd_session TO datadog ;
+```
+
+{{% /tab %}}
+
+{{< /tabs >}}
 
 ## Configure the Agent
 

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -310,9 +310,9 @@ WHERE
   AND s.indx = w.kslwtsid
   AND w.kslwtevt = e.indx
   AND s.ksusesqi = sq.sql_id(+)
-  AND s.ksusesph = sq.plan_hash_value(+)
+  AND decode(s.ksusesch, 65535, TO_NUMBER(NULL), s.ksusesch) = sq.child_number(+)
   AND s.ksusepsi = sq_prev.sql_id(+)
-  AND s.ksusepha = sq_prev.plan_hash_value(+)
+  AND decode(s.ksusepch, 65535, TO_NUMBER(NULL), s.ksusepch) = sq_prev.child_number(+)
   AND s.con_id = c.con_id(+)
   AND s.ksuudoct = comm.command_type(+)
 ;

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -154,8 +154,8 @@ FROM
   x$ksuse s,
   x$kslwt w,
   x$ksled e,
-  v$sqlstats sq,
-  v$sqlstats sq_prev,
+  v$sql sq,
+  v$sql sq_prev,
   v$containers c,
   v$sqlcommand comm
 WHERE
@@ -165,9 +165,9 @@ WHERE
   AND s.indx = w.kslwtsid
   AND w.kslwtevt = e.indx
   AND s.ksusesqi = sq.sql_id(+)
-  AND s.ksusesph = sq.plan_hash_value(+)
+  AND decode(s.ksusesch, 65535, TO_NUMBER(NULL), s.ksusesch) = sq.child_number(+)
   AND s.ksusepsi = sq_prev.sql_id(+)
-  AND s.ksusepha = sq_prev.plan_hash_value(+)
+  AND decode(s.ksusepch, 65535, TO_NUMBER(NULL), s.ksusepch) = sq_prev.child_number(+)
   AND s.con_id = c.con_id(+)
   AND s.ksuudoct = comm.command_type(+)
 ;


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Update the version
- Add support for the Oracle non-CDB architecture
- Recommend customers not installing an official release lower than `7.49.0`
- Update the activity view definition

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->