### PR TITLE
update python tracer documentation for its 2.0.0 release

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -47,22 +47,22 @@ The `ddtrace` library includes support for a number of web frameworks, including
 
 | Framework                 | Supported Version | Automatic | Library Documentation                                              |
 | ------------------------- | ----------------- | --------- |------------------------------------------------------------------ |
-| [asgi][3]                 | >= 3.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#asgi    |
-| [aiohttp][4] (client)     | >= 3.7            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
-| [aiohttp][4] (server)     | >= 3.7            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
-| [Bottle][5]               | >= 0.12           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#bottle  |
-| [CherryPy][6]             | >= 17.0           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#cherrypy|
-| [Django][7]               | >= 3.2            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
-| [djangorestframework][7]  | >= 3.11           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
-| [Falcon][8]               | >= 3.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#falcon  |
-| [Flask][9]                | >= 1.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask   |
-| [FastAPI][10]             | >= 0.64           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#fastapi |
+| [asgi][3]                 | >= 2.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#asgi    |
+| [aiohttp][4] (client)     | >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
+| [aiohttp][4] (server)     | >= 2.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
+| [Bottle][5]               | >= 0.11           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#bottle  |
+| [CherryPy][6]             | >= 11.2.0         | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#cherrypy|
+| [Django][7]               | >= 1.8            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
+| [djangorestframework][7]  | >= 3.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
+| [Falcon][8]               | >= 1.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#falcon  |
+| [Flask][9]                | >= 0.10           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask   |
+| [FastAPI][10]             | >= 0.51           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#fastapi |
 | [Gunicorn][61]            | >= 20.0.04        | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gunicorn |
-| [Molten][11]              | >= 1.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#molten  |
-| [Pyramid][13]             | >= 1.10           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyramid |
-| [Sanic][15]               | >= 20.12.0        | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sanic   |
-| [Starlette][16]           | >= 0.14.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#starlette |
-| [Tornado][17]             | >= 5.1            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#tornado |
+| [Molten][11]              | >= 0.7.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#molten  |
+| [Pyramid][13]             | >= 1.7            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyramid |
+| [Sanic][15]               | >= 19.6.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sanic   |
+| [Starlette][16]           | >= 0.13.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#starlette |
+| [Tornado][17]             | >= 4.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#tornado |
 | [wsgi][76]                | Fully Supported   | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#wsgi |
 
 
@@ -73,32 +73,33 @@ The `ddtrace` library includes support for the following data stores:
 
 | Datastore                         | Supported Version | Automatic |  Library Documentation                                                                         |
 | ----------------------------      | ----------------- | --------- | --------------------------------------------------------------------------------------------- |
-| [algoliasearch][18]               | >= 2.5.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#algoliasearch                       |
-| [asyncpg][19]                     | >= 0.22.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#asyncpg                             |
-| [Cassandra][20]                   | >= 3.24           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#cassandra                           |
-| [Elasticsearch][21]               | >= 1.10, < 8.0    | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#elasticsearch                       |
-| [Flask Cache][22]                 | >= 0.13           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask-cache                         |
+| [algoliasearch][18]               | >= 1.20.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#algoliasearch                       |
+| [asyncpg][19]                     | >= 0.18.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#asyncpg                             |
+| [Cassandra][20]                   | >= 3.5            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#cassandra                           |
+| [Elasticsearch][21]               | >= 1.6, < 8.0     | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#elasticsearch                       |
+| [Flask Cache][22]                 | >= 0.12           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask-cache                         |
 | [Kafka][64] [confluent-kafka][65] | >= 1.9.2          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#kafka|
 | [Mariadb][23]                     | >= 1.0.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mariadb                             |
-| [Memcached][24] [pylibmc][25]     | >= 1.6.2          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pylibmc                             |
-| [Memcached][24] [pymemcache][26]  | >= 3.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymemcache                          |
-| [MongoDB][27] [Mongoengine][28]   | >= 0.23           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mongoengine                         |
-| [MongoDB][27] [Pymongo][29]       | >= 3.12.3         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymongo                             |
+| [Memcached][24] [pylibmc][25]     | >= 1.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pylibmc                             |
+| [Memcached][24] [pymemcache][26]  | >= 1.3            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymemcache                          |
+| [MongoDB][27] [Mongoengine][28]   | >= 0.11           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mongoengine                         |
+| [MongoDB][27] [Pymongo][29]       | >= 3.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymongo                             |
 | [MySQL][30] [MySQL-python][31]    | >= 1.2.3          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][30] [mysqlclient][32]     | >= 1.3            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.mysqldb
 | [MySQL][30] [aiomysql][66]        | >= 0.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiomysql |
