### PR TITLE
WEB-4165 | update timeout for preview check on synthetics

### DIFF
--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           URL="https://docs-staging.datadoghq.com/${{steps.extract_branch.outputs.branch}}"
           SUCCESS_CODES=("200" "302" "304")
-          for i in {1..10}
+          for i in {1..15}
           do
             status=$(curl -o /dev/null -s -w "%{http_code}\n" $URL)
             if [[ " ${SUCCESS_CODES[@]} " =~ " ${status} " ]]; then
@@ -39,8 +39,8 @@ jobs:
               echo "Currently returning ${status}"
               sleep 60
             fi
-            if [[ $i -eq 10 && ! (" ${SUCCESS_CODES[@]} " =~ " ${status} ") ]]; then
-              echo "Preview site returned ${status} for 10 minutes, there may be an issue with the preview site build"
+            if [[ $i -eq 15 && ! (" ${SUCCESS_CODES[@]} " =~ " ${status} ") ]]; then
+              echo "Preview site returned ${status} for 15 minutes, there may be an issue with the preview site build"
               exit 1
             fi
           done


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Bumps the timeout of synthetics action to 15 minutes based on the average docs preview build time found [here](https://dd-corpsite.datadoghq.com/dashboard/4jg-n7c-9kt/pipeline-durations?refresh_mode=sliding&from_ts=1697718816524&to_ts=1697733216524&live=true)
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->