### PR TITLE
Swap windows installers json link to new one

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -42,7 +42,7 @@ If installing the Datadog Agent on a domain environment, see the [installation r
 
 1. Download the [Datadog Agent installer][1] to install the latest version of the Agent.
 
-   <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://s3.amazonaws.com/ddagent-windows-stable/installers.json">installer list</a>.</div>
+   <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json">installer list</a>.</div>
 
 2. Run the installer (as **Administrator**) by opening `datadog-agent-7-latest.amd64.msi`.
 3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].

--- a/content/en/agent/faq/agent-downgrade-major.md
+++ b/content/en/agent/faq/agent-downgrade-major.md
@@ -36,7 +36,7 @@ The command works on all supported versions of Amazon Linux, CentOS, Debian, Fed
 [1]: /agent/guide/how-do-i-uninstall-the-agent/
 [2]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-6-latest.amd64.msi
 [3]: https://app.datadoghq.com/organization-settings/api-keys
-[4]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
+[4]: https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json
 {{% /tab %}}
 {{% tab "MacOS" %}}
 

--- a/content/en/agent/versions/upgrade_to_agent_v7.md
+++ b/content/en/agent/versions/upgrade_to_agent_v7.md
@@ -33,7 +33,7 @@ The following command works on Amazon Linux, CentOS, Debian, Fedora, Red Hat, Ub
 
 [1]: https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-7-latest.amd64.msi
 [2]: https://app.datadoghq.com/organization-settings/api-keys
-[3]: https://s3.amazonaws.com/ddagent-windows-stable/installers.json
+[3]: https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json
 {{% /tab %}}
 {{% tab "MacOS" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updating all links in documentation to use new installers_v2 link to prepare for deprecation of the old link.

https://datadoghq.atlassian.net/browse/WINA-451


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->