### PR TITLE
Document per-thread information in the profiler

### DIFF
--- a/content/en/profiler/profile_visualizations.md
+++ b/content/en/profiler/profile_visualizations.md
@@ -151,6 +151,46 @@ Lanes on the top are runtime activities that may add extra latency to your reque
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
+## Per-thread information
+
+Depending on the runtime and language, you may be able to see per-thread information in the flame graph view (using the right sidebar), as well as in the timeline view:
+
+{{< programming-lang-wrapper langs="java,ruby,dotnet,python,ddprof" >}}
+{{< programming-lang lang="java" >}}
+
+You can see and filter by the thread name.
+
+{{< /programming-lang >}}
+{{< programming-lang lang="ruby" >}}
+
+You can see and filter by the thread name, as well as the thread id.
+
+The thread id is shown as "native thread id (ruby object id)" with the native thread id being the same as `Thread#native_thread_id` (when available) and the ruby object id being `Thread#object_id.`
+
+Note that the Ruby VM/your OS may reuse native thread ids.
+
+{{< /programming-lang >}}
+{{< programming-lang lang="dotnet" >}}
+
+You can see and filter by the thread name, as well as the thread id.
+
+The thread id is shown as "\<unique id\> [#OS thread id]"; the OS thread id is also shown as part of the thread name.
+
+Note that your OS may reuse thread ids.
+
+{{< /programming-lang >}}
+{{< programming-lang lang="python" >}}
+
+You can see and filter by the thread name, as well as the thread id.
+
+{{< /programming-lang >}}
+{{< programming-lang lang="ddprof" >}}
+
+You can see and filter by the OS thread id.
+
+{{< /programming-lang >}}
+{{< /programming-lang-wrapper >}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/profiler/profile_visualizations.md
+++ b/content/en/profiler/profile_visualizations.md
@@ -133,9 +133,9 @@ See [prerequisites][1] to learn how to enable this feature for Ruby.
 
 Each lane represents a **thread**. Threads from a common pool are grouped together. You can expand the pool to view details for each thread.
 
-The thread id is shown as "native thread id (ruby object id)" with the native thread id being the same as `Thread#native_thread_id` (when available) and the ruby object id being `Thread#object_id.`
+The thread ID is shown as `native-thread-id (ruby-object-id)` where the native thread ID is `Thread#native_thread_id` (when available) and the Ruby object ID is `Thread#object_id`.
 
-**Note:** The Ruby VM/your OS may reuse native thread ids.
+**Note**: The Ruby VM or your operating system might reuse native thread IDs.
 
 [1]: /profiler/connect_traces_and_profiles/#prerequisites
 {{< /programming-lang >}}
@@ -144,9 +144,10 @@ Each lane represents a **thread**. Threads from a common pool are grouped togeth
 
 Lanes on top are runtime activities that may impact performance.
 
-The thread id is shown as "\<unique id\> [#OS thread id]".
+The thread ID is shown as `<unique-id> [#OS-thread-id]`.
 
-**Note:** Your OS may reuse thread ids.
+**Note**: Your operating system might reuse thread IDs.
+
 {{< /programming-lang >}}
 {{< programming-lang lang="php" >}}
 See [prerequisites][1] to learn how to enable this feature for PHP.

--- a/content/en/profiler/profile_visualizations.md
+++ b/content/en/profiler/profile_visualizations.md
@@ -133,12 +133,20 @@ See [prerequisites][1] to learn how to enable this feature for Ruby.
 
 Each lane represents a **thread**. Threads from a common pool are grouped together. You can expand the pool to view details for each thread.
 
+The thread id is shown as "native thread id (ruby object id)" with the native thread id being the same as `Thread#native_thread_id` (when available) and the ruby object id being `Thread#object_id.`
+
+**Note:** The Ruby VM/your OS may reuse native thread ids.
+
 [1]: /profiler/connect_traces_and_profiles/#prerequisites
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
 Each lane represents a **thread**. Threads from a common pool are grouped together. You can expand the pool to view details for each thread.
 
 Lanes on top are runtime activities that may impact performance.
+
+The thread id is shown as "\<unique id\> [#OS thread id]".
+
+**Note:** Your OS may reuse thread ids.
 {{< /programming-lang >}}
 {{< programming-lang lang="php" >}}
 See [prerequisites][1] to learn how to enable this feature for PHP.
@@ -148,46 +156,6 @@ There is one lane for the PHP **thread**. Fibers that run in this **thread** are
 Lanes on the top are runtime activities that may add extra latency to your request, due to file compilation and garbage collection.
 
 [1]: /profiler/connect_traces_and_profiles/#prerequisites
-{{< /programming-lang >}}
-{{< /programming-lang-wrapper >}}
-
-## Per-thread information
-
-Depending on the runtime and language, you may be able to see per-thread information in the flame graph view (using the right sidebar), as well as in the timeline view:
-
-{{< programming-lang-wrapper langs="java,ruby,dotnet,python,ddprof" >}}
-{{< programming-lang lang="java" >}}
-
-You can see and filter by the thread name.
-
-{{< /programming-lang >}}
-{{< programming-lang lang="ruby" >}}
-
-You can see and filter by the thread name, as well as the thread id.
-
-The thread id is shown as "native thread id (ruby object id)" with the native thread id being the same as `Thread#native_thread_id` (when available) and the ruby object id being `Thread#object_id.`
-
-**Note:** The Ruby VM/your OS may reuse native thread ids.
-
-{{< /programming-lang >}}
-{{< programming-lang lang="dotnet" >}}
-
-You can see and filter by the thread name, as well as the thread id.
-
-The thread id is shown as "\<unique id\> [#OS thread id]"; the OS thread id is also shown as part of the thread name.
-
-**Note:** Your OS may reuse thread ids.
-
-{{< /programming-lang >}}
-{{< programming-lang lang="python" >}}
-
-You can see and filter by the thread name, as well as the thread id.
-
-{{< /programming-lang >}}
-{{< programming-lang lang="ddprof" >}}
-
-You can see and filter by the OS thread id.
-
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 

--- a/content/en/profiler/profile_visualizations.md
+++ b/content/en/profiler/profile_visualizations.md
@@ -167,7 +167,7 @@ You can see and filter by the thread name, as well as the thread id.
 
 The thread id is shown as "native thread id (ruby object id)" with the native thread id being the same as `Thread#native_thread_id` (when available) and the ruby object id being `Thread#object_id.`
 
-Note that the Ruby VM/your OS may reuse native thread ids.
+**Note:** The Ruby VM/your OS may reuse native thread ids.
 
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
@@ -176,7 +176,7 @@ You can see and filter by the thread name, as well as the thread id.
 
 The thread id is shown as "\<unique id\> [#OS thread id]"; the OS thread id is also shown as part of the thread name.
 
-Note that your OS may reuse thread ids.
+**Note:** Your OS may reuse thread ids.
 
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR documents what per-thread filtering capabilities exist for each profiler, as well as what format is used for displaying this information.

We've been showing this data for quite some time, but some of the identifiers were not actually documented anywhere.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->