### PR TITLE
Update the latest python runtime version that the dd-tracer supports

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/python.md
+++ b/content/en/tracing/trace_collection/dd_libraries/python.md
@@ -26,7 +26,7 @@ further_reading:
       text: 'Advanced Usage'
 ---
 ## Compatibility requirements
-The latest Python Tracer supports CPython versions 2.7 and 3.5-3.10.
+The latest Python Tracer supports CPython versions 2.7 and 3.5-3.11.
 
 For a full list of Datadog's Python version and framework support (including legacy and maintenance versions), read the [Compatibility Requirements][1] page.
 


### PR DESCRIPTION
We now support 3.11, per mentioned here: https://docs.datadoghq.com/tracing/trace_collection/compatibility/python/ and here: here:https://ddtrace.readthedocs.io/en/stable/versioning.html#supported-runtimes Not having the latest information in this page has caused confusion for some customers.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
We now support 3.11, per mentioned here: https://docs.datadoghq.com/tracing/trace_collection/compatibility/python/ and here: here:https://ddtrace.readthedocs.io/en/stable/versioning.html#supported-runtimes Not having the latest information in this page has caused confusion for some customers.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->