### PR TITLE
Add "Test Suite" to Docs Glossary

### DIFF
--- a/content/en/glossary/terms/test_service.md
+++ b/content/en/glossary/terms/test_service.md
@@ -1,9 +1,9 @@
 ---
 # Glossary Term
 title: test service
-
 core_product:
   - ci-cd
-
+related_terms:
+  - test_suite
 ---
 A test service is a group of tests associated with, for example, a project or repo. It contains all the individual tests for your code, optionally organized into test suites, which are like folders for your tests. For more information, <a href="/continuous_integration/search/?tab=tests#test-suite-performance">see the documentation</a>.

--- a/content/en/glossary/terms/test_service.md
+++ b/content/en/glossary/terms/test_service.md
@@ -3,7 +3,8 @@
 title: test service
 core_product:
   - ci-cd
+  - synthetic monitoring
 related_terms:
-  - test_suite
+  - test suite
 ---
-A test service is a group of tests associated with, for example, a project or repo. It contains all the individual tests for your code, optionally organized into test suites, which are like folders for your tests. For more information, <a href="/continuous_integration/search/?tab=tests#test-suite-performance">see the documentation</a>.
+In Datadog Synthetic Monitoring and CI Visibility, a test service is generally a group of tests associated with, for example, a project or repo. It contains all the individual tests for your code, optionally organized into test suites, which are like folders for your tests. For more information, <a href="/continuous_integration/search/?tab=tests#test-suite-performance">see the documentation</a>.

--- a/content/en/glossary/terms/test_suite.md
+++ b/content/en/glossary/terms/test_suite.md
@@ -7,4 +7,4 @@ core_product:
 related_terms:
   - test service
 ---
-In Datadog Synthetic Monitoring and CI Visibility, a test suite is a group of tests exercising the same unit of code depending on your language and testing framework. You can access an <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/junit/__tests__/upload.test.ts">example of a test suite</a> which corresponds to a test file in the `datadog-ci` repository. For more information, <a href="/continuous_integration/search/?tab=tests/#setup">see the documentation</a>.
+In Datadog Synthetic Monitoring and CI Visibility, a test suite is generally a group of tests exercising the same unit of code depending on your language and testing framework. You can access an <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/junit/__tests__/upload.test.ts">example of a test suite</a> which corresponds to a test file in the `datadog-ci` repository. For more information, <a href="/continuous_integration/search/?tab=tests/#setup">see the documentation</a>.

--- a/content/en/glossary/terms/test_suite.md
+++ b/content/en/glossary/terms/test_suite.md
@@ -1,0 +1,10 @@
+---
+# Glossary Term
+title: test suite
+core_product:
+  - ci-cd
+  - synthetic monitoring
+related_terms:
+  - test service
+---
+In Datadog Synthetic Monitoring and CI Visibility, a test suite is a group of tests exercising the same unit of code depending on your language and testing framework. You can access an <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/junit/__tests__/upload.test.ts">example of a test suite</a> which corresponds to a test file in the `datadog-ci` repository. For more information, <a href="/continuous_integration/search/?tab=tests/#setup">see the documentation</a>.

--- a/content/en/glossary/terms/test_suite.md
+++ b/content/en/glossary/terms/test_suite.md
@@ -7,4 +7,4 @@ core_product:
 related_terms:
   - test service
 ---
-In Datadog Synthetic Monitoring and CI Visibility, a test suite is generally a group of tests exercising the same unit of code depending on your language and testing framework. You can access an <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/junit/__tests__/upload.test.ts">example of a test suite</a> which corresponds to a test file in the `datadog-ci` repository. For more information, <a href="/continuous_integration/search/?tab=tests/#setup">see the documentation</a>.
+In Datadog Synthetic Monitoring and CI Visibility, a test suite is generally a group of tests exercising the same unit of code depending on your language and testing framework. You can access an <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/junit/__tests__/upload.test.ts">example of a test suite</a> which corresponds to a test file in the `datadog-ci` repository. For more information, <a href="/continuous_integration/search/?tab=tests#setup">see the documentation</a>.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Add new term for "test suite" in the Docs Glossary for Continuous Testing + CI Visibility, and updates the same definition for "test service" which is a related term.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->