### PR TITLE
document GA for exception profiling

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -144,7 +144,7 @@ in version `0.96.0`.
 `DD_PROFILING_EXCEPTION_SAMPLING_DISTANCE`
 : **INI**: `datadog.profiling.exception_sampling_distance`. INI available since `0.96.0`.<br>
 **Default**: `100`<br>
-Configure the sampling distance for exceptions. The higher the sampling distance, the fewer samples are created and the lower the overhead.
+Configure the sampling distance for exceptions. The higher the sampling distance, the fewer samples are created and the lower the overhead.<br><br>
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE` environment variable (`datadog.profiling.experimental_exception_sampling_distance` INI setting), which was available since `0.92`. If both are set, this one takes precedence.
 
 `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED`

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -134,15 +134,18 @@ Enable the allocation size and allocation bytes profile type. Added in version `
 **Default**: `1`<br>
 Enable the experimental CPU profile type. Added in version `0.69.0`. For version `0.76` and below it defaulted to `0`.
 
-`DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED`
-: **INI**: `datadog.profiling.experimental_exception_enabled`. INI available since `0.92.0`.<br>
+`DD_PROFILING_EXCEPTION_ENABLED`
+: **INI**: `datadog.profiling.exception_enabled`. INI available since `0.95.0`.<br>
 **Default**: `0`<br>
-Enable the experimental exception profile type. Added in version `0.92.0`.
+Enable the experimental exception profile type. Added in version `0.92.0` and GA
+in version `0.95.0`.
+**Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED` environment variable (`datadog.profiling.experimental_exception_enabled` INI setting), which was available since `0.92`. If both are set, this one takes precedence.
 
-`DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE`
-: **INI**: `datadog.profiling.experimental_exception_sampling_distance`. INI available since `0.92.0`.<br>
+`DD_PROFILING_EXCEPTION_SAMPLING_DISTANCE`
+: **INI**: `datadog.profiling.exception_sampling_distance`. INI available since `0.95.0`.<br>
 **Default**: `100`<br>
 Configure the sampling distance for exceptions. The higher the sampling distance, the fewer samples are created and the lower the overhead.
+**Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE` environment variable (`datadog.profiling.experimental_exception_sampling_distance` INI setting), which was available since `0.92`. If both are set, this one takes precedence.
 
 `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED`
 : **INI**: `datadog.profiling.experimental_timeline_enabled`. INI available since `0.89.0`.<br>

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -136,8 +136,8 @@ Enable the experimental CPU profile type. Added in version `0.69.0`. For version
 
 `DD_PROFILING_EXCEPTION_ENABLED`
 : **INI**: `datadog.profiling.exception_enabled`. INI available since `0.95.0`.<br>
-**Default**: `0`<br>
-Enable the experimental exception profile type. Added in version `0.92.0` and GA
+**Default**: `1`<br>
+Enable the exception profile type. Added in version `0.92.0` and GA
 in version `0.95.0`.
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED` environment variable (`datadog.profiling.experimental_exception_enabled` INI setting), which was available since `0.92`. If both are set, this one takes precedence.
 

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -135,14 +135,14 @@ Enable the allocation size and allocation bytes profile type. Added in version `
 Enable the experimental CPU profile type. Added in version `0.69.0`. For version `0.76` and below it defaulted to `0`.
 
 `DD_PROFILING_EXCEPTION_ENABLED`
-: **INI**: `datadog.profiling.exception_enabled`. INI available since `0.95.0`.<br>
+: **INI**: `datadog.profiling.exception_enabled`. INI available since `0.96.0`.<br>
 **Default**: `1`<br>
 Enable the exception profile type. Added in version `0.92.0` and GA
-in version `0.95.0`.
+in version `0.96.0`.
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED` environment variable (`datadog.profiling.experimental_exception_enabled` INI setting), which was available since `0.92`. If both are set, this one takes precedence.
 
 `DD_PROFILING_EXCEPTION_SAMPLING_DISTANCE`
-: **INI**: `datadog.profiling.exception_sampling_distance`. INI available since `0.95.0`.<br>
+: **INI**: `datadog.profiling.exception_sampling_distance`. INI available since `0.96.0`.<br>
 **Default**: `100`<br>
 Configure the sampling distance for exceptions. The higher the sampling distance, the fewer samples are created and the lower the overhead.
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE` environment variable (`datadog.profiling.experimental_exception_sampling_distance` INI setting), which was available since `0.92`. If both are set, this one takes precedence.

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -138,7 +138,7 @@ Enable the experimental CPU profile type. Added in version `0.69.0`. For version
 : **INI**: `datadog.profiling.exception_enabled`. INI available since `0.96.0`.<br>
 **Default**: `1`<br>
 Enable the exception profile type. Added in version `0.92.0` and GA
-in version `0.96.0`.
+in version `0.96.0`.<br><br>
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED` environment variable (`datadog.profiling.experimental_exception_enabled` INI setting), which was available since `0.92`. If both are set, this one takes precedence.
 
 `DD_PROFILING_EXCEPTION_SAMPLING_DISTANCE`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

PHP Exception profiling will be GA with the next release (0.96.0) and the docs should reflect this
PROF-8429

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->