### PR TITLE
Add reference to the new diagnose command in the fips documentation

### DIFF
--- a/content/en/agent/configuration/agent-fips-proxy.md
+++ b/content/en/agent/configuration/agent-fips-proxy.md
@@ -138,7 +138,9 @@ Verify that metrics, traces, and logs are correctly reported in the app.
 For metrics, run the connectivity diagnostic command and verify that all checks pass:
 
 ```shell
-sudo -u dd-agent datadog-agent diagnose datadog-connectivity
+sudo -u dd-agent datadog-agent diagnose --include connectivity-datadog-core-endpoints
+# For Agent version < 7.48 run the following command
+# sudo -u dd-agent datadog-agent diagnose datadog-connectivity
 ```
 
 If you don't see metrics, traces, or logs reported in the app, see the [Troubleshooting](#troubleshooting-a-bare-metal-or-vm-installation) section.
@@ -255,7 +257,9 @@ In the following example, the Datadog Agent FIPS Proxy is unable to bind a socke
 To check for network issues, check the logs at `/var/log/datadog/agent.log`, or run:
 
 ```shell
-datadog-agent diagnose datadog-connectivity
+datadog-agent diagnose --include connectivity-datadog-core-endpoints
+# For Agent version < 7.48 run the following command
+# datadog-agent diagnose datadog-connectivity
 ```
 
 Look for errors such as:

--- a/content/en/agent/configuration/agent-fips-proxy.md
+++ b/content/en/agent/configuration/agent-fips-proxy.md
@@ -139,7 +139,7 @@ For metrics, run the connectivity diagnostic command and verify that all checks 
 
 ```shell
 sudo -u dd-agent datadog-agent diagnose --include connectivity-datadog-core-endpoints
-# For Agent version < 7.48 run the following command
+# For Agent version < 7.48, run the following command:
 # sudo -u dd-agent datadog-agent diagnose datadog-connectivity
 ```
 
@@ -258,7 +258,7 @@ To check for network issues, check the logs at `/var/log/datadog/agent.log`, or 
 
 ```shell
 datadog-agent diagnose --include connectivity-datadog-core-endpoints
-# For Agent version < 7.48 run the following command
+# For Agent version < 7.48, run the following command:
 # datadog-agent diagnose datadog-connectivity
 ```
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Add reference to the new Agent diagnose CLI in the FIPS instructions

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes

https://docs-staging.datadoghq.com/nicolas.guerguadj/update-diagnose-reference-in-fips-docs/agent/configuration/agent-fips-proxy/?tab=hostorvm#agent-is-unable-to-connect-to-the-proxy