### PR TITLE
PROF-8461: Endpoint profiling no longer turns on code hotspots

### DIFF
--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -277,12 +277,9 @@ Endpoint profiling (beta) is NOT enabled by default when you [turn on profiling 
 export DD_PROFILING_ENDPOINT_COLLECTION_ENABLED=true
 ```
 
-Setting this environment variable also turns on [Code Hotspots (beta)][2] which is needed for endpoint profiling.
-
 Requires `dd-trace-js` version 4.17.0+ or 3.38.0+.
 
 [1]: /profiler/enabling/nodejs
-[2]: /profiler/connect_traces_and_profiles/?code-lang=nodejs#identify-code-hotspots-in-slow-traces
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Removes a sentence that cautions the user that turning on Endpoint Profiling also turns on Code Hotspots in Node.js; this is no longer the case for few weeks now, we made the features independent of one another.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->