### PR TITLE
[DOCS-6244] Add Rate Limit Setting to Java Docs

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -103,7 +103,7 @@ Prior to version 0.96.0 this setting only applied to request header tags. To cha
 
 `dd.trace.rate.limit`
 : **Environment Variable**: `DD_TRACE_RATE_LIMIT`<br>
-**Default**: `200` when `dd.trace.rate.limit` is set. Otherwise, delegates rate limiting to the Datadog Agent.<br>
+**Default**: `100` when `dd.trace.rate.limit` is set. Otherwise, delegates rate limiting to the Datadog Agent.<br>
 Maximum number of spans to sample per second, for each Java process.
 
 `dd.trace.request_header.tags`

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -103,8 +103,8 @@ Prior to version 0.96.0 this setting only applied to request header tags. To cha
 
 `dd.trace.rate.limit`
 : **Environment Variable**: `DD_TRACE_RATE_LIMIT`<br>
-**Default**: `100` when `dd.trace.rate.limit` is set. Otherwise, delegates rate limiting to the Datadog Agent.<br>
-Maximum number of spans to sample per second, for each Java process.
+**Default**: `100`<br>
+Maximum number of spans to sample per second, per process, when `DD_TRACE_SAMPLING_SERVICE_RULES` or `DD_TRACE_SAMPLE_RATE` is set. Otherwise, the Datadog Agent controls rate limiting.
 
 `dd.trace.request_header.tags`
 : **Environment Variable**: `DD_TRACE_REQUEST_HEADER_TAGS`<br>

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -104,7 +104,7 @@ Prior to version 0.96.0 this setting only applied to request header tags. To cha
 `dd.trace.rate.limit`
 : **Environment Variable**: `DD_TRACE_RATE_LIMIT`<br>
 **Default**: `200` when `dd.trace.rate.limit` is set. Otherwise, delegates rate limiting to the Datadog Agent.<br>
-Maximum number of spans to sample per-second, per-Java process.
+Maximum number of spans to sample per second, for each Java process.
 
 `dd.trace.request_header.tags`
 : **Environment Variable**: `DD_TRACE_REQUEST_HEADER_TAGS`<br>

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -103,7 +103,7 @@ Prior to version 0.96.0 this setting only applied to request header tags. To cha
 
 `dd.trace.rate.limit`
 : **Environment Variable**: `DD_TRACE_RATE_LIMIT`<br>
-**Default**: `100` when `dd.trace.rate.limit` is set. Otherwise, delegates rate limiting to the Datadog Agent.<br>
+**Default**: `200` when `dd.trace.rate.limit` is set. Otherwise, delegates rate limiting to the Datadog Agent.<br>
 Maximum number of spans to sample per-second, per-Java process.
 
 `dd.trace.request_header.tags`

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -101,6 +101,11 @@ Accepts a map of case-insensitive header keys to tag names and automatically app
 Prior to version 0.96.0 this setting only applied to request header tags. To change back to the old behavior, add the setting `-Ddd.trace.header.tags.legacy.parsing.enabled=true` or the environment variable `DD_TRACE_HEADER_TAGS_LEGACY_PARSING_ENABLED=true`.<br><br>
 **Beta**: Starting in version 1.18.3, if [Agent Remote Configuration][16] is enabled where this service runs, you can set `DD_TRACE_HEADER_TAGS` in the [Service Catalog][17] UI.
 
+`dd.trace.rate.limit`
+: **Environment Variable**: `DD_TRACE_RATE_LIMIT`<br>
+**Default**: `100` when `dd.trace.rate.limit` is set. Otherwise, delegates rate limiting to the Datadog Agent.<br>
+Maximum number of spans to sample per-second, per-Java process.
+
 `dd.trace.request_header.tags`
 : **Environment Variable**: `DD_TRACE_REQUEST_HEADER_TAGS`<br>
 **Default**: `null`<br>

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -104,7 +104,7 @@ Prior to version 0.96.0 this setting only applied to request header tags. To cha
 `dd.trace.rate.limit`
 : **Environment Variable**: `DD_TRACE_RATE_LIMIT`<br>
 **Default**: `100`<br>
-Maximum number of spans to sample per second, per process, when `DD_TRACE_SAMPLING_SERVICE_RULES` or `DD_TRACE_SAMPLE_RATE` is set. Otherwise, the Datadog Agent controls rate limiting.
+Maximum number of spans to sample per second, per process, when `DD_TRACE_SAMPLING_RULES` or `DD_TRACE_SAMPLE_RATE` is set. Otherwise, the Datadog Agent controls rate limiting.
 
 `dd.trace.request_header.tags`
 : **Environment Variable**: `DD_TRACE_REQUEST_HEADER_TAGS`<br>

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -483,7 +483,7 @@ The following table shows how the injection configuration values map to the corr
 | `health_metrics_enabled` | `dd.trace.health.metrics.enabled` |    n/a   |    n/a  | n/a |
 | `runtime_metrics_enabled` | `dd.jmxfetch.enabled` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` |
 | `tracing_sampling_rate` | `dd.trace.sample.rate` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE`  |
