### PR TITLE
DOCS-6625 updates to k8s apm instructions

### DIFF
--- a/content/en/containers/guide/kubernetes_daemonset.md
+++ b/content/en/containers/guide/kubernetes_daemonset.md
@@ -99,7 +99,7 @@ To enable APM trace collection over TCP, open the DaemonSet configuration file a
       # (...)
     ```
 
-- **If using an old agent version (7.17 or lower)**, in addition to the steps above, set the `DD_APM_NON_LOCAL_TRAFFIC` and `DD_APM_ENABLED` variable to `true` in your `env` section of the `datadog.yaml` trace Agent manifest:
+- **If using Agent version 7.17 or previous**, in addition to the steps above, set the `DD_APM_NON_LOCAL_TRAFFIC` and `DD_APM_ENABLED` variables to `true` in your `env` section of the `datadog.yaml` trace Agent manifest:
 
   ```yaml
     # (...)

--- a/content/en/containers/guide/kubernetes_daemonset.md
+++ b/content/en/containers/guide/kubernetes_daemonset.md
@@ -78,6 +78,76 @@ To install the Datadog Agent on your Kubernetes cluster:
 
 ## Configuration
 
+### Trace collection
+
+{{< tabs >}}
+{{% tab "TCP" %}}
+
+To enable APM trace collection over TCP, open the DaemonSet configuration file and edit the following:
+
+- Allow incoming data from port `8126` (forwarding traffic from the host to the agent) within the `trace-agent` container:
+    ```yaml
+      # (...)
+      containers:
+        - name: trace-agent
+          # (...)
+          ports:
+            - containerPort: 8126
+              hostPort: 8126
+              name: traceport
+              protocol: TCP
+      # (...)
+    ```
+
+- **If using an old agent version (7.17 or lower)**, in addition to the steps above, set the `DD_APM_NON_LOCAL_TRAFFIC` and `DD_APM_ENABLED` variable to `true` in your `env` section of the `datadog.yaml` trace Agent manifest:
+
+  ```yaml
+    # (...)
+    containers:
+      - name: trace-agent
+        # (...)
+        env:
+          - name: DD_APM_ENABLED
+            value: 'true'
+          - name: DD_APM_NON_LOCAL_TRAFFIC
+            value: "true"
+          # (...)
+  ```
+
+**Warning**: The `hostPort` parameter opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources. If your network plugin doesn't support `hostPorts`, add `hostNetwork: true` in your Agent pod specifications. This shares the network namespace of your host with the Datadog Agent. This also means that all ports opened on the container are opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod does not start. Some Kubernetes installations do not allow this.
+
+
+{{% /tab %}}
+{{% tab "Unix Domain Socket (UDS)" %}}
+
+To enable APM trace collection over UDS, open the DaemonSet configuration file and edit the following:
+
+  ```yaml
+    # (...)
+    containers:
+    - name: trace-agent
+      # (...)
+      env:
+      - name: DD_APM_ENABLED
+        value: "true"
+      - name: DD_APM_RECEIVER_SOCKET
+        value: "/var/run/datadog/apm.socket"
+    # (...)
+      volumeMounts:
+      - name: apmsocket
+        mountPath: /var/run/datadog/
+    volumes:
+    - hostPath:
+        path: /var/run/datadog/
+        type: DirectoryOrCreate
+    # (...)
+  ```
+
+This configuration creates a directory on the host and mounts it within the Agent. The Agent then creates and listens on a socket file in that directory with the `DD_APM_RECEIVER_SOCKET` value of `/var/run/datadog/apm.socket`. The application pods can then similarly mount this volume and write to this same socket.
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### Log collection
 
 **Note**: This option is not supported on Windows. Use the [Helm][22] option instead.

--- a/content/en/containers/kubernetes/apm.md
+++ b/content/en/containers/kubernetes/apm.md
@@ -21,118 +21,24 @@ further_reading:
   text: "Assign tags to all data emitted by a container"
 ---
 
