### PR TITLE
Remove temporary callout for breaking ACA change

### DIFF
--- a/content/en/serverless/azure_app_services/azure_app_services_container.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_container.md
@@ -37,11 +37,6 @@ Images are tagged based on semantic versioning, with each new version receiving 
 
 * `1`, `1-alpine`: use these to track the latest minor releases, without breaking chagnes
 * `1.x.x`, `1.x.x-alpine`: use these to pin to a precise version of the library
-
-<div class="alert alert-info">
-The latest tag of /serverless-init will be applied to Beta9 through 9/1/2023 to provide additional time for Beta users to adjust and include the additional required `DD_AZURE_SUBSCRIPTION_ID` and `DD_RESOURCE_GROUP` variables
-</div>
-
 * `latest`, `latest-apline`: use these to follow the latest version release, which may include breaking changes
 
 {{< programming-lang-wrapper langs="nodejs,python,java,go,dotnet,ruby,php" >}}


### PR DESCRIPTION
Remove temporary callout re: tagged version related to breaking change in serverless-init 1.0

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->