### PR TITLE
hugo micro perf updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -224,7 +224,20 @@ algolia_sync_preview:manual:
   allow_failure: true
   interruptible: true
   timeout: 2h
+  cache:
+    - *hugo_cache
+    - *yarn_cache
+    - *pip_cache
+  dependencies:
+    - build_preview
   script:
+    # build the site to get algolia.json ondemand
+    - touch Makefile.config preview_error.log
+    - make dependencies
+    - make config
+    - yarn run prebuild
+    - build_site
+    # end build
     - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v0.3.29.tgz
     - >
       ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id')

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -141,3 +141,5 @@ outputFormats:
 
 timeout: "90s"
 
+minify:
+  disableSVG: true

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -1,4 +1,4 @@
-{{- if ne hugo.Environment "development" -}}
+{{- if (or (eq hugo.Environment "live") (eq (os.Getenv "CI_JOB_NAME" | default "" ) "algolia_sync_preview:manual")) -}}
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}

--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -25,7 +25,7 @@
       <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
         {{ range last 1 $v.Pages }}
           {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}
-          {{ $int_logo := partial "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") }}
+          {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") $basename }}
           {{ if $int_logo }}
             <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
           {{ else }}
@@ -65,7 +65,7 @@
             <!-- e.g gcp.project use source -->
             {{ $basename = .Params.source }}
           {{ end }}
-          {{ $int_logo := partial "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") }}
+          {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") $basename }}
           {{ if $int_logo }}
             <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
           {{ else }}

--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -25,7 +25,7 @@
       <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
         {{ range last 1 $v.Pages }}
           {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}
-          {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") $basename }}
+          {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") $basename "avatar" }}
           {{ if $int_logo }}
             <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
           {{ else }}
@@ -65,7 +65,7 @@
             <!-- e.g gcp.project use source -->
             {{ $basename = .Params.source }}
           {{ end }}
-          {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") $basename }}
+          {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" $basename "variant" "avatar" "fallback" "cloud") $basename "avatar" }}
           {{ if $int_logo }}
             <img src="{{ $int_logo }}" height="17" alt="{{ htmlEscape .Params.Source }}"/>
           {{ else }}

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -8,5 +8,5 @@
 {{ end }}
 
 <div class="main-nav-wrapper">
-  {{ partial "nav/main-nav" . }} {{/* imported from websites-modules */}}
+  {{ partialCached "nav/main-nav" . }} {{/* imported from websites-modules */}}
 </div>

--- a/layouts/partials/nav/left-nav-api.html
+++ b/layouts/partials/nav/left-nav-api.html
@@ -24,23 +24,22 @@
 {{ end }}
 
 
-{{/*  
-    build array ($engMenuChildren) of english menu items with parents from "menus.en.yaml". 
-    for use in providing english names for anchoring the nav-links (.nav-link)  
+{{/*
+    build array ($engMenuChildren) of english menu items with parents from "menus.en.yaml".
+    for use in providing english names for anchoring the nav-links (.nav-link)
 */}}
 {{ if ne $currentPage.Lang "en" }}
 {{$engMenu := (index .Sites.First.Menus $apiMenu) }}
-{{$dot.Scratch.Set "engMenuChildren" slice}}
 {{ range $engMenu }}
     {{ if and (.HasChildren) (ne $currentPage.CurrentSection.RelPermalink "/api/") }}
     {{ range .Children }}
-        {{$dot.Scratch.Add "engMenuChildren" (dict "identifier" .Identifier "name" .Name) }}
+        {{ $dot.Scratch.SetInMap "engMenuChildren" .Identifier .Name }}
     {{ end }}
     {{ end }}
 {{ end }}
 {{ end }}
 
-{{$engMenuChildren := $dot.Scratch.Get "engMenuChildren"}}
+{{$engMenuChildren := $dot.Scratch.Get "engMenuChildren" | default dict}}
 
 <ul class="list-unstyled">
 {{ range $menu }}
@@ -54,14 +53,12 @@
                 {{ range sort .Children ".Params.order" "asc"  }}
                     <li class="row nav-item {{ if $currentPage.IsMenuCurrent $apiMenu . }}active{{ end }}">
                         {{$identifier := .Identifier}}
-                        {{/*                           
-                            lookup english equivalent of non-english menu item identifier attr.  
+                        {{/*
+                            lookup english equivalent of non-english menu item identifier attr.
                             pull the name attr and plug into anchor href.
                         */}}
                         {{ if ne $currentPage.Lang "en" }}
-                        {{ range where $engMenuChildren "identifier" $identifier  }}
-                            {{$dot.Scratch.Set "name" .name}}
-                        {{ end }}
+                        {{ $dot.Scratch.Set "name" (index $engMenuChildren $identifier) }}
                         {{ end }}
 
                         {{$engName := $dot.Scratch.Get "name"}}

--- a/layouts/security_rules/single.html
+++ b/layouts/security_rules/single.html
@@ -58,9 +58,9 @@
 		</div>
 	</div>
 
-	{{ if isset .Params "source" }}
-		{{ with .Site.GetPage (print "/integrations/" .Params.source ) }}
-			<p>Set up the <a href="{{ (strings.TrimLeft "/" .RelPermalink) | absLangURL }}">{{ $dot.Params.source }}</a> integration.</p>
+	{{ with $dot.Params.source }}
+    {{ if (fileExists (print "content/en/integrations/" . ".md")) }}
+			<p>Set up the <a href="{{ (print "integrations/" .) | absLangURL }}">{{ . }}</a> integration.</p>
 		{{ end }}
 	{{ end }}
 

--- a/layouts/security_rules/single.html
+++ b/layouts/security_rules/single.html
@@ -20,7 +20,7 @@
         <!-- e.g gcp.project use source -->
         {{ $basename = .Params.source }}
     {{ end }}
-		{{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar") }}
+		{{ $int_logo := partialCached "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar") $basename }}
 		{{ if $int_logo }}
 			<div class="col-3 col-lg-2 d-flex justify-content-center">
 				<img src="{{ $int_logo }}?auto=format&width=120" width="80px" max-height="100px" alt="{{ htmlEscape .Params.Source }}" />

--- a/layouts/security_rules/single.html
+++ b/layouts/security_rules/single.html
@@ -20,7 +20,7 @@
         <!-- e.g gcp.project use source -->
         {{ $basename = .Params.source }}
     {{ end }}
-		{{ $int_logo := partialCached "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar") $basename }}
+		{{ $int_logo := partialCached "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "avatar") $basename "avatar" }}
 		{{ if $int_logo }}
 			<div class="col-3 col-lg-2 d-flex justify-content-center">
 				<img src="{{ $int_logo }}?auto=format&width=120" width="80px" max-height="100px" alt="{{ htmlEscape .Params.Source }}" />

--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -43,7 +43,7 @@
   {{- if in (slice "system" "network") $v.Params.integration_id  -}}
     {{- $basename = ($v.Params.name | lower) | default ($v.File.TranslationBaseName | lower) -}}
   {{- end -}}
-  {{- $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "large") -}}
+  {{- $int_logo := partialCached "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "large") $basename -}}
   {{- $s.SetInMap $path "int_logo" $int_logo -}}
   {{ if $int_logo }}
     {{- $s.SetInMap "hits" $path ($s.Get $path) -}}

--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -43,7 +43,7 @@
   {{- if in (slice "system" "network") $v.Params.integration_id  -}}
     {{- $basename = ($v.Params.name | lower) | default ($v.File.TranslationBaseName | lower) -}}
   {{- end -}}
-  {{- $int_logo := partialCached "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "large") $basename -}}
+  {{- $int_logo := partialCached "integrations-logo.html" (dict "context" $dot "basename" $basename "variant" "large") $basename "large" -}}
   {{- $s.SetInMap $path "int_logo" $int_logo -}}
   {{ if $int_logo }}
     {{- $s.SetInMap "hits" $path ($s.Get $path) -}}

--- a/layouts/standard-attributes/list.html
+++ b/layouts/standard-attributes/list.html
@@ -8,7 +8,7 @@
 
 
 {{ define "partials/get-icon" }}
-  {{ $int_logo := partialCached "integrations-logo.html" (dict "context" .ctx "basename" .name "variant" "avatar") .name }}
+  {{ $int_logo := partialCached "integrations-logo.html" (dict "context" .ctx "basename" .name "variant" "avatar") .name "avatar" }}
   {{ if $int_logo }}
     <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}"/>
   {{ else }}
@@ -116,7 +116,7 @@
                     {{ partial "throw-error" (dict "ctx_product_source" $ctx_product_source "ctx_file_path" $ctx.File.Path) }}
 
                     {{/*  Get integration logos for android, ios, roku, and flutter  */}}
-                    {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" . "variant" "avatar") . }}
+                    {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" . "variant" "avatar") . "avatar" }}
                     {{ if $int_logo }}
                       <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}" title="{{ . }}" data-bs-toggle="tooltip" data-bs-placement="top"/>
                     {{ end }}

--- a/layouts/standard-attributes/list.html
+++ b/layouts/standard-attributes/list.html
@@ -1,18 +1,18 @@
 {{/*  Local Partials start  */}}
 {{ define "partials/throw-error" }}
-  {{/*  Verify platorm sources (i.e. android, ios, roku, browser and flutter ) are accompanied by RUM source in product_source list */}}	
-  {{ if not (in .ctx_product_source "icon-rum") }}	
-  {{ errorf "Sources 'android', 'flutter', 'roku', 'browser' and 'ios' must be accompanied by 'icon-rum' source. Fix 'product_source' frontmatter in %q" .ctx_file_path }}	
-  {{ end }}	
+  {{/*  Verify platorm sources (i.e. android, ios, roku, browser and flutter ) are accompanied by RUM source in product_source list */}}
+  {{ if not (in .ctx_product_source "icon-rum") }}
+  {{ errorf "Sources 'android', 'flutter', 'roku', 'browser' and 'ios' must be accompanied by 'icon-rum' source. Fix 'product_source' frontmatter in %q" .ctx_file_path }}
+  {{ end }}
 {{ end }}
 
 
 {{ define "partials/get-icon" }}
-  {{ $int_logo := partial "integrations-logo.html" (dict "context" .ctx "basename" .name "variant" "avatar") }}	
-  {{ if $int_logo }}	
-    <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}"/>	
+  {{ $int_logo := partialCached "integrations-logo.html" (dict "context" .ctx "basename" .name "variant" "avatar") .name }}
+  {{ if $int_logo }}
+    <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}"/>
   {{ else }}
-    {{ partial "icon" (dict "name" .name "size" "18px")}}	
+    {{ partial "icon" (dict "name" .name "size" "18px")}}
   {{ end }}
 {{ end }}
 {{/*  Local Partials end  */}}
@@ -29,10 +29,10 @@
         {{ partial "breadcrumbs.html" . }}
     </div>
   </div>
-  {{ partial "translate_status_banner/translate_status_banner.html" . }} 
-  
+  {{ partial "translate_status_banner/translate_status_banner.html" . }}
+
   {{ $products := slice }}
-  <div 
+  <div
   class="standard-attributes-main row w-100"
   x-data="{
     filterValue: '',
@@ -64,7 +64,7 @@
       const productValues = datasetArr[0].replaceAll('icon-', '').replace('log', 'logs')
       const searchValues = this.searchValue.split(' ')
 
-      const containsFilteredValue = productValues.includes(this.filterValue) // checks product attrs in dataset 
+      const containsFilteredValue = productValues.includes(this.filterValue) // checks product attrs in dataset
       const containsSearchValues = searchValues.some(word => datasetArr.slice(1).join(' ').includes(word.toLowerCase())) // checks other attrs in dataset
 
       return containsSearchValues && containsFilteredValue
@@ -77,7 +77,7 @@
     }
   }"
   x-init="updateWithURLParams()">
-    <div 
+    <div
     class="table-wrapper order-1">
       <table>
         <thead class="table-header">
@@ -97,10 +97,10 @@
           {{ $pad.Set "attribute_info" (slice (delimit .product_source ",") .name .domain .type (replaceRE "(`|')" "" .description )) }}
           {{ $attribute_info := (delimit ($pad.Get "attribute_info") ";") | lower }}
 
-          <tr 
+          <tr
           class="table-row"
           :class="shouldShowAttribute('{{ $attribute_info }}') && 'show'"
-          x-cloak x-show="shouldShowAttribute('{{ $attribute_info }}')" 
+          x-cloak x-show="shouldShowAttribute('{{ $attribute_info }}')"
           x-transition.opacity.duration.250ms
           >
             <td>
@@ -110,18 +110,18 @@
                   {{ if in . "icon-"}}
                     {{ $product := (substr . 5) }}
                     {{ partial "icon" (dict "name" $product "size" "18px" "color" "#7c3eb9" "title" (cond (eq $product "log") (printf "%ss" $product) $product) )}}
- 
-                  {{ else if in (slice "android" "ios" "flutter" "roku") . }}	
-                    {{/*  Local partial */}}	
+
+                  {{ else if in (slice "android" "ios" "flutter" "roku") . }}
+                    {{/*  Local partial */}}
                     {{ partial "throw-error" (dict "ctx_product_source" $ctx_product_source "ctx_file_path" $ctx.File.Path) }}
 
                     {{/*  Get integration logos for android, ios, roku, and flutter  */}}
-                    {{ $int_logo := partial "integrations-logo.html" (dict "context" $ctx "basename" . "variant" "avatar") }}	
-                    {{ if $int_logo }}	
-                      <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}" title="{{ . }}" data-bs-toggle="tooltip" data-bs-placement="top"/>	
-                    {{ end }}	
+                    {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" . "variant" "avatar") . }}
+                    {{ if $int_logo }}
+                      <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}" title="{{ . }}" data-bs-toggle="tooltip" data-bs-placement="top"/>
+                    {{ end }}
                   {{ else if eq . "browser" }}
-                    {{/*  Local partial */}}	
+                    {{/*  Local partial */}}
                     {{ partial "throw-error" (dict "ctx_product_source" $ctx_product_source "ctx_file_path" $ctx.File.Path) }}
 
                     {{ partial "icon" (dict "name" . "size" "18px" "color" "#7c3eb9" "title" .)}}
@@ -146,16 +146,16 @@
       {{/*  FILTER BTNS - Keep here. $products slice needs to form */}}
       <div class="filters-standard-attributes">
         {{ if  $products }}
-            <button 
+            <button
             @click="filterValue = ''; pushState()"
             class="filter-btn mb-1 me-1 btn btn-sm-tag btn-outline-secondary"
             :class="(filterValue === 'all' || !filterValue) && 'active'"
-            data-filter="{{ .Params.filter_all | lower }}">{{ .Params.filter_all }}</button> 
+            data-filter="{{ .Params.filter_all | lower }}">{{ .Params.filter_all }}</button>
         {{ end }}
         {{ $sortedProduct := (split (replaceRE `icon-` "" (delimit $products " ")) " ") | sort }}
         {{ range $sortedProduct }}
             {{ $product := cond (eq . "log") (printf "%ss" .) .}}
-            <button 
+            <button
             @click="filterValue = '{{ $product }}'; pushState()"
             class="filter-btn mb-1 me-1 btn btn-sm-tag btn-outline-secondary"
             :class="($el.dataset.filter === filterValue) && 'active'"
@@ -168,7 +168,7 @@
         {{ end }}
       </div>
       {{/*  SEARCH  */}}
-      <form 
+      <form
       class="search-standard-attributes mt-2">
         <input type="text" placeholder="Search here" class="w-100" x-model="searchValue" @input.debounce="pushState(false)">
       </form>


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR improves performance of the hugo build step

- Cache logo lookups 18s down to 10s cumulative
- left nav api lookups 15s down to <1s cumulative
- defer algolia json creation on preview
- using fileexists over getpage on security_rules/single saves 5s cumulative
- Cache header main nav from websites modules. On docs the top main nav doesn't change page to page.
- Sets `disableSVG: true` for hugo minification of html. This is due to the fact it was modifying svg values in the html unnecessarily this in turn causing us to deploy html files that hadn't really changed.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes

#### What difference is it making?

Showing the hugo build at around 1 min instead of 3-4 mins

#### What to test?

- Check logos appear normal on https://docs-staging.datadoghq.com/david.jones/micro-perf/integrations/
- Check left nav on api appears normal https://docs-staging.datadoghq.com/david.jones/micro-perf/api/latest/
- Spot check some security rule detailed pages link to the integration e.g `Set up the 1password integration.`  on https://docs-staging.datadoghq.com/david.jones/micro-perf/security/default_rules/1password-item-exfiltration-by-user/ works
- Check the header nav (the one thats shared with corpsite) appears normal on various pages

example build
https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/367648287
