### PR TITLE
Add unskippable tests documentation for Java ITR

### DIFF
--- a/content/en/continuous_integration/intelligent_test_runner/java.md
+++ b/content/en/continuous_integration/intelligent_test_runner/java.md
@@ -76,7 +76,7 @@ mvn clean verify
 
 ## Disabling skipping for specific tests
 
-You can override the Intelligent Test Runner’s behavior and prevent specific tests from being skipped. These tests are referred to as unskippable tests.
+You can override the Intelligent Test Runner's behavior and prevent specific tests from being skipped. These tests are referred to as unskippable tests.
 
 ### Why make tests unskippable?
 
@@ -121,7 +121,7 @@ public class MyTestSuite {
 }
 ```
 
-#### Test Suite
+#### Test suite
 
 Add a JUnit `Tag` with the value `datadog_itr_unskippable` to your test suite to mark it as unskippable.
 
@@ -166,7 +166,7 @@ public class MyTestSuite {
 }
 ```
 
-#### Test Suite
+#### Test suite
 
 Add a JUnit `Tag` with the value `datadog_itr_unskippable` to your test suite to mark it as unskippable.
 You do not have to create the `datadog_itr_unskippable` for every test case or test suite, one category is enough for the entire project.
@@ -208,7 +208,7 @@ public class MyTestSuite {
 }
 ```
 
-#### Test Suite
+#### Test suite
 
 Add a group with the value `datadog_itr_unskippable` to your test suite to mark it as unskippable.
 
@@ -247,7 +247,7 @@ class MyTestSuite extends Specification {
 }
 ```
 
-#### Test Suite
+#### Test suite
 
 Add a `spock.lang.Tag` with the value `datadog_itr_unskippable` to your test suite to mark it as unskippable.
 

--- a/content/en/continuous_integration/intelligent_test_runner/java.md
+++ b/content/en/continuous_integration/intelligent_test_runner/java.md
@@ -15,7 +15,13 @@ further_reading:
 
 ## Compatibility
 
-Intelligent Test Runner is supported in `dd-java-agent >= 1.21.0`.
+Intelligent Test Runner is supported in `dd-java-agent >= 1.22.0`.
+
+The following test frameworks are supported:
+- JUnit >= 4.10 and >= 5.3
+- TestNG >= 6.4
+- Spock >= 2.0
+- Cucumber >= 5.4.0
 
 ## Setup
 
