### PR TITLE
[DOCS-6515] Re-structure CSM vulnerabilities setup page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3137,6 +3137,11 @@ main:
     parent: csm_setup
     identifier: csm_setup_workload_security
     weight: 10010
+  - name: CSM Vulnerabilities
+    url: security/cloud_security_management/setup/csm_vulnerabilities
+    parent: csm_setup
+    identifier: csm_setup_vulnerabilities
+    weight: 10020
   - name: Threats
     url: security/threats/
     parent: csm
@@ -3217,11 +3222,6 @@ main:
     parent: csm
     identifier: infrastructure_vulnerabilities
     weight: 18
-  - name: Setup
-    url: security/infrastructure_vulnerabilities/setup
-    parent: infrastructure_vulnerabilities
-    identifier: infra_vm_setup
-    weight: 201
   - name: Default Detection Rules
     url: security/default_rules/#cat-cloud-security-management
     parent: csm

--- a/content/en/security/cloud_security_management/setup/csm_vulnerabilities.md
+++ b/content/en/security/cloud_security_management/setup/csm_vulnerabilities.md
@@ -7,6 +7,7 @@ further_reading:
   text: "CSM Vulnerabilities"
 aliases:
   - /security/infrastructure_vulnerability/setup/
+  - /security/infrastructure_vulnerabilities/setup/
 ---
 
 {{< site-region region="gov" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- This PR moves and re-names the Infra (CSM vulnerabilities) setup page under CSM -> Setup -> CSM Vulnerabilities. This new page will contain only pre-requisite information with the actual setup pages as follows:
         - Containers only setup will live under CSM Pro as a new section in the TOC
         - Containers & Hosts setup will live under CSM Enterprise as a new section in the TOC
- Also adds added for old page

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->