### PR TITLE
Redirect users to the list widget

### DIFF
--- a/content/en/dashboards/widgets/log_stream.md
+++ b/content/en/dashboards/widgets/log_stream.md
@@ -5,42 +5,6 @@ widget_type: log_stream
 description: "Display a filtered log stream in your Datadog dashboards."
 aliases:
 - /graphing/widgets/log_stream/
-further_reading:
-- link: "/logs/explorer/analytics/"
-  tag: "Documentation"
-  text: "Log Analytics"
-- link: "/dashboards/graphing_json/"
-  tag: "Documentation"
-  text: "Building Dashboards using JSON"
-
 ---
 
-The Log Stream displays a log flow matching the defined query.
-
-## Setup
-
-{{< img src="/dashboards/widgets/log_stream/log_stream_config.png" alt="Log stream configuration filtered by source:nodejs with three columns for date, host, and service " style="width:100%;" >}}
-
-### Configuration
-
-1. Enter a [search query][1] to filter the log stream.
-1. You can group logs into event subsets of [Log Analytics][2], which include `Patterns` and `Transactions`.
-1. Update the columns to display the values of your [facets][3] and [measures][4].
-1. Give your graph a title or leave the box blank for the suggested title.
-
-## API
-
-This widget can be used with the **[Dashboards API][5]**. See the following table for the [widget JSON schema definition][6]:
-
-{{< dashboards-widgets-api >}}
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
-
-[1]: /logs/explorer/search/
-[2]: /logs/explorer/analytics/
-[3]: /logs/explorer/facets/
-[4]: /logs/explorer/facets/#measures
-[5]: /api/latest/dashboards/
-[6]: /dashboards/graphing_json/widget_json/
+<div class="alert alert-warning">The Log Stream widget is supported through the <a href="https://docs.datadoghq.com/dashboards/widgets/list/">List widget</a>.</div>

--- a/content/en/dashboards/widgets/log_stream.md
+++ b/content/en/dashboards/widgets/log_stream.md
@@ -7,4 +7,4 @@ aliases:
 - /graphing/widgets/log_stream/
 ---
 
-<div class="alert alert-warning">The Log Stream widget is supported through the <a href="https://docs.datadoghq.com/dashboards/widgets/list/">List widget</a>.</div>
+<div class="alert alert-warning">View the Log Management stream through the <a href="https://docs.datadoghq.com/dashboards/widgets/list/">List widget</a>.</div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Redirect customers using the log stream widget to the List widget page.
- Log stream is not an individual widget offered on the Dashboard, you can access this functionality through the list widget.
- Change requested by the Dashboard PM

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing
