### PR TITLE
[DOCS-6161] Update remap section and change VRL to DPL

### DIFF
--- a/content/en/observability_pipelines/guide/control_log_volume_and_size.md
+++ b/content/en/observability_pipelines/guide/control_log_volume_and_size.md
@@ -82,7 +82,7 @@ Use the [filter transform][4] when you want only certain logs that meet a specif
 
 In those cases, insert a component that contains a [filter transform][4] to filter logs that uses the [Datadog Processing Language (DPL)][5] or [Datadog Log Search syntax][6] to set the conditions. Logs that don't match the conditions are dropped. 
 
-The example below uses the filter transform and Vector Remap Language to send only logs with a `status` of `500`.
+The example below uses the filter transform and Datadog Processing Language to send only logs with a `status` of `500`.
 
 {{< tabs >}}
 {{% tab "YAML" %}}
@@ -439,7 +439,7 @@ The following logs are generated:
 
 Logs can contain fields that are unnecessary. When processing terabytes of data a day, dropping fields that are superfluous can significantly reduce the total number of logs your destination ingests and indexes. 
 
-To remove unnecessary fields, use the [Vector Remap Language][5] to remap your log data. The following example removes unnecessary tags using `del`. 
+To remove unnecessary fields, use the [Datadog Processing Language][5] to remap your log data. The following example removes unnecessary tags using `del`. 
 
 {{< tabs >}}
 {{% tab "YAML" %}}

--- a/content/en/observability_pipelines/guide/control_log_volume_and_size.md
+++ b/content/en/observability_pipelines/guide/control_log_volume_and_size.md
@@ -80,7 +80,7 @@ Use the [filter transform][4] when you want only certain logs that meet a specif
 - A specific tag, such as `env`.
 - A specific field value, such as the `status` field must be `400`.
 
-In those cases, insert a component that contains a [filter transform][4] to filter logs that uses the [Vector Remap Language (VRL)][5] or [Datadog Log Search syntax][6] to set the conditions. Logs that don't match the conditions are dropped. 
+In those cases, insert a component that contains a [filter transform][4] to filter logs that uses the [Datadog Processing Language (DPL)][5] or [Datadog Log Search syntax][6] to set the conditions. Logs that don't match the conditions are dropped. 
 
 The example below uses the filter transform and Vector Remap Language to send only logs with a `status` of `500`.
 
@@ -138,7 +138,7 @@ inputs = [ "my-source-or-transform-id" ]
 
 When analyzing data that comes in large volumes or contains a lot of noise, such as CDN logs, sending all the logs to a destination is unnecessary. Instead, use the [sample transform][7] to send only the logs necessary to perform analysis that is statistically significant.
 
-The `exclude` field excludes events from being sampled, and also supports VRL or Datadog Log Search syntax. The example below shows a configuration that samples every 10 events, which is set by the `rate`.
+The `exclude` field excludes events from being sampled, and also supports DPL or Datadog Log Search syntax. The example below shows a configuration that samples every 10 events, which is set by the `rate`.
 
 {{< tabs >}}
 {{% tab "YAML" %}}
