### PR TITLE
Add alternative options for downloading Java agent

### DIFF
--- a/content/en/continuous_integration/tests/setup/java.md
+++ b/content/en/continuous_integration/tests/setup/java.md
@@ -95,7 +95,7 @@ export DD_TRACER_FOLDER=... // e.g. ~/.datadog
 Run the command below to download the tracer JAR to the specified folder:
 
 {{< code-block lang="shell" >}}
-wget -O $DD_TRACER_FOLDER/dd-java-agent.jar https://dtdg.co/latest-java-tracer
+wget -O $DD_TRACER_FOLDER/dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
 {{< /code-block >}}
 
 You can run the `java -jar $DD_TRACER_FOLDER/dd-java-agent.jar` command to check the version of the tracer library.

--- a/content/en/dynamic_instrumentation/enabling/java.md
+++ b/content/en/dynamic_instrumentation/enabling/java.md
@@ -27,12 +27,12 @@ The Datadog Dynamic Instrumentation library is supported in JDK version 8 and ab
 
 3. Download `dd-java-agent.jar`:
  {{< tabs >}}
- {{% tab "cURL" %}}
+ {{% tab "Wget" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 {{% /tab %}}
-{{% tab "Wget" %}}
+{{% tab "cURL" %}}
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```

--- a/content/en/dynamic_instrumentation/enabling/java.md
+++ b/content/en/dynamic_instrumentation/enabling/java.md
@@ -26,10 +26,24 @@ The Datadog Dynamic Instrumentation library is supported in JDK version 8 and ab
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 
 3. Download `dd-java-agent.jar`:
-
+ {{< tabs >}}
+ {{% tab "curl" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
+{{% /tab %}}
+{{% tab "wget" %}}
+   ```shell
+   curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+   ```
+{{% /tab %}}
+{{% tab "Dockerfile" %}}
+   ```dockerfile
+   ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
+   ```
+{{% /tab %}}
+{{< /tabs >}}
+
    **Note**: Dynamic Instrumentation is available in the `dd-java-agent.jar` library in versions 1.24.0 and later.
 
 3. Run your service with Dynamic Instrumentation enabled by setting `-Ddd.dynamic.instrumentation.enabled` flag or `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `dd.service`, `dd.env`, and `dd.version` Unified Service Tags so you can filter and group your probes and target active clients across these dimensions.

--- a/content/en/dynamic_instrumentation/enabling/java.md
+++ b/content/en/dynamic_instrumentation/enabling/java.md
@@ -27,12 +27,12 @@ The Datadog Dynamic Instrumentation library is supported in JDK version 8 and ab
 
 3. Download `dd-java-agent.jar`:
  {{< tabs >}}
- {{% tab "curl" %}}
+ {{% tab "cURL" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 {{% /tab %}}
-{{% tab "wget" %}}
+{{% tab "Wget" %}}
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -77,12 +77,12 @@ To begin profiling applications:
 2. Download `dd-java-agent.jar`, which contains the Java Agent class files:
 
 {{< tabs >}}
-{{% tab "curl" %}}
+{{% tab "cURL" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 {{% /tab %}}
-{{% tab "wget" %}}
+{{% tab "Wget" %}}
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -77,12 +77,12 @@ To begin profiling applications:
 2. Download `dd-java-agent.jar`, which contains the Java Agent class files:
 
 {{< tabs >}}
-{{% tab "cURL" %}}
+{{% tab "Wget" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 {{% /tab %}}
-{{% tab "Wget" %}}
+{{% tab "cURL" %}}
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -76,9 +76,23 @@ To begin profiling applications:
 
 2. Download `dd-java-agent.jar`, which contains the Java Agent class files:
 
-    ```shell
-    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
-    ```
+{{< tabs >}}
+{{% tab "curl" %}}
+   ```shell
+   wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+   ```
+{{% /tab %}}
+{{% tab "wget" %}}
+   ```shell
+   curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+   ```
+{{% /tab %}}
+{{% tab "Dockerfile" %}}
+   ```dockerfile
+   ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
+   ```
+{{% /tab %}}
+{{< /tabs >}}
 
      **Note**: Profiler is available in the `dd-java-agent.jar` library in versions 0.55+.
 

--- a/content/en/security/application_security/enabling/java.md
+++ b/content/en/security/application_security/enabling/java.md
@@ -33,9 +33,23 @@ You can monitor application security for Java apps running in Docker, Kubernetes
 ### Get started
 
 1. **Update your [Datadog Java library][1]** to at least version 0.94.0 (at least version 1.1.4 for Application Vulnerability Management vulnerability detection features):
+   {{< tabs >}}
+   {{% tab "curl" %}}
    ```shell
-   wget -O dd-java-agent.jar 'https://github.com/DataDog/dd-trace-java/releases/latest/download/dd-java-agent.jar'
+   wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
+{{% /tab %}}
+{{% tab "wget" %}}
+   ```shell
+   curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+   ```
+{{% /tab %}}
+{{% tab "Dockerfile" %}}
+   ```dockerfile
+   ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
+   ```
+{{% /tab %}}
+{{< /tabs >}}
 
    To check that your service's language and framework versions are supported for ASM capabilities, see [Compatibility][2].
 

--- a/content/en/security/application_security/enabling/java.md
+++ b/content/en/security/application_security/enabling/java.md
@@ -34,12 +34,12 @@ You can monitor application security for Java apps running in Docker, Kubernetes
 
 1. **Update your [Datadog Java library][1]** to at least version 0.94.0 (at least version 1.1.4 for Application Vulnerability Management vulnerability detection features):
    {{< tabs >}}
-   {{% tab "cURL" %}}
+   {{% tab "Wget" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 {{% /tab %}}
-{{% tab "Wget" %}}
+{{% tab "cURL" %}}
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```

--- a/content/en/security/application_security/enabling/java.md
+++ b/content/en/security/application_security/enabling/java.md
@@ -34,12 +34,12 @@ You can monitor application security for Java apps running in Docker, Kubernetes
 
 1. **Update your [Datadog Java library][1]** to at least version 0.94.0 (at least version 1.1.4 for Application Vulnerability Management vulnerability detection features):
    {{< tabs >}}
-   {{% tab "curl" %}}
+   {{% tab "cURL" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 {{% /tab %}}
-{{% tab "wget" %}}
+{{% tab "Wget" %}}
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```

--- a/content/en/security/application_security/enabling/serverless.md
+++ b/content/en/security/application_security/enabling/serverless.md
@@ -51,14 +51,14 @@ To install and configure the Datadog Serverless Framework plugin:
    ```sh
    serverless plugin install --name serverless-plugin-datadog
    ```
-    
+
 2. Enable ASM by updating your `serverless.yml` with the `enableASM` configuration parameter:
    ```yaml
    custom:
      datadog:
        enableASM: true
    ```
-   
+
    Overall, your new `serverless.yml` file should contain at least:
    ```yaml
    custom:
@@ -68,7 +68,7 @@ To install and configure the Datadog Serverless Framework plugin:
        enableASM: true
    ```
    See also the complete list of [plugin parameters][4] to further configure your lambda settings.
-   
+
 4. Redeploy the function and invoke it. After a few minutes, it appears in [ASM views][3].
 
 [1]: https://docs.datadoghq.com/serverless/serverless_integrations/plugin
@@ -130,7 +130,7 @@ The Datadog CLI modifies existing Lambda function configurations to enable instr
     ```
 
     To fill in the placeholders:
-    - Replace `<functionname>` and `<another_functionname>` with your Lambda function names. 
+    - Replace `<functionname>` and `<another_functionname>` with your Lambda function names.
     - Alternatively, you can use `--functions-regex` to automatically instrument multiple functions whose names match the given regular expression.
     - Replace `<aws_region>` with the AWS region name.
 
@@ -191,7 +191,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 {{< site-region region="us,us3,us5,eu,gov" >}}
 1. Install the Datadog tracer:
-   - **Python** 
+   - **Python**
        ```sh
        # Use this format for x86-based Lambda deployed in AWS commercial regions
           arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:72
@@ -207,16 +207,16 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
           ```
           Replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. The available `RUNTIME` options are `Python37`, `Python38` and `Python39`.
 
-   - **Node**   
+   - **Node**
        ``` sh
        # Use this format for AWS commercial regions
          arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:91
 
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
-         ```  
+         ```
          Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available RUNTIME options are `Node12-x`, `Node14-x`, `Node16-x` and         `Node18-x`.
-        
+
    - **Java**: [Configure the layers][1] for your Lambda function using the ARN in one of the following formats, depending on where your Lambda is deployed. Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`:
      ```sh
      # In AWS commercial regions
@@ -255,7 +255,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 
 {{< site-region region="ap1" >}}
 1. Install the Datadog tracer:
-   - **Python** 
+   - **Python**
        ```sh
        # Use this format for x86-based Lambda deployed in AWS commercial regions
           arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:72
@@ -271,16 +271,16 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
           ```
           Replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. The available `RUNTIME` options are `Python37`, `Python38`, `Python39`, `Python310`, and `Python311`.
 
-   - **Node**   
+   - **Node**
        ``` sh
        # Use this format for AWS commercial regions
          arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:91
 
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
-         ```  
+         ```
          Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available RUNTIME options are `Node12-x`, `Node14-x`, `Node16-x` and         `Node18-x`.
-  
+
 
    - **Java**: [Configure the layers][1] for your Lambda function using the ARN in one of the following formats, depending on where your Lambda is deployed. Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`:
      ```sh
@@ -327,7 +327,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
    ```
 
 4. For **Node** and **Python** functions only, double-check that the function's handler is set correctly:
-    - **Node**: Set your function's handler to `/opt/nodejs/node_modules/datadog-lambda-js/handler.handler`. 
+    - **Node**: Set your function's handler to `/opt/nodejs/node_modules/datadog-lambda-js/handler.handler`.
        - Also, set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
     - **Python**: Set your function's handler to `datadog_lambda.handler.handler`.
        - Also, set the environment variable `DD_LAMBDA_HANDLER` to your original handler, for example, `myfunc.handler`.
@@ -374,7 +374,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Copy the Datadog Node.JS tracer into your Docker image. 
+2. Copy the Datadog Node.JS tracer into your Docker image.
 
    ```dockerfile
    COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
@@ -391,7 +391,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ENV DD_APPSEC_ENABLED=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-node).
 
    ```dockerfile
@@ -454,7 +454,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Install the Datadog Python tracer. 
+2. Install the Datadog Python tracer.
    ```dockerfile
    RUN pip install --target /dd_tracer/python/ ddtrace
    ```
@@ -468,7 +468,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ENV DD_APPSEC_ENABLED=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-python).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -515,7 +515,7 @@ Add the following instructions and arguments to your Dockerfile.
 
 ```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -530,9 +530,9 @@ CMD ["./mvnw", "spring-boot:run"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Add the Datadog Java tracer to your Docker image. 
+2. Add the Datadog Java tracer to your Docker image.
    ```dockerfile
-   ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+   ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
@@ -544,7 +544,7 @@ CMD ["./mvnw", "spring-boot:run"]
    ENV DD_APPSEC_ENABLED=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-java).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -560,7 +560,7 @@ If you already have an entrypoint defined inside your Dockerfile, you can instea
 
 {{< highlight dockerfile "hl_lines=7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -572,7 +572,7 @@ If you require your entrypoint to be instrumented as well, you can swap your ent
 
 {{< highlight dockerfile "hl_lines=7-8" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -606,7 +606,7 @@ ENV DD_APPSEC_ENABLED=1
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-go).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -768,7 +768,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
    ENV DD_TRACE_PROPAGATION_STYLE=datadog
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-ruby).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -823,7 +823,7 @@ ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
 # use the following for an Apache and mod_php based image
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["apache2-foreground"]
 
@@ -857,17 +857,17 @@ CMD php-fpm; nginx -g daemon off;
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-php).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your application.
-   
+
    Use the following for an Apache and mod_php based image:
    ```dockerfile
-   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
    EXPOSE 8080
    CMD ["apache2-foreground"]
    ```
@@ -888,7 +888,7 @@ RUN php /datadog-setup.php --php-bin=all
 ENV DD_SERVICE=datadog-demo-run-php
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["/app/datadog-init", "apache2-foreground"]
 {{< /highlight >}}
@@ -905,7 +905,7 @@ ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
 # use the following for an Apache and mod_php based image
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["your_entrypoint.sh", "apache2-foreground"]
 

--- a/content/en/serverless/aws_lambda/installation/java.md
+++ b/content/en/serverless/aws_lambda/installation/java.md
@@ -125,7 +125,7 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
 
 <div class="alert alert-info">Instrumenting Java functions through the Datadog CDK construct is only available for AWS CDK apps written in Node.js and Python.</div>
 
-The [Datadog CDK construct][1] automatically installs Datadog on your functions using Lambda layers. It configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension. 
+The [Datadog CDK construct][1] automatically installs Datadog on your functions using Lambda layers. It configures your functions to send metrics, traces, and logs to Datadog through the Datadog Lambda Extension.
 
 1. Install the Datadog CDK constructs library
 
@@ -206,7 +206,7 @@ The [Datadog CDK construct][1] automatically installs Datadog on your functions 
 
     ```dockerfile
     RUN yum -y install tar wget gzip
-    RUN wget -O /opt/java/lib/dd-java-agent.jar https://dtdg.co/latest-java-tracer
+    RUN wget -O /opt/java/lib/dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
     ```
 
 3. Set the required environment variables

--- a/content/en/serverless/azure_app_services/azure_app_services_container.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_container.md
@@ -67,7 +67,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Copy the Datadog Node.JS tracer into your Docker image. 
+2. Copy the Datadog Node.JS tracer into your Docker image.
 
    ```
    COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
@@ -116,7 +116,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Install the Datadog Python tracer. 
+2. Install the Datadog Python tracer.
    ```
    RUN pip install --target /dd_tracer/python/ ddtrace
    ```
@@ -147,7 +147,7 @@ Add the following instructions and arguments to your Dockerfile.
 
 ```
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -162,9 +162,9 @@ CMD ["./mvnw", "spring-boot:run"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Add the Datadog Java tracer to your Docker image. 
+2. Add the Datadog Java tracer to your Docker image.
    ```
-   ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+   ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
@@ -226,7 +226,7 @@ CMD ["/path/to/your-go-binary"]
 
 #### Orchestrion
 
-**Note**: [Orchestrion][2] is a tool for automatically instrumenting Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications through Dockerfile. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support. 
+**Note**: [Orchestrion][2] is a tool for automatically instrumenting Go code, which is currently in Private Beta. With Orchestrion, it is possible to instrument your Go applications through Dockerfile. If you are interested in participating in the Beta or providing feedback on Orchestrion, please open a Github issue or reach out to support.
 
 ```
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
@@ -240,7 +240,7 @@ ENV DD_VERSION=1
 CMD ["/path/to/your-go-binary"]
 ```
 
-[1]: /tracing/trace_collection/library_config/go/ 
+[1]: /tracing/trace_collection/library_config/go/
 [2]: https://github.com/DataDog/orchestrion
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
@@ -352,7 +352,7 @@ ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
 # use the following for an apache and mod_php based image
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["apache2-foreground"]
 
@@ -392,10 +392,10 @@ CMD php-fpm; nginx -g daemon off;
    ```
 
 5. Execute your application.
-   
+
    Use the following for an apache and mod_php based image:
    ```
-   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
    EXPOSE 8080
    CMD ["apache2-foreground"]
    ```

--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -61,7 +61,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Copy the Datadog Node.JS tracer into your Docker image. 
+2. Copy the Datadog Node.JS tracer into your Docker image.
 
    ```dockerfile
    COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
@@ -77,7 +77,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-node).
 
    ```dockerfile
@@ -137,7 +137,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Install the Datadog Python tracer. 
+2. Install the Datadog Python tracer.
    ```dockerfile
    RUN pip install --target /dd_tracer/python/ ddtrace
    ```
@@ -150,7 +150,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-python).
 
    ```dockerfile
@@ -196,7 +196,7 @@ Add the following instructions and arguments to your Dockerfile.
 
 ```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -211,9 +211,9 @@ CMD ["./mvnw", "spring-boot:run"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Add the Datadog Java tracer to your Docker image. 
+2. Add the Datadog Java tracer to your Docker image.
    ```dockerfile
-   ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+   ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
@@ -224,7 +224,7 @@ CMD ["./mvnw", "spring-boot:run"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-java).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -240,7 +240,7 @@ If you already have an entrypoint defined inside your Dockerfile, you can instea
 
 {{< highlight dockerfile "hl_lines=6" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -251,7 +251,7 @@ If you require your entrypoint to be instrumented as well, you can swap your ent
 
 {{< highlight dockerfile "hl_lines=6-7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -283,7 +283,7 @@ CMD ["/path/to/your-go-binary"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-go).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -343,7 +343,7 @@ ENV DD_VERSION=1
 CMD ["/path/to/your-go-binary"]
 ```
 
-[1]: /tracing/trace_collection/library_config/go/ 
+[1]: /tracing/trace_collection/library_config/go/
 [2]: https://github.com/DataDog/orchestrion
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
@@ -380,7 +380,7 @@ CMD ["dotnet", "helloworld.dll"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-dotnet).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -507,7 +507,7 @@ ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
 # use the following for an Apache and mod_php based image
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["apache2-foreground"]
 
@@ -541,17 +541,17 @@ CMD php-fpm; nginx -g daemon off;
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-php).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your application.
-   
+
    Use the following for an apache and mod_php based image:
    ```dockerfile
-   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
    EXPOSE 8080
    CMD ["apache2-foreground"]
    ```
@@ -572,7 +572,7 @@ RUN php /datadog-setup.php --php-bin=all
 ENV DD_SERVICE=datadog-demo-run-php
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["/app/datadog-init", "apache2-foreground"]
 {{< /highlight >}}
@@ -589,7 +589,7 @@ ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
 # use the following for an Apache and mod_php based image
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["your_entrypoint.sh", "apache2-foreground"]
 

--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -64,7 +64,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Copy the Datadog Node.JS tracer into your Docker image. 
+2. Copy the Datadog Node.JS tracer into your Docker image.
 
    ```dockerfile
    COPY --from=datadog/dd-lib-js-init /operator-build/node_modules /dd_tracer/node/
@@ -80,7 +80,7 @@ CMD ["/nodejs/bin/node", "/path/to/your/app.js"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-node).
 
    ```dockerfile
@@ -139,7 +139,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Install the Datadog Python tracer. 
+2. Install the Datadog Python tracer.
    ```dockerfile
    RUN pip install --target /dd_tracer/python/ ddtrace
    ```
@@ -152,7 +152,7 @@ CMD ["/dd_tracer/python/bin/ddtrace-run", "python", "app.py"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-python).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -196,7 +196,7 @@ Add the following instructions and arguments to your Dockerfile.
 
 ```dockerfile
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -211,9 +211,9 @@ CMD ["./mvnw", "spring-boot:run"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-2. Add the Datadog Java tracer to your Docker image. 
+2. Add the Datadog Java tracer to your Docker image.
    ```dockerfile
-   ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+   ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
    ```
    If you install the Datadog tracer library directly in your application, as outlined in the [manual tracer instrumentation instructions][1], omit this step.
 
@@ -224,7 +224,7 @@ CMD ["./mvnw", "spring-boot:run"]
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-java).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -240,7 +240,7 @@ If you already have an entrypoint defined inside your Dockerfile, you can instea
 
 {{< highlight dockerfile "hl_lines=6" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -251,7 +251,7 @@ If you require your entrypoint to be instrumented as well, you can swap your ent
 
 {{< highlight dockerfile "hl_lines=6-7" >}}
 COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-ADD https://dtdg.co/latest-java-tracer /dd_tracer/java/dd-java-agent.jar
+ADD 'https://dtdg.co/latest-java-tracer' /dd_tracer/java/dd-java-agent.jar
 ENV DD_SERVICE=datadog-demo-run-java
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -283,7 +283,7 @@ CMD ["/path/to/your-go-binary"]
    COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-go).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -343,7 +343,7 @@ ENV DD_VERSION=1
 CMD ["/path/to/your-go-binary"]
 ```
 
-[1]: /tracing/trace_collection/library_config/go/ 
+[1]: /tracing/trace_collection/library_config/go/
 [2]: https://github.com/DataDog/orchestrion
 {{< /programming-lang >}}
 {{< programming-lang lang="dotnet" >}}
@@ -453,7 +453,7 @@ CMD ["rails", "server", "-b", "0.0.0.0"]
    ENV DD_TRACE_PROPAGATION_STYLE=datadog
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-ruby).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
@@ -506,7 +506,7 @@ ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
 # use the following for an Apache and mod_php based image
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["apache2-foreground"]
 
@@ -540,17 +540,17 @@ CMD php-fpm; nginx -g daemon off;
    ENV DD_VERSION=1
    ```
 
-4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process. 
+4. Change the entrypoint to wrap your application in the Datadog `serverless-init` process.
    **Note**: If you already have an entrypoint defined inside your Dockerfile, see the [alternative configuration](#alt-php).
    ```dockerfile
    ENTRYPOINT ["/app/datadog-init"]
    ```
 
 5. Execute your application.
-   
+
    Use the following for an Apache and mod_php based image:
    ```dockerfile
-   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+   RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
    EXPOSE 8080
    CMD ["apache2-foreground"]
    ```
@@ -571,7 +571,7 @@ RUN php /datadog-setup.php --php-bin=all
 ENV DD_SERVICE=datadog-demo-run-php
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["/app/datadog-init", "apache2-foreground"]
 {{< /highlight >}}
@@ -588,7 +588,7 @@ ENV DD_VERSION=1
 ENTRYPOINT ["/app/datadog-init"]
 
 # use the following for an Apache and mod_php based image
-RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf 
+RUN sed -i "s/Listen 80/Listen 8080/" /etc/apache2/ports.conf
 EXPOSE 8080
 CMD ["your_entrypoint.sh", "apache2-foreground"]
 
@@ -606,7 +606,7 @@ As long as your command to run is passed as an argument to `datadog-init`, you w
 
 ### Buildpack
 
-[`Pack Buildpacks`][3] provide a convenient way to package your container without using a Dockerfile. 
+[`Pack Buildpacks`][3] provide a convenient way to package your container without using a Dockerfile.
 
 First, manually install your tracer:
 - [Node.JS][14]
@@ -702,7 +702,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 [9]: /metrics/distributions/
 [10]: /metrics/#time-and-space-aggregation
 [11]: https://cloud.google.com/run/docs/configuring/secrets
-[12]: /tracing/trace_collection/library_config/go/ 
+[12]: /tracing/trace_collection/library_config/go/
 [13]: /tracing/trace_collection/dd_libraries/python/?tab=containers#instrument-your-application
 [14]: /tracing/trace_collection/dd_libraries/nodejs/?tab=containers#instrument-your-application
 [15]: /tracing/trace_collection/dd_libraries/java/?tab=containers#instrument-your-application

--- a/content/en/tracing/guide/inferred-service-opt-in.md
+++ b/content/en/tracing/guide/inferred-service-opt-in.md
@@ -98,7 +98,7 @@ For example, if you're using environment variables and you need to rename the pe
 DD_TRACE_PEER_SERVICE_MAPPING=10.0.32.3:my-service
 ```
 
-[1]: 'https://dtdg.co/latest-java-tracer'
+[1]: https://dtdg.co/latest-java-tracer
 
 {{% /tab %}}
 

--- a/content/en/tracing/guide/inferred-service-opt-in.md
+++ b/content/en/tracing/guide/inferred-service-opt-in.md
@@ -98,7 +98,7 @@ For example, if you're using environment variables and you need to rename the pe
 DD_TRACE_PEER_SERVICE_MAPPING=10.0.32.3:my-service
 ```
 
-[1]: https://dtdg.co/latest-java-tracer
+[1]: 'https://dtdg.co/latest-java-tracer'
 
 {{% /tab %}}
 
@@ -283,7 +283,7 @@ For example, to set the `peer.service` value for all Dalli spans, use
 
 ### Global default service naming migration
 
-When you enable the `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED` environment variable, it improves how service-to-service connections and inferred services are represented in Datadog visualizations, across all supported tracing library languages and integrations. 
+When you enable the `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED` environment variable, it improves how service-to-service connections and inferred services are represented in Datadog visualizations, across all supported tracing library languages and integrations.
 
 Previously, some tracing libraries included the name of the associated integration in service name tagging. For example, .NET tagged gRCP calls as `service:<DD_SERVICE>-grpc-client` while Python tagged them as `service:grpc-client`. With this option enabled, all supported tracing libraries tag spans from the downstream services with the calling service's name, `service:<DD_SERVICE>`, thereby providing a _global default service name_.
 

--- a/content/en/tracing/guide/tutorial-enable-java-aws-ecs-ec2.md
+++ b/content/en/tracing/guide/tutorial-enable-java-aws-ecs-ec2.md
@@ -21,7 +21,7 @@ further_reading:
 
 ## Overview
 
-This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a cluster on AWS Elastic Container Service (ECS). In this scenario, the Datadog Agent is also installed in the cluster. 
+This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a cluster on AWS Elastic Container Service (ECS). In this scenario, the Datadog Agent is also installed in the cluster.
 
 For other scenarios, including on a host, in a container, on other cloud infrastructure, and on applications written in other languages, see the other [Enabling Tracing tutorials][1]. Some of those other tutorials, for example, the ones using containers or EKS, step through the differences seen in Datadog between automatic and custom instrumentation. This tutorial skips right to a fully custom instrumented example.
 
@@ -47,7 +47,7 @@ The code sample for this tutorial is on GitHub, at [github.com/DataDog/apm-tutor
 git clone https://github.com/DataDog/apm-tutorial-java-host.git
 {{< /code-block >}}
 
-The repository contains a multi-service Java application pre-configured to run inside Docker containers. The `docker-compose` YAML files to make the containers are located in the `docker` directory. This tutorial uses the `service-docker-compose-ECS.yaml` file, which builds containers for the application. 
+The repository contains a multi-service Java application pre-configured to run inside Docker containers. The `docker-compose` YAML files to make the containers are located in the `docker` directory. This tutorial uses the `service-docker-compose-ECS.yaml` file, which builds containers for the application.
 
 In each of the `notes` and `calendar` directories, there are two sets of Dockerfiles for building the applications, either with Maven or with Gradle. This tutorial uses the Maven build, but if you are more familiar with Gradle, you can use it instead with the corresponding changes to build commands.
 
@@ -157,7 +157,7 @@ Now that you have a working Java application, configure it to enable tracing.
 1. Add the Java tracing package to your project. Because the Agent runs on EC2 instances, ensure that the Dockerfiles are configured properly, and there is no need to install anything. Open the `notes/dockerfile.notes.maven` file and uncomment the line that downloads `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `notes/dockerfile.notes.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
@@ -165,18 +165,18 @@ Now that you have a working Java application, configure it to enable tracing.
    ```
    ENTRYPOINT ["java" , "-javaagent:../dd-java-agent.jar", "-Ddd.trace.sample.rate=1", "-jar" , "target/notes-0.0.1-SNAPSHOT.jar"]
    ```
-   
+
    Repeat this step with the other service, `calendar`. Open `calendar/dockerfile.calendar.maven`, and comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
 
    ```
-   ENTRYPOINT ["java", "-javaagent:../dd-java-agent.jar", "-Ddd.trace.sample.rate=1", "-jar" , "target/calendar-0.0.1-SNAPSHOT.jar"] 
+   ENTRYPOINT ["java", "-javaagent:../dd-java-agent.jar", "-Ddd.trace.sample.rate=1", "-jar" , "target/calendar-0.0.1-SNAPSHOT.jar"]
    ```
 
    Now both services will have automatic instrumentation.
 
    <div class="alert alert-warning"><strong>Note</strong>: The flags on these sample commands, particularly the sample rate, are not necessarily appropriate for environments outside this tutorial. For information about what to use in your real environment, read <a href="#tracing-configuration">Tracing configuration</a>.</div>
 
-3. Automatic instrumentation is convenient, but sometimes you want more fine-grained spans. Datadog's Java DD Trace API allows you to specify spans within your code using annotations or code. Add some annotations to the code to trace into some sample methods. 
+3. Automatic instrumentation is convenient, but sometimes you want more fine-grained spans. Datadog's Java DD Trace API allows you to specify spans within your code using annotations or code. Add some annotations to the code to trace into some sample methods.
 
    Open `/notes/src/main/java/com/datadog/example/notes/NotesHelper.java`. This example already contains commented-out code that demonstrates the different ways to set up custom tracing on the code.
 
@@ -211,7 +211,7 @@ Now that you have a working Java application, configure it to enable tracing.
                .withTag(DDTags.RESOURCE_NAME, "privateMethod1")
                .start();
            try (Scope scope = tracer.activateSpan(span)) {
-               // Tags can also be set after creation 
+               // Tags can also be set after creation
                span.setTag("postCreationTag", 1);
                Thread.sleep(30);
                Log.info("Hello from the custom privateMethod1");
@@ -223,7 +223,7 @@ Now that you have a working Java application, configure it to enable tracing.
             span.setTag(Tags.ERROR, true);
             span.setTag(DDTags.ERROR_MSG, e.getMessage());
             span.setTag(DDTags.ERROR_TYPE, e.getClass().getName());
-            
+
             final StringWriter errorString = new StringWriter();
             e.printStackTrace(new PrintWriter(errorString));
             span.setTag(DDTags.ERROR_STACK, errorString.toString());
@@ -236,12 +236,12 @@ Now that you have a working Java application, configure it to enable tracing.
 7. Update your Maven build by opening `notes/pom.xml` and uncommenting the lines configuring dependencies for manual tracing. The `dd-trace-api` library is used for the `@Trace` annotations, and `opentracing-util` and `opentracing-api` are used for manual span creation.
 
 8. [Universal Service Tags][10] identify traced services across different versions and deployment environments so that they can be correlated within Datadog, and so you can use them to search and filter. The three environment variables used for Unified Service Tagging are `DD_SERVICE`, `DD_ENV`, and `DD_VERSION`. For applications deployed on ECS, these environment variables are set within the task definition for the containers.
-   
+
    For this tutorial, the `/terraform/EC2/deployment/main.tf` file already has these environment variables defined for the notes and calendar applications, for example, for `notes`:
 
    ```yaml
    ...
-   
+
       name : "notes",
       image : "${module.settings.aws_ecr_repository}:notes",
       essential : true,
@@ -349,8 +349,8 @@ Next, deploy the Datadog Agent to collect the trace data from your instrumented 
      },
      ...
    ```
- 
-2. Register the Agent task definition, replacing the profile and region with your information. From the `terraform/EC2` folder, run: 
+
+2. Register the Agent task definition, replacing the profile and region with your information. From the `terraform/EC2` folder, run:
 
    ```sh
    aws ecs register-task-definition --cli-input-json file://dd_agent_task_definition.json --profile <AWS_PROFILE> --region <AWS_REGION>
@@ -382,22 +382,22 @@ Redeploy the application and exercise the API:
 
    `curl -X GET 'BASE_DOMAIN:8080/notes'`
    : `[]`
-   
+
    `curl -X POST 'BASE_DOMAIN:8080/notes?desc=hello'`
    : `{"id":1,"description":"hello"}`
-   
+
    `curl -X GET 'BASE_DOMAIN:8080/notes?id=1'`
    : `{"id":1,"description":"hello"}`
-   
+
    `curl -X GET 'BASE_DOMAIN:8080/notes'`
    : `[{"id":1,"description":"hello"}]`
-   
+
    `curl -X PUT 'BASE_DOMAIN:8080/notes?id=1&desc=UpdatedNote'`
    : `{"id":1,"description":"UpdatedNote"}`
-   
+
    `curl -X GET 'BASE_DOMAIN:8080/notes'`
    : `[{"id":1,"description":"hello"}]`
-   
+
    `curl -X POST 'BASE_DOMAIN:8080/notes?desc=NewestNote&add_date=y'`
    : `{"id":2,"description":"NewestNote with date 12/02/2022."}`
    : This command calls both the `notes` and `calendar` services.
@@ -412,14 +412,14 @@ If you don't see traces after several minutes, clear any filter in the Traces Se
 
 ### Examine a trace
 
-On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application). 
+On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application).
 
-The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth. 
+The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth.
 
 On the Trace Explorer, click into one of the `GET` requests, and see a flame graph like this:
 
 {{< img src="tracing/guide/tutorials/tutorial-java-container-custom-flame.png" alt="A flame graph for a GET trace with custom instrumentation." style="width:100%;" >}}
-   
+
 The `privateMethod` around which you created a manual span shows up as a separate block from the other calls and is highlighted by a different color. The other methods where you used the `@Trace` annotation show under the same service and color as the `GET` request, which is the `notes` application. Custom instrumentation is valuable when there are key parts of the code that need to be highlighted and monitored.
 
 For more information, read [Custom Instrumentation][12].

--- a/content/en/tracing/guide/tutorial-enable-java-aws-ecs-fargate.md
+++ b/content/en/tracing/guide/tutorial-enable-java-aws-ecs-fargate.md
@@ -21,7 +21,7 @@ further_reading:
 
 ## Overview
 
-This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a cluster on AWS Elastic Container Service (ECS) with Fargate. In this scenario, the Datadog Agent is also installed in the cluster. 
+This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a cluster on AWS Elastic Container Service (ECS) with Fargate. In this scenario, the Datadog Agent is also installed in the cluster.
 
 For other scenarios, including on a host, in a container, on other cloud infrastructure, and on applications written in other languages, see the other [Enabling Tracing tutorials][1]. Some of those other tutorials, for example, the ones using containers or EKS, step through the differences seen in Datadog between automatic and custom instrumentation. This tutorial skips right to a fully custom instrumented example.
 
@@ -47,7 +47,7 @@ The code sample for this tutorial is on GitHub, at [github.com/DataDog/apm-tutor
 git clone https://github.com/DataDog/apm-tutorial-java-host.git
 {{< /code-block >}}
 
-The repository contains a multi-service Java application pre-configured to run inside Docker containers. The `docker-compose` YAML files to make the containers are located in the `docker` directory. This tutorial uses the `service-docker-compose-ECS.yaml` file, which builds containers for the application. 
+The repository contains a multi-service Java application pre-configured to run inside Docker containers. The `docker-compose` YAML files to make the containers are located in the `docker` directory. This tutorial uses the `service-docker-compose-ECS.yaml` file, which builds containers for the application.
 
 In each of the `notes` and `calendar` directories, there are two sets of Dockerfiles for building the applications, either with Maven or with Gradle. This tutorial uses the Maven build, but if you are more familiar with Gradle, you can use it instead with the corresponding changes to build commands.
 
@@ -157,7 +157,7 @@ Now that you have a working Java application, configure it to enable tracing.
 1. Edit the dockerfile to add the Java tracing package which is needed by the application to generate traces. Open the `notes/dockerfile.notes.maven` file and uncomment the line that downloads `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `notes/dockerfile.notes.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
@@ -165,18 +165,18 @@ Now that you have a working Java application, configure it to enable tracing.
    ```
    ENTRYPOINT ["java" , "-javaagent:../dd-java-agent.jar", "-Ddd.trace.sample.rate=1", "-jar" , "target/notes-0.0.1-SNAPSHOT.jar"]
    ```
-   
+
    Repeat this step with the other service, `calendar`. Open `calendar/dockerfile.calendar.maven`, and comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
 
    ```
-   ENTRYPOINT ["java", "-javaagent:../dd-java-agent.jar", "-Ddd.trace.sample.rate=1", "-jar" , "target/calendar-0.0.1-SNAPSHOT.jar"] 
+   ENTRYPOINT ["java", "-javaagent:../dd-java-agent.jar", "-Ddd.trace.sample.rate=1", "-jar" , "target/calendar-0.0.1-SNAPSHOT.jar"]
    ```
 
    Now both services will have automatic instrumentation.
 
    <div class="alert alert-warning"><strong>Note</strong>: The flags on these sample commands, particularly the sample rate, are not necessarily appropriate for environments outside this tutorial. For information about what to use in your real environment, read <a href="#tracing-configuration">Tracing configuration</a>.</div>
 
-3. Automatic instrumentation is convenient, but sometimes you want more fine-grained spans. Datadog's Java DD Trace API allows you to specify spans within your code using annotations or code. Add some annotations to the code to trace into some sample methods. 
+3. Automatic instrumentation is convenient, but sometimes you want more fine-grained spans. Datadog's Java DD Trace API allows you to specify spans within your code using annotations or code. Add some annotations to the code to trace into some sample methods.
 
    Open `/notes/src/main/java/com/datadog/example/notes/NotesHelper.java`. This example already contains commented-out code that demonstrates the different ways to set up custom tracing on the code.
 
@@ -211,7 +211,7 @@ Now that you have a working Java application, configure it to enable tracing.
                .withTag(DDTags.RESOURCE_NAME, "privateMethod1")
                .start();
            try (Scope scope = tracer.activateSpan(span)) {
-               // Tags can also be set after creation 
+               // Tags can also be set after creation
                span.setTag("postCreationTag", 1);
                Thread.sleep(30);
                Log.info("Hello from the custom privateMethod1");
@@ -223,7 +223,7 @@ Now that you have a working Java application, configure it to enable tracing.
             span.setTag(Tags.ERROR, true);
             span.setTag(DDTags.ERROR_MSG, e.getMessage());
             span.setTag(DDTags.ERROR_TYPE, e.getClass().getName());
-            
+
             final StringWriter errorString = new StringWriter();
             e.printStackTrace(new PrintWriter(errorString));
             span.setTag(DDTags.ERROR_STACK, errorString.toString());
@@ -240,12 +240,12 @@ Now that you have a working Java application, configure it to enable tracing.
 9. Provide the API key variable with a value. Open `terraform/Fargate/global_constants/variables.tf` and uncomment the `output "datadog_api_key"` section and provide your organization's Datadog API key.
 
 10. [Universal Service Tags][10] identify traced services across different versions and deployment environments so that they can be correlated within Datadog, and so you can use them to search and filter. The three environment variables used for Unified Service Tagging are `DD_SERVICE`, `DD_ENV`, and `DD_VERSION`. For applications deployed on ECS, these environment variables are set within the task definition for the containers.
-   
+
     For this tutorial, the `/terraform/Fargate/Instrumented/main.tf` file already has these environment variables defined for the notes and calendar applications, for example, for `notes`:
 
     ```yaml
     ...
-    
+
        name : "notes",
        image : "${module.settings.aws_ecr_repository}:notes",
        essential : true,
@@ -352,22 +352,22 @@ Redeploy the application and exercise the API:
 
    `curl -X GET 'BASE_DOMAIN:8080/notes'`
    : `[]`
-   
+
    `curl -X POST 'BASE_DOMAIN:8080/notes?desc=hello'`
    : `{"id":1,"description":"hello"}`
-   
+
    `curl -X GET 'BASE_DOMAIN:8080/notes?id=1'`
    : `{"id":1,"description":"hello"}`
-   
+
    `curl -X GET 'BASE_DOMAIN:8080/notes'`
    : `[{"id":1,"description":"hello"}]`
-   
+
    `curl -X PUT 'BASE_DOMAIN:8080/notes?id=1&desc=UpdatedNote'`
    : `{"id":1,"description":"UpdatedNote"}`
-   
+
    `curl -X GET 'BASE_DOMAIN:8080/notes'`
    : `[{"id":1,"description":"hello"}]`
-   
+
    `curl -X POST 'BASE_DOMAIN:8080/notes?desc=NewestNote&add_date=y'`
    : `{"id":2,"description":"NewestNote with date 12/02/2022."}`
    : This command calls both the `notes` and `calendar` services.
@@ -382,14 +382,14 @@ If you don't see traces after several minutes, clear any filter in the Traces Se
 
 ### Examine a trace
 
-On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application). 
+On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application).
 
-The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth. 
+The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth.
 
 On the Trace Explorer, click into one of the `GET` requests, and see a flame graph like this:
 
 {{< img src="tracing/guide/tutorials/tutorial-java-container-custom-flame.png" alt="A flame graph for a GET trace with custom instrumentation." style="width:100%;" >}}
-   
+
 The `privateMethod` around which you created a manual span shows up as a separate block from the other calls and is highlighted by a different color. The other methods where you used the `@Trace` annotation show under the same service and color as the `GET` request, which is the `notes` application. Custom instrumentation is valuable when there are key parts of the code that need to be highlighted and monitored.
 
 For more information, read [Custom Instrumentation][12].

--- a/content/en/tracing/guide/tutorial-enable-java-aws-eks.md
+++ b/content/en/tracing/guide/tutorial-enable-java-aws-eks.md
@@ -21,7 +21,7 @@ further_reading:
 
 ## Overview
 
-This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a cluster on AWS Elastic Kubernetes Service (EKS). In this scenario, the Datadog Agent is also installed in the cluster. 
+This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a cluster on AWS Elastic Kubernetes Service (EKS). In this scenario, the Datadog Agent is also installed in the cluster.
 
 For other scenarios, including on a host, in a container, on other cloud infrastructure, and on applications written in other languages, see the other [Enabling Tracing tutorials][1].
 
@@ -53,7 +53,7 @@ The code sample for this tutorial is on GitHub, at [github.com/DataDog/apm-tutor
 git clone https://github.com/DataDog/apm-tutorial-java-host.git
 {{< /code-block >}}
 
-The repository contains a multi-service Java application pre-configured to run inside a Kubernetes cluster. The sample app is a basic notes app with a REST API to add and change data. The `docker-compose` YAML files to make the containers for the Kubernetes pods are located in the `docker` directory. This tutorial uses the `service-docker-compose-k8s.yaml` file, which builds containers for the application. 
+The repository contains a multi-service Java application pre-configured to run inside a Kubernetes cluster. The sample app is a basic notes app with a REST API to add and change data. The `docker-compose` YAML files to make the containers for the Kubernetes pods are located in the `docker` directory. This tutorial uses the `service-docker-compose-k8s.yaml` file, which builds containers for the application.
 
 In each of the `notes` and `calendar` directories, there are two sets of Dockerfiles for building the applications, either with Maven or with Gradle. This tutorial uses the Maven build, but if you are more familiar with Gradle, you can use it instead with the corresponding changes to build commands.
 
@@ -98,13 +98,13 @@ Your application is containerized and available for EKS clusters to pull.
 
 ### Update AWS cluster inbound security policies
 
-To communicate with the sample applications, ensure that the cluster's security rules are configured with ports `30080` and `30090` open. 
+To communicate with the sample applications, ensure that the cluster's security rules are configured with ports `30080` and `30090` open.
 
-1. Open AWS Console and navigate to your deployed cluster within the EKS service. 
+1. Open AWS Console and navigate to your deployed cluster within the EKS service.
 
 2. On the cluster console, select the networking tab, and click your cluster security group.
 
-3. In your security group settings, edit the inbound rules. Add a rule allowing custom TCP traffic, a port range of `30060` to `30100`, and source of `0.0.0.0/0`. 
+3. In your security group settings, edit the inbound rules. Add a rule allowing custom TCP traffic, a port range of `30060` to `30100`, and source of `0.0.0.0/0`.
 
 4. Save the rule.
 
@@ -134,7 +134,7 @@ kubectl get pods -o wide{{< /code-block >}}
 
       {{< code-block lang="sh" >}}
 kubectl get nodes -o wide{{< /code-block >}}
-   
+
    {{< img src="tracing/guide/tutorials/tutorial-java-eks-external-ip.png" alt="Output of the kubectl command showing the external IP value for the node" style="width:100%;" >}}
 
    In the examples shown, the `notes-app` is running on node `ip-192-189-63-129.ec2.internal`, which has an external IP of `34.230.7.210`.
@@ -164,7 +164,7 @@ Now that you have a working Java application, configure it to enable tracing.
 1. Add the Java tracing package to your project. Because the Agent runs in an EKS cluster, ensure that the Dockerfiles are configured properly, and there is no need to install anything. Open the `notes/dockerfile.notes.maven` file and uncomment the line that downloads `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `notes/dockerfile.notes.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
@@ -178,14 +178,14 @@ Now that you have a working Java application, configure it to enable tracing.
    <div class="alert alert-warning"><strong>Note</strong>: The flags on these sample commands, particularly the sample rate, are not necessarily appropriate for environments outside this tutorial. For information about what to use in your real environment, read <a href="#tracing-configuration">Tracing configuration</a>.</div>
 
 3. [Universal Service Tags][10] identify traced services across different versions and deployment environments so that they can be correlated within Datadog, and so you can use them to search and filter. The three environment variables used for Unified Service Tagging are `DD_SERVICE`, `DD_ENV`, and `DD_VERSION`. For applications deployed with Kubernetes, these environment variables can be added within the deployment YAML file, specifically for the deployment object, pod spec, and pod container template.
-   
+
    For this tutorial, the `kubernetes/notes-app.yaml` file already has these environment variables defined for the notes application for the deployment object, the pod spec, and the pod container template, for example:
 
    ```yaml
    ...
    spec:
      replicas: 1
-     selector: 
+     selector:
        matchLabels:
          name: notes-app-pod
          app: java-tutorial-app
@@ -253,9 +253,9 @@ If you don't see traces after several minutes, clear any filter in the Traces Se
 
 ### Examine a trace
 
-On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application). 
+On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application).
 
-The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth. 
+The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth.
 
 The flame graph for a `POST` trace looks something like this:
 
@@ -316,7 +316,7 @@ kubectl delete -f notes-app.yaml{{< /code-block >}}
                .withTag(DDTags.RESOURCE_NAME, "privateMethod1")
                .start();
            try (Scope scope = tracer.activateSpan(span)) {
-               // Tags can also be set after creation 
+               // Tags can also be set after creation
                span.setTag("postCreationTag", 1);
                Thread.sleep(30);
                Log.info("Hello from the custom privateMethod1");
@@ -328,7 +328,7 @@ kubectl delete -f notes-app.yaml{{< /code-block >}}
             span.setTag(Tags.ERROR, true);
             span.setTag(DDTags.ERROR_MSG, e.getMessage());
             span.setTag(DDTags.ERROR_TYPE, e.getClass().getName());
-            
+
             final StringWriter errorString = new StringWriter();
             e.printStackTrace(new PrintWriter(errorString));
             span.setTag(DDTags.ERROR_STACK, errorString.toString());
@@ -349,13 +349,13 @@ docker tag docker-notes:latest <ECR_REGISTRY_URL>:notes
 docker push <ECR_REGISTRY_URL>:notes
 {{< /code-block >}}
 
-8. Using [the same steps as before](#configure-the-application-locally-and-deploy), deploy the `notes` app with `kubectl create -f notes-app.yaml` and find the external IP address for the node it runs on. 
+8. Using [the same steps as before](#configure-the-application-locally-and-deploy), deploy the `notes` app with `kubectl create -f notes-app.yaml` and find the external IP address for the node it runs on.
 
 9. Resend some HTTP requests, specifically some `GET` requests.
 10. On the Trace Explorer, click on one of the new `GET` requests, and see a flame graph like this:
 
     {{< img src="tracing/guide/tutorials/tutorial-java-container-custom-flame.png" alt="A flame graph for a GET trace with custom instrumentation." style="width:100%;" >}}
-   
+
     Note the higher level of detail in the stack trace now that the `getAll` function has custom tracing.
 
     The `privateMethod` around which you created a manual span now shows up as a separate block from the other calls and is highlighted by a different color. The other methods where you used the `@Trace` annotation show under the same service and color as the `GET` request, which is the `notes` application. Custom instrumentation is valuable when there are key parts of the code that need to be highlighted and monitored.
@@ -364,14 +364,14 @@ For more information, read [Custom Instrumentation][12].
 
 ## Add a second application to see distributed traces
 
-Tracing a single application is a great start, but the real value in tracing is seeing how requests flow through your services. This is called _distributed tracing_. 
+Tracing a single application is a great start, but the real value in tracing is seeing how requests flow through your services. This is called _distributed tracing_.
 
 The sample project includes a second application called `calendar` that returns a random date whenever it is invoked. The `POST` endpoint in the Notes application has a second query parameter named `add_date`. When it is set to `y`, Notes calls the calendar application to get a date to add to the note.
 
 1. Configure the `calendar` app for tracing by adding `dd-java-agent` to the startup command in the Dockerfile, like you previously did for the notes app. Open `calendar/dockerfile.calendar.maven` and see that it is already downloading `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `calendar/dockerfile.calendar.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:

--- a/content/en/tracing/guide/tutorial-enable-java-container-agent-host.md
+++ b/content/en/tracing/guide/tutorial-enable-java-container-agent-host.md
@@ -125,7 +125,7 @@ Now that you have a working Java application, configure it to enable tracing.
 1. Add the Java tracing package to your project. Open the `notes/dockerfile.notes.maven` file and uncomment the line that downloads `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `notes/dockerfile.notes.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
@@ -339,7 +339,7 @@ The sample project includes a second application called `calendar` that returns 
 
 1. Configure the calendar app for tracing by adding `dd-java-agent` to the startup command in the Dockerfile, like you previously did for the notes app. Open `calendar/Dockerfile.calendar.maven` and see that it is already downloading `dd-java-agent`:
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `calendar/dockerfile.calendar.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:

--- a/content/en/tracing/guide/tutorial-enable-java-containers.md
+++ b/content/en/tracing/guide/tutorial-enable-java-containers.md
@@ -21,7 +21,7 @@ further_reading:
 
 ## Overview
 
-This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a container. In this scenario, the Datadog Agent is also installed in a container. 
+This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a container. In this scenario, the Datadog Agent is also installed in a container.
 
 For other scenarios, including the application and Agent on a host, the application in a container and Agent on a host, the application and Agent on cloud infrastructure, and on applications written in other languages, see the other [Enabling Tracing tutorials][1].
 
@@ -30,7 +30,7 @@ See [Tracing Java Applications][2] for general comprehensive tracing setup docum
 ### Prerequisites
 
 - A Datadog account and [organization API key][3]
-- Git 
+- Git
 - Docker
 - Curl
 
@@ -44,7 +44,7 @@ git clone https://github.com/DataDog/apm-tutorial-java-host.git
 
 The repository contains a multi-service Java application pre-configured to be run within Docker containers. The sample app is a basic notes app with a REST API to add and change data. The `docker-compose` YAML files are located in the `docker` directory.
 
-This tutorial uses the `all-docker-compose.yaml` file, which builds containers for both the application and the Datadog Agent. 
+This tutorial uses the `all-docker-compose.yaml` file, which builds containers for both the application and the Datadog Agent.
 
 In each of the `notes` and `calendar` directories, there are two sets of Dockerfiles for building the applications, either with Maven or with Gradle. This tutorial uses the Maven build, but if you are more familiar with Gradle, you can use it instead with the corresponding changes to build commands.
 
@@ -64,7 +64,7 @@ docker-compose -f all-docker-compose.yaml build notes
 docker-compose -f all-docker-compose.yaml up notes
 {{< /code-block >}}
 
-   You can verify that it's running by viewing the running containers with the `docker ps` command. 
+   You can verify that it's running by viewing the running containers with the `docker ps` command.
 
 3. Open up another terminal and send API requests to exercise the app. The notes application is a REST API that stores data in an in-memory H2 database running on the same container. Send it a few commands:
 
@@ -101,7 +101,7 @@ Now that you have a working Java application, configure it to enable tracing.
 1. Add the Java tracing package to your project. Because the Agent runs in a container, ensure that the Dockerfiles are configured properly, and there is no need to install anything. Open the `notes/dockerfile.notes.maven` file and uncomment the line that downloads `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `notes/dockerfile.notes.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
@@ -124,7 +124,7 @@ Now that you have a working Java application, configure it to enable tracing.
        - DD_VERSION=0.0.1
    ```
 
-4. You can also see that Docker labels for the same Universal Service Tags `service`, `env`, and `version` values are set in the Dockerfile. This allows you also to get Docker metrics once your application is running. 
+4. You can also see that Docker labels for the same Universal Service Tags `service`, `env`, and `version` values are set in the Dockerfile. This allows you also to get Docker metrics once your application is running.
 
    ```yaml
      labels:
@@ -151,7 +151,7 @@ Add the Datadog Agent in the services section of your `all-docker-compose.yaml` 
        volumes:
          - /var/run/docker.sock:/var/run/docker.sock
          - /proc/:/host/proc/:ro
-         - /sys/fs/cgroup:/host/sys/fs/cgroup:ro 
+         - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
    ```
 
 3. Uncomment the `depends_on` fields for `datadog-agent` in the `notes` container.
@@ -161,7 +161,7 @@ Add the Datadog Agent in the services section of your `all-docker-compose.yaml` 
    notes:
      container_name: notes
      restart: always
-     build: 
+     build:
        context: ../
        dockerfile: notes/dockerfile.notes.maven
      ports:
@@ -220,9 +220,9 @@ If you don't see traces after several minutes, clear any filter in the Traces Se
 
 ### Examine a trace
 
-On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application). 
+On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application).
 
-The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth. 
+The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth.
 
 The flame graph for a `POST` trace looks something like this:
 
@@ -279,7 +279,7 @@ The following steps walk you through adding annotations to the code to trace som
                .withTag(DDTags.RESOURCE_NAME, "privateMethod1")
                .start();
            try (Scope scope = tracer.activateSpan(span)) {
-               // Tags can also be set after creation 
+               // Tags can also be set after creation
                span.setTag("postCreationTag", 1);
                Thread.sleep(30);
                Log.info("Hello from the custom privateMethod1");
@@ -291,7 +291,7 @@ The following steps walk you through adding annotations to the code to trace som
             span.setTag(Tags.ERROR, true);
             span.setTag(DDTags.ERROR_MSG, e.getMessage());
             span.setTag(DDTags.ERROR_TYPE, e.getClass().getName());
-            
+
             final StringWriter errorString = new StringWriter();
             e.printStackTrace(new PrintWriter(errorString));
             span.setTag(DDTags.ERROR_STACK, errorString.toString());
@@ -314,7 +314,7 @@ The following steps walk you through adding annotations to the code to trace som
 8. On the Trace Explorer, click on one of the new `GET` requests, and see a flame graph like this:
 
    {{< img src="tracing/guide/tutorials/tutorial-java-container-custom-flame.png" alt="A flame graph for a GET trace with custom instrumentation." style="width:100%;" >}}
-   
+
    Note the higher level of detail in the stack trace now that the `getAll` function has custom tracing.
 
    The `privateMethod` around which you created a manual span now shows up as a separate block from the other calls and is highlighted by a different color. The other methods where you used the `@Trace` annotation show under the same service and color as the `GET` request, which is the `notes` application. Custom instrumentation is valuable when there are key parts of the code that need to be highlighted and monitored.
@@ -323,14 +323,14 @@ For more information, read [Custom Instrumentation][12].
 
 ## Add a second application to see distributed traces
 
-Tracing a single application is a great start, but the real value in tracing is seeing how requests flow through your services. This is called _distributed tracing_. 
+Tracing a single application is a great start, but the real value in tracing is seeing how requests flow through your services. This is called _distributed tracing_.
 
 The sample project includes a second application called `calendar` that returns a random date whenever it is invoked. The `POST` endpoint in the Notes application has a second query parameter named `add_date`. When it is set to `y`, Notes calls the calendar application to get a date to add to the note.
 
 1. Configure the calendar app for tracing by adding `dd-java-agent` to the startup command in the Dockerfile, like you previously did for the notes app. Open `calendar/Dockerfile.calendar.maven` and see that it is already downloading `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `calendar/dockerfile.calendar.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
@@ -347,7 +347,7 @@ The sample project includes a second application called `calendar` that returns 
      calendar:
        container_name: calendar
        restart: always
-       build: 
+       build:
          context: ../
          dockerfile: calendar/dockerfile.calendar.maven
        labels:

--- a/content/en/tracing/guide/tutorial-enable-java-gke.md
+++ b/content/en/tracing/guide/tutorial-enable-java-gke.md
@@ -21,7 +21,7 @@ further_reading:
 
 ## Overview
 
-This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a cluster on Google Kubernetes Engine (GKE). In this scenario, the Datadog Agent is also installed in the cluster. 
+This tutorial walks you through the steps for enabling tracing on a sample Java application installed in a cluster on Google Kubernetes Engine (GKE). In this scenario, the Datadog Agent is also installed in the cluster.
 
 For other scenarios, including on a host, in a container, on other cloud infrastructure, and on applications written in other languages, see the other [Enabling Tracing tutorials][1].
 
@@ -34,7 +34,7 @@ See [Tracing Java Applications][2] for general comprehensive tracing setup docum
 - Kubectl
 - GCloud - Set the `USE_GKE_GCLOUD_AUTH_PLUGIN` environment variable and configure additional properties for your GCloud project by running these commands:
   {{< code-block lang="sh" >}}
-export USE_GKE_GCLOUD_AUTH_PLUGIN=True	
+export USE_GKE_GCLOUD_AUTH_PLUGIN=True
 gcloud config set project <PROJECT_NAME>
 gcloud config set compute/zone <COMPUTE_ZONE>
 gcloud config set compute/region <COMPUTE_REGION>{{< /code-block >}}
@@ -58,7 +58,7 @@ The code sample for this tutorial is on GitHub, at [github.com/DataDog/apm-tutor
 git clone https://github.com/DataDog/apm-tutorial-java-host.git
 {{< /code-block >}}
 
-The repository contains a multi-service Java application pre-configured to run inside a Kubernetes cluster. The sample app is a basic notes app with a REST API to add and change data. The `docker-compose` YAML files to make the containers for the Kubernetes pods are located in the `docker` directory. This tutorial uses the `service-docker-compose-k8s.yaml` file, which builds containers for the application. 
+The repository contains a multi-service Java application pre-configured to run inside a Kubernetes cluster. The sample app is a basic notes app with a REST API to add and change data. The `docker-compose` YAML files to make the containers for the Kubernetes pods are located in the `docker` directory. This tutorial uses the `service-docker-compose-k8s.yaml` file, which builds containers for the application.
 
 In each of the `notes` and `calendar` directories, there are two sets of Dockerfiles for building the applications, either with Maven or with Gradle. This tutorial uses the Maven build, but if you are more familiar with Gradle, you can use it instead with the corresponding changes to build commands.
 
@@ -83,11 +83,11 @@ gcloud compute networks subnets list{{< /code-block >}}
 gcloud container clusters get-credentials <CLUSTER_NAME>
 gcloud config set container/cluster <CLUSTER_NAME>{{< /code-block >}}
 
-3. To facilitate communication with the applications that will be deployed, [edit the network's firewall rules][17] to ensure that the GKE cluster allows TCP traffic on ports `30080` and `30090`. 
+3. To facilitate communication with the applications that will be deployed, [edit the network's firewall rules][17] to ensure that the GKE cluster allows TCP traffic on ports `30080` and `30090`.
 
 ### Build and upload the application image
 
-If you're not familiar with Google Container Registry (GCR), it might be helpful to read [Quickstart for Container Registry][16]. 
+If you're not familiar with Google Container Registry (GCR), it might be helpful to read [Quickstart for Container Registry][16].
 
 In the sample project's `/docker` directory, run the following commands:
 
@@ -135,7 +135,7 @@ kubectl get pods -o wide{{< /code-block >}}
 
       {{< code-block lang="sh" >}}
 kubectl get nodes -o wide{{< /code-block >}}
-   
+
    {{< img src="tracing/guide/tutorials/tutorial-java-gke-external-ip.png" alt="Output of the kubectl command showing the external IP value for the node" style="width:100%;" >}}
 
    In the examples shown, the `notes-app` is running on node `gke-java-tracing-gke-default-pool-ccbd5526-dd3d`, which has an external IP of `35.196.6.199`.
@@ -165,7 +165,7 @@ Now that you have a working Java application, configure it to enable tracing.
 1. Add the Java tracing package to your project. Because the Agent runs in a GKE cluster, ensure that the Dockerfiles are configured properly, and there is no need to install anything. Open the `notes/dockerfile.notes.maven` file and uncomment the line that downloads `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `notes/dockerfile.notes.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:
@@ -179,14 +179,14 @@ Now that you have a working Java application, configure it to enable tracing.
    <div class="alert alert-warning"><strong>Note</strong>: The flags on these sample commands, particularly the sample rate, are not necessarily appropriate for environments outside this tutorial. For information about what to use in your real environment, read <a href="#tracing-configuration">Tracing configuration</a>.</div>
 
 3. [Universal Service Tags][10] identify traced services across different versions and deployment environments so that they can be correlated within Datadog, and so you can use them to search and filter. The three environment variables used for Unified Service Tagging are `DD_SERVICE`, `DD_ENV`, and `DD_VERSION`. For applications deployed with Kubernetes, these environment variables can be added within the deployment YAML file, specifically for the deployment object, pod spec, and pod container template.
-   
+
    For this tutorial, the `kubernetes/notes-app.yaml` file already has these environment variables defined for the notes application for the deployment object, the pod spec, and the pod container template, for example:
 
    ```yaml
    ...
    spec:
      replicas: 1
-     selector: 
+     selector:
        matchLabels:
          name: notes-app-pod
          app: java-tutorial-app
@@ -253,9 +253,9 @@ If you don't see traces after several minutes, clear any filter in the Traces Se
 
 ### Examine a trace
 
-On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application). 
+On the Traces page, click on a `POST /notes` trace to see a flame graph that shows how long each span took and what other spans occurred before a span completed. The bar at the top of the graph is the span you selected on the previous screen (in this case, the initial entry point into the notes application).
 
-The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth. 
+The width of a bar indicates how long it took to complete. A bar at a lower depth represents a span that completes during the lifetime of a bar at a higher depth.
 
 The flame graph for a `POST` trace looks something like this:
 
@@ -316,7 +316,7 @@ kubectl delete -f notes-app.yaml{{< /code-block >}}
                .withTag(DDTags.RESOURCE_NAME, "privateMethod1")
                .start();
            try (Scope scope = tracer.activateSpan(span)) {
-               // Tags can also be set after creation 
+               // Tags can also be set after creation
                span.setTag("postCreationTag", 1);
                Thread.sleep(30);
                Log.info("Hello from the custom privateMethod1");
@@ -328,7 +328,7 @@ kubectl delete -f notes-app.yaml{{< /code-block >}}
             span.setTag(Tags.ERROR, true);
             span.setTag(DDTags.ERROR_MSG, e.getMessage());
             span.setTag(DDTags.ERROR_TYPE, e.getClass().getName());
-            
+
             final StringWriter errorString = new StringWriter();
             e.printStackTrace(new PrintWriter(errorString));
             span.setTag(DDTags.ERROR_STACK, errorString.toString());
@@ -349,13 +349,13 @@ docker tag docker-notes:latest  gcr.io/<PROJECT_NAME>/notes-tutorial:notes
 docker push gcr.io/<PROJECT_NAME>/notes-tutorial:notes
 {{< /code-block >}}
 
-8. Using [the same steps as before](#configure-the-application-locally-and-deploy), deploy the `notes` app with `kubectl create -f notes-app.yaml` and find the external IP address for the node it runs on. 
+8. Using [the same steps as before](#configure-the-application-locally-and-deploy), deploy the `notes` app with `kubectl create -f notes-app.yaml` and find the external IP address for the node it runs on.
 
 9. Resend some HTTP requests, specifically some `GET` requests.
 10. On the Trace Explorer, click on one of the new `GET` requests, and see a flame graph like this:
 
     {{< img src="tracing/guide/tutorials/tutorial-java-container-custom-flame.png" alt="A flame graph for a GET trace with custom instrumentation." style="width:100%;" >}}
-   
+
     Note the higher level of detail in the stack trace now that the `getAll` function has custom tracing.
 
     The `privateMethod` around which you created a manual span now shows up as a separate block from the other calls and is highlighted by a different color. The other methods where you used the `@Trace` annotation show under the same service and color as the `GET` request, which is the `notes` application. Custom instrumentation is valuable when there are key parts of the code that need to be highlighted and monitored.
@@ -364,14 +364,14 @@ For more information, read [Custom Instrumentation][12].
 
 ## Add a second application to see distributed traces
 
-Tracing a single application is a great start, but the real value in tracing is seeing how requests flow through your services. This is called _distributed tracing_. 
+Tracing a single application is a great start, but the real value in tracing is seeing how requests flow through your services. This is called _distributed tracing_.
 
 The sample project includes a second application called `calendar` that returns a random date whenever it is invoked. The `POST` endpoint in the Notes application has a second query parameter named `add_date`. When it is set to `y`, Notes calls the calendar application to get a date to add to the note.
 
 1. Configure the `calendar` app for tracing by adding `dd-java-agent` to the startup command in the Dockerfile, like you previously did for the notes app. Open `calendar/dockerfile.calendar.maven` and see that it is already downloading `dd-java-agent`:
 
    ```
-   RUN curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   RUN curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 
 2. Within the same `calendar/dockerfile.calendar.maven` file, comment out the `ENTRYPOINT` line for running without tracing. Then uncomment the `ENTRYPOINT` line, which runs the application with tracing enabled:

--- a/content/en/tracing/guide/tutorial-enable-java-host.md
+++ b/content/en/tracing/guide/tutorial-enable-java-host.md
@@ -152,10 +152,10 @@ Run more API calls to see the application in action. When you're done, type Ctrl
 Next, download the Java tracing library (sometimes called the Java Agent). From your `apm-tutorial-java-host` directory, run:
 
 {{< code-block lang="sh" >}}
-curl -Lo dd-java-agent.jar https://dtdg.co/latest-java-tracer
+curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
 {{< /code-block >}}
 
-If your operating system does not support curl, you can go directly to `https://dtdg.co/latest-java-tracer ` to download the `dd-java-agent.jar` file.
+If your operating system does not support curl, you can go directly to `'https://dtdg.co/latest-java-tracer' ` to download the `dd-java-agent.jar` file.
 
 ## Launch the Java application with automatic instrumentation
 

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -47,9 +47,23 @@ After the Agent is installed, to begin tracing your applications:
 
 1. Download `dd-java-agent.jar` that contains the latest tracer class files, to a folder that is accessible by your Datadog user:
 
+{{< tabs >}}
+{{% tab "curl" %}}
    ```shell
-   wget -O dd-java-agent.jar https://dtdg.co/latest-java-tracer
+   wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
+{{% /tab %}}
+{{% tab "wget" %}}
+   ```shell
+   curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+   ```
+{{% /tab %}}
+{{% tab "Dockerfile" %}}
+   ```dockerfile
+   ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
+   ```
+{{% /tab %}}
+{{< /tabs >}}
 
    **Note:** To download the latest build of a specific **major** version, use the `https://dtdg.co/java-tracer-vX` link instead, where `X` is the desired major version.
    For example, use `https://dtdg.co/java-tracer-v1` for the latest version 1 build. Minor version numbers must not be included. Alternatively, see Datadog's [Maven repository][3] for any specific version.

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -48,12 +48,12 @@ After the Agent is installed, to begin tracing your applications:
 1. Download `dd-java-agent.jar` that contains the latest tracer class files, to a folder that is accessible by your Datadog user:
 
 {{< tabs >}}
-{{% tab "curl" %}}
+{{% tab "cURL" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 {{% /tab %}}
-{{% tab "wget" %}}
+{{% tab "Wget" %}}
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```

--- a/content/en/tracing/trace_collection/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/dd_libraries/java.md
@@ -48,12 +48,12 @@ After the Agent is installed, to begin tracing your applications:
 1. Download `dd-java-agent.jar` that contains the latest tracer class files, to a folder that is accessible by your Datadog user:
 
 {{< tabs >}}
-{{% tab "cURL" %}}
+{{% tab "Wget" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
 {{% /tab %}}
-{{% tab "Wget" %}}
+{{% tab "cURL" %}}
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds additional options for downloading the Java tracer, using `wget`, `curl`, or `ADD`

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing
- [ ] Pending review from eng/support team member

### Additional notes
<!-- Anything else we should know when reviewing?-->
My editor removed extraneous whitespace when I did a find-and-replace to add single quotes around the URL. If this is undesired, I can revert this change

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->