### PR TITLE
Make documentation around IAM authentication clearer

### DIFF
--- a/content/en/database_monitoring/guide/managed_authentication.md
+++ b/content/en/database_monitoring/guide/managed_authentication.md
@@ -84,6 +84,7 @@ instances:
  port: 5432
  username: datadog
  aws:
+   instance_endpoint: example-endpoint.us-east-2.rds.amazonaws.com
    region: us-east-2
 ```
 

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -242,7 +242,9 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
    ssl: allow
    ```
 
-If you want to authenticate with IAM, set the `region` and `instance_endpoint` parameters. **Note**: only set the `region` parameter if you want to use IAM authentication. IAM authentication takes precedence over the `password` field.
+   If you want to authenticate with IAM, set the `region` and `instance_endpoint` parameters. 
+   
+   **Note**: only set the `region` parameter if you want to use IAM authentication. IAM authentication takes precedence over the `password` field.
 
    ```yaml
    init_config:
@@ -263,13 +265,14 @@ If you want to authenticate with IAM, set the `region` and `instance_endpoint` p
        # dbname: '<DB_NAME>'
    ```
 
-Please see [this guide][9] on how to configure IAM authentication on your RDS instance.
+   For information on configuring IAM authentication on your RDS instance, see [Connecting with Managed Authentication][3].
 
 2. [Restart the Agent][2].
 
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example
 [2]: /agent/configuration/agent-commands/#start-stop-and-restart-the-agent
+[3]: /database_monitoring/guide/managed_authentication
 {{% /tab %}}
 {{% tab "Docker" %}}
 

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -242,7 +242,7 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
    ssl: allow
    ```
 
-If you want to authenticate via IAM, set the `region` and `instance_endpoint` parameters. **Note**: only set the `region` parameter if you want to use IAM authentication, it will take precedence over the `password` field.
+If you want to authenticate with IAM, set the `region` and `instance_endpoint` parameters. **Note**: only set the `region` parameter if you want to use IAM authentication. IAM authentication takes precedence over the `password` field.
 
    ```yaml
    init_config:

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -218,7 +218,7 @@ To monitor RDS hosts, install the Datadog Agent in your infrastructure and confi
 
 To configure collecting Database Monitoring metrics for an Agent running on a host, for example when you provision a small EC2 instance for the Agent to collect from an RDS database:
 
-1. Edit the `postgres.d/conf.yaml` file to point to your `host` / `port` and set the masters to monitor. Set the `region` parameter to configure the Agent to connect using IAM authentication. See the [sample postgres.d/conf.yaml][1] for all available configuration options.
+1. Edit the `postgres.d/conf.yaml` file to point to your `host` / `port` and set the masters to monitor. See the [sample postgres.d/conf.yaml][1] for all available configuration options.
    ```yaml
    init_config:
    instances:
@@ -227,9 +227,6 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
        port: 5432
        username: datadog
        password: '<PASSWORD>'
-       aws:
-         instance_endpoint: '<AWS_INSTANCE_ENDPOINT>'
-         region: '<REGION>'
        tags:
          - "dbinstanceidentifier:<DB_INSTANCE_NAME>"
        ## Required for Postgres 9.6: Uncomment these lines to use the functions created in the setup
@@ -244,6 +241,29 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
    ```yaml
    ssl: allow
    ```
+
+If you want to authenticate via IAM, set the `region` and `instance_endpoint` parameters. **Note**: only set the `region` parameter if you want to use IAM authentication, it will take precedence over the `password` field.
+
+   ```yaml
+   init_config:
+   instances:
+     - dbm: true
+       host: '<AWS_INSTANCE_ENDPOINT>'
+       port: 5432
+       username: datadog
+       aws:
+         instance_endpoint: '<AWS_INSTANCE_ENDPOINT>'
+         region: '<REGION>'
+       tags:
+         - "dbinstanceidentifier:<DB_INSTANCE_NAME>"
+       ## Required for Postgres 9.6: Uncomment these lines to use the functions created in the setup
+       # pg_stat_statements_view: datadog.pg_stat_statements()
+       # pg_stat_activity_view: datadog.pg_stat_activity()
+       ## Optional: Connect to a different database if needed for `custom_queries`
+       # dbname: '<DB_NAME>'
+   ```
+
+Please see [this guide][9] on how to configure IAM authentication on your RDS instance.
 
 2. [Restart the Agent][2].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Updates docs to make it clear that the `region` parameter in the aws blocks enabled IAM authentication AND this takes precedence over setting the `password` explicitly in your YAML config. This is in response to new customers reporting issues with setting up IAM / accidentally enabling IAM, which causes authentication errors at start up. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->