@@ -497,7 +497,7 @@ del(.unecessary_tag_field)"""
 [2]: /observability_pipelines/configurations/
 [3]: /observability_pipelines/reference/transforms/#dedupe
 [4]: /observability_pipelines/reference/transforms/#filter
-[5]: https://vector.dev/docs/reference/vrl/
+[5]: /observability_pipelines/reference/processing_language/
 [6]: /logs/explorer/search_syntax/
 [7]: /observability_pipelines/reference/transforms/#sample
 [8]: /observability_pipelines/reference/transforms/#logtometric

--- a/content/en/observability_pipelines/guide/control_log_volume_and_size.md
+++ b/content/en/observability_pipelines/guide/control_log_volume_and_size.md
@@ -82,7 +82,7 @@ Use the [filter transform][4] when you want only certain logs that meet a specif
 
 In those cases, insert a component that contains a [filter transform][4] to filter logs that uses the [Datadog Processing Language (DPL)][5] or [Datadog Log Search syntax][6] to set the conditions. Logs that don't match the conditions are dropped. 
 
-The example below uses the filter transform and DPL to send only logs with a `status` of `500`. **Note**: DPL was previously VRL which is why the `type` is set to `vrl`.
+The example below uses the filter transform and DPL to send only logs with a `status` of `500`. **Note**: DPL was previously called VRL which is why the `type` is set to `vrl`.
 
 {{< tabs >}}
 {{% tab "YAML" %}}

--- a/content/en/observability_pipelines/guide/control_log_volume_and_size.md
+++ b/content/en/observability_pipelines/guide/control_log_volume_and_size.md
@@ -82,7 +82,7 @@ Use the [filter transform][4] when you want only certain logs that meet a specif
 
 In those cases, insert a component that contains a [filter transform][4] to filter logs that uses the [Datadog Processing Language (DPL)][5] or [Datadog Log Search syntax][6] to set the conditions. Logs that don't match the conditions are dropped. 
 
-The example below uses the filter transform and Datadog Processing Language to send only logs with a `status` of `500`.
+The example below uses the filter transform and DPL to send only logs with a `status` of `500`. **Note**: DPL was previously VRL which is why the `type` is set to `vrl`.
 
 {{< tabs >}}
 {{% tab "YAML" %}}

--- a/content/en/observability_pipelines/guide/custom-metrics-governance.md
+++ b/content/en/observability_pipelines/guide/custom-metrics-governance.md
@@ -22,7 +22,7 @@ This guide walks you through how to use Observability Pipelines to govern and co
 
 ## Prerequisites
 
-This guide assumes that you have already set up the Observability Pipelines Worker, a tool for collecting, processing, and routing telemetry data. If you're not familiar with Observability Pipelines, see the [Installation][4] documentation and [Vector Remap Language][5] for more information.
+This guide assumes that you have already set up the Observability Pipelines Worker, a tool for collecting, processing, and routing telemetry data. If you're not familiar with Observability Pipelines, see the [Installation][4] documentation and [Datadog Processing Language][5] for more information.
 
 ## Drop metrics missing specific tags or the metric's namespace
 

--- a/content/en/observability_pipelines/guide/custom-metrics-governance.md
+++ b/content/en/observability_pipelines/guide/custom-metrics-governance.md
@@ -76,7 +76,7 @@ To address this issue, you can use Observability Pipelines to do one of the foll
 
 To drop a specific tag on custom metrics before they get ingested into Datadog, you can use Observability Pipelines' [`remap` transform][7], which comes with a domain-specific language to manipulate metrics. 
 
-For the basic use case of dropping a single metric tag, you can use the `del()` function in VRL. For example, the following component drops the `tag_to_drop` tag.
+For the basic use case of dropping a single metric tag, you can use the `del()` function in DPL. For example, the following component drops the `tag_to_drop` tag.
 
 ```yaml
 transforms:
@@ -210,8 +210,8 @@ transforms:
 [2]: /account_management/billing/usage_attribution/
 [3]: /metrics/metrics-without-limits/
 [4]: /observability_pipelines/setup/
-[5]: https://vector.dev/docs/reference/vrl/
+[5]: /observability_pipelines/reference/processing_language/
 [6]: /account_management/billing/usage_attribution/
-[7]: https://vector.dev/docs/reference/vrl/
+[7]: /observability_pipelines/reference/transforms/#remap
 [8]: /account_management/billing/custom_metrics/?tab=countrategauge
 [9]: /observability_pipelines/reference/transforms/#tagcardinalitylimit

--- a/content/en/observability_pipelines/reference/processing_language/_index.md
+++ b/content/en/observability_pipelines/reference/processing_language/_index.md
@@ -2,35 +2,33 @@
 title: Datadog Processing Language
 ---
 
-Datadog Processing Language (DPL) is an expression-oriented, domain specific language designed for transforming observability data (logs and metrics). It features a simple syntax and [built-in functions][1] tailored to observability use cases.
+The Datadog Processing Language (DPL) is an expression-oriented, domain-specific language designed for transforming data (logs and metrics (beta)) sent to Observability Pipelines. It features a simple syntax and [built-in functions][1].
 
-Datadog Processing Language is supported in the `remap` transform.
+You can use DPL in the [`remap` transform][2] to:
 
-Remap transforms act on a single event and can be used to transform them or specify conditions for routing and filtering. You can use DPL in the following ways:
+- Manipulate [arrays][3], [strings][4], and other data types.
+- Encode and decode values using [Codec][5].
+- [Encrypt][6] and [decrypt][7] values.
+- [Coerce][8] one datatype to another datatype (for example, from an integer to a string).
+- [Convert syslog values][9] to read-able values.
+- Enrich values by using [enrichment tables][10].
+- [Manipulate IP values][11].
+- [Parse][12] values with custom rules (for example, grok, regex, and so on) and out-of-the-box functions (for example, syslog, apache, VPC flow logs, and so on).
+- Manipulate event [metadata][13] and [paths][14].
 
-- Manipulate [arrays][2], [strings][3], and other data types.
-- Encode and decode values using [Codec][4].
-- [Encrypt][5] and [decrypt][6] values.
-- [Coerce][7] one datatype to another datatype (for example, from an integer to a string).
-- [Convert syslog values][8] to read-able values.
-- Enrich values by using [enrichment tables][9].
-- [Manipulate IP values][10].
-- [Parse][11] values with custom rules (for example, grok, regex, and so on) and out-of-the-box functions (for example, syslog, apache, VPC flow logs, and so on).
-- Manipulate event [metadata][12] and [paths][13].
-
-See [DPL Functions Reference][14] for a full list of DPL built-in functions.
+See [DPL Functions Reference][1] for a full list of DPL built-in functions.
 
 [1]: /observability_pipelines/reference/processing_language/functions/
-[2]: /observability_pipelines/reference/processing_language/functions/#array
-[3]: /observability_pipelines/reference/processing_language/functions/#string
-[4]: /observability_pipelines/reference/processing_language/functions/#codec
-[5]: /observability_pipelines/reference/processing_language/functions/#encrypt
-[6]: /observability_pipelines/reference/processing_language/functions/#decrypt
-[7]: /observability_pipelines/reference/processing_language/functions/#coerce
-[8]: /observability_pipelines/reference/processing_language/functions/#convert
-[9]: /observability_pipelines/reference/processing_language/functions/#enrichment
-[10]: /observability_pipelines/reference/processing_language/functions/#ip
-[11]: /observability_pipelines/reference/processing_language/functions/#parse
-[12]: /observability_pipelines/reference/processing_language/functions/#event
-[13]: /observability_pipelines/reference/processing_language/functions/#path
-[14]: /observability_pipelines/reference/processing_language/functions/
+[2]: /observability_pipelines/reference/transforms/#remap
+[3]: /observability_pipelines/reference/processing_language/functions/#array
+[4]: /observability_pipelines/reference/processing_language/functions/#string
+[5]: /observability_pipelines/reference/processing_language/functions/#codec
+[6]: /observability_pipelines/reference/processing_language/functions/#encrypt
+[7]: /observability_pipelines/reference/processing_language/functions/#decrypt
+[8]: /observability_pipelines/reference/processing_language/functions/#coerce
+[9]: /observability_pipelines/reference/processing_language/functions/#convert
+[10]: /observability_pipelines/reference/processing_language/functions/#enrichment
+[11]: /observability_pipelines/reference/processing_language/functions/#ip
+[12]: /observability_pipelines/reference/processing_language/functions/#parse
+[13]: /observability_pipelines/reference/processing_language/functions/#event
+[14]: /observability_pipelines/reference/processing_language/functions/#path

--- a/content/en/observability_pipelines/reference/processing_language/_index.md
+++ b/content/en/observability_pipelines/reference/processing_language/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Processing Language
+title: Datadog Processing Language
 ---
 
 Datadog Processing Language (DPL) is an expression-oriented, domain specific language designed for transforming observability data (logs and metrics). It features a simple syntax and [built-in functions][1] tailored to observability use cases.

--- a/content/en/observability_pipelines/reference/processing_language/_index.md
+++ b/content/en/observability_pipelines/reference/processing_language/_index.md
@@ -18,6 +18,8 @@ Remap transforms act on a single event and can be used to transform them or spec
 - [Parse][11] values with custom rules (for example, grok, regex, and so on) and out-of-the-box functions (for example, syslog, apache, VPC flow logs, and so on).
 - Manipulate event [metadata][12] and [paths][13].
 
+See [DPL Functions Reference][14] for a full list of DPL built-in functions.
+
 [1]: /observability_pipelines/reference/processing_language/functions/
 [2]: /observability_pipelines/reference/processing_language/functions/#array
 [3]: /observability_pipelines/reference/processing_language/functions/#string
@@ -31,3 +33,4 @@ Remap transforms act on a single event and can be used to transform them or spec
 [11]: /observability_pipelines/reference/processing_language/functions/#parse
 [12]: /observability_pipelines/reference/processing_language/functions/#event
 [13]: /observability_pipelines/reference/processing_language/functions/#path
+[14]: /observability_pipelines/reference/processing_language/functions/

--- a/content/en/observability_pipelines/reference/processing_language/_index.md
+++ b/content/en/observability_pipelines/reference/processing_language/_index.md
@@ -9,8 +9,8 @@ You can use DPL in the [`remap` transform][2] to:
 - Manipulate [arrays][3], [strings][4], and other data types.
 - Encode and decode values using [Codec][5].
 - [Encrypt][6] and [decrypt][7] values.
-- [Coerce][8] one datatype to another datatype (for example, from an integer to a string).
-- [Convert syslog values][9] to read-able values.
+- [Coerce][8] one data type to another data type (for example, from an integer to a string).
+- [Convert syslog values][9] to readable values.
 - Enrich values by using [enrichment tables][10].
 - [Manipulate IP values][11].
 - [Parse][12] values with custom rules (for example, grok, regex, and so on) and out-of-the-box functions (for example, syslog, apache, VPC flow logs, and so on).

--- a/content/en/observability_pipelines/working_with_data.md
+++ b/content/en/observability_pipelines/working_with_data.md
@@ -35,30 +35,11 @@ further_reading:
 
 Observability Pipelines enables you to shape and transform observability data. Similar to Logging without Limits™ pipelines, you can configure pipelines for Observability Pipelines that are composed of a series of `transform` components. These transforms allow you to parse, structure, and enrich data with built-in type safety.
 
-## Remap data with VRL
+## Remap data with DPL
 
-Vector Remap Language (VRL) is an expression-oriented, domain specific language designed for transforming observability data (logs and metrics). It features a simple syntax and [built-in functions][1] tailored to observability use cases.
+The `remap` transform acts on a single event and can transform the event or specify conditions for routing and filtering the event. Use Datadog Processing Language (DPL) in the `remap` transform to manipulate arrays and strings, encode and decode vlaues, encrypt and decrypt values, and more. See [Datadog Processing Language][1] for more information and the [DPL Functions reference][10] for a full list of DPL built-in functions.
 
-Vector Remap Language is supported in the `remap` transform. 
-
-Remap transforms act on a single event and can be used to transform them or specify conditions for routing and filtering. You can use VRL in the following ways:
-
-- Manipulate [arrays][2], [strings][3], and other data types.
-- Encode and decode values using [Codec][4].
-- [Encrypt][5] and [decrypt][6] values.
-- [Coerce][7] one datatype to another datatype (for example, from an integer to a string).
-- [Convert syslog values][8] to read-able values.
-- Enrich values by using [enrichment tables][9].
-- [Manipulate IP values][10].
-- [Parse][11] values with custom rules (for example, grok, regex, and so on) and out-of-the-box functions (for example, syslog, apache, VPC flow logs, and so on).
-- Manipulate event [metadata][12] and [paths][13].
-
-See [VRL Function Reference][1] for a full list of VRL built-in functions.
-
-To get started, see the following example for a basic remap transform that contains a VRL program in the `source` field:
-
-{{< tabs >}}
-{{% tab "YAML" %}}
+To get started, see the following example for a basic remap transform that contains a DPL program in the `source` field:
 
 ```yaml
 transforms:
@@ -71,54 +52,19 @@ transforms:
         .timestamp = now()
 ```
 
-{{% /tab %}}
-{{% tab "TOML" %}}
-
-```toml
-[transforms.modify]
-type = "remap"
-inputs = ["previous_component_id"]
-source = '''
-  del(.user_info)
-  .timestamp = now()
-'''
-```
-
-{{% /tab %}}
-{{% tab "JSON" %}}
-
-```json
-{
-  "transforms": {
-    "modify": {
-      "type": "remap",
-      "inputs": [
-        "previous_component_id"
-      ],
-      "source": "  del(.user_info)\n  .timestamp = now()\n"
-    }
-  }
-}
-```
-
-{{% /tab %}}
-{{< /tabs >}}
-
 In this example, the `type` field is set to a `remap` transform. The `inputs` field defines where it receives events from the previously defined `previous_component_id` source. The first line in the `source` field deletes the `.user_info` field. At scale, dropping fields is particularly useful for reducing the payload of your events and cutting down on spend for your downstream services. 
 
 The second line adds the `.timestamp` field and the value to the event, changing the content of every event that passes through this transform.
 
-See [VRL References][14] and [Configurations][15] for more information.
-
 ## Parse data
 
-Parsing showcases more advanced use cases of VRL. The below snippet is an HTTP log event in JSON format:
+Parsing showcases more advanced use cases of DPL. The below snippet is an HTTP log event in JSON format:
 
 ```
 "{\"status\":200,\"timestamp\":\"2021-03-01T19:19:24.646170Z\",\"message\":\"SUCCESS\",\"username\":\"ub40fan4life\"}"
 ```
 
-The configuration below uses VRL to modify the log event by: 
+The configuration below uses DPL to modify the log event by: 
 
 - Parsing the raw string into JSON. 
 - Reformatting the time into a UNIX timestamp. 
@@ -190,15 +136,15 @@ This configuration returns the following:
 
 Sampling, reducing, filtering, and aggregating are common transforms to reduce the volume of observability data delivered to downstream services. Observability Pipelines offers a variety of ways to control your data volume:
 
-- [Sample events][16] based on supplied criteria and at a configurable rate.
-- [Reduce and collapse][17] multiple events into a single event.
+- [Sample events][2] based on supplied criteria and at a configurable rate.
+- [Reduce and collapse][3] multiple events into a single event.
 - Remove unnecessary fields.
-- [Deduplicate][18] events. 
-- [Filter events][19] based on a set of conditions.
-- [Aggregate multiple metric events][20] into a single metric event based on a defined interval window.
-- [Convert metrics to logs][21].
+- [Deduplicate][4] events. 
+- [Filter events][5] based on a set of conditions.
+- [Aggregate multiple metric events][6] into a single metric event based on a defined interval window.
+- [Convert metrics to logs][7].
 
-See [Control Log Volume and Size][22] for examples on how to use these transforms.
+See [Control Log Volume and Size][8] for examples on how to use these transforms.
 
 ## Route data
 
@@ -327,7 +273,7 @@ compression = "gzip"
 {{% /tab %}}
 {{< /tabs >}}
 
-See the [Route Transform documentation][23] for more information.
+See the [Route Transform documentation][9] for more information.
 
 ## Throttle data
 
@@ -386,26 +332,13 @@ The `threshold` field defines the number of events allowed for a given bucket. `
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://vector.dev/docs/reference/vrl/functions/
-[2]: https://vector.dev/docs/reference/vrl/functions/#array-functions
-[3]: https://vector.dev/docs/reference/vrl/functions/#string-functions
-[4]: https://vector.dev/docs/reference/vrl/functions/#codec-functions
-[5]: https://vector.dev/docs/reference/vrl/functions/#encrypt
-[6]: https://vector.dev/docs/reference/vrl/functions/#decrypt
-[7]: https://vector.dev/docs/reference/vrl/functions/#coerce-functions
-[8]: https://vector.dev/docs/reference/vrl/functions/#convert-functions
-[9]: https://vector.dev/docs/reference/vrl/functions/#enrichment-functions
-[10]: https://vector.dev/docs/reference/vrl/functions/#ip-functions
-[11]: https://vector.dev/docs/reference/vrl/functions/#parse-functions
-[12]: https://vector.dev/docs/reference/vrl/functions/#event-functions
-[13]: https://vector.dev/docs/reference/vrl/functions/#path-functions
-[14]: https://vector.dev/docs/reference/vrl/#reference
-[15]: /observability_pipelines/configurations/
-[16]: /observability_pipelines/reference/transforms/#sample
-[17]: /observability_pipelines/reference/transforms/#reduce
-[18]: /observability_pipelines/reference/transforms/#dedupe
-[19]: /observability_pipelines/reference/transforms/#filter
-[20]: /observability_pipelines/reference/transforms/#aggregate
-[21]: /observability_pipelines/reference/transforms/#metrictolog
-[22]: /observability_pipelines/guide/control_log_volume_and_size/
-[23]: /observability_pipelines/reference/transforms/#route
+[1]: /observability_pipelines/reference/processing_language/
+[2]: /observability_pipelines/reference/transforms/#sample
+[3]: /observability_pipelines/reference/transforms/#reduce
+[4]: /observability_pipelines/reference/transforms/#dedupe
+[5]: /observability_pipelines/reference/transforms/#filter
+[6]: /observability_pipelines/reference/transforms/#aggregate
+[7]: /observability_pipelines/reference/transforms/#metrictolog
+[8]: /observability_pipelines/guide/control_log_volume_and_size/
+[9]: /observability_pipelines/reference/transforms/#route
+[10]: /observability_pipelines/reference/processing_language/functions/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The Datadog Process Language (DPL) reference section is now live. This PR:

- Moves some of the remap section to the new DPL page.
- Updates `VRL` to `DPL`.

[DOCS-6161](https://datadoghq.atlassian.net/browse/DOCS-6161)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6161]: https://datadoghq.atlassian.net/browse/DOCS-6161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