### PR TITLE
Clarify the beta feature is only for GRACE-supported resources not le…

### DIFF
--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -27,7 +27,7 @@ Use the different principals to control access patterns in your organization and
 The feature to gain access to individual resources is in private beta. To request access, <a href="/help">contact Support</a>.
 </div>
 
-A user with the `user_access_manage` permission can gain edit access to any individual resource that has restricted access. To get access, click the **Gain Edit Access** button in the granular access control modal.
+A user with the `user_access_manage` permission can gain edit access to any individual resource that supports team, role, and user / service account-based restrictions. Resources with only role-based access restrictions are not supported. To get access, click the **Gain Edit Access** button in the granular access control modal.
 
 [1]: /account_management/teams/
 [2]: /dashboards/#permissions

--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -27,7 +27,7 @@ Use the different principals to control access patterns in your organization and
 The feature to gain access to individual resources is in private beta. To request access, <a href="/help">contact Support</a>.
 </div>
 
-A user with the `user_access_manage` permission can gain edit access to any individual resource that supports team, role, and user / service account-based restrictions. Resources with only role-based access restrictions are not supported. To get access, click the **Gain Edit Access** button in the granular access control modal.
+A user with the `user_access_manage` permission can gain edit access to any individual resource that supports restrictions based on team, role, and user or service account. Resources with only role-based access restrictions are not supported. To get access, click the **Gain Edit Access** button in the granular access control modal.
 
 [1]: /account_management/teams/
 [2]: /dashboards/#permissions


### PR DESCRIPTION
…gacy granular access

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
I want to be more clear that monitors & synthetics tests aren’t supported just yet for this "beta gain access feature" though they will be in a few qtrs once they migrate from the legacy granular access control system to GRACE. It’s only available on dashboards, notebooks, security rules, and SLOs (see the table in the docs above the section I edited. If all 3 types of restrictions are supported, then it's on the new GRACE system. If it only supports role restrictions, then it's on the legacy granular access control system which this feature doesn't touch). 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->