### PR TITLE
Fix mistake in subtitle on /real_user_monitoring/error_tracking

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -40,7 +40,7 @@ Error Tracking enables you to:
 - Follow issues over time to know when they first started, if they are still ongoing, and how often they are occurring.
 - Collect all the necessary context in one place to facilitate troubleshooting.
 
-## Upload crash reports
+## Upload source maps
 
 {{< whatsnext desc="To get started with Datadog Error Tracking for RUM, see the corresponding documentation to upload source maps for your framework:" >}}
     {{< nextlink href="real_user_monitoring/error_tracking/browser" >}}Browser{{< /nextlink >}}

--- a/content/en/real_user_monitoring/error_tracking/_index.md
+++ b/content/en/real_user_monitoring/error_tracking/_index.md
@@ -31,7 +31,7 @@ It is critical for your system's health to consistently monitor the errors colle
 
 {{< img src="real_user_monitoring/error_tracking/rum_error_tracking.png" alt="The Error Tracking Explorer for RUM displaying issues from your web and mobile applications' crash reports" style="width:100%;" >}}
 
-Once you have set up [RUM][2] for **Web and Mobile Apps** error tracking, the issue list populates with cards. Navigate to [**UX Monitoring** > **Error Tracking**][3] to view open, ignored, or all issues, sort issues by volume or age, and filter issues by all custom and default facets on your web and mobile applications.
+Once you have set up [RUM][2] for **Web and Mobile Apps** error tracking, the issue list populates with cards. Navigate to [**UX Monitoring** > **Error Tracking**][1] to view open, ignored, or all issues, sort issues by volume or age, and filter issues by all custom and default facets on your web and mobile applications.
 
 Error Tracking enables you to:
 
@@ -65,4 +65,3 @@ Click on an issue to view debugging information, such as the stack trace, user s
 
 [1]: https://app.datadoghq.com/rum/error-tracking
 [2]: /real_user_monitoring/
-[3]: https://app.datadoghq.com/rum/error-tracking


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

I believe there is a mistake in a sub-title on the [`/real_user_monitoring/error_tracking`](https://docs.datadoghq.com/real_user_monitoring/error_tracking/#upload-crash-reports) page

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

None