### PR TITLE
Move SQL Server propagation blurb higher up

### DIFF
--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -32,6 +32,8 @@ APM tracer integrations support a *Propagation Mode*, which controls the amount 
 - `service` mode sends the service name, allowing you to understand which services are the contributors to database load. This is the only supported mode for SQL Server applications.
 - `none` mode disables propagation and does not send any information from applications.
 
+SQL Server does not support `full` propagation mode due to the inability for the server to cache statements which contain full trace context.
+
 | DD_DBM_PROPAGATION_MODE  | Postgres  |   MySQL   |  SQL Server  |
 |:-------------------------|:---------:|:---------:|:------------:|
 | `full`                   | {{< X >}} | {{< X >}} |          |
@@ -286,8 +288,6 @@ Ensure that you are using a supported client library. For example, `Npgsql`.
 Enable the database monitoring propagation feature by setting the following environment variable:
    - For Postgres and MySQL: `DD_DBM_PROPAGATION_MODE=full`
    - For SQL Server: `DD_DBM_PROPAGATION_MODE=service`
-
-SQL Server does not support full propagation mode due to the inability for the server to cache statements which contain full trace context.
 
 [1]: /tracing/trace_collection/dd_libraries/dotnet-framework
 [2]: /tracing/trace_collection/dd_libraries/dotnet-core

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -32,7 +32,7 @@ APM tracer integrations support a *Propagation Mode*, which controls the amount 
 - `service` mode sends the service name, allowing you to understand which services are the contributors to database load. This is the only supported mode for SQL Server applications.
 - `none` mode disables propagation and does not send any information from applications.
 
-SQL Server does not support `full` propagation mode due to the inability for the server to cache statements which contain full trace context.
+SQL Server does not support `full` propagation mode due to statement caching behavior which could cause performance issues when including full trace context.
 
 | DD_DBM_PROPAGATION_MODE  | Postgres  |   MySQL   |  SQL Server  |
 |:-------------------------|:---------:|:---------:|:------------:|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This phrase is nested under the .NET tab, when it should apply to any SQL Server datastores. This change moves it higher up in the doc so that it's more accurate and easier to find.

SQL Server does not support full propagation mode due to the inability for the server to cache statements which contain full trace context.

### Merge instructions
- [x] Please merge after reviewing

### Additional notes