### PR TITLE
Use otel context function and ignore non-recording spans.

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -46,10 +46,12 @@ class CustomDatadogLogProcessor(object):
         # An example of adding datadog formatted trace context to logs
         # from: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/b53b9a012f76c4fc883c3c245fddc29142706d0d/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py#L122-L129 
         current_span = trace.get_current_span()
+        if not current_span.is_recording():
+            return eventDict
 
-        if current_span is not None:
-            event_dict['dd.trace_id'] = str(current_span.context.trace_id & 0xFFFFFFFFFFFFFFFF)
-            event_dict['dd.span_id'] = str(current_span.context.span_id)
+        if context := current_span.get_span_context():
+            event_dict["dd.trace_id"] = str(context.trace_id & 0xFFFFFFFFFFFFFFFF)
+            event_dict["dd.span_id"] = str(context.span_id)
 
         return event_dict        
 # ##########

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -49,7 +49,8 @@ class CustomDatadogLogProcessor(object):
         if not current_span.is_recording():
             return eventDict
 
-        if context := current_span.get_span_context():
+        context = current_span.get_span_context() if current_span is not None else None
+        if context is not None:
             event_dict["dd.trace_id"] = str(context.trace_id & 0xFFFFFFFFFFFFFFFF)
             event_dict["dd.span_id"] = str(context.span_id)
 

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -47,7 +47,7 @@ class CustomDatadogLogProcessor(object):
         # from: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/b53b9a012f76c4fc883c3c245fddc29142706d0d/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py#L122-L129 
         current_span = trace.get_current_span()
         if not current_span.is_recording():
-            return eventDict
+            return event_dict
 
         context = current_span.get_span_context() if current_span is not None else None
         if context is not None:


### PR DESCRIPTION
The span object is always present, but a non-recording span won't have a context. Additionally `span.context` no longer exists, `get_span_context()` on the `Span` interface replaces it.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This fixes the example `structlog` injector to be inline with recent opentelemetry package releases. A slightly modified version of the code is being used in production.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->