### PR TITLE
[APM] Add tracing teams as codeowners on tracing folders

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -69,6 +69,13 @@ content/en/logs/log_collection/ios.md                            @Datadog/rum-mo
 content/en/tracing/trace_collection/dd_libraries/android.md     @Datadog/rum-mobile @DataDog/documentation
 content/en/tracing/trace_collection/dd_libraries/ios.md         @Datadog/rum-mobile @DataDog/documentation
 content/en/tracing/**/*dotnet*                                  @DataDog/tracing-dotnet @DataDog/documentation
+content/en/tracing/**/*php*                                     @DataDog/tracing-php @DataDog/documentation
+content/en/tracing/**/*ruby*                                    @DataDog/tracing-ruby @DataDog/documentation
+content/en/tracing/**/*nodejs*                                  @DataDog/apm-js @DataDog/documentation
+content/en/tracing/**/*python*                                  @DataDog/apm-core-python @DataDog/documentation
+content/en/tracing/**/*cpp*                                v    @DataDog/apm-proxy @DataDog/documentation
+content/en/tracing/**/*go*                                      @DataDog/tracing-go @DataDog/documentation
+content/en/tracing/**/*java*                                    @DataDog/apm-java @DataDog/documentation
 
 # Mobile SDK
 content/en/real_user_monitoring/android/                        @Datadog/rum-mobile @DataDog/documentation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Notifies the tracing teams for doc changes so that they validate them as well.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->