### PR TITLE
Update Serverless -> Google Cloud Run Java section 

### DIFF
--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -204,18 +204,6 @@ ENTRYPOINT ["/app/datadog-init"]
 CMD ["./mvnw", "spring-boot:run"]
 ```
 
-If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. To understand why this may be required, please refer to [how serverless-init works](#how-it-works)
-
-{{< highlight dockerfile "hl_lines=7" >}}
-COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
-ENV DD_SERVICE=datadog-demo-run-nodejs
-ENV DD_ENV=datadog-demo
-ENV DD_VERSION=1
-ENTRYPOINT ["/app/datadog-init"]
-CMD ["/your_entrypoint.sh", "/nodejs/bin/node", "/path/to/your/app.js"]
-{{< /highlight >}}
-
 #### Explanation
 
 1. Copy the Datadog `serverless-init` into your Docker image.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR removes a section from the Java tab under Serverless -> Google Cloud Run that isn't relevant. 
Verified with @ceciliawatt 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->