### PR TITLE
fix fetch headers collection

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -348,6 +348,7 @@ datadogRum.init({
         if (event.type === 'resource' && event.resource.type === 'fetch') {
             event.context.responseHeaders = Object.fromEntries(context.response.headers)
         }
+        return true
     },
     ...
 });
@@ -363,6 +364,7 @@ window.DD_RUM.onReady(function() {
             if (event.type === 'resource' && event.resource.type === 'fetch') {
                 event.context.responseHeaders = Object.fromEntries(context.response.headers)
             }
+            return true
         },
         ...
     })
@@ -379,6 +381,7 @@ window.DD_RUM &&
             if (event.type === 'resource' && event.resource.type === 'fetch') {
                 event.context.responseHeaders = Object.fromEntries(context.response.headers)
             }
+            return true
         },
         ...
     });

--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -346,7 +346,7 @@ datadogRum.init({
     beforeSend: (event, context) => {
         // collect a RUM resource's response headers
         if (event.type === 'resource' && event.resource.type === 'fetch') {
-            event.context = {...event.context, responseHeaders: context.response.headers}
+            event.context.responseHeaders = Object.fromEntries(context.response.headers)
         }
     },
     ...
@@ -361,7 +361,7 @@ window.DD_RUM.onReady(function() {
         beforeSend: (event, context) => {
             // collect a RUM resource's response headers
             if (event.type === 'resource' && event.resource.type === 'fetch') {
-                event.context = {...event.context, responseHeaders: context.response.headers}
+                event.context.responseHeaders = Object.fromEntries(context.response.headers)
             }
         },
         ...
@@ -377,7 +377,7 @@ window.DD_RUM &&
         beforeSend: (event, context) => {
             // collect a RUM resource's response headers
             if (event.type === 'resource' && event.resource.type === 'fetch') {
-                event.context = {...event.context, responseHeaders: context.response.headers}
+                event.context.responseHeaders = Object.fromEntries(context.response.headers)
             }
         },
         ...

--- a/content/en/real_user_monitoring/guide/enrich-and-control-rum-data.md
+++ b/content/en/real_user_monitoring/guide/enrich-and-control-rum-data.md
@@ -9,7 +9,7 @@ further_reading:
 
 ## Overview
 
-The RUM Browser SDK captures RUM events and populates their main attributes. The `beforeSend` callback function gives you access to every event collected by the RUM SDK before they are sent to Datadog. 
+The RUM Browser SDK captures RUM events and populates their main attributes. The `beforeSend` callback function gives you access to every event collected by the RUM SDK before they are sent to Datadog.
 
 Intercepting the RUM events allows you to:
 
@@ -64,7 +64,7 @@ datadogRum.init({
     beforeSend: (event, context) => {
         // collect a RUM resource's response headers
         if (event.type === 'resource' && event.resource.type === 'fetch') {
-            event.context = {...event.context, responseHeaders: context.response.headers}
+            event.context.responseHeaders = Object.fromEntries(context.response.headers)
         }
     },
     ...

--- a/content/en/real_user_monitoring/guide/enrich-and-control-rum-data.md
+++ b/content/en/real_user_monitoring/guide/enrich-and-control-rum-data.md
@@ -66,6 +66,7 @@ datadogRum.init({
         if (event.type === 'resource' && event.resource.type === 'fetch') {
             event.context.responseHeaders = Object.fromEntries(context.response.headers)
         }
+        return true
     },
     ...
 });

--- a/content/fr/real_user_monitoring/guide/enrich-and-control-rum-data.md
+++ b/content/fr/real_user_monitoring/guide/enrich-and-control-rum-data.md
@@ -63,6 +63,7 @@ datadogRum.init({
         if (event.type === 'resource' && event.resource.type === 'fetch') {
             event.context.responseHeaders = Object.fromEntries(context.response.headers)
         }
+        return true
     },
     ...
 });

--- a/content/fr/real_user_monitoring/guide/enrich-and-control-rum-data.md
+++ b/content/fr/real_user_monitoring/guide/enrich-and-control-rum-data.md
@@ -61,7 +61,7 @@ datadogRum.init({
     beforeSend: (event, context) => {
         // recueillir des en-têtes de réponse d'une ressource RUM
         if (event.type === 'resource' && event.resource.type === 'fetch') {
-            event.context = {...event.context, responseHeaders: context.response.headers}
+            event.context.responseHeaders = Object.fromEntries(context.response.headers)
         }
     },
     ...

--- a/content/ja/real_user_monitoring/guide/enrich-and-control-rum-data.md
+++ b/content/ja/real_user_monitoring/guide/enrich-and-control-rum-data.md
@@ -64,7 +64,7 @@ datadogRum.init({
     beforeSend: (event, context) => {
         // RUM リソースの応答ヘッダーを収集します
         if (event.type === 'resource' && event.resource.type === 'fetch') {
-            event.context = {...event.context, responseHeaders: context.response.headers}
+            event.context.responseHeaders = Object.fromEntries(context.response.headers)
         }
     },
     ...

--- a/content/ja/real_user_monitoring/guide/enrich-and-control-rum-data.md
+++ b/content/ja/real_user_monitoring/guide/enrich-and-control-rum-data.md
@@ -66,6 +66,7 @@ datadogRum.init({
         if (event.type === 'resource' && event.resource.type === 'fetch') {
             event.context.responseHeaders = Object.fromEntries(context.response.headers)
         }
+        return true
     },
     ...
 });


### PR DESCRIPTION



<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fix RUM example on using `beforeSend` to collect `fetch` response headers.

* `context.response.headers` is not serializable as JSON. We need to convert it to an object before.
* Also, it's fine to mutate the `event.context` directly. It simplifies the examples a little bit.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->