-| [MySQL][30] [mysql-connector][33] | >= 8.0.5          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mysql-connector                     |
-| [Postgres][34] [aiopg][35]        | >= 0.16.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiopg                               |
-| [Postgres][34] [psycopg][36]      | >= 2.8            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.psycopg      |
-| [PyMySQL][37]                     | >= 1.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html?highlight=pymysql#pymysql |
-| [PynamoDB][38]                    | >= 5.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pynamodb |
-| [PyODBC][39]                      | >= 4.0.31         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyodbc                               |
-| [Redis][40]                       | >= 4.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#redis                               |
-| [Redis][40] [redis-py-cluster][41]| >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.rediscluster |
+| [MySQL][30] [mysql-connector][33] | >= 2.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mysql-connector                     |
+| [Postgres][34] [aiopg][35]        | >= 0.12.0, <= 0.16| yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiopg                               |
+| [Postgres][34] [psycopg][36]      | >= 2.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.psycopg      |
+| [PyMySQL][37]                     | >= 0.7            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html?highlight=pymysql#pymysql |
+| [PynamoDB][38]                    | >= 4.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pynamodb |
+| [PyODBC][39]                      | >= 4.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyodbc                               |
+| [Redis][40]                       | >= 2.6            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#redis                               |
+| [Redis][40] [redis-py-cluster][41]| >= 1.3.5          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.rediscluster |
 | [Redis][40] [aioredis][67]        | >= 1.3            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|aioredis
 | [Redis][40] [aredis][68]          | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|aredis
 | [Redis][40] [yaaredis][77]        | >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|yaaredis
-| [snowflake-connector-python][62]  | >= 2.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#snowflake
-| [SQLAlchemy][42]                  | >= 1.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlalchemy                          |
+| [snowflake-connector-python][62]  | >= 2.1            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#snowflake
+| [SQLAlchemy][42]                  | >= 1.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlalchemy                          |
 | [SQLite3][43]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlite                              |
 | [Vertica][44]                     | >= 0.6            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#vertica                             |
 
@@ -108,30 +109,31 @@ The `ddtrace` library includes support for the following libraries:
 
 | Library                           | Supported Version |  Automatic       | Library Documentation                                                    |
 | -----------------                 | ----------------- | ---------------- | ------------------------------------------------------------------------ |
-| [aiobotocore][45]                 | >= 1.4.2          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiobotocore |
+| [aiobotocore][45]                 | >= 0.2.3          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiobotocore |
 | [asyncio][46]                     | Fully Supported   | > Python 3.7 yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#asyncio     |
-| [Botocore][47]                    | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#botocore    |
-| [Celery][49]                      | >= 4.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#celery      |
-| [Consul][50]                      | >= 1.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#consul      |
+| [Botocore][47]                    | >= 1.4.51         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#botocore    |
+| [Boto2][48]                       | >= 2.29.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#boto2       |
+| [Celery][49]                      | >= 3.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#celery      |
+| [Consul][50]                      | >= 0.7            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#consul      |
 | [dogpile.cache][69]               | >= 0.9            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#dogpile-cache      |
 | [Futures][51]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#futures     |
-| [gevent][52]                      | >= 1.5            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gevent      |
+| [gevent][52]                      | >= 1.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gevent      |
 | [graphene][70]                    | >= 3.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphene        |
-| [graphql-core][60]                | >= 3.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql |
-| [Grpc][53]                        | >= 1.34           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#grpc        |
+| [graphql-core][60]                | >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql |
+| [Grpc][53]                        | >= 1.8.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#grpc        |
 | [httplib][54]                     | Fully Supported   | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#httplib     |
 | [httpx][71]                       | >= 0.17           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#httpx     |
-| [Jinja2][55]                      | >= 2.11           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#jinja2      |
+| [Jinja2][55]                      | >= 2.7            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#jinja2      |
 | [Jinja2][55] [aiohttp-jinja2][63] | >= 1.5            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp-jinja2      |
-| [Kombu][56]                       | >= 4.2            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#kombu       |
+| [Kombu][56]                       | >= 4.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#kombu       |
 | [langchain][72]                   | >= 0.0.192        | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#langchain       |
-| [Mako][57]                        | >= 1.1.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mako        |
+| [Mako][57]                        | >= 0.1.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mako        |
 | [OpenAI][73]                      | >= 0.26.5         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#openai        |
 | [opensearch-py][74]               | >= 1.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#opensearch-py        |
-| [Requests][58]                    | >= 2.20           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#requests    |
+| [Requests][58]                    | >= 2.08           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#requests    |
 | [rq][75]                          | >= 1.8            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#requests    |
-| [urllib3][59]                     | >= 1.25.8         | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#urllib3     |
-| [pytest][14]                      | >= 6.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pytest  |
+| [urllib3][59]                     | >= 1.22           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#urllib3     |
+| [pytest][14]                      | >= 3.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pytest  |
 
 ## Further Reading
 
