### PR TITLE
[DOCS-6328] clarifying lower helm versions

### DIFF
--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -158,7 +158,7 @@ Using the Datadog Operator requires the following prerequisites:
 - `<TARGET_SYSTEM>`: The name of your OS. For example, `linux` or `windows`.
 
 
-**Note**: If you are using Helm v2.x, run the following:
+**Note**: If you are using Helm `2.x`, run the following:
    ```bash
    helm install --name <RELEASE_NAME> \
     -f datadog-values.yaml \

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -158,7 +158,7 @@ Using the Datadog Operator requires the following prerequisites:
 - `<TARGET_SYSTEM>`: The name of your OS. For example, `linux` or `windows`.
 
 
-**Note**: If you are using Helm < v3, run the following:
+**Note**: If you are using Helm v2.x, run the following:
    ```bash
    helm install --name <RELEASE_NAME> \
     -f datadog-values.yaml \


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR addresses hotjar feedback where the reader pointed out that the `--name` flag was deprecated on Helm `v3`, the docs stated "for Helm < v3.. use.." (Helm version _less than v3_) the use of the greater than; less than signs can cause confusion, so added clarification that if the reader is using Helm `v2.x` they need to use the `--name` flag. 

Helm `v1.x` is deprecated so no need to say "lower than v3".

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->