### PR TITLE
increase timeout for scheduled pa11y runs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -440,6 +440,7 @@ run_pa11y:schedule:
       when: always
     - if: $CI_COMMIT_TAG != null || $CI_COMMIT_BRANCH =~ "/pull/\/.*/"
       when: never
+  timeout: 2h
 
 run_pa11y:manual:
   <<: *pa11y_live_template


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Due to the increase in languages, the pa11y job can timeout. This pr increases the timeout for pa11y scheduled runs.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->