@@ -169,6 +171,7 @@ The `ddtrace` library includes support for the following libraries:
 [29]: https://api.mongodb.com/python/current
 [30]: https://www.mysql.com
 [31]: https://pypi.org/project/MySQL-python
+[32]: https://pypi.org/project/mysqlclient
 [33]: https://dev.mysql.com/doc/connector-python/en/
 [34]: https://www.postgresql.org
 [35]: https://aiopg.readthedocs.io

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -114,6 +114,7 @@ The `ddtrace` library includes support for the following libraries:
 | [dogpile.cache][69]               | >= 0.9            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#dogpile-cache      |
 | [Futures][51]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#futures     |
 | [gevent][52]                      | >= 1.5            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gevent      |
+| [graphene][70]                    | >= 3.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphene        |
 | [Grpc][53]                        | >= 1.34           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#grpc        |
 | [httplib][54]                     | Fully Supported   | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#httplib     |
 | [Jinja2][55]                      | >= 2.11           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#jinja2      |
@@ -199,3 +200,4 @@ The `ddtrace` library includes support for the following libraries:
 [67]: https://pypi.org/project/aioredis/
 [68]: https://pypi.org/project/aredis/
 [69]: https://pypi.org/project/dogpile.cache/
+[70]: https://pypi.org/project/graphene/

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -41,8 +41,11 @@ The library supports the following runtimes:
 
 To request support for additional libraries, contact our awesome [support team][2].
 
-### Web framework compatibility
+This document describes the minimum supported version of each library across all of the major-version release lines.
+For more specific information on the library version support of a particular ddtrace version, consult the
+[library documentation][78] and select the version you're interested in.
 
+### Web framework compatibility
 The `ddtrace` library includes support for a number of web frameworks, including:
 
 | Framework                 | Supported Version | Automatic | Library Documentation                                              |
@@ -217,3 +220,4 @@ The `ddtrace` library includes support for the following libraries:
 [75]: https://pypi.org/project/rq/
 [76]: https://wsgi.readthedocs.io/en/latest/what.html
 [77]: https://pypi.org/project/yaaredis/
+[78]: https://ddtrace.readthedocs.io/en/stable/#supported-libraries

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -111,6 +111,7 @@ The `ddtrace` library includes support for the following libraries:
 | [Botocore][47]                    | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#botocore    |
 | [Celery][49]                      | >= 4.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#celery      |
 | [Consul][50]                      | >= 1.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#consul      |
+| [dogpile.cache][69]               | >= 0.9            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#dogpile-cache      |
 | [Futures][51]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#futures     |
 | [gevent][52]                      | >= 1.5            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gevent      |
 | [Grpc][53]                        | >= 1.34           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#grpc        |
@@ -197,3 +198,4 @@ The `ddtrace` library includes support for the following libraries:
 [66]: https://pypi.org/project/aiomysql/
 [67]: https://pypi.org/project/aioredis/
 [68]: https://pypi.org/project/aredis/
+[69]: https://pypi.org/project/dogpile.cache/

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -22,7 +22,8 @@ Two release branches are supported:
 
 | Release    | Support level        |
 |------------|----------------------|
-| `<2`       | Maintenance           |
+| `<1`       | End of Life          |
+| `<2`       | Maintenance          |
 | `>=2.0,<3` | General Availability |
 
 And the library supports the following runtimes:
@@ -30,8 +31,11 @@ And the library supports the following runtimes:
 | OS      | CPU                   | Runtime | Runtime version | Support ddtrace versions |
 |---------|-----------------------|---------|-----------------|--------------------------|
 | Linux   | x86-64, i686, AArch64 | CPython | 3.7-3.12        | `<3`                     |
+| Linux   | x86-64, i686, AArch64 | CPython | 2.7-3.6         | `<2`                     |
 | MacOS   | Intel, Apple Silicon  | CPython | 3.7-3.12        | `<3`                     |
+| MacOS   | Intel, Apple Silicon  | CPython | 2.7-3.6         | `<2`                     |
 | Windows | 64bit, 32bit          | CPython | 3.7-3.12        | `<3`                     |
+| Windows | 64bit, 32bit          | CPython | 2.7-3.6         | `<2`                     |
 
 ## Integrations
 

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -93,6 +93,7 @@ The `ddtrace` library includes support for the following data stores:
 | [PyODBC][39]                      | >= 4.0.31         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyodbc                               |
 | [Redis][40]                       | >= 4.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#redis                               |
 | [Redis][40] [redis-py-cluster][41]| >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.rediscluster |
+| [Redis][40] [aioredis][67]        | >= 1.3            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|aioredis
 | [snowflake-connector-python][62]  | >= 2.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#snowflake
 | [SQLAlchemy][42]                  | >= 1.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlalchemy                          |
 | [SQLite3][43]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlite                              |
