### PR TITLE
Use remoteConfiguration.enabled

### DIFF
--- a/content/en/agent/remote_config/_index.md
+++ b/content/en/agent/remote_config/_index.md
@@ -141,8 +141,8 @@ Add the following to your Helm chart, specifying the API key that has Remote Con
 ```yaml
 datadog:
   apiKey: xxx
-  remoteConfiguration:
-    enabled: true
+remoteConfiguration:
+  enabled: true
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
Use `remoteConfiguration.enabled` instead of `datadog.remoteConfiguration.enabled` as it's prefered. 
See: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L1958C1-L1962C16