### PR TITLE
[DOCS-6571] Add missing tiles to Log Collection

### DIFF
--- a/layouts/partials/logs/logs-languages.html
+++ b/layouts/partials/logs/logs-languages.html
@@ -54,14 +54,42 @@
 <div class="col">
 <a class="card h-100" href="/logs/log_collection/javascript">
 <div class="card-body text-center py-2 px-1">
-{{ partial "img.html" (dict "root" . "src" "integrations_logos/javascript.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
+{{ partial "img.html" (dict "root" . "src" "integrations_logos/javascript.png" "class" "img-fluid" "alt" "Javascript" "width" "400") }}
+</div>
+</a>
+</div>
+<div class="col">
+<a class="card h-100" href="/logs/log_collection/reactnative">
+<div class="card-body text-center py-2 px-1">
+{{ partial "img.html" (dict "root" . "src" "integrations_logos/react_native.png" "class" "img-fluid" "alt" "React Native" "width" "400") }}
 </div>
 </a>
 </div>
 <div class="col">
 <a class="card h-100" href="/logs/log_collection/android">
 <div class="card-body text-center py-2 px-1">
-{{ partial "img.html" (dict "root" . "src" "integrations_logos/android.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
+{{ partial "img.html" (dict "root" . "src" "integrations_logos/android.png" "class" "img-fluid" "alt" "Android" "width" "400") }}
+</div>
+</a>
+</div>
+<div class="col">
+<a class="card h-100" href="/logs/log_collection/ios">
+<div class="card-body text-center py-2 px-1">
+{{ partial "img.html" (dict "root" . "src" "integrations_logos/ios_large.svg" "class" "img-fluid" "alt" "ios" "width" "400") }}
+</div>
+</a>
+</div>
+<div class="col">
+<a class="card h-100" href="/logs/log_collection/flutter">
+<div class="card-body text-center py-2 px-1">
+{{ partial "img.html" (dict "root" . "src" "integrations_logos/flutter_large.svg" "class" "img-fluid" "alt" "Flutter" "width" "400") }}
+</div>
+</a>
+</div>
+<div class="col">
+<a class="card h-100" href="/logs/log_collection/roku">
+<div class="card-body text-center py-2 px-1">
+{{ partial "img.html" (dict "root" . "src" "integrations_logos/roku_large.svg" "class" "img-fluid" "alt" "Roku" "width" "400") }}
 </div>
 </a>
 </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds missing tiles for iOS, React Native, Flutter, and Roku.
Fix alt text for Javascript and Android.

[DOCS-6571](https://datadoghq.atlassian.net/browse/DOCS-6571)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6571]: https://datadoghq.atlassian.net/browse/DOCS-6571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