### PR TITLE
(DOCS-5834) Fix API redirects

### DIFF
--- a/content/en/api/_index.md
+++ b/content/en/api/_index.md
@@ -4,4 +4,13 @@ type: api
 external_redirect: /api/latest/
 algolia:
   tags: ['api']
+cascade:
+- _target:
+    path: /api/latest/downtimes/_index.md
+  aliases:
+    - /api/latest/downtimes/s
+- _target:
+    path: /api/latest/dashboards/_index.md
+  aliases:
+    - /api/screenboards/
 ---


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Turns out the frontmatter in the API docs is overwritten by updates to the API spec, so this is the only way for redirects to stick.

These should redirect once the build completes:
- [https://docs-staging.datadoghq.com/heston/more-redirects/api/latest/downtimes/s](https://docs-staging.datadoghq.com/heston/more-redirects/api/latest/downtimes/s)
- [https://docs-staging.datadoghq.com/heston/more-redirects/api/screenboards/](https://docs-staging.datadoghq.com/heston/more-redirects/api/screenboards/)

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->