### PR TITLE
[DOCS-6801] Split OP deployment modes section

### DIFF
--- a/content/en/observability_pipelines/setup/_index.md
+++ b/content/en/observability_pipelines/setup/_index.md
@@ -37,6 +37,10 @@ There are several ways to get started with the Observability Pipelines Worker.
 
 This document walks you through the quickstart installation steps and then provides resources for next steps.
 
+## Deployment Modes
+
+{{% op-deployment-modes %}}
+
 ## Prerequisites
 
 To install the Observability Pipelines Worker, you need the following:
@@ -387,6 +391,10 @@ EOT
 
 See [Working with Data][7] for more information on transforming your data.
 
+## Updating deployment modes
+
+{{% op-updating-deployment-modes %}}
+
 ## Next steps
 
 The quickstart walked you through installing the Worker and deploying a sample pipeline configuration. For instructions on how to install the Worker to receive and route data from your Datadog Agents to Datadog or to receive and route data from your Splunk HEC to Splunk and Datadog, select your specific use case:
@@ -397,30 +405,6 @@ For recommendations on deploying and scaling multiple Workers:
 
 - See [Deployment Design and Principles][8] for information on what to consider when designing your Observability Pipelines architecture.
 - See [Best Practices for OP Worker Aggregator Architecture][9].
-
-## Deployment Modes
-
-<div class="alert alert-warning">
-  Remote configuration for Observability Pipelines is in private beta. Contact <a href="https://docs.datadoghq.com/help/">Datadog support</a> or your Customer Success Manager for access.
-</div>
-
-If you are enrolled in the private beta of [Remote Configuration][10], you can remotely roll out changes to your Workers from the Datadog UI, rather than make updates to your pipeline configuration in a text editor and then manually rolling out your changes. Choose your deployment method when you create a pipeline and install your Workers.
-
-After deploying a pipeline, you can also switch deployment methods, such as going from a manually managed pipeline to a remote configuration enabled pipeline or vice versa. 
-
-If you want to switch from a remote configuration deployment to a manually managed deployment:
-1. Navigate to Observability Pipelines.
-2. Click the settings cog.
-3. In **Deployment Mode**, select **manual** to enable it.
-4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `false` and restart the Worker. Workers that are not restarted with this flag continue to be remote configuration enabled, which means that the Workers are not updated manually through a local configuration file.
-
-If you want to switch from manually managed deployment to a remote configuration deployment:
-1. Navigate to Observability Pipelines.
-2. Click the settings cog.
-3. In **Deployment Mode**, select **Remote Configuration** to enable it.
-4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `true` and restart the Worker. Workers that are not restarted with this flag are not polled for configurations deployed in the UI. 
-6. Deploy a version in your version history, so that the Workers receive the new version configuration. Click on a version. Click **Edit as Draft** and then click **Deploy**. 
-
 
 ## Further reading
 
@@ -435,4 +419,3 @@ If you want to switch from manually managed deployment to a remote configuration
 [7]: /observability_pipelines/working_with_data/
 [8]: /observability_pipelines/production_deployment_overview/
 [9]: /observability_pipelines/architecture/
-[10]: /agent/remote_config

--- a/content/en/observability_pipelines/setup/datadog.md
+++ b/content/en/observability_pipelines/setup/datadog.md
@@ -28,6 +28,10 @@ This guide walks you through deploying the Worker in your common tools cluster a
 
 {{< img src="observability_pipelines/setup/opw-dd-pipeline.png" alt="A diagram of a couple of workload clusters sending their data through the Observability Pipelines aggregator." >}}
 
+## Deployment Modes
+
+{{% op-deployment-modes %}}
+
 ## Assumptions
 * You are already using Datadog and want to use Observability Pipelines.
 * You have administrative access to the clusters where the Observability Pipelines Worker is going to be deployed, as well as to the workloads that are going to be aggregated.
@@ -559,6 +563,10 @@ kubectl get svc opw-observability-pipelines-worker
 For Terraform installs, the `lb-dns` output provides the necessary value. For CloudFormation installs, the `LoadBalancerDNS` CloudFormation output has the correct URL to use.
 
 At this point, your observability data should be going to the Worker and is available for data processing. The next section goes through what processing is included by default and the additional options that are available.
+
+## Updating deployment modes
+
+{{% op-updating-deployment-modes %}}
 
 ## Working with data
 The sample configuration provided has example processing steps that demonstrate Observability Pipelines tools and ensures that data sent to Datadog is in the correct format.

--- a/content/en/observability_pipelines/setup/datadog_with_archiving.md
+++ b/content/en/observability_pipelines/setup/datadog_with_archiving.md
@@ -20,6 +20,10 @@ The [Observability Pipelines Worker][1] can collect, process, and route logs and
 
 This guide walks you through deploying the Worker in your common tools cluster and configuring it to send logs in a Datadog-rehydratable format to a cloud storage for archiving.
 
