### PR TITLE
Update trace context propagation documentation for Java tracer

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -445,7 +445,7 @@ Available since version 1.9.0
 `trace.propagation.extract.first`
 : **Environment Variable**: `DD_TRACE_PROPAGATION_EXTRACT_FIRST`<br>
 **Default**: `false`<br>
-When set to `true` stop extracting trace context when a valid one is found.
+When set to `true`, stop extracting trace context when a valid one is found.
 
 #### Deprecated extraction and injection settings
 

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -426,21 +426,26 @@ For information about valid values and using the following configuration options
 
 `dd.trace.propagation.style.inject`
 : **Environment Variable**: `DD_TRACE_PROPAGATION_STYLE_INJECT`<br>
-**Default**: `datadog`<br>
+**Default**: `datadog,tracecontext`<br>
 A comma-separated list of header formats to include to propagate distributed traces between services.<br>
 Available since version 1.9.0
 
 `dd.trace.propagation.style.extract`
 : **Environment Variable**: `DD_TRACE_PROPAGATION_STYLE_EXTRACT`<br>
-**Default**: `datadog`<br>
+**Default**: `datadog,tracecontext`<br>
 A comma-separated list of header formats from which to attempt to extract distributed tracing propagation data. The first format found with complete and valid headers is used to define the trace to continue.<br>
 Available since version 1.9.0
 
 `dd.trace.propagation.style`
 : **Environment Variable**: `DD_TRACE_PROPAGATION_STYLE`<br>
-**Default**: `datadog`<br>
+**Default**: `datadog,tracecontext`<br>
 A comma-separated list of header formats from which to attempt to inject and extract distributed tracing propagation data. The first format found with complete and valid headers is used to define the trace to continue. The more specific `dd.trace.propagation.style.inject` and `dd.trace.propagation.style.extract` configuration settings take priority when present.<br>
 Available since version 1.9.0
+
+`trace.propagation.extract.first`
+: **Environment Variable**: `DD_TRACE_PROPAGATION_EXTRACT_FIRST`<br>
+**Default**: `false`<br>
+When set to `true` stop extracting trace context when a valid one is found.
 
 #### Deprecated extraction and injection settings
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -34,7 +34,7 @@ Extraction styles can be configured using:
 - System Property: `-Ddd.trace.propagation.style.extract=datadog,b3multi`
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog,b3multi`
 
-The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default the `datadog,tracecontext` extraction styles is enabled.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default, the `datadog` and `tracecontext` extraction styles are enabled.
 
 If multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -34,9 +34,9 @@ Extraction styles can be configured using:
 - System Property: `-Ddd.trace.propagation.style.extract=datadog,b3multi`
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog,b3multi`
 
-The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default, the `datadog` and `tracecontext` extraction styles are enabled.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default, the `datadog` and `tracecontext` extraction styles are enabled using `datadog,tracecontext` setting, meaning the `datadog` style has higher priority than the `thetracestate` style.
 
-If multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
+When multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
 
 For reference details about the context propagation settings and other configuration, read [Java Tracing Library Configuration][1].
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -36,7 +36,7 @@ Extraction styles can be configured using:
 
 The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default, the `datadog` and `tracecontext` extraction styles are enabled using the `datadog,tracecontext` setting, meaning the `datadog` style has higher priority than the `tracecontext` style.
 
-When multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured, and the first successful extracted value is used. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if the `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
+When multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured, using the first successful extracted value. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if the `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
 
 For reference details about the context propagation settings and other configuration, read [Java Tracing Library Configuration][1].
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -36,7 +36,7 @@ Extraction styles can be configured using:
 
 The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default the `datadog,tracecontext` extraction styles is enabled.
 
-If multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used. If later valid trace contexts are found, they will be terminated, and appended as span links. Moreover, if `tracecontext` style is enabled, W3C Tracestate will be propagated if W3C Traceparent matches the extracted context.
+If multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
 
 For reference details about the context propagation settings and other configuration, read [Java Tracing Library Configuration][1].
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -34,7 +34,7 @@ Extraction styles can be configured using:
 - System Property: `-Ddd.trace.propagation.style.extract=datadog,b3multi`
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog,b3multi`
 
-The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default, the `datadog` and `tracecontext` extraction styles are enabled using `datadog,tracecontext` setting, meaning the `datadog` style has higher priority than the `thetracestate` style.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default, the `datadog` and `tracecontext` extraction styles are enabled using the `datadog,tracecontext` setting, meaning the `datadog` style has higher priority than the `tracecontext` style.
 
 When multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -27,16 +27,16 @@ Injection styles can be configured using:
 - System Property: `-Ddd.trace.propagation.style.inject=datadog,b3multi`
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_INJECT=datadog,b3multi`
 
-The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default only Datadog injection style is enabled.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default the `datadog,tracecontext` injection styles are enabled.
 
 Extraction styles can be configured using:
 
 - System Property: `-Ddd.trace.propagation.style.extract=datadog,b3multi`
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog,b3multi`
 
-The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default only Datadog extraction style is enabled.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default the `datadog,tracecontext` extraction styles is enabled.
 
-If multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used.
+If multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used. If later valid trace contexts are found, they will be terminated, and appended as span links. Moreover, if `tracecontext` style is enabled, W3C Tracestate will be propagated if W3C Traceparent matches the extracted context.
 
 For reference details about the context propagation settings and other configuration, read [Java Tracing Library Configuration][1].
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -27,7 +27,7 @@ Injection styles can be configured using:
 - System Property: `-Ddd.trace.propagation.style.inject=datadog,b3multi`
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_INJECT=datadog,b3multi`
 
-The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default the `datadog,tracecontext` injection styles are enabled.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default, the `datadog,tracecontext` injection styles are enabled.
 
 Extraction styles can be configured using:
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -27,7 +27,7 @@ Injection styles can be configured using:
 - System Property: `-Ddd.trace.propagation.style.inject=datadog,b3multi`
 - Environment Variable: `DD_TRACE_PROPAGATION_STYLE_INJECT=datadog,b3multi`
 
-The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default, the `datadog,tracecontext` injection styles are enabled.
+The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for injection. By default, the `datadog` and `tracecontext` injection styles are enabled.
 
 Extraction styles can be configured using:
 

--- a/content/en/tracing/trace_collection/trace_context_propagation/java.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/java.md
@@ -36,7 +36,7 @@ Extraction styles can be configured using:
 
 The value of the property or environment variable is a comma (or space) separated list of header styles that are enabled for extraction. By default, the `datadog` and `tracecontext` extraction styles are enabled using the `datadog,tracecontext` setting, meaning the `datadog` style has higher priority than the `tracecontext` style.
 
-When multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured and first successful extracted value is used. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
+When multiple extraction styles are enabled, the extraction attempt is done on the order those styles are configured, and the first successful extracted value is used. If later valid trace contexts are found, they are terminated and appended as span links. Moreover, if the `tracecontext` style is enabled, W3C Tracestate is propagated if W3C Traceparent matches the extracted context.
 
 For reference details about the context propagation settings and other configuration, read [Java Tracing Library Configuration][1].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR updates the trace context documentation for Java tracer about changes introduces for re:Invent.
It includes:
* The default propagation style changes, 
* The multiple trace context extraction (`tracestate` propagation and terminated context as span links)
* And the new `DD_TRACE_PROPAGATION_EXTRACT_FIRST` setting to revert back to the previous behavior.

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->