### PR TITLE
Fix CSM setup links

### DIFF
--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -98,7 +98,7 @@ To [enable CSM Pro][1], you must first set up the Datadog cloud account integrat
 
 ## Next steps
 
-To get started setting up CSM, navigate to the [**Security** > **Setup**][3] section in Datadog, which has detailed steps on how to set up and configure CSM. For detailed instructions, see the [CSM Enterprise][1], [CSM Pro][2], and [CSM Workload Security][3] setup docs.
+To get started setting up CSM, navigate to the [**Security** > **Setup**][4] section in Datadog, which has detailed steps on how to set up and configure CSM. For detailed instructions, see the [CSM Enterprise][1], [CSM Pro][2], and [CSM Workload Security][3] setup docs.
 
 ## Further Reading
 

--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -73,7 +73,7 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
 
 #### Follow the in-app instructions (recommended)
 
-To enable CSM on the Agent, navigate to the [**Cloud Security Management Setup** page][8] and click **Hosts and containers**.
+To enable CSM on the Agent, navigate to the [**Cloud Security Management Setup** page][5] and click **Hosts and containers**.
 
 {{< img src="security/csm/hosts_containers_setup.png" alt="The Hosts and containers section on the Cloud Security Management Setup page" width="80%">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fixes a couple of links that point to the wrong destination URl.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->