### PR TITLE
Change 'Count' example metric

### DIFF
--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -158,7 +158,7 @@ If you send `X` values for a DISTRIBUTION metric `<METRIC_NAME>` in a given time
 {{< tabs >}}
 {{% tab "COUNT" %}}
 
-Suppose you are submitting a COUNT metric, `activeusers.basket_size`, from a single host running the Datadog Agent. This host emits the following values in a flush time interval: `[1,1,1,2,2,2,3,3]`.
+Suppose you are submitting a COUNT metric, `notifications.sent`, from a single host running the Datadog Agent. This host emits the following values in a flush time interval: `[1,1,1,2,2,2,3,3]`.
 
 The Agent adds all of the values received in one time interval. Then, it submits the total number, in this case `15`, as the COUNT metric's value.
 


### PR DESCRIPTION
As proposed by a customer from https://datadog.zendesk.com/agent/tickets/1454373

They explained the following
"
It proposes emitting `activeusers.basket_size` as count, while the basket size can increase and decrease. Besides, computing the total of the emitted values for `activeusers.basket_size` doesn't add up to a number one'd find valuable/informative. Using this metric name for GAUGE would make sense.

Something like `notifications.sent` would be a correct and more intuitive example. "

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Changes the example metric for count type metrics from
'activeusers.basket_size' to 'notifications.sent'

This was at the request from a customer who believes this would be a more intuitive example. 
https://datadog.zendesk.com/agent/tickets/1454373

They explained the following
"
It proposes emitting `activeusers.basket_size` as count, while the basket size can increase and decrease. Besides, computing the total of the emitted values for `activeusers.basket_size` doesn't add up to a number one'd find valuable/informative. Using this metric name for GAUGE would make sense.

Something like `notifications.sent` would be a correct and more intuitive example. "

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->