### PR TITLE
DOCS-6471, DOCS-6472 Getting Started with Private Locations, Private Locations Configuration Update

### DIFF
--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -42,25 +42,44 @@ Your private locations test results display identically to your managed location
 
 ## Create your private location
 
+{{% site-region region="gov" %}}
+
+By default, the `disableFipsCompliance` parameter is set to `true` in the private location configuration file for FIPS compliance. If you have an operating system where FIPS is enabled by default, you need to disable FIPS on an operating system-level.
+
+For example:
+
+```
+  },
+  "concurrency": 8,
+  "disableFipsCompliance": false,
+  "dnsServer": [
+    "0.0.0.0",
+    "1.1.1.1"
+  ],
+```
+
+{{% /site-region %}} 
+
 1. Install [Docker][4] on a Unix-like machine, or use another container runtime such as [Podman][10].
 
    To get started quickly, you can install Docker on a virtual machine such as [Vagrant Ubuntu 22.04][11].
 
 2. In the Datadog site, hover over **[UX Monitoring][5]** and select **Settings** > **Private Locations**. 
 3. Click **Add Private Location**.
-4. Fill out your private location details. Only `Name` and `API key` fields are mandatory. If you are configuring a private location for Windows, select **This is a Windows Private Location**.
-5. Click **Save Location and Generate Configuration File** to generate the configuration file associated with your private location on your worker.
+4. Fill out your private location details. Only `Name` and `API key` fields are mandatory. 
+5. Click **Save Location and Generate Configuration File** to generate the configuration file associated with your private location on your worker. 
 6. Depending on where you installed your private location, you may need to input additional parameters to your configuration file: 
     - If you are using a proxy, input the URL as `http://<YOUR_USER>:<YOUR_PWD>@<YOUR_IP>:<YOUR_PORT>`. 
     - If you want to block reserved IPs, toggle **Block reserved IPs** and enter the IP ranges. 
-    
-   For more information, see [Private Locations Configuration Options][6] and [Run Synthetic Tests from Private Locations][7]. 
+
+    For more information, see [Private Locations Configuration Options][6] and [Run Synthetic Tests from Private Locations][7]. 
+
 7. Copy and paste your private location configuration file to your working directory.
 
     **Note**: The configuration file contains secrets for private location authentication, test configuration decryption, and test result encryption. Datadog does not store the secrets, so store them locally before leaving the **Private Locations** creation form. **You need to be able to reference the secrets again in order to add more workers to your private location**. 
 8. When you are ready, click **View Installation Instructions**.
 9. Follow the installation instructions based on the environment you want to run the Private Location worker in.
-10. If you use Docker for example, launch your worker as a standalone container using the Docker `run` command and your configuration file:
+10. If you are using Docker, launch your worker as a standalone container using the Docker `run` command and your configuration file:
 
     ```shell
     docker run --rm -v $PWD/worker-config-<LOCATION_ID>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker
@@ -82,6 +101,9 @@ Your private locations test results display identically to your managed location
     2022-02-28 16:20:04 [info]: Fetching 10 messages from queue - 10 slots available
     ```
 12. Once you're done testing your internal endpoint, click **OK**.
+
+
+
 ## Run Synthetic tests with your private location
 
 Use your new private location just like a managed location in your Synthetic tests.

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -131,11 +131,30 @@ Navigate to [**Synthetic Monitoring** > **Settings** > **Private Locations**][22
 Fill out your private location details:
 
 1. Specify your private location's **Name** and **Description**.
-2. Add any **Tags** you would like to associate with your private location. If you are configuring a private location for Windows, select **This is a Windows Private Location**.
+2. Add any **Tags** you would like to associate with your private location.
 3. Choose one of your existing **API Keys**. Selecting an API key allows communication between your private location and Datadog. If you don't have an existing API key, click **Generate API key** to create one on the dedicated page. Only `Name` and `API key` fields are mandatory.
 4. Set access for your private location and click **Save Location and Generate Configuration File**. Datadog creates your private location and generates the associated configuration file.
 
 {{< img src="synthetics/private_locations/pl_creation_1.png" alt="Add details to private location" style="width:85%;">}}
+
+{{% site-region region="gov" %}}
+
+By default, the `disableFipsCompliance` parameter is set to `true` in the private location configuration file for FIPS compliance. If you have an operating system where FIPS is enabled by default, you need to disable FIPS on an operating system-level.
+
+For example:
+
+```
+  },
+  "concurrency": 8,
+  "disableFipsCompliance": false,
+  "dnsServer": [
+    "0.0.0.0",
+    "1.1.1.1"
+  ],
+```
+
+{{% /site-region %}} 
+
 ### Configure your private location
 
 Configure your private location by customizing the generated configuration file. When you add initial configuration parameters such as [proxies](#proxy-configuration) and [blocked reserved IPs](#blocking-reserved-ips) in **Step 3**, your generated configuration file updates automatically in **Step 4**.

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -134,6 +134,11 @@ Maximum number of tests fetched from Datadog.
 **Default**: `none`<br>
 Proxy URL used by the private location to send requests to Datadog (for example, `--proxyDatadog=http://<YOUR_USER>:<YOUR_PWD>@<YOUR_IP>:<YOUR_PORT>`).
 
+`--disableFipsCompliance`
+: **Type:** Boolean <br>
+**Default**: `true`<br>
+Disables the FIPS compliance for a private location using `ddgov-gov.com`.
+
 `--dumpConfig`
 : **Type**: Boolean <br>
 **Default**: `none`<br>


### PR DESCRIPTION
Documents the `disableFipsCompliance` parameter in the Getting Started with Private Locations, index page, and child page.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Documents the `disableFipsCompliance` parameter in the Getting Started with Private Locations and Private Locations index page.

Decided not to put the site region shortcode in the Configuration page to not break up the table of all commands.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->