### PR TITLE
Move granular access to its own page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -4288,7 +4288,7 @@ main:
     url: account_management/org_settings/ip_allowlist
     parent: organization_settings
     weight: 206
-  - name: RBAC
+  - name: Access Control
     url: account_management/rbac/
     parent: account_management
     identifier: account_management_rbac

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -4293,11 +4293,16 @@ main:
     parent: account_management
     identifier: account_management_rbac
     weight: 3
+  - name: Granular Access
+    url: account_management/rbac/granular_access
+    parent: account_management_rbac
+    identifier: account_management_rbac_granular_access
+    weight: 301
   - name: Permissions
     url: account_management/rbac/permissions
     parent: account_management_rbac
     identifier: account_management_rbac_permissions
-    weight: 301
+    weight: 302
   - name: SSO with SAML
     url: account_management/saml/
     identifier: account_management_saml

--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Role Based Access Control
+title: Access Control
 kind: documentation
 aliases:
     - /guides/rbac
@@ -25,39 +25,49 @@ further_reading:
       text: "Build compliance, governance, and transparency across your teams with Datadog Audit Trail"
 ---
 
+## Overview
+
+Datadog offers a flexible access management system that allows you to customize the level at which you control access to your Datadog resources.
+
+Users looking for basic functionality have access to OOTB roles with permissions. For more flexibility, create your own custom roles to combine permissions into new roles. Permissions attached to a custom role apply to all resources of a particular resource type.
+
+Organizations and users that need maximum flexibility can control access to individual dashboards, notebooks, and other resources with [granular access control][1].
+
+## Role based access control
+
 Roles categorize users and define what account permissions those users have, such as what data they can read or what account assets they can modify. By default, Datadog offers three roles, and you can create [custom roles](#custom-roles) so you can define a better mapping between your users and their permissions.
 
 By granting permissions to roles, any user who is associated with that role receives that permission. When users are associated with multiple roles, they receive all the permissions granted to each of their roles. The more roles a user is associated with, the more access they have within a Datadog account.
 
-If a user in a [child organization][1] has `org_management` permission, it does not mean that they have the same permission in the parent org. Users' roles are not shared between parent and child organizations.
+If a user in a [child organization][2] has `org_management` permission, it does not mean that they have the same permission in the parent org. Users' roles are not shared between parent and child organizations.
 
-**Note**: If you use a SAML identity provider, you can integrate it with Datadog for authentication, and you can map identity attributes to Datadog default and custom roles. For more information, see [SAML group mapping][2].
+**Note**: If you use a SAML identity provider, you can integrate it with Datadog for authentication, and you can map identity attributes to Datadog default and custom roles. For more information, see [SAML group mapping][3].
 
 ## Datadog default roles
 
 Datadog Admin Role
-: Users have access to billing information and the ability to revoke API keys. They can manage users and configure [read-only dashboards][3]. They can also promote standard users to administrators.
+: Users have access to billing information and the ability to revoke API keys. They can manage users and configure [read-only dashboards][4]. They can also promote standard users to administrators.
 
 Datadog Standard Role
-: Users are allowed to view and modify all monitoring features that Datadog offers, such as [dashboards][3], [monitors][4], [events][5], and [notebooks][6]. Standard users can also invite other users to organizations.
+: Users are allowed to view and modify all monitoring features that Datadog offers, such as [dashboards][4], [monitors][5], [events][6], and [notebooks][7]. Standard users can also invite other users to organizations.
 
 Datadog Read Only Role
-: Users do not have access to edit within Datadog. This comes in handy when you'd like to share specific read-only views with a client, or when a member of one business unit needs to share a [dashboard][3] with someone outside their unit.
+: Users do not have access to edit within Datadog. This comes in handy when you'd like to share specific read-only views with a client, or when a member of one business unit needs to share a [dashboard][4] with someone outside their unit.
 
 ## Custom roles
 
-The custom roles feature gives your organization the ability to create new roles with unique permission sets. Manage your custom roles through the Datadog site, the [Datadog Role API][6], or SAML directly. Find out below how to create, update, or delete a role. See [Datadog Role Permissions][7] for more information about available permissions. Only users with the User Access Manage permission can create or edit roles in Datadog.
+The custom roles feature gives your organization the ability to create new roles with unique permission sets. Manage your custom roles through the Datadog site, the [Datadog Role API][7], or SAML directly. Find out below how to create, update, or delete a role. See [Datadog Role Permissions][8] for more information about available permissions. Only users with the User Access Manage permission can create or edit roles in Datadog.
 
 ### Enable custom roles
 
-1. Navigate to [Organization Settings][8]. 
+1. Navigate to [Organization Settings][9]. 
 2. On the left side of the page, select **Roles**.
 3. Click the gear in the upper right corner. The Custom Roles pop-up appears.
 4. In the Custom Roles pop-up, click **Enable**.
 
 {{< img src="account_management/rbac/enable_custom_roles.png" alt="Custom Roles pop-up with Enable button" style="width:90%;">}}
 
-Alternatively, making a POST call to the [Create Role API endpoint][9] automatically enables custom roles for your organization.
+Alternatively, making a POST call to the [Create Role API endpoint][10] automatically enables custom roles for your organization.
 
 ### Create a custom role
 
@@ -185,12 +195,13 @@ When creating or updating a role on the Datadog site, use a Datadog role templat
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /account_management/multi_organization/
-[2]: /account_management/saml/mapping/
-[3]: /dashboards/
-[4]: /monitors/
-[5]: /events/
-[6]: /api/v2/roles/
-[7]: /account_management/rbac/permissions/
-[8]: https://app.datadoghq.com/organization-settings/
-[9]: /api/latest/roles/#create-role
+[1]: /account_management/rbac/granular_access/
+[2]: /account_management/multi_organization/
+[3]: /account_management/saml/mapping/
+[4]: /dashboards/
+[5]: /monitors/
+[6]: /events/
+[7]: /api/v2/roles/
+[8]: /account_management/rbac/permissions/
+[9]: https://app.datadoghq.com/organization-settings/
+[10]: /api/latest/roles/#create-role

--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -31,7 +31,7 @@ By granting permissions to roles, any user who is associated with that role rece
 
 If a user in a [child organization][1] has `org_management` permission, it does not mean that they have the same permission in the parent org. Users' roles are not shared between parent and child organizations.
 
-**Note**: If you use a SAML identity provider, you can integrate it with Datadog for authentication, and you can map identity attributes to Datadog default and custom roles. For more information, see [Single Sign On With SAML][2].
+**Note**: If you use a SAML identity provider, you can integrate it with Datadog for authentication, and you can map identity attributes to Datadog default and custom roles. For more information, see [SAML group mapping][2].
 
 ## Datadog default roles
 
@@ -46,18 +46,18 @@ Datadog Read Only Role
 
 ## Custom roles
 
-The custom roles feature gives your organization the ability to create new roles with unique permission sets. Manage your custom roles through the Datadog site, the [Datadog Role API][7], or SAML directly. Find out below how to create, update, or delete a role. See [Datadog Role Permissions][8] for more information about available permissions. Only users with the User Access Manage permission can create or edit roles in Datadog.
+The custom roles feature gives your organization the ability to create new roles with unique permission sets. Manage your custom roles through the Datadog site, the [Datadog Role API][6], or SAML directly. Find out below how to create, update, or delete a role. See [Datadog Role Permissions][7] for more information about available permissions. Only users with the User Access Manage permission can create or edit roles in Datadog.
 
 ### Enable custom roles
 
-1. Navigate to [Organization Settings][9]. 
+1. Navigate to [Organization Settings][8]. 
 2. On the left side of the page, select **Roles**.
 3. Click the gear in the upper right corner. The Custom Roles pop-up appears.
 4. In the Custom Roles pop-up, click **Enable**.
 
 {{< img src="account_management/rbac/enable_custom_roles.png" alt="Custom Roles pop-up with Enable button" style="width:90%;">}}
 
-Alternatively, making a POST call to the [Create Role API endpoint][10] automatically enables custom roles for your organization.
+Alternatively, making a POST call to the [Create Role API endpoint][9] automatically enables custom roles for your organization.
 
 ### Create a custom role
 
@@ -181,38 +181,16 @@ When creating or updating a role on the Datadog site, use a Datadog role templat
 
 {{< img src="account_management/rbac/role_templates.png" alt="Role Templates dropdown menu with Datadog Billing Admin Role selected" style="width:90%;">}}
 
-## Restrict access to individual resources (granular access controls)
-
-Some resources allow you to restrict access to individual resources by roles, [Teams][16] (beta), or users (beta). Datadog recommends that you use teams to map access to functional groups in your organizations (for example, restrict editing of a dashboard to the application team owning it), roles to map access to personas (for example, restrict editing of payment methods to billing administrators), and individual users only when necessary. This encourages knowledge sharing and collaboration.
-
-
-| Supported Resources with Granular Access Control | Team-Based Access | Role-Based Access | User / Service Account-Based Access |
-|--------------------------------------------------|-------------------|-------------------|-------------------------------------|
-| [Dashboards][11]                                 | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
-| [Monitors][12]                                   |                   | {{< X >}}         |                                     |
-| [Notebooks][6]                                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
-| [Security rules][13]                             | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
-| [Service Level Objectives][14]                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
-| [Synthetic tests][15]                            |                   | {{< X >}}         |                                     |
-
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /account_management/multi_organization/
-[2]: /account_management/saml/
+[2]: /account_management/saml/mapping/
 [3]: /dashboards/
 [4]: /monitors/
 [5]: /events/
-[6]: /notebooks/#limit-edit-access
-[7]: /api/v2/roles/
-[8]: /account_management/rbac/permissions/
-[9]: https://app.datadoghq.com/organization-settings/
-[10]: /api/latest/roles/#create-role
-[11]: /dashboards/#permissions
-[12]: /monitors/notify/#permissions
-[13]: /security/detection_rules/#limit-edit-access
-[14]: /service_management/service_level_objectives/#permissions
-[15]: /synthetics/browser_tests/#permissions
-[16]: /account_management/teams/
+[6]: /api/v2/roles/
+[7]: /account_management/rbac/permissions/
+[8]: https://app.datadoghq.com/organization-settings/
+[9]: /api/latest/roles/#create-role

--- a/content/en/account_management/rbac/_index.md
+++ b/content/en/account_management/rbac/_index.md
@@ -29,9 +29,9 @@ further_reading:
 
 Datadog offers a flexible access management system that allows you to customize the level at which you control access to your Datadog resources.
 
-Users looking for basic functionality have access to OOTB roles with permissions. For more flexibility, create your own custom roles to combine permissions into new roles. Permissions attached to a custom role apply to all resources of a particular resource type.
+Users looking for basic functionality have access to OOTB [roles](#role-based-access-control) with [permissions][1]. For more flexibility, create your own [custom roles](#custom-roles) to combine permissions into new roles. Permissions attached to a custom role apply to all resources of a particular resource type.
 
-Organizations and users that need maximum flexibility can control access to individual dashboards, notebooks, and other resources with [granular access control][1].
+Organizations and users that need maximum flexibility can control access to individual dashboards, notebooks, and other resources with [granular access control][2].
 
 ## Role based access control
 
@@ -39,24 +39,24 @@ Roles categorize users and define what account permissions those users have, suc
 
 By granting permissions to roles, any user who is associated with that role receives that permission. When users are associated with multiple roles, they receive all the permissions granted to each of their roles. The more roles a user is associated with, the more access they have within a Datadog account.
 
-If a user in a [child organization][2] has `org_management` permission, it does not mean that they have the same permission in the parent org. Users' roles are not shared between parent and child organizations.
+If a user in a [child organization][3] has `org_management` permission, it does not mean that they have the same permission in the parent org. Users' roles are not shared between parent and child organizations.
 
-**Note**: If you use a SAML identity provider, you can integrate it with Datadog for authentication, and you can map identity attributes to Datadog default and custom roles. For more information, see [SAML group mapping][3].
+**Note**: If you use a SAML identity provider, you can integrate it with Datadog for authentication, and you can map identity attributes to Datadog default and custom roles. For more information, see [SAML group mapping][4].
 
 ## Datadog default roles
 
 Datadog Admin Role
-: Users have access to billing information and the ability to revoke API keys. They can manage users and configure [read-only dashboards][4]. They can also promote standard users to administrators.
+: Users have access to billing information and the ability to revoke API keys. They can manage users and configure [read-only dashboards][5]. They can also promote standard users to administrators.
 
 Datadog Standard Role
-: Users are allowed to view and modify all monitoring features that Datadog offers, such as [dashboards][4], [monitors][5], [events][6], and [notebooks][7]. Standard users can also invite other users to organizations.
+: Users are allowed to view and modify all monitoring features that Datadog offers, such as [dashboards][5], [monitors][6], [events][7], and [notebooks][8]. Standard users can also invite other users to organizations.
 
 Datadog Read Only Role
-: Users do not have access to edit within Datadog. This comes in handy when you'd like to share specific read-only views with a client, or when a member of one business unit needs to share a [dashboard][4] with someone outside their unit.
+: Users do not have access to edit within Datadog. This comes in handy when you'd like to share specific read-only views with a client, or when a member of one business unit needs to share a [dashboard][5] with someone outside their unit.
 
 ## Custom roles
 
-The custom roles feature gives your organization the ability to create new roles with unique permission sets. Manage your custom roles through the Datadog site, the [Datadog Role API][7], or SAML directly. Find out below how to create, update, or delete a role. See [Datadog Role Permissions][8] for more information about available permissions. Only users with the User Access Manage permission can create or edit roles in Datadog.
+The custom roles feature gives your organization the ability to create new roles with unique permission sets. Manage your custom roles through the Datadog site, the [Datadog Role API][8], or SAML directly. Find out below how to create, update, or delete a role. See [Datadog Role Permissions][1] for more information about available permissions. Only users with the User Access Manage permission can create or edit roles in Datadog.
 
 ### Enable custom roles
 
@@ -195,13 +195,13 @@ When creating or updating a role on the Datadog site, use a Datadog role templat
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /account_management/rbac/granular_access/
-[2]: /account_management/multi_organization/
-[3]: /account_management/saml/mapping/
-[4]: /dashboards/
-[5]: /monitors/
-[6]: /events/
-[7]: /api/v2/roles/
-[8]: /account_management/rbac/permissions/
+[1]: /account_management/rbac/permissions/
+[2]: /account_management/rbac/granular_access/
+[3]: /account_management/multi_organization/
+[4]: /account_management/saml/mapping/
+[5]: /dashboards/
+[6]: /monitors/
+[7]: /events/
+[8]: /api/v2/roles/
 [9]: https://app.datadoghq.com/organization-settings/
 [10]: /api/latest/roles/#create-role

--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -4,7 +4,7 @@ kind: documentation
 ---
 ## Restrict access to individual resources
 
-Some resources allow you to restrict access to individual resources by roles, [Teams][1] (beta), or users (beta).
+Some resources allow you to restrict access to individual resources by roles, [Teams][1], or users (beta).
 
 Use the different principals to control access patterns in your organization and encourage knowledge sharing and collaboration:
 - Use Teams to map access to functional groups in your organizations. For example, restrict editing of a dashboard to the application team that owns it.

--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -4,17 +4,22 @@ kind: documentation
 ---
 ## Restrict access to individual resources
 
-Some resources allow you to restrict access to individual resources by roles, [Teams][1] (beta), or users (beta). Datadog recommends that you use teams to map access to functional groups in your organizations (for example, restrict editing of a dashboard to the application team owning it), roles to map access to personas (for example, restrict editing of payment methods to billing administrators), and individual users only when necessary. This encourages knowledge sharing and collaboration.
+Some resources allow you to restrict access to individual resources by roles, [Teams][1] (beta), or users (beta).
+
+Use the different principals to control access patterns in your organization and encourage knowledge sharing and collaboration:
+- Use Teams to map access to functional groups in your organizations. For example, restrict editing of a dashboard to the application team that owns it.
+- Use roles to map access to personas. For example, restrict editing of payment methods to billing administrators.
+- Allocate access to individual users only when necessary.
 
 
-| Supported Resources with Granular Access Control | Team-Based Access | Role-Based Access | User / Service Account-Based Access |
+| Supported resources with granular access control | Team-based access | Role-based access | User / service account-based access |
 |--------------------------------------------------|-------------------|-------------------|-------------------------------------|
-| [Dashboards][2]                                 | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
-| [Monitors][3]                                   |                   | {{< X >}}         |                                     |
+| [Dashboards][2]                                  | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Monitors][3]                                    |                   | {{< X >}}         |                                     |
 | [Notebooks][4]                                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
-| [Security rules][5]                             | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
-| [Service Level Objectives][6]                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
-| [Synthetic tests][7]                            |                   | {{< X >}}         |                                     |
+| [Security rules][5]                              | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Service Level Objectives][6]                    | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Synthetic tests][7]                             |                   | {{< X >}}         |                                     |
 
 [1]: /account_management/teams/
 [2]: /dashboards/#permissions

