### PR TITLE
Remove granular access beta tags from SLO page

### DIFF
--- a/content/en/service_management/service_level_objectives/_index.md
+++ b/content/en/service_management/service_level_objectives/_index.md
@@ -105,7 +105,7 @@ Restrict access to individual SLOs by specifying a list of [roles][8] that are a
 1. Select **Permissions**.
 1. Click **Restrict Access**.
 1. The dialog box updates to show that members of your organization have **Viewer** access by default.
-1. Use the drop-down to select one or more roles, teams (beta), or users (beta) that may edit the SLO.
+1. Use the drop-down to select one or more roles, teams, or users that may edit the SLO.
 1. Click **Add**.
 1. The dialog box updates to show that the role you selected has the **Editor** permission.
 1. Click **Save**


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR removes `(beta)` tags from the SLO page now that user and team based access controls are available to all customers. Similar to https://github.com/DataDog/documentation/pull/20072.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->