### PR TITLE
build disable svg warnings

### DIFF
--- a/layouts/partials/integrations-logo.html
+++ b/layouts/partials/integrations-logo.html
@@ -140,7 +140,7 @@ Both of these should return the same image.
       {{- if eq $ctx.Page.Language.Lang "en" -}}
         <!-- For security monitoring its an accepted that certain categories won't have an image to fall back to agent.svg, lets reduce that noise -->
         {{- if not (in (slice "runtime security" "file integrity monitoring") $basename) -}}
-          <!--{{- warnf "missing integration svg %q called from %q" $basename $ctx.Page.Permalink -}}-->
+          <!--{{/*- warnf "missing integration svg %q called from %q" $basename $ctx.Page.Permalink -*/}}-->
         {{- end -}}
         {{- $output_image = "" -}}
       {{- end -}}

--- a/layouts/partials/integrations-logo.html
+++ b/layouts/partials/integrations-logo.html
@@ -140,7 +140,7 @@ Both of these should return the same image.
       {{- if eq $ctx.Page.Language.Lang "en" -}}
         <!-- For security monitoring its an accepted that certain categories won't have an image to fall back to agent.svg, lets reduce that noise -->
         {{- if not (in (slice "runtime security" "file integrity monitoring") $basename) -}}
-          {{- warnf "missing integration svg %q called from %q" $basename $ctx.Page.Permalink -}}
+          <!--{{- warnf "missing integration svg %q called from %q" $basename $ctx.Page.Permalink -}}-->
         {{- end -}}
         {{- $output_image = "" -}}
       {{- end -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR removes the warning messages we had for svgs that weren't found. 
Lets revisit other ways to identifiy these and reduce noise in the build logs.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->