### PR TITLE
Update _index.md to reflect UI updates for RC next week

### DIFF
--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -398,11 +398,22 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 <div class="alert alert-warning">
   Remote configuration for Observability Pipelines is in private beta. Contact <a href="https://docs.datadoghq.com/help/">Datadog support</a> or your Customer Success Manager for access.
 </div>
-If you are enrolled in the private beta of [Remote Configuration][7] to remotely roll out changes to your OP Workers, you can switch deployment methods in the settings cog (i.e. going from manually managed pipeline to remote configuration enabled pipeline). When switching deployment methods, ensure that you restart the Worker with the new deployment mode flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED`, set to match the UI.
+If you are enrolled in the private beta of [Remote Configuration][7] to remotely roll out changes to your OP Workers, you remotely roll out changes to your Workers from the Datadog UI, rather than making updates to your pipeline configuration in a text editor and rolling out your changes manually. You can choose your deployment method when you create a pipeline and install your Workers.
 
-When going from remote configuration to manual deployment mode, even if you switch the deployment mode in the UI, if you do not switch the deployment mode of each Workers by turning the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag off, the Workers themselves will be remote configuration enabled so therefore will continue pulling a version configuration.
+After deploying a pipeline, you can also switch deployment methods, such as going from manually managed pipeline to remote configuration enabled pipeline or vice versa. 
 
-When going from manual to remote configuration deployment mode, after restarting the Worker with  flag, you will need to deploy a version in your version history, so that the Workers receive the new version configuration. 
+If you want to switch from a remote configuration deployment to a manually managed deployment:
+1. Navigate to Observability Pipelines.
+2. Click the settings cog.
+3. In **Deployment Mode**, select **manual** to enable it.
+4. Set the flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED` to `false` and restart the Worker. Workers that aren't restarted with this flag will continue to be remote configuration enabled, which means that the Worker will not be updated manually through a local configuration file
+
+If you want to switch from manually managed deployment to a remote configuration deployment:
+1. Navigate to Observability Pipelines.
+2. Click the settings cog.
+3. In **Deployment Mode**, select **Remote Configuration** to enable it.
+4. Set the flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED` to `true` and restart the Worker. Workers that aren't restarted with this flag will not poll for configurations deployed in the UI. 
+6. Deploy a version in your version history, so that the Workers receive the new version configuration. Click on a version, click _Edit as Draft_, then click _Deploy_. 
 
 
 ## Further reading

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -400,7 +400,6 @@ When going from remote configuration to manual deployment mode, even if you swit
 
 When going from manual to remote configuration deployment mode, after restarting the Worker with  flag, you will need to deploy a version in your version history, so that the Workers receive the new version configuration. 
 
-If you are interested in getting early access to remote configuration, please reach out to support or your customer success manager.
 
 ## Further reading
 

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -406,7 +406,7 @@ If you want to switch from a remote configuration deployment to a manually manag
 1. Navigate to Observability Pipelines.
 2. Click the settings cog.
 3. In **Deployment Mode**, select **manual** to enable it.
-4. Set the flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED` to `false` and restart the Worker. Workers that aren't restarted with this flag will continue to be remote configuration enabled, which means that the Worker will not be updated manually through a local configuration file
+4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `false` and restart the Worker. Workers that aren't restarted with this flag continue to be remote configuration enabled, which means that the Workers are not updated manually through a local configuration file.
 
 If you want to switch from manually managed deployment to a remote configuration deployment:
 1. Navigate to Observability Pipelines.

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -393,12 +393,14 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 - See [Deployment Design and Principles][7] for information on what to consider when designing your Observability Pipelines architecture.
 - See [Best Practices for OPW Aggregator Architecture][8] for details on the recommended Observability Pipelines aggregator architecture, which is optimized for scaling.
 