@@ -38,6 +44,8 @@ Prior to setting up Intelligent Test Runner, set up [Test Visibility for Java][1
 {{% /tab %}}
 
 {{< /tabs >}}
+
+## Running tests with the Intelligent Test Runner enabled
 
 After configuring the environment, run your tests as you normally do:
 
@@ -65,6 +73,231 @@ mvn clean verify
 
 {{% /tab %}}
 {{< /tabs >}}
+
+## Disabling skipping for specific tests
+
+You can override the Intelligent Test Runner’s behavior and prevent specific tests from being skipped. These tests are referred to as unskippable tests.
+
+### Why make tests unskippable?
+
+The Intelligent Test Runner uses code coverage data to determine whether or not tests should be skipped. In some cases, this data may not be sufficient to make this determination.
+
+Examples include:
+
+- Tests that read data from text files
+- Tests that interact with APIs outside of the code being tested (such as remote REST APIs)
+- Designating tests as unskippable ensures that the Intelligent Test Runner runs them regardless of coverage data.
+
+### Compatibility
+
+Unskippable tests are supported in the following versions and testing frameworks:
+
+- JUnit >= 4.10 and >= 5.3
+- TestNG >= 6.4
+- Spock >= 2.2
+- Cucumber >= 5.4.0
+
+### Marking tests as unskippable
+
+{{< tabs >}}
+{{% tab "JUnit 5" %}}
+
+#### Individual test case
+
+Add a JUnit `Tag` with the value `datadog_itr_unskippable` to your test case to mark it as unskippable.
+
+```java
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
+import org.junit.jupiter.api.Test;
+
+public class MyTestSuite {
+
+  @Test
+  @Tags({@Tag("datadog_itr_unskippable")})
+  public void myTest() {
+    // ...
+  }
+}
+```
+
+#### Test Suite
+
+Add a JUnit `Tag` with the value `datadog_itr_unskippable` to your test suite to mark it as unskippable.
+
+If a suite is marked as unskippable, none of the test cases from that suite can be skipped by ITR.
+
+```java
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Tags;
+import org.junit.jupiter.api.Test;
+
+@Tags({@Tag("datadog_itr_unskippable")})
+public class MyTestSuite {
+
+  @Test
+  public void myTest() {
+    // ...
+  }
+}
+```
+
+{{% /tab %}}
+{{% tab "JUnit 4" %}}
+
+#### Individual test case
+
+Add a JUnit `Category` with the value `datadog_itr_unskippable` to your test case to mark it as unskippable.
+You do not have to create the `datadog_itr_unskippable` for every test case or test suite, one category is enough for the entire project.
+
+```java
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class MyTestSuite {
+
+  @Category(datadog_itr_unskippable.class)
+  @Test
+  public void myTest() {
+    // ...
+  }
+
+  public interface datadog_itr_unskippable {}
+}
+```
+
+#### Test Suite
+
+Add a JUnit `Tag` with the value `datadog_itr_unskippable` to your test suite to mark it as unskippable.
+You do not have to create the `datadog_itr_unskippable` for every test case or test suite, one category is enough for the entire project.
+
+If a suite is marked as unskippable, none of the test cases from that suite can be skipped by ITR.
+
+```java
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(MyTestSuite.datadog_itr_unskippable.class)
+public class MyTestSuite {
+
+  @Test
+  public void myTest() {
+    // ...
+  }
+
+  public interface datadog_itr_unskippable {}
+}
+```
+
+{{% /tab %}}
+{{% tab "TestNG" %}}
+
+#### Individual test case
+
+Add a group with the value `datadog_itr_unskippable` to your test case to mark it as unskippable.
+
+```java
+import org.testng.annotations.Test;
+
+public class MyTestSuite {
+
+  @Test(groups = "datadog_itr_unskippable")
+  public void myTest() {
+    // ...
+  }
+}
+```
+
+#### Test Suite
+
+Add a group with the value `datadog_itr_unskippable` to your test suite to mark it as unskippable.
+
+If a suite is marked as unskippable, none of the test cases from that suite can be skipped by ITR.
+
+```java
+import org.testng.annotations.Test;
+
+@Test(groups = "datadog_itr_unskippable")
+public class MyTestSuite {
+
+  @Test
+  public void myTest() {
+    // ...
+  }
+}
+```
+
+{{% /tab %}}
+{{% tab "Spock" %}}
+
+#### Individual test case
+
+Add a `spock.lang.Tag` with the value `datadog_itr_unskippable` to your test case to mark it as unskippable.
+
+```java
+import spock.lang.Specification
+import spock.lang.Tag
+
+class MyTestSuite extends Specification {
+
+  @Tag("datadog_itr_unskippable")
+  def myTest() {
+    // ...
+  }
+}
+```
+
+#### Test Suite
+
+Add a `spock.lang.Tag` with the value `datadog_itr_unskippable` to your test suite to mark it as unskippable.
+
+If a suite is marked as unskippable, none of the test cases from that suite can be skipped by ITR.
+
+```java
+import spock.lang.Specification
+import spock.lang.Tag
+
+@Tag("datadog_itr_unskippable")
+class MyTestSuite extends Specification {
+
+  def myTest() {
+    // ...
+  }
+}
+```
+
+{{% /tab %}}
+{{% tab "Cucumber" %}}
+
+#### Individual scenario
+
+Add `datadog_itr_unskippable` tag to your gherkin scenario to mark it as unskippable.
+
+```gherkin
+Feature: My Feature
+
+  @datadog_itr_unskippable
+  Scenario: My Scenario
+    # ...
+```
+
+#### Feature
+
+Add `datadog_itr_unskippable` tag to your gherkin feature to mark it as unskippable.
+
+If a feature is marked as unskippable, none of the scenarios from that feature can be skipped by ITR.
+
+```gherkin
+@datadog_itr_unskippable
+Feature: My Feature
+
+  Scenario: My Scenario
+    # ...
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This change updates CI Visibility Intelligent Test Runner documentation for Java.
Upcoming tracer release will introduce "unskippable tests" feature that will allow to mark specific tests or suites to make sure Intelligent Test Runner never skips them.
A section describing this new feature is added to the Java ITR page.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

This PR should be merged after DD Trace Java v1.22.0 is released.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->