### PR TITLE
Updating serverless_tracing_and_bundlers.md documentation to AWS SDK v3 and fixing documentation

### DIFF
--- a/content/en/serverless/guide/serverless_tracing_and_bundlers.md
+++ b/content/en/serverless/guide/serverless_tracing_and_bundlers.md
@@ -32,7 +32,14 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with bun
         rules: [
           {
             // Provided by the Datadog Lambda layer and the Lambda Runtime.
-            exclude: ['/aws-sdk/', '/datadog-lambda-js/', '/dd-trace/'],
+            exclude: [
+              // AWS SDK v3
+              /^@aws-sdk.*/,
+              // AWS SDK v2
+              /aws-sdk/,
+              /datadog-lambda-js/,
+              /dd-trace/
+            ],
           }
         ]
       },
@@ -50,6 +57,9 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with bun
         includeModules:
           # ... your existing configuration for includeModules
           forceExclude:
+            # @aws-sdk for the AWS SDK v3
+            - @aws-sdk
+            # aws-sdk for the AWS SDK v2
             - aws-sdk
             - datadog-lambda-js
             - dd-trace
@@ -65,6 +75,9 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with bun
     custom:
       webpack:
         forceExclude:
+          # @aws-sdk for the AWS SDK v3
+          - @aws-sdk
+          # aws-sdk for the AWS SDK v2
           - aws-sdk
           - datadog-lambda-js
           - dd-trace
@@ -96,7 +109,9 @@ Datadog's tracing libraries (`dd-trace`) are known to be not compatible with bun
     custom:
       esbuild:
         exclude: 
-          # aws-sdk is needed because it is the default value for `exclude`
+          # @aws-sdk for the AWS SDK v3
+          - @aws-sdk
+          # aws-sdk for the AWS SDK v2
           - aws-sdk
           - datadog-lambda-js
           - dd-trace


### PR DESCRIPTION
Update documentation adding AWS SDK v3 and fix regex expression for AWK SDK for webpack

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Updating documentation to handle AWS SDK v3
- Fixing Webpack exclude list using regex to pick up exclusions

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->