### PR TITLE
[RUM-253] add documentation about compressed RUM data

### DIFF
--- a/content/en/integrations/content_security_policy_logs.md
+++ b/content/en/integrations/content_security_policy_logs.md
@@ -174,9 +174,9 @@ Depending on the `site` option used to initialize [Real User Monitoring][4] or [
 connect-src https://{{< region-param key="browser_sdk_endpoint_domain" >}}
 ```
 
-### Session Replay worker
+### Web Worker
 
-If you are using Session Replay, make sure to allow workers with `blob:` URI schemes by adding the following `worker-src` entry:
+If you are using Session Replay or the RUM [`compressIntakeRequests` initialization parameter][4], make sure to allow workers with `blob:` URI schemes by adding the following `worker-src` entry:
 
 ```txt
 worker-src blob:;

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -1814,6 +1814,12 @@ A list of request origins ignored when computing the page activity. See [How pag
 **Type**: String<br/>
 URL pointing to the Datadog Browser SDK Worker JavaScript file. The URL can be relative or absolute, but is required to have the same origin as the web application. See [Content Security Policy guidelines][22] for more information.
 
+`compressIntakeRequests`
+: Optional<br/>
+**Type**: Boolean<br/>
+**Default**: `false`<br/>
+Compress requests sent to the Datadog intake to reduce bandwidth usage when sending large amount of data. The compression is done in a Worker thread, see [Content Security Policy guidelines][22] for more information.
+
 `storeContextsAcrossPages`
 : Optional<br/>
 **Type**: String<br/>

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -70,6 +70,8 @@ To successfully proxy request to Datadog:
 3. Forward the request to the Datadog intake URL using the POST method.
 4. Leave the request body unchanged.
 
+The request body can contain binary data and should not be converted to a string. Make sure your proxy implementation forwards the raw body without conversion.
+
 The site parameter is an SDK [initialization parameter][1]. Datadog intake origins for each site are listed below:
 
 | Site    | Site Parameter            | Datadog intake origin                      |


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We implemented a new Browser SDK option to compress intake requests. This PR adds documentation around it.

* Add `compressIntakeRequests` to the parameters list

* Update the CSP doc to mention compressed RUM data (beside Session Replay)

* Update the Proxy doc to warn that requests can contain binary data and should not be converted to a string.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->