### PR TITLE
Add google-pubsub to java tracer doc

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -94,6 +94,7 @@ The following instrumentations are disabled by default and can be enabled with t
 | ----------------------- |---------------------------------------------- |
 | JAX-WS		              | `-Ddd.integration.jax-ws.enabled=true`|
 | Mulesoft		            | `-Ddd.integration.mule.enabled=true`, `-Ddd.integration.grizzly-client.enabled=true`, `-Ddd.integration.grizzly-filterchain.enabled=true`|
+| Google Pub/Sub          | `-Ddd.integration.google-pubsub.enabled=true`|
 | Grizzly                 | `-Ddd.integration.grizzly-client.enabled=true`|
 | Grizzly-HTTP            | `-Ddd.integration.grizzly-filterchain.enabled=true`|
 | Ning                    | `-Ddd.integration.ning.enabled=true`|
@@ -122,6 +123,7 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 | Camel-OpenTelemetry      | 3.12.0+     | Beta            | [opentelemetry-1][5]                           |
 | Commons HTTP Client      | 2.0+        | Fully Supported | `commons-http-client`                          |
 | Google HTTP Client       | 1.19.0+     | Fully Supported | `google-http-client`                           |
+| Google Pub/Sub           | 1.116.0+    | [Beta](#framework-integrations-disabled-by-default) | `google-pubsub` |
 | Grizzly HTTP Client      | 1.9+        | [Beta](#framework-integrations-disabled-by-default) | `grizzly-client`     |
 | gRPC                     | 1.5+        | Fully Supported | `grpc`, `grpc-client`, `grpc-server`           |
 | HttpURLConnection        | all         | Fully Supported | `httpurlconnection`, `urlconnection`           |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds google pubsub to supported framework since added starting from 1.24.0

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->