### PR TITLE
Add note about java prepared statements

### DIFF
--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -1,7 +1,7 @@
 ---
 title: Connect Database Monitoring and Traces
 kind: documentation
-aliases: 
+aliases:
 - /database_monitoring/guide/connect_dbm_and_apm/
 further_reading:
   - link: 'https://www.datadoghq.com/blog/link-dbm-and-apm/'
@@ -180,6 +180,8 @@ public class Application {
     }
 }
 ```
+
+**Note:** Prepared statements are not supported in `full` mode, and all JDBC API calls that use prepared statements will automatically be downgraded to `service` mode. Since the vast majority of java SQL libraries use prepared statements by default, this means that **most** java applications will only be able to take advantage of `service` mode.
 
 [1]: /tracing/trace_collection/dd_libraries/java/
 [2]: /tracing/trace_collection/compatibility/java/#data-store-compatibility

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -181,7 +181,7 @@ public class Application {
 }
 ```
 
-**Note:** Prepared statements are not supported in `full` mode, and all JDBC API calls that use prepared statements will automatically be downgraded to `service` mode. Since the vast majority of java SQL libraries use prepared statements by default, this means that **most** java applications will only be able to take advantage of `service` mode.
+**Note**: Prepared statements are not supported in `full` mode, and all JDBC API calls that use prepared statements are automatically downgraded to `service` mode. Since most Java SQL libraries use prepared statements by default, this means that **most** Java applications are only able to use `service` mode.
 
 [1]: /tracing/trace_collection/dd_libraries/java/
 [2]: /tracing/trace_collection/compatibility/java/#data-store-compatibility


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds a note to our APM-DBM link java tracer docs about prepared statement support for trace propagation. This is a response to some customers filing support tickets after enabling `full` mode, but not seeing any traces in the DBM UI for their samples. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->