### PR TITLE
AWS lambda: clarifying source type per transifex feedback

### DIFF
--- a/content/en/serverless/aws_lambda/configuration.md
+++ b/content/en/serverless/aws_lambda/configuration.md
@@ -360,7 +360,7 @@ This guide explains how to rename both upstream and downstream services in Datad
 
 | Source Type | Service | Identifier | DD_SERVICE_MAPPING Value |
 |---|---|---|---|
-| General | API Gateway | `lambda_api_gateway` | `"lambda_api_gateway:newServiceName"` |
+| General Identifiers| API Gateway | `lambda_api_gateway` | `"lambda_api_gateway:newServiceName"` |
 | | SNS | `lambda_sns` | `"lambda_sns:newServiceName"` |
 | | SQS | `lambda_sqs` | `"lambda_sqs:newServiceName"` |
 | | S3 | `lambda_s3` | `"lambda_s3:newServiceName"` |
@@ -368,7 +368,7 @@ This guide explains how to rename both upstream and downstream services in Datad
 | | Kinesis | `lambda_kinesis` | `"lambda_kinesis:newServiceName"` |
 | | DynamoDB | `lambda_dynamodb` | `"lambda_dynamodb:newServiceName"` |
 | | Lambda URLs | `lambda_url` | `"lambda_url:newServiceName"` |
-| Specific | API Gateway | API ID | `"r3pmxmplak:newServiceName"` |
+| Specific Identifiers | API Gateway | API ID | `"r3pmxmplak:newServiceName"` |
 | | SNS | Topic name | `"ExampleTopic:newServiceName"` |
 | | SQS | Queue name | `"MyQueue:newServiceName"` |
 | | S3 | Bucket name | `"example-bucket:newServiceName"` |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds the word identifiers to the source type column in the table here:
https://docs.datadoghq.com/serverless/aws_lambda/configuration/?tab=datadogcli#rename-upstream-service-names

This came from feedback from transifex where it was causing confusion in our Japanese translated pages.

From the SME:
```
General is meant to be “General Identifiers” and Specific is meant to be “Specific Identifiers”. For instance if the call always goes through the "xyz" gateway before reaching the downstream service, this would be better to use instead of the lambda_api_gateway key
```

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->