### PR TITLE
Remove CSM guide from left nav

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3292,11 +3292,6 @@ main:
     parent: cspm
     identifier: resource_catalog
     weight: 114
-  - name: Resource Evaluation Filters
-    url: /security/cloud_security_management/guide/resource_evaluation_filters
-    parent: cspm
-    identifier: resource_evaluation_filters
-    weight: 116
   - name: Identity Risks
     url: security/identity_risks/
     parent: csm


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
I added a new guide and included it in the left nav. But apparently that causes weird behavior when navigating between the guide and the main guide index, so I'm removing the guide from the left nav for now.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->