### PR TITLE
[APPSEC-15184] Update ASM threat intelligence sources

### DIFF
--- a/content/en/security/application_security/threats/threat-intelligence.md
+++ b/content/en/security/application_security/threats/threat-intelligence.md
@@ -26,8 +26,6 @@ Datadog recommends _against_ the following:
 
 ## Which sources are surfaced in ASM
 
-- [abuse.ch](https://threatfox-api.abuse.ch)
-- [spur](https://spur.us/) (only the `malware` category)
 - [Tor Exit Nodes](https://www.dan.me.uk/torlist/?exit)
 
 To search for all traces flagged by a specific source, use the following query with the source name:


### PR DESCRIPTION
- [APPSEC-15184] Remove abuse.ch and spur references from ASM docs

### What does this PR do? What is the motivation?

`abuse.ch` and `spur:malware` threat intelligence sources are a bit too noisy currently, so the forwarding for ASM has been disabled in some situations.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[APPSEC-15184]: https://datadoghq.atlassian.net/browse/APPSEC-15184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