### PR TITLE
Remove note about ASM compatibility with PHP 5x

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/php.md
+++ b/content/en/security/application_security/enabling/compatibility/php.md
@@ -36,7 +36,7 @@ The minimum tracer version to get all supported ASM capabilities for PHP is 0.86
 
 <div class="alert alert-info">
 <strong>Note:</strong>
-It's recommended to use <a href="https://www.php.net/supported-versions">officially supported versions</a> of PHP, especially 7.4, 8.0, and 8.1.
+It's recommended to use <a href="https://www.php.net/supported-versions">officially supported versions</a> of PHP, especially 8.0, 8.1 and 8.2.
 </div>
 
 | PHP Version    | Support level                         | Package version |

--- a/content/en/security/application_security/enabling/compatibility/php.md
+++ b/content/en/security/application_security/enabling/compatibility/php.md
@@ -36,13 +36,6 @@ The minimum tracer version to get all supported ASM capabilities for PHP is 0.86
 
 <div class="alert alert-info">
 <strong>Note:</strong>
-PHP 5.x is fully supported until version 0.75.0. It is now in maintenance mode and supported with security and important bug fixes until December 31, 2023.
-
-<br>
-<br>
-
-If you are using PHP 5.x version in your application and have a feature request which is critical for your business needs, contact <a href="https://www.datadoghq.com/support/">Datadog Support</a>.
-
 It's recommended to use <a href="https://www.php.net/supported-versions">officially supported versions</a> of PHP, especially 7.4, 8.0, and 8.1.
 </div>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

PHP ASM is not compatible with PHP 5.x, this was updated yesterday, however there still remains a note which could cause confusion. This PR removes said note.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->