### PR TITLE
Add jFlow as a supported NetFlow protocol.md

### DIFF
--- a/content/en/network_monitoring/devices/netflow.md
+++ b/content/en/network_monitoring/devices/netflow.md
@@ -30,7 +30,7 @@ To use NetFlow Monitoring with Network Device Monitoring, ensure you are using t
 
 ## Configuration
 
-To configure your devices to send NetFlow, sFlow, or IPFIX traffic to the Agent NetFlow server, your devices must be configured to send traffic to the IP address that the Datadog Agent is installed on, specifically the `flow_type` and `port`.
+To configure your devices to send NetFlow, jFlow, sFlow, or IPFIX traffic to the Agent NetFlow server, your devices must be configured to send traffic to the IP address that the Datadog Agent is installed on, specifically the `flow_type` and `port`.
 
 Edit your [`datadog.yaml`][3] Agent configuration file to enable NetFlow:
 


### PR DESCRIPTION
We support jFlow as part of NetFlow monitoring now - this is also reflected in our pricing page. Proposing this update to keep the NDM page up to date.


### Merge instructions
- [ x] Please merge after reviewing