### PR TITLE
pip cache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ variables:
   YARN_CACHE_FOLDER: "${CI_PROJECT_DIR}/.yarn/cache/"
   PREVIEW_PATTERN: '/.+?\/[a-zA-Z0-9_-]+/'
   PREVIEW_ERROR_LOG: "/go/src/github.com/DataDog/documentation/preview_error.log"
+  PIP_CACHE_DIR: "${CI_PROJECT_DIR}/.pipcache/"
 
 
 # ================== copy scripts =============== #
@@ -87,6 +88,14 @@ before_script:
       - ${YARN_CACHE_FOLDER}
     policy: pull-push
 
+.pip_cache: &pip_cache
+  - key:
+      files:
+        - local/etc/requirements3.txt
+    paths:
+      - ${PIP_CACHE_DIR}
+    policy: pull-push
+
 # ==================== rules ==================== #
 .preview_rules: &preview_rules
   rules:
@@ -128,6 +137,7 @@ build_preview:
   cache:
     - *hugo_cache
     - *yarn_cache_pull_push
+    - *pip_cache
   environment: "preview"
   variables:
     URL: ${PREVIEW_DOMAIN}
@@ -235,6 +245,8 @@ algolia_sync_live:
   allow_failure: true
   interruptible: true
   timeout: 2h
+  dependencies:
+    - build_live
   script:
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
     - >
@@ -296,6 +308,7 @@ build_live:
   cache:
     - *hugo_cache
     - *yarn_cache_pull_push
+    - *pip_cache
   environment: "live"
   retry: 1
   variables:

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -21,6 +21,11 @@ defaultContentLanguageInSubdir: false
 # set this as a default otherwise we get "Error: found overlapping content dirs"
 # contentDir: "content/en"
 
+caches:
+    getjson:
+        dir: :cacheDir/:project
+        maxAge: '1h'
+
 # gitinfo vars
 enableGitInfo: true
 

--- a/local/etc/requirements3.txt
+++ b/local/etc/requirements3.txt
@@ -15,3 +15,4 @@ datadog==0.35.0
 markdown2==2.3.8
 Jinja2==3.0.1
 GitPython
+


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR:
- adds a pip cache from build to build so that installing python dependencies is slightly faster. (It would make sense to cache the virtualenv too but the way we are installing the assetlib is making this troublesome so leaving this out.)
- Sets a hugo getjson cache for 1hour as a minor tweak, when validating logos existence.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes

Just check that the build is successful