### PR TITLE
Add some better installation notes for OP in K8s

### DIFF
--- a/content/en/observability_pipelines/setup/datadog.md
+++ b/content/en/observability_pipelines/setup/datadog.md
@@ -45,14 +45,30 @@ Ensure that your machine is configured to run Docker.
 {{% tab "AWS EKS" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.
 
-* The [AWS Load Balancer controller][1] is required. To see if it is installed, run the following command and look for `aws-load-balancer-controller` in the list:
+* The [EBS CSI driver][1] is required. To see if it is installed, run the following command and look for `ebs-csi-controller` in the list:
+
+  ```shell
+  kubectl get pods -n kube-system
+  ```
+
+* A `StorageClass` is required for the Workers to provision the correct EBS drives. To see if it is installed already, run the following command and look for `io2` in the list:
+
+  ```shell
+  kubectl get storageclass
+  ```
+
+  If `io2` is not present, download [the StorageClass YAML][2] and `kubectl apply` it.
+
+* The [AWS Load Balancer controller][3] is required. To see if it is installed, run the following command and look for `aws-load-balancer-controller` in the list:
 
   ```shell
   helm list -A
   ```
 * Datadog recommends using Amazon EKS >= 1.16.
 
-[1]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
+[1]: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+[2]: /resources/yaml/observability_pipelines/helm/storageclass.yaml
+[3]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.

--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -49,14 +49,30 @@ Ensure that your machine is configured to run Docker.
 {{% tab "AWS EKS" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.
 
-* The [AWS Load Balancer controller][1] is required. To see if it is installed, run the following command and look for `aws-load-balancer-controller` in the list:
+* The [EBS CSI driver][1] is required. To see if it is installed, run the following command and look for `ebs-csi-controller` in the list:
+
+  ```shell
+  kubectl get pods -n kube-system
+  ```
+
+* A `StorageClass` is required for the Workers to provision the correct EBS drives. To see if it is installed already, run the following command and look for `io2` in the list:
+
+  ```shell
+  kubectl get storageclass
+  ```
+
+  If `io2` is not present, download [the StorageClass YAML][2] and `kubectl apply` it.
+
+* The [AWS Load Balancer controller][3] is required. To see if it is installed, run the following command and look for `aws-load-balancer-controller` in the list:
 
   ```shell
   helm list -A
   ```
 * Datadog recommends using Amazon EKS >= 1.16.
 
-[1]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
+[1]: https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html
+[2]: /resources/yaml/observability_pipelines/helm/storageclass.yaml
+[3]: https://docs.aws.amazon.com/eks/latest/userguide/aws-load-balancer-controller.html
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
 To run the Worker on your Kubernetes nodes, you need a minimum of two nodes with one CPU and 512MB RAM available. Datadog recommends creating a separate node pool for the Workers, which is also the recommended configuration for production deployments.

--- a/static/resources/yaml/observability_pipelines/datadog/aws_eks_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/datadog/aws_eks_rc.yaml
@@ -47,6 +47,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Datadog Agent source.
+  ports:
+    - port: 8282
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/datadog/azure_aks_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/datadog/azure_aks_rc.yaml
@@ -47,6 +47,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Datadog Agent source.
+  ports:
+    - port: 8282
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/datadog/google_gke_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/datadog/google_gke_rc.yaml
@@ -47,6 +47,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Datadog Agent source.
+  ports:
+    - port: 8282
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/helm/storageclass.yaml
+++ b/static/resources/yaml/observability_pipelines/helm/storageclass.yaml
@@ -1,0 +1,9 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: io2
+provisioner: ebs.csi.aws.com
+volumeBindingMode: WaitForFirstConsumer
+parameters:
+  type: io2
+  iopsPerGB: "200"

--- a/static/resources/yaml/observability_pipelines/splunk/aws_eks_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/aws_eks_rc.yaml
@@ -53,6 +53,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Splunk source.
+  ports:
+    - port: 8088
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/splunk/azure_aks_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/azure_aks_rc.yaml
@@ -53,6 +53,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Splunk source.
+  ports:
+    - port: 8088
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/splunk/google_gke_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/google_gke_rc.yaml
@@ -53,6 +53,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Splunk source.
+  ports:
+    - port: 8088
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds two important things to the installation of OPW in Kubernetes environments:

* In EKS environments, the EBS driver is also required for buffers, as well as a `StorageClass` that is compatible with the OPW charts. I've included links to the necessary resources here.
* In addition, for remote configuration installs, ports must be manually specified in the Helm charts. Otherwise, no Load Balancer will be created at all.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->