-## Switching Deployment Modes
+## Deployment Modes
 If you are enrolled in the private beta of [Remote Configuration][7] to remotely roll out changes to your OP Workers, you can switch deployment methods in the settings cog (i.e. going from manually managed pipeline to remote configuration enabled pipeline). When switching deployment methods, ensure that you restart the Worker with the new deployment mode flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED`, set to match the UI.
 
 When going from remote configuration to manual deployment mode, even if you switch the deployment mode in the UI, if you do not switch the deployment mode of each Workers by turning the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag off, the Workers themselves will be remote configuration enabled so therefore will continue pulling a version configuration.
 
 When going from manual to remote configuration deployment mode, after restarting the Worker with  flag, you will need to deploy a version in your version history, so that the Workers receive the new version configuration. 
+
+If you are interested in getting early access to remote configuration, please reach out to support or your customer success manager.
 
 ## Further reading
 

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -407,7 +407,7 @@ If you want to switch from a remote configuration deployment to a manually manag
 1. Navigate to Observability Pipelines.
 2. Click the settings cog.
 3. In **Deployment Mode**, select **manual** to enable it.
-4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `false` and restart the Worker. Workers that aren't restarted with this flag continue to be remote configuration enabled, which means that the Workers are not updated manually through a local configuration file.
+4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `false` and restart the Worker. Workers that are not restarted with this flag continue to be remote configuration enabled, which means that the Workers are not updated manually through a local configuration file.
 
 If you want to switch from manually managed deployment to a remote configuration deployment:
 1. Navigate to Observability Pipelines.

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -398,7 +398,7 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 <div class="alert alert-warning">
   Remote configuration for Observability Pipelines is in private beta. Contact <a href="https://docs.datadoghq.com/help/">Datadog support</a> or your Customer Success Manager for access.
 </div>
-If you are enrolled in the private beta of [Remote Configuration][7] to remotely roll out changes to your OP Workers, you remotely roll out changes to your Workers from the Datadog UI, rather than making updates to your pipeline configuration in a text editor and rolling out your changes manually. You can choose your deployment method when you create a pipeline and install your Workers.
+If you are enrolled in the private beta of [Remote Configuration][9], you can remotely roll out changes to your Workers from the Datadog UI, rather than make updates to your pipeline configuration in a text editor and then manually rolling out your changes. Choose your deployment method when you create a pipeline and install your Workers.
 
 After deploying a pipeline, you can also switch deployment methods, such as going from a manually managed pipeline to a remote configuration enabled pipeline or vice versa. 
 

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -413,7 +413,7 @@ If you want to switch from manually managed deployment to a remote configuration
 2. Click the settings cog.
 3. In **Deployment Mode**, select **Remote Configuration** to enable it.
 4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `true` and restart the Worker. Workers that are not restarted with this flag are not polled for configurations deployed in the UI. 
-6. Deploy a version in your version history, so that the Workers receive the new version configuration. Click on a version, click _Edit as Draft_, then click _Deploy_. 
+6. Deploy a version in your version history, so that the Workers receive the new version configuration. Click on a version. Click **Edit as Draft** and then click **Deploy**. 
 
 
 ## Further reading

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -412,7 +412,7 @@ If you want to switch from manually managed deployment to a remote configuration
 1. Navigate to Observability Pipelines.
 2. Click the settings cog.
 3. In **Deployment Mode**, select **Remote Configuration** to enable it.
-4. Set the flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED` to `true` and restart the Worker. Workers that aren't restarted with this flag will not poll for configurations deployed in the UI. 
+4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `true` and restart the Worker. Workers that are not restarted with this flag are not polled for configurations deployed in the UI. 
 6. Deploy a version in your version history, so that the Workers receive the new version configuration. Click on a version, click _Edit as Draft_, then click _Deploy_. 
 
 

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -400,7 +400,7 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 </div>
 If you are enrolled in the private beta of [Remote Configuration][7] to remotely roll out changes to your OP Workers, you remotely roll out changes to your Workers from the Datadog UI, rather than making updates to your pipeline configuration in a text editor and rolling out your changes manually. You can choose your deployment method when you create a pipeline and install your Workers.
 
-After deploying a pipeline, you can also switch deployment methods, such as going from manually managed pipeline to remote configuration enabled pipeline or vice versa. 
+After deploying a pipeline, you can also switch deployment methods, such as going from a manually managed pipeline to a remote configuration enabled pipeline or vice versa. 
 
 If you want to switch from a remote configuration deployment to a manually managed deployment:
 1. Navigate to Observability Pipelines.

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -393,6 +393,13 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 - See [Deployment Design and Principles][7] for information on what to consider when designing your Observability Pipelines architecture.
 - See [Best Practices for OPW Aggregator Architecture][8] for details on the recommended Observability Pipelines aggregator architecture, which is optimized for scaling.
 
