### PR TITLE
Update Infra vulnerability setup documentation

### DIFF
--- a/content/en/security/infrastructure_vulnerabilities/setup.md
+++ b/content/en/security/infrastructure_vulnerabilities/setup.md
@@ -34,16 +34,12 @@ The following instructions enables the container image metadata collection and [
 Add the following to your `values.yaml` helm configuration file:
 
 ```yaml
-agents:
-  containers:
-    agent:
-      env:
-        - name: DD_CONTAINER_IMAGE_ENABLED
-          value: "true"
-        - name: DD_SBOM_ENABLED
-          value: "true"
-        - name: DD_SBOM_CONTAINER_IMAGE_ENABLED
-          value: "true"
+datadog:
+  containerImageCollection:
+    enabled: true
+  sbom:
+    containerImage:
+      enabled: true
 ```
 
 {{% /tab %}}
@@ -123,14 +119,10 @@ container_image:
 {{% tab "Kubernetes" %}}
 
 ```yaml
-agents:
-  containers:
-    agent:
-      env:
-        - name: DD_SBOM_ENABLED
-          value: "true"
-        - name: DD_SBOM_HOST_ENABLED
-          value: "true"
+datadog:
+  sbom:
+    host:
+      enabled: true
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
Since the pull request https://github.com/DataDog/helm-charts/pull/1116 has been merge is simpler to configured the container image and host infrastructure vulnerabilities feature in the Datadog Agent thanks to the helm chart.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Since the pull request https://github.com/DataDog/helm-charts/pull/1116 has been merge is simpler to configured the container image and host infrastructure vulnerabilities feature in the Datadog Agent thanks to the helm chart.

this Pull request update the helm chart instruction for configuring the  infrastructure vulnerabilities feature in the Datadog helm chart.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->