@@ -193,3 +194,4 @@ The `ddtrace` library includes support for the following libraries:
 [64]: https://kafka.apache.org/
 [65]: https://pypi.org/project/confluent-kafka/
 [66]: https://pypi.org/project/aiomysql/
+[67]: https://pypi.org/project/aioredis/

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -63,6 +63,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | [Sanic][15]               | >= 20.12.0        | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sanic   |
 | [Starlette][16]           | >= 0.14.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#starlette |
 | [Tornado][17]             | >= 5.1            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#tornado |
+| [wsgi][76]                | Fully Supported   | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#wsgi |
 
 
 
@@ -95,6 +96,7 @@ The `ddtrace` library includes support for the following data stores:
 | [Redis][40] [redis-py-cluster][41]| >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.rediscluster |
 | [Redis][40] [aioredis][67]        | >= 1.3            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|aioredis
 | [Redis][40] [aredis][68]          | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|aredis
+| [Redis][40] [yaaredis][77]        | >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|yaaredis
 | [snowflake-connector-python][62]  | >= 2.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#snowflake
 | [SQLAlchemy][42]                  | >= 1.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlalchemy                          |
 | [SQLite3][43]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlite                              |
@@ -115,15 +117,20 @@ The `ddtrace` library includes support for the following libraries:
 | [Futures][51]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#futures     |
 | [gevent][52]                      | >= 1.5            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gevent      |
 | [graphene][70]                    | >= 3.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphene        |
+| [graphql-core][60]                | >= 3.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql |
 | [Grpc][53]                        | >= 1.34           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#grpc        |
 | [httplib][54]                     | Fully Supported   | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#httplib     |
+| [httpx][71]                       | >= 0.17           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#httpx     |
 | [Jinja2][55]                      | >= 2.11           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#jinja2      |
 | [Jinja2][55] [aiohttp-jinja2][63] | >= 1.5            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp-jinja2      |
 | [Kombu][56]                       | >= 4.2            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#kombu       |
+| [langchain][72]                   | >= 0.0.192        | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#langchain       |
 | [Mako][57]                        | >= 1.1.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mako        |
+| [OpenAI][73]                      | >= 0.26.5         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#openai        |
+| [opensearch-py][74]               | >= 1.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#opensearch-py        |
 | [Requests][58]                    | >= 2.20           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#requests    |
+| [rq][75]                          | >= 1.8            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#requests    |
 | [urllib3][59]                     | >= 1.25.8         | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#urllib3     |
-| [graphql-core][60]                | >= 3.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql |
 | [pytest][14]                      | >= 6.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pytest  |
 
 ## Further Reading
@@ -162,7 +169,6 @@ The `ddtrace` library includes support for the following libraries:
 [29]: https://api.mongodb.com/python/current
 [30]: https://www.mysql.com
 [31]: https://pypi.org/project/MySQL-python
-[32]: https://pypi.org/project/mysqlclient
 [33]: https://dev.mysql.com/doc/connector-python/en/
 [34]: https://www.postgresql.org
 [35]: https://aiopg.readthedocs.io
@@ -201,3 +207,10 @@ The `ddtrace` library includes support for the following libraries:
 [68]: https://pypi.org/project/aredis/
 [69]: https://pypi.org/project/dogpile.cache/
 [70]: https://pypi.org/project/graphene/
+[71]: https://pypi.org/project/httpx/
+[72]: https://pypi.org/project/langchain/
+[73]: https://openai.com/
+[74]: https://pypi.org/project/opensearch-py/
+[75]: https://pypi.org/project/rq/
+[76]: https://wsgi.readthedocs.io/en/latest/what.html
+[77]: https://pypi.org/project/yaaredis/

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -84,6 +84,7 @@ The `ddtrace` library includes support for the following data stores:
 | [MongoDB][27] [Mongoengine][28]   | >= 0.23           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mongoengine                         |
 | [MongoDB][27] [Pymongo][29]       | >= 3.12.3         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymongo                             |
 | [MySQL][30] [MySQL-python][31]    | >= 1.2.3          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][30] [aiomysql][66]        | >= 0.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiomysql |
 | [MySQL][30] [mysql-connector][33] | >= 8.0.5          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mysql-connector                     |
 | [Postgres][34] [aiopg][35]        | >= 0.16.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiopg                               |
 | [Postgres][34] [psycopg][36]      | >= 2.8            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.psycopg      |
@@ -191,3 +192,4 @@ The `ddtrace` library includes support for the following libraries:
 [63]: https://pypi.org/project/aiohttp-jinja2/
 [64]: https://kafka.apache.org/
 [65]: https://pypi.org/project/confluent-kafka/
+[66]: https://pypi.org/project/aiomysql/

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -22,16 +22,16 @@ Two release branches are supported:
 
 | Release    | Support level        |
 |------------|----------------------|
