### PR TITLE
[DOCS-2071] Clarify context passing for Go

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -113,7 +113,7 @@ span.Finish(tracer.WithError(err))
 If you aren't using supported library instrumentation (see [Library compatibility][3]), you may want to to manually instrument your code.
 
 <div class="alert alert-info">
-Unlike other Datadog tracing libraries, when tracing Go applications, you need to explicitly manage and pass the context of your spans. For more information, see the [Go context library documentation][12] or documentation for any third-party libraries integrated with your application.
+Unlike other Datadog tracing libraries, when tracing Go applications, you need to explicitly manage and pass the context of your spans. For more information, see the <a href="https://pkg.go.dev/context">Go context library documentation</a> or documentation for any third-party libraries integrated with your application.
 </div>
 
 ### Manually creating a new span
@@ -223,4 +223,3 @@ Traces can be excluded based on their resource name, to remove synthetic traffic
 [7]: /tracing/glossary/#trace
 [9]: /tracing/security
 [11]: /tracing/trace_collection/trace_context_propagation/go/
-[12]: https://pkg.go.dev/context

--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -113,7 +113,7 @@ span.Finish(tracer.WithError(err))
 If you aren't using supported library instrumentation (see [Library compatibility][3]), you may want to to manually instrument your code.
 
 <div class="alert alert-info">
-Unlike other Datadog tracing libraries, when tracing Go applications, you need to explicitly manage and pass the context of your spans. For more information, see the <a href="https://pkg.go.dev/context">Go context library documentation</a> or documentation for any third-party libraries integrated with your application.
+Unlike other Datadog tracing libraries, when tracing Go applications, it's recommended that you explicitly manage and pass the Go context of your spans. This approach ensures accurate span relationships and meaningful tracing. For more information, see the <a href="https://pkg.go.dev/context">Go context library documentation</a> or documentation for any third-party libraries integrated with your application.
 </div>
 
 ### Manually creating a new span

--- a/content/en/tracing/trace_collection/custom_instrumentation/go.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go.md
@@ -112,6 +112,10 @@ span.Finish(tracer.WithError(err))
 
 If you aren't using supported library instrumentation (see [Library compatibility][3]), you may want to to manually instrument your code.
 
+<div class="alert alert-info">
+Unlike other Datadog tracing libraries, when tracing Go applications, you need to explicitly manage and pass the context of your spans. For more information, see the [Go context library documentation][12] or documentation for any third-party libraries integrated with your application.
+</div>
+
 ### Manually creating a new span
 
 To make use of manual instrumentation, use the `tracer` package which is documented on Datadog's [godoc page][4]:
@@ -219,3 +223,4 @@ Traces can be excluded based on their resource name, to remove synthetic traffic
 [7]: /tracing/glossary/#trace
 [9]: /tracing/security
 [11]: /tracing/trace_collection/trace_context_propagation/go/
+[12]: https://pkg.go.dev/context


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
https://datadoghq.atlassian.net/browse/DOCS-2071
* The Go tracing library is unique in that users need to manage and pass span context manually.
* Added a note to the _Adding spans_ to make sure users are aware before they dive into the docs that follow.
* Linked to Go context library docs.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->