### PR TITLE
add glossary tests to github action

### DIFF
--- a/general.preview.synthetics.json
+++ b/general.preview.synthetics.json
@@ -23,6 +23,24 @@
       "config": {
         "startUrl": "https://docs-staging.datadoghq.com/{{CI_COMMIT_REF_NAME}}/logs/log_collection/"
       }
+    },
+    {
+      "id": "bqt-kt3-zvy",
+      "config": {
+        "startUrl": "https://docs-staging.datadoghq.com/{{CI_COMMIT_REF_NAME}}/glossary/"
+      }
+    },
+    {
+      "id": "dbg-37u-r55",
+      "config": {
+        "startUrl": "https://docs-staging.datadoghq.com/{{CI_COMMIT_REF_NAME}}/glossary/"
+      }
+    },
+    {
+      "id": "d6h-28c-ij9",
+      "config": {
+        "startUrl": "https://docs-staging.datadoghq.com/{{CI_COMMIT_REF_NAME}}/glossary/?product=alerts"
+      }
     }
   ]
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

adds the following synthetic tests to the github actions pipeline. these tests run on every docs pull request:

[[bqt-kt3-zvy](https://dd-corpsite.datadoghq.com/synthetics/details/bqt-kt3-zvy?from_ts=1698064231603&to_ts=1698067831603&live=true)] "[DOCS] [Glossary] Should filter terms by product selection"
[[d6h-28c-ij9](https://dd-corpsite.datadoghq.com/synthetics/details/d6h-28c-ij9?from_ts=1698064298935&to_ts=1698067898935&live=true)] "[DOCS] [Glossary] Should filter on page load"
[[dbg-37u-r55](https://dd-corpsite.datadoghq.com/synthetics/details/dbg-37u-r55?from_ts=1698064379255&to_ts=1698067979255&live=true)] "[DOCS] [Glossary] Should add filter value to url params"

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb reviews

### Additional notes
<!-- Anything else we should know when reviewing?-->

See that pipeline and `synthetic_testing` job ran successfully:
https://github.com/DataDog/documentation/actions/runs/6592547400/job/17913390229?pr=20288


no change here: https://docs-staging.datadoghq.com/stefon.simmons/add-glossary-sythetics-to-ci/
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->