### PR TITLE
Exit on missing rbac perms

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -174,6 +174,7 @@ build_preview:
       - ./logs
       - ./public/redirects.txt
       - $PREVIEW_ERROR_LOG
+      - ./latest-cached.tar.gz
   after_script:
     - |
       if [ -s $PREVIEW_ERROR_LOG && $CI_JOB_STATUS != 'success' ]; then

--- a/layouts/shortcodes/permissions.html
+++ b/layouts/shortcodes/permissions.html
@@ -25,6 +25,10 @@
     {{- end -}}
   {{- end -}}
 {{- else -}}
-  {{ warnf "Could not load RBAC permission set" }}
+  {{ if hugo.IsDevelopment }}
+    {{ warnf "Could not load RBAC permission set" }}
+  {{ else }}
+    {{ errorf "Could not load RBAC permission set" }}
+  {{ end }}
 {{- end -}}
 

--- a/local/bin/py/build/content_manager.py
+++ b/local/bin/py/build/content_manager.py
@@ -232,11 +232,11 @@ def prepare_content(self, configuration, github_token, extract_dir):
 
 def download_and_extract_cached_files_from_s3():
     s3_url = f'https://origin-static-assets.s3.amazonaws.com/build_artifacts/master/latest-cached.tar.gz'
-    artifact_download_response = requests.get(s3_url, stream=True)
-
-    with tarfile.open(mode='r|gz', fileobj=artifact_download_response.raw) as artifact_tarfile:
+    r = requests.get(s3_url)
+    with open('./latest-cached.tar.gz', 'wb') as f:
+        f.write(r.content)
+    with tarfile.open("./latest-cached.tar.gz", "r:gz") as artifact_tarfile:
         artifact_tarfile.extractall('temp')
-        artifact_tarfile.close()
 
 
 def download_cached_content_into_repo(self):


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- throw an error when rbac perms is not found in preview/live which will exit building the site
- switch from streaming cached artifact to download and extracting

### Merge instructions

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->