### PR TITLE
Hackathon 2023 Q4: Enhance Further Reading

### DIFF
--- a/content/en/brett_test/_index.md
+++ b/content/en/brett_test/_index.md
@@ -1,0 +1,67 @@
+---
+title: Further Reading
+kind: documentation
+further_reading:
+  - link: "https://app.datadoghq.com/release-notes?category=APM"
+    tag: "Release Notes"
+    text: "Check out the latest Datadog APM releases! (App login required)."
+  - link: "/tracing/guide/setting_primary_tags_to_scope/"
+    tag: "Documentation"
+  - link: "/tracing/guide/add_span_md_and_graph_it/"
+    tag: "Documentation"
+  - link: "/tracing/guide/security/"
+    tag: "Documentation"
+  - link: "/tracing/metrics/metrics_namespace/"
+    tag: "Documentation"
+    text: "Learn about trace metrics and their tags"
+  - link: "https://www.datadoghq.com/blog/span-based-metrics/"
+    tag: "Blog"
+    text: "Generate span-based metrics to track historical trends in application performance"
+  - link: "https://www.datadoghq.com/blog/apm-security-view/"
+    tag: "Blog"
+    text: "Gain visibility into risks, vulnerabilities, and attacks with APM Security View"
+---
+## Overview
+
+Hexagon ennui air plant tacos stumptown. Plaid tofu readymade celiac DSA jean shorts. Hoodie air plant tofu tonx ramps polaroid direct trade yr organic. Edison bulb jawn blog vice solarpunk distillery you probably haven't heard of them occupy bicycle rights trust fund jean shorts coloring book, ennui grailed neutra. +1 tbh aesthetic VHS bespoke fashion axe celiac venmo bushwick hashtag. Polaroid chambray retro dreamcatcher umami.
+
+Pickled meggings live-edge, vibecession tilde raw denim gatekeep narwhal chillwave swag squid activated charcoal 8-bit photo booth food truck. Af coloring book irony pok pok VHS, butcher live-edge mixtape 3 wolf moon truffaut. Cloud bread flexitarian stumptown, vegan quinoa selvage yr bushwick. Keytar farm-to-table schlitz tousled.
+
+Frontmatter:
+
+```
+  - link: "https://app.datadoghq.com/release-notes?category=APM"
+    tag: "Release Notes"
+    text: "Check out the latest Datadog APM releases! (App login required)."
+  - link: "/tracing/guide/setting_primary_tags_to_scope/"
+    tag: "Documentation"
+  - link: "/tracing/guide/add_span_md_and_graph_it/"
+    tag: "Documentation"
+  - link: "/tracing/guide/security/"
+    tag: "Documentation"
+  - link: "/tracing/metrics/metrics_namespace/"
+    tag: "Documentation"
+    text: "Learn about trace metrics and their tags"
+  - link: "https://www.datadoghq.com/blog/span-based-metrics/"
+    tag: "Blog"
+    text: "Generate span-based metrics to track historical trends in application performance"
+  - link: "https://www.datadoghq.com/blog/apm-security-view/"
+    tag: "Blog"
+    text: "Gain visibility into risks, vulnerabilities, and attacks with APM Security View"
+```
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+## Further reading (debug)
+
+{{< partial name="whats-next/whats-next-debug.html" >}}
+
+## Get aliased title
+
+Aliased page:
+{{< getPage "/tracing/guide/security" >}}
+
+Unaliased page:
+{{< getPage "/tracing/guide/setting_primary_tags_to_scope" >}}

