### PR TITLE
Update processors.md

### DIFF
--- a/content/en/logs/log_configuration/processors.md
+++ b/content/en/logs/log_configuration/processors.md
@@ -105,7 +105,7 @@ To see how a custom date and time format can be parsed in Datadog, see [Parsing 
 * Log events can be submitted up to 18 hours in the past and two hours in the future.
 * As of ISO 8601-1:2019, the basic format is `T[hh][mm][ss]` and the extended format is `T[hh]:[mm]:[ss]`. Earlier versions omitted the T (representing time) in both formats.
 * If your logs don't contain any of the default attributes and you haven't defined your own date attribute, Datadog timestamps the logs with the date it received them.
-* If multiple log date remapper processors are applied to a given log, only the first one (according to the pipeline's order) is taken into account.
+* If multiple log date remapper processors are applied to a given log within the pipeline, only the first one (according to the pipeline's order) is taken into account.
 
 {{< tabs >}}
 {{% tab "UI" %}}
@@ -162,7 +162,7 @@ Each incoming status value is mapped as follows:
 * Strings beginning with **o** or **s**, or matching **OK** or **Success** (case-insensitive) map to **OK**
 * All others map to **info (6)**
 
-**Note**: If multiple log status remapper processors are applied to a given log, only the first one (according to the pipeline's order) is taken into account.
+**Note**: If multiple log status remapper processors are applied to a given log within the pipeline, only the first one (according to the pipeline's order) is taken into account.
 
 {{< tabs >}}
 {{% tab "UI" %}}
@@ -201,7 +201,7 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following log status rem
 
 The service remapper processor assigns one or more attributes to your logs as the official service.
 
-**Note**: If multiple service remapper processors are applied to a given log, only the first one (according to the pipeline's order) is taken into account.
+**Note**: If multiple service remapper processors are applied to a given log within the pipeline, only the first one (according to the pipeline's order) is taken into account.
 
 {{< tabs >}}
 {{% tab "UI" %}}
@@ -244,7 +244,7 @@ Use the log message remapper processor to define one or more attributes as the o
 
 To define message attributes, first use the [string builder processor](#string-builder-processor) to create a new string attribute for each of the attributes you want to use. Then, use the log message remapper to remap the string attributes as the message.
 
-**Note**: If multiple log message remapper processors are applied to a given log, only the first one (according to the pipeline order) is taken into account.
+**Note**: If multiple log message remapper processors are applied to a given log within the pipeline, only the first one (according to the pipeline order) is taken into account.
 
 {{< tabs >}}
 {{% tab "UI" %}}


### PR DESCRIPTION
Edited Notes section for remappers from:

"If multiple log date remapper processors are applied to a given log, only the first one (according to the pipeline’s order) is taken into account."

to 

"If multiple log date remapper processors are applied to a given log within the pipeline, only the first one (according to the pipeline’s order) is taken into account."

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->