### PR TITLE
Make timeouts clearer for NPM DNS monitoring

### DIFF
--- a/content/en/network_monitoring/dns/_index.md
+++ b/content/en/network_monitoring/dns/_index.md
@@ -81,7 +81,7 @@ The following DNS metrics are available:
 | **DNS requests**         | The number of DNS requests made from the client.                                                                         |
 | **DNS requests / second** | The rate of DNS requests made by the client.                                                                             |
 | **DNS response time**    | The average response time of the DNS server to a request from the client.                                                |
-| **Timeouts**             | The number of timed out DNS requests from the client (displayed as a percentage of all DNS responses).                    |
+| **Timeouts**             | The number of timed out DNS requests from the client (displayed as a percentage of all DNS responses). Note that these are not the same DNS timeouts reported by DNS clients or server, but a metric computed by NPM internally, and so may not align with DNS timeouts reported from outside of NPM.                |
 | **Errors**               | The number of requests from the client that generated DNS error codes (displayed as a percentage of all DNS responses).   |
 | **SERVFAIL**             | The number of requests from the client that generated SERVFAIL (DNS server failed to respond) codes (displayed as a percentage of all DNS responses).   |
 | **NXDOMAIN**             | The number of requests from the client that generated NXDOMAIN (domain name does not exist) codes (displayed as a percentage of all DNS responses).   |

--- a/content/en/network_monitoring/dns/_index.md
+++ b/content/en/network_monitoring/dns/_index.md
@@ -81,7 +81,7 @@ The following DNS metrics are available:
 | **DNS requests**         | The number of DNS requests made from the client.                                                                         |
 | **DNS requests / second** | The rate of DNS requests made by the client.                                                                             |
 | **DNS response time**    | The average response time of the DNS server to a request from the client.                                                |
-| **Timeouts**             | The number of timed out DNS requests from the client (displayed as a percentage of all DNS responses). Note that these are not the same DNS timeouts reported by DNS clients or server, but a metric computed by NPM internally, and so may not align with DNS timeouts reported from outside of NPM.                |
+| **Timeouts**             | The number of timed out DNS requests from the client (displayed as a percentage of all DNS responses). <br  /><br />**Note**: These timeouts are a metric computed by NPM internally, and may not align with DNS timeouts reported from outside of NPM. They are not the same as the DNS timeouts reported by DNS clients or servers.                |
 | **Errors**               | The number of requests from the client that generated DNS error codes (displayed as a percentage of all DNS responses).   |
 | **SERVFAIL**             | The number of requests from the client that generated SERVFAIL (DNS server failed to respond) codes (displayed as a percentage of all DNS responses).   |
 | **NXDOMAIN**             | The number of requests from the client that generated NXDOMAIN (domain name does not exist) codes (displayed as a percentage of all DNS responses).   |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
There has been some confusion from customers about the timeout shown in NPM DNS monitoring. This PR attempts to add more details on how these timeouts differ from timeouts reported by other non-NPM products.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->