-In order to start collecting your application traces you must be [running the Datadog Agent in your Kubernetes cluster][1].
-
-## Setup
-
-You can configure the Agent to intake traces by using TCP (`IP:Port`), Unix Domain Socket (UDS), or both. The Agent can receive traces from both setups at the same time if needed.
+This page describes how to setup and configure [Application Performance Monitoring (APM)][10] for your Kubernetes application.
 
 {{< img src="tracing/visualization/troubleshooting_pipeline_kubernetes.png" alt="The APM troubleshooting pipeline: The tracer sends traces and metrics data from the application pod to the Agent pod, which sends it to the Datadog backend to be shown in the Datadog UI.">}}
 
-### Configure the Datadog Agent to accept traces
+You can send traces over Unix Domain Socket (UDS), TCP (`IP:Port`), or Kubernetes service. Datadog recommends that you use UDS, but it is possible to use all three at the same time, if necessary.
+
+## Setup
+1. If you haven't already, [install the Datadog Agent][1] in your Kubernetes environment.
+2. [Configure the Datadog Agent](#configure-the-datadog-agent-to-collect-traces) to collect traces.
+3. [Configure application pods](#configure-your-application-pods-to-submit-traces-to-datadog-agent) to submit traces to the Datadog Agent.
+
+### Configure the Datadog Agent to collect traces
+
+The instructions in this section configure the Datadog Agent to receive traces over UDS. To use TCP, see the [additional configuration](#additional-configuration) section. To use Kubernetes service, see [Setting up APM with Kubernetes Service][9].
+
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-- If you haven't already, [install][1] the Helm chart.
-
-The default configuration creates a directory on the host and mounts it within the Agent. The Agent then creates and listens on a socket file `/var/run/datadog/apm.socket`. The application pods can then similarly mount this volume and write to this same socket. You can modify the path and socket with the `datadog.apm.hostSocketPath` and `datadog.apm.socketPath` configuration values.
-
-This feature can be disabled with `datadog.apm.socketEnabled`.
-
-#### Optional - Configure the Datadog Agent to accept traces over TCP
-
-The Datadog Agent can also be configured to receive traces over TCP. To enable this feature:
-
-- Update your `values.yaml` file with the following APM configuration:
-    ```yaml
-    datadog:
-      ## Enable apm agent and provide custom configs
-      apm:
-        # datadog.apm.portEnabled -- Enable APM over TCP communication (port 8126 by default)
-        ## ref: https://docs.datadoghq.com/agent/kubernetes/apm/
-        portEnabled: true
-    ```
-
-Then, upgrade your Datadog Helm chart using the following command: `helm upgrade -f values.yaml <RELEASE NAME> datadog/datadog`. If you did not set your operating system in `values.yaml`, add `--set targetSystem=linux` or `--set targetSystem=windows` to this command.
-
-**Warning**: The `datadog.apm.portEnabled` parameter opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources. If your network plugin doesn't support `hostPorts`, add `hostNetwork: true` in your Agent pod specifications. This shares the network namespace of your host with the Datadog Agent. This also means that all ports opened on the container are opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod does not start. Some Kubernetes installations do not allow this.
-
-[1]: /agent/kubernetes/?tab=helm
-{{% /tab %}}
-{{% tab "DaemonSet" %}}
-
-To enable APM trace collection, open the DaemonSet configuration file and edit the following:
-
-- Allow incoming data from port `8126` (forwarding traffic from the host to the agent) within the `trace-agent` container:
-    ```yaml
-      # (...)
-      containers:
-        - name: trace-agent
-          # (...)
-          ports:
-            - containerPort: 8126
-              hostPort: 8126
-              name: traceport
-              protocol: TCP
-      # (...)
-    ```
-
-- **If using an old agent version (7.17 or lower)**, in addition to the steps above, set the `DD_APM_NON_LOCAL_TRAFFIC` and `DD_APM_ENABLED` variable to `true` in your `env` section of the `datadog.yaml` trace Agent manifest:
-
-  ```yaml
-    # (...)
-    containers:
-      - name: trace-agent
-        # (...)
-        env:
-          - name: DD_APM_ENABLED
-            value: 'true'
-          - name: DD_APM_NON_LOCAL_TRAFFIC
-            value: "true"
-          # (...)
-  ```
-
-**Warning**: The `hostPort` parameter opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources. If your network plugin doesn't support `hostPorts`, add `hostNetwork: true` in your Agent pod specifications. This shares the network namespace of your host with the Datadog Agent. This also means that all ports opened on the container are opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod does not start. Some Kubernetes installations do not allow this.
-
-
-{{% /tab %}}
-{{% tab "DaemonSet (UDS)" %}}
-
-To enable APM trace collection, open the DaemonSet configuration file and edit the following:
-
-  ```yaml
-    # (...)
-    containers:
-    - name: trace-agent
-      # (...)
-      env:
-      - name: DD_APM_ENABLED
-        value: "true"
-      - name: DD_APM_RECEIVER_SOCKET
-        value: "/var/run/datadog/apm.socket"
-    # (...)
-      volumeMounts:
-      - name: apmsocket
-        mountPath: /var/run/datadog/
-    volumes:
-    - hostPath:
-        path: /var/run/datadog/
-        type: DirectoryOrCreate
-    # (...)
-  ```
-
-This configuration creates a directory on the host and mounts it within the Agent. The Agent then creates and listens on a socket file in that directory with the `DD_APM_RECEIVER_SOCKET` value of `/var/run/datadog/apm.socket`. The application pods can then similarly mount this volume and write to this same socket.
-
-{{% /tab %}}
 {{% tab "Operator" %}}
-
-When APM is enabled, the default configuration creates a directory on the host and mounts it within the Agent. The Agent then creates and listens on a socket file `/var/run/datadog/apm/apm.socket`. The application pods can then similarly mount this volume and write to this same socket. You can modify the path and socket with the `features.apm.unixDomainSocketConfig.path` configuration value.
-
-#### Optional - Configure the Datadog Agent to accept traces over TCP
-
-The Datadog Agent can also be configured to receive traces over TCP. To enable this feature:
-
-Update your `DatadogAgent` manifest with the following:
+After you [use Operator to install the Datadog Agent][1], edit your `datadog-agent.yaml` to set `features.apm.enabled` to `true`.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -143,31 +49,54 @@ spec:
   global:
     credentials:
       apiKey: <DATADOG_API_KEY>
-    site: <DATADOG_SITE>
 
   features:
     apm:
       enabled: true
-      hostPortConfig:
-        enabled: true
-```
-Where your `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
-
-See the sample [manifest with APM and metrics collection enabled][1] for a complete example.
-
-Then apply the new configuration:
-
-```shell
-kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
+      unixDomainSocketConfig:
+        path: /var/run/datadog/apm.sock # default
 ```
 
-**Warning**: The `hostPort` parameter opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources. If your network plugin doesn't support `hostPorts`, add `hostNetwork: true` in your Agent pod specifications. This shares the network namespace of your host with the Datadog Agent. This also means that all ports opened on the container are opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod does not start. Some Kubernetes installations do not allow this.
+When APM is enabled, the default configuration creates a directory on the host and mounts it within the Agent. The Agent then creates and listens on a socket file `/var/run/datadog/apm/apm.socket`. The application pods can then similarly mount this volume and write to this same socket. You can modify the path and socket with the `features.apm.unixDomainSocketConfig.path` configuration value.
 
-[1]: https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/v2alpha1/datadog-agent-apm.yaml
+{{% k8s-operator-redeploy %}}
+
+**Note**: On minikube, you may receive an `Unable to detect the kubelet URL automatically` error. In this case, set `global.kubelet.tlsVerify` to `false`.
+
+[1]: /containers/kubernetes/installation/?tab=operator#installation
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+If you [used Helm to install the Datadog Agent][1], APM is **enabled by default** over UDS or Windows named pipe.
+
+To verify, ensure that `datadog.apm.socketEnabled` is set to `true` in your `values.yaml`.
+
+```yaml
+datadog:
+  apm:
+    socketEnabled: true    
+```
+
+The default configuration creates a directory on the host and mounts it within the Agent. The Agent then creates and listens on a socket file `/var/run/datadog/apm.socket`. The application pods can then similarly mount this volume and write to this same socket. You can modify the path and socket with the `datadog.apm.hostSocketPath` and `datadog.apm.socketPath` configuration values.
+
+```yaml
+datadog:
+  apm:
+    # the following values are default:
+    socketEnabled: true
+    hostSocketPath: /var/run/datadog/
+    socketPath: /var/run/datadog/apm.socket
+```
+
+To disable APM, set `datadog.apm.socketEnabled` to `false`.
+
+{{% k8s-helm-redeploy %}}
+
+**Note**: On minikube, you may receive an `Unable to detect the kubelet URL automatically` error. In this case, set `datadog.kubelet.tlsVerify` to `false`.
+
+[1]: /containers/kubernetes/installation?tab=helm#installation
 {{% /tab %}}
 {{< /tabs >}}
-
-**Note**: On minikube, you may receive an `Unable to detect the kubelet URL automatically` error. In this case, set `DD_KUBELET_TLS_VERIFY=false`.
 
 ### Configure your application pods to submit traces to Datadog Agent
 
@@ -182,8 +111,8 @@ Use the Datadog Admission Controller to inject environment variables and mount t
 [2]: /tracing/trace_collection/library_injection_local/
 {{% /tab %}}
 
-{{% tab "UDS" %}}
-If you are sending traces to the Agent by using Unix Domain Socket (UDS), mount the host directory the socket is in (that the Agent created) to the application container and specify the path to the socket with `DD_TRACE_AGENT_URL`:
+{{% tab "Unix Domain Socket (UDS)" %}}
+If you are sending traces to the Agent by using UDS, mount the host directory the socket is in (that the Agent created) to the application container and specify the path to the socket with `DD_TRACE_AGENT_URL`:
 
 ```yaml
 apiVersion: apps/v1
@@ -207,7 +136,7 @@ kind: Deployment
 ```
 
 ### Configure your application tracers to emit traces:
-After configuring your Datadog Agent to collect traces and giving your application pods the configuration on *where* to send traces, install the Datadog tracer into your applications to emit the traces. Once this is done, the tracer sends the traces to the appropriate `DD_AGENT_HOST` (for `IP:Port`) or `DD_TRACE_AGENT_URL` (for UDS) endpoint.
+After configuring your Datadog Agent to collect traces and giving your application pods the configuration on *where* to send traces, install the Datadog tracer into your applications to emit the traces. Once this is done, the tracer sends the traces to the appropriate `DD_TRACE_AGENT_URL` endpoint.
 
 {{% /tab %}}
 
@@ -232,7 +161,7 @@ kind: Deployment
 **Note:** This configuration requires the Agent to be configured to accept traces over TCP
 
 ### Configure your application tracers to emit traces:
-After configuring your Datadog Agent to collect traces and giving your application pods the configuration on *where* to send traces, install the Datadog tracer into your applications to emit the traces. Once this is done, the tracer automatically sends the traces to the appropriate `DD_AGENT_HOST` (for `IP:Port`) or `DD_TRACE_AGENT_URL` (for UDS) endpoint.
+After configuring your Datadog Agent to collect traces and giving your application pods the configuration on *where* to send traces, install the Datadog tracer into your applications to emit the traces. Once this is done, the tracer automatically sends the traces to the appropriate `DD_AGENT_HOST` endpoint.
 
 [1]: /agent/cluster_agent/admission_controller/
 {{% /tab %}}
@@ -241,6 +170,52 @@ After configuring your Datadog Agent to collect traces and giving your applicati
 
 Refer to the [language-specific APM instrumentation docs][2] for more examples.
 
+## Additional configuration
+
+### Configure the Datadog Agent to accept traces over TCP
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+Update your `datadog-agent.yaml` with the following:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+
+  features:
+    apm:
+      enabled: true
+      hostPortConfig:
+        enabled: true
+        hostPort: 8126 # default
+```
+
+{{% k8s-operator-redeploy %}}
+
+**Warning**: The `hostPort` parameter opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources. If your network plugin doesn't support `hostPorts`, add `hostNetwork: true` in your Agent pod specifications. This shares the network namespace of your host with the Datadog Agent. This also means that all ports opened on the container are opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod does not start. Some Kubernetes installations do not allow this.
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+Update your `values.yaml` file with the following APM configuration:
+
+```yaml
+datadog:
+  apm:
+    portEnabled: true
+    port: 8126 # default
+```
+
+{{% k8s-helm-redeploy %}}
+
+**Warning**: The `datadog.apm.portEnabled` parameter opens a port on your host. Make sure your firewall only allows access from your applications or trusted sources. If your network plugin doesn't support `hostPorts`, add `hostNetwork: true` in your Agent pod specifications. This shares the network namespace of your host with the Datadog Agent. This also means that all ports opened on the container are opened on the host. If a port is used both on the host and in your container, they conflict (since they share the same network namespace) and the pod does not start. Some Kubernetes installations do not allow this.
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Agent environment variables
 
@@ -282,7 +257,7 @@ List of all environment variables available for tracing within the Agent running
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /agent/kubernetes/
+[1]: /containers/kubernetes/installation
 [2]: /tracing/setup/
 [3]: /getting_started/tagging/unified_service_tagging
 [4]: /tracing/configure_data_security#scrub-sensitive-data-from-your-spans
@@ -290,3 +265,5 @@ List of all environment variables available for tracing within the Agent running
 [6]: https://github.com/DataDog/docker-dd-agent#tracing-from-the-host
 [7]: https://docs.datadoghq.com/agent/docker/?tab=standard#environment-variables
 [8]: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+[9]: /tracing/guide/setting_up_apm_with_kubernetes_service/
+[10]: /tracing

--- a/content/en/containers/kubernetes/apm.md
+++ b/content/en/containers/kubernetes/apm.md
@@ -21,7 +21,7 @@ further_reading:
   text: "Assign tags to all data emitted by a container"
 ---
 
-This page describes how to setup and configure [Application Performance Monitoring (APM)][10] for your Kubernetes application.
+This page describes how to set up and configure [Application Performance Monitoring (APM)][10] for your Kubernetes application.
 
 {{< img src="tracing/visualization/troubleshooting_pipeline_kubernetes.png" alt="The APM troubleshooting pipeline: The tracer sends traces and metrics data from the application pod to the Agent pod, which sends it to the Datadog backend to be shown in the Datadog UI.">}}
 
@@ -38,7 +38,7 @@ The instructions in this section configure the Datadog Agent to receive traces o
 
 {{< tabs >}}
 {{% tab "Operator" %}}
-After you [use Operator to install the Datadog Agent][1], edit your `datadog-agent.yaml` to set `features.apm.enabled` to `true`.
+After you [use the Operator to install the Datadog Agent][1], edit your `datadog-agent.yaml` to set `features.apm.enabled` to `true`.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1

--- a/content/en/containers/kubernetes/configuration.md
+++ b/content/en/containers/kubernetes/configuration.md
@@ -38,7 +38,43 @@ After you have installed the Datadog Agent in your Kubernetes environment, you m
 
 ## Enable APM and tracing
 
-If you have installed Kubernetes using the Datadog Operator or Helm, **APM is enabled by default**.
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+Edit your `datadog-agent.yaml` to set `features.apm.enabled` to `true`.
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+
+  features:
+    apm:
+      enabled: true
+```
+
+{{% k8s-operator-redeploy %}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+In Helm, APM is **enabled by default** over UDS or Windows named pipe.
+
+To verify, ensure that `datadog.apm.socketEnabled` is set to `true` in your `values.yaml`.
+
+```yaml
+datadog:
+  apm:
+    socketEnabled: true    
+```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 For more information, see [Kubernetes Trace Collection][16].
 

--- a/layouts/shortcodes/k8s-helm-redeploy.md
+++ b/layouts/shortcodes/k8s-helm-redeploy.md
@@ -1,0 +1,7 @@
+After making your changes, upgrade your Datadog Helm chart using the following command: 
+
+```shell
+helm upgrade -f values.yaml <RELEASE NAME> datadog/datadog
+```
+
+If you did not set your operating system in `values.yaml`, add `--set targetSystem=linux` or `--set targetSystem=windows` to this command.

--- a/layouts/shortcodes/k8s-operator-redeploy.md
+++ b/layouts/shortcodes/k8s-operator-redeploy.md
@@ -1,0 +1,5 @@
+After making your changes, apply the new configuration by using the following command:
+
+```shell
+kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
+```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
There were some discrepancies in the instructions for enabling APM on helm/operator. This PR updates the K8s APM page, the K8s further configuration page, and the ol' legacy daemonset configuration guide. Also adds two shortcodes for reuse.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->