### PR TITLE
Remove beta warning / label since "Gain Access" feature is GA now

### DIFF
--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -21,11 +21,7 @@ Use the different principals to control access patterns in your organization and
 | [Service Level Objectives][6]                    | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Synthetic tests][7]                             |                   | {{< X >}}         |                                     |
 
-### Gain access to individual resources (private beta)
-
-<div class="alert alert-warning">
-The feature to gain access to individual resources is in private beta. To request access, <a href="/help">contact Support</a>.
-</div>
+### Gain access to individual resources
 
 A user with the `user_access_manage` permission can gain edit access to any individual resource that supports restrictions based on team, role, and user or service account. Resources with only role-based access restrictions are not supported. To get access, click the **Gain Edit Access** button in the granular access control modal.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes the yellow beta banner & "beta" label in the heading because the "Gain Access" feature is GA as of today. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Will also remove the beta labels on Confluence docs, so it's consistent. 

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->