### PR TITLE
Update python.md to include json parsing examples

### DIFF
--- a/content/en/logs/log_collection/python.md
+++ b/content/en/logs/log_collection/python.md
@@ -77,6 +77,47 @@ If logs are in JSON format, Datadog automatically [parses the log messages][10] 
 
 If APM is enabled for this application, connect your logs and traces by automatically adding trace IDs, span IDs, `env`, `service`, and `version` to your logs by [following the APM Python instructions][4].
 
+If logs are in JSON format, these values will automatically be extracted if at the top level of the JSON, `extra`, or `record.extra` blocks.
+
+```json
+{
+  "message":"Hello from the private method",
+  "dd.trace_id":"18287620314539322434",
+  "dd.span_id":"8440638443344356350",
+  "dd.env":"dev",
+  "dd.service":"logs",
+  "dd.version":"1.0.0"
+}
+```
+
+```json
+{
+  "message":"Hello from the private method",
+  "extra":{
+    "dd.trace_id":"18287620314539322434",
+    "dd.span_id":"8440638443344356350",
+    "dd.env":"dev",
+    "dd.service":"logs",
+    "dd.version":"1.0.0"
+  }
+}
+```
+
+```json
+{
+"message":"Hello from the private method",
+  "record":{
+    "extra":{
+      "dd.trace_id":"1734396609740561719",
+      "dd.span_id":"17877262712156101004",
+      "dd.env":"dev",
+      "dd.service":"logs",
+      "dd.version":"1.0.0"
+    }
+  }
+}
+```
+
 **Note**: If the APM tracer injects `service` into your logs, it overrides the value set in the agent configuration.
 
 Once this is done, the log should have the following format:

--- a/content/en/logs/log_collection/python.md
+++ b/content/en/logs/log_collection/python.md
@@ -77,7 +77,7 @@ If logs are in JSON format, Datadog automatically [parses the log messages][10] 
 
 If APM is enabled for this application, connect your logs and traces by automatically adding trace IDs, span IDs, `env`, `service`, and `version` to your logs by [following the APM Python instructions][4].
 
-If logs are in JSON format, these values will automatically be extracted if at the top level of the JSON, `extra`, or `record.extra` blocks.
+If logs are in JSON format, trace values are automatically extracted if at the top level of the JSON, `extra`, or `record.extra` blocks.
 
 ```json
 {


### PR DESCRIPTION
Update the docs to include changes made to the python logging integration for parsing trace values.

The new examples cover all the old and new cases where the default JSON parser would extract trace values and automatically correlate logs and traces

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->