### PR TITLE
Remove region availability banner from Flex Logs doc

### DIFF
--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -16,10 +16,6 @@ further_reading:
   text: "Log Archives"
 ---
 
-{{< site-region region="eu,gov,us3,us5,ap1" >}}
-<div class="alert alert-warning">Flex Logs is not supported for the Datadog {{< region-param key="dd_site_name" >}} site.</div>
-{{< /site-region >}}
-
 {{< callout url="https://docs.google.com/forms/d/15FJG6RTFMmp7c7aRE8bcTy6B1Tt8ia4OmiesQa_zkZ4/viewform?edit_requested=true" btn_hidden="false" header="Request Access!">}}
 Flex Logs is in Limited Availability, but you can request access! Use this form to submit your request today.
 {{< /callout >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

PM request (Sid). Flex Logs is available in all regions now.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->