-| `<1`       | Maintenance           |
-| `>=1.0,<2` | General Availability |
+| `<2`       | Maintenance           |
+| `>=2.0,<3` | General Availability |
 
 And the library supports the following runtimes:
 
 | OS      | CPU                   | Runtime | Runtime version | Support ddtrace versions |
 |---------|-----------------------|---------|-----------------|--------------------------|
-| Linux   | x86-64, i686, AArch64 | CPython | 2.7, 3.5-3.11   | `<2`                     |
-| MacOS   | Intel, Apple Silicon  | CPython | 2.7, 3.5-3.11   | `<2`                     |
-| Windows | 64bit, 32bit          | CPython | 2.7, 3.5-3.11   | `<2`                     |
+| Linux   | x86-64, i686, AArch64 | CPython | 3.7-3.12        | `<3`                     |
+| MacOS   | Intel, Apple Silicon  | CPython | 3.7-3.12        | `<3`                     |
+| Windows | 64bit, 32bit          | CPython | 3.7-3.12        | `<3`                     |
 
 ## Integrations
 
@@ -43,23 +43,22 @@ The `ddtrace` library includes support for a number of web frameworks, including
 
 | Framework                 | Supported Version | Automatic | Library Documentation                                              |
 | ------------------------- | ----------------- | --------- |------------------------------------------------------------------ |
-| [asgi][3]                 | >= 2.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#asgi    |
-| [aiohttp][4] (client)     | >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
-| [aiohttp][4] (server)     | >= 2.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
-| [Bottle][5]               | >= 0.11           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#bottle  |
-| [CherryPy][6]            | >= 11.2.0         | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#cherrypy|
-| [Django][7]               | >= 1.8            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
-| [djangorestframework][7]  | >= 3.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
-| [Falcon][8]               | >= 1.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#falcon  |
-| [Flask][9]                | >= 0.10           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask   |
-| [FastAPI][10]              | >= 0.51           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#fastapi |
+| [asgi][3]                 | >= 3.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#asgi    |
+| [aiohttp][4] (client)     | >= 3.7            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
+| [aiohttp][4] (server)     | >= 3.7            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp |
+| [Bottle][5]               | >= 0.12           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#bottle  |
+| [CherryPy][6]             | >= 17.0           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#cherrypy|
+| [Django][7]               | >= 3.2            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
+| [djangorestframework][7]  | >= 3.11           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#django  |
+| [Falcon][8]               | >= 3.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#falcon  |
+| [Flask][9]                | >= 1.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask   |
+| [FastAPI][10]             | >= 0.64           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#fastapi |
 | [Gunicorn][61]            | >= 20.0.04        | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gunicorn |
-| [Molten][11]               | >= 0.7.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#molten  |
-| [Pylons][12]              | >= 0.9.6          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pylons  |
-| [Pyramid][13]             | >= 1.7            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyramid |
-| [Sanic][15]               | >= 19.6.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sanic   |
-| [Starlette][16]           | >= 0.13.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#starlette |
-| [Tornado][17]             | >= 4.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#tornado |
+| [Molten][11]              | >= 1.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#molten  |
+| [Pyramid][13]             | >= 1.10           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyramid |
+| [Sanic][15]               | >= 20.12.0        | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sanic   |
+| [Starlette][16]           | >= 0.14.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#starlette |
+| [Tornado][17]             | >= 5.1            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#tornado |
 
 
 
@@ -67,56 +66,56 @@ The `ddtrace` library includes support for a number of web frameworks, including
 
 The `ddtrace` library includes support for the following data stores:
 