--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -2,9 +2,9 @@
 title: Granular Access Control
 kind: documentation
 ---
-## Restrict access to individual resources
+## Manage access to individual resources
 
-Some resources allow you to restrict access to individual resources by roles, [Teams][1], or users (beta).
+Some resources allow you to restrict access to individual resources by roles, [Teams][1], or users.
 
 Use the different principals to control access patterns in your organization and encourage knowledge sharing and collaboration:
 - Use Teams to map access to functional groups in your organizations. For example, restrict editing of a dashboard to the application team that owns it.
@@ -20,6 +20,14 @@ Use the different principals to control access patterns in your organization and
 | [Security rules][5]                              | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Service Level Objectives][6]                    | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Synthetic tests][7]                             |                   | {{< X >}}         |                                     |
+
+### Gain access to individual resources (private beta)
+
+<div class="alert alert-warning">
+The feature to gain access to individual resources is in private beta. To request access, <a href="/help">contact Support</a>.
+</div>
+
+A user with the `user_access_manage` permission can gain edit access to any individual resource that has restricted access. To get access, click the **Gain Edit Access** button in the granular access control modal.
 
 [1]: /account_management/teams/
 [2]: /dashboards/#permissions

--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -1,0 +1,25 @@
+---
+title: Granular Access Control
+kind: documentation
+---
+## Restrict access to individual resources
+
+Some resources allow you to restrict access to individual resources by roles, [Teams][1] (beta), or users (beta). Datadog recommends that you use teams to map access to functional groups in your organizations (for example, restrict editing of a dashboard to the application team owning it), roles to map access to personas (for example, restrict editing of payment methods to billing administrators), and individual users only when necessary. This encourages knowledge sharing and collaboration.
+
+
+| Supported Resources with Granular Access Control | Team-Based Access | Role-Based Access | User / Service Account-Based Access |
+|--------------------------------------------------|-------------------|-------------------|-------------------------------------|
+| [Dashboards][2]                                 | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Monitors][3]                                   |                   | {{< X >}}         |                                     |
+| [Notebooks][4]                                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Security rules][5]                             | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Service Level Objectives][6]                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Synthetic tests][7]                            |                   | {{< X >}}         |                                     |
+
+[1]: /account_management/teams/
+[2]: /dashboards/#permissions
+[3]: /monitors/notify/#permissions
+[4]: /notebooks/#limit-edit-access
+[5]: /security/detection_rules/#limit-edit-access
+[6]: /service_management/service_level_objectives/#permissions
+[7]: /synthetics/browser_tests/#permissions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/DOCS-6186
- Moves the section on granular access to its own page for ease of reading and clearer organization.
- Adds an introduction to the RBAC page to describe the different ways you can control access to Datadog resources.
- Adds instructions for the private beta feature of gaining access to restricted resources for admins.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
In the future, I plan to create a top-level "Access" page with the introduction, and have RBAC, Granular access, and Permissions as child pages of "Access". That reorganization requires moving the approximately 150 incoming links to the RBAC page, so I'm deferring that work until December when I anticipate I'll have more time.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->