### PR TITLE
fix distorted images on integration carousels - [WEB-4203]

### DIFF
--- a/assets/styles/components/_integrations.scss
+++ b/assets/styles/components/_integrations.scss
@@ -725,6 +725,9 @@ $screen-md-max: ($screen-lg-min - 1) !default;
                             cursor: zoom-in;
                         }
                     }
+                    img:not(.play-overlay) {
+                        object-fit: contain;
+                    }
                     .play-overlay {
                         z-index: 2;
                         cursor: pointer;
@@ -861,7 +864,9 @@ $screen-md-max: ($screen-lg-min - 1) !default;
                         max-width: 1026px;
                         grid-column: 1/-1;
                         grid-row: 1/-1;
-
+                        img:not(.play-overlay) {
+                            object-fit: contain;
+                        }
                         .play-overlay {
                             z-index: 2;
                             cursor: pointer;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
fixes distorted images on integration carousels

motivation: https://datadoghq.atlassian.net/browse/WEB-4203
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

click into an [integration](https://docs-staging.datadoghq.com/stefon.simmons/fix-integration-carousel-images/integrations/), check that images in the carousel are not stretched.
example pages:
- https://docs-staging.datadoghq.com/stefon.simmons/fix-integration-carousel-images/integrations/yugabytedb_managed/

- https://docs-staging.datadoghq.com/stefon.simmons/fix-integration-carousel-images/integrations/agentil_software_services_5_days/

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->