-| Datastore                          | Supported Version | Automatic |  Library Documentation                                                                         |
-| ---------------------------------- | ----------------- | --------- | --------------------------------------------------------------------------------------------- |
-| [algoliasearch][18]                | >= 1.20.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#algoliasearch                       |
-| [asyncpg][19]                      | >= 0.18.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#asyncpg                             |
-| [Cassandra][20]                    | >= 3.5            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#cassandra                           |
-| [Elasticsearch][21]                | >= 1.6, < 8.0     | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#elasticsearch                       |
-| [Flask Cache][22]                  | >= 0.12           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask-cache                         |
-| [Mariadb][23]                      | >= 1.0.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mariadb                             |
-| [Memcached][24] [pylibmc][25]      | >= 1.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pylibmc                             |
-| [Memcached][24] [pymemcache][26]   | >= 1.3            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymemcache                          |
-| [MongoDB][27] [Mongoengine][28]    | >= 0.11           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mongoengine                         |
-| [MongoDB][27] [Pymongo][29]        | >= 3.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymongo                             |
-| [MySQL][30] [MySQL-python][31]     | >= 1.2.3          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.mysqldb      |
-| [MySQL][30] [mysqlclient][32]      | >= 1.3            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.mysqldb      |
-| [MySQL][30] [mysql-connector][33]  | >= 2.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mysql-connector                     |
-| [Postgres][34] [aiopg][35]         | >= 0.12.0, <=&nbsp;0.16        | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiopg                               |
-| [Postgres][34] [psycopg][36]       | >= 2.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.psycopg      |
-| [PyMySQL][37]                      | >= 0.7            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html?highlight=pymysql#pymysql |
-| [PynamoDB][38]                     | >= 4.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pynamodb |
-| [PyODBC][39]                       | >= 4.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyodbc                               |
-| [Redis][40]                        | >= 2.6            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#redis                               |
-| [Redis][40] [redis-py-cluster][41] | >= 1.3.5          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.rediscluster |
-| [snowflake-connector-python][62]   | >= 2.1            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#snowflake
-| [SQLAlchemy][42]                   | >= 1.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlalchemy                          |
-| [SQLite3][43]                      | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlite                              |
-| [Vertica][44]                      | >= 0.6            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#vertica                             |
+| Datastore                         | Supported Version | Automatic |  Library Documentation                                                                         |
+| ----------------------------      | ----------------- | --------- | --------------------------------------------------------------------------------------------- |
+| [algoliasearch][18]               | >= 2.5.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#algoliasearch                       |
+| [asyncpg][19]                     | >= 0.22.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#asyncpg                             |
+| [Cassandra][20]                   | >= 3.24           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#cassandra                           |
+| [Elasticsearch][21]               | >= 1.10, < 8.0    | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#elasticsearch                       |
+| [Flask Cache][22]                 | >= 0.13           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#flask-cache                         |
+| [Kafka][64] [confluent-kafka][65] | >= 1.9.2          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#kafka|
+| [Mariadb][23]                     | >= 1.0.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mariadb                             |
+| [Memcached][24] [pylibmc][25]     | >= 1.6.2          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pylibmc                             |
+| [Memcached][24] [pymemcache][26]  | >= 3.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymemcache                          |
+| [MongoDB][27] [Mongoengine][28]   | >= 0.23           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mongoengine                         |
+| [MongoDB][27] [Pymongo][29]       | >= 3.12.3         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pymongo                             |
+| [MySQL][30] [MySQL-python][31]    | >= 1.2.3          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.mysqldb      |
+| [MySQL][30] [mysql-connector][33] | >= 8.0.5          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mysql-connector                     |
+| [Postgres][34] [aiopg][35]        | >= 0.16.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiopg                               |
+| [Postgres][34] [psycopg][36]      | >= 2.8            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.psycopg      |
+| [PyMySQL][37]                     | >= 1.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html?highlight=pymysql#pymysql |
+| [PynamoDB][38]                    | >= 5.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pynamodb |
+| [PyODBC][39]                      | >= 4.0.31         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyodbc                               |
+| [Redis][40]                       | >= 4.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#redis                               |
+| [Redis][40] [redis-py-cluster][41]| >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.rediscluster |
+| [snowflake-connector-python][62]  | >= 2.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#snowflake
+| [SQLAlchemy][42]                  | >= 1.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlalchemy                          |
+| [SQLite3][43]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlite                              |
+| [Vertica][44]                     | >= 0.6            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#vertica                             |
 
 ### Library compatibility
 
 The `ddtrace` library includes support for the following libraries:
 
-| Library           | Supported Version |  Automatic       | Library Documentation                                                    |
-| ----------------- | ----------------- | ---------------- | ------------------------------------------------------------------------ |
-| [aiobotocore][45] | >= 0.2.3          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiobotocore |
-| [asyncio][46]     | Fully Supported   | > Python 3.7 yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#asyncio     |
-| [Botocore][47]    | >= 1.4.51         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#botocore    |
-| [Boto2][48]       | >= 2.29.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#boto2       |
-| [Celery][49]      | >= 3.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#celery      |
-| [Consul][50]      | >= 0.7            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#consul      |
-| [Futures][51]     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#futures     |
-| [gevent][52]      | >= 1.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gevent      |
-| [Grpc][53]        | >= 1.8.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#grpc        |
-| [httplib][54]     | Fully Supported   | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#httplib     |
-| [Jinja2][55]      | >= 2.7            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#jinja2      |
-| [Kombu][56]       | >= 4.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#kombu       |
-| [Mako][57]        | >= 0.1.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mako        |
-| [Requests][58]    | >= 2.08           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#requests    |
-| [urllib3][59]     | >= 1.22           | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#urllib3     |
-| [graphql-core][60]| >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql |
-| [pytest][14]              | >= 3.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pytest  |
+| Library                           | Supported Version |  Automatic       | Library Documentation                                                    |
+| -----------------                 | ----------------- | ---------------- | ------------------------------------------------------------------------ |
+| [aiobotocore][45]                 | >= 1.4.2          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiobotocore |
+| [asyncio][46]                     | Fully Supported   | > Python 3.7 yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#asyncio     |
+| [Botocore][47]                    | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#botocore    |
+| [Celery][49]                      | >= 4.4            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#celery      |
+| [Consul][50]                      | >= 1.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#consul      |
+| [Futures][51]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#futures     |
+| [gevent][52]                      | >= 1.5            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gevent      |
+| [Grpc][53]                        | >= 1.34           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#grpc        |
+| [httplib][54]                     | Fully Supported   | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#httplib     |
+| [Jinja2][55]                      | >= 2.11           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#jinja2      |
+| [Jinja2][55] [aiohttp-jinja2][63] | >= 1.5            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#aiohttp-jinja2      |
+| [Kombu][56]                       | >= 4.2            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#kombu       |
+| [Mako][57]                        | >= 1.1.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#mako        |
+| [Requests][58]                    | >= 2.20           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#requests    |
+| [urllib3][59]                     | >= 1.25.8         | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#urllib3     |
+| [graphql-core][60]                | >= 3.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#graphql |
+| [pytest][14]                      | >= 6.0            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pytest  |
 
 ## Further Reading
 
