### PR TITLE
add json and yaml copy buttons - [WEB-4048]

### DIFF
--- a/assets/scripts/components/copy-code.js
+++ b/assets/scripts/components/copy-code.js
@@ -18,7 +18,7 @@ function initCopyCode () {
 
 // Adds copy button to code examples that use the highlight hugo function or are fenced code blocks in markdown
 function addCopyButton () {
-    const fencedLang = ['shell'] // target specific fenced codeblocks by language
+    const fencedLang = ['shell', 'json', 'yaml'] // target specific fenced codeblocks by language
     const highlights = document.querySelectorAll("div.highlight")
 
     highlights.forEach(highlightEl => {

--- a/layouts/shortcodes/dashboards-widgets-api.html
+++ b/layouts/shortcodes/dashboards-widgets-api.html
@@ -62,10 +62,7 @@
 
       <div role="tabpanel" class="tab-pane js-tab-example" id="example">
         <div class="code-snippet-wrapper">
-          <div class="code-snippet">
-            <div class="code-button-wrapper position-absolute">
-              <button class="btn text-primary js-copy-button">{{ i18n "copy" }}</button>
-            </div>
+          <div class="code-snippet append-copy-btn">
             {{ print $json | safeHTML }}
           </div>
         </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

adds copy button to `json` and `yaml` code blocks throughout  docs.
fix duplicate copy button rendering from the **dashboards-widget-api** shortcode.

**Motivation:** https://datadoghq.atlassian.net/browse/WEB-4048

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after CorpWeb reviews

### Additional notes
<!-- Anything else we should know when reviewing?-->
Hover over code examples to see the copy button. click the copy button to copy to clipboard. ensure code example can be pasted.
- json ex : https://docs-staging.datadoghq.com/stefon.simmons/copy-json-yaml-fenced/integrations/guide/aws-manual-setup/?tab=roledelegation#aws-integration-iam-policy
- json ex from pulled integration (.gitignored): https://docs-staging.datadoghq.com/stefon.simmons/copy-json-yaml-fenced/integrations/amazon_elasticbeanstalk/?tab=multiplecontainers#datadog-agent-configuration
- yaml ex: https://docs-staging.datadoghq.com/stefon.simmons/copy-json-yaml-fenced/getting_started/integrations/?tab=multiplecontainers#configuring-agent-integrations
- yaml ex from pulled integration (.gitignored): https://docs-staging.datadoghq.com/stefon.simmons/copy-json-yaml-fenced/integrations/otel/
- dashboards-widget-api ex (see Example tab under api): https://docs-staging.datadoghq.com/stefon.simmons/copy-json-yaml-fenced/dashboards/widgets/alert_value/?tab=nocontainerslinux#api
- dashboards-widget-api ex (see Example tab under api): https://docs-staging.datadoghq.com/stefon.simmons/copy-json-yaml-fenced/dashboards/widgets/funnel/#api

 
also, here's a new document on confluence on how to add copy buttons to docs code-examples: [here](https://datadoghq.atlassian.net/wiki/spaces/WEB/pages/3204743310/Add+Copy+Buttons+to+Code+Examples)

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->