### PR TITLE
[DOCS-6854] Add Troubleshooting/Admission Controller doc

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -661,6 +661,11 @@ main:
     parent: containers_troubleshooting
     identifier: containers_troubleshooting_hpa
     weight: 804
+  - name: Admission Controller
+    url: containers/troubleshooting/admission-controller
+    parent: containers_troubleshooting
+    identifier: containers_troubleshooting_admission_controller
+    weight: 805
   - name: Guides
     url: containers/guide
     parent: containers

--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -188,7 +188,7 @@ Possible options:
 
 ## Troubleshooting
 
-There are a few common problems with the configuration aspects and networking rules with the Admission Controller. See the dedicated [Admission Controller Troubleshooting guide][6] for more details.
+See [Admission Controller Troubleshooting][6].
 
 ## Further Reading
 

--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -7,6 +7,9 @@ further_reading:
 - link: "/agent/cluster_agent/troubleshooting/"
   tag: "Documentation"
   text: "Troubleshooting the Datadog Cluster Agent"
+- link: "/containers/troubleshooting/admission-controller"
+  tag: "Documentation"
+  text: "Troubleshooting the Admission Controller"
 - link: "https://www.datadoghq.com/blog/auto-instrument-kubernetes-tracing-with-datadog/"
   tag: "Blog"
   text: "Use library injection to auto-instrument tracing for Kubernetes applications with Datadog APM"
@@ -185,22 +188,7 @@ Possible options:
 
 ## Troubleshooting
 
-- The Admission Controller needs to be deployed and configured before the creation of new application Pods. It cannot update Pods that already exist.
-
-  View the Cluster Agent logs to ensure the Admission Controller has started successfully. Observe the following `INFO` logs:
-
-```
-  <date/time> | CLUSTER | INFO | (pkg/clusteragent/admission/api_discovery.go:122 in useAdmissionV1) | Group version 'admissionregistration.k8s.io/v1' is available, using it
-  <date/time> | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/secret/controller.go:74 in Run) | Starting secrets controller for <namespace>/webhook-certificate
-  <date/time> | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/webhook/controller_v1.go:76 in Run) | Starting webhook
-```
-
-- To disable the Admission Controller injection feature, use the Cluster Agent configuration: `DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED=false`
-- By using the Datadog Admission Controller, users can skip configuring the application Pods using downward API ([step 2 in Kubernetes Trace Collection setup][3]).
-- Private clusters need specific networking rules because Datadog's Admission Controller webhook receives requests on port `443` and directs to a service on port `8000`:
-    - In a GKE private cluster, you need to [add a firewall rule for the control plane][4]. By default, the network for the cluster should have a firewall rule named `gke-<CLUSTER_NAME>-master`. This rule's source filters match the cluster's control plane address range. Edit this firewall rule to allow ingress to the TCP port `8000`.
-    - In an EKS private cluster, you need to [add an inbound rule for the node security group][5], where the Datadog Cluster Agent is located. Edit this rule to allow TCP port `8000` with the `Source` referencing the cluster security group (automatically created by AWS corresponding to the EKS control plane).
-
+There are a few common problems with the configuration aspects and networking rules with the Admission Controller. See the dedicated [Admission Controller Troubleshooting guide][6] for more details.
 
 ## Further Reading
 
@@ -211,3 +199,4 @@ Possible options:
 [3]: https://docs.datadoghq.com/agent/kubernetes/apm/?tab=helm#setup
 [4]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
 [5]: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html#security-group-rule-components
+[6]: /containers/troubleshooting/admission-controller

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -172,7 +172,7 @@ In EKS clusters the Cluster Agent pod can be deployed on any of your Linux based
 
 You can use a "Port Range" as long as this covers the `8000` port and required "Source" Security Group. If you have multiple Managed Node Groups with distinct Security Groups in each, ensure this inbound connectivity is added to each.
 
-Within EKS you can additionally turn on the [EKS Control Plane Logging for the “API server”][7].
+Within EKS you can additionally turn on the [EKS Control Plane Logging for the "API server"][7].
 
 Once this is enabled delete one of your pods to re-trigger a request through the Admission Controller. If the request fails from the networking perspective you should see logs in your AWS CloudWatch log group and log stream(s) for this cluster like:
 
@@ -223,7 +223,7 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 {{< /tabs >}}
 
 #### GKE