@@ -185,3 +184,6 @@ The `ddtrace` library includes support for the following libraries:
 [60]: https://graphql-core-3.readthedocs.io/en/latest/intro.html
 [61]: https://gunicorn.org/
 [62]: https://snowflake.com/
+[63]: https://pypi.org/project/aiohttp-jinja2/
+[64]: https://kafka.apache.org/
+[65]: https://pypi.org/project/confluent-kafka/

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -18,7 +18,7 @@ further_reading:
 
 The Python APM Client library follows a [versioning policy][1] that specifies the support level for the different versions of the library and Python runtime.
 
-Two release branches are supported:
+This is the current state of the library's various release branches:
 
 | Release    | Support level        |
 |------------|----------------------|
@@ -26,7 +26,7 @@ Two release branches are supported:
 | `<2`       | Maintenance          |
 | `>=2.0,<3` | General Availability |
 
-And the library supports the following runtimes:
+The library supports the following runtimes:
 
 | OS      | CPU                   | Runtime | Runtime version | Support ddtrace versions |
 |---------|-----------------------|---------|-----------------|--------------------------|

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -62,6 +62,7 @@ The `ddtrace` library includes support for a number of web frameworks, including
 | [FastAPI][10]             | >= 0.51           | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#fastapi |
 | [Gunicorn][61]            | >= 20.0.04        | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#gunicorn |
 | [Molten][11]              | >= 0.7.0          | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#molten  |
+| [Pylons][12]              | >= 0.9.6          | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pylons  |
 | [Pyramid][13]             | >= 1.7            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#pyramid |
 | [Sanic][15]               | >= 19.6.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sanic   |
 | [Starlette][16]           | >= 0.13.0         | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#starlette |

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -94,6 +94,7 @@ The `ddtrace` library includes support for the following data stores:
 | [Redis][40]                       | >= 4.1            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#redis                               |
 | [Redis][40] [redis-py-cluster][41]| >= 2.0            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#module-ddtrace.contrib.rediscluster |
 | [Redis][40] [aioredis][67]        | >= 1.3            | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|aioredis
+| [Redis][40] [aredis][68]          | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#|aredis
 | [snowflake-connector-python][62]  | >= 2.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#snowflake
 | [SQLAlchemy][42]                  | >= 1.3            | no | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlalchemy                          |
 | [SQLite3][43]                     | Fully Supported   | yes | https://ddtrace.readthedocs.io/en/stable/integrations.html#sqlite                              |
@@ -195,3 +196,4 @@ The `ddtrace` library includes support for the following libraries:
 [65]: https://pypi.org/project/confluent-kafka/
 [66]: https://pypi.org/project/aiomysql/
 [67]: https://pypi.org/project/aioredis/
+[68]: https://pypi.org/project/aredis/

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -31,11 +31,11 @@ And the library supports the following runtimes:
 | OS      | CPU                   | Runtime | Runtime version | Support ddtrace versions |
 |---------|-----------------------|---------|-----------------|--------------------------|
 | Linux   | x86-64, i686, AArch64 | CPython | 3.7-3.12        | `<3`                     |
-| Linux   | x86-64, i686, AArch64 | CPython | 2.7-3.6         | `<2`                     |
+| Linux   | x86-64, i686, AArch64 | CPython | 2.7-3.11        | `<2`                     |
 | MacOS   | Intel, Apple Silicon  | CPython | 3.7-3.12        | `<3`                     |
-| MacOS   | Intel, Apple Silicon  | CPython | 2.7-3.6         | `<2`                     |
+| MacOS   | Intel, Apple Silicon  | CPython | 2.7-3.11        | `<2`                     |
 | Windows | 64bit, 32bit          | CPython | 3.7-3.12        | `<3`                     |
