### PR TITLE
update integrations number to 650+

### DIFF
--- a/data/partials/home.es.yaml
+++ b/data/partials/home.es.yaml
@@ -3,7 +3,7 @@ guides:
   link: getting_started/agent/
   link_text: Empezando con el Agent
   title: Instalar el Agent
-- desc: Recopila métricas, trazas y logs con más de 650+ integraciones de serie para
+- desc: Recopila métricas, trazas y logs con más de 650 integraciones de serie para
     enviar a Datadog.
   link: getting_started/integrations/
   link_text: Empezando con las integraciones

--- a/data/partials/home.es.yaml
+++ b/data/partials/home.es.yaml
@@ -3,7 +3,7 @@ guides:
   link: getting_started/agent/
   link_text: Empezando con el Agent
   title: Instalar el Agent
-- desc: Recopila métricas, trazas y logs con más de 600 integraciones de serie para
+- desc: Recopila métricas, trazas y logs con más de 650+ integraciones de serie para
     enviar a Datadog.
   link: getting_started/integrations/
   link_text: Empezando con las integraciones

--- a/data/partials/home.fr.yaml
+++ b/data/partials/home.fr.yaml
@@ -4,7 +4,7 @@ guides:
   link: getting_started/agent/
   link_text: Débuter avec l'Agent
   title: Installer l'Agent
-- desc: Récupérez des métriques, des traces et des logs grâce à plus de 650+ intégrations
+- desc: Récupérez des métriques, des traces et des logs grâce à plus de 650 intégrations
     afin de les envoyer à Datadog.
   link: getting_started/integrations/
   link_text: Débuter avec les intégrations

--- a/data/partials/home.fr.yaml
+++ b/data/partials/home.fr.yaml
@@ -4,7 +4,7 @@ guides:
   link: getting_started/agent/
   link_text: Débuter avec l'Agent
   title: Installer l'Agent
-- desc: Récupérez des métriques, des traces et des logs grâce à plus de 600 intégrations
+- desc: Récupérez des métriques, des traces et des logs grâce à plus de 650+ intégrations
     afin de les envoyer à Datadog.
   link: getting_started/integrations/
   link_text: Débuter avec les intégrations

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -7,7 +7,7 @@ guides:
     link_text: Getting Started with the Agent
     link: getting_started/agent/
   - title: Set Up Integrations
-    desc: Gather metrics, traces, and logs with over 650+ built-in integrations to send to Datadog.
+    desc: Gather metrics, traces, and logs with over 650 built-in integrations to send to Datadog.
     link_text: Getting Started with Integrations
     link: getting_started/integrations/
   - title: Get Started in App

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -7,7 +7,7 @@ guides:
     link_text: Getting Started with the Agent
     link: getting_started/agent/
   - title: Set Up Integrations
-    desc: Gather metrics, traces, and logs with over 600 built-in integrations to send to Datadog.
+    desc: Gather metrics, traces, and logs with over 650+ built-in integrations to send to Datadog.
     link_text: Getting Started with Integrations
     link: getting_started/integrations/
   - title: Get Started in App


### PR DESCRIPTION
### What does this PR do? What is the motivation?
update integrations number from 600 to 650+
https://datadoghq.atlassian.net/browse/WEB-4125

### Merge instructions
Do not merge right away. Stakeholder will give green light and I will notify docs team.

### Preview
https://docs-staging.datadoghq.com/renzo.renteria/update-integrations-number/