### PR TITLE
dan.chiniara/add-audit-variables-for-monitor-doc

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -322,7 +322,7 @@ To include **any** attribute or tag from a log, a trace span, a RUM event, a CI 
 | Trace Analytics | `{{span.attributes.key}}` or `{{span.tags.key}}` |
 | Error Tracking  | Traces: `{{span.attributes.[error.message]}}`<br>RUM Events: `{{rum.attributes.[error.message]}}`<br>Logs: `{{log.attributes.[error.message]}}`             |
 | RUM             | `{{rum.attributes.key}}` or `{{rum.tags.key}}`   |
-| Audit Trail     | `{{audit.attributes.key}}` or `audit.message`    |
+| Audit Trail     | `{{audit.attributes.key}}` or `{{audit.message}}`    |
 | CI Pipeline     | `{{cipipeline.attributes.key}}`                  |
 | CI Test         | `{{citest.attributes.key}}`                      |
 | Database Monitoring | `{{databasemonitoring.attributes.key}}`      |

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -322,6 +322,7 @@ To include **any** attribute or tag from a log, a trace span, a RUM event, a CI 
 | Trace Analytics | `{{span.attributes.key}}` or `{{span.tags.key}}` |
 | Error Tracking  | Traces: `{{span.attributes.[error.message]}}`<br>RUM Events: `{{rum.attributes.[error.message]}}`<br>Logs: `{{log.attributes.[error.message]}}`             |
 | RUM             | `{{rum.attributes.key}}` or `{{rum.tags.key}}`   |
+| Audit Trail     | `{{audit.attributes.key}}` or `audit.message`    |
 | CI Pipeline     | `{{cipipeline.attributes.key}}`                  |
 | CI Test         | `{{citest.attributes.key}}`                      |
 | Database Monitoring | `{{databasemonitoring.attributes.key}}`      |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds `{{audit.attributes.key}}` and `{{audit.message}}` to [Variables doc](https://docs.datadoghq.com/monitors/notify/variables/#?tab=is_alert)

![screenshot of doc](https://github.com/DataDog/documentation/assets/6266179/f75364f6-9290-47b0-ab33-149ffbe549c4)
[screenshot](https://a.cl.ly/d5uJ9b8R)

### Merge instructions

- [ ] Please merge after reviewing 

Note: I'm double checking with Audit Trail Team before merging ([slack](https://dd.slack.com/archives/C038LN8RB39/p1698263232051609)).

### Additional notes

Preview Page: https://docs-staging.datadoghq.com/dan.chiniara/add-audit-variables-for-monitor-doc/monitors/notify/variables

Related Escalation: https://datadoghq.atlassian.net/browse/MNTS-90191