### PR TITLE
DBMON-2973 Mark support for Postgres 15 on Google Cloud SQL

### DIFF
--- a/content/en/database_monitoring/guide/pg15_upgrade.md
+++ b/content/en/database_monitoring/guide/pg15_upgrade.md
@@ -26,7 +26,7 @@ ssl: allow
 Restart the agent after applying this change.
 {{% /tab %}}
 {{% tab "Google Cloud SQL" %}}
-Agent versions prior to `7.50` may attempt to connect to the `cloudsqladmin` database which can generate error logs on the database as well as warning logs in the agent. In order to silence warnings, it is recommended to add `cloudsqladmin` to the [ignore_databases][1] list:
+Agent versions prior to `7.50` may attempt to connect to the `cloudsqladmin` database. This can cause error logs on the database as well as warning logs in the agent. In order to silence those logs, it is recommended to add `cloudsqladmin` to the [ignore_databases][1] list:
 
 ```yaml
 ignore_databases:

--- a/content/en/database_monitoring/guide/pg15_upgrade.md
+++ b/content/en/database_monitoring/guide/pg15_upgrade.md
@@ -26,7 +26,7 @@ ssl: allow
 Restart the agent after applying this change.
 {{% /tab %}}
 {{% tab "Google Cloud SQL" %}}
-Agent versions prior to `7.50` may attempt to connect to the `cloudsqladmin` database. This can cause error logs on the database as well as warning logs in the agent. In order to silence those logs, it is recommended to add `cloudsqladmin` to the [ignore_databases][1] list:
+Agent versions prior to `7.50` may attempt to connect to the `cloudsqladmin` database. This can cause error logs on the database as well as warning logs in the Agent. In order to silence those logs, add `cloudsqladmin` to the [ignore_databases][1] list:
 
 ```yaml
 ignore_databases:

--- a/content/en/database_monitoring/guide/pg15_upgrade.md
+++ b/content/en/database_monitoring/guide/pg15_upgrade.md
@@ -1,8 +1,16 @@
 ---
-title: Upgrading to PostgreSQL 15 on RDS
+title: Upgrading to PostgreSQL 15
 kind: guide
 ---
 
+Run this command on each database host to enable the additional permission needed for the `datadog` user:
+
+```SQL
+ALTER ROLE datadog INHERIT;
+```
+
+{{< tabs >}}
+{{% tab "RDS" %}}
 Agent versions prior to `7.49` may be unable to connect to PostgreSQL RDS instances without a configuration change. New RDS instances have a default value of `1` for the `rds.force_ssl` parameter. In Agent versions prior to `7.49`, this causes the following error when the Agent tries to issue queries:
 
 ```
@@ -16,9 +24,26 @@ ssl: allow
 ```
 
 Restart the agent after applying this change.
+{{% /tab %}}
+{{% tab "Google Cloud SQL" %}}
+Agent versions prior to `7.50` may attempt to connect to the `cloudsqladmin` database which can generate error logs on the database as well as warning logs in the agent. In order to silence warnings, it is recommended to add `cloudsqladmin` to the [ignore_databases][1] list:
 
-Run this command on each database host to enable the additional permission needed for the `datadog` user:
-
-```SQL
-ALTER ROLE datadog INHERIT;
+```yaml
+ignore_databases:
+  - template%
+  - rdsadmin
+  - azure_maintenance
+  - cloudsqladmin
 ```
+
+If using [database autodiscovery][2], also add `cloudsqladmin` to [excluded databases][3]:
+
+```yaml
+  exclude:
+   - cloudsqladmin
+```
+[1]: https://github.com/DataDog/integrations-core/blob/7.49.x/postgres/datadog_checks/postgres/data/conf.yaml.example#L56-L64
+[2]: https://github.com/DataDog/integrations-core/blob/7.49.x/postgres/datadog_checks/postgres/data/conf.yaml.example#L250
+[3]: https://github.com/DataDog/integrations-core/blob/7.49.x/postgres/datadog_checks/postgres/data/conf.yaml.example#L277-L279
+{{% /tab %}}
+{{< /tabs >}}

--- a/content/en/database_monitoring/setup_postgres/_index.md
+++ b/content/en/database_monitoring/setup_postgres/_index.md
@@ -20,7 +20,7 @@ disable_sidebar: true
 | Postgres 12 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
 | Postgres 13 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
 | Postgres 14 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
-| Postgres 15 | {{< X >}} | {{< X >}} |  |  |  |
+| Postgres 15 | {{< X >}} | {{< X >}} |  | {{< X >}} |  |
 
 
 For setup instructions, select your hosting type:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
As we're wrapping up testing of Postgres 15 on Google Cloud SQL, this marks it as a supported configuration for DBM and also notes a few recommended configurations to help with the upgrade. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->