### PR TITLE
zachg/add how to flag root span as error

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/python.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/python.md
@@ -208,6 +208,21 @@ span = tracer.trace("operation")
 span.error = 1
 span.finish()
 ```
+
+In the event you want to flag the local root span with the error raised:
+
+```python
+import os
+from ddtrace import tracer
+
+try:
+    raise TypeError
+except TypeError as e:
+    root_span = tracer.current_root_span()
+    (exc_type, exc_val, exc_tb) = sys.exc_info()
+    # this sets the error type, marks the span as an error, and adds the traceback
+    root_span.set_exc_info(exc_type, exc_val, exc_tb)
+```
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
As discussed with @meghanlo on error tracking. Error tracking only records top level spans with errors. Therefore it's helpful to provide an easy way for users to bubble the error up to the top level.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->