### PR TITLE
Remove live TMs job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -404,16 +404,17 @@ link_checks:on-schedule:
   interruptible: true
   allow_failure: true
 
-test_missing_tms_live:
-  <<: *base_template
-  <<: *live_rules
-  stage: post-deploy
-  cache: {}
-  environment: "live"
-  dependencies:
-    - build_live
-  script:
-    - check_missing_tms
+# We are relying on the preview version of this job due to the length of time it takes
+# test_missing_tms_live:
+#   <<: *base_template
+#   <<: *live_rules
+#   stage: post-deploy
+#   cache: {}
+#   environment: "live"
+#   dependencies:
+#     - build_live
+#   script:
+#     - check_missing_tms
 
 # template for what runs in pa11y to avoid duplication
 .pa11y_live_template: &pa11y_live_template


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes the live TMs job from the CI. We are running this same test on branches/PRs against changed files. With the size of Docs now and the additional languages, this live job checks the whole site over again which has been timing out the runners. This test is redundant since we perform this check on the branches/PRs.
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->