-If you are using a [GKE *Private* Cluster this restricts the request][9] to Cluster Agent pod by default. You need to add a firewall rule to allow the inbound access from the control plane to this port. By default, the network for the cluster should have a firewall rule named `gke-<CLUSTER_NAME>-master`. This rule’s source filters should match the cluster’s "Control plane address range" found in the "Networking" section. Edit this firewall rule to allow ingress to the `TCP` protocol and port `8000`.
+If you are using a [GKE *Private* Cluster this restricts the request][9] to Cluster Agent pod by default. You need to add a firewall rule to allow the inbound access from the control plane to this port. By default, the network for the cluster should have a firewall rule named `gke-<CLUSTER_NAME>-master`. This rule's source filters should match the cluster's "Control plane address range" found in the "Networking" section. Edit this firewall rule to allow ingress to the `TCP` protocol and port `8000`.
 
 #### Rancher
 

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -1,0 +1,43 @@
+---
+title: Troubleshooting Admission Controller
+kind: documentation
+further_reading:
+- link: "https://www.datadoghq.com/blog/auto-instrument-kubernetes-tracing-with-datadog/"
+  tag: "Blog"
+  text: "Auto Instrument Kubernetes Tracing"
+- link: "/containers/cluster_agent/admission_controller/"
+  tag: "Documentation"
+  text: "Cluster Agent Admission Controller"
+- link: "/tracing/trace_collection/library_injection_local/?tab=kubernetes"
+  tag: "Documentation"
+  text: "Kubernetes Library Injection"
+---
+
+## Common problems
+
+### Labels and Annotations
+
+### Order
+
+## Review cluster agent logs and status
+
+### Admission controller status
+
+### Admission controller logs
+
+## Networking
+
+### Network policies
+
+### Kubernetes distributions
+
+#### EKS
+
+#### AKS
+
+#### GKE
+
+#### OpenShift
+
+#### Rancher
+

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -18,7 +18,7 @@ The [Cluster Agent's Admission Controller][1] feature helps setup APM in Kuberne
 ## Common problems
 
 ### Order
-The Admission Controller responds to the creation of new pods within your Kubernetes cluster. More specifically the Cluster Agent receives a request from Kubernetes at pod creation, and responds with the details of what changes to make to the pod. 
+The Admission Controller responds to the creation of new pods within your Kubernetes cluster. More specifically the Cluster Agent receives a request from Kubernetes at pod creation, and responds with the details of what changes (if any) to make to the pod.
 
 This does mean that the Admission Controller does not mutate existing pods within your cluster. If you have recently enabled the Admission Controller or made other environmental changes, you can delete your existing pod and let Kubernetes re-create it to verify if the Admission Controller has updated your pod. 
 
@@ -91,9 +91,9 @@ The above output is relative to the Cluster Agent deployed in the `default` name
 
 ### Admission controller logs
 
-It can be helpful to [enable debug logging][3] for the Cluster Agent, especially at startup to validate it has setup the Admission Controller properly. With debug logging you would see logs like:
+It can be helpful to [enable debug logging][3] for the Cluster Agent, especially at startup to validate it has set up the Admission Controller properly. With debug logging you would see logs like:
 
-#### Discovery of datadog-webhook
+#### Reconciling the datadog-webhook
 ```
 <TIMESTAMP> | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/secret/controller.go:73 in Run) | Starting secrets controller for default/webhook-certificate
 <TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:148 in enqueue) | Adding object with key default/webhook-certificate to the queue
@@ -108,26 +108,26 @@ It can be helpful to [enable debug logging][3] for the Cluster Agent, especially
 
 If you are not seeing that the `datadog-webhook` has been reconciled successfully, double check that you have enabled the Admission Controller correctly relative to the [provided configurations][1]. 
 
-#### Processing a sample pod
+#### Processing an example pod
 
 ```
-<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:140 in enqueue) | Adding object with key default/webhook-certificate to the queue
-<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:211 in reconcile) | The certificate is up-to-date, doing nothing. Duration before expiration: 8558h12m28.007769373s
-<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:174 in processNextWorkItem) | Secret default/webhook-certificate reconciled successfully
-<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_TRACE_AGENT_URL' into pod with generate name example-pod-123456789-
-<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_DOGSTATSD_URL' into pod with generate name example-pod-123456789-
-<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_ENTITY_ID' into pod with generate name example-pod-123456789-
-<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_SERVICE' into pod with generate name example-pod-123456789-
-<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/auto_instrumentation.go:336 in injectLibInitContainer) | Injecting init container named "datadog-lib-python-init" with image "gcr.io/datadoghq/dd-lib-python-init:v1.18.0" into pod with generate name example-pod-123456789-
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:140 in enqueue) | Adding object with key default/webhook-certificate to the queue
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:211 in reconcile) | The certificate is up-to-date, doing nothing. Duration before expiration: 8558h12m28.007769373s
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:174 in processNextWorkItem) | Secret default/webhook-certificate reconciled successfully
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_TRACE_AGENT_URL' into pod with generate name example-pod-123456789-
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_DOGSTATSD_URL' into pod with generate name example-pod-123456789-
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_ENTITY_ID' into pod with generate name example-pod-123456789-
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_SERVICE' into pod with generate name example-pod-123456789-
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/auto_instrumentation.go:336 in injectLibInitContainer) | Injecting init container named "datadog-lib-python-init" with image "gcr.io/datadoghq/dd-lib-python-init:v1.18.0" into pod with generate name example-pod-123456789-
 ```
 
-The Cluster Agent will print debug logs when it is working with a given pod. If you are seeing errors with the injection for a given pod reach out to Datadog support with your Datadog configuration as well as your pod configuration. 
+The Cluster Agent prints debug logs when it is working with a given pod. If you are seeing errors with the injection for a given pod, reach out to Datadog support with your Datadog configuration as well as your pod configuration.
 
 If you are not seeing the injection attempts for *any pod* first double check your `mutateUnlabelled` settings and that your pod labels match up with the expected value. If these match up the issue is more likely with the networking between the control plane, webhook, and service.
 
 ## Networking
 
-When a pod is creating the Kubernetes cluster will send a request from the control plane, to the datadog-webhook, through the service, and finally to the Cluster Agent pod. This request requires inbound connectivity from the control plane to the node that the Cluster Agent is on, over its Admission Controller port (`8000`). Once resolved the Cluster Agent will mutate your pod to configure the connection for the Datadog tracer.
+When a pod is created the Kubernetes cluster sends a request from the control plane, to the datadog-webhook, through the service, and finally to the Cluster Agent pod. This request requires inbound connectivity from the control plane to the node that the Cluster Agent is on, over its Admission Controller port (`8000`). Once resolved the Cluster Agent mutates your pod to configure the network connection for the Datadog tracer.
 
 Depending on your Kubernetes distribution this may have some additional requirements for your security rules and Admission Controller settings.
 
@@ -135,7 +135,7 @@ Depending on your Kubernetes distribution this may have some additional requirem
 
 Kubernetes has the optional feature of [Network Policies][4]. These can take a few different forms between using the out-of-box resource (`NetworkPolicy`) or custom ones like [Cilium][5] (`CiliumNetworkPolicy`). These help control different Ingress (Inbound) and Egress (Outbound) flows of traffic to your pods.
 
-If you are using these features we recommend to create the corresponding policies for the Cluster Agent to ensure the connectivity to the pod over this port. This can be configured with the configurations below. When setting the below option you can also specify a flavor. The default is `kubernetes` and corresponds to the creation of `NetworkPolicy` resources, alternatively set the flavor to `cilium` to create the corresponding `CiliumNetworkPolicy` for Cilium based environments.
+If you are using these features we recommend creating the corresponding policies for the Cluster Agent to ensure the connectivity to the pod over this port. This can be configured with the configurations below. When setting the below option you can also specify a flavor. The default is `kubernetes` and corresponds to the creation of `NetworkPolicy` resources, alternatively set the flavor to `cilium` to create the corresponding `CiliumNetworkPolicy` for Cilium based environments.
 
 {{< tabs >}}
 {{% tab "Operator" %}}
@@ -172,7 +172,7 @@ You can use a "Port Range" as long as this covers the `8000` port and required "
 
 Within EKS you can additionally turn on the [EKS Control Plane Logging for the “API server”][7].
 
-Once this is enabled the delete one of your pods to re-trigger a request through the Admission Controller. If the request fail from the networking perspective you should see logs in your AWS CloudWatch log group and log stream(s) for this cluster like:
+Once this is enabled delete one of your pods to re-trigger a request through the Admission Controller. If the request fails from the networking perspective you should see logs in your AWS CloudWatch log group and log stream(s) for this cluster like:
 
 ```
 W0908 <TIMESTAMP> 10 dispatcher.go:202] Failed calling webhook, failing open datadog.webhook.auto.instrumentation: failed calling webhook "datadog.webhook.auto.instrumentation": failed to call webhook: Post "https://datadog-cluster-agent-admission-controller.default.svc:443/injectlib?timeout=10s": context deadline exceeded
