### PR TITLE
[DOCS-6372] removing Beta from ASM libraries pages

### DIFF
--- a/layouts/shortcodes/appsec-getstarted-with-rc.md
+++ b/layouts/shortcodes/appsec-getstarted-with-rc.md
@@ -1,2 +1,2 @@
-<div class="alert alert-info"><strong>Beta: 1-Click Enablement</strong><br>
+<div class="alert alert-info"><strong>1-Click Enablement</strong><br>
 If your service is running with <a href="/agent/guide/how_rc_works/#enabling-remote-configuration">an Agent with Remote Configuration enabled and a tracing library version that supports it</a>, hover over the <strong>Not Enabled</strong> indicator in the ASM Status column and click <strong>Enable ASM</strong>. There's no need to re-launch the service with the <code>DD_APPSEC_ENABLED=true</code> or <code>--enable-appsec</code> flags.</div><br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
[DOCS-6372](https://datadoghq.atlassian.net/browse/DOCS-6372)
This PR removes the Beta verbiage from the How to enable ASM page and it's relevant library pages , via a reuse shortcode. I elected to keep the banner as it's a nice callout, but just removed the word beta as this feature has been in GA for awhile now and this got missed.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6372]: https://datadoghq.atlassian.net/browse/DOCS-6372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