### PR TITLE
Introduce a configuration for receiving from Splunk Forwarders directly.

### DIFF
--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -594,7 +594,7 @@ By default, a 288GB EBS drive is allocated to each instance, and is auto-mounted
 
 After you install and configure the Observability Pipelines Worker to send logs to your Splunk index, you must update your existing forwarders and collectors to point to the Worker.
 
-## Connect Splunk Forwarders to the Observability Pipelines Worker
+## Connect Splunk forwarders to the Observability Pipelines Worker
 You can update your Splunk Heavy/Universal Forwarders to point to the IP/URL of the host (or load balancer) associated with the Observability Pipelines Worker.
 
 For Terraform installs, the `lb-dns` output provides the necessary value. For CloudFormation installs, the `LoadBalancerDNS` CloudFormation output has the correct URL to use.

--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -595,7 +595,7 @@ By default, a 288GB EBS drive is allocated to each instance, and is auto-mounted
 After you install and configure the Observability Pipelines Worker to send logs to your Splunk index, you must update your existing forwarders and collectors to point to the Worker.
 
 ## Connect Splunk forwarders to the Observability Pipelines Worker
-You can update your Splunk Heavy/Universal Forwarders to point to the IP/URL of the host (or load balancer) associated with the Observability Pipelines Worker.
+Update your Splunk Heavy/Universal Forwarders to point to the IP/URL of the host (or load balancer) associated with the Observability Pipelines Worker.
 
 For Terraform installs, the `lb-dns` output provides the necessary value. For CloudFormation installs, the `LoadBalancerDNS` CloudFormation output has the correct URL to use.
 

--- a/static/resources/yaml/observability_pipelines/cloudformation/splunk.yaml
+++ b/static/resources/yaml/observability_pipelines/cloudformation/splunk.yaml
@@ -121,6 +121,19 @@ Resources:
           - InstanceSecurityGroup
           - GroupId
   
+  # Allow ingress to the Splunk tcpout port.
+  InstanceSecurityGroupTCPIngress8099:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: tcp
+      FromPort: 8099
+      ToPort: 8099
+      SourceSecurityGroupId: !Ref NLBSecurityGroup
+      GroupId:
+        Fn::GetAtt:
+          - InstanceSecurityGroup
+          - GroupId
+  
   # Allow egress to anywhere.
   InstanceSecurityGroupTCPEgress:
     Type: AWS::EC2::SecurityGroupEgress
@@ -242,6 +255,7 @@ Resources:
       VPCZoneIdentifier: !Ref SubnetIDs
       TargetGroupARNs:
         - !Ref NLBTarget8088
+        - !Ref NLBTarget8099
   
   # This load balancer should be to communicate with the OPW
   # instances. It is set as internal-only, so it is not accessible
@@ -273,6 +287,24 @@ Resources:
       Port: 8088
       VpcId: !Ref VPCID
 
+  NLBListener8099:
+    Type: AWS::ElasticLoadBalancingV2::Listener
+    Properties:
+      Protocol: TCP
+      Port: 8099
+      LoadBalancerArn: !Ref NLB
+      DefaultActions:
+        - Type: forward
+          TargetGroupArn: 
+            Ref: NLBTarget8099
+
+  NLBTarget8099:
+    Type: AWS::ElasticLoadBalancingV2::TargetGroup
+    Properties:
+      Protocol: TCP
+      Port: 8099
+      VpcId: !Ref VPCID
+
   NLBSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -288,6 +320,18 @@ Resources:
       IpProtocol: tcp
       FromPort: 8088
       ToPort: 8088
+      CidrIp: 0.0.0.0/0
+      GroupId:
+        Fn::GetAtt:
+          - NLBSecurityGroup
+          - GroupId
+
+  NLBSecurityGroupTCPIngress8099:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      IpProtocol: tcp
+      FromPort: 8099
+      ToPort: 8099
       CidrIp: 0.0.0.0/0
       GroupId:
         Fn::GetAtt:

--- a/static/resources/yaml/observability_pipelines/splunk/aws_eks.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/aws_eks.yaml
@@ -79,13 +79,31 @@ persistence:
 ## getting started with OP.
 pipelineConfig:
   sources:
-    splunk_receiver:
+    splunk_hec_receiver:
       type: splunk_hec
       address: 0.0.0.0:8088
       valid_tokens:
           - ${SPLUNK_TOKEN}
 
+    ## This source receives log data directly from Splunk Universal and
+    ## Heavy Forwarders (with attendant tcpout configuration).
+    splunk_forwarders:
+      type: socket
+      address: 0.0.0.0:8099
+      mode: tcp
+      host_key: ""
+      port_key: ""
+
   transforms:
+    ## This step removes an unnecessary attribute from logs received from
+    ## Splunk Forwarders.
+    splunk_forwarder_cleanup:
+      type: remap
+      inputs:
+        - splunk_forwarders
+      source: |-
+        del(.source_type)
+
     ## This is a placeholder for your own remap (or other transform)
     ## steps with tags set up. Datadog recommends these tag assignments.
     ## They show which data has been moved over to OP and what still needs
@@ -93,7 +111,8 @@ pipelineConfig:
     logs_enrich:
       type: remap
       inputs:
-        - splunk_receiver
+        - splunk_hec_receiver
+        - splunk_forwarder_cleanup
       source: |
         .sender = "observability_pipelines_worker"
         .opw_aggregator = get_hostname!()

--- a/static/resources/yaml/observability_pipelines/splunk/aws_eks_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/aws_eks_rc.yaml
@@ -53,9 +53,10 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
-  ## You must manually specify the ports to open; this will match the Splunk source.
+  ## You must manually specify the ports to open; this will match the Splunk sources.
   ports:
     - port: 8088
