### PR TITLE
Fix links to Manage Downtimes page

### DIFF
--- a/content/en/monitors/downtimes/_index.md
+++ b/content/en/monitors/downtimes/_index.md
@@ -183,7 +183,7 @@ Datadog can proactively mute monitors related to the manual shutdown of certain 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/monitors#/downtime
+[1]: https://app.datadoghq.com/monitors/downtimes
 [2]: /monitors/guide/scoping_downtimes
 [3]: /monitors/manage/#monitor-tags
 [4]: /monitors/manage/search/

--- a/content/ja/monitors/downtimes/_index.md
+++ b/content/ja/monitors/downtimes/_index.md
@@ -144,7 +144,7 @@ Datadog は、特定のクラウドワークロードの手動シャットダウ
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/monitors#/downtime
+[1]: https://app.datadoghq.com/monitors/downtimes
 [2]: /ja/monitors/manage/#monitor-tags
 [3]: /ja/monitors/configuration/?tab=thresholdalert#alert-grouping
 [4]: /ja/monitors/guide/scoping_downtimes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fix the link in Downtimes documentation page to not link to a "Not found" page.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->