### PR TITLE
[WEB-4172] Re-index only English pages on master pipelines; full Algolia index during nightly build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,9 +212,9 @@ algolia_sync_preview:manual:
   timeout: 2h
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
-    - |
-      ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id')
-      ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key')
+    - >
+      ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id') 
+      ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') 
       CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE
       yarn run algolia:sync
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,7 +212,11 @@ algolia_sync_preview:manual:
   timeout: 2h
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
-    - ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE CI_ENVIRONMENT_NAME=$CI_ENVIRONMENT_NAME yarn run algolia:sync
+    - |
+      ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id')
+      ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key')
+      CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE
+      yarn run algolia:sync
   rules:
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
       when: never
@@ -226,10 +230,14 @@ algolia_sync_live:
   environment: "live"
   allow_failure: true
   interruptible: true
-  timeout: 1h 30m
+  timeout: 2h
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
-    - ALGOLIA_APP_ID=$(get_secret 'algolia_docsearch_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_docsearch_api_key') yarn run algolia:sync
+    - |
+      ALGOLIA_APP_ID=$(get_secret 'algolia_docsearch_application_id')
+      ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_docsearch_api_key') 
+      CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE
+      yarn run algolia:sync
 
 sourcemaps_preview:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -233,7 +233,7 @@ algolia_sync_live:
   timeout: 2h
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
-    - |
+    - >
       ALGOLIA_APP_ID=$(get_secret 'algolia_docsearch_application_id')
       ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_docsearch_api_key') 
       CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -209,10 +209,14 @@ algolia_sync_preview:manual:
   environment: "preview"
   allow_failure: true
   interruptible: true
-  timeout: 1h 30m
+  timeout: 2h
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
-    - ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') yarn run algolia:sync
+    - ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id') \
+      ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') \
+      CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE \
+      CI_ENVIRONMENT_NAME=$CI_ENVIRONMENT_NAME \
+      yarn run algolia:sync
   rules:
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
       when: never

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -212,11 +212,7 @@ algolia_sync_preview:manual:
   timeout: 2h
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
-    - ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id') \
-      ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') \
-      CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE \
-      CI_ENVIRONMENT_NAME=$CI_ENVIRONMENT_NAME \
-      yarn run algolia:sync
+    - ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id') ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key') CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE CI_ENVIRONMENT_NAME=$CI_ENVIRONMENT_NAME yarn run algolia:sync
   rules:
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
       when: never

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -158,6 +158,7 @@ const sync = () => {
         .then(() => console.log(`${indexName} synonyms update complete`))
         .catch((err) => console.error(err));
 
+    console.info('Syncing index...')
     updateIndex(indexName);
 };
 

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -123,8 +123,8 @@ const updateIndex = (indexName) => {
     console.info('Syncing index...')
     const localAlogliaSearchIndex = require('../../../public/algolia.json');
     const localEnglishOnlyIndex = localAlogliaSearchIndex.filter(record => record.language === "en")
-    console.log(localAlogliaSearchIndex.length)
-    console.log(localEnglishOnlyIndex.length)
+    console.info(process.env.CI_ENVIRONMENT_NAME)
+    console.info(process.env.CI_PIPELINE_SOURCE)
 
     const cb = (error, result) => {
         if (error) {

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -142,7 +142,7 @@ const updateIndex = (indexName) => {
         console.log(result);
     };
 
-    atomicalgolia(indexName, localEnglishOnlyIndex, { verbose: true }, cb);
+    atomicalgolia(indexName, localAlgoliaSearchIndex, { verbose: true }, cb);
 };
 
 const sync = () => {

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -120,7 +120,11 @@ const updateReplicas = (client, indexName) => {
 };
 
 const updateIndex = (indexName) => {
+    console.info('Syncing index...')
     const localAlogliaSearchIndex = require('../../../public/algolia.json');
+    const localEnglishOnlyIndex = localAlogliaSearchIndex.filter(record => record.language === "en")
+    console.log(localAlogliaSearchIndex.length)
+    console.log(localEnglishOnlyIndex.length)
 
     const cb = (error, result) => {
         if (error) {
@@ -131,7 +135,7 @@ const updateIndex = (indexName) => {
         console.log(result);
     };
 
-    atomicalgolia(indexName, localAlogliaSearchIndex, { verbose: true }, cb);
+    atomicalgolia(indexName, localEnglishOnlyIndex, { verbose: true }, cb);
 };
 
 const sync = () => {
@@ -158,7 +162,6 @@ const sync = () => {
         .then(() => console.log(`${indexName} synonyms update complete`))
         .catch((err) => console.error(err));
 
-    console.info('Syncing index...')
     updateIndex(indexName);
 };
 

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -120,11 +120,18 @@ const updateReplicas = (client, indexName) => {
 };
 
 const updateIndex = (indexName) => {
-    console.info('Syncing index...')
-    const localAlogliaSearchIndex = require('../../../public/algolia.json');
-    const localEnglishOnlyIndex = localAlogliaSearchIndex.filter(record => record.language === "en")
-    console.info(process.env.CI_ENVIRONMENT_NAME)
-    console.info(process.env.CI_PIPELINE_SOURCE)
+    console.info('Syncing local index with Algolia...')
+    const fullLocalAlogliaSearchIndex = require('../../../public/algolia.json');
+    let localAlgoliaSearchIndex
+
+    // Only the full nightly build re-indexes all language pages in Algolia.
+    // Master/preview pipelines will re-index only English pages automatically.
+    // This is done to improve performance as Docs continues scaling.
+    if (process.env.CI_PIPELINE_SOURCE.toLowerCase() !== 'schedule') {
+        localAlgoliaSearchIndex = fullLocalAlogliaSearchIndex.filter(record => record.language === "en")
+    } else {
+        localAlgoliaSearchIndex = fullLocalAlogliaSearchIndex
+    }
 
     const cb = (error, result) => {
         if (error) {


### PR DESCRIPTION
### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/WEB-4172

- Instead of re-indexing all languages on every `master` push, this only updates the English records.   The full index (including all languages) will be re-indexed as part of the nightly scheduled build.    This makes the Algolia job run much faster after each `master` pipeline - from 1hr+ to [6 minutes in the most recent preview run](https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/354081782).
 
- The Algolia sync indexing job [has been timing out lately](https://dd.slack.com/archives/C3CT8QA11/p1697665327071059).   With Docs scaling / addition of new languages we've seen the indexing times getting slower.    We will continue to work on delivering solutions that improve indexing performance.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge only after CorpWeb reviews

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->