### PR TITLE
[WEB-4139]Update grouped-item-listings.js

### DIFF
--- a/assets/scripts/components/grouped-item-listings.js
+++ b/assets/scripts/components/grouped-item-listings.js
@@ -50,7 +50,7 @@ export function initializeGroupedListings() {
     }
 
     const handleEmptyResultSet = () => {
-        const searchQuery = inputSearch.value;
+        const searchQuery = inputSearch?.value;
         const activeEl = document.querySelector('.controls .active');
         const txt = (activeEl) ? activeEl.textContent : '';
         const activeCategoryFilter = stringToTitleCase(txt);


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add question mark operator to `searchQuery` variable definition statement to resolve js console error `Uncaught TypeError: Cannot read properties of null (reading 'value')`.

Restores tab queryParam functionality when selecting elements from the left side nav.

### Motivation
https://datadoghq.atlassian.net/browse/WEB-4139

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Preview
https://docs-staging.datadoghq.com/brooklyne.finni/tabs_fix

### Additional notes
<!-- Anything else we should know when reviewing?-->
Navigate to the CSM setup page /security/cloud_security_management/setup/?tab=csmenterprise and select `CSM Workload Security`. The tabs query parameter should be appended to the url and the tabs should be displayed above the code block(s).

Test several other links from the left side nav and ensure that tabs query parameter is appended to the url and that the tabs and tab content appear as expected

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->