### PR TITLE
[DOCS-3899]Add profiler to list of "other telemetry" you can connect traces to

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1840,8 +1840,13 @@ main:
   - name: Connect Synthetics and Traces
     url: /synthetics/apm/
     parent: tracing_other_telemetry
-    identifier: tracing_connect_sythetics
+    identifier: tracing_connect_synthetics
     weight: 403
+  - name: Connect Profiles and Traces
+    url: /profiler/connect_traces_and_profiles/
+    parent: tracing_other_telemetry
+    identifier: tracing_connect_profiles
+    weight: 404
   - name: Trace Explorer
     url: tracing/trace_explorer/
     parent: tracing

--- a/content/en/tracing/other_telemetry/_index.md
+++ b/content/en/tracing/other_telemetry/_index.md
@@ -40,7 +40,7 @@ Follow the data from failing synthetic tests directly through to the root causes
 
 ## Connect profiles and traces
 
-Performance data for application code that has both tracing and profiling enabled is automatically correlated, letting you move between the two types of analysis to troubleshoot and problem solve. You can move directly from span information to profiling data on the Code Hotspots tab, and find specific lines of code related to performance issues. Similarly, you can also debug slow and resource consuming endpoints directly in the Profiling UI. 
+Performance data for application code that has both tracing and profiling enabled is automatically correlated, letting you move between the two types of analysis to troubleshoot and problem solve. You can move directly from span information to profiling data on the Code Hotspots tab, and find specific lines of code related to performance issues. Similarly, you can debug slow and resource-consuming endpoints directly in the Profiling UI. 
 
 Read [Investigate Slow Traces or Endpoints][5] for more information.
 

--- a/content/en/tracing/other_telemetry/_index.md
+++ b/content/en/tracing/other_telemetry/_index.md
@@ -13,30 +13,38 @@ further_reading:
 
 Correlating data by various Datadog products gives context to help estimate the business impact and find the root cause of an issue in a few clicks. Set up connections between incoming data to facilitate quick pivots in your explorers and dashboards.
 
-## Connect Database Monitoring and Traces
+## Connect Database Monitoring and traces
 
 Inject trace IDs into DBM data collection to correlate the two data sources. View database information in APM and APM information in DBM to see a comprehensive, unified view of your system's performance. See [Connect DBM and Traces][4] to set it up.
 
 {{< img src="database_monitoring/dbm_filter_by_calling_service.png" alt="Filter your database hosts by the APM services that call them.">}}
 
 
-## Connect Logs and Traces
+## Connect logs and traces
 
 Inject trace IDs into logs, and leverage unified service tagging to find the exact logs associated with a specific service and version, or all logs correlated to an observed trace. See [Connect Logs and Traces][1] to set it up.
 
 {{< img src="tracing/index/ConnectLogsWithTraces.png" alt="Connect Logs And Traces" style="width:100%;">}}
 
-## Connect RUM and Traces
+## Connect RUM and traces
 
 Correlate data collected in front end views with trace and spans on the back end by [Connecting RUM and Traces][2]. Pinpoint issues anywhere in your stack and understand what your users are experiencing. 
 
 {{< img src="tracing/index/RumTraces.png" alt="Connect RUM sessions and traces" style="width:100%;">}}
 
-## Connect Synthetics and Traces
+## Connect synthetic tests and traces
 
 Follow the data from failing synthetic tests directly through to the root causes by digging into related traces. [Connect Synthetics and Traces][3] to speed up troubleshooting your code.
 
 {{< img src="tracing/index/Synthetics.png" alt="Synthetic tests" style="width:100%;">}}
+
+## Connect profiles and traces
+
+Performance data for application code that has both tracing and profiling enabled is automatically correlated, letting you move between the two types of analysis to troubleshoot and problem solve. You can move directly from span information to profiling data on the Code Hotspots tab, and find specific lines of code related to performance issues. Similarly, you can also debug slow and resource consuming endpoints directly in the Profiling UI. 
+
+Read [Investigate Slow Traces or Endpoints][5] for more information.
+
+{{< img src="profiler/code_hotspots_tab-2.mp4" alt="Code Hotspots tab shows profiling information for a APM trace span" video=true >}}
 
 ## Further Reading
 
@@ -46,3 +54,4 @@ Follow the data from failing synthetic tests directly through to the root causes
 [2]: /real_user_monitoring/connect_rum_and_traces/
 [3]: /synthetics/apm/
 [4]: /database_monitoring/connect_dbm_and_apm/
+[5]: /profiler/connect_traces_and_profiles/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Links profiler page on traces/profiles integration use cases into APM docs on correlating with other telemetry types.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->