+## Deployment Modes: Remote Configuration
+If you are enrolled in the private beta of [Remote Configuration][7] to remotely roll out changes to your OP Workers, you can switch deployment methods in the settings cog (i.e. going from manually managed pipeline to remote configuration enabled pipeline). When switching deployment methods, ensure that you restart the Worker with the new deployment mode flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED`, set to match the UI.
+
+When going from remote configuration to manual deployment mode, even if you switch the deployment mode in the UI, if you do not switch the deployment mode of each Workers by turning the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag off, the Workers themselves will be remote configuration enabled so therefore will continue pulling a version configuration.
+
+When going from manual to remote configuration deployment mode, after restarting the Worker with  flag, you will need to deploy a version in your version history, so that the Workers receive the new version configuration. 
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -405,3 +412,4 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 [6]: /observability_pipelines/working_with_data/
 [7]: /observability_pipelines/production_deployment_overview/
 [8]: /observability_pipelines/architecture/
+[9]: /agent/remote_config

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -394,6 +394,10 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 - See [Best Practices for OPW Aggregator Architecture][8] for details on the recommended Observability Pipelines aggregator architecture, which is optimized for scaling.
 
 ## Deployment Modes
+
+<div class="alert alert-warning">
+  Remote configuration for Observability Pipelines is in private beta. Contact <a href="https://docs.datadoghq.com/help/">Datadog support</a> or your Customer Success Manager for access.
+</div>
 If you are enrolled in the private beta of [Remote Configuration][7] to remotely roll out changes to your OP Workers, you can switch deployment methods in the settings cog (i.e. going from manually managed pipeline to remote configuration enabled pipeline). When switching deployment methods, ensure that you restart the Worker with the new deployment mode flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED`, set to match the UI.
 
 When going from remote configuration to manual deployment mode, even if you switch the deployment mode in the UI, if you do not switch the deployment mode of each Workers by turning the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag off, the Workers themselves will be remote configuration enabled so therefore will continue pulling a version configuration.

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -398,6 +398,7 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 <div class="alert alert-warning">
   Remote configuration for Observability Pipelines is in private beta. Contact <a href="https://docs.datadoghq.com/help/">Datadog support</a> or your Customer Success Manager for access.
 </div>
+
 If you are enrolled in the private beta of [Remote Configuration][9], you can remotely roll out changes to your Workers from the Datadog UI, rather than make updates to your pipeline configuration in a text editor and then manually rolling out your changes. Choose your deployment method when you create a pipeline and install your Workers.
 
 After deploying a pipeline, you can also switch deployment methods, such as going from a manually managed pipeline to a remote configuration enabled pipeline or vice versa. 

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -393,7 +393,7 @@ For a deeper dive into recommendations for deploying and scaling multiple Worker
 - See [Deployment Design and Principles][7] for information on what to consider when designing your Observability Pipelines architecture.
 - See [Best Practices for OPW Aggregator Architecture][8] for details on the recommended Observability Pipelines aggregator architecture, which is optimized for scaling.
 
-## Deployment Modes: Remote Configuration
+## Switching Deployment Modes
 If you are enrolled in the private beta of [Remote Configuration][7] to remotely roll out changes to your OP Workers, you can switch deployment methods in the settings cog (i.e. going from manually managed pipeline to remote configuration enabled pipeline). When switching deployment methods, ensure that you restart the Worker with the new deployment mode flag, `DD_OP_REMOTE_CONFIGURATION_ENABLED`, set to match the UI.
 
 When going from remote configuration to manual deployment mode, even if you switch the deployment mode in the UI, if you do not switch the deployment mode of each Workers by turning the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag off, the Workers themselves will be remote configuration enabled so therefore will continue pulling a version configuration.


### PR DESCRIPTION
We are introducing a new toggle in the UI that let's the users to have switch between deployment methods - manual vs remote config (https://a.cl.ly/NQu5J87q). Only users enrolled in remote config are affected but we will be rolling this update out next week. We are updating the docs so that the affected users understand specific edge cases when we roll this out

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->