### PR TITLE
[APPSEC] Fix suggested getting-started script threshold

### DIFF
--- a/content/en/getting_started/application_security/_index.md
+++ b/content/en/getting_started/application_security/_index.md
@@ -78,7 +78,7 @@ Once enabled, ASM immediately identifies application vulnerabilities and detects
 2. **Validate attacks**: Send attack patterns to trigger a test detection rule. From your terminal, run the following script:
 
   {{< code-block lang="sh" >}}
-  for ((i=1;i<=200;i++)); do
+  for ((i=1;i<=250;i++)); do
   # Target existing service's routes
   curl https://your-application-url/<EXISTING ROUTE> -A
   'dd-test-scanner-log';

--- a/content/en/security/application_security/troubleshooting.md
+++ b/content/en/security/application_security/troubleshooting.md
@@ -51,7 +51,7 @@ ASM data is sent with APM traces. See [APM troubleshooting][4] to [confirm APM s
 {{< programming-lang lang="java" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # Target existing service's routes
 curl https://your-application-url/existing-route -A dd-test-scanner-log;
@@ -66,7 +66,7 @@ done
 {{< programming-lang lang=".NET" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # Target existing service's routes
 curl https://your-application-url/existing-route -A dd-test-scanner-log;
@@ -81,7 +81,7 @@ done
 {{< programming-lang lang="go" >}}
 
  ```bash
- for ((i=1;i<=200;i++));
+ for ((i=1;i<=250;i++));
 do
 # Target existing service's routes
 curl https://your-application-url/existing-route -A Arachni/v1.0;
@@ -94,7 +94,7 @@ done
 {{< programming-lang lang="ruby" >}}
 
  ```bash
- for ((i=1;i<=200;i++));
+ for ((i=1;i<=250;i++));
 do
 # Target existing service's routes
 curl https://your-application-url/existing-route -A Arachni/v1.0;
@@ -107,7 +107,7 @@ done
 {{< programming-lang lang="PHP" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # Target existing service's routes
 curl https://your-application-url/existing-route -A dd-test-scanner-log;
@@ -122,7 +122,7 @@ done
 {{< programming-lang lang="Node.js" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # Target existing service's routes
 curl https://your-application-url/existing-route -A dd-test-scanner-log;
@@ -136,7 +136,7 @@ done
 {{< programming-lang lang="python" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # Target existing service's routes
 curl https://your-application-url/existing-route -A dd-test-scanner-log;

--- a/content/ja/getting_started/application_security/_index.md
+++ b/content/ja/getting_started/application_security/_index.md
@@ -76,7 +76,7 @@ ASM を有効にすると、アプリケーションの脆弱性を即座に識�
 2. **攻撃の検証**: テスト検出ルールをトリガーする攻撃パターンを送信します。ターミナルから以下のスクリプトを実行します。
 
   {{< code-block lang="sh" >}}
-  for ((i=1;i<=200;i++)); do
+  for ((i=1;i<=250;i++)); do
   # 既存サービスのルートをターゲットにする
   curl https://your-application-url/<EXISTING ROUTE> -A
   'dd-test-scanner-log';

--- a/content/ja/security/application_security/troubleshooting.md
+++ b/content/ja/security/application_security/troubleshooting.md
@@ -51,7 +51,7 @@ ASM の設定をテストするには、次の curl スクリプトを含むフ�
 {{< programming-lang lang="java" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # 既存サービスのルートが対象
 curl https://your-application-url/existing-route -A dd-test-scanner-log;
@@ -66,7 +66,7 @@ done
 {{< programming-lang lang=".NET" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # 既存サービスのルートが対象
 curl https://your-application-url/existing-route -A dd-test-scanner-log;
@@ -81,7 +81,7 @@ done
 {{< programming-lang lang="go" >}}
 
  ```bash
- for ((i=1;i<=200;i++));
+ for ((i=1;i<=250;i++));
 do
 # 既存サービスのルートが対象
 curl https://your-application-url/existing-route -A Arachni/v1.0;
@@ -94,7 +94,7 @@ done
 {{< programming-lang lang="ruby" >}}
 
  ```bash
- for ((i=1;i<=200;i++));
+ for ((i=1;i<=250;i++));
 do
 # 既存サービスのルートが対象
 curl https://your-application-url/existing-route -A Arachni/v1.0;
@@ -107,7 +107,7 @@ done
 {{< programming-lang lang="PHP" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # 既存サービスのルートが対象
 curl https://your-application-url/existing-route -A dd-test-scanner-log;
@@ -122,7 +122,7 @@ done
 {{< programming-lang lang="Node.js" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # 既存サービスのルートが対象
 curl https://your-application-url/existing-route -A dd-test-scanner-log;
@@ -136,7 +136,7 @@ done
 {{< programming-lang lang="python" >}}
 
 ```bash
-for ((i=1;i<=200;i++));
+for ((i=1;i<=250;i++));
 do
 # 既存サービスのルートが対象
 curl https://your-application-url/existing-route -A dd-test-scanner-log;

--- a/content/ko/getting_started/application_security/_index.md
+++ b/content/ko/getting_started/application_security/_index.md
@@ -78,7 +78,7 @@ ASM이 활성화되면 애플리케이션 취약성을 즉시 파악하고 서�
 2. **공격 확인**: 공격 패턴을 보내 테스트 탐지 규칙을 트리거합니다. 단말기에서 다음 스크립트를 실행합니다:
 
   {{< code-block lang="sh" >}}
-  for ((i=1;i<=200;i++)); do
+  for ((i=1;i<=250;i++)); do
   # 기존 서비스의 경로 타겟
   curl https://your-application-url/<EXISTING ROUTE> -A
   'dd-test-scanner-log';

--- a/layouts/shortcodes/appsec-getstarted-2-canary.md
+++ b/layouts/shortcodes/appsec-getstarted-2-canary.md
@@ -2,7 +2,7 @@
    
 3.  **To see Application Security Management threat detection in action, send known attack patterns to your application**. For example, trigger the [Security Scanner Detected][203] rule by running a file that contains the following curl script:
     <div>
-    <pre><code>for ((i=1;i<=200;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A dd-test-scanner-log;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A dd-test-scanner-log;<br>done</code></pre></div>
+    <pre><code>for ((i=1;i<=250;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A dd-test-scanner-log;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A dd-test-scanner-log;<br>done</code></pre></div>
 
     **Note**: The `dd-test-scanner-log` value is supported in the most recent releases.
 

--- a/layouts/shortcodes/appsec-getstarted-2-plusrisk.md
+++ b/layouts/shortcodes/appsec-getstarted-2-plusrisk.md
@@ -2,7 +2,7 @@
    
 3.  **To see Application Security Management threat detection in action, send known attack patterns to your application**. For example, trigger the [Security Scanner Detected][203] rule by running a file that contains the following curl script:
     <div>
-    <pre><code>for ((i=1;i<=200;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A dd-test-scanner-log;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A dd-test-scanner-log;<br>done</code></pre></div>
+    <pre><code>for ((i=1;i<=250;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A dd-test-scanner-log;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A dd-test-scanner-log;<br>done</code></pre></div>
 
     **Note**: The `dd-test-scanner-log` value is supported in the most recent releases.
 

--- a/layouts/shortcodes/appsec-getstarted-2.md
+++ b/layouts/shortcodes/appsec-getstarted-2.md
@@ -2,7 +2,7 @@
    
 1.  **To see Application Security Management threat detection in action, send known attack patterns to your application**. For example, trigger the [Security Scanner Detected][203] rule by running a file that contains the following curl script:
     <div>
-    <pre><code>for ((i=1;i<=200;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A Arachni/v1.0;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A Arachni/v1.0;<br>done</code></pre></div>
+    <pre><code>for ((i=1;i<=250;i++)); <br>do<br># Target existing service’s routes<br>curl https://your-application-url/existing-route -A Arachni/v1.0;<br># Target non existing service’s routes<br>curl https://your-application-url/non-existing-route -A Arachni/v1.0;<br>done</code></pre></div>
 
     A few minutes after you enable your application and exercise it, **threat information appears in the [Application Trace and Signals Explorer][201] in Datadog**.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The getting started script suggests sending 200 events, but the default rule thresholds in ASM are ">200". So minimum we would need to send "201" events for any chance of triggering a signal.

Bumping the default threshold to 250 to have a bit of a buffer, and eliminate issues where customers can't generate signals.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->