-| `tracing_rate_limit` | n/a       | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
+| `tracing_rate_limit` | `DD_TRACE_RATE_LIMIT`    | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
 | `tracing_tags` | `dd.tags` | `DD_TAGS` | `DD_TAGS` | `DD_TAGS` |
 | `tracing_service_mapping` | `dd.service.mapping` | `DD_SERVICE_MAPPING` | `DD_TRACE_SERVICE_MAPPING` | `DD_SERVICE_MAPPING` |
 | `tracing_agent_timeout` | `dd.trace.agent.timeout` |  n/a | n/a | n/a |
@@ -736,7 +736,7 @@ The following table shows how the injection configuration values map to the corr
 | `health_metrics_enabled` | `dd.trace.health.metrics.enabled` |    n/a   |    n/a  | n/a |
 | `runtime_metrics_enabled` | `dd.jmxfetch.enabled` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` |
 | `tracing_sampling_rate` | `dd.trace.sample.rate` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE`  |
-| `tracing_rate_limit` | n/a       | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
+| `tracing_rate_limit` | `DD_TRACE_RATE_LIMIT`       | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
 | `tracing_tags` | `dd.tags` | `DD_TAGS` | `DD_TAGS` | `DD_TAGS` |
 | `tracing_service_mapping` | `dd.service.mapping` | `DD_SERVICE_MAPPING` | `DD_TRACE_SERVICE_MAPPING` | `DD_SERVICE_MAPPING` |
 | `tracing_agent_timeout` | `dd.trace.agent.timeout` |  n/a | n/a | n/a |

--- a/content/en/tracing/trace_collection/library_injection_local.md
+++ b/content/en/tracing/trace_collection/library_injection_local.md
@@ -483,7 +483,7 @@ The following table shows how the injection configuration values map to the corr
 | `health_metrics_enabled` | `dd.trace.health.metrics.enabled` |    n/a   |    n/a  | n/a |
 | `runtime_metrics_enabled` | `dd.jmxfetch.enabled` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` |
 | `tracing_sampling_rate` | `dd.trace.sample.rate` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE`  |
-| `tracing_rate_limit` | `DD_TRACE_RATE_LIMIT`    | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
+| `tracing_rate_limit` | `dd.trace.rate.limit`    | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
 | `tracing_tags` | `dd.tags` | `DD_TAGS` | `DD_TAGS` | `DD_TAGS` |
 | `tracing_service_mapping` | `dd.service.mapping` | `DD_SERVICE_MAPPING` | `DD_TRACE_SERVICE_MAPPING` | `DD_SERVICE_MAPPING` |
 | `tracing_agent_timeout` | `dd.trace.agent.timeout` |  n/a | n/a | n/a |
@@ -736,7 +736,7 @@ The following table shows how the injection configuration values map to the corr
 | `health_metrics_enabled` | `dd.trace.health.metrics.enabled` |    n/a   |    n/a  | n/a |
 | `runtime_metrics_enabled` | `dd.jmxfetch.enabled` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` |
 | `tracing_sampling_rate` | `dd.trace.sample.rate` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE`  |
-| `tracing_rate_limit` | `DD_TRACE_RATE_LIMIT`       | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
+| `tracing_rate_limit` | `dd.trace.rate.limit`       | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
 | `tracing_tags` | `dd.tags` | `DD_TAGS` | `DD_TAGS` | `DD_TAGS` |
 | `tracing_service_mapping` | `dd.service.mapping` | `DD_SERVICE_MAPPING` | `DD_TRACE_SERVICE_MAPPING` | `DD_SERVICE_MAPPING` |
 | `tracing_agent_timeout` | `dd.trace.agent.timeout` |  n/a | n/a | n/a |
@@ -934,7 +934,7 @@ The following table shows how the injection configuration values map to the corr
 | `health_metrics_enabled` | `dd.trace.health.metrics.enabled` |    n/a   |    n/a  | n/a |
 | `runtime_metrics_enabled` | `dd.jmxfetch.enabled` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` | `DD_RUNTIME_METRICS_ENABLED` |
 | `tracing_sampling_rate` | `dd.trace.sample.rate` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE` | `DD_TRACE_SAMPLE_RATE`  |
-| `tracing_rate_limit` | n/a       | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
+| `tracing_rate_limit` | `dd.trace.rate.limit`       | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` | `DD_TRACE_RATE_LIMIT` |
 | `tracing_tags` | `dd.tags` | `DD_TAGS` | `DD_TAGS` | `DD_TAGS` |
 | `tracing_service_mapping` | `dd.service.mapping` | `DD_SERVICE_MAPPING` | `DD_TRACE_SERVICE_MAPPING` | `DD_SERVICE_MAPPING` |
 | `tracing_agent_timeout` | `dd.trace.agent.timeout` |  n/a | n/a | n/a |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
https://datadoghq.atlassian.net/browse/DOCS-6244

- Add `dd.trace.rate.limit` to Java library docs.
- Note support for this in local library injection docs too.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

I need someone from the Java team to verify before merging.

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->