--- a/layouts/partials/whats-next/whats-next-debug.html
+++ b/layouts/partials/whats-next/whats-next-debug.html
@@ -1,0 +1,44 @@
+{{- $dot := . -}}
+<div class="whatsnext">
+  <p>{{- i18n "additional_sentence" -}}:</p>
+  <div class="list-group">
+    {{- range $dot.Page.Params.further_reading -}}
+      {{- $link := .link -}}
+      {{ printf "link: %s" $link }} <!-- Debug: print $link -->
+      {{- $linkedPage := $.Site.GetPage (printf "/%s" (trim .link "/")) -}}
+
+      {{ printf "linkedPage: %v" $linkedPage }} <!-- Debug: print $linkedPage -->
+      {{- if not $linkedPage -}} 
+        {{- range $.Site.Pages -}}
+          {{- if in .Aliases $link -}}
+            {{- $linkedPage = . -}}
+            {{- break -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+
+      {{- $displayText := .text | default "" -}}
+      {{ printf "displayText (before): %s" $displayText }} <!-- Debug: print $displayText before update -->
+      {{- if eq $displayText "" -}}
+          {{- if $linkedPage -}}
+              {{- $displayText = $linkedPage.Title -}}
+              {{- $link = $linkedPage.RelPermalink -}} {{/* Update link to the correct permalink */}}
+          {{- else -}}
+              {{- $displayText = "Title not found" -}} {{/* Fallback text */}}
+          {{- end -}}
+      {{- end -}}
+      {{ printf "displayText (after): %s" $displayText }} <!-- Debug: print $displayText after update -->
+      <a class="list-group-item list-group-item-action list-group-item-white d-flex justify-content-between align-items-center" href="{{- $link -}}">
+        <span class="w-100 d-flex justify-content-between">
+          <span class="text">{{- $displayText -}}</span>
+          {{- if .tag -}}
+            <span class="badge badge-white pe-2 border-0">{{- .tag | upper -}}</span>
+            {{ printf "tag: %s" .tag }} <!-- Debug: print .tag -->
+          {{- end -}}
+        </span>
+        {{- partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-1.png" "class" "img-fluid static" "alt" "more") -}}
+        {{- partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-2.png" "class" "img-fluid hover" "alt" "more" "disable_lazy" "true") -}}
+      </a>
+    {{- end -}}
+  </div>
+</div>

--- a/layouts/partials/whats-next/whats-next.html
+++ b/layouts/partials/whats-next/whats-next.html
@@ -2,36 +2,44 @@
 <div class="whatsnext">
   <p>{{- i18n "additional_sentence" -}}:</p>
   <div class="list-group">
+
+    <!-- Iterate over items in the 'further_reading' parameter of the page -->
     {{- range $dot.Page.Params.further_reading -}}
-      {{- if eq (substr .link 0 4) "http" -}}
-          {{- $.Scratch.Set "link" .link -}}
-      {{- else -}}
-          {{- if eq (substr .link 0 1) "/" -}}
-              {{- if in .link "#" -}}
-                  {{- $.Scratch.Set "link" ((substr .link 1) | relLangURL) -}}
-              {{- else -}}
-                  {{- $.Scratch.Set "link" ((substr .link 1) | absLangURL) -}}
-              {{- end -}}
+      <!-- Retrieve the link and page for each item -->
+      {{- $link := .link -}}
+      {{- $linkedPage := $.Site.GetPage (printf "/%s" (trim .link "/")) -}}
+
+      <!-- Fallback logic if the linked page is not directly found -->
+      {{- if not $linkedPage -}} 
+        {{- range $.Site.Pages -}}
+          {{- if in .Aliases $link -}}
+            {{- $linkedPage = . -}}
+            {{- break -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+
+      <!-- Set the display text for the item -->
+      {{- $displayText := .text | default "" -}}
+      {{- if eq $displayText "" -}}
+          {{- if $linkedPage -}}
+              {{- $displayText = $linkedPage.Title -}}
+              {{- $link = $linkedPage.RelPermalink -}} <!-- Update link to the correct permalink -->
           {{- else -}}
-              {{- $.Scratch.Set "link" (.link | absLangURL) -}}
-              {{- if in .link "#" -}}
-                  {{- $.Scratch.Set "link" (.link | relLangURL) -}}
-              {{- else -}}
-                  {{- $.Scratch.Set "link" (.link | absLangURL) -}}
-              {{- end -}}
+              {{- $displayText = "Title not found" -}} <!-- Fallback text -->
           {{- end -}}
       {{- end -}}
-      {{- $link := $.Scratch.Get "link" -}}
-      <a class="list-group-item list-group-item-action list-group-item-white  d-flex justify-content-between align-items-center" href="{{- $link -}}">
+
+      <a class="list-group-item list-group-item-action list-group-item-white d-flex justify-content-between align-items-center" href="{{- $link -}}">
         <span class="w-100 d-flex justify-content-between">
-            <span class="text">{{- .text -}}</span>
-            {{- if .tag -}}
-                <span class="badge badge-white pe-2 border-0">{{- .tag | upper -}}</span>
-            {{- end -}}
+          <span class="text">{{- $displayText -}}</span>
+          {{- if .tag -}}
+            <span class="badge badge-white pe-2 border-0">{{- .tag | upper -}}</span>
+          {{- end -}}
         </span>
         {{- partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-1.png" "class" "img-fluid static" "alt" "more") -}}
         {{- partial "img.html" (dict "root" $dot "src" "icons/list-group-whats-next-arrow-2.png" "class" "img-fluid hover" "alt" "more" "disable_lazy" "true") -}}
       </a>
     {{- end -}}
-    </div>
+  </div>
 </div>

--- a/layouts/shortcodes/getPage.html
+++ b/layouts/shortcodes/getPage.html
@@ -1,0 +1,18 @@
+{{ $link := .Get 0 }}
+{{ if not $link }}
+{{ errorf "No page title specified" }}
+{{ end }}
+
+{{ $hash := .Get 1 }}
+
+{{ $page := site.GetPage $link }}
+{{ if not $page }}
+{{ printf "Error in link shortcode at content/%s. No page found at %s." $.Page.File $link }}
+{{ end }}
+<div class="jump">
+  <a href="{{ $link }}{{ with $hash }}#{{ . }}{{ end }}">
+        <span class="dark:text-gray-300 text-gray-700 tracking-tight text-base">
+          {{ $page.Title }}
+        </span>
+  </a>
+</div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Taking inspiration from the `jump` shortcode in the Vector docs, I wanted to see if we could automatically pull titles for internal links in our Further Reading sections (whats-new.html partial).

This would offer a few benefits:
- Less for us to configure in frontmatter.
- Fewer strings to translate.
- Automatically adjusts to align with new page titles.

This draft works _except for_ aliased cases. ☹️ 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
**This doesn't fully work yet.**