### PR TITLE
[oracle] Add access right for the agent releases 7.50.0 and 7.49.1-oracle-dbm-1.3 (DBMON-3068)

### DIFF
--- a/content/en/database_monitoring/setup_oracle/autonomous_database.md
+++ b/content/en/database_monitoring/setup_oracle/autonomous_database.md
@@ -66,6 +66,10 @@ grant select on V$CONTAINERS to datadog ;
 grant select on V$SQL_PLAN_STATISTICS_ALL to datadog ;
 grant select on V$SQL to datadog ;
 grant select on V$PGASTAT to datadog ;
+grant select on v$asm_diskgroup to datadog ;
+grant select on v$rsrcmgrmetric to datadog ;
+grant select on v$dataguard_config to datadog ;
+grant select on v$dataguard_stats to datadog ;
 ```
 
 ## Configure the Agent

--- a/content/en/database_monitoring/setup_oracle/rds.md
+++ b/content/en/database_monitoring/setup_oracle/rds.md
@@ -67,6 +67,10 @@ exec rdsadmin.rdsadmin_util.grant_sys_object('V_$CONTAINERS','DATADOG','SELECT',
 exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL_PLAN_STATISTICS_ALL','DATADOG','SELECT',p_grant_option => false);
 exec rdsadmin.rdsadmin_util.grant_sys_object('V_$SQL','DATADOG','SELECT',p_grant_option => false);
 exec rdsadmin.rdsadmin_util.grant_sys_object('V_$PGASTAT','DATADOG','SELECT',p_grant_option => false);
+exec rdsadmin.rdsadmin_util.grant_sys_object('V_$ASM_DISKGROUP','DATADOG','SELECT',p_grant_option => false);
+exec rdsadmin.rdsadmin_util.grant_sys_object('V_$RSRCMGRMETRIC','DATADOG','SELECT',p_grant_option => false);
+exec rdsadmin.rdsadmin_util.grant_sys_object('V_$DATAGUARD_CONFIG','DATADOG','SELECT',p_grant_option => false);
+exec rdsadmin.rdsadmin_util.grant_sys_object('V_$DATAGUARD_STATS','DATADOG','SELECT',p_grant_option => false);
 ```
 
 ## Configure the Agent

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -435,6 +435,10 @@ grant select on V_$SQL to datadog ;
 grant select on V_$PGASTAT to datadog ;
 grant select on dba_tablespace_usage_metrics to datadog ;
 grant select on dba_tablespaces to datadog ;
+grant select on v_$asm_diskgroup to datadog ;
+grant select on v_$rsrcmgrmetric to datadog ;
+grant select on v_$dataguard_config to datadog ;
+grant select on v_$dataguard_stats to datadog ;
 ```
 
 ### Create view

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -73,6 +73,10 @@ grant select on V_$CONTAINERS to c##datadog ;
 grant select on V_$SQL_PLAN_STATISTICS_ALL to c##datadog ;
 grant select on V_$SQL to c##datadog ;
 grant select on V_$PGASTAT to c##datadog ;
+grant select on v_$asm_diskgroup to c##datadog ;
+grant select on v_$rsrcmgrmetric to c##datadog ;
+grant select on v_$dataguard_config to c##datadog ;
+grant select on v_$dataguard_stats to c##datadog ;
 ```
 
 If you conifgured custom queries that run on a pluggable database (PDB), you must grant `set container` privilege to the `C##DATADOG` user:
@@ -258,6 +262,10 @@ grant select on V_$CONTAINERS to datadog ;
 grant select on V_$SQL_PLAN_STATISTICS_ALL to datadog ;
 grant select on V_$SQL to datadog ;
 grant select on V_$PGASTAT to datadog ;
+grant select on v_$asm_diskgroup to datadog ;
+grant select on v_$rsrcmgrmetric to datadog ;
+grant select on v_$dataguard_config to datadog ;
+grant select on v_$dataguard_stats to datadog ;
 ```
 
 ### Create view


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adding access rights that will be used by the upcoming agent releases `7.50.0` and `7.49.1-oracle-dbm-1.3`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->