### PR TITLE
Docs: Add hint to arm64 AWS Lambda configuration layers

### DIFF
--- a/content/en/serverless/aws_lambda/installation/ruby.md
+++ b/content/en/serverless/aws_lambda/installation/ruby.md
@@ -234,17 +234,18 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     - Option A: [Configure the layers][1] for your Lambda function using the ARN in the following format:
 
       ```sh
-      # Use this format for x86-based library for AWS in commercial regions
+      # Use this format for x86-based Lambda deployed in AWS commercial regions
+
       arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="ruby" >}}
 
-      # Use this format for arm64-based library for AWS in commercial regions
+      # Use this format for arm64-based Lambda deployed in AWS commercial regions
       arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>-ARM:{{< latest-lambda-layer-version layer="ruby" >}}
 
 
-      # Use this format for x86-based library in AWS GovCloud regions
+      # Use this format for x86-based Lambda deployed in AWS GovCloud regions
       arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="ruby" >}}
 
-      # Use this format for arm64-based library in AWS GovCloud regions
+      # Use this format for arm64-based Lambda deployed in AWS GovCloud regions
       arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:{{< latest-lambda-layer-version layer="ruby" >}}
       ```
 

--- a/content/en/serverless/aws_lambda/installation/ruby.md
+++ b/content/en/serverless/aws_lambda/installation/ruby.md
@@ -234,11 +234,18 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     - Option A: [Configure the layers][1] for your Lambda function using the ARN in the following format:
 
       ```sh
-      # Use this format for AWS commercial regions
+      # Use this format for x86-based library for AWS in commercial regions
       arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="ruby" >}}
 
-      # Use this format for AWS GovCloud regions
+      # Use this format for arm64-based library for AWS in commercial regions
+      arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>-ARM:{{< latest-lambda-layer-version layer="ruby" >}}
+
+
+      # Use this format for x86-based library in AWS GovCloud regions
       arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="ruby" >}}
+
+      # Use this format for arm64-based library in AWS GovCloud regions
+      arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:{{< latest-lambda-layer-version layer="ruby" >}}
       ```
 
       Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `RUNTIME` options are `Ruby2-7`, and `Ruby3-2`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Regarding the AWS Lambda integration for DataDog: The docs currently don't distinguish between x86 & arm64 versions of the `datadog-lambda` ruby gem. The docs don't mention the arm64 existence of those layers nor the necessity to use them.

The status quo is pretty misleading if you're trying to set up an arm64-based ruby lambda function and you're hinted to the arm64-based extension layer, but **not** the arm-based gem/library. The error messages also don't help much.

Picking the correct `...-ARM`-based layer fixes the issue, but their existence isn't mentioned in the docs. This pull request fixes the docs here.

These ARM layers actually exist, see here: https://github.com/DataDog/datadog-lambda-rb/releases/tag/v2.21.0

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing
