### PR TITLE
Update lock pressure wording

### DIFF
--- a/content/en/watchdog/insights.md
+++ b/content/en/watchdog/insights.md
@@ -146,7 +146,7 @@ In the full side panel, you can see a latency distribution graph for the tag and
 {{% /tab %}}
 {{% tab "Profiling" %}}
 
-### Lock pressure outlier
+### Lock contention outlier
 
 In the banner card view, you can see:
 
@@ -154,11 +154,11 @@ In the banner card view, you can see:
   * The number of threads impacted
   * The potential CPU savings (and estimated cost savings)
     
-{{< img src="watchdog/small_card_profiling_lock_pressure.png" alt="Profiling insight on Lock Pressure" style="width:50%;">}}
+{{< img src="watchdog/small_card_profiling_lock_pressure.png" alt="Profiling insight on Lock Contention" style="width:50%;">}}
 
-In the full side panel, you can see instructions on how to resolve the lock pressure:
+In the full side panel, you can see instructions on how to resolve the lock contention:
 
-{{< img src="watchdog/side_panel_profiling_lock_pressure.png" alt="Side panel with all the information on how to adress the Lock Pressure outlier" style="width:100%;">}}
+{{< img src="watchdog/side_panel_profiling_lock_pressure.png" alt="Side panel with all the information on how to adress the Lock Contention outlier" style="width:100%;">}}
 
 ### Garbage collection outlier
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Translator was confused about "lock pressure", which is the same as "lock contention" and shown in the UI, so updating the docs to say "lock contention" instead.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->