### PR TITLE
DOCS-5743 - region-specific messaging for integrations

### DIFF
--- a/content/en/integrations/adobe_experience_manager.md
+++ b/content/en/integrations/adobe_experience_manager.md
@@ -26,9 +26,9 @@ further_reading:
 integration_id: "adobe"
 ---
 
-{{% site-region region="us3" %}}
-<div class="alert alert-warning">The Adobe Experience Manager integration is not supported for your selected Datadog site ({{< region-param key="dd_site_name" >}}).</div>
-{{% /site-region %}}
+{{< site-region region="us3,ap1" >}}
+<div class="alert alert-warning">The Adobe Experience Manager integration is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
 
 ## Overview
 

--- a/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
+++ b/content/en/integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose.md
@@ -9,8 +9,8 @@ further_reading:
   tag: "Blog"
   text: "Collect Amazon CloudWatch metrics using Metric Streams"
 ---
-{{% site-region region="us3,us5,gov" %}}
-**The AWS CloudWatch Metric Streams with Kinesis Data Firehose is not supported on this Datadog site.**
+{{% site-region region="us3,gov" %}}
+AWS CloudWatch Metric Streams with Kinesis Data Firehose is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).
 {{% /site-region %}}
  
 Using Amazon CloudWatch Metric Streams and Amazon Kinesis Data Firehose, you can get CloudWatch metrics into Datadog faster with a 2-3 minute latency. This is significantly faster than Datadog's default API polling approach, which provides updated metrics every 10 minutes. You can learn more about the API polling approach in the [Cloud Metric Delay documentation][1].

--- a/content/en/integrations/guide/cloud-metric-delay.md
+++ b/content/en/integrations/guide/cloud-metric-delay.md
@@ -39,8 +39,8 @@ AWS offers two levels of granularity for metrics (5 and 1 minute metrics). If yo
 
 Further, the CloudWatch API only offers a metric-by-metric crawl to pull data. The CloudWatch APIs have a rate limit that varies based on the combination of authentication credentials, region, and service. Metrics are made available by AWS dependent on the account level. For example, if you are paying for *detailed metrics* within AWS, they are available more quickly. This level of service for detailed metrics also applies to granularity, with some metrics being available per minute and others per five minutes.
 
-{{% site-region region="us,eu,ap1" %}}
-If you're using the US1, EU, or AP1 [Datadog site][1], you can optionally configure Amazon CloudWatch Metric Streams and Amazon Kinesis Data Firehose to get CloudWatch metrics into Datadog faster with a 2-3 minute latency. Visit the [documentation on metric streaming][2] to learn more about this approach.
+{{% site-region region="us,us5,eu,ap1" %}}
+On your selected [Datadog site][1] ({{< region-param key="dd_site_name" >}}), you can optionally configure Amazon CloudWatch Metric Streams and Amazon Kinesis Data Firehose to get CloudWatch metrics into Datadog faster with a 2-3 minute latency. Visit the [documentation on metric streaming][2] to learn more about this approach.
 
 [1]: /getting_started/site/
 [2]: /integrations/guide/aws-cloudwatch-metric-streams-with-kinesis-data-firehose/

--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -25,6 +25,10 @@ integration_id: "syslog_ng"
 
 Configure Syslog-ng to gather logs from your host, containers, & services.
 
+{{< site-region region="us3,ap1" >}}
+<div class="alert alert-warning">Log collection for <code>syslog-ng</code> is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 ## Setup
 
 ### Log collection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds region-specific messaging for integrations

NOTE: the `adobe_experience_manager` and `syslog_ng` integration readmes have been updated. both of these integrations live in the docs repo (this one)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->