### PR TITLE
Rewrite introduction to permissions page

### DIFF
--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -19,7 +19,7 @@ algolia:
 
 ## Overview
 
-Permissions define the type of access a user has to given resource. Typically, permissions give a user the right to read, edit, or delete an object. Permissions underlie the access rights of all roles, including the three out-of-the-box roles and custom roles.
+Permissions define the type of access a user has to a given resource. Typically, permissions give a user the right to read, edit, or delete an object. Permissions underlie the access rights of all roles, including the three out-of-the-box roles and custom roles.
 
 ### Out-of-the-box roles
 

--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -21,7 +21,7 @@ algolia:
 
 Permissions define the type of access a user has to given resource. Typically, permissions give a user the right to read, edit, or delete an object. Permissions underlie the access rights of all roles, including the three out-of-the-box roles and custom roles.
 
-## Out-of-the-box roles
+### Out-of-the-box roles
 
 By default, existing users are associated with one of the three out-of-the-box roles:
 
@@ -31,7 +31,7 @@ By default, existing users are associated with one of the three out-of-the-box r
 
 All users with one of these roles can read all data types, except for [individually read-restricted][1] resources. Admin and Standard users have write permissions on assets. Admin users have additional read and write permissions for sensitive assets relating to user management, org management, billing, and usage. 
 
-## Custom roles
+### Custom roles
 
 Create a custom role to combine permissions into new roles. A custom role gives you the ability to define a persona, for example, a billing administrator, and then assign the appropriate permissions for that role. After creating a role, assign or remove permissions to this role directly by [updating the role in Datadog][2], or through the [Datadog Permission API][3].
 

--- a/content/en/account_management/rbac/permissions.md
+++ b/content/en/account_management/rbac/permissions.md
@@ -17,9 +17,11 @@ algolia:
     subcategory: Datadog Role Permissions
 ---
 
-After creating a role, assign or remove permissions to this role directly by [updating the role in Datadog][1], or through the [Datadog Permission API][2]. Find below a list of available permissions.
-
 ## Overview
+
+Permissions define the type of access a user has to given resource. Typically, permissions give a user the right to read, edit, or delete an object. Permissions underlie the access rights of all roles, including the three out-of-the-box roles and custom roles.
+
+## Out-of-the-box roles
 
 By default, existing users are associated with one of the three out-of-the-box roles:
 
@@ -27,11 +29,19 @@ By default, existing users are associated with one of the three out-of-the-box r
 - Datadog Standard
 - Datadog Read Only
 
-All users with one of these roles can read all data types. Admin and Standard users have write permissions on assets. Admin users have additional read and write permissions for sensitive assets relating to user management, org management, billing, and usage.
+All users with one of these roles can read all data types, except for [individually read-restricted][1] resources. Admin and Standard users have write permissions on assets. Admin users have additional read and write permissions for sensitive assets relating to user management, org management, billing, and usage. 
 
-**Note**: When adding a new custom role to a user, make sure to remove the out-of-the-box Datadog role associated with that user in order to enforce the new role permissions.
+## Custom roles
 
-Each asset type has corresponding read and write permissions. In the tables below, find the details of these permissions.
+Create a custom role to combine permissions into new roles. A custom role gives you the ability to define a persona, for example, a billing administrator, and then assign the appropriate permissions for that role. After creating a role, assign or remove permissions to this role directly by [updating the role in Datadog][2], or through the [Datadog Permission API][3].
+
+**Note**: When adding a new custom role to a user, make sure to remove the out-of-the-box Datadog role associated with that user to enforce the new role permissions.
+
+## Permissions list
+
+The following table lists the name, description, and default role for all available permissions in Datadog. Each asset type has corresponding read and write permissions. 
+
+Each out-of-the-box role inherits all of the permissions from the less powerful roles. Therefore, the Datadog Standard role has all of the permissions listed in the table with Datadog Read Only as the default role. Additionally, the Datadog Admin role contains all of the permissions from both the Datadog Standard and the Datadog Read Only role.
 
 {{% permissions %}}
 
@@ -42,5 +52,6 @@ Each asset type has corresponding read and write permissions. In the tables belo
 <br>
 *Log Rehydration is a trademark of Datadog, Inc.
 
-[1]: /account_management/users/#edit-a-user-s-roles
-[2]: /api/latest/roles/#list-permissions
+[1]: /account_management/rbac/granular_access
+[2]: /account_management/users/#edit-a-user-s-roles
+[3]: /api/latest/roles/#list-permissions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
On WEB-3821, Stefon added information to the permissions table about which OOTB role has that permission by default. I took an action item to add a line to the page explaining that more powerful roles also get all of the permissions from the less powerful ones, since it's not obvious from the table.

While thinking about where to add the line, I noticed that the introduction to the permissions page could use better organization and additional explanation.

This PR reorganizes and adds explanation to the permissions page introduction. It also adds information about how more powerful OOTB roles inherit all of the permissions of the less powerful ones.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->