+    - port: 8099
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/splunk/azure_aks.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/azure_aks.yaml
@@ -72,13 +72,31 @@ persistence:
 ## for your own processing steps.
 pipelineConfig:
   sources:
-    splunk_receiver:
+    splunk_hec_receiver:
       type: splunk_hec
       address: 0.0.0.0:8088
       valid_tokens:
           - ${SPLUNK_TOKEN}
 
+    ## This source receives log data directly from Splunk Universal and
+    ## Heavy Forwarders (with attendant tcpout configuration).
+    splunk_forwarders:
+      type: socket
+      address: 0.0.0.0:8099
+      mode: tcp
+      host_key: ""
+      port_key: ""
+
   transforms:
+    ## This step removes an unnecessary attribute from logs received from
+    ## Splunk Forwarders.
+    splunk_forwarder_cleanup:
+      type: remap
+      inputs:
+        - splunk_forwarders
+      source: |-
+        del(.source_type)
+
     ## This is a placeholder for your own remap (or other transform)
     ## steps with tags set up. Datadog recommends these tag assignments.
     ## They show which data has been moved over to OP and what still needs
@@ -86,7 +104,8 @@ pipelineConfig:
     logs_enrich:
       type: remap
       inputs:
-        - splunk_receiver
+        - splunk_hec_receiver
+        - splunk_forwarder_cleanup
       source: |
         .sender = "observability_pipelines_worker"
         .opw_aggregator = get_hostname!()

--- a/static/resources/yaml/observability_pipelines/splunk/azure_aks_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/azure_aks_rc.yaml
@@ -53,9 +53,10 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
-  ## You must manually specify the ports to open; this will match the Splunk source.
+  ## You must manually specify the ports to open; this will match the Splunk sources.
   ports:
     - port: 8088
+    - port: 8099
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/splunk/google_gke.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/google_gke.yaml
@@ -74,13 +74,31 @@ persistence:
 ## for your own processing steps.
 pipelineConfig:
   sources:
-    splunk_receiver:
+    splunk_hec_receiver:
       type: splunk_hec
       address: 0.0.0.0:8088
       valid_tokens:
           - ${SPLUNK_TOKEN}
 
+    ## This source receives log data directly from Splunk Universal and
+    ## Heavy Forwarders (with attendant tcpout configuration).
+    splunk_forwarders:
+      type: socket
+      address: 0.0.0.0:8099
+      mode: tcp
+      host_key: ""
+      port_key: ""
+
   transforms:
+    ## This step removes an unnecessary attribute from logs received from
+    ## Splunk Forwarders.
+    splunk_forwarder_cleanup:
+      type: remap
+      inputs:
+        - splunk_forwarders
+      source: |-
+        del(.source_type)
+
     ## This is a placeholder for your own remap (or other transform)
     ## steps with tags set up. Datadog recommends these tag assignments.
     ## They show which data has been moved over to OP and what still needs
@@ -88,7 +106,8 @@ pipelineConfig:
     logs_enrich:
       type: remap
       inputs:
-        - splunk_receiver
+        - splunk_hec_receiver
+        - splunk_forwarder_cleanup
       source: |
         .sender = "observability_pipelines_worker"
         .opw_aggregator = get_hostname!()

--- a/static/resources/yaml/observability_pipelines/splunk/google_gke_rc.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/google_gke_rc.yaml
@@ -53,9 +53,10 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 service:
   enabled: true
-  ## You must manually specify the ports to open; this will match the Splunk source.
+  ## You must manually specify the ports to open; this will match the Splunk sources.
   ports:
     - port: 8088
+    - port: 8099
   type: "LoadBalancer"
   externalTrafficPolicy: "Local"
   annotations:

--- a/static/resources/yaml/observability_pipelines/splunk/pipeline.yaml
+++ b/static/resources/yaml/observability_pipelines/splunk/pipeline.yaml
@@ -1,13 +1,31 @@
 ## SOURCES: Data sources that Observability Pipelines Worker collects data from.
 ## For a Splunk use case, we are receiving data from a Splunk index.
 sources:
-  splunk_receiver:
+  splunk_hec_receiver:
     type: splunk_hec
     address: 0.0.0.0:8088
     valid_tokens:
         - ${SPLUNK_TOKEN}
 
+  ## This source receives log data directly from Splunk Universal and
+  ## Heavy Forwarders (with attendant tcpout configuration).
+  splunk_forwarders:
+    type: socket
+    address: 0.0.0.0:8099
+    mode: tcp
+    host_key: ""
+    port_key: ""
+
 transforms:
+  ## This step removes an unnecessary attribute from logs received from
+  ## Splunk Forwarders.
+  splunk_forwarder_cleanup:
+    type: remap
+    inputs:
+      - splunk_forwarders
+    source: |-
+      del(.source_type)
+
   ## This is a placeholder for your own remap (or other transform)
   ## steps with tags set up. Datadog recommends these tag assignments.
   ## They show which data has been moved over to OP and what still needs
@@ -15,7 +33,8 @@ transforms:
   logs_enrich:
     type: remap
     inputs:
-      - splunk_receiver
+      - splunk_hec_receiver
+      - splunk_forwarder_cleanup
     source: |
       .sender = "observability_pipelines_worker"
       .opw_aggregator = get_hostname!()


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR introduces a set of instructions for connecting Splunk Forwarders directly to OPW instead of just using HEC. Also included are configurations for CloudFormation, Terraform, and Helm that will receive from those Forwarders and into an Index.

### Merge instructions
This PR is developed in prep for the upcoming OPW 1.6 release, where the necessary `socket` source will be re-added; until that is released, this should not be merged.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->