### PR TITLE
Source Code Integrations docs improvements

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -118,9 +118,7 @@ COPY .git ./.git
 
 ### Configure telemetry tagging
 
-For unsupported languages, use the git.commit.sha and git.repository_url tags to link data to a specific commit.
-
-To link data to a specific commit, tag your telemetry with `git.commit.sha` and `git.repository_url` tags. Ensure that the `git.repository_url` tag does not contain protocols. For example, if your repository URL is `https://github.com/example/repo`, the value for the `git.repository_url` tag should be `github.com/example/repo`.
+For unsupported languages, use the `git.commit.sha` and `git.repository_url` tags to link data to a specific commit. Ensure that the `git.repository_url` tag does not contain protocols. For example, if your repository URL is `https://github.com/example/repo`, the value for the `git.repository_url` tag should be `github.com/example/repo`.
 
 {{< tabs >}}
 {{% tab "Docker Runtime" %}}

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -17,10 +17,14 @@ further_reading:
 ## Overview
 
 <div class="alert alert-info">
-The source code integration supports:</br></br>Languages:<ul><li>Go</li><li>Java</li><li>JavaScript (doesn't support transpiled JavaScript)</li><li>Python</li><li>.NET</li><li>Ruby</li></ul></br>Git providers:<ul><li>GitHub</li><li>GitLab</li><li>BitBucket</li><li>Azure DevOps</li></ul>
+The source code integration supports:
+</br>
+Languages: **Go**, **Java**, **JavaScript** (except transpiled JavaScript), **Python**, **.NET**, **Ruby**.
+</br>
+Git providers:**GitHub**, **GitLab**, **BitBucket**, **Azure DevOps**.
 </div>
 
-Datadog's source code integration allows you to connect your telemetry with your Git repositories hosted in GitHub, GitLab, Bitbucket, or Azure DevOps. Once you have enabled the [source code integration][7], you can debug stack traces, slow profiles, and other issues by quickly accessing the relevant lines of your source code.
+Datadog's source code integration allows you to connect your telemetry with your Git repositories. It allows debugging stack traces, slow profiles, and other issues by quickly accessing the relevant lines of your source code.
 
 {{< img src="integrations/guide/source_code_integration/inline-code-snippet.png" alt="Inline code snippet of a Java RuntimeException with a button to view the code in GitHub" style="width:100%;">}}
 
@@ -35,7 +39,7 @@ If you have [APM][6] set up already, navigate to [**Integrations** > **Link Sour
 
 Your telemetry needs to be tagged with Git information tying the running version with a particular repository and commit.
 
-For supported languages, it's recommended to [embed git information](#embed-git-information-in-your-artifacts-on-ci) in the deployed artifacts, which will be extracted by the [Datadog Tracing Libraries][9] automatically.
+For supported languages, it's recommended to [embed git information](#embed-git-information-in-your-artifacts-on-ci) in the deployed artifacts, which is be extracted by the [Datadog Tracing Libraries][9] automatically.
 For other languages and configurations, you can [configure telemetry tagging](#configure-telemetry-tagging) yourself.
 
 ### Embed git information in your build artifacts

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -238,7 +238,7 @@ You can see links from stack frames to their source repository in [Error Trackin
 
 {{< img src="integrations/guide/source_code_integration/error-tracking-panel-full.png" alt="A view repository button with three options (view file, view blame, and view commit) available on the right side of an error stack trace in Error Tracking, along with inline code snippets in the stack trace" style="width:100%;">}}
 
-If you're using the GitHub integration, or if you're hosting your repositories on the GitLab SaaS instance (gitlab.com), you're able to click **Connect to preview** to see inline code snippets directly in the stack trace.
+If you're using the GitHub integration, or if you're hosting your repositories on the GitLab SaaS instance (gitlab.com), click **Connect to preview** on stack frames. You can see inline code snippets directly in the stack trace.
 
 [1]: /tracing/error_tracking/
 [2]: https://app.datadoghq.com/apm/error-tracking

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -118,6 +118,8 @@ COPY .git ./.git
 
 ### Configure telemetry tagging
 
+For unsupported languages, use the git.commit.sha and git.repository_url tags to link data to a specific commit.
+
 To link data to a specific commit, tag your telemetry with `git.commit.sha` and `git.repository_url` tags. Ensure that the `git.repository_url` tag does not contain protocols. For example, if your repository URL is `https://github.com/example/repo`, the value for the `git.repository_url` tag should be `github.com/example/repo`.
 
 {{< tabs >}}

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -19,9 +19,9 @@ further_reading:
 <div class="alert alert-info">
 The source code integration supports:
 </br>
-Languages: **Go**, **Java**, **JavaScript** (except transpiled JavaScript), **Python**, **.NET**, **Ruby**.
+Languages:<b>Go</b>,<b>Java</b>,<b>JavaScript</b> (except transpiled JavaScript),<b>Python</b>,<b>.NET</b>,<b>Ruby</b>.
 </br>
-Git providers:**GitHub**, **GitLab**, **BitBucket**, **Azure DevOps**.
+Git providers:**GitHub</b>,<b>GitLab</b>,<b>BitBucket</b>,<b>Azure DevOps</b>.
 </div>
 
 Datadog's source code integration allows you to connect your telemetry with your Git repositories. It allows debugging stack traces, slow profiles, and other issues by quickly accessing the relevant lines of your source code.

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -200,7 +200,7 @@ Setting up the GitHub integration also allows you to see inline code snippets in
 {{% tab "Other Git Providers" %}}
 
 <div class="alert alert-warning">
-Repositories on self-hosted instances or private URLs are not supported out-of-the-box by the Source Code Integration. Please reach out to support.
+Repositories on self-hosted instances or private URLs are not supported out-of-the-box by the Source Code Integration. To enable this feature, <a href="/help">contact Support</a>.
 </div>
 
 To link telemetry to your source code, Datadog collects metadata for every commit SHA from your Git repository with the [`datadog-ci git-metadata upload`][1] command.

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -236,7 +236,7 @@ You can see links from stack frames to their source repository in [Error Trackin
 2. Click on an issue. The **Issue Details** panel appears on the right.
 3. Under **Latest Event**, click the **View** button on the right of a frame or select **View file**, **View Git blame**, or **View commit** to be redirected to your source code management tool.
 
-{{< img src="integrations/guide/source_code_integration/error-tracking-panel-full.png" alt=A view repository button with three options (view file, view blame, and view commit) available on the right side of an error stack trace in Error Tracking, along with inline code snippets in the stack trace" style="width:100%;">}}
+{{< img src="integrations/guide/source_code_integration/error-tracking-panel-full.png" alt="A view repository button with three options (view file, view blame, and view commit) available on the right side of an error stack trace in Error Tracking, along with inline code snippets in the stack trace" style="width:100%;">}}
 
 If you're using the GitHub integration, or if you're hosting your repositories on gitlab.com, you will be able to click **Connect to preview** to see inline code snippets directly in the stack trace.
 

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -19,9 +19,9 @@ further_reading:
 <div class="alert alert-info">
 The source code integration supports:
 </br>
-Languages:<b>Go</b>,<b>Java</b>,<b>JavaScript</b> (except transpiled JavaScript),<b>Python</b>,<b>.NET</b>,<b>Ruby</b>.
+Languages: Go, Java, JavaScript (except transpiled JavaScript), Python, .NET, Ruby.
 </br>
-Git providers:**GitHub</b>,<b>GitLab</b>,<b>BitBucket</b>,<b>Azure DevOps</b>.
+Git providers: GitHub, GitLab, BitBucket, Azure DevOps.
 </div>
 
 Datadog's source code integration allows you to connect your telemetry with your Git repositories. It allows debugging stack traces, slow profiles, and other issues by accessing the relevant lines of your source code.

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -33,18 +33,19 @@ If you have [APM][6] set up already, navigate to [**Integrations** > **Link Sour
 
 ## Tag your telemetry with Git information
 
-For supported languages, it's recommended to [embed git information](#embed-git-information-in-your-artifacts-on-ci) in the deployed artifacts.
-For other languages and configurations, you can [tag your telemetry](#tag-your-telemetry).
+Your telemetry needs to be tagged with Git information tying the running version with a particular repository and commit.
+
+For supported languages, it's recommended to [embed git information](#embed-git-information-in-your-artifacts-on-ci) in the deployed artifacts, which will be extracted by the [Datadog Tracing Libraries][9] automatically.
+For other languages and configurations, you can [configure telemetry tagging](#configure-telemetry-tagging) yourself.
 
 ### Embed git information in your build artifacts
 
-You can embed git information such as the repository URL and commit hash in your artifact. The [Datadog Tracing Libraries][9] use this information to automatically link the active commit to your APM service.
+You can embed git information such as the repository URL and commit hash in your artifact. The [Datadog Tracing Libraries][9] use this information to automatically add the right tags to your APM service.
 
 Select one of the following languages that supports embedding git information:
 
 {{< tabs >}}
 {{% tab "Go" %}}
-
 [Go embeds version control information][1] in binaries starting in version 1.18.
 
 Ensure your service meets all the following requirements:
@@ -111,7 +112,7 @@ If your build process is executed in CI within a Docker container, perform the f
 COPY .git ./.git
 ```
 
-### Tag your telemetry
+### Configure telemetry tagging
 
 To link data to a specific commit, tag your telemetry with `git.commit.sha` and `git.repository_url` tags. Ensure that the `git.repository_url` tag does not contain protocols. For example, if your repository URL is `https://github.com/example_repo`, the value for the `git.repository_url` tag should be `github.com/example_repo`.
 
@@ -188,7 +189,7 @@ Datadog doesn't store the actual content of files in your repository, only Git c
 
 Install Datadog's [GitHub integration][1] on the [GitHub integration tile][2] to let Datadog synchronize your repository metadata automatically. When specifying permissions on the integration tile, select at least **Read** permissions for **Contents**.
 
-By setting up the GitHub integration, you can see inline code snippets in **Error Tracking**. For more information, see [Inline Source Code](#inline-source-code).
+By setting up the GitHub integration, you can also see inline code snippets in **Error Tracking**. For more information, see [Inline Source Code](#inline-source-code).
 
 [1]: https://docs.datadoghq.com/integrations/github/
 [2]: https://app.datadoghq.com/integrations/github/
@@ -220,7 +221,7 @@ Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@gi
 ### Links to Git providers
 
 <div class="alert alert-warning">
-Self-hosted instances or private URLs are not supported.
+Repositories on self-hosted instances or private URLs are not supported out-of-the-box. Please reach out to support.
 </div>
 
 {{< tabs >}}
@@ -231,7 +232,9 @@ You can see links from stack frames to their source repository in [Error Trackin
 2. Click on an issue. The **Issue Details** panel appears on the right.
 3. Under **Latest Event**, click the **View** button on the right of a frame or select **View file**, **View Git blame**, or **View commit** to be redirected to your source code management tool.
 
-{{< img src="integrations/guide/source_code_integration/links-to-git-error-full.png" alt="A view repository button with three options (view file, view blame, and view commit) available on the right side of an error stack trace in Error Tracking" style="width:100%;">}}
+{{< img src="integrations/guide/source_code_integration/error-tracking-panel-full.png" alt=A view repository button with three options (view file, view blame, and view commit) available on the right side of an error stack trace in Error Tracking, along with inline code snippets in the stack trace" style="width:100%;">}}
+
+If you're using the GitHub integration, or if you're hosting your repositories on gitlab.com, you will be able to click **Connect to preview** to see inline code snippets directly in the stack trace.
 
 [1]: /tracing/error_tracking/
 [2]: https://app.datadoghq.com/apm/error-tracking
@@ -251,37 +254,6 @@ You can see links from profile frames to their source repository in the [Continu
 [2]: https://app.datadoghq.com/profiling/search
 {{% /tab %}}
 {{< /tabs >}}
-
-### Inline source code
-
-{{< tabs >}}
-{{% tab "GitHub" %}}
-
-Install Datadog's [GitHub integration][1] to directly inline code snippets from your GitHub repository in your stack traces in [Error Tracking][2].
-
-**Note:** When specifying permissions on the integration tile, enable Datadog read permissions to **Contents**.
-
-[1]: https://app.datadoghq.com/integrations/github/
-[2]: /tracing/error_tracking/
-{{% /tab %}}
-{{% tab "GitLab" %}}
-
-<div class="alert alert-warning">
-Self managed GitLab is not supported.
-</div>
-
-If you are a GitLab.com user, no setup is required to inline code snippets from your GitLab repository in your stack traces in [Error Tracking][1].
-
-[1]: /tracing/error_tracking/
-{{% /tab %}}
-{{< /tabs >}}
-
-1. Navigate to [**APM** > **Error Tracking**][1].
-2. Click on an issue. The **Issue Details** panel appears on the right.
-3. Click **Connect to Preview** and **Authorize** to access the source code snippet containing the error.
-4. Under **Latest Event**, click the **View Code** button on the right of a frame or select **View file**, **View Git blame**, or **View commit** to be redirected to your source code management tool.
-
-{{< img src="integrations/guide/source_code_integration/error-tracking-panel-full.png" alt="An inline code snippet in a stack trace" style="width:100%;">}}
 
 ## Further Reading
 

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -19,9 +19,9 @@ further_reading:
 <div class="alert alert-info">
 The source code integration supports:
 </br>
-Languages: Go, Java, JavaScript (except transpiled JavaScript), Python, .NET, Ruby.
+<b>Languages</b>: Go, Java, JavaScript (except transpiled JavaScript), Python, .NET, Ruby
 </br>
-Git providers: GitHub, GitLab, BitBucket, Azure DevOps.
+<b>Git providers</b>: GitHub, GitLab, BitBucket, Azure DevOps
 </div>
 
 Datadog's source code integration allows you to connect your telemetry with your Git repositories. It allows debugging stack traces, slow profiles, and other issues by accessing the relevant lines of your source code.
@@ -37,12 +37,12 @@ If you have [APM][6] set up already, navigate to [**Integrations** > **Link Sour
 
 ## Tag your telemetry with Git information
 
-Your telemetry needs to be tagged with Git information tying the running application version with a particular repository and commit.
+Your telemetry must be tagged with Git information that ties the running application version with a particular repository and commit.
 
-For supported languages, it's recommended to [embed git information](#embed-git-information-in-your-artifacts-on-ci) in the deployed artifacts, which is then extracted by the [Datadog Tracing Libraries][9] automatically.
+For supported languages, Datadog recommends [embedding Git information](#embed-git-information-in-your-build-artifacts) in the deployed artifacts, which is then extracted by the [Datadog Tracing Libraries][9] automatically.
 For other languages and configurations, you can [configure telemetry tagging](#configure-telemetry-tagging) yourself.
 
-### Embed git information in your build artifacts
+### Embed Git information in your build artifacts
 
 You can embed the repository URL and commit hash in your build artifact. The [Datadog Tracing Libraries][9] use this information to automatically add the right tags to your APM service telemetry.
 
@@ -124,11 +124,10 @@ To link data to a specific commit, tag your telemetry with `git.commit.sha` and 
 {{% tab "Docker Runtime" %}}
 
 <div class="alert alert-warning">
-This approach requires Docker, or containerd >= 1.5.6. It doesn't support containers running on AWS Fargate.
-For other container setups, see the <a href="https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=host#tag-your-telemetry">Host</a> tab.
+This approach requires Docker or containerd >= 1.5.6. Containers running on AWS Fargate are not suported. For other container setups, see the <a href="https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=host#tag-your-telemetry">Host</a> tab.
 </div>
 
-If you are running your app in containers, Datadog can extract source code information directly from your images' Docker labels. During build time, follow the [Open Containers standard][1] to add the git commit SHA and repository URL as Docker labels:
+If you are running your app in containers, Datadog can extract source code information directly from your images' Docker labels. During build time, follow the [Open Containers standard][1] to add the Git commit SHA and repository URL as Docker labels:
 
 ```
 docker build . \
@@ -182,7 +181,7 @@ export DD_TAGS="git.commit.sha:<FULL_GIT_COMMIT_SHA>,git.repository_url:git-prov
 
 ## Synchronize your repository metadata
 
-To link your telemetry with source code, your repository metadata needs to be synchronized to Datadog.
+To link your telemetry with source code, your repository metadata must be synchronized to Datadog.
 
 <div class="alert alert-info">
 Datadog doesn't store the actual content of files in your repository, only Git commit and tree objects.
@@ -191,7 +190,7 @@ Datadog doesn't store the actual content of files in your repository, only Git c
 {{< tabs >}}
 {{% tab "GitHub" %}}
 
-Install Datadog's [GitHub integration][1] on the [GitHub integration tile][2] to let Datadog synchronize your repository metadata automatically. When specifying permissions on the integration tile, select at least **Read** permissions for **Contents**.
+Install Datadog's [GitHub integration][1] on the [GitHub integration tile][2] to allow Datadog to synchronize your repository metadata automatically. When specifying permissions on the integration tile, select at least **Read** permissions for **Contents**.
 
 Setting up the GitHub integration also allows you to see inline code snippets in **Error Tracking**.
 

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -37,14 +37,14 @@ If you have [APM][6] set up already, navigate to [**Integrations** > **Link Sour
 
 ## Tag your telemetry with Git information
 
-Your telemetry needs to be tagged with Git information tying the running version with a particular repository and commit.
+Your telemetry needs to be tagged with Git information tying the running application version with a particular repository and commit.
 
 For supported languages, it's recommended to [embed git information](#embed-git-information-in-your-artifacts-on-ci) in the deployed artifacts, which is be extracted by the [Datadog Tracing Libraries][9] automatically.
 For other languages and configurations, you can [configure telemetry tagging](#configure-telemetry-tagging) yourself.
 
 ### Embed git information in your build artifacts
 
-You can embed git information such as the repository URL and commit hash in your artifact. The [Datadog Tracing Libraries][9] use this information to automatically add the right tags to your APM service.
+You can embed the repository URL and commit hash in your build artifact. The [Datadog Tracing Libraries][9] use this information to automatically add the right tags to your APM service telemetry.
 
 Select one of the following languages that supports embedding git information:
 
@@ -118,14 +118,14 @@ COPY .git ./.git
 
 ### Configure telemetry tagging
 
-To link data to a specific commit, tag your telemetry with `git.commit.sha` and `git.repository_url` tags. Ensure that the `git.repository_url` tag does not contain protocols. For example, if your repository URL is `https://github.com/example_repo`, the value for the `git.repository_url` tag should be `github.com/example_repo`.
+To link data to a specific commit, tag your telemetry with `git.commit.sha` and `git.repository_url` tags. Ensure that the `git.repository_url` tag does not contain protocols. For example, if your repository URL is `https://github.com/example/repo`, the value for the `git.repository_url` tag should be `github.com/example/repo`.
 
 {{< tabs >}}
 {{% tab "Docker Runtime" %}}
 
 <div class="alert alert-warning">
 This approach requires Docker, or containerd >= 1.5.6. It doesn't support containers running on AWS Fargate.
-For additional container setups, see the <a href="https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=host#tag-your-telemetry">Host</a> tab.
+For other container setups, see the <a href="https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=host#tag-your-telemetry">Host</a> tab.
 </div>
 
 If you are running your app in containers, Datadog can extract source code information directly from your images' Docker labels. During build time, follow the [Open Containers standard][1] to add the git commit SHA and repository URL as Docker labels:
@@ -182,7 +182,7 @@ export DD_TAGS="git.commit.sha:<FULL_GIT_COMMIT_SHA>,git.repository_url:git-prov
 
 ## Synchronize your repository metadata
 
-To link your runtime telemetry with source code, your repository metadata needs to be synchronized to Datadog.
+To link your telemetry with source code, your repository metadata needs to be synchronized to Datadog.
 
 <div class="alert alert-info">
 Datadog doesn't store the actual content of files in your repository, only Git commit and tree objects.
@@ -193,7 +193,7 @@ Datadog doesn't store the actual content of files in your repository, only Git c
 
 Install Datadog's [GitHub integration][1] on the [GitHub integration tile][2] to let Datadog synchronize your repository metadata automatically. When specifying permissions on the integration tile, select at least **Read** permissions for **Contents**.
 
-By setting up the GitHub integration, you can also see inline code snippets in **Error Tracking**. For more information, see [Inline Source Code](#inline-source-code).
+Setting up the GitHub integration also allows you to see inline code snippets in **Error Tracking**.
 
 [1]: https://docs.datadoghq.com/integrations/github/
 [2]: https://app.datadoghq.com/integrations/github/

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -24,7 +24,7 @@ Languages:<b>Go</b>,<b>Java</b>,<b>JavaScript</b> (except transpiled JavaScript)
 Git providers:**GitHub</b>,<b>GitLab</b>,<b>BitBucket</b>,<b>Azure DevOps</b>.
 </div>
 
-Datadog's source code integration allows you to connect your telemetry with your Git repositories. It allows debugging stack traces, slow profiles, and other issues by quickly accessing the relevant lines of your source code.
+Datadog's source code integration allows you to connect your telemetry with your Git repositories. It allows debugging stack traces, slow profiles, and other issues by accessing the relevant lines of your source code.
 
 {{< img src="integrations/guide/source_code_integration/inline-code-snippet.png" alt="Inline code snippet of a Java RuntimeException with a button to view the code in GitHub" style="width:100%;">}}
 
@@ -39,7 +39,7 @@ If you have [APM][6] set up already, navigate to [**Integrations** > **Link Sour
 
 Your telemetry needs to be tagged with Git information tying the running application version with a particular repository and commit.
 
-For supported languages, it's recommended to [embed git information](#embed-git-information-in-your-artifacts-on-ci) in the deployed artifacts, which is be extracted by the [Datadog Tracing Libraries][9] automatically.
+For supported languages, it's recommended to [embed git information](#embed-git-information-in-your-artifacts-on-ci) in the deployed artifacts, which is then extracted by the [Datadog Tracing Libraries][9] automatically.
 For other languages and configurations, you can [configure telemetry tagging](#configure-telemetry-tagging) yourself.
 
 ### Embed git information in your build artifacts
@@ -200,6 +200,10 @@ Setting up the GitHub integration also allows you to see inline code snippets in
 {{% /tab %}}
 {{% tab "Other Git Providers" %}}
 
+<div class="alert alert-warning">
+Repositories on self-hosted instances or private URLs are not supported out-of-the-box by the Source Code Integration. Please reach out to support.
+</div>
+
 To link telemetry to your source code, Datadog collects metadata for every commit SHA from your Git repository with the [`datadog-ci git-metadata upload`][1] command.
 
 When you run `datadog-ci git-metadata upload` within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths.
@@ -224,10 +228,6 @@ Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@gi
 
 ### Links to Git providers
 
-<div class="alert alert-warning">
-Repositories on self-hosted instances or private URLs are not supported out-of-the-box. Please reach out to support.
-</div>
-
 {{< tabs >}}
 {{% tab "Error Tracking" %}}
 You can see links from stack frames to their source repository in [Error Tracking][1].
@@ -238,7 +238,7 @@ You can see links from stack frames to their source repository in [Error Trackin
 
 {{< img src="integrations/guide/source_code_integration/error-tracking-panel-full.png" alt="A view repository button with three options (view file, view blame, and view commit) available on the right side of an error stack trace in Error Tracking, along with inline code snippets in the stack trace" style="width:100%;">}}
 
-If you're using the GitHub integration, or if you're hosting your repositories on gitlab.com, you will be able to click **Connect to preview** to see inline code snippets directly in the stack trace.
+If you're using the GitHub integration, or if you're hosting your repositories on the GitLab SaaS instance (gitlab.com), you will be able to click **Connect to preview** to see inline code snippets directly in the stack trace.
 
 [1]: /tracing/error_tracking/
 [2]: https://app.datadoghq.com/apm/error-tracking

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -238,7 +238,7 @@ You can see links from stack frames to their source repository in [Error Trackin
 
 {{< img src="integrations/guide/source_code_integration/error-tracking-panel-full.png" alt="A view repository button with three options (view file, view blame, and view commit) available on the right side of an error stack trace in Error Tracking, along with inline code snippets in the stack trace" style="width:100%;">}}
 
-If you're using the GitHub integration, or if you're hosting your repositories on the GitLab SaaS instance (gitlab.com), you will be able to click **Connect to preview** to see inline code snippets directly in the stack trace.
+If you're using the GitHub integration, or if you're hosting your repositories on the GitLab SaaS instance (gitlab.com), you're able to click **Connect to preview** to see inline code snippets directly in the stack trace.
 
 [1]: /tracing/error_tracking/
 [2]: https://app.datadoghq.com/apm/error-tracking


### PR DESCRIPTION
Preview: https://docs-staging.datadoghq.com/ronan/sci-improvements/integrations/guide/source-code-integration/?tab=go

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Various improvements to the Source Code Integration setup guide:
- Clarify wording: `Link active commits` -> `Tag your telemetry with Git information`, and `Configure your repositories` -> `Synchronize your repository metadata`
- Move `Embed git information in your artifacts on CI` first (since it should be the method we encourage for supported languages), with a short introduction sentence explaining what it does.
- Clarify what repo metadata sync does, what we do and do not store
- For on-prem repositories, mentioned that it's not supported _out of the box_, but added a mention to reach out to support since we still want to track feature requests, and we're able to enable overrides in our backend

- Removed the `Inline source code` section in the usage section at the bottom, and mentioned code snippets directly in the `Links to Git providers` section. Since this feature doesn't require any additional setup and it's self-explanatory, I don't think we need a dedicated section, with duplicate instructions including all the steps to open Error Tracking, etc.
- Support info panel: put a comma separated list to save vertical space, and removed duplicate list of providers in the sentence right below

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->