### PR TITLE
add wrapper to tables in imported libraries

### DIFF
--- a/layouts/multi-code-lang/single.html
+++ b/layouts/multi-code-lang/single.html
@@ -16,9 +16,9 @@
             {{ partial "breadcrumbs.html" . }}
         </div>
     </div>
-    
+
     {{ partial "translate_status_banner/translate_status_banner.html" . }}
 
-    <div>{{ .Content }}</div>
+    <div>{{ replaceRE `<\/table>` "</table></div>" (replaceRE `(<table>)` "<div class='table-wrapper'><table>" .Content) | safeHTML }}</div>
 
 {{ end }}

--- a/layouts/multi-code-lang/single.html
+++ b/layouts/multi-code-lang/single.html
@@ -19,6 +19,8 @@
 
     {{ partial "translate_status_banner/translate_status_banner.html" . }}
 
+    {{/* Add `table-wrapper` div to tables in imported markdown to fix overflow issues */}}
+      
     <div>{{ replaceRE `<\/table>` "</table></div>" (replaceRE `(<table>)` "<div class='table-wrapper'><table>" .Content) | safeHTML }}</div>
 
 {{ end }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Certain types of imported content had tables that were too wide for the page, and the nature of the generated markdown meant that they didn’t get wrapped in the div necessary to make the tables side-scroll: https://datadoghq.atlassian.net/browse/WEB-4102

It seemed appropriate to me to try to resolve this at build time instead of using front-end scripting, so I used regex on the appropriate template to add in the wrapping div.

https://docs-staging.datadoghq.com/fitzage/table-fix/tracing/trace_collection/dd_libraries/ruby/#grpc

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->