### PR TITLE
Remove beta tag for Dynamic Instrumentation

### DIFF
--- a/content/en/agent/remote_config/_index.md
+++ b/content/en/agent/remote_config/_index.md
@@ -65,7 +65,6 @@ The following products and features are supported with Remote Configuration:
 
 
 ### Dynamic Instrumentation
-<div class="alert alert-info">This feature is in beta.</div>
 
 - Send critical metrics, traces, and logs from your live applications with no code changes.
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?
Remove "beta" tag for the Dynamic Instrumentation product now that it's GA. We already covered most of this in #20588 , but we left out one entry in the Remote Config docs page.


### Merge instructions

- [-] Please merge after reviewing
