### PR TITLE
Add Remote Configuration instructions to all setup pages.

### DIFF
--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -62,6 +62,22 @@ Follow the below instructions to install the Worker and deploy a sample pipeline
 
 The Observability Pipelines Worker Docker image is published to Docker Hub [here][1].
 
+### Remote Configuration
+2. Run the following command to start the Observability Pipelines Worker with Docker:
+    
+    ```shell
+    docker run -i -e DD_API_KEY=<API_KEY> \
+      -e DD_OP_PIPELINE_ID=<PIPELINE_ID> \
+      -e DD_SITE=<SITE> \
+      -e DD_OP_REMOTE_CONFIGURATION_ENABLED=true \
+      -p 8282:8282 \
+      datadog/observability-pipelines-worker run
+    ```
+
+    Replace `<API_KEY>` with your Datadog API key, `<PIPELINE_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the Datadog Agent port.
+
+### Manual Configuration
+
 1. Download the [sample pipeline configuration file][2]. This configuration emits demo data, parses and structures the data, and then sends them to the console and Datadog. See [Configurations][3] for more information about the source, transform, and sink used in the sample configuration.
 
 2. Run the following command to start the Observability Pipelines Worker with Docker:
@@ -75,13 +91,32 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
       datadog/observability-pipelines-worker run
     ```
 
-    Replace `<API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. **Note**: `./pipeline.yaml` must be the relative or absolute path to the configuration you downloaded in step 1.
+    Replace `<API_KEY>` with your Datadog API key, `<PIPELINE_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. **Note**: `./pipeline.yaml` must be the relative or absolute path to the configuration you downloaded in step 1.
 
 [1]: https://hub.docker.com/r/datadog/observability-pipelines-worker
 [2]: /resources/yaml/observability_pipelines/quickstart/pipeline.yaml
 [3]: /observability_pipelines/configurations/
 {{% /tab %}}
 {{% tab "AWS EKS" %}}
+### Remote Configuration
+
+1. Download the [Remote Configuration Helm chart][3] for AWS EKS. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+        opw datadog/observability-pipelines-worker \
+        -f aws_eks_rc.yaml
+    ```
+
+### Manual Configuration
 1. Download the [Helm chart][1] for AWS EKS. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
 
 2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
@@ -100,8 +135,29 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 
 [1]: /resources/yaml/observability_pipelines/quickstart/aws_eks.yaml
 [2]: /observability_pipelines/configurations/
+[3]: /resources/yaml/observability_pipelines/quickstart/aws_eks_rc.yaml
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
+
+### Remote Configuration
+
+1. Download the [Remote Configuration Helm chart][3] for Azure AKS. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+      opw datadog/observability-pipelines-worker \
+      -f azure_aks_rc.yaml
+    ```
+
+### Manual Configuration
 1. Download the [Helm chart][1] for Azure AKS. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
 
 2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
@@ -120,8 +176,30 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 
 [1]: /resources/yaml/observability_pipelines/quickstart/azure_aks.yaml
 [2]: /observability_pipelines/configurations/
+[3]: /resources/yaml/observability_pipelines/quickstart/azure_eks_rc.yaml
 {{% /tab %}}
 {{% tab "Google GKE" %}}
+
+### Remote Configuration
+
+1. Download the [Remote Configuration Helm chart][1] for Google GKE. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+      opw datadog/observability-pipelines-worker \
+      -f google_gke_rc.yaml
+    ```
+
+### Manual Configuration
+
 1. Download the [Helm chart][1] for Google GKE. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
 
 2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
@@ -140,6 +218,7 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 
 [1]: /resources/yaml/observability_pipelines/quickstart/google_gke.yaml
 [2]: /observability_pipelines/configurations/
+[3]: /resources/yaml/observability_pipelines/quickstart/google_gke_rc.yaml
 {{% /tab %}}
 {{% tab "APT-based Linux" %}}
 
@@ -149,7 +228,7 @@ Install the Worker with the one-line install script or manually.
 1. Run the one-line install command to install the Worker. Replace `<DD_API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}.
 
     ```
-    DD_API_KEY=<DD_API_KEY> DD_OP_PIPELINE_ID=<PIPELINES_ID> DD_SITE=<SITE> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_op_worker1.sh)"
+    DD_API_KEY=<DD_API_KEY> DD_OP_PIPELINE_ID=<PIPELINES_ID> DD_OP_REMOTE_CONFIGURATION_ENABLED=true DD_SITE=<SITE> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_op_worker1.sh)"
     ```
 
 2. Download the [sample configuration file][1] to `/etc/observability-pipelines-worker/pipeline.yaml` on the host. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
@@ -187,6 +266,27 @@ Install the Worker with the one-line install script or manually.
     sudo apt-get install observability-pipelines-worker datadog-signing-keys
     ```
 
+### Remote Configuration
+
+4. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
+
+    ```
+    sudo cat <<-EOF > /etc/default/observability-pipelines-worker
+    DD_API_KEY=<API_KEY>
+    DD_OP_PIPELINE_ID=<PIPELINE_ID>
+    DD_SITE=<SITE>
+    DD_OP_REMOTE_CONFIGURATION_ENABLED=true
+    EOF
+    ```
+
+5. Start the Worker:
+    
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+### Manual Configuration
+
 4. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
 
     ```
@@ -217,7 +317,7 @@ Install the Worker with the one-line install script or manually.
 1. Run the one-line install command to install the Worker. Replace `<DD_API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}.
 
     ```
-    DD_API_KEY=<DD_API_KEY> DD_OP_PIPELINE_ID=<PIPELINES_ID> DD_SITE=<SITE> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_op_worker1.sh)"
+    DD_API_KEY=<DD_API_KEY> DD_OP_PIPELINE_ID=<PIPELINES_ID> DD_OP_REMOTE_CONFIGURATION_ENABLED=true DD_SITE=<SITE> bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_op_worker1.sh)"
     ```
 
 2. Download the [sample configuration file][1] to `/etc/observability-pipelines-worker/pipeline.yaml` on the host. See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
@@ -256,6 +356,26 @@ Install the Worker with the one-line install script or manually.
     sudo yum install observability-pipelines-worker
     ```
 
+### Remote Configuration
+
+3. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
+
+    ```
+    sudo cat <<-EOF > /etc/default/observability-pipelines-worker
+    DD_API_KEY=<API_KEY>
+    DD_OP_PIPELINE_ID=<PIPELINE_ID>
+    DD_SITE=<SITE>
+    DD_OP_REMOTE_CONFIGURATION_ENABLED=true
+    EOF
+    ```
+
+4. Run the following command to start the Worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+### Manual Configuration
+
 3. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
 
     ```
@@ -280,6 +400,23 @@ Install the Worker with the one-line install script or manually.
 Set up the Worker module in your existing Terraform using this sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline.
 
 See [Configurations][2] for more information about the source, transform, and sink used in the sample configuration.
+
+### Remote Configuration
+
+```
+module "opw" {
+    source     = "https://github.com/DataDog/opw-terraform//aws"
+    vpc-id     = "{VPC ID}"
+    subnet-ids = ["{SUBNET ID 1}", "{SUBNET ID 2}"]
+    region     = "{REGION}"
+
+    datadog-api-key = "{DATADOG API KEY}"
+    pipeline-id = "{OP PIPELINE ID}"
+    remote-configuration = true
+}
+```
+
+### Manual Configuration
 
 ```
 module "opw" {

--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -63,18 +63,18 @@ Follow the below instructions to install the Worker and deploy a sample pipeline
 The Observability Pipelines Worker Docker image is published to Docker Hub [here][1].
 
 ### Remote Configuration
-2. Run the following command to start the Observability Pipelines Worker with Docker:
+Run the following command to start the Observability Pipelines Worker with Docker:
     
-    ```shell
-    docker run -i -e DD_API_KEY=<API_KEY> \
-      -e DD_OP_PIPELINE_ID=<PIPELINE_ID> \
-      -e DD_SITE=<SITE> \
-      -e DD_OP_REMOTE_CONFIGURATION_ENABLED=true \
-      -p 8282:8282 \
-      datadog/observability-pipelines-worker run
+```shell
+docker run -i -e DD_API_KEY=<API_KEY> \
+  -e DD_OP_PIPELINE_ID=<PIPELINE_ID> \
+  -e DD_SITE=<SITE> \
+  -e DD_OP_REMOTE_CONFIGURATION_ENABLED=true \
+  -p 8282:8282 \
+  datadog/observability-pipelines-worker run
     ```
 
-    Replace `<API_KEY>` with your Datadog API key, `<PIPELINE_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the Datadog Agent port.
+Replace `<API_KEY>` with your Datadog API key, `<PIPELINE_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the Datadog Agent port.
 
 ### Manual Configuration
 

--- a/content/en/observability_pipelines/setup/datadog.md
+++ b/content/en/observability_pipelines/setup/datadog.md
@@ -125,7 +125,7 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 
 ### Remote Configuration
 
-1. Run the following command to start the Observability Pipelines Worker with Docker:
+Run the following command to start the Observability Pipelines Worker with Docker:
     ```
     docker run -i -e DD_API_KEY=<API_KEY> \
       -e DD_OP_PIPELINE_ID=<PIPELINE_ID> \
@@ -134,7 +134,7 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
       -p 8282:8282 \
       datadog/observability-pipelines-worker run
     ```
-    Replace `<API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the Datadog Agent port.
+Replace `<API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the Datadog Agent port.
 
 ### Manual Configuration
 
@@ -409,7 +409,7 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 [1]: /resources/yaml/observability_pipelines/datadog/pipeline.yaml
 {{% /tab %}}
 {{% tab "Terraform (AWS)" %}}
-Set up the Worker module in your existing Terraform using this sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline. Make sure to specify the ports that your configuration needs, in the `tcp-ports` input. The sample configuration given opens up the Datadog Agent port, `8282`, by default.
+Set up the Worker module in your existing Terraform using the below sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline. Make sure to specify the ports that your configuration needs, in the `tcp-ports` input. The sample configuration given opens up the Datadog Agent port, `8282`, by default.
 
 ### Remote Configuration
 

--- a/content/en/observability_pipelines/setup/datadog.md
+++ b/content/en/observability_pipelines/setup/datadog.md
@@ -123,6 +123,21 @@ In order to run the Worker in your AWS account, you need administrative access t
 
 The Observability Pipelines Worker Docker image is published to Docker Hub [here][1].
 
+### Remote Configuration
+
+1. Run the following command to start the Observability Pipelines Worker with Docker:
+    ```
+    docker run -i -e DD_API_KEY=<API_KEY> \
+      -e DD_OP_PIPELINE_ID=<PIPELINE_ID> \
+      -e DD_SITE=<SITE> \
+      -e DD_OP_REMOTE_CONFIGURATION_ENABLED=true \
+      -p 8282:8282 \
+      datadog/observability-pipelines-worker run
+    ```
+    Replace `<API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the Datadog Agent port.
+
+### Manual Configuration
+
 1. Download the [sample pipeline configuration file][2].
 
 2. Run the following command to start the Observability Pipelines Worker with Docker:
@@ -140,7 +155,28 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 [2]: /resources/yaml/observability_pipelines/datadog/pipeline.yaml
 {{% /tab %}}
 {{% tab "AWS EKS" %}}
-1. Download the [Helm chart][1] for AWS EKS.
+
+### Remote Configuration
+1. Download the [Remote Configuration Helm chart][1] for AWS EKS.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Make sure to specify any ports that your configuration uses in the `service.ports` section. The provided Helm chart already opens the Datadog Agent port, `8282`.
+
+3. Install the Worker in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+        opw datadog/observability-pipelines-worker \
+        -f aws_eks_rc.yaml
+    ```
+
+### Manual Configuration
+1. Download the [Helm chart][2] for AWS EKS.
 
 2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
 
@@ -156,10 +192,32 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
         -f aws_eks.yaml
     ```
 
-[1]: /resources/yaml/observability_pipelines/datadog/aws_eks.yaml
+[1]: /resources/yaml/observability_pipelines/datadog/aws_eks_rc.yaml
+[2]: /resources/yaml/observability_pipelines/datadog/aws_eks.yaml
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
-1. Download the [Helm chart][1] for Azure AKS.
+
+### Remote Configuration
+1. Download the [Remote Configuration Helm chart][1] for Azure AKS.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Make sure to specify any ports that your configuration uses in the `service.ports` section. The provided Helm chart already opens the Datadog Agent port, `8282`.
+
+3. Install the Worker in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+      opw datadog/observability-pipelines-worker \
+      -f azure_aks_rc.yaml
+    ```
+
+### Manual Configuration
+1. Download the [Helm chart][2] for Azure AKS.
 
 2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
 
@@ -175,10 +233,32 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
       -f azure_aks.yaml
     ```
 
-[1]: /resources/yaml/observability_pipelines/datadog/azure_aks.yaml
+[1]: /resources/yaml/observability_pipelines/datadog/azure_aks_rc.yaml
+[2]: /resources/yaml/observability_pipelines/datadog/azure_aks.yaml
 {{% /tab %}}
 {{% tab "Google GKE" %}}
-1. Download the [Helm chart][1] for Google GKE.
+
+### Remote Configuration
+1. Download the [Remote Configuration Helm chart][1] for Google GKE.
+
+2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Make sure to specify any ports that your configuration uses in the `service.ports` section. The provided Helm chart already opens the Datadog Agent port, `8282`.
+
+3. Install the Worker in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+      opw datadog/observability-pipelines-worker \
+      -f google_gke_rc.yaml
+    ```
+
+### Manual Configuration
+1. Download the [Helm chart][2] for Google GKE.
 
 2. In the Helm chart, replace the `datadog.apiKey` and `datadog.pipelineId` values to match your pipeline and use {{< region-param key="dd_site" code="true" >}} for the `site` value. Then, install it in your cluster with the following commands:
 
@@ -194,7 +274,8 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
       -f google_gke.yaml
     ```
 
-[1]: /resources/yaml/observability_pipelines/datadog/google_gke.yaml
+[1]: /resources/yaml/observability_pipelines/datadog/google_gke_rc.yaml
+[2]: /resources/yaml/observability_pipelines/datadog/google_gke.yaml
 {{% /tab %}}
 {{% tab "APT-based Linux" %}}
 1. Run the following commands to set up APT to download through HTTPS:
@@ -221,6 +302,26 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
     sudo apt-get update
     sudo apt-get install observability-pipelines-worker datadog-signing-keys
     ```
+
+### Remote Configuration
+
+4. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
+
+    ```
+    sudo cat <<-EOF > /etc/default/observability-pipelines-worker
+    DD_API_KEY=<API_KEY>
+    DD_OP_PIPELINE_ID=<PIPELINE_ID>
+    DD_SITE=<SITE>
+    DD_OP_REMOTE_CONFIGURATION_ENABLED=true
+    EOF
+    ```
+
+5. Start the worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+### Manual Configuration
 
 4. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
 
@@ -268,6 +369,26 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
     sudo yum install observability-pipelines-worker
     ```
 
+### Remote Configuration
+
+3. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
+
+    ```
+    sudo cat <<-EOF > /etc/default/observability-pipelines-worker
+    DD_API_KEY=<API_KEY>
+    DD_OP_PIPELINE_ID=<PIPELINE_ID>
+    DD_SITE=<SITE>
+    DD_OP_REMOTE_CONFIGURATION_ENABLED=true
+    EOF
+    ```
+
+4. Start the worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+### Manual Configuration
+
 3. Add your keys and the site ({{< region-param key="dd_site" code="true" >}}) to the Worker's environment variables:
 
     ```
@@ -288,7 +409,24 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 [1]: /resources/yaml/observability_pipelines/datadog/pipeline.yaml
 {{% /tab %}}
 {{% tab "Terraform (AWS)" %}}
-Set up the Worker module in your existing Terraform using this sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline.
+Set up the Worker module in your existing Terraform using this sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline. Make sure to specify the ports that your configuration needs, in the `tcp-ports` input. The sample configuration given opens up the Datadog Agent port, `8282`, by default.
+
+### Remote Configuration
+
+```
+module "opw" {
+    source     = "git::https://github.com/DataDog/opw-terraform//aws"
+    vpc-id     = "{VPC ID}"
+    subnet-ids = ["{SUBNET ID 1}", "{SUBNET ID 2}"]
+    region     = "{REGION}"
+
+    datadog-api-key      = "{DATADOG API KEY}"
+    pipeline-id          = "{OP PIPELINE ID}"
+    remote-configuration = true
+}
+```
+
+### Manual Configuration
 
 ```
 module "opw" {

--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -140,6 +140,22 @@ After you add the input, Splunk creates a token for you. The token is typically 
 
 The Observability Pipelines Worker Docker image is published to Docker Hub [here][1].
 
+### Remote Configuration
+1. Run the following command to start the Observability Pipelines Worker with Docker:
+    ```
+    docker run -i -e DD_API_KEY=<API_KEY> \
+      -e DD_OP_PIPELINE_ID=<PIPELINE_ID> \
+      -e DD_SITE=<SITE> \
+      -e DD_OP_REMOTE_CONFIGURATION_ENABLED=true \
+      -e SPLUNK_HEC_ENDPOINT=<SPLUNK_URL> \
+      -e SPLUNK_TOKEN=<SPLUNK_TOKEN> \
+      -p 8088:8088 \
+      datadog/observability-pipelines-worker run
+    ```
+   Replace `<API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Be sure to also update `SPLUNK_HEC_ENDPOINT` and `SPLUNK_TOKEN` with values that match the Splunk deployment you created in [Setting up the Splunk Index](#setting-up-the-splunk-index). Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the default Splunk HEC port.
+
+### Manual Configuration
+
 1. Download the [sample pipeline configuration file][2].
 
 2. Run the following command to start the Observability Pipelines Worker with Docker:
@@ -159,7 +175,45 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 [2]: /resources/yaml/observability_pipelines/splunk/pipeline.yaml
 {{% /tab %}}
 {{% tab "AWS EKS" %}}
-1. Download the [Helm chart][1] for AWS EKS.
+### Remote Configuration
+1. Download the [Remote Configuration Helm chart][1] for AWS EKS.
+
+2. In the Helm chart, replace `datadog.apiKey` and `datadog.pipelineId` with their respective values and replace `<site>` with {{< region-param key="dd_site" code="true" >}}:
+    ```yaml
+    datadog:
+      apiKey: "<datadog_api_key>"
+      pipelineId: "<observability_pipelines_configuration_id>"
+      site: "<site>"
+    ```
+
+3. Replace the values for `SPLUNK_HEC_ENDPOINT` and `SPLUNK_HEC_TOKEN` to match your Splunk deployment, including the token you created in [Setting up the Splunk Index](#setting-up-the-splunk-index):
+    ```yaml
+    env:
+      - name: SPLUNK_HEC_ENDPOINT
+        value: <https://your.splunk.index:8088/>
+      - name: SPLUNK_TOKEN
+        value: <a_random_token_usually_a_uuid>
+    ```
+
+4. Make sure to specify any ports that your configuration uses in the `service.ports` section. The provided Helm chart already opens the default Splunk HEC port, `8088`.
+
+5. Install the Helm chart in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+        opw datadog/observability-pipelines-worker \
+        -f aws_eks_rc.yaml
+    ```
+
+### Manual Configuration
+
+1. Download the [Helm chart][2] for AWS EKS.
 
 2. In the Helm chart, replace `datadog.apiKey` and `datadog.pipelineId` with their respective values and replace `<site>` with {{< region-param key="dd_site" code="true" >}}:
     ```yaml
@@ -192,10 +246,49 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
         -f aws_eks.yaml
     ```
 
-[1]: /resources/yaml/observability_pipelines/splunk/aws_eks.yaml
+[1]: /resources/yaml/observability_pipelines/splunk/aws_eks_rc.yaml
+[2]: /resources/yaml/observability_pipelines/splunk/aws_eks.yaml
 {{% /tab %}}
 {{% tab "Azure AKS" %}}
-1. Download the [Helm chart][1] for Azure AKS.
+### Remote Configuration
+1. Download the [Remote Configuration Helm chart][1] for Azure AKS.
+
+2. In the Helm chart, replace `datadog.apiKey` and `datadog.pipelineId` with their respective values and replace `<site>` with {{< region-param key="dd_site" code="true" >}}:
+    ```yaml
+    datadog:
+      apiKey: "<datadog_api_key>"
+      pipelineId: "<observability_pipelines_configuration_id>"
+      site: "<site>"
+    ```
+
+3. Replace the values for `SPLUNK_HEC_ENDPOINT` and `SPLUNK_HEC_TOKEN` to match your Splunk deployment, including the token you created in [Setting up the Splunk Index](#setting-up-the-splunk-index):
+    ```yaml
+    env:
+      - name: SPLUNK_HEC_ENDPOINT
+        value: <https://your.splunk.index:8088/>
+      - name: SPLUNK_TOKEN
+        value: <a_random_token_usually_a_uuid>
+    ```
+
+4. Make sure to specify any ports that your configuration uses in the `service.ports` section. The provided Helm chart already opens the default Splunk HEC port, `8088`.
+
+5. Install the Helm chart in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+        opw datadog/observability-pipelines-worker \
+        -f azure_aks_rc.yaml
+    ```
+
+### Manual Configuration
+
+1. Download the [Helm chart][2] for Azure AKS.
 
 2. In the Helm chart, replace `datadog.apiKey` and `datadog.pipelineId` with their respective values and replace `<site>` with {{< region-param key="dd_site" code="true" >}}:
     ```yaml
@@ -228,10 +321,51 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
       -f azure_aks.yaml
     ```
 
-[1]: /resources/yaml/observability_pipelines/splunk/azure_aks.yaml
+[1]: /resources/yaml/observability_pipelines/splunk/azure_aks_rc.yaml
+[2]: /resources/yaml/observability_pipelines/splunk/azure_aks.yaml
 {{% /tab %}}
 {{% tab "Google GKE" %}}
-1. Download the [Helm chart][1] for Google GKE.
+
+### Remote Configuration
+
+1. Download the [Remote Configuration Helm chart][1] for Google GKE.
+
+2. In the Helm chart, replace `datadog.apiKey` and `datadog.pipelineId` with their respective values and replace `<site>` with {{< region-param key="dd_site" code="true" >}}:
+    ```yaml
+    datadog:
+      apiKey: "<datadog_api_key>"
+      pipelineId: "<observability_pipelines_configuration_id>"
+      site: "<site>"
+    ```
+
+3. Replace the values for `SPLUNK_HEC_ENDPOINT` and `SPLUNK_HEC_TOKEN` to match your Splunk deployment, including the token you created in [Setting up the Splunk Index](#setting-up-the-splunk-index):
+    ```yaml
+    env:
+      - name: SPLUNK_HEC_ENDPOINT
+        value: <https://your.splunk.index:8088/>
+      - name: SPLUNK_TOKEN
+        value: <a_random_token_usually_a_uuid>
+    ```
+
+4. Make sure to specify any ports that your configuration uses in the `service.ports` section. The provided Helm chart already opens the default Splunk HEC port, `8088`.
+
+5. Install the Helm chart in your cluster with the following commands:
+
+    ```shell
+    helm repo add datadog https://helm.datadoghq.com
+    ```
+    ```shell
+    helm repo update
+    ```
+    ```shell
+    helm upgrade --install \
+        opw datadog/observability-pipelines-worker \
+        -f google_gke_rc.yaml
+    ```
+
+### Manual Configuration
+
+1. Download the [Helm chart][2] for Google GKE.
 
 2. In the Helm chart, replace `datadog.apiKey` and `datadog.pipelineId` with their respective values and replace `<site>` with {{< region-param key="dd_site" code="true" >}}:
     ```yaml
@@ -264,7 +398,8 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
       -f google_gke.yaml
     ```
 
-[1]: /resources/yaml/observability_pipelines/splunk/google_gke.yaml
+[1]: /resources/yaml/observability_pipelines/splunk/google_gke_rc.yaml
+[2]: /resources/yaml/observability_pipelines/splunk/google_gke.yaml
 {{% /tab %}}
 {{% tab "APT-based Linux" %}}
 1. Run the following commands to set up APT to download through HTTPS:
@@ -291,6 +426,28 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
     sudo apt-get update
     sudo apt-get install observability-pipelines-worker datadog-signing-keys
     ```
+
+### Remote Configuration
+
+4. Add your keys, site ({{< region-param key="dd_site" code="true" >}}), and Splunk information to the Worker's environment variables:
+
+    ```
+    sudo cat <<-EOF > /etc/default/observability-pipelines-worker
+    DD_API_KEY=<API_KEY>
+    DD_OP_PIPELINE_ID=<PIPELINE_ID>
+    DD_SITE=<SITE>
+    DD_OP_REMOTE_CONFIGURATION_ENABLED=true
+    SPLUNK_HEC_ENDPOINT=<SPLUNK_URL>
+    SPLUNK_TOKEN=<SPLUNK_TOKEN>
+    EOF
+    ```
+
+5. Start the worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+### Manual Configuration
 
 4. Add your keys, site ({{< region-param key="dd_site" code="true" >}}), and Splunk information to the Worker's environment variables:
 
@@ -338,6 +495,28 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
     sudo yum install observability-pipelines-worker
     ```
 
+### Remote Configuration
+
+3. Add your keys, site ({{< region-param key="dd_site" code="true" >}}), and Splunk information to the Worker's environment variables:
+
+    ```
+    sudo cat <<-EOF > /etc/default/observability-pipelines-worker
+    DD_API_KEY=<API_KEY>
+    DD_OP_PIPELINE_ID=<PIPELINE_ID>
+    DD_SITE=<SITE>
+    DD_OP_REMOTE_CONFIGURATION_ENABLED=true
+    SPLUNK_HEC_ENDPOINT=<SPLUNK_URL>
+    SPLUNK_TOKEN=<SPLUNK_TOKEN>
+    EOF
+    ```
+
+4. Start the worker:
+    ```
+    sudo systemctl restart observability-pipelines-worker
+    ```
+
+### Manual Configuration
+
 3. Add your keys, site ({{< region-param key="dd_site" code="true" >}}), and Splunk information to the Worker's environment variables:
 
     ```
@@ -360,7 +539,27 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 [1]: /resources/yaml/observability_pipelines/splunk/pipeline.yaml
 {{% /tab %}}
 {{% tab "Terraform (AWS)" %}}
-Setup the Worker module in your existing Terraform using this sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline.
+Setup the Worker module in your existing Terraform using this sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline. Make sure to specify the ports that your configuration needs, in the `tcp-ports` input. The sample configuration given opens up the Datadog Agent port, `8282`, by default.
+
+### Remote Configuration
+
+```
+module "opw" {
+    source     = "git::https://github.com/DataDog/opw-terraform//aws"
+    vpc-id     = "{VPC ID}"
+    subnet-ids = ["{SUBNET ID 1}", "{SUBNET ID 2}"]
+    region     = "{REGION}"
+
+    datadog-api-key = "{DATADOG API KEY}"
+    pipeline-id = "{OP PIPELINE ID}"
+    environment = {
+      "SPLUNK_TOKEN": "<SPLUNK TOKEN>",
+    }
+    remote-configuration = true
+}
+```
+
+### Manual Configuration
 
 ```
 module "opw" {

--- a/content/en/observability_pipelines/setup/splunk.md
+++ b/content/en/observability_pipelines/setup/splunk.md
@@ -141,7 +141,7 @@ After you add the input, Splunk creates a token for you. The token is typically 
 The Observability Pipelines Worker Docker image is published to Docker Hub [here][1].
 
 ### Remote Configuration
-1. Run the following command to start the Observability Pipelines Worker with Docker:
+Run the following command to start the Observability Pipelines Worker with Docker:
     ```
     docker run -i -e DD_API_KEY=<API_KEY> \
       -e DD_OP_PIPELINE_ID=<PIPELINE_ID> \
@@ -152,7 +152,7 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
       -p 8088:8088 \
       datadog/observability-pipelines-worker run
     ```
-   Replace `<API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Be sure to also update `SPLUNK_HEC_ENDPOINT` and `SPLUNK_TOKEN` with values that match the Splunk deployment you created in [Setting up the Splunk Index](#setting-up-the-splunk-index). Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the default Splunk HEC port.
+Replace `<API_KEY>` with your Datadog API key, `<PIPELINES_ID>` with your Observability Pipelines configuration ID, and `<SITE>` with {{< region-param key="dd_site" code="true" >}}. Be sure to also update `SPLUNK_HEC_ENDPOINT` and `SPLUNK_TOKEN` with values that match the Splunk deployment you created in [Setting up the Splunk Index](#setting-up-the-splunk-index). Any ports that your configuration uses must also be manually specified, using `-p <PORT>:<PORT>` to forward them from the local host to the Docker container. The sample command given above opens the default Splunk HEC port.
 
 ### Manual Configuration
 
@@ -539,7 +539,7 @@ The Observability Pipelines Worker Docker image is published to Docker Hub [here
 [1]: /resources/yaml/observability_pipelines/splunk/pipeline.yaml
 {{% /tab %}}
 {{% tab "Terraform (AWS)" %}}
-Setup the Worker module in your existing Terraform using this sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline. Make sure to specify the ports that your configuration needs, in the `tcp-ports` input. The sample configuration given opens up the Datadog Agent port, `8282`, by default.
+Setup the Worker module in your existing Terraform using the below sample configuration. Update the values in `vpc-id`, `subnet-ids`, and `region` to match your AWS deployment. Update the values in `datadog-api-key` and `pipeline-id` to match your pipeline. Make sure to specify the ports that your configuration needs, in the `tcp-ports` input. The sample configuration given opens up the Datadog Agent port, `8282`, by default.
 
 ### Remote Configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR should make it easy for folks to deploy RC-enabled OP Workers, no matter their installation method.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->