### PR TITLE
Add SQL Server 2022 to the support table

### DIFF
--- a/content/en/database_monitoring/setup_sql_server/_index.md
+++ b/content/en/database_monitoring/setup_sql_server/_index.md
@@ -11,13 +11,14 @@ disable_sidebar: true
 
 ### SQL Server versions supported
 
-|                 | Self-hosted | Azure | Amazon RDS | Google Cloud SQL |
-|-----------------|-----------|------|-----------|------------------|
-| SQL Server 2012 | {{< X >}} | {{< X >}} | {{< X >}} |               |
-| SQL Server 2014 | {{< X >}} | {{< X >}} | {{< X >}} |               |
-| SQL Server 2016 | {{< X >}} | {{< X >}} | {{< X >}} |               |
-| SQL Server 2017 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}}        |
-| SQL Server 2019 | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}}        |
+|                 | Self-hosted | Azure     | Amazon RDS | Google Cloud SQL |
+|-----------------|-------------|-----------|------------|------------------|
+| SQL Server 2012 | {{< X >}}   | {{< X >}} | {{< X >}}  |                  |
+| SQL Server 2014 | {{< X >}}   | {{< X >}} | {{< X >}}  |                  |
+| SQL Server 2016 | {{< X >}}   | {{< X >}} | {{< X >}}  |                  |
+| SQL Server 2017 | {{< X >}}   | {{< X >}} | {{< X >}}  | {{< X >}}        |
+| SQL Server 2019 | {{< X >}}   | {{< X >}} | {{< X >}}  | {{< X >}}        |
+| SQL Server 2022 | {{< X >}}   | {{< X >}} | {{< X >}}  | {{< X >}}        |
 
 For setup instructions, select your hosting type:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
DOCS-6651, SQL Server 2022 was not in the support table on the DBM setup page for SQL Server.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->