### PR TITLE
get highest versioned stable action - [WEB-4206]

### DIFF
--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
-stability = 'dev'
+stability = 'stable'
 
 TEMPLATE = """\
 ---

--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -110,7 +110,7 @@ def get_filtered_actions(actions):
         action_name = action_with_version.group(1) if action_with_version else action_name
         action_version = int(action_with_version.group(2)) if action_with_version else 0
 
-        if (not highest_versioned_actions.get(action_name)) or (action_version > highest_versioned_actions[action_name]):
+        if (not highest_versioned_actions.get(action_name)) or (action_version > highest_versioned_actions.get(action_name)):
             highest_versioned_actions[action_name] = action_version
             
 

--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -40,7 +40,7 @@ def workflows(content, content_dir):
             if data and data.get('stability', '') == 'stable':
                 
                 for action_name, action_data in filter_actions(data.get('actions', {})).items():
-                    action_name = re.split(r':[vV]\d+', action_name)[0] # clean action_name
+                    action_name = re.split(r':V\d+', action_name)[0] # clean action_name. no version identifier
                     # for each action of a bundle
                     if should_show_action(action_data.get('stability'), data):
                         output_file_name = data.get('name')\
@@ -103,7 +103,7 @@ def filter_actions(actions):
     highest_versioned_actions = {}
 
     for action_name in actions:
-        action_with_version = re.match(r"(\w+):[vV](\d+)", action_name)
+        action_with_version = re.match(r"(\w+):V(\d+)", action_name)
         
         action_name = action_with_version.group(1) if action_with_version else action_name
         action_version = int(action_with_version.group(2)) if action_with_version else 0
@@ -112,6 +112,6 @@ def filter_actions(actions):
             highest_versioned_actions[action_name] = action_version
             
 
-    filtered_actions = dict((f'{key}:V{v}' if v else key, actions.get(f'{key}:V{v}')) for key, v in highest_versioned_actions.items())
+    filtered_actions = dict((f'{key}:V{v}' if v else key, actions.get(f'{key}:V{v}' if v else key)) for key, v in highest_versioned_actions.items())
 
     return filtered_actions

--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -104,6 +104,7 @@ def get_filtered_actions(actions):
     highest_versioned_actions = {}
 
     for action_name in actions:
+        # 'V' in the action name with a version is expected to be capitalized
         action_with_version = re.match(r"(\w+):V(\d+)", action_name)
         
         action_name = action_with_version.group(1) if action_with_version else action_name

--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.WARNING)
+stability = 'dev'
 
 TEMPLATE = """\
 ---
@@ -37,7 +38,7 @@ def workflows(content, content_dir):
                         data = json.loads(f.read())
                     except:
                         logger.warn(f"Error parsing {file_name}")
-            if data and data.get('stability', '') == 'stable':
+            if data and data.get('stability', '') == stability:
                 
                 for action_name, action_data in get_filtered_actions(data.get('actions', {})).items():
                     action_name = re.split(r':V\d+', action_name)[0] # clean action_name. no version identifier
@@ -73,7 +74,7 @@ def should_show_action(action_stability, data):
     @param data {dict}
     @return {boolean}
     """
-    return (not action_stability or action_stability == 'stable') and not data.get('internal') and not data.get('hidden') and not data.get('deprecated')
+    return (not action_stability or action_stability == stability) and not data.get('internal') and not data.get('hidden') and not data.get('deprecated')
 
 
 

--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -39,7 +39,7 @@ def workflows(content, content_dir):
                         logger.warn(f"Error parsing {file_name}")
             if data and data.get('stability', '') == 'stable':
                 
-                for action_name, action_data in filter_actions(data.get('actions', {})).items():
+                for action_name, action_data in get_filtered_actions(data.get('actions', {})).items():
                     action_name = re.split(r':V\d+', action_name)[0] # clean action_name. no version identifier
                     # for each action of a bundle
                     if should_show_action(action_data.get('stability'), data):
@@ -77,7 +77,7 @@ def should_show_action(action_stability, data):
 
 
 
-def filter_actions(actions):
+def get_filtered_actions(actions):
     """
     Filter a bundle's actions to only include the highest versioned action for a particular action
     e.g.

--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import glob
 import json
-import os
+import re
 import yaml
 from itertools import chain
 import logging
