### PR TITLE
Heston/update categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ package-lock.json
 # Ignoring all integrations file
 content/en/integrations/*.md
 data/integrations/
+layouts/shortcodes/integration_categories.md
 content/en/integrations/guide/amazon_cloudformation.md
 !content/en/integrations/_index.md
 !content/en/integrations/cloudcheckr.md

--- a/layouts/shortcodes/integration_categories.md
+++ b/layouts/shortcodes/integration_categories.md
@@ -1,5 +1,6 @@
 | Name | Description |
 | --- | --- |
+| Category::AI | Integrations that monitor AI technologies. |
 | Category::Alerting | Integrations that collect Datadog data to alert on, or send alerts into Datadog. |
 | Category::Automation | Integrations for technologies that automate processes such as security, compliance, testing, and AIOps. |
 | Category::AWS | Integrations that send in data from Amazon Web Services and its related services. |
@@ -21,6 +22,7 @@
 | Category::Kubernetes | Integrations that send in data from Kubernetes and Kubernetes-related services. |
 | Category::Languages | Integrations that send metrics and additional data based on specific programming languages. |
 | Category::Log Collection | Integrations that submit or query logs from Datadog. |
+| Category::Machine Learning & LLM | Integrations that monitor Machine Learning technologies, Large Language Models, and assist with ML Operations. |
 | Category::Mainframe | Integrations that monitor mainframe systems such as IBM z/OS. |
 | Category::Marketplace | Integrations that are sold in the Datadog Marketplace for an additional fee. |
 | Category::Messaging | Integrations that monitor messaging queues and messaging systems. |


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This file is automatically generated, so it's better to put it in .gitignore. But I don't want the local (short) build to fail if the file isn't found, so the compromise is to have some slightly out-of-date information in it when you run the short build. Full `make start` builds will fetch the most up-to-date info from the assetlib.

Just to be clear, the docs website will always have the most up-to-date information

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->