### PR TITLE
update assetlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ placeholders:
 hugpython: local/etc/requirements3.txt
 	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<;\
 	if [[ "$(CI_COMMIT_REF_NAME)" != "" ]]; then \
-		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.19158099-py3-none-any.whl; \
+		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.20386518-py3-none-any.whl; \
 	fi
 
 update_pre_build:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This updates the assetlib used on docs which contains some updated validation for integrations filters/classifications.

The purpose of this update is so that upcoming integrations that are added will show on docs now that the validation has been updated too.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes

Should look as it does now
https://docs-staging.datadoghq.com/david.jones/bump-assetlib/integrations/

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->