### PR TITLE
Specify that Session Replay recordings need to be started manually before v5

### DIFF
--- a/content/en/real_user_monitoring/session_replay/_index.md
+++ b/content/en/real_user_monitoring/session_replay/_index.md
@@ -43,7 +43,9 @@ Session Replay is available in the RUM Browser SDK. To start collecting data for
 
 ## Usage
 
-The Session Replay starts recording automatically when calling `init()`. To conditionally start the recording, use the `startSessionReplayRecordingManually` init parameter and call `startSessionReplayRecording()`. For example, to only record authenticated user sessions:
+Starting with v5.0.0 of the RUM Browser SDK, the Session Replay starts recording automatically when calling `init()`. To conditionally start the recording, use the `startSessionReplayRecordingManually` init parameter and call `startSessionReplayRecording()`. 
+
+For example, to only record authenticated user sessions:
 
 ```javascript
 window.DD_RUM.init({
@@ -65,6 +67,8 @@ if (user.isAuthenticated) {
 ```
 
 To stop the Session Replay recording, call `stopSessionReplayRecording()`.
+
+<div class="alert alert-warning">When using a version of the RUM Browser SDK older than v5.0.0, Session Replay recording does not begin automatically. Call `startSessionReplayRecording()` to begin recording.</div>
 
 ## Disable Session Replay
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR specifies that before v5 of the RUM Browser SDK, which starts Session Replay recordings automatically, that the Session Replay recorder must be started manually

### Merge instructions

- [x ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->