### PR TITLE
Use generic hosts in examples

### DIFF
--- a/layouts/shortcodes/dbm-postgres-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-postgres-agent-config-examples.md
@@ -5,32 +5,32 @@ In these cases, Datadog recommends limiting the number of instances per Agent to
 init_config:
 instances:
   - dbm: true
-    host: products-primary.123456789012.us-east-1.rds.amazonaws.com
+    host: example-service-primary.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
-      - 'service:product-recommendation'
+      - 'service:example-service'
   - dbm: true
-    host: products–replica-1.us-east-1.rds.amazonaws.com
+    host: example-service–replica-1.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
-      - 'service:product-recommendation'
+      - 'service:example-service'
   - dbm: true
-    host: products–replica-2.us-east-1.rds.amazonaws.com
+    host: example-service–replica-2.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
-      - 'service:product-recommendation'
+      - 'service:example-service'
     [...]
 ```
 
@@ -83,17 +83,17 @@ instances:
   # This instance is the "DBM" instance. It will connect to the
   # `postgres` database and send DBM telemetry from all databases
   - dbm: true
-    host: products-primary.123456789012.us-east-1.rds.amazonaws.com
+    host: example-service.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'
-  # This instance only collects data from the `on_sale` database
+  # This instance only collects data from the `users` database
   # and collects relation metrics from tables prefixed by "2022_"
-  - host: products-primary.123456789012.us-east-1.rds.amazonaws.com
+  - host: example-service.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'
-    dbname: on_sale
+    dbname: users
     dbstrict: true
     relations:
       - relation_regex: 2022_.*
@@ -102,7 +102,7 @@ instances:
           - i
   # This instance only collects data from the `inventory` database
   # and collects relation metrics only from the specified tables
-  - host: products-primary.123456789012.us-east-1.rds.amazonaws.com
+  - host: example-service.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'
@@ -123,11 +123,11 @@ instances:
     port: 5000
     username: datadog
     password: '<PASSWORD>'
-    reported_hostname: products-primary
+    reported_hostname: example-service-primary
   - dbm: true
     host: localhost
     port: 5001
     username: datadog
     password: '<PASSWORD>'
-    reported_hostname: products-replica-1
+    reported_hostname: example-service-replica-1
 ```

--- a/layouts/shortcodes/dbm-postgres-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-postgres-agent-config-examples.md
@@ -76,20 +76,20 @@ instances:
 ### Monitoring relation metrics for multiple logical databases
 In order to collect relation metrics (such as `postgresql.seq_scans`, `postgresql.dead_rows`, `postgresql.index_rows_read`, and `postgresql.table_size`), the Agent must be configured to connect to each logical database (by default, the Agent only connects to the `postgres` database).
 
-Specify a single "DBM" instance to collect DBM telemetry from all databases. Additionally, specify all logical databases the Agent must connect to. It is important to only have `dbm: true` on one configuration instance per host in order to prevent duplication of metrics.
+Specify a single "DBM" instance to collect DBM telemetry from all databases. Additionally, specify all logical databases the Agent must connect to. It is important to only have `dbm: true` on one configuration instance per host to prevent duplication of metrics.
 ```yaml
 init_config:
 instances:
   # This instance is the "DBM" instance. It will connect to the
   # `postgres` database and send DBM telemetry from all databases
   - dbm: true
-    host: example-service.example-host.com
+    host: example-service-primary.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'
   # This instance only collects data from the `users` database
   # and collects relation metrics from tables prefixed by "2022_"
-  - host: example-service.example-host.com
+  - host: example-service-primary.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'
@@ -102,7 +102,7 @@ instances:
           - i
   # This instance only collects data from the `inventory` database
   # and collects relation metrics only from the specified tables
-  - host: example-service.example-host.com
+  - host: example-service-primary.example-host.com
     port: 5432
     username: datadog
     password: '<PASSWORD>'

--- a/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
@@ -47,7 +47,7 @@ In these cases, Datadog recommends limiting the number of instances per Agent to
 init_config:
 instances:
   - dbm: true
-    host: 'products-primary.123456789012.us-east-1.rds.amazonaws.com,1433'
+    host: 'example-service-primary.example-host.com,1433'
     username: datadog
     connector: adodbapi
     adoprovider: MSOLEDBSQL
@@ -55,9 +55,9 @@ instances:
     tags:
       - 'env:prod'
       - 'team:team-discovery'
-      - 'service:product-recommendation'
+      - 'service:example-service'
   - dbm: true
-    host: 'products–replica-1.us-east-1.rds.amazonaws.com,1433'
+    host: 'example-service–replica-1.example-host.com,1433'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     username: datadog
@@ -65,9 +65,9 @@ instances:
     tags:
       - 'env:prod'
       - 'team:team-discovery'
-      - 'service:product-recommendation'
+      - 'service:example-service'
   - dbm: true
-    host: 'products–replica-2.us-east-1.rds.amazonaws.com,1433'
+    host: 'example-service–replica-2.example-host.com,1433'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     username: datadog
@@ -75,7 +75,7 @@ instances:
     tags:
       - 'env:prod'
       - 'team:team-discovery'
-      - 'service:product-recommendation'
+      - 'service:example-service'
     [...]
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
DOCS-6314
Use more generic hosts in examples, since the example configs are used across RDS, AWS, etc. setup guides.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->