@@ -181,10 +181,10 @@ E0908 <TIMESTAMP> 10 dispatcher.go:206] failed calling webhook "datadog.webhook.
 
 These failures were relative to a Cluster Agent deployed in the `default` namespace, the DNS name would adjust relative to your namespace used.
 
-You would see failures for the other the other Admission Controller webhooks such as as well such as `datadog.webhook.tags` and `datadodg.webhook.config`. **Note:** EKS often generates two log streams within the CloudWatch log group for the cluster. Be sure to check both for these types of logs.
+You would see failures for the other Admission Controller webhooks such as as well such as `datadog.webhook.tags` and `datadodg.webhook.config`. **Note:** EKS often generates two log streams within the CloudWatch log group for the cluster. Be sure to check both for these types of logs.
 
 #### AKS
-When creating the `datadog-webhook` for the `MutatingWebhookConfiguration` AKS will adjust the [format slightly to ensure you avoid the control-plane pods][8]. Provide the Cluster Agent the configuration below to ensure it can create and reconcile this format accordingly.
+When creating the `datadog-webhook` for the `MutatingWebhookConfiguration` AKS adjusts the [format slightly to ensure you avoid the control-plane pods][8]. Provide the Cluster Agent the configuration below to ensure it can create and reconcile this format accordingly.
 
 {{< tabs >}}
 {{% tab "Operator" %}}
@@ -221,13 +221,13 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 {{< /tabs >}}
 
 #### GKE
-If you are using a [GKE *Private* Cluster this restricts the flow of data][9] to the pod by default. You will need to add a firewal rule to allow the inbound access from the control plane to this port. By default, the network for the cluster should have a firewall rule named `gke-<CLUSTER_NAME>-master`. This rule’s source filters should match the cluster’s "Control plane address range" found in the "Networking" section. Edit this firewall rule to allow ingress to the `TCP` protocol and port `8000`.
+If you are using a [GKE *Private* Cluster this restricts the request][9] to Cluster Agent pod by default. You need to add a firewall rule to allow the inbound access from the control plane to this port. By default, the network for the cluster should have a firewall rule named `gke-<CLUSTER_NAME>-master`. This rule’s source filters should match the cluster’s "Control plane address range" found in the "Networking" section. Edit this firewall rule to allow ingress to the `TCP` protocol and port `8000`.
 
 #### Rancher
 
 There can be issues with Rancher depending on the underlying environment used. You can consult the [Rancher documentation][10] for a similar issue with the Rancher-Webhook (another Mutating Admission Controller) within GKE Private Clusters or EKS Clusters using the Calico CNI.
 
-In GKE Private clusters you can consult the [GKE steps above][#GKE] to add the corresponding firewall rule.
+In GKE Private clusters you can consult the [GKE steps above](#gke) to add the corresponding firewall rule.
 
 In EKS clusters you can similarly deploy the Cluster Agent pod with the `hostNetwork: true` setting to allow this connectivity.
 
@@ -257,22 +257,22 @@ clusterAgent:
 {{< /tabs >}}
 
 ## Application pods blocked
-The Helm and Operator setups by default will match Admission Controller's injection config mode (`socket`, `hostip`, `service`) relative to the APM receivers enabled. In other words if you have the (UDS) socket mode enabled in your Agent and the Host Port disabled, the Admission Controller should use the `socket` mode. Preferring `socket` over `hostip`. The default APM receiver in the Agent is the `socket` mode, so by default the default Admission Controller mode is also `socket`.
+The Helm and Operator setups by default match Admission Controller's injection config mode (`socket`, `hostip`, `service`) relative to the APM receivers enabled. In other words if you have the (UDS) socket mode enabled in your Agent and the Host Port disabled, the Admission Controller should use the `socket` mode. Preferring `socket` over `hostip`. The default APM receiver in the Agent is the `socket` mode, so by default the default Admission Controller mode is also `socket`.
 
 This injection mode may need to be tailored depending on your environment.
 
 ### GKE Autopilot
-GKE Autopilot restricts the use of any `volumes` with a `hostPath`. So if the Admission Controller is injecting the (UDS) `socket` the pods will be blocked from scheduling by the GKE Warden.
+GKE Autopilot restricts the use of any `volumes` with a `hostPath`. So if the Admission Controller injects the (UDS) `socket` the pods get blocked from scheduling by the GKE Warden.
 
-This setup is typically blocked when setting your Helm configuration in to GKE Autopilot mode (`providers.gke.autpilot=true`). However, be sure you are not explicitly attempting to override the configuration to use the `socket` mode when in GKE Autopilot. Instead use the `hostip` mode (the default) or `service` mode.
+This setup is typically blocked when setting your Helm configuration into GKE Autopilot mode (`providers.gke.autpilot=true`). However, be sure you are not explicitly attempting to override the configuration to use the `socket` mode when in GKE Autopilot. Instead use the `hostip` mode (the default) or `service` mode.
 
 ### OpenShift
-In OpenShift there are `SecurityContextConstraints` (SCC) that are required to deploy pods with extra permissions, such as a `volume` using a `hostPath`. As we deploy our Datadog components we deploy SCCs to allow this activity specific to the Datadog pods, however we do not create SCCs for other pods. This can cause issues if the `socket` mode is used, as it will inject a `volume` with a `hostPath` into these other pods, which will make them forbidden from being deployed as they are unable to validate against any security context constraint.
+In OpenShift there are `SecurityContextConstraints` (SCC) that are required to deploy pods with extra permissions, such as a `volume` using a `hostPath`. We deploy our Datadog components with SCCs to allow this activity specific to the Datadog pods, however we do not create SCCs for other pods. This can cause issues if the `socket` mode is used, as it injects a `volume` with a `hostPath` into these other pods. This makes them forbidden from being deployed as they are unable to validate against any security context constraint.
 
 With this in mind in OpenShift you can use either:
 
 #### Port option
-The port option enables the `hostPort` in your Agent pod and injects the `hostip` configuration into your appliction pods. This is a "safe" configuration and should not be forbidden within your security contexts.
+The port option enables the `hostPort` in your Agent pod and injects the `hostip` configuration into your application pods. This is a "safe" configuration and should not be forbidden within your security contexts.
 
 {{< tabs >}}
 {{% tab "Operator" %}}
@@ -302,7 +302,7 @@ datadog:
 {{< /tabs >}}
 
 #### Socket option
-If you would like to use the (UDS) `socket` option for connectivity, you will need to [create a custom SCC][11] for your application pods and the Service Accounts that they are using. This SCC needs to allow the `volumes` of the type `hostPath`. For example:
+If you would like to use the (UDS) `socket` option for connectivity, you need to [create a custom SCC][11] for your application pods and the Service Accounts that they are using. This SCC needs to allow the `volumes` of the type `hostPath`. For example:
 
 ```yaml
 kind: SecurityContextConstraints

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -13,11 +13,35 @@ further_reading:
   text: "Kubernetes Library Injection"
 ---
 
+The [Cluster Agent's Admission Controller][1] feature helps setup APM in Kubernetes between [Library Injection][2], APM Configuration, and Unified Service Tagging. The document below can help diagnose common problems with the Admission Controller setup and networking requirements. 
+
 ## Common problems
 
-### Labels and Annotations
-
 ### Order
+The Admission Controller responds to the creation of new pods within your Kubernetes cluster. More specifically the Cluster Agent receives a request from Kubernetes at pod creation, and responds with the details of what changes to make to the pod. 
+
+This does mean that the Admission Controller does not mutate existing pods within your cluster. If you have recently enabled the Admission Controller or made other environmental changes, you can delete your existing pod and let Kubernetes re-create it to verify if the Admission Controller has updated your pod. 
+
+### Labels and Annotations
+The Cluster Agent responds to labels and annotations on the created pod, not the workload (Deployment, DaemonSet, CronJob, etc) that created that pod. Be sure to double check that your pod template references this accordingly. For example:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-deployment
+spec:
+  #(...)  
+  template:
+    metadata:
+      labels:
+        admission.datadoghq.com/enabled: "true"
+      annotations:
+        admission.datadoghq.com/<LANGUAGE>-lib.version: <VERSION>
+    spec:
+      containers:
+      #(...)
+```
 
 ## Review cluster agent logs and status
 
@@ -41,3 +65,5 @@ further_reading:
 
 #### Rancher
 
+[1]: /containers/cluster_agent/admission_controller
+[2]: /tracing/trace_collection/library_injection_local/?tab=kubernetes"

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -316,6 +316,10 @@ volumes:
 - hostPath
 ```
 
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
 [1]: /containers/cluster_agent/admission_controller
 [2]: /tracing/trace_collection/library_injection_local/?tab=kubernetes
 [3]: /agent/troubleshooting/debug_mode/

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -46,8 +46,84 @@ spec:
 ## Review cluster agent logs and status
 
 ### Admission controller status
+The Cluster Agent's status output provides information to verify that it has created the `datadog-webhook` for the `MutatingWebhookConfiguration` and has a valid certificate.
+
+```
+% kubectl exec -it <Cluster Agent Pod> -- agent status
+...
+Admission Controller
+====================
+  
+    Webhooks info
+    -------------
+      MutatingWebhookConfigurations name: datadog-webhook
+      Created at: 2023-09-25T22:32:07Z
+      ---------
+        Name: datadog.webhook.auto.instrumentation
+        CA bundle digest: f24b6c0c40feaad2
+        Object selector: &LabelSelector{MatchLabels:map[string]string{admission.datadoghq.com/enabled: true,},MatchExpressions:[]LabelSelectorRequirement{},}
+        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
+        Service: default/datadog-admission-controller - Port: 443 - Path: /injectlib
+      ---------
+        Name: datadog.webhook.config
+        CA bundle digest: f24b6c0c40feaad2
+        Object selector: &LabelSelector{MatchLabels:map[string]string{admission.datadoghq.com/enabled: true,},MatchExpressions:[]LabelSelectorRequirement{},}
+        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
+        Service: default/datadog-admission-controller - Port: 443 - Path: /injectconfig
+      ---------
+        Name: datadog.webhook.tags
+        CA bundle digest: f24b6c0c40feaad2
+        Object selector: &LabelSelector{MatchLabels:map[string]string{admission.datadoghq.com/enabled: true,},MatchExpressions:[]LabelSelectorRequirement{},}
+        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
+        Service: default/datadog-admission-controller - Port: 443 - Path: /injecttags
+  
+    Secret info
+    -----------
+    Secret name: webhook-certificate
+    Secret namespace: default
+    Created at: 2023-09-25T22:32:07Z
+    CA bundle digest: f24b6c0c40feaad2
+    Duration before certificate expiration: 8643h34m2.557676864s
+...
+```
+
+The above output is relative to the Cluster Agent deployed in the `default` namespace. The Service and Secret should match your corresponding namespace.
 
 ### Admission controller logs
+
+It can be helpful to [enable debug logging][3] for the Cluster Agent, especially at startup to validate it has setup the Admission Controller properly. With debug logging you would see logs like:
+
+#### Discovery of datadog-webhook
+```
+<TIMESTAMP> | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/secret/controller.go:73 in Run) | Starting secrets controller for default/webhook-certificate
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:148 in enqueue) | Adding object with key default/webhook-certificate to the queue
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:140 in enqueue) | Adding object with key default/webhook-certificate to the queue
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:148 in enqueue) | Adding object with key datadog-webhook to the queue
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/util/kubernetes/apiserver/util.go:47 in func1) | Sync done for informer admissionregistration.k8s.io/v1/mutatingwebhookconfigurations in 101.116625ms, last resource version: 152728
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/webhook/controller_v1.go:140 in reconcile) | The Webhook datadog-webhook was found, updating it
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:211 in reconcile) | The certificate is up-to-date, doing nothing. Duration before expiration: 8558h17m27.909792831s
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:174 in processNextWorkItem) | Secret default/webhook-certificate reconciled successfully
+<TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:176 in processNextWorkItem) | Webhook datadog-webhook reconciled successfully
+```
+
+If you are not seeing that the `datadog-webhook` has been reconciled successfully, double check that you have enabled the Admission Controller correctly relative to the [provided configurations][1]. 
+
+#### Processing a sample pod
+
+```
+<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:140 in enqueue) | Adding object with key default/webhook-certificate to the queue
+<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:211 in reconcile) | The certificate is up-to-date, doing nothing. Duration before expiration: 8558h12m28.007769373s
+<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:174 in processNextWorkItem) | Secret default/webhook-certificate reconciled successfully
+<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_TRACE_AGENT_URL' into pod with generate name example-pod-123456789-
+<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_DOGSTATSD_URL' into pod with generate name example-pod-123456789-
+<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_ENTITY_ID' into pod with generate name example-pod-123456789-
+<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/common.go:74 in injectEnv) | Injecting env var 'DD_SERVICE' into pod with generate name example-pod-123456789-
+<TIMESTAMP>  | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/auto_instrumentation.go:336 in injectLibInitContainer) | Injecting init container named "datadog-lib-python-init" with image "gcr.io/datadoghq/dd-lib-python-init:v1.18.0" into pod with generate name example-pod-123456789-
+```
+
+The Cluster Agent will print debug logs when it is working with a given pod. If you are seeing errors with the injection for a given pod reach out to Datadog support with your Datadog configuration as well as your pod configuration. 
+
+If you are not seeing the injection attempts for *any pod* first double check your `mutateUnlabelled` settings and that your pod labels match up with the expected value. If these match up the issue is more likely with the networking between the Control Plane, Webhook, and Service.
 
 ## Networking
 
@@ -66,4 +142,5 @@ spec:
 #### Rancher
 
 [1]: /containers/cluster_agent/admission_controller
-[2]: /tracing/trace_collection/library_injection_local/?tab=kubernetes"
+[2]: /tracing/trace_collection/library_injection_local/?tab=kubernetes
+[3]: /agent/troubleshooting/debug_mode/

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -47,7 +47,7 @@ spec:
       #(...)
 ```
 
