### PR TITLE
Add reference links for metric monitors and logs best practices

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -8,8 +8,8 @@ kind: documentation
 Datadog calculates your current estimated usage in near real-time. Estimated usage metrics enable you to:
 
 * Graph your estimated usage
-* Create monitors around your estimated usage based on thresholds of your choosing
-* Get instant alerts of spikes or drops in your usage
+* Create [monitors][3] around your estimated usage based on thresholds of your choosing
+* Get [monitor alerts][4] of spikes or drops in your usage
 * Assess the potential impact of code changes on your usage in near real-time
 
 **Note**: These usage metrics are estimates that are not always matched to billable usage given their real-time nature. There is a 10-20% difference between estimated usage and billable usage on average. Due to the nature of the estimations, the margin of error is larger for small usage.
@@ -76,3 +76,5 @@ For billing questions, contact your [Customer Success][2] Manager.
 
 [1]: /help/
 [2]: mailto:success@datadoghq.com
+[3]: /monitors/types/metric/?tab=threshold
+[4]: /logs/guide/best-practices-for-log-management/#alert-on-indexed-logs-volume-since-the-beginning-of-the-month


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Add reference links for metric monitors and log example showing usage monitor alerts.
- [DOCS-6259](https://datadoghq.atlassian.net/browse/DOCS-6259)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

[DOCS-6259]: https://datadoghq.atlassian.net/browse/DOCS-6259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