### PR TITLE
ET count monitors on APM work only w/ retention filters

### DIFF
--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -61,6 +61,8 @@ Select **Web and Mobile Apps** from the dropdown menu. If you select **Backend S
 2. Construct a search query using the same logic as a [RUM Explorer search][1], [APM Explorer search][3], or [Log Explorer search][4] for the issues' error occurrences.
 3. Optionally, configure the alerting grouping strategy. For more information, see [Monitor Configuration][2].
 
+<div class="alert alert-info"><strong>Note</strong>: **Count** monitors for APM can only be created based on spans retained by [custom retention filters][6] (not the intelligent retention filter).</div>
+
 ### Set alert conditions
 
 Triggers when the error count is `above` or `above or equal to`. An alert is triggered whenever a metric crosses a threshold.
@@ -95,6 +97,7 @@ The monitor triggers when the number of errors is `above` or `above or equal to`
 [3]: /tracing/trace_explorer/?tab=listview#filtering
 [4]: /monitors/configuration/#alert-grouping/
 [5]: /logs/explorer/search/
+[6]: /tracing/trace_pipeline/trace_retention/#create-your-own-retention-filter
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -97,7 +97,6 @@ The monitor triggers when the number of errors is `above` or `above or equal to`
 [3]: /tracing/trace_explorer/?tab=listview#filtering
 [4]: /monitors/configuration/#alert-grouping/
 [5]: /logs/explorer/search/
-[6]: /tracing/trace_pipeline/trace_retention/#create-your-own-retention-filter
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -61,7 +61,7 @@ Select **Web and Mobile Apps** from the dropdown menu. If you select **Backend S
 2. Construct a search query using the same logic as a [RUM Explorer search][1], [APM Explorer search][3], or [Log Explorer search][4] for the issues' error occurrences.
 3. Optionally, configure the alerting grouping strategy. For more information, see [Monitor Configuration][2].
 
-<div class="alert alert-info"><strong>Note</strong>: **Count** monitors for APM can only be created based on spans retained by [custom retention filters][6] (not the intelligent retention filter).</div>
+<div class="alert alert-info"><strong>Note</strong>: Count monitors for APM can only be created based on spans retained by <a href="/tracing/trace_pipeline/trace_retention/#create-your-own-retention-filter/">custom retention filters</a> (not the intelligent retention filter).</div>
 
 ### Set alert conditions
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Add a note clarifying that Error Tracking "count" monitors on APM spans only work for spans retained by custom retention filters. Basically the same note as https://docs.datadoghq.com/monitors/types/apm/?tab=traceanalytics#monitor-creation but for Error Tracking monitors.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing