### PR TITLE
[APPSEC] Remove FireHol from threat intel docs

### DIFF
--- a/content/en/security/application_security/threats/threat-intelligence.md
+++ b/content/en/security/application_security/threats/threat-intelligence.md
@@ -27,7 +27,6 @@ Datadog recommends _against_ the following:
 ## Which sources are surfaced in ASM
 
 - [abuse.ch](https://threatfox-api.abuse.ch)
-- [FireHOL](https://iplists.firehol.org/)
 - [spur](https://spur.us/) (only the `malware` category)
 - [Tor Exit Nodes](https://www.dan.me.uk/torlist/?exit)
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The FireHOL source has been removed due to it being false positive prone, and having it in the docs is misleading.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->