### PR TITLE
Add info about Git for Windows path expansion

### DIFF
--- a/content/en/continuous_integration/tests/setup/junit_xml.md
+++ b/content/en/continuous_integration/tests/setup/junit_xml.md
@@ -431,7 +431,7 @@ datadog-ci junit upload --service service_name \
 {{< /tabs >}}
 
 <div class="alert alert-warning">
-  When using bash from Git for Windows you will need to define the <strong>MSYS_NO_PATHCONV=1</strong> environment variable.
+  When using bash from Git for Windows, define the <strong>MSYS_NO_PATHCONV=1</strong> environment variable.
   Otherwise, any argument starting with <strong>/</strong> will be expanded to a Windows path.
 </div>
 

--- a/content/en/continuous_integration/tests/setup/junit_xml.md
+++ b/content/en/continuous_integration/tests/setup/junit_xml.md
@@ -430,6 +430,11 @@ datadog-ci junit upload --service service_name \
 
 {{< /tabs >}}
 
+<div class="alert alert-warning">
+  When using bash from Git for Windows you will need to define the <strong>MSYS_NO_PATHCONV=1</strong> environment variable.
+  Otherwise, any argument starting with <strong>/</strong> will be expanded to a Windows path.
+</div>
+
 ## Providing metadata through property elements
 
 Another way to provide additional tags to specific tests is including `<property name="dd_tags[key]" value="value">` elements within the `<testsuite>` or `<testcase>` elements. If you add these tags to a `<testcase>` element, they are stored in its test span. If you add the tags to a `<testsuite>` element, they are stored in all of that suite's test spans.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

When using Bash that comes with Git for windows command line arguments like `--xpath-tag=test.suite=/testcase/@classname` are converted to `--xpath-tag=test.suite=C:/Program Files/git/testcase/@classname`

### Merge instructions

- [x] Please merge after reviewing

### Additional notes

Feel free to update the formating if needed.

I think that it helps to raise this issue in the documentation as many arguments start with a slash.
