### PR TITLE
Update documentation for 128 bit trace ID generation for java

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -296,7 +296,7 @@ When `true`, the tracer collects [telemetry data][8]. Available for versions 0.1
 `dd.trace.128.bit.traceid.generation.enabled`
 : **Environment Variable**: `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`<br>
 **Default**: `true`<br>
-When `true`, the tracer will generate 128 bit Trace IDs and will encode Trace ID as 32 lower-case hexadecimal characters with zero-padding.
+When `true`, the tracer generates 128 bit Trace IDs and encodes Trace ID as 32 lower-case hexadecimal characters with zero-padding.
 
 **Note**:
 

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -293,6 +293,11 @@ When `true`, user principal is collected. Available for versions 0.61+.
 **Default**: `true`<br>
 When `true`, the tracer collects [telemetry data][8]. Available for versions 0.104+. Defaults to `true` for versions 0.115+.
 
+`dd.trace.128.bit.traceid.generation.enabled`
+: **Environment Variable**: `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`<br>
+**Default**: `true`<br>
+When `true`, the tracer will generate 128 bit Trace IDs and will encode Trace ID as 32 lower-case hexadecimal characters with zero-padding.
+
 **Note**:
 
 - If the same key type is set for both, the system property configuration takes priority.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds documentation about a new flag in the java tracer that is used for enabling 128 bit trace id generation

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ✅ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->