### PR TITLE
DOCS-5743 - region-specific messaging for integrations

### DIFF
--- a/content/en/agent/remote_config/_index.md
+++ b/content/en/agent/remote_config/_index.md
@@ -24,11 +24,9 @@ algolia:
   tags: ['remote config', 'remote configuration']
 ---
 
-{{% site-region region="gov" %}}
-
-<div class="alert alert-warning">Remote configuration is not available on the US1-FED Datadog site.</div>
-
-{{% /site-region %}}
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Remote Configuration is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
 
 ## Overview
 Remote Configuration is a Datadog capability that allows you to remotely configure and change the behavior of Datadog components (for example, Agents, tracing libraries, and Observability Pipelines Worker) deployed in your infrastructure, for select product features. Use Remote Configuration to apply configurations to Datadog components in your environment on demand, decreasing management costs, reducing friction between teams, and accelerating issue resolution times.

--- a/content/en/developers/_index.md
+++ b/content/en/developers/_index.md
@@ -33,10 +33,6 @@ If the solution you require is truly unavailable, you can contact [Datadog Suppo
 
 ### Partners and the Datadog Marketplace
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning">Datadog Marketplace is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
-
 You may also be a partner who wants to build on Datadog and contribute to the [Datadog Marketplace][10] or to Datadog's community [integrations][6]. 
 
 {{< whatsnext desc="To develop an offering, see the appropriate documentation:" >}}

--- a/content/en/developers/_index.md
+++ b/content/en/developers/_index.md
@@ -33,6 +33,10 @@ If the solution you require is truly unavailable, you can contact [Datadog Suppo
 
 ### Partners and the Datadog Marketplace
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Datadog Marketplace is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 You may also be a partner who wants to build on Datadog and contribute to the [Datadog Marketplace][10] or to Datadog's community [integrations][6]. 
 
 {{< whatsnext desc="To develop an offering, see the appropriate documentation:" >}}

--- a/content/en/developers/integrations/_index.md
+++ b/content/en/developers/integrations/_index.md
@@ -36,6 +36,10 @@ The [Integrations page][101] includes integrations built by both Datadog and our
 {{% /tab %}}
 {{% tab "Marketplace" %}}
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Datadog Marketplace is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 The [Marketplace page][101] is a commercial platform for Technology Partners to _sell_ a variety of offerings, including integrations, software licenses, and professional services to Datadog customers.
 
 {{< img src="developers/marketplace/marketplace_updated_overview.png" alt="The Datadog Marketplace page" style="width:100%" >}}

--- a/content/en/developers/integrations/_index.md
+++ b/content/en/developers/integrations/_index.md
@@ -36,10 +36,6 @@ The [Integrations page][101] includes integrations built by both Datadog and our
 {{% /tab %}}
 {{% tab "Marketplace" %}}
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning">Datadog Marketplace is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
-
 The [Marketplace page][101] is a commercial platform for Technology Partners to _sell_ a variety of offerings, including integrations, software licenses, and professional services to Datadog customers.
 
 {{< img src="developers/marketplace/marketplace_updated_overview.png" alt="The Datadog Marketplace page" style="width:100%" >}}

--- a/content/en/developers/integrations/marketplace_offering.md
+++ b/content/en/developers/integrations/marketplace_offering.md
@@ -20,6 +20,10 @@ description: Learn about the Datadog marketplace.
 ---
 ## Overview
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Datadog Marketplace is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 The [Datadog Marketplace][2] is a digital marketplace where Technology Partners can list their paid offerings to Datadog users.  
 
 While the **Integrations** page includes integrations built by both Datadog and Technology Partners at no cost, the **Marketplace** page is a commercial platform for Datadog customers and Technology Partners to buy and sell a variety of offerings, including Agent-based or API-based integrations, software licenses, and professional services.

--- a/content/en/developers/integrations/marketplace_offering.md
+++ b/content/en/developers/integrations/marketplace_offering.md
@@ -20,10 +20,6 @@ description: Learn about the Datadog marketplace.
 ---
 ## Overview
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning">Datadog Marketplace is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
-
 The [Datadog Marketplace][2] is a digital marketplace where Technology Partners can list their paid offerings to Datadog users.  
 
 While the **Integrations** page includes integrations built by both Datadog and Technology Partners at no cost, the **Marketplace** page is a commercial platform for Datadog customers and Technology Partners to buy and sell a variety of offerings, including Agent-based or API-based integrations, software licenses, and professional services.

--- a/content/en/dynamic_instrumentation/_index.md
+++ b/content/en/dynamic_instrumentation/_index.md
@@ -24,6 +24,11 @@ further_reading:
   text: "Learn more about Metrics"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Dynamic Instrumentation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+
 ## Overview
 
 Dynamic instrumentation allows you to add instrumentation into your running production systems without any restarts and at any location in your application's code, including third-party libraries. You can add or modify telemetry for logs, metrics, spans, and corresponding tagging, from the Datadog UI. Dynamic Instrumentation has low overhead and has no side effects on your system.

--- a/content/en/dynamic_instrumentation/_index.md
+++ b/content/en/dynamic_instrumentation/_index.md
@@ -24,7 +24,7 @@ further_reading:
   text: "Learn more about Metrics"
 ---
 
-{{< site-region region="gov" >}}
+{{< site-region region="gov,ap1" >}}
 <div class="alert alert-warning">Dynamic Instrumentation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 

--- a/content/en/integrations/adobe_experience_manager.md
+++ b/content/en/integrations/adobe_experience_manager.md
@@ -26,9 +26,10 @@ further_reading:
 integration_id: "adobe"
 ---
 
-{{% site-region region="us3" %}}
-<div class="alert alert-warning">The Adobe Experience Manager integration is not supported for your selected Datadog site ({{< region-param key="dd_site_name" >}}).</div>
-{{% /site-region %}}
+{{< site-region region="us3,ap1" >}}
+<div class="alert alert-warning">The Adobe Experience Manager integration is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 
 ## Overview
 

--- a/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -9,8 +9,8 @@ further_reading:
   tag: "Blog"
   text: "Collect Amazon CloudWatch metrics using Metric Streams"
 ---
-{{% site-region region="us3,us5,gov" %}}
-**The AWS CloudWatch Metric Streams with Kinesis Data Firehose is not supported on this Datadog site.**
+{{% site-region region="us3,gov" %}}
+AWS CloudWatch Metric Streams with Kinesis Data Firehose is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).
 {{% /site-region %}}
  
 Using Amazon CloudWatch Metric Streams and Amazon Kinesis Data Firehose, you can get CloudWatch metrics into Datadog faster with a 2-3 minute latency. This is significantly faster than Datadog's default API polling approach, which provides updated metrics every 10 minutes. You can learn more about the API polling approach in the [Cloud Metric Delay documentation][1].

--- a/content/en/integrations/guide/cloud-metric-delay.md
+++ b/content/en/integrations/guide/cloud-metric-delay.md
@@ -39,8 +39,8 @@ AWS offers two levels of granularity for metrics (5 and 1 minute metrics). If yo
 
 Further, the CloudWatch API only offers a metric-by-metric crawl to pull data. The CloudWatch APIs have a rate limit that varies based on the combination of authentication credentials, region, and service. Metrics are made available by AWS dependent on the account level. For example, if you are paying for *detailed metrics* within AWS, they are available more quickly. This level of service for detailed metrics also applies to granularity, with some metrics being available per minute and others per five minutes.
 
-{{% site-region region="us,eu,ap1" %}}
-If you're using the US1, EU, or AP1 [Datadog site][1], you can optionally configure Amazon CloudWatch Metric Streams and Amazon Kinesis Data Firehose to get CloudWatch metrics into Datadog faster with a 2-3 minute latency. Visit the [documentation on metric streaming][2] to learn more about this approach.
+{{% site-region region="us,us5,eu,ap1" %}}
+On your selected [Datadog site][1] ({{< region-param key="dd_site_name" >}}), you can optionally configure Amazon CloudWatch Metric Streams and Amazon Kinesis Data Firehose to get CloudWatch metrics into Datadog faster with a 2-3 minute latency. Visit the [documentation on metric streaming][2] to learn more about this approach.
 
 [1]: /getting_started/site/
 [2]: /integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/

--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -25,6 +25,11 @@ integration_id: "syslog_ng"
 
 Configure Syslog-ng to gather logs from your host, containers, & services.
 
+{{< site-region region="us3,ap1" >}}
+<div class="alert alert-warning">Log collection for <code>syslog-ng</code> is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+
 ## Setup
 
 ### Log collection

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -29,6 +29,10 @@ Configure your Datadog account to forward all the logs ingested—whether [index
 
 Navigate to the [**Log Forwarding** page][14] to set up an archive for forwarding ingested logs to your own cloud-hosted storage bucket.
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Log Forwarding is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 1. If you haven't already, set up a Datadog [integration](#set-up-an-integration) for your cloud provider.
 2. Create a [storage bucket](#create-a-storage-bucket).
 3. Set [permissions](#set-permissions) to `read` and/or `write` on that archive.

--- a/content/en/mobile_app_testing/_index.md
+++ b/content/en/mobile_app_testing/_index.md
@@ -24,7 +24,7 @@ cascade:
 ---
 
 {{< site-region region="us3,us5,gov,eu,ap1" >}}
-<div class="alert alert-warning">Mobile Application Testing is not supported on this site.</div>
+<div class="alert alert-warning">Mobile Application Testing is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 {{< site-region region="us" >}}

--- a/content/en/observability_pipelines/_index.md
+++ b/content/en/observability_pipelines/_index.md
@@ -19,7 +19,7 @@ cascade:
 ---
 
 {{< site-region region="gov" >}}
-<div class="alert alert-warning">Observability Pipelines are not available in the selected site ({{< region-param key="dd_site_name" >}}).</div>
+<div class="alert alert-warning">Observability Pipelines are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 

--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -40,6 +40,10 @@ further_reading:
   text: "Threat modeling with Datadog Application Security Management"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Application Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 {{< img src="/security/application_security/app-sec-landing-page.png" alt="A security signal panel in Datadog, which displays attack flows and flame graphs" width="75%">}}
 
 Datadog Application Security Management (ASM) provides protection against application-level attacks that aim to exploit code-level vulnerabilities, such as Server-Side-Request-Forgery (SSRF), SQL injection, Log4Shell, and Reflected Cross-Site-Scripting (XSS). You can monitor and protect apps hosted directly on a server, Docker, Kubernetes, AWS ECS, and (for supported languages) AWS Fargate.

--- a/content/en/security/application_security/enabling/_index.md
+++ b/content/en/security/application_security/enabling/_index.md
@@ -29,6 +29,10 @@ further_reading:
   text: "Secure serverless applications with Datadog ASM"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Application Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 Enable your application to [detect and protect against threats][1] targeting your production systems, and to [manage risks][2] in your code and its open source dependencies, using the Datadog library for your application language. You can detect vulnerabilities and threats for apps hosted on a server, Docker, Kubernetes, AWS ECS, and (for supported languages) AWS Fargate.
 
 {{% appsec-getstarted %}}

--- a/content/en/security/application_security/how-appsec-works.md
+++ b/content/en/security/application_security/how-appsec-works.md
@@ -17,6 +17,10 @@ further_reading:
   text: "Enable Application Security Management"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Application Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 ## Overview
 
 Datadog Application Security Management (ASM) provides observability into application-level attacks that aim to exploit code-level vulnerabilities or abuse the business logic of your application, and into any bad actors targeting your systems.

--- a/content/en/security/application_security/terms.md
+++ b/content/en/security/application_security/terms.md
@@ -14,6 +14,10 @@ further_reading:
   text: "Application Vulnerability Management"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Application Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 Datadog Application Security Management (ASM) monitors threats and provides protection against application-level attacks that aim to exploit code-level vulnerabilities. It leverages runtime code execution context, trace and error data, and user attribution.
 
 ## General application security terms

--- a/content/en/security/application_security/threats/_index.md
+++ b/content/en/security/application_security/threats/_index.md
@@ -16,6 +16,10 @@ further_reading:
   text: "How ASM Works"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Application Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 ASM Threat Monitoring and Protection uses trace telemetry from your APM-instrumented applications to identify threats and attacks on your running services by comparing the observed behavior against known attack patterns, or by identifying business logic abuse.
 
 Security signals raised by Threat Monitoring are summarized and surfaced in views you already commonly visit to monitor service health and performance. The [Service Catalog][1] and individual Service Pages in APM provide insights into application threat signals, allowing you to investigate vulnerabilities, block attackers, and review attack exposures.

--- a/content/en/security/application_security/vulnerability_management/_index.md
+++ b/content/en/security/application_security/vulnerability_management/_index.md
@@ -15,6 +15,10 @@ further_reading:
   text: "Getting started with Application Vulnerability Management"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Application Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 ## Overview
 
 Application Vulnerability Management offers built-in detection capabilities that warn you about the vulnerabilities detected in your services' open source dependencies. Details of that information are shown in the [Vulnerability Explorer][3], identifying the severity, affected services, potentially vulnerable infrastructure, and remediation instructions to solve the surfaced risks.

--- a/content/en/security/cloud_security_management/_index.md
+++ b/content/en/security/cloud_security_management/_index.md
@@ -38,6 +38,10 @@ algolia:
   tags: ['inbox']
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Cloud Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 Datadog Cloud Security Management (CSM) delivers real-time threat detection and continuous configuration audits across your entire cloud infrastructure, all in a unified view for seamless collaboration and faster remediation. Powered by observability data, security teams can determine the impact of a threat by tracing the full attack flow and identify the resource owner where a vulnerability was triggered.
 
 CSM leverages the Datadog Agent and platform-wide cloud integrations and includes:

--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -37,6 +37,10 @@ further_reading:
   text: "Catch attacks at the network layer with DNS-based threat detection"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Cloud Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">Cloud Security Management offerings are now available in three separate packages: CSM Enterprise, CSM Pro, and CSM Workload Security. For more information, see <a href="https://www.datadoghq.com/blog/cloud-security-management-changes/">Changes to Datadog Cloud Security Management</a>.</div>
 
 Cloud Security Management (CSM) delivers real-time threat detection and continuous configuration audits across your entire cloud infrastructure, all in a unified view for seamless collaboration and faster remediation.

--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -58,7 +58,7 @@ To enable resource scanning for your cloud accounts, you must first set up the i
 ### Enable Remote Configuration
 
 {{< site-region region="us3,us5,eu,gov,ap1" >}}
-<div class="alert alert-warning">Remote Configuration for Cloud Workload Security is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+<div class="alert alert-warning">Remote Configuration for CSM Threats is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 <div class="alert alert-info">Remote Configuration for CSM Threats is in beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>

--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -57,7 +57,7 @@ To enable resource scanning for your cloud accounts, you must first set up the i
 
 ### Enable Remote Configuration
 
-{{< site-region region="us3, us5, eu, gov, ap1" >}}
+{{< site-region region="us3,us5,eu,gov,ap1" >}}
 <div class="alert alert-warning">Remote Configuration for Cloud Workload Security is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 

--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -57,6 +57,10 @@ To enable resource scanning for your cloud accounts, you must first set up the i
 
 ### Enable Remote Configuration
 
+{{< site-region region="us3, us5, eu, gov, ap1" >}}
+<div class="alert alert-warning">Remote Configuration for Cloud Workload Security is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">Remote Configuration for CSM Threats is in beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
 
 [Remote Configuration][6] is a Datadog capability that allows you to remotely configure the behavior of Datadog resources deployed in your infrastructure. For CSM Threats, enabling Remote Configuration allows you to receive new and updated Agent rules automatically when they're released.

--- a/content/en/security/cloud_security_management/setup/csm_workload_security.md
+++ b/content/en/security/cloud_security_management/setup/csm_workload_security.md
@@ -24,7 +24,7 @@ The Cloud Security Management (CSM) Workload Security package includes [CSM Thre
 ### Enable Remote Configuration
 
 {{< site-region region="us3,us5,eu,gov,ap1" >}}
-<div class="alert alert-warning">Remote Configuration for Cloud Workload Security is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+<div class="alert alert-warning">Remote Configuration for CSM Threats is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 <div class="alert alert-info">Remote Configuration for CSM Threats is in beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>

--- a/content/en/security/cloud_security_management/setup/csm_workload_security.md
+++ b/content/en/security/cloud_security_management/setup/csm_workload_security.md
@@ -23,6 +23,10 @@ The Cloud Security Management (CSM) Workload Security package includes [CSM Thre
 
 ### Enable Remote Configuration
 
+{{< site-region region="us3, us5, eu, gov, ap1" >}}
+<div class="alert alert-warning">Remote Configuration for Cloud Workload Security is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">Remote Configuration for CSM Threats is in beta. If you have any feedback or questions, contact <a href="/help">Datadog support</a>.</div>
 
 [Remote Configuration][4] is a Datadog capability that allows you to remotely configure the behavior of Datadog resources deployed in your infrastructure. For CSM Threats, enabling Remote Configuration allows you to receive new and updated Agent rules automatically when they're released.

--- a/content/en/security/cloud_security_management/setup/csm_workload_security.md
+++ b/content/en/security/cloud_security_management/setup/csm_workload_security.md
@@ -23,7 +23,7 @@ The Cloud Security Management (CSM) Workload Security package includes [CSM Thre
 
 ### Enable Remote Configuration
 
-{{< site-region region="us3, us5, eu, gov, ap1" >}}
+{{< site-region region="us3,us5,eu,gov,ap1" >}}
 <div class="alert alert-warning">Remote Configuration for Cloud Workload Security is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 

--- a/content/en/security/cloud_security_management/workflows.md
+++ b/content/en/security/cloud_security_management/workflows.md
@@ -10,6 +10,10 @@ further_reading:
     text: Workflow Automation
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Cloud Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 [Datadog Workflow Automation][1] allows you to orchestrate and automate your end-to-end processes by building workflows made up of actions that connect to your infrastructure and tools. 
 
 Use Workflow Automation with [Cloud Security Management (CSM)][2] to automate your security-related workflows. For example, you can create workflows that allow you to [block access to a public AWS S3 bucket via an interactive Slack message](#block-access-to-aws-s3-bucket-via-slack), or [automatically create a Jira issue and assign it to a team](#automatically-create-and-assign-a-jira-issue).

--- a/content/en/security/identity_risks/_index.md
+++ b/content/en/security/identity_risks/_index.md
@@ -11,9 +11,7 @@ further_reading:
 ---
 
 {{< site-region region="gov" >}}
-<div class="alert alert-warning">
-CSM Identity Risks is not available in this site.
-</div>
+<div class="alert alert-warning">Cloud Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 <div class="alert alert-info">CSM Identity Risks is in beta.</div>

--- a/content/en/security/infrastructure_vulnerabilities/_index.md
+++ b/content/en/security/infrastructure_vulnerabilities/_index.md
@@ -11,9 +11,7 @@ further_reading:
 ---
 
 {{< site-region region="gov" >}}
-<div class="alert alert-warning">
-CSM Vulnerabilities is not available on the US1-FED Datadog site.
-</div>
+<div class="alert alert-warning">Cloud Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 <div class="alert alert-info">CSM Vulnerabilities is in beta.</div>

--- a/content/en/security/misconfigurations/_index.md
+++ b/content/en/security/misconfigurations/_index.md
@@ -10,9 +10,7 @@ algolia:
 ---
 
 {{< site-region region="gov" >}}
-<div class="alert alert-warning">
-CSM Misconfigurations is not available in the selected site.
-</div>
+<div class="alert alert-warning">Cloud Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 Cloud Security Management Misconfigurations (CSM Misconfigurations) makes it easier to assess and visualize the current and historic security posture of your cloud resources, automate audit evidence collection, and remediate misconfigurations that leave your organization vulnerable to attacks. By continuously surfacing security weaknesses resulting from misconfigurations, teams can mitigate risks while ensuring compliance with industry standards.

--- a/content/en/security/threats/_index.md
+++ b/content/en/security/threats/_index.md
@@ -8,6 +8,10 @@ aliases:
   - /security/cloud_workload_security/backend/
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Cloud Security Management is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 Cloud Security Management Threats (CSM Threats) monitors file, network, and process activity across your environment to detect real-time threats to your infrastructure. As part of the Datadog platform, you can combine the real-time threat detection of CSM Threats with metrics, logs, traces, and other telemetry to see the full context surrounding a potential attack on your workloads.
 
 ## Detect threats to your production workloads in real-time

--- a/content/en/security/threats/security_profiles.md
+++ b/content/en/security/threats/security_profiles.md
@@ -12,6 +12,10 @@ further_reading:
     text: "Managing CSM Threats Detection Rules"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Workload Security Profiles are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 Workload Security Profiles provides a baseline of expected workload activity through a behavioral learning model that helps identify potential threats or misconfigurations. This insight can be used when investigating security alerts, including [generating suppression suggestions](#suppress-signals-based-on-suggestions) for known, acceptable workload behavior, as well as identifying previously unseen, anomalous behavior.
 
 ## Compatibility

--- a/content/en/service_management/workflows/_index.md
+++ b/content/en/service_management/workflows/_index.md
@@ -13,6 +13,10 @@ further_reading:
   text: "Automate common security tasks and stay ahead of threats with Datadog Workflows and Cloud SIEM"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Workflow Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 {{< vimeo url="https://player.vimeo.com/progressive_redirect/playback/852419580/rendition/1080p/file.mp4?loc=external&signature=fb7ae8df018e24c9f90954f62ff3217bc1b904b92e600f3d3eb3f5a9d143213e" poster="/images/poster/workflow_automation.png" >}}
 
 Datadog Workflow Automation allows you to orchestrate and automate your end-to-end processes. Build workflows made up of [actions][1] that connect to your infrastructure and tools. These actions can also perform data and logical operations, allowing you to build complex flows with branches, decisions, and data operations.

--- a/content/en/service_management/workflows/access.md
+++ b/content/en/service_management/workflows/access.md
@@ -15,6 +15,10 @@ further_reading:
   text: "See the list of workflow actions"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Workflow Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 A few tools control access and authentication for workflows and their components.
 
 ## Workflow identity

--- a/content/en/service_management/workflows/actions_catalog/_index.md
+++ b/content/en/service_management/workflows/actions_catalog/_index.md
@@ -14,6 +14,10 @@ cascade:
       rank: 40
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Workflow Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 Datadog Workflow Automation provides actions that can be performed against your infrastructure and integrations. You can orchestrate and automate your end-to-end processes by linking together actions that perform tasks in your cloud providers, SaaS tools, and Datadog accounts.
 
 In addition to the workflow actions listed below, you can:

--- a/content/en/service_management/workflows/build.md
+++ b/content/en/service_management/workflows/build.md
@@ -13,6 +13,10 @@ further_reading:
   text: "Automate Security Workflows with Workflow Automation"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Workflow Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 You can create workflows or edit existing workflows from the Workflow Automation [Explore][1] tab. The **Explore** tab lists information about existing workflows, such as the workflow's owner, the trigger type, the dates that each workflow was last modified and executed, and whether the workflow is published or not.
 - Hover over a workflow for the options to delete or clone the workflow.
 - Toggle **My workflows** if you want to see only workflows that you created.

--- a/content/en/service_management/workflows/connections.md
+++ b/content/en/service_management/workflows/connections.md
@@ -8,6 +8,10 @@ aliases:
 disable_toc: false
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Workflow Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 Because workflow actions connect with external software systems, you may need to authenticate your Datadog account to the corresponding integration. A workflow can run successfully only if every workflow action that requires authentication can verify the identity of your Datadog account. When granting permissions to Datadog, ensure that you're following security best practice and only granting the permissions necessary for a workflow to run.
 
 Workflow actions can be authenticated in two ways:

--- a/content/en/service_management/workflows/trigger.md
+++ b/content/en/service_management/workflows/trigger.md
@@ -22,6 +22,10 @@ further_reading:
   text: "Automate Security Workflows with Workflow Automation"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Workflow Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 You can trigger a workflow manually or automatically.
 
 A workflow can either run with the identity of the user who owns it, or with the identity of a service account associated with the workflow. For more information on service accounts, see [Service accounts for Workflow Automation][1].

--- a/content/en/tracing/api_catalog/_index.md
+++ b/content/en/tracing/api_catalog/_index.md
@@ -8,6 +8,10 @@ further_reading:
   text: "Datadog Service Catalog"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Dynamic Instrumentation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 {{< callout url="https://www.datadoghq.com/api-catalog-public-beta-request/" >}}
 API Catalog is in limited availability. Use this form to get early access. 
 {{< /callout >}} 

--- a/content/en/tracing/api_catalog/_index.md
+++ b/content/en/tracing/api_catalog/_index.md
@@ -8,8 +8,8 @@ further_reading:
   text: "Datadog Service Catalog"
 ---
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning">Dynamic Instrumentation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< site-region region="gov,ap1" >}}
+<div class="alert alert-warning">API Catalog is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 {{< callout url="https://www.datadoghq.com/api-catalog-public-beta-request/" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
adds region-specific messaging for integrations pages
note that this PR touches `adobe_experience_manager` and `syslog_ng` integration readmes, both of which live in the docs repo (this one)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->