### PR TITLE
Recommend removal of sensitive HTTP headers

### DIFF
--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -61,7 +61,7 @@ window.DD_RUM &&
 
 When your proxy receives data from the RUM Browser SDK, it must be forwarded to Datadog. The RUM Browser SDK adds the `ddforward` query parameter to all POST requests to your proxy. This query parameter contains the URL path and parameters that all data must be forwarded to.
 
-To successfully proxy request to Datadog:
+To successfully proxy your RUM requests to Datadog:
 
 1. Build the final Datadog intake URL by using:
     - the Datadog intake origin corresponding to your site. See table below.
@@ -69,6 +69,8 @@ To successfully proxy request to Datadog:
 2. Add a `X-Forwarded-For` header containing the request client IP address for accurate geoIP.
 3. Forward the request to the Datadog intake URL using the POST method.
 4. Leave the request body unchanged.
+
+<div class="alert alert-info">For security reasons, remove any HTTP headers potentially containing sensitive information, e.g. the `cookie` or `referer` headers.</div>
 
 The site parameter is an SDK [initialization parameter][1]. Datadog intake origins for each site are listed below:
 

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -70,7 +70,7 @@ To successfully proxy your RUM requests to Datadog:
 3. Forward the request to the Datadog intake URL using the POST method.
 4. Leave the request body unchanged.
 
-<div class="alert alert-info">For security reasons, remove any HTTP headers potentially containing sensitive information, e.g. the `cookie` or `referer` headers.</div>
+<div class="alert alert-info">For security reasons, remove any HTTP headers potentially containing sensitive information, e.g. the `cookie` header.</div>
 
 The site parameter is an SDK [initialization parameter][1]. Datadog intake origins for each site are listed below:
 

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -70,7 +70,7 @@ To successfully proxy your RUM requests to Datadog:
 3. Forward the request to the Datadog intake URL using the POST method.
 4. Leave the request body unchanged.
 
-<div class="alert alert-info">For security reasons, remove any HTTP headers potentially containing sensitive information, e.g. the `cookie` header.</div>
+<div class="alert alert-warning">For security reasons, remove any HTTP headers that potentially contain sensitive information, such as the <code>cookie</code> header.</div>
 
 The site parameter is an SDK [initialization parameter][1]. Datadog intake origins for each site are listed below:
 


### PR DESCRIPTION
In light of [incident-22155](https://app.datadoghq.com/incidents/22155) we want to recommend customers to avoid sending sensitive data when proxying RUM requests.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds a "For security reasons" alert-info block below the instructions to proxy RUM requests.
Also fixes a typo.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->