### PR TITLE
Add FA link to beta callout

### DIFF
--- a/content/en/agent/fleet_automation/_index.md
+++ b/content/en/agent/fleet_automation/_index.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Centrally govern and remotely manage Datadog Agents at scale with Fleet Automation"
 ---
 
-{{< callout btn_hidden="true">}}Fleet Automation is in beta. You can access it from the <a href="https://app.datadoghq.com/fleet">Fleet Automation</a> page in Datadog.{{< /callout >}}
+{{< callout btn_hidden="true">}}Fleet Automation is in beta. Access it from the <a href="https://app.datadoghq.com/fleet">Fleet Automation</a> page in Datadog.{{< /callout >}}
 
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">Fleet Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>

--- a/content/en/agent/fleet_automation/_index.md
+++ b/content/en/agent/fleet_automation/_index.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Centrally govern and remotely manage Datadog Agents at scale with Fleet Automation"
 ---
 
-{{< callout btn_hidden="true">}}Fleet Automation is in beta.{{< /callout >}}
+{{< callout btn_hidden="true">}}Fleet Automation is in beta. You can access it from the [Fleet Automation][1] page in Datadog.{{< /callout >}}
 
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">Fleet Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>

--- a/content/en/agent/fleet_automation/_index.md
+++ b/content/en/agent/fleet_automation/_index.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Centrally govern and remotely manage Datadog Agents at scale with Fleet Automation"
 ---
 
-{{< callout btn_hidden="true">}}Fleet Automation is in beta. You can access it from the [Fleet Automation][1] page in Datadog.{{< /callout >}}
+{{< callout btn_hidden="true">}}Fleet Automation is in beta. You can access it from the <a href="https://app.datadoghq.com/fleet">Fleet Automation</a> page in Datadog.{{< /callout >}}
 
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">Fleet Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>


### PR DESCRIPTION
Adds a link to the Fleet Automation page to the beta callout

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
From Slack. Add a link to the beta callout.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->