### PR TITLE
Update python.md b3 propagation style configs

### DIFF
--- a/content/en/tracing/trace_collection/trace_context_propagation/python.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/python.md
@@ -14,11 +14,11 @@ The Datadog APM tracer supports extraction and injection of [B3][2] and [W3C Tra
 
 Distributed headers injection and extraction is controlled by
 configuring injection and extraction styles. Supported styles are:
-`tracecontext`, `datadog`, `B3` and `B3 single header`.
+`tracecontext`, `datadog`, `b3multi` and `b3 single header`.
 
-- Configure injection styles using the `DD_TRACE_PROPAGATION_STYLE_INJECT=tracecontext,B3` environment variable.
-- Configure extraction styles using the `DD_TRACE_PROPAGATION_STYLE_EXTRACT=tracecontext,B3` environment variable.
-- Configure both injection and extraction styles using the `DD_TRACE_PROPAGATION_STYLE=tracecontext,B3` environment variable.
+- Configure injection styles using the `DD_TRACE_PROPAGATION_STYLE_INJECT=tracecontext,b3mutli` environment variable.
+- Configure extraction styles using the `DD_TRACE_PROPAGATION_STYLE_EXTRACT=tracecontext,b3multi` environment variable.
+- Configure both injection and extraction styles using the `DD_TRACE_PROPAGATION_STYLE=tracecontext,b3multi` environment variable.
 
 The values of these environment variables are comma-separated lists of
 header styles enabled for injection or extraction. By default,


### PR DESCRIPTION
We've had `b3` propagations style deprecated and suggested `b3multi` for some time. With Python tracer version 2.0.0 we remove `b3` propagation style, therefore we should remove it here as well, and customers should use `b3multi` instead.
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->