### PR TITLE
[DOCS-6354] Rename duplicate anchor to fix page scroll

### DIFF
--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -618,7 +618,7 @@ remote_configuration:
 If these properties are set to different values, change them to match. If they are not present, add them. Restart the Datadog Agent. 
 
 
-## Configure Docker injection
+## Configure Docker injection {#configure-docker-injection-2}
 
 If the default configuration doesn't meet your needs, you can edit `/etc/datadog-agent/inject/docker_config.yaml` and add the following YAML configuration for the injection:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- There are two "Configure Docker injection" headings on this page, which prevents us from linking to the sections correctly.
- The links function, but the page doesn't scroll to the heading.
- As a workaround, we can change the anchor so that each section has a unique anchor id.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
- I already verified that we only link to this heading in the "Agent and app in separate containers" tabs, so it should be ok to change the one in "Agent on host, app in containers".

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->