### PR TITLE
Bumps timeout for Algolia sync jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,6 +209,7 @@ algolia_sync_preview:manual:
   environment: "preview"
   allow_failure: true
   interruptible: true
+  timeout: 1h 30m
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
     - ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') yarn run algolia:sync
@@ -225,6 +226,7 @@ algolia_sync_live:
   environment: "live"
   allow_failure: true
   interruptible: true
+  timeout: 1h 30m
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
     - ALGOLIA_APP_ID=$(get_secret 'algolia_docsearch_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_docsearch_api_key') yarn run algolia:sync


### PR DESCRIPTION
### What does this PR do? What is the motivation?
- Bumps the timeout to 1h 30m for the algolia sync jobs.    The current job has been timing out: https://dd.slack.com/archives/C3CT8QA11/p1697665327071059

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->