### PR TITLE
Fix GitHub links to RUM iOS SDK repo

### DIFF
--- a/content/en/real_user_monitoring/ios/advanced_configuration.md
+++ b/content/en/real_user_monitoring/ios/advanced_configuration.md
@@ -67,7 +67,7 @@ DDRUMMonitor *rum = [DDRUMMonitor shared];
 {{% /tab %}}
 {{< /tabs >}}
 
-Find more details and available options in the [`DDRUMMonitor` class][9].
+For more details and available options, filter the [relevant file on GitHub][9] for the `DDRUMMonitor` class.
 
 ### Add your own performance timing
 
@@ -761,4 +761,4 @@ For more information, see the [URLSessionConfiguration.connectionProxyDictionary
 [6]: /real_user_monitoring/connect_rum_and_traces?tab=browserrum
 [7]: /real_user_monitoring/ios/data_collected?tab=session#default-attributes
 [8]: https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1411499-connectionproxydictionary
-[9]: https://github.com/DataDog/dd-sdk-ios/blob/master/Sources/Datadog/DDRUMMonitor.swift
+[9]: https://github.com/DataDog/dd-sdk-ios/blob/56e972a6d3070279adbe01850f51cb8c0c929c52/DatadogObjc/Sources/RUM/RUM%2Bobjc.swift

--- a/content/en/real_user_monitoring/ios/mobile_vitals.md
+++ b/content/en/real_user_monitoring/ios/mobile_vitals.md
@@ -1,6 +1,4 @@
 ---
-dependencies:
-- https://github.com/DataDog/dd-sdk-ios/blob/master/docs/rum_mobile_vitals.md
 description: Collect RUM data from your iOS projects.
 further_reading:
 - link: https://github.com/DataDog/dd-sdk-ios

--- a/content/en/real_user_monitoring/ios/troubleshooting.md
+++ b/content/en/real_user_monitoring/ios/troubleshooting.md
@@ -80,7 +80,7 @@ private class YourCustomDelegateURLSessionDelegate: NSObject, URLSessionTaskDele
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /real_user_monitoring/ios/advanced_configuration/?tab=swift#automatically-track-network-requests
-[2]: https://github.com/DataDog/dd-sdk-ios/blob/master/Sources/Datadog/URLSessionAutoInstrumentation/DDURLSessionDelegate.swift#L12
+[2]: https://github.com/DataDog/dd-sdk-ios/blob/56e972a6d3070279adbe01850f51cb8c0c929c52/DatadogInternal/Sources/NetworkInstrumentation/URLSession/DatadogURLSessionDelegate.swift#L14
 [3]: https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1643148-urlsession
 [4]: https://developer.apple.com/documentation/foundation/urlsessiontaskdelegate/1411610-urlsession
 [5]: https://developer.apple.com/documentation/foundation/urlsessiondatadelegate/1411528-urlsession


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
DOCS-6286

Fixes some 404ing links to an external repo. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->