### PR TITLE
Document Monitor recoverty threshold template variables

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -230,9 +230,9 @@ This is the escalation message @dev-team@company.com
 {{% /tab %}}
 {{< /tabs >}}
 
-If you configure a conditional block for a state transition into `alert` or `warning` conditions with an **@-notifications** handle, it is recommended to configure a corresponding `recovery` condition in order for a recovery notification to be sent to the handle. 
+If you configure a conditional block for a state transition into `alert` or `warning` conditions with an **@-notifications** handle, it is recommended to configure a corresponding `recovery` condition in order for a recovery notification to be sent to the handle.
 
-**Note**: Any text or notification handle placed **outside** the configured conditional variables is invoked with every monitor state transition. Any text or notification handle placed **inside** of configured conditional variables is only invoked if the monitor state transition matches its condition. 
+**Note**: Any text or notification handle placed **outside** the configured conditional variables is invoked with every monitor state transition. Any text or notification handle placed **inside** of configured conditional variables is only invoked if the monitor state transition matches its condition.
 
 ## Attribute and tag variables
 
@@ -395,18 +395,20 @@ Variable content is escaped by default. To prevent content such as JSON or code 
 
 Use template variables to customize your monitor notifications. The built-in variables are:
 
-| Variable                       | Description                                                                   |
-|--------------------------------|-------------------------------------------------------------------------------|
-| `{{value}}`                    | The value that breached the alert for metric based query monitors.            |
-| `{{threshold}}`                | The value of the alert threshold set in the monitor's alert conditions.       |
-| `{{warn_threshold}}`           | The value of the warning threshold set in the monitor's alert conditions.     |
-| `{{ok_threshold}}`             | The value that recovered the Service Check monitor.                            |
-| `{{comparator}}`               | The relational value set in the monitor's alert conditions.                   |
-| `{{first_triggered_at}}`       | The UTC date and time when the monitor first triggered.                       |
-| `{{first_triggered_at_epoch}}` | The UTC date and time when the monitor first triggered in epoch milliseconds. |
-| `{{last_triggered_at}}`        | The UTC date and time when the monitor last triggered.                        |
-| `{{last_triggered_at_epoch}}`  | The UTC date and time when the monitor last triggered in epoch milliseconds.  |
-| `{{triggered_duration_sec}}`   | The number of seconds the monitor has been in a triggered state.              |
+| Variable                          | Description                                                                   |
+|-----------------------------------|-------------------------------------------------------------------------------|
+| `{{value}}`                       | The value that breached the alert for metric based query monitors.            |
+| `{{threshold}}`                   | The value of the alert threshold set in the monitor's alert conditions.       |
+| `{{warn_threshold}}`              | The value of the warning threshold set in the monitor's alert conditions.     |
+| `{{alert_recovery_threshold}}`    | The value that recovered the monitor from its `ALERT` state.                  |
+| `{{warn_recovery_threshold}}`     | The value that recovered the monitor from its `WARN` state.                   |
+| `{{ok_threshold}}`                | The value that recovered the Service Check monitor.                           |
+| `{{comparator}}`                  | The relational value set in the monitor's alert conditions.                   |
+| `{{first_triggered_at}}`          | The UTC date and time when the monitor first triggered.                       |
+| `{{first_triggered_at_epoch}}`    | The UTC date and time when the monitor first triggered in epoch milliseconds. |
+| `{{last_triggered_at}}`           | The UTC date and time when the monitor last triggered.                        |
+| `{{last_triggered_at_epoch}}`     | The UTC date and time when the monitor last triggered in epoch milliseconds.  |
+| `{{triggered_duration_sec}}`      | The number of seconds the monitor has been in a triggered state.              |
 
 ### Evaluation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Documents alert and warn recovery threshold template variables for Monitors.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->