### PR TITLE
Add NIST Cybersecurity Framework 1.1

### DIFF
--- a/content/en/security/misconfigurations/frameworks_and_benchmarks.md
+++ b/content/en/security/misconfigurations/frameworks_and_benchmarks.md
@@ -43,6 +43,7 @@ Cloud Security Management Misconfigurations (CSM Misconfigurations) comes with m
 - [GDPR][10]
 - [NIST 800-53][30]
 - [NIST 800-171][31]
+- [NIST Cybersecurity Framework v1.1][32]
 
 *To pass the Monitoring Section of the [CIS AWS Foundations benchmark][2], you **must** enable [Cloud SIEM][11] and forward [CloudTrail logs to Datadog][12].
 
@@ -126,3 +127,4 @@ Create your own compliance framework by adding a custom tag to the compliance ru
 [29]: /api/latest/security-monitoring/#update-an-existing-rule
 [30]: https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final
 [31]: https://csrc.nist.gov/pubs/sp/800/171/r2/upd1/final
+[32]: https://www.nist.gov/cyberframework/framework


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds NIST Cybersecurity Framework 1.1 to list of supported frameworks for CSM Misconfigurations.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->