### PR TITLE
Remove Otel tile from advanced configuration page

### DIFF
--- a/layouts/partials/rum/rum-getting-started-mobile-advanced.html
+++ b/layouts/partials/rum/rum-getting-started-mobile-advanced.html
@@ -37,14 +37,6 @@
                 </a>
             </div>
             <div class="col">
-                <a class="card h-100" href="flutter#opentelemetry-setup">
-                    <div class="card-body text-center py-2 px-1">
-                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/otel_large.svg" "class"
-                        "img-fluid" "alt" "otel" "width" "200") }}
-                    </div>
-                </a>
-            </div>
-            <div class="col">
                 <a class="card h-100" href="android">
                     <div class="card-body text-center py-2 px-1">
                         {{ partial "img.html" (dict "root" . "src" "integrations_logos/android_tv_large.svg" "class"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
DOCS-6741

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
Preview URL is /real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->