### PR TITLE
Add ports to the quickstart Helm charts.

### DIFF
--- a/static/resources/yaml/observability_pipelines/quickstart/aws_eks_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/aws_eks_rc.yaml
@@ -53,6 +53,9 @@ affinity:
 ## In the meantime, beware of cost implications of running this LB!
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Datadog Agent source.
+  ports:
+    - port: 8282
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/quickstart/azure_aks_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/azure_aks_rc.yaml
@@ -53,6 +53,9 @@ affinity:
 ## In the meantime, beware of cost implications of running this LB!
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Datadog Agent source.
+  ports:
+    - port: 8282
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/quickstart/google_gke_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/google_gke_rc.yaml
@@ -53,6 +53,9 @@ affinity:
 ## In the meantime, beware of cost implications of running this LB!
 service:
   enabled: true
+  ## You must manually specify the ports to open; this will match the Datadog Agent source.
+  ports:
+    - port: 8282
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This adds a `datadog_agent` source-compatible port to the load balancers we provision for the quickstart use case. This should make it easier to hook up the customers' Datadog Agents to OPW should they go down this installation path.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->