-### Application pods are blocked
+### Application pods are not created
 
 Admission Controller's injection mode (`socket`, `hostip`, `service`) is set by the configuration of your Cluster Agent. For example, if you have `socket` mode enabled in your Agent, Admission Controller also uses `socket` mode.
 
@@ -57,34 +57,24 @@ If you are using GKE Autopilot or OpenShift, you need to use a specific injectio
 
 GKE Autopilot restricts the use of any `volumes` with a `hostPath`. Therefore, if Admission Controller uses `socket` mode, the Pods are blocked from scheduling by the GKE Warden.
 
-If you are using GKE Autopilot, use `hostip` or `service` mode. The following configuration enables `hostip` mode:
+Enabling GKE Autopilot mode in the Helm chart disables the `socket` mode to prevent this from ocurring. To enable APM, enable the port and use the `hostip` or `service` method instead. The Admission Controller will default to `hostip` to match.
 
 {{< tabs >}}
-{{% tab "Datadog Operator" %}}
-```yaml
-apiVersion: datadoghq.com/v2alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  features:
-    apm:
-      enabled: true
-      hostPortConfig:
-        enabled: true
-      unixDomainSocketConfig:
-        enabled: false
-```
-{{% /tab %}}
 {{% tab "Helm" %}}
 ```yaml
 datadog:
   apm:
     portEnabled: true
-    socketEnabled: false
+  #(...)
+
+providers:
+  gke:
+    autopilot: true
 ```
 {{% /tab %}}
 {{< /tabs >}}
+
+Refer to the [Kubernetes Distributions][17] for more configuration details regarding Autopilot.
 
 #### OpenShift
 
@@ -118,6 +108,8 @@ datadog:
 ```
 {{% /tab %}}
 {{< /tabs >}}
+
+Refer to the [Kubernetes Distributions][18] for more configuration details regarding Autopilot.
 
 ## View Admission Controller status
 
@@ -416,3 +408,5 @@ To use Rancher in a private GKE cluster, edit your firewall rules to allow inbou
 [14]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#step_1_view_control_planes_cidr_block
 [15]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
 [16]: https://ranchermanager.docs.rancher.com/reference-guides/rancher-webhook#common-issues
+[17]: /containers/kubernetes/distributions/#autopilot
+[18]: /containers/kubernetes/distributions/#Openshift

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -13,17 +13,21 @@ further_reading:
   text: "Kubernetes Library Injection"
 ---
 
-The [Cluster Agent's Admission Controller][1] feature helps setup APM in Kubernetes between [Library Injection][2], APM Configuration, and Unified Service Tagging. The document below can help diagnose common problems with the Admission Controller setup and networking requirements. 
+## Overview
+
+This page provides troubleshooting for the Datadog Cluster Agent's [Admission Controller][1].
 
 ## Common problems
 
-### Order
-The Admission Controller responds to the creation of new pods within your Kubernetes cluster. More specifically the Cluster Agent receives a request from Kubernetes at pod creation, and responds with the details of what changes (if any) to make to the pod.
+### Update pre-existing pods
+Admission Controller responds to the creation of new pods within your Kubernetes cluster: at pod creation, the Cluster Agent receives a request from Kubernetes and responds with the details of what changes (if any) to make to the pod.
 
-This does mean that the Admission Controller does not mutate existing pods within your cluster. If you have recently enabled the Admission Controller or made other environmental changes, you can delete your existing pod and let Kubernetes re-create it to verify if the Admission Controller has updated your pod. 
+Therefore, **Admission Controller does not mutate existing pods within your cluster**. If you recently enabled the Admission Controller or made other environmental changes, delete your existing pod and let Kubernetes recreate it. This ensures that Admission Controller updates your pod. 
 
-### Labels and Annotations
-The Cluster Agent responds to labels and annotations on the created pod, not the workload (Deployment, DaemonSet, CronJob, etc) that created that pod. Be sure to double check that your pod template references this accordingly. For example:
+### Labels and annotations
+The Cluster Agent responds to labels and annotations on the created pod—**not** the workload (Deployment, DaemonSet, CronJob, etc.) that created that pod. Ensure that your pod template references this accordingly. 
+
+For example, the following template sets the [label for APM configuration][2] and the [annotation for library injection][3]:
 
 ```yaml
 apiVersion: apps/v1
@@ -43,15 +47,91 @@ spec:
       #(...)
 ```
 
-This sets the [label for APM configuration][11] as well as the [annotation for library injection][2].
+### Application pods are blocked
 
-## Review cluster agent logs and status
+Admission Controller's injection mode (`socket`, `hostip`, `service`) is set by the configuration of your Cluster Agent. For example, if you have `socket` mode enabled in your Agent, Admission Controller also uses `socket` mode.
 
-### Admission controller status
+If you are using GKE Autopilot or OpenShift, you need to use a specific injection mode.
+
+#### GKE Autopilot
+
+GKE Autopilot restricts the use of any `volumes` with a `hostPath`. Therefore, if Admission Controller uses `socket` mode, the Pods are blocked from scheduling by the GKE Warden.
+
+If you are using GKE Autopilot, use `hostip` or `service` mode. The following configuration enables `hostip` mode:
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  features:
+    apm:
+      enabled: true
+      hostPortConfig:
+        enabled: true
+      unixDomainSocketConfig:
+        enabled: false
+```
+{{% /tab %}}
+{{% tab "Helm" %}}
+```yaml
+datadog:
+  apm:
+    portEnabled: true
+    socketEnabled: false
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+#### OpenShift
+
+OpenShift has `SecurityContextConstraints` (SCCs) that are required to deploy pods with extra permissions, such as a `volume` with a `hostPath`. Datadog components are deployed with SCCs to allow activity specific to Datadog pods, but Datadog does not create SCCs for other pods. 
+
+If you are using OpenShift, use `hostip` mode. The following configuration enables `hostip` mode:
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  features:
+    apm:
+      enabled: true
+      hostPortConfig:
+        enabled: true
+      unixDomainSocketConfig:
+        enabled: false
+```
+{{% /tab %}}
+{{% tab "Helm" %}}
+```yaml
+datadog:
+  apm:
+    portEnabled: true
+    socketEnabled: false
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+## View Admission Controller status
+
 The Cluster Agent's status output provides information to verify that it has created the `datadog-webhook` for the `MutatingWebhookConfiguration` and has a valid certificate.
 
-```
+Run the following command:
+
+```bash
 % kubectl exec -it <Cluster Agent Pod> -- agent status
+```
+
+Your output resembles the following:
+
+```
 ...
 Admission Controller
 ====================
@@ -89,13 +169,43 @@ Admission Controller
 ...
 ```
 
-The above output is relative to the Cluster Agent deployed in the `default` namespace. The Service and Secret should match your corresponding namespace used.
+This output is relative to the Cluster Agent deployed in the `default` namespace. The `Service` and `Secret` should match the namespace used.
 
-### Admission controller logs
+## View Admission Controller logs
 
-It can be helpful to [enable debug logging][3] for the Cluster Agent, especially at startup to validate it has set up the Admission Controller properly. With debug logging you would see logs like:
+Debug logs help validate that you have set up Admission Controller properly. [Enable debug logs][3] with the following configuration:
 
-#### Reconciling the datadog-webhook
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+    site: <DATADOG_SITE>
+    logLevel: debug
+```
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+```yaml
+datadog:
+  logLevel: debug
+```
+
+{{% /tab %}}
+{{< /tabs >}}
+
+### Validate `datadog-webhook`
+
+**Example logs**:
+
 ```
 <TIMESTAMP> | CLUSTER | INFO | (pkg/clusteragent/admission/controllers/secret/controller.go:73 in Run) | Starting secrets controller for default/webhook-certificate
 <TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:148 in enqueue) | Adding object with key default/webhook-certificate to the queue
@@ -108,9 +218,11 @@ It can be helpful to [enable debug logging][3] for the Cluster Agent, especially
 <TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/webhook/controller_base.go:176 in processNextWorkItem) | Webhook datadog-webhook reconciled successfully
 ```
 
-If you are not seeing that the `datadog-webhook` has been reconciled successfully, double check that you have enabled the Admission Controller correctly relative to the [provided configurations][1]. 
+If do not see that the `datadog-webhook` webhook has been reconciled successfully, ensure that you have correctly enabled Admission Controller according to the [configuration instructions][1]. 
 
-#### Processing an example pod
+### Validate injection
+
+**Example logs**:
 
 ```
 <TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/controllers/secret/controller.go:140 in enqueue) | Adding object with key default/webhook-certificate to the queue
@@ -123,24 +235,20 @@ If you are not seeing that the `datadog-webhook` has been reconciled successfull
 <TIMESTAMP> | CLUSTER | DEBUG | (pkg/clusteragent/admission/mutate/auto_instrumentation.go:336 in injectLibInitContainer) | Injecting init container named "datadog-lib-python-init" with image "gcr.io/datadoghq/dd-lib-python-init:v1.18.0" into pod with generate name example-pod-123456789-
 ```
 
-The Cluster Agent prints debug logs when it is working with a given pod. If you are seeing errors with the injection for a given pod, reach out to Datadog support with your Datadog configuration as well as your pod configuration.
+If you see errors with the injection for a given pod, contact Datadog support with your Datadog configuration and your pod configuration.
 
-If you are not seeing the injection attempts for *any pod* first double check your `mutateUnlabelled` settings and that your pod labels match up with the expected value. If these match up the issue is more likely with the networking between the control plane, webhook, and service.
+If you do not see the injection attempts for *any* pod, verify your `mutateUnlabelled` settings and ensure your pod labels match up with the expected values. If these match up, your problem is likely with the networking between the control plane, webhook, and service. See [Networking](#networking) for further information.
 
 ## Networking
 
-When a pod is created the Kubernetes cluster sends a request from the control plane, to the datadog-webhook, through the service, and finally to the Cluster Agent pod. This request requires inbound connectivity from the control plane to the node that the Cluster Agent is on, over its Admission Controller port (`8000`). Once resolved the Cluster Agent mutates your pod to configure the network connection for the Datadog tracer.
-
-Depending on your Kubernetes distribution this may have some additional requirements for your security rules and Admission Controller settings.
-
 ### Network policies
 
-Kubernetes has the optional feature of [Network Policies][4]. These can take a few different forms between using the out-of-box resource (`NetworkPolicy`) or custom ones like [Cilium][5] (`CiliumNetworkPolicy`). These help control different Ingress (Inbound) and Egress (Outbound) flows of traffic to your pods.
+Kubernetes [Network Policies][5] help you control different ingress (inbound) and egress (outbound) flows of traffic to your pods.
 
-If you are using network policies we recommend creating the corresponding policies for the Cluster Agent to ensure the connectivity to the pod over this port. This can be configured with the configurations below. When setting the below option you can also specify a flavor. The default is `kubernetes` and corresponds to the creation of `NetworkPolicy` resources, alternatively set the flavor to `cilium` to create the corresponding `CiliumNetworkPolicy` for Cilium based environments.
+If you are using network policies, Datadog recommends creating corresponding policies for the Cluster Agent to ensure connectivity to the pod over this port. You can do this with the following configuration:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
@@ -165,31 +273,50 @@ datadog:
 {{% /tab %}}
 {{< /tabs >}}
 
-### Kubernetes distributions
+Set `flavor` to `kubernetes` to create a `NetworkPolicy` resource. 
 
-#### EKS
-In EKS clusters the Cluster Agent pod can be deployed on any of your Linux based nodes by default. These nodes and their EC2 instances need to have a [Security Group which has an Inbound Rule][6] that allows access over the `TCP` protocol, port `8000`, and the "Source" matching *either* the Cluster Security Group or one of the Additional Security Groups of the EKS cluster. These security groups can be found on the EKS cluster's "Networking" page. This gives access for the Control Plane to access the node and the downstream Cluster Agent over its port `8000`.
+Alternatively, for Cilium-based environments, set `flavor` to `cilium` to create a `CiliumNetworkPolicy` resource.
 
-You can use a "Port Range" as long as this covers the `8000` port and required "Source" Security Group. If you have multiple Managed Node Groups with distinct Security Groups in each, ensure this inbound connectivity is added to each.
+### Network troubleshooting for Kubernetes distributions
 
-Within EKS you can additionally turn on the [EKS Control Plane Logging for the "API server"][7].
+When a pod is created, the Kubernetes cluster sends a request from the control plane, to `datadog-webhook`, through the service, and finally to the Cluster Agent pod. This request requires inbound connectivity from the control plane to the node that the Cluster Agent is on, over its Admission Controller port (`8000`). After this request is resolved, the Cluster Agent mutates your pod to configure the network connection for the Datadog tracer.
 
-Once this is enabled delete one of your pods to re-trigger a request through the Admission Controller. If the request fails from the networking perspective you should see logs in your AWS CloudWatch log group and log stream(s) for this cluster like:
+Depending on your Kubernetes distribution, this may have some additional requirements for your security rules and Admission Controller settings.
+
+#### Amazon Elastic Kubernetes Service (EKS)
+
+In an EKS cluster, you can deploy the Cluster Agent pod on any of your Linux-based nodes by default. These nodes and their EC2 instances need a [security group][6] with the following [inbound rule][7]:
+- **Protocol**: TCP
+- **Port range**: `8000`, or a range that covers `8000`
+- **Source**: The ID of _either_ the cluster security group, or one of your cluster's additional security groups. You can find these IDs in the EKS console, under the _Networking_ tab for your EKS cluster.
+
+This security group rule allows the control plane to access the node and the downstream Cluster Agent over port `8000`.
+
+If you have multiple [managed node groups][8], each with distinct security groups, add this inbound rule to each security group.
+
+##### Control plane logging
+
+To validate your networking configuration, enable [EKS control plane logging][9] for the API server. You can view these logs in the [CloudWatch console][10].
+
+Then, delete one of your pods to re-trigger a request through Admission Controller. When the request fails, you can view logs that resemble the following:
 
 ```
 W0908 <TIMESTAMP> 10 dispatcher.go:202] Failed calling webhook, failing open datadog.webhook.auto.instrumentation: failed calling webhook "datadog.webhook.auto.instrumentation": failed to call webhook: Post "https://datadog-cluster-agent-admission-controller.default.svc:443/injectlib?timeout=10s": context deadline exceeded
 E0908 <TIMESTAMP> 10 dispatcher.go:206] failed calling webhook "datadog.webhook.auto.instrumentation": failed to call webhook: Post "https://datadog-cluster-agent-admission-controller.default.svc:443/injectlib?timeout=10s": context deadline exceeded
 ```
 
-These failures were relative to a Cluster Agent deployed in the `default` namespace, the DNS name would adjust relative to your namespace used.
+These failures are relative to a Cluster Agent deployed in the `default` namespace; the DNS name adjusts relative to the namespace used.
 
-You would generally also see failures for the other Admission Controller webhooks, such as `datadog.webhook.tags` and `datadodg.webhook.config`. **Note:** EKS often generates two log streams within the CloudWatch log group for the cluster. Be sure to check both for these types of logs.
+You may also see failures for the other Admission Controller webhooks, such as `datadog.webhook.tags` and `datadodg.webhook.config`. 
 
-#### AKS
-When creating the `datadog-webhook` for the `MutatingWebhookConfiguration` AKS adjusts the [format slightly to ensure you avoid the control-plane pods][8]. Provide the Cluster Agent the configuration below to ensure it can create and reconcile this format accordingly.
+**Note:** EKS often generates two log streams within the CloudWatch log group for the cluster. Be sure to check both for these types of logs.
+
+#### Azure Kubernetes Service (AKS)
+
+To use [admission controller webhooks on AKS][11], use the following configuration:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 ```yaml
 kind: DatadogAgent
@@ -218,23 +345,29 @@ providers:
     enabled: true
 ```
 
-The `providers.aks.enabled` option sets the necessary environment variable `DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS="true"` for you.
+The `providers.aks.enabled` option sets the environment variable `DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS="true"`.
 {{% /tab %}}
 {{< /tabs >}}
 
-#### GKE
-If you are using a [GKE *Private* Cluster this restricts the request][9] to Cluster Agent pod by default. You need to add a firewall rule to allow the inbound access from the control plane to this port. By default, the network for the cluster should have a firewall rule named `gke-<CLUSTER_NAME>-master`. This rule's source filters should match the cluster's "Control plane address range" found in the "Networking" section. Edit this firewall rule to allow ingress to the `TCP` protocol and port `8000`.
+#### Google Kubernetes Engine (GKE)
+
+If you are using a [GKE private cluster][12], you need to adjust your firewall rules to allow inbound access from the control plane to port `8000`.
+
+[Add a firewall rule][13] to allow ingress over TCP on port `8000`.
+
+You can also edit an existing rule. By default, the network for your cluster has a firewall rule named `gke-<CLUSTER_NAME>-master`. Ensure that this rule's _source filters_ include [your cluster control plane's CIDR block][14]. Edit this rule to allow access over protocol `tcp` on port `8000`.
+
+For more information, see [Adding firewall rules for specific use cases][15] in the GKE documentation.
 
 #### Rancher
 
-There can be issues with Rancher depending on the underlying environment used. You can consult the [Rancher documentation][10] for a similar issue with the Rancher-Webhook (another Mutating Admission Controller) within GKE Private Clusters or EKS Clusters using the Calico CNI.
+If you are using Rancher with an EKS cluster or a private GKE cluster, additional configuration is required. For more information, see [Rancher Webhook - Common Issues][16] in the Rancher documentation.
 
-In GKE Private clusters you can consult the [GKE steps above](#gke) to add the corresponding firewall rule.
-
-In EKS clusters you can similarly deploy the Cluster Agent pod with the `hostNetwork: true` setting to allow this connectivity.
+##### Rancher and EKS
+To use Rancher in an EKS cluster, deploy the Cluster Agent pod with the following configuration:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
@@ -258,60 +391,28 @@ clusterAgent:
 {{% /tab %}}
 {{< /tabs >}}
 
-## Application pods blocked
-The Helm and Operator setups by default match Admission Controller's injection config mode (`socket`, `hostip`, `service`) relative to the APM receivers enabled. In other words if you have the (UDS) socket mode enabled in your Agent and the Host Port disabled, the Admission Controller should use the `socket` mode. Preferring `socket` over `hostip`. The default APM receiver in the Agent is the `socket` mode, so by default the default Admission Controller mode is also `socket`.
+You must also add a security group inbound rule, as described in the [Amazon EKS](#amazon-elastic-kubernetes-service-eks) section on this page.
 
-This injection mode may need to be tailored depending on your environment.
-
-### GKE Autopilot
-GKE Autopilot restricts the use of any `volumes` with a `hostPath`. So if the Admission Controller injects the (UDS) `socket` the pods get blocked from scheduling by the GKE Warden.
-
-This setup is typically blocked when setting your Helm configuration into GKE Autopilot mode (`providers.gke.autpilot=true`). However, be sure you are not explicitly attempting to override the configuration to use the `socket` mode when in GKE Autopilot. Instead use the `hostip` mode (the default) or `service` mode.
-
-### OpenShift
-In OpenShift there are `SecurityContextConstraints` (SCC) that are required to deploy pods with extra permissions, such as a `volume` using a `hostPath`. We deploy our Datadog components with SCCs to allow this activity specific to the Datadog pods, however we do not create SCCs for other pods. This can cause issues if the `socket` mode is used, as it injects a `volume` with a `hostPath` into these other pods. This makes them forbidden from being deployed as they are unable to validate against any security context constraint.
-
-With this in mind in OpenShift you should use the `hostip` configuration.This option enables the `hostPort` in your Agent pod and injects the `hostip` configuration into your application pods. This is a "safe" configuration and should not be forbidden within your security contexts.
-
-{{< tabs >}}
-{{% tab "Operator" %}}
-```yaml
-apiVersion: datadoghq.com/v2alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  features:
-    apm:
-      enabled: true
-      hostPortConfig:
-        enabled: true
-      unixDomainSocketConfig:
-        enabled: false
-```
-{{% /tab %}}
-{{% tab "Helm" %}}
-```yaml
-datadog:
-  apm:
-    portEnabled: true
-    socketEnabled: false
-```
-{{% /tab %}}
-{{< /tabs >}}
+##### Rancher and GKE
+To use Rancher in a private GKE cluster, edit your firewall rules to allow inbound access over TCP on port `8000` and port `9443`. See the [GKE](#google-kubernetes-engine-gke) section on this page.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /containers/cluster_agent/admission_controller
-[2]: /tracing/trace_collection/library_injection_local/?tab=kubernetes
-[3]: /agent/troubleshooting/debug_mode/
-[4]: https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource
-[5]: https://docs.cilium.io/en/latest/security/policy/language/
-[6]: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html#security-group-rule-components
-[7]: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
-[8]: https://docs.microsoft.com/en-us/azure/aks/faq#can-i-use-admission-controller-webhooks-on-aks
-[9]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
-[10]: https://ranchermanager.docs.rancher.com/reference-guides/rancher-webhook#common-issues
-[11]: /containers/cluster_agent/admission_controller/#apm-and-dogstatsd
+[2]: /containers/cluster_agent/admission_controller/#apm-and-dogstatsd
+[3]: /tracing/trace_collection/library_injection_local/?tab=kubernetes
+[4]: /agent/troubleshooting/debug_mode/
+[5]: https://kubernetes.io/docs/concepts/services-networking/network-policies/#networkpolicy-resource
+[6]: https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html
+[7]: https://docs.aws.amazon.com/vpc/latest/userguide/security-group-rules.html#security-group-rule-components
+[8]: https://docs.aws.amazon.com/eks/latest/userguide/managed-node-groups.html
+[9]: https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html
+[10]: https://console.aws.amazon.com/cloudwatch/home#logs:prefix=/aws/eks
+[11]: https://docs.microsoft.com/en-us/azure/aks/faq#can-i-use-admission-controller-webhooks-on-aks
+[12]: https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster-concept
+[13]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#step_3_add_a_firewall_rule
+[14]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#step_1_view_control_planes_cidr_block
+[15]: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
+[16]: https://ranchermanager.docs.rancher.com/reference-guides/rancher-webhook#common-issues


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add a dedicated doc for troubleshooting the Admission Controller. This is a slight follow up to https://github.com/DataDog/documentation/pull/20103 where the Cluster Agent troubleshooting was broken up. This publicizes a lot of our internal troubleshooting scenarios for common problems, distribution specific steps, and networking rules. 

This also adds the new menu option and re-directs the main Admission Controller > Troubleshooting section to this new doc.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Will be checking in with a few more Container teams as well.

Notes for a later PR:
- The core Admission Controller doc could use a few organizational changes for labels / mutate unlabelled. But leaving those for another PR
- Using the `socket` mode in OpenShift is still a work in progress. You can create a SCC to allow the hostPath volume, but SELinux restrictions prevent the other pod from communicating through it. So keeping OpenShift as `hostip` mode recommended for now, pending further investigation
- This digs more into "did the Admission Controller inject properly" rather than "did the injected APM Tracer link up with the app correctly", the latter is tracked in (https://docs.datadoghq.com/tracing/trace_collection/library_injection_local/?tab=kubernetes#check-that-the-library-injection-was-successful)


<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->