### PR TITLE
[DOCS-6745] fixing broken orchestrator explorer links

### DIFF
--- a/content/en/containers/kubernetes/configuration.md
+++ b/content/en/containers/kubernetes/configuration.md
@@ -750,7 +750,7 @@ Starting with Agent v6.4.0 (and v6.5.0 for the Trace Agent), you can override th
 [17]: /containers/kubernetes/log
 [18]: /network_monitoring/performance/
 [19]: /developers/dogstatsd
-[20]: https://app.datadoghq.com/orchestration/overview/
+[20]: https://app.datadoghq.com/orchestration/overview
 [21]: /infrastructure/containers/orchestrator_explorer
 [22]: /containers/guide/cluster_agent_autoscaling_metrics/?tab=helm
 [23]: /infrastructure/process/ 

--- a/content/en/infrastructure/containers/_index.md
+++ b/content/en/infrastructure/containers/_index.md
@@ -251,6 +251,6 @@ You can see indexed logs that you have chosen to index and persist by selecting 
 [15]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog
 [16]: /infrastructure/containers/configuration
 [17]: /infrastructure/faq/live-containers-legacy-configuration
-[18]: https://app.datadoghq.com/orchestration/overview/
+[18]: https://app.datadoghq.com/orchestration/overview
 [19]: /infrastructure/containers/orchestrator_explorer/
 [20]: /infrastructure/containers/kubernetes_resources

--- a/content/en/infrastructure/containers/orchestrator_explorer.md
+++ b/content/en/infrastructure/containers/orchestrator_explorer.md
@@ -138,7 +138,7 @@ All of these columns support sorting, which helps you to pinpoint individual wor
 * Data is updated automatically in constant intervals. Update intervals may change during beta.
 * In clusters with 1000+ Deployments or ReplicaSets you may notice elevated CPU usage from the Cluster Agent. There is an option to disable container scrubbing in the Helm chart. See [the Helm Chart repo][15] for more details.
 
-[1]: https://app.datadoghq.com/orchestration/overview/
+[1]: https://app.datadoghq.com/orchestration/overview
 [2]: /infrastructure/containers/?tab=datadogoperator#setup
 
 [9]: /logs

--- a/content/fr/containers/kubernetes/configuration.md
+++ b/content/fr/containers/kubernetes/configuration.md
@@ -697,7 +697,7 @@ Vous pouvez ajouter d'autres écouteurs et fournisseurs de configuration à l'ai
 [17]: /fr/containers/kubernetes/log
 [18]: /fr/network_monitoring/performance/
 [19]: /fr/developers/dogstatsd
-[20]: https://app.datadoghq.com/orchestration/overview/
+[20]: https://app.datadoghq.com/orchestration/overview
 [21]: /fr/infrastructure/containers/orchestrator_explorer
 [22]: /fr/containers/guide/cluster_agent_autoscaling_metrics/?tab=helm
 [23]: /fr/infrastructure/process/ 

--- a/content/ja/containers/kubernetes/configuration.md
+++ b/content/ja/containers/kubernetes/configuration.md
@@ -697,7 +697,7 @@ Agent v6.4.0 (トレース Agent の場合は v6.5.0) より、以下の環境�
 [17]: /ja/containers/kubernetes/log
 [18]: /ja/network_monitoring/performance/
 [19]: /ja/developers/dogstatsd
-[20]: https://app.datadoghq.com/orchestration/overview/
+[20]: https://app.datadoghq.com/orchestration/overview
 [21]: /ja/infrastructure/containers/orchestrator_explorer
 [22]: /ja/containers/guide/cluster_agent_autoscaling_metrics/?tab=helm
 [23]: /ja/infrastructure/process/ 

--- a/content/ja/infrastructure/containers/_index.md
+++ b/content/ja/infrastructure/containers/_index.md
@@ -251,6 +251,6 @@ Live Tail を使用すると、すべてのコンテナログがストリーミ�
 [15]: https://github.com/DataDog/helm-charts/tree/master/charts/datadog
 [16]: /ja/infrastructure/containers/configuration
 [17]: /ja/infrastructure/faq/live-containers-legacy-configuration
-[18]: https://app.datadoghq.com/orchestration/overview/
+[18]: https://app.datadoghq.com/orchestration/overview
 [19]: /ja/infrastructure/containers/orchestrator_explorer/
 [20]: /ja/infrastructure/containers/kubernetes_resources

--- a/content/ja/infrastructure/containers/orchestrator_explorer.md
+++ b/content/ja/infrastructure/containers/orchestrator_explorer.md
@@ -140,7 +140,7 @@ datadog:
 * データは一定の間隔で自動的に更新されます。ベータ版の更新間隔は変更される可能性があります。
 * 1000 以上のデプロイまたは ReplicaSets を持つクラスターでは、Cluster Agent からの CPU 使用率が上昇する場合があります。Helm チャートにはコンテナのスクラブを無効にするオプションがあります。詳細については、[Helm チャートリポジトリ][15]を参照してください。
 
-[1]: https://app.datadoghq.com/orchestration/overview/
+[1]: https://app.datadoghq.com/orchestration/overview
 [2]: /ja/infrastructure/containers/?tab=datadogoperator#setup
 
 [9]: /ja/logs


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
[DOCS-6745](https://datadoghq.atlassian.net/browse/DOCS-6745)
Fixing broken links to orchestrator explorer, in this instance just needed to remove the trailing `/`
I went ahead and updated the non-English language pages that were affected too.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6745]: https://datadoghq.atlassian.net/browse/DOCS-6745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