### PR TITLE
[CCM] add links to Labels as tags configuration

### DIFF
--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -35,7 +35,7 @@ For Kubernetes allocation, a Kubernetes node is joined with its associated EC2 i
 
 Next, Datadog looks at all of the pods running on that node for the day. The cost of the node is allocated to the pod based on the resources it has used and the length of time it ran. This calculated cost is enriched with all of the pod's tags.
 
-Note: Only _tags_ from pods and nodes are added to cost metrics. To include labels, enable labels as tags for [Nodes][7] and [Pods][8].
+**Note**: Only _tags_ from pods and nodes are added to cost metrics. To include labels, enable labels as tags for [nodes][7] and [pods][8].
 
 ### ECS on EC2
 

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -35,6 +35,8 @@ For Kubernetes allocation, a Kubernetes node is joined with its associated EC2 i
 
 Next, Datadog looks at all of the pods running on that node for the day. The cost of the node is allocated to the pod based on the resources it has used and the length of time it ran. This calculated cost is enriched with all of the pod's tags.
 
+Note: Only _tags_ from pods and nodes are added to cost metrics. To include labels, enable labels as tags for [Nodes][7] and [Pods][8].
+
 ### ECS on EC2
 
 For ECS allocation, Datadog determines which tasks ran on each EC2 instance used for ECS. If you enable AWS Split Cost Allocation, the metrics allocate ECS costs by usage instead of reservation, providing more granular detail.
@@ -118,3 +120,5 @@ In addition to ECS task tags, the following out-of-the-box tags are applied to c
 [4]: https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html
 [5]: https://docs.aws.amazon.com/cur/latest/userguide/enabling-split-cost-allocation-data.html
 [6]: /infrastructure/containers/orchestrator_explorer?tab=datadogoperator
+[7]: /containers/kubernetes/tag/?tab=containerizedagent#node-labels-as-tags
+[8]: /containers/kubernetes/tag/?tab=containerizedagent#pod-labels-as-tags


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This adds instructions for enabling Labels as tags, in order to add labels as tags on cost metrics.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->