### PR TITLE
[ACCESS-1903] Add UAI mention to dashboards public docs under permissions

### DIFF
--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -187,7 +187,7 @@ If the dashboard was created with the deprecated "read only" setting, the access
 
 If you manage your dashboards with Terraform, you can use the latest version of the Datadog Terraform provider to control which roles can edit your dashboards. For more information, see the [Terraform Dashboard role restriction guide][16].
 
-The access indicator appears at the top right of each edit-restricted dashboard. Depending on your permissions, it may say **Gain Edit Access** or **Request Edit Access**. Click on the access indicator to understand your access permissions and what steps to take to edit the dashboard.
+The access indicator appears at the top right of each edit-restricted dashboard. Depending on your permissions, it may say **Gain Edit Access** or **Request Edit Access**. Click the access indicator to understand your access permissions and what steps to take to edit the dashboard.
 
 **Note:** View restrictions on individual dashboards are available to anyone on an Enterprise tier plan. Reach out to your account team or [Datadog support][17] to enable this feature. 
 

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -187,6 +187,8 @@ If the dashboard was created with the deprecated "read only" setting, the access
 
 If you manage your dashboards with Terraform, you can use the latest version of the Datadog Terraform provider to control which roles can edit your dashboards. For more information, see the [Terraform Dashboard role restriction guide][16].
 
+To understand your access permissions on a dashboard and learn how to become an editor, see the access indicator in the header. 
+
 **Note:** View restrictions on individual dashboards are available to anyone on an Enterprise tier plan. Reach out to your account team or [Datadog support][17] to enable this feature. 
 
 #### High-density mode

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -187,7 +187,7 @@ If the dashboard was created with the deprecated "read only" setting, the access
 
 If you manage your dashboards with Terraform, you can use the latest version of the Datadog Terraform provider to control which roles can edit your dashboards. For more information, see the [Terraform Dashboard role restriction guide][16].
 
-The access indicator appears at the top right of each edit-restricted dashboard. Depending on your permissions, it may say **Gain Edit Access** or **Request Edit Access**. Hover over the access indicator to understand your access permissions and what steps to take to edit the dashboard.
+The access indicator appears at the top right of each edit-restricted dashboard. Depending on your permissions, it may say **Gain Edit Access** or **Request Edit Access**. Click on the access indicator to understand your access permissions and what steps to take to edit the dashboard.
 
 **Note:** View restrictions on individual dashboards are available to anyone on an Enterprise tier plan. Reach out to your account team or [Datadog support][17] to enable this feature. 
 

--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -187,7 +187,7 @@ If the dashboard was created with the deprecated "read only" setting, the access
 
 If you manage your dashboards with Terraform, you can use the latest version of the Datadog Terraform provider to control which roles can edit your dashboards. For more information, see the [Terraform Dashboard role restriction guide][16].
 
-To understand your access permissions on a dashboard and learn how to become an editor, see the access indicator in the header. 
+The access indicator appears at the top right of each edit-restricted dashboard. Depending on your permissions, it may say **Gain Edit Access** or **Request Edit Access**. Hover over the access indicator to understand your access permissions and what steps to take to edit the dashboard.
 
 **Note:** View restrictions on individual dashboards are available to anyone on an Enterprise tier plan. Reach out to your account team or [Datadog support][17] to enable this feature. 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Mentions the Universal Access Indicator feature which is a header change on dashboards that tells you if you're a viewer, how you can get edit access (if you're missing the capability and/or granular permission)

We're ready to GA this whenever the public docs are ready to be merged! (So probably in a few days)

My main question is for @urseberry , if my change makes sense? (I thought creating a different section, not under Permissions might be too much? I also thought about adding a single screenshot but thought that might be too much.)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->