@@ -38,10 +38,11 @@ def workflows(content, content_dir):
                     except:
                         logger.warn(f"Error parsing {file_name}")
             if data and data.get('stability', '') == 'stable':
-                p = Path(file_name)
-                for action_name, action_data in data.get('actions', {}).items():
-                    action_stability = action_data.get('stability')
-                    if not action_stability or action_stability == 'stable' and not data.get('internal') and not data.get('hidden') and not data.get('deprecated'):
+                
+                for action_name, action_data in filter_actions(data.get('actions', {})).items():
+                    action_name = re.split(r':[vV]\d+', action_name)[0] # clean action_name
+                    # for each action of a bundle
+                    if should_show_action(action_data.get('stability'), data):
                         output_file_name = data.get('name')\
                             .replace('com.datadoghq.dd.','')\
                             .replace('com.datadoghq.','')\
@@ -61,3 +62,56 @@ def workflows(content, content_dir):
                         dest_file = dest_dir.joinpath(name).with_suffix('.md')
                         with open(dest_file, mode='w', encoding='utf-8') as out_file:
                             out_file.write(output_content)
+
+
+def should_show_action(action_stability, data):
+    """
+    An 'action' should have no 'stability' key or 'stability' key equal to 'stable'
+    and should not be tagged as 'internal', 'hidden' or 'deprecated'.
+
+    @param action_stability {str}
+    @param data {dict}
+    @return {boolean}
+    """
+    return (not action_stability or action_stability == 'stable') and not data.get('internal') and not data.get('hidden') and not data.get('deprecated')
+
+
+
+def filter_actions(actions):
+    """
+    Filter a bundle's actions to only include the highest versioned action for a particular action
+    e.g.
+        input:
+            {
+                "list_distributions:V3": {<action_data>}, 
+                "list_distributions": {<action_data>},
+                "list_distributions:V2": {<action_data>},
+                "get_invalidation": {<action_data>},
+                "create_invalidation": {<action_data>} 
+                "create_invalidation:V1": {<action_data>} 
+            }
+        output:
+            {
+                "list_distributions:V3": {<action_data>}, 
+                "get_invalidation": {<action_data>},
+                "create_invalidation:V1": {<action_data>} 
+            }
+
+    @param actions {dict}
+    @return {dict}
+    """
+    highest_versioned_actions = {}
+
+    for action_name in actions:
+        action_with_version = re.match(r"(\w+):[vV](\d+)", action_name)
+        
+        action_name = action_with_version.group(1) if action_with_version else action_name
+        action_version = int(action_with_version.group(2)) if action_with_version else 0
+
+        if (not highest_versioned_actions.get(action_name)) or (action_version > highest_versioned_actions[action_name]):
+            highest_versioned_actions[action_name] = action_version
+            
+
+    filtered_actions = dict((f'{key}:V{v}' if v else key, actions.get(f'{key}:V{v}')) for key, v in highest_versioned_actions.items())
+
+    return filtered_actions

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

updates `workflow` script to only write to file  the highest versioned action.

motivation: https://datadoghq.atlassian.net/browse/WEB-4206 

prevew:  https://docs-staging.datadoghq.com/stefon.simmons/highest-stable-action-version/service_management/workflows/actions_catalog/#experimental
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after Corp reviews

### Additional notes
<!-- Anything else we should know when reviewing?-->
for review: preview shows actions tagged as `stability: dev` ([this line](https://github.com/DataDog/documentation/pull/20514/files#diff-5ed255a15fad115a8b5602e6a9e0e0aedc0a5cd021281e92046ff9c10868fb58R12)): Do not merge
  - the `testAction` actions [here](https://github.com/DataDog/dd-source/blob/main/domains/workflow/actionplatform/apps/wf-actions-worker/src/runner/bundles/com.datadoghq.experimental/manifest.json#L360-L396) should be filtered to only show `testAction:V2` in the ([preview](https://docs-staging.datadoghq.com/stefon.simmons/highest-stable-action-version/service_management/workflows/actions_catalog/experimental_testaction/)). `:V2` should be stripped from the action name but you can see the action content should match `:V2` content from the [manifest.json](https://github.com/DataDog/dd-source/blob/main/domains/workflow/actionplatform/apps/wf-actions-worker/src/runner/bundles/com.datadoghq.experimental/manifest.json#L360-L396) file
  
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->