### PR TITLE
Make Permissions section of Dashboard docs consistent with other GRAC…

### DIFF
--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -170,7 +170,7 @@ Use granular access controls to limit the [roles][18] that may edit a particular
 1. Select **Permissions**.
 1. Click **Restrict Access**.
 1. The dialog box updates to show that members of your organization have **Viewer** access by default.
-1. Use the dropdown to select one or more roles, teams (beta), or users (beta) that may edit the notebook.
+1. Use the dropdown to select one or more roles, teams (beta), or users (beta) that may edit the dashboard.
 1. Click **Add**.
 1. The dialog box updates to show that the role you selected has the **Editor** permission.
 1. Click **Save**

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -165,7 +165,7 @@ To limit the search to a specific dashboard, include the dashboard's name in the
 
 {{< img src="dashboards/access_popup.png" alt="Dialog box with dropdown menu allowing users to choose a role to access the dashboard." style="width:70%;">}}
 
-Use granular access controls to limit the [roles][18] that may edit a particular dashboard:
+Use granular access controls to limit the [roles][15] that may edit a particular dashboard:
 1. While viewing a dashboard, click on the cog in the upper right. The settings menu opens.
 1. Select **Permissions**.
 1. Click **Restrict Access**.

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -177,7 +177,7 @@ Use granular access controls to limit the [roles][18] that may edit a particular
 
 **Note:** To maintain your edit access to the dashboard, the system requires you to include at least one role that you are a member of before saving. For more information about roles, see the [RBAC documentation][15].
 
-To restore general access to a notebook with restricted access, follow the steps below:
+To restore general access to a dashboard with restricted access, follow the steps below:
 1. While viewing the dashboard, click on the cog in the upper right. The settings menu opens.
 1. Select **Permissions**.
 1. Click **Restore Full Access**.

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -163,13 +163,25 @@ To limit the search to a specific dashboard, include the dashboard's name in the
 
 #### Permissions
 
-At the top of the dashboard, click on configure and select *Permissions*.
-
-Use the pop-up to select one or more roles, teams (beta), or users (beta) that may edit the dashboard.
-
 {{< img src="dashboards/access_popup.png" alt="Dialog box with dropdown menu allowing users to choose a role to access the dashboard." style="width:70%;">}}
 
-Any user setting access control rules has to include one or more roles they are a part of to prevent locking an organization out. For more information about roles, see the [RBAC documentation][15].
+Use granular access controls to limit the [roles][18] that may edit a particular dashboard:
+1. While viewing a dashboard, click on the cog in the upper right. The settings menu opens.
+1. Select **Permissions**.
+1. Click **Restrict Access**.
+1. The dialog box updates to show that members of your organization have **Viewer** access by default.
+1. Use the dropdown to select one or more roles, teams (beta), or users (beta) that may edit the notebook.
+1. Click **Add**.
+1. The dialog box updates to show that the role you selected has the **Editor** permission.
+1. Click **Save**
+
+**Note:** To maintain your edit access to the dashboard, the system requires you to include at least one role that you are a member of before saving. For more information about roles, see the [RBAC documentation][15].
+
+To restore general access to a notebook with restricted access, follow the steps below:
+1. While viewing the dashboard, click on the cog in the upper right. The settings menu opens.
+1. Select **Permissions**.
+1. Click **Restore Full Access**.
+1. Click **Save**.
 
 If the dashboard was created with the deprecated "read only" setting, the access control list pre-populates with a list of roles that have the Access Management (`user_access_manage`) permission.
 


### PR DESCRIPTION
…E products

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Makes the Dashboard permissions page [Dashboards](https://docs.datadoghq.com/dashboards/#permissions) in the public docs have the same numbered steps that the other GRACE-controlled products ([Notebooks](https://docs.datadoghq.com/notebooks/#limit-edit-access), [Security rules](https://docs.datadoghq.com/security/detection_rules/#limit-edit-access) , [Service Level Objectives](https://docs.datadoghq.com/service_management/service_level_objectives/#permissions) ) have to be more consistent.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->