### PR TITLE
[DOCS-4810] Adjust ignoring based on span tags content

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -37,7 +37,11 @@ You can specify span tags to require or reject by using a list of keys and value
 `DD_APM_FILTER_TAGS_REJECT`
 : Rejects traces that have root spans with an exact match for the specified span tags and values. If it matches this rule, the trace is dropped. For example, `DD_APM_FILTER_TAGS_REJECT="key1:value1 key2:value2"`.
 
-Or you can set them in the Agent configuration with a comma-separated list:
+
+{{< tabs >}}
+{{% tab "datadog.yaml" %}}
+
+Alternatively, you can set them in the Agent configuration with a comma-separated list:
 
 {{< code-block lang="yaml" filename="datadog.yaml" >}}
 apm_config:
@@ -53,6 +57,24 @@ apm_config:
   filter_tags:
     reject: ["http.url:http://localhost:5050/healthcheck"]
 {{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Kubernetes Helm" %}}
+
+In the `traceAgent` section of the `values.yaml` file, add `DD_APM_FILTER_TAGS_REJECT` in the `env` section, then [spin up helm as usual][1]. For multiple tags, separate each key:value with a space.
+
+{{< code-block lang="yaml" filename="values.yaml" >}}
+  traceAgent:
+      # agents.containers.traceAgent.env -- Additional environment variables for the trace-agent container
+      env:
+        - name: DD_APM_FILTER_TAGS_REJECT
+          value: tag_key1:tag_val2 tag_key2:tag_val2
+
+{{< /code-block >}}
+
+[1]: /agent/kubernetes/?tab=helm#installation
+{{% /tab %}}
+{{< /tabs >}}
 
 Filtering traces this way removes these requests from [trace metrics][3]. For more information on how to reduce ingestion without affecting the trace metrics, see [Ingestion Controls][4].
 

--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -64,11 +64,11 @@ apm_config:
 In the `traceAgent` section of the `values.yaml` file, add `DD_APM_FILTER_TAGS_REJECT` in the `env` section, then [spin up helm as usual][1]. For multiple tags, separate each key:value with a space.
 
 {{< code-block lang="yaml" filename="values.yaml" >}}
-  traceAgent:
-      # agents.containers.traceAgent.env -- Additional environment variables for the trace-agent container
-      env:
-        - name: DD_APM_FILTER_TAGS_REJECT
-          value: tag_key1:tag_val2 tag_key2:tag_val2
+traceAgent:
+  # agents.containers.traceAgent.env -- Additional environment variables for the trace-agent container
+    env:
+      - name: DD_APM_FILTER_TAGS_REJECT
+        value: tag_key1:tag_val2 tag_key2:tag_val2
 
 {{< /code-block >}}
 

--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -29,7 +29,7 @@ If you can programmatically identify a set of traces that you know you don't wan
 
 The filter tags option requires an exact string match. If your use case requires ignoring by regex, see [Ignoring based on resources](#ignoring-based-on-resources).
 
-You can specify span tags to require or reject by using a comma-separated list of keys and values in environment variables:
+You can specify span tags to require or reject by using a list of keys and values separated by spaces in environment variables:
 
 `DD_APM_FILTER_TAGS_REQUIRE`
 : Collects only traces that have root spans with an exact match for the specified span tags and values. If it does not match this rule, the trace is dropped. For example, `DD_APM_FILTER_TAGS_REQUIRE="key1:value1 key2:value2"`.
@@ -37,7 +37,7 @@ You can specify span tags to require or reject by using a comma-separated list o
 `DD_APM_FILTER_TAGS_REJECT`
 : Rejects traces that have root spans with an exact match for the specified span tags and values. If it matches this rule, the trace is dropped. For example, `DD_APM_FILTER_TAGS_REJECT="key1:value1 key2:value2"`.
 
-Or you can set them in the Agent configuration file:
+Or you can set them in the Agent configuration with a comma-separated list:
 
 {{< code-block lang="yaml" filename="datadog.yaml" >}}
 apm_config:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
https://datadoghq.atlassian.net/browse/DOCS-4810
* Support noted customer confusion around tag filter syntax.
* Also, there is a lack of Kubernetes Helm examples for ignoring based on span tags.

To resolve:
* Fixed error stating that you can specific span tags to require or reject with a **comma-separated list** in env vars. Tags should be separated by a space, as shown in the example that @ajgajg1134 fixed a few weeks ago (thanks!).
* Added tabs similar to the Ignoring based on resources further down the page. Other than the structure, the only new content is the addition of Kubernetes Helm specific instructions/examples.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->