### PR TITLE
Updating documentation with datadog node runtime layer - removing node12 and adding node20

### DIFF
--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -309,7 +309,7 @@ Fill in variables accordingly:
         </tr>
     </table>
 
-   In the ARN, replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. Replace `<RUNTIME>` with `Node12-x`, `Node14-x`, `Node16-x`, or `Node18-x`.
+   In the ARN, replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. Replace `<RUNTIME>` with `Node14-x`, `Node16-x`, `Node18-x` or `Node20-x`.
 
 2. Replace `<DATADOG_EXTENSION_ARN>` with the ARN of the appropriate Datadog Lambda Extension for your region and architecture:
 


### PR DESCRIPTION
As https://github.com/DataDog/datadog-lambda-js/releases/tag/v7.100.0 has been released we can add `Node20-x` to the documentation as part of the https://github.com/DataDog/datadog-lambda-js/issues/436

Additionally, removing node12 on https://github.com/DataDog/datadog-lambda-js/releases/tag/v7.90.0

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->