### PR TITLE
[kubernetes_state_core] Fix duplicated kubernetes_state metrics

### DIFF
--- a/content/en/integrations/kubernetes_state_core.md
+++ b/content/en/integrations/kubernetes_state_core.md
@@ -369,12 +369,6 @@ datadog:
 `kubernetes_state.container.status_report.count.terminated`
 : Describes the reason the container is currently in a terminated state. Tags:`kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` from standard labels).
 
-`kubernetes_state.container.status_report.count.waiting`
-: Describes the reason the container is currently in a waiting state. Tags:`kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` from standard labels).
-
-`kubernetes_state.container.status_report.count.terminated`
-: Describes the reason the container is currently in a terminated state. Tags:`kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` from standard labels).
-
 `kubernetes_state.crd.count`
 : Number of custom resource definition.
 

--- a/content/ja/integrations/kubernetes_state_core.md
+++ b/content/ja/integrations/kubernetes_state_core.md
@@ -370,12 +370,6 @@ datadog:
 `kubernetes_state.container.status_report.count.terminated`
 : コンテナが現在終了状態にある理由を示します。タグ: `kube_namespace` `pod_name` `kube_container_name` `reason` (標準ラベルの `env` `service` `version`)。
 
-`kubernetes_state.container.status_report.count.waiting`
-: コンテナが現在待機状態にある理由を説明します。タグ: `kube_namespace` `pod_name` `kube_container_name` `reason` (標準ラベルの `env` `service` `version`)。
-
-`kubernetes_state.container.status_report.count.terminated`
-: コンテナが現在終了状態にある理由を示します。タグ: `kube_namespace` `pod_name` `kube_container_name` `reason` (標準ラベルの `env` `service` `version`)。
-
 `kubernetes_state.crd.count`
 : カスタムリソース定義の数。
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The `kubernetes_state.container.status_report.count.waiting` and `kubernetes_state.container.status_report.count.terminated` are duplicated in the documentation https://docs.datadoghq.com/integrations/kubernetes_state_core

They are correct here: https://github.com/DataDog/integrations-core/blob/master/kubernetes_state_core/metadata.csv

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
English and Japanese documentations updated. Korean documentations seems to be automatically generated.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->