### PR TITLE
Ruby profiler: Remove `google-protobuf` as needed dependency

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -46,12 +46,13 @@ To begin profiling applications:
 
 1. If you are already using Datadog, upgrade your agent to version [7.20.2][2]+ or [6.20.2][3]+.
 
-2. Add the `ddtrace` and `google-protobuf` gems to your `Gemfile` or `gems.rb` file:
+2. Add the `ddtrace` gem to your `Gemfile` or `gems.rb` file:
 
     ```ruby
-    gem 'ddtrace', '~> 1.0'
-    gem 'google-protobuf', '~> 3.0'
+    gem 'ddtrace', '~> 1.15'
     ```
+
+    (If you're running a version of `ddtrace` older than 1.15.0, you'll also need to add the `google-protobuf` gem as a dependency.)
 
 2. Install the gems with `bundle install`.
 

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -52,7 +52,7 @@ To begin profiling applications:
     gem 'ddtrace', '~> 1.15'
     ```
 
-    (If you're running a version of `ddtrace` older than 1.15.0, you'll also need to add the `google-protobuf` gem as a dependency.)
+    If you're running a version of `ddtrace` older than 1.15.0, add the `google-protobuf` gem (version ~> 3.0) as a dependency.
 
 2. Install the gems with `bundle install`.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Starting with `ddtrace` 1.15.0, the Ruby profiler no longer needs the `google-protobuf` dependency. Thus, I've updated the docs to reflect that.

I did keep a reference to it, assuming that some customers may already have an older `ddtrace` and may want to add profiling to it without upgrading -- feedback welcome on the wording there (or if we don't usually do this kind of reference, we could drop it as well -- the library does have a good error message saying that `google-protobuf` is needed, so customers would spot it quickly).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

The 1.15 review is planned to go out on monday, so I've not checked the "merge after reviewing" box.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->