### PR TITLE
adds CCM subcategory for search results display

### DIFF
--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -18,10 +18,10 @@ further_reading:
     tag: "Documentation"
     text: "Standardize tags across Cloud Cost with Tag Pipelines"
 cascade:
-    subcategory: 'Cloud Cost Management'
     algolia:
-        rank: 70
-        tags: ['cloud cost', 'cloud cost management', 'cloud cost aws', 'cloud cost azure', 'cloud cost google cloud', 'cloud cost gcp']
+      subcategory: 'Cloud Cost Management'
+      rank: 70
+      tags: ['cloud cost', 'cloud cost management', 'cloud cost aws', 'cloud cost azure', 'cloud cost google cloud', 'cloud cost gcp']
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -18,6 +18,7 @@ further_reading:
     tag: "Documentation"
     text: "Standardize tags across Cloud Cost with Tag Pipelines"
 cascade:
+    subcategory: 'Cloud Cost Management'
     algolia:
         rank: 70
         tags: ['cloud cost', 'cloud cost management', 'cloud cost aws', 'cloud cost azure', 'cloud cost google cloud', 'cloud cost gcp']


### PR DESCRIPTION
### What does this PR do? What is the motivation?
adds a `Cloud Cost Management` subcategory for display in the title hierarchy on search results.   [First mentioned in this slack thread](https://dd.slack.com/archives/C0DESMBQU/p1701277316279959?thread_ts=1701271042.707909&cid=C0DESMBQU).

[I've created a card](https://datadoghq.atlassian.net/browse/WEB-4324) to look into setting defaults for `subcategory` to avoid this kind of confusion in the future as well.

### Merge instructions
- [ ] Please merge after reviewing

### Additional notes
[In the preview site](https://docs-staging.datadoghq.com/brian.deutsch/ccm-subcategory-search/search/?s=azure), the second search result should specify `Cloud Cost Management`, as compared to [live](https://docs.datadoghq.com/search/?s=azure).   This feels a bit more descriptive.