### PR TITLE
[DOCS-6331] updating ASM library pages with right nav for threat detection

### DIFF
--- a/content/en/security/application_security/enabling/dotnet.md
+++ b/content/en/security/application_security/enabling/dotnet.md
@@ -28,7 +28,8 @@ You can monitor application security for .NET apps running in Docker, Kubernetes
 
 {{% appsec-getstarted-with-rc %}}
 
-## Get started
+## Enabling threat detection
+### Get started
 
 1. **Update your [Datadog .NET library][1]** to at least version 2.2.0 (at least version 2.16.0 for Application Vulnerability Management vulnerability detection features) for your target operating system architecture.
 

--- a/content/en/security/application_security/enabling/go.md
+++ b/content/en/security/application_security/enabling/go.md
@@ -27,7 +27,8 @@ You can monitor application security for Go apps running in Docker, Kubernetes, 
 {{% appsec-getstarted %}}
 - Your service is [supported][2].
 
-## Get started
+## Enabling threat detection
+### Get started
 
 1. **Add to your program's go.mod dependencies** the latest version of the Datadog Go library (version 1.53.0 or later):
 

--- a/content/en/security/application_security/enabling/java.md
+++ b/content/en/security/application_security/enabling/java.md
@@ -29,7 +29,8 @@ You can monitor application security for Java apps running in Docker, Kubernetes
 
 {{% appsec-getstarted-with-rc %}}
 
-## Get started
+## Enabling threat detection
+### Get started
 
 1. **Update your [Datadog Java library][1]** to at least version 0.94.0 (at least version 1.1.4 for Application Vulnerability Management vulnerability detection features):
    ```shell

--- a/content/en/security/application_security/enabling/nodejs.md
+++ b/content/en/security/application_security/enabling/nodejs.md
@@ -28,7 +28,8 @@ You can monitor application security for Node.js apps running in Docker, Kuberne
 
 {{% appsec-getstarted-with-rc %}}
 
-## Get started
+## Enabling threat detection
+### Get started
 
 1. **Update your Datadog Node.js library package** to at least version 2.23.0 (for NodeJS 12+) or 3.10.0 (for NodeJS 14+), by running one of these commands:
    ```shell

--- a/content/en/security/application_security/enabling/php.md
+++ b/content/en/security/application_security/enabling/php.md
@@ -26,7 +26,8 @@ You can monitor application security for PHP apps running in host-based or conta
 
 {{% appsec-getstarted %}}
 
-## Get started
+## Enabling threat detection
+### Get started
 
 1. **Install the latest Datadog PHP library** by downloading and running the installer:
    ```shell

--- a/content/en/security/application_security/enabling/python.md
+++ b/content/en/security/application_security/enabling/python.md
@@ -26,7 +26,8 @@ You can monitor the security of your Python apps running in Docker, Kubernetes, 
 
 {{% appsec-getstarted %}}
 
-## Get started
+## Enabling threat detection
+### Get started
 
 1. **Update your Datadog Python library package** to at least version 1.2.2 (at least version 1.5.0 for Application Vulnerability Management vulnerability detection features). Run the following:
    ```shell

--- a/content/en/security/application_security/enabling/ruby.md
+++ b/content/en/security/application_security/enabling/ruby.md
@@ -26,7 +26,8 @@ You can monitor application security for Ruby apps running in Docker, Kubernetes
 
 {{% appsec-getstarted %}}
 
-## Get started
+## Enabling threat detection
+### Get started
 
 1. **Update your Gemfile to include the Datadog library**:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds an H2 to the right nav of each of the ASM library pages to make it easier for a customer to differentiate how to configure ASM threat detection vs ASM code-level vulnerabilities relative to each library, as it was causing confusion to the user. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [] Please merge after reviewing
- Do not merge, waiting for PM approval

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->