### PR TITLE
dan.chiniara/specify query alert for alert graph widget

### DIFF
--- a/content/en/dashboards/widgets/alert_graph.md
+++ b/content/en/dashboards/widgets/alert_graph.md
@@ -15,7 +15,7 @@ Alert graphs are timeseries graphs showing the current status of most monitors d
 
 {{< img src="dashboards/widgets/alert_graph/alert_graph.png" alt="Alert Graph" >}}
 
-This widget is supported for metric, anomaly, outlier, forecast, APM, and integration monitors.
+This widget is supported in query alert monitors such as metric, anomaly, outlier, forecast, APM, and integration.
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Specify that query alerts are supported for the Alert Graph widget. It's not supported for trace analytic monitors and service check-based Integration monitors. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

[https://docs-staging.datadoghq.com/dan.chiniara/specify-query-alert-for-alert-graph-widget/dashboards/widgets/alert_graph](https://docs-staging.datadoghq.com/dan.chiniara/specify-query-alert-for-alert-graph-widget/dashboards/widgets/alert_graph)