### PR TITLE
apm: clarify default apm metric collection

### DIFF
--- a/content/en/tracing/metrics/_index.md
+++ b/content/en/tracing/metrics/_index.md
@@ -19,12 +19,13 @@ further_reading:
 [Tracing application metrics][1] are collected after enabling trace collection and instrumenting your application. These metrics are available for dashboards and monitors.
 These metrics capture **request** counts, **error** counts, and **latency** measures. They are calculated based on 100% of the application's traffic, regardless of any [trace ingestion sampling][2] configuration.
 
+By default, these metrics are calculated in the Datadog Agent based on the traces sent from an instrumented application to the Agent.
 
 Ingested span and traces are kept for 15 minutes. Indexed spans and traces that retention filters keep are stored in Datadog for 15 days. But if you generate custom metrics from ingested data, the metrics are retained for 15 months.
 
 ## Runtime metrics
 
-Enable [runtime metrics collection][3] in supported tracing libraries to gain insights into an application's performance.
+Enable [runtime metrics collection][3] in supported tracing libraries to gain insights into an application's performance. These metrics are sent to the Datadog Agent over the configured DogStatsD port.
 
 
 ## Next steps


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Clarify that the two types of APM metrics are different in that trace metrics are calculated in the Datadog Agent whereas runtime metrics are calculated in the tracer library.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->