+## Deployment Modes
+
+{{% op-deployment-modes %}}
+
 ## Assumptions
 * You are already using Datadog and want to use Observability Pipelines.
 * You have administrative access to the clusters where the Observability Pipelines Worker is going to be deployed, as well as to the workloads that are going to be aggregated.
@@ -532,6 +536,10 @@ kubectl get svc opw-observability-pipelines-worker
 For Terraform installs, the `lb-dns` output provides the necessary value.
 
 At this point, your observability data should be going to the Worker and then sent along to your S3 archive.
+
+## Updating deployment modes
+
+{{% op-updating-deployment-modes %}}
 
 ## Rehydrate your archives
 

--- a/layouts/shortcodes/op-deployment-modes.md
+++ b/layouts/shortcodes/op-deployment-modes.md
@@ -1,0 +1,9 @@
+<div class="alert alert-warning">
+  Remote configuration for Observability Pipelines is in private beta. Contact <a href="https://docs.datadoghq.com/help/">Datadog support</a> or your Customer Success Manager for access.
+</div>
+
+If you are enrolled in the private beta of [Remote Configuration][101], you can remotely roll out changes to your Workers from the Datadog UI, rather than make updates to your pipeline configuration in a text editor and then manually rolling out your changes. Choose your deployment method when you create a pipeline and install your Workers.
+
+See [Updating deployment modes](#updating-deployment-modes) on how to change the deployment mode after a pipeline is deployed.
+
+[101]: /agent/remote_config

--- a/layouts/shortcodes/op-updating-deployment-modes.md
+++ b/layouts/shortcodes/op-updating-deployment-modes.md
@@ -1,0 +1,15 @@
+
+After deploying a pipeline, you can also switch deployment methods, such as going from a manually managed pipeline to a remote configuration enabled pipeline or vice versa. 
+
+If you want to switch from a remote configuration deployment to a manually managed deployment:
+1. Navigate to Observability Pipelines.
+2. Click the settings cog.
+3. In **Deployment Mode**, select **manual** to enable it.
+4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `false` and restart the Worker. Workers that are not restarted with this flag continue to be remote configuration enabled, which means that the Workers are not updated manually through a local configuration file.
+
+If you want to switch from manually managed deployment to a remote configuration deployment:
+1. Navigate to Observability Pipelines.
+2. Click the settings cog.
+3. In **Deployment Mode**, select **Remote Configuration** to enable it.
+4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `true` and restart the Worker. Workers that are not restarted with this flag are not polled for configurations deployed in the UI. 
+6. Deploy a version in your version history, so that the Workers receive the new version configuration. Click on a version. Click **Edit as Draft** and then click **Deploy**. 

--- a/layouts/shortcodes/op-updating-deployment-modes.md
+++ b/layouts/shortcodes/op-updating-deployment-modes.md
@@ -8,7 +8,7 @@ If you want to switch from a remote configuration deployment to a manually manag
 4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `false` and restart the Worker. Workers that are not restarted with this flag continue to be remote configuration enabled, which means that the Workers are not updated manually through a local configuration file.
 
 If you want to switch from manually managed deployment to a remote configuration deployment:
-1. Navigate to Observability Pipelines.
+1. Navigate to Observability Pipelines and select the pipeline.
 2. Click the settings cog.
 3. In **Deployment Mode**, select **Remote Configuration** to enable it.
 4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `true` and restart the Worker. Workers that are not restarted with this flag are not polled for configurations deployed in the UI. 

--- a/layouts/shortcodes/op-updating-deployment-modes.md
+++ b/layouts/shortcodes/op-updating-deployment-modes.md
@@ -2,7 +2,7 @@
 After deploying a pipeline, you can also switch deployment methods, such as going from a manually managed pipeline to a remote configuration enabled pipeline or vice versa. 
 
 If you want to switch from a remote configuration deployment to a manually managed deployment:
-1. Navigate to Observability Pipelines.
+1. Navigate to Observability Pipelines and select the pipeline.
 2. Click the settings cog.
 3. In **Deployment Mode**, select **manual** to enable it.
 4. Set the `DD_OP_REMOTE_CONFIGURATION_ENABLED` flag to `false` and restart the Worker. Workers that are not restarted with this flag continue to be remote configuration enabled, which means that the Workers are not updated manually through a local configuration file.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Splits the OP Deployment Modes section
- Adds the sections as general reuse shortcodes
- Add sections to Datadog and Datadog with Archiving docs

[DOCS-6801](https://datadoghq.atlassian.net/browse/DOCS-6801)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6801]: https://datadoghq.atlassian.net/browse/DOCS-6801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