### PR TITLE
Add incident management tile to the docs landing page

### DIFF
--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -96,6 +96,10 @@ nav_sections:
         link: mobile/
         icon: mobile
         desc: View Datadog alerts, incidents, and more on your mobile device
+      - title: Incident Management
+        link: service_management/incident_management
+        icon: incidents
+        desc: Identify, analyze, and mitigate disruptive incidents in your organization
       - title: Datadog Watchdog
         link: watchdog/
         icon: watchdog


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add incident management tile to the docs landing page, this was requested by the PM
[DOCS-6307](https://datadoghq.atlassian.net/browse/DOCS-6307)

<img width="544" alt="Datadog Docs 2023-09-29 at 10 33 26 AM" src="https://github.com/DataDog/documentation/assets/41168354/b3092d0a-3ad8-4b0b-a418-f9c30ef1c66d">

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing


[DOCS-6307]: https://datadoghq.atlassian.net/browse/DOCS-6307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