### PR TITLE
[SCI] Fix Ruby containers instructions

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -244,6 +244,8 @@ If you are using a host, configure your application with `DD_GIT_*` environment 
 {{% /tab %}}
 {{% tab "Ruby" %}}
 
+<div class="alert alert-info">The Ruby client library version 1.6.0 or later is required.</div>
+
 #### Containers
 
 If you are using Docker containers, you have two options: using Docker or configuring your application with the `DD_TAGS` environment variable.

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -250,7 +250,7 @@ If you are using Docker containers, you have two options: using Docker or config
 
 ##### Option 1: Docker
 
-{{% sci-docker %}}
+{{% sci-docker-ddtags %}}
 
 ##### Option 2: `DD_TAGS` Environment Variable
 
@@ -442,7 +442,7 @@ You can see links from errors in your Lambda functions' associated stack traces 
 2. Click on a Lambda function and click the **Open Trace** button for an invocation with an associated stack trace.
 3. Click **View Code** to open the error in its source code repository.
 
-If you're using the GitHub integration, click **Connect to preview** on error frames. You can see inline code snippets directly in the Lambda function's stack trace. 
+If you're using the GitHub integration, click **Connect to preview** on error frames. You can see inline code snippets directly in the Lambda function's stack trace.
 
 {{< img src="integrations/guide/source_code_integration/serverless-aws-function-errors.mp4" alt="Link to GitHub from Serverless Monitoring" video="true" >}}
 
@@ -472,7 +472,7 @@ You can see links from errors in your security signals' associated stack traces 
 2. Scroll down to the **Traces** section on the **Related Signals** tab and click on an associated stack trace.
 3. Click **View Code** to open the error in its source code repository.
 
-If you're using the GitHub integration, click **Connect to preview** on error frames. You can see inline code snippets directly in the security signal's stack trace. 
+If you're using the GitHub integration, click **Connect to preview** on error frames. You can see inline code snippets directly in the security signal's stack trace.
 
 {{< img src="integrations/guide/source_code_integration/asm-signal-trace-blur.png" alt="Link to GitHub from Application Security Monitoring" style="width:100%;">}}
 

--- a/layouts/shortcodes/sci-docker-ddtags.md
+++ b/layouts/shortcodes/sci-docker-ddtags.md
@@ -1,0 +1,16 @@
+1. Add the following lines to your application's Dockerfile:
+
+   ```go
+   ARG DD_GIT_REPOSITORY_URL
+   ARG DD_GIT_COMMIT_SHA
+   ENV DD_TAGS="git.repository_url:${DD_GIT_REPOSITORY_URL},git.commit.sha:${DD_GIT_COMMIT_SHA}"
+   ```
+
+1. Add the following arguments to your Docker build command:
+
+   ```go
+   docker build . \
+    -t my-application \
+    --build-arg DD_GIT_REPOSITORY_URL=<git-provider.example/me/my-repo> \
+    --build-arg DD_GIT_COMMIT_SHA=$(git rev-parse HEAD)
+   ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This updates the Ruby SCI setup instructions with:
- the minimum tracer version required, 1.6.0
- a fix to the container setup instructions, since the Ruby tracer doesn't support DD_GIT_* env vars

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->