-| Windows | 64bit, 32bit          | CPython | 2.7-3.6         | `<2`                     |
+| Windows | 64bit, 32bit          | CPython | 2.7-3.11        | `<2`                     |
 
 ## Integrations
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -46,7 +46,7 @@ The steps for enabling debug mode in the Datadog Python Tracer depends on the ve
 
 1. To enable debug mode: `DD_TRACE_DEBUG=true`
 
-2. To route logs to the console, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
+2. To route logs to the console, configure `logging.basicConfig()` .
 
 ### Scenario 3: ddtrace version 0.x
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -54,7 +54,7 @@ The steps for enabling debug mode in the Datadog Python Tracer depends on the ve
 
 1. To enable debug mode: `DD_TRACE_DEBUG=true`
 
-2. To route logs to the console, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
+2. To route logs to the console, configure `logging.basicConfig()`.
 
 ### Scenario 4: Configuring debug logging in the application code with the standard logging library
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -50,6 +50,8 @@ The steps for enabling debug mode in the Datadog Python Tracer depends on the ve
 
 ### Scenario 3: ddtrace version 0.x
 
+**ddtrace-py 0.x has reached the end of its life. Please upgrade to 2.x.**
+
 1. To enable debug mode: `DD_TRACE_DEBUG=true`
 
 2. To route logs to the console, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -39,22 +39,13 @@ The steps for enabling debug mode in the Datadog Python Tracer depends on the ve
 2. To route debug logs to a log file, set `DD_TRACE_LOG_FILE` with a filename that tracer logs should be written to, relative to the current working directory. For example, `DD_TRACE_LOG_FILE=ddtrace_logs.log`.
    By default, the file size is 15728640 bytes (about 15MB) and one backup log file is created. To increase the default log file size, specify the size in bytes with the `DD_TRACE_LOG_FILE_SIZE_BYTES` setting.
 
-3. To route logs to the console, for **Python 2** applications, configure `logging.basicConfig()` or similar. Logs are automatically sent to the console for **Python 3** applications.
-
-
 ### Scenario 2: ddtrace version 1.0.x to 1.2.x
 
 1. To enable debug mode: `DD_TRACE_DEBUG=true`
 
-2. To route logs to the console, for **Python 2 or Python 3** applications, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
+2. To route logs to the console, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
 
-### Scenario 3: ddtrace version 0.x
-
-1. To enable debug mode: `DD_TRACE_DEBUG=true`
-
-2. To route logs to the console, for **Python 2 or Python 3** applications, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
-
-### Scenario 4: Configuring debug logging in the application code with the standard logging library
+### Scenario 3: Configuring debug logging in the application code with the standard logging library
 
 For any version of ddtrace, rather than setting the `DD_TRACE_DEBUG` tracer environment variable, you can enable debug logging in the application code by using the `logging` standard library directly:
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -46,9 +46,15 @@ The steps for enabling debug mode in the Datadog Python Tracer depends on the ve
 
 1. To enable debug mode: `DD_TRACE_DEBUG=true`
 
-2. To route logs to the console, for **Python 2 or Python 3** applications, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
+2. To route logs to the console, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
 
-### Scenario 3: Configuring debug logging in the application code with the standard logging library
+### Scenario 3: ddtrace version 0.x
+
+1. To enable debug mode: `DD_TRACE_DEBUG=true`
+
+2. To route logs to the console, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
+
+### Scenario 4: Configuring debug logging in the application code with the standard logging library
 
 For any version of ddtrace, rather than setting the `DD_TRACE_DEBUG` tracer environment variable, you can enable debug logging in the application code by using the `logging` standard library directly:
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -39,11 +39,14 @@ The steps for enabling debug mode in the Datadog Python Tracer depends on the ve
 2. To route debug logs to a log file, set `DD_TRACE_LOG_FILE` with a filename that tracer logs should be written to, relative to the current working directory. For example, `DD_TRACE_LOG_FILE=ddtrace_logs.log`.
    By default, the file size is 15728640 bytes (about 15MB) and one backup log file is created. To increase the default log file size, specify the size in bytes with the `DD_TRACE_LOG_FILE_SIZE_BYTES` setting.
 
+3. To route logs to the console, for **Python 2** applications, configure `logging.basicConfig()` or similar. Logs are automatically sent to the console for **Python 3** applications.
+
+
 ### Scenario 2: ddtrace version 1.0.x to 1.2.x
 
 1. To enable debug mode: `DD_TRACE_DEBUG=true`
 
-2. To route logs to the console, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
+2. To route logs to the console, for **Python 2 or Python 3** applications, configure `logging.basicConfig()` or use `DD_CALL_BASIC_CONFIG=true`.
 
 ### Scenario 3: Configuring debug logging in the application code with the standard logging library
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This change updates the Python tracer's documentation to reflect the recent release of [major version 2.0.0](https://github.com/DataDog/dd-trace-py/releases/tag/v2.0.0).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing