### PR TITLE
Use "DD_*" environment variables in the quality gates page

### DIFF
--- a/content/en/continuous_integration/quality_gates/_index.md
+++ b/content/en/continuous_integration/quality_gates/_index.md
@@ -68,11 +68,11 @@ Otherwise, the rules might have an incorrect behavior due to the absence of the 
 
 The command requires the `DD_API_KEY` and `DD_APP_KEY` environment variables to point to your [Datadog API Key][5]
 and [Datadog Application Key][6]. Also, you need to set the `DD_BETA_COMMANDS_ENABLED` environment
-variable as `true`. Optionally, you can specify the `DATADOG_SITE` environment variable to point to a specific datadog site (default value is `datadoghq.com`).
+variable as `true`. Optionally, you can specify the `DD_SITE` environment variable to point to a specific datadog site (default value is `datadoghq.com`).
 
 <pre>
 <code>
-DD_BETA_COMMANDS_ENABLED=true DATADOG_SITE={{< region-param key="dd_site" >}} DD_API_KEY=&lt;API_KEY&gt; DD_APP_KEY=&lt;APP_KEY&gt; datadog-ci gate evaluate
+DD_BETA_COMMANDS_ENABLED=true DD_SITE={{< region-param key="dd_site" >}} DD_API_KEY=&lt;API_KEY&gt; DD_APP_KEY=&lt;APP_KEY&gt; datadog-ci gate evaluate
 </code>
 </pre>
 


### PR DESCRIPTION
We have removed support of `DATADOG_*` environment variables from the `datadog-ci gate` command.

https://github.com/DataDog/datadog-ci/pull/1067

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing