### PR TITLE
Remove beta mention from Heroku

### DIFF
--- a/content/en/logs/guide/collect-heroku-logs.md
+++ b/content/en/logs/guide/collect-heroku-logs.md
@@ -3,8 +3,6 @@ title: Collect Heroku logs
 kind: guide
 ---
 
-**This log integration is currently in public beta**
-
 Heroku provides 3 types of logs:
 
 * `App Logs`: output from the application you pushed on the platform.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Remove a mention on a log guide for Heroku integration. This integration has been available for a while, and this mention should not be present anymore.

### Merge instructions
- [x] Please merge after reviewing