### PR TITLE
[PHP] Update manual logs injection snippets and Clarify Annotations usages

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -95,7 +95,7 @@ The PHP tracer replaces the placeholders with the corresponding values. For exam
 ## Manual injection
 
 <div class="alert alert-warning">
-Note that the function <code>\DDTrace\current_context()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a> and returns decimal trace identifiers.
+**Note**: The function <code>\DDTrace\current_context()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a> and returns decimal trace identifiers.
 </div>
 
 To connect your logs and traces together, your logs must contain the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -95,7 +95,7 @@ The PHP tracer replaces the placeholders with the corresponding values. For exam
 ## Manual injection
 
 <div class="alert alert-warning">
-**Note**: The function <code>\DDTrace\current_context()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a> and returns decimal trace identifiers.
+<strong>Note:</strong> The function <code>\DDTrace\current_context()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a> and returns decimal trace identifiers.
 </div>
 
 To connect your logs and traces together, your logs must contain the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/php.md
@@ -95,7 +95,7 @@ The PHP tracer replaces the placeholders with the corresponding values. For exam
 ## Manual injection
 
 <div class="alert alert-warning">
-Note that the function <code>\DDTrace\current_context()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a>.
+Note that the function <code>\DDTrace\current_context()</code> has been introduced in version <a href="https://github.com/DataDog/dd-trace-php/releases/tag/0.61.0">0.61.0</a> and returns decimal trace identifiers.
 </div>
 
 To connect your logs and traces together, your logs must contain the `dd.trace_id` and `dd.span_id` attributes that respectively contain your trace ID and your span ID.
@@ -106,11 +106,10 @@ For instance, you would append those two attributes to your logs with:
 
 ```php
   <?php
-  $context = \DDTrace\current_context();
   $append = sprintf(
       ' [dd.trace_id=%s dd.span_id=%s]',
-      $context['trace_id'],
-      $context['span_id']
+      \DDTrace\logs_correlation_trace_id(),
+      \dd_trace_peek_span_id()
   );
   my_error_logger('Error message.' . $append);
 ?>
@@ -121,11 +120,10 @@ If the logger implements the [**monolog/monolog** library][4], use `Logger::push
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-      $context = \DDTrace\current_context();
       $record['message'] .= sprintf(
           ' [dd.trace_id=%s dd.span_id=%s]',
-          $context['trace_id'],
-          $context['span_id']
+          \DDTrace\logs_correlation_trace_id(),
+          \dd_trace_peek_span_id()
       );
       return $record;
   });
@@ -137,11 +135,10 @@ For monolog v2, add the following configuration:
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-      $context = \DDTrace\current_context();
       return $record->with(message: $record['message'] . sprintf(
           ' [dd.trace_id=%s dd.span_id=%s]',
-          $context['trace_id'],
-          $context['span_id']
+          \DDTrace\logs_correlation_trace_id(),
+          \dd_trace_peek_span_id()
       ));
     });
   ?>
@@ -151,11 +148,10 @@ If your application uses JSON logs format, you can add a first-level key `dd` th
 
 ```php
 <?php
-  $context = \DDTrace\current_context();
   $logger->pushProcessor(function ($record) use ($context) {
       $record['dd'] = [
-          'trace_id' => $context['trace_id'],
-          'span_id'  => $context['span_id'],
+          'trace_id' => \DDTrace\logs_correlation_trace_id(),
+          'span_id'  => \dd_trace_peek_span_id()
       ];
 
       return $record;
@@ -168,10 +164,9 @@ For monolog v3, add the following configuration:
 ```php
 <?php
   $logger->pushProcessor(function ($record) {
-        $context = \DDTrace\current_context();
         $record->extra['dd'] = [
-            'trace_id' => $context['trace_id'],
-            'span_id'  => $context['span_id'],
+            'trace_id' => \DDTrace\logs_correlation_trace_id(),
+            'span_id'  => \dd_trace_peek_span_id()
         ];
         return $record;
     });

--- a/content/en/tracing/trace_collection/custom_instrumentation/php.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php.md
@@ -54,7 +54,7 @@ You can provide the following arguments:
 - `$run_if_limited`: Whether the function shall be traced in limited mode. (For example, when span limit exceeded)
 
 <div class="alert alert-warning">
-if a namespace is present, you <strong>must</strong> use the fully qualified name of the attribute <code>#[\DDTrace\Trace]</code>. Alternatively, you can import the namespace with <code>use DDTrace\Trace;</code> and use <code>#[Trace]</code>.
+If a namespace is present, you <strong>must</strong> use the fully qualified name of the attribute <code>#[\DDTrace\Trace]</code>. Alternatively, you can import the namespace with <code>use DDTrace\Trace;</code> and use <code>#[Trace]</code>.
 </div>
 
 ## Writing custom instrumentation

--- a/content/en/tracing/trace_collection/custom_instrumentation/php.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php.md
@@ -54,7 +54,7 @@ You can provide the following arguments:
 - `$run_if_limited`: Whether the function shall be traced in limited mode. (For example, when span limit exceeded)
 
 <div class="alert alert-warning">
-if a namespace is present, you <strong>must</strong> use the fully qualified name of the attribute, for example `#[\DDTrace\Trace]`, or import the namespace with `use DDTrace\Trace;` and use `#[Trace]`.
+if a namespace is present, you <strong>must</strong> use the fully qualified name of the attribute `#[\DDTrace\Trace]`. Alternatively, you can import the namespace with `use DDTrace\Trace;` and use `#[Trace]`.
 </div>
 
 ## Writing custom instrumentation

--- a/content/en/tracing/trace_collection/custom_instrumentation/php.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php.md
@@ -53,6 +53,10 @@ You can provide the following arguments:
 - `$recurse`: Whether recursive calls shall be traced.
 - `$run_if_limited`: Whether the function shall be traced in limited mode. (For example, when span limit exceeded)
 
+<div class="alert alert-warning">
+if a namespace is present, you <strong>must</strong> use the fully qualified name of the attribute, for example `#[\DDTrace\Trace]`, or import the namespace with `use DDTrace\Trace;` and use `#[Trace]`.
+</div>
+
 ## Writing custom instrumentation
 
 If you do need to write your own custom instrumentation, consider the following sample application and walk through the coding examples.

--- a/content/en/tracing/trace_collection/custom_instrumentation/php.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php.md
@@ -54,7 +54,7 @@ You can provide the following arguments:
 - `$run_if_limited`: Whether the function shall be traced in limited mode. (For example, when span limit exceeded)
 
 <div class="alert alert-warning">
-if a namespace is present, you <strong>must</strong> use the fully qualified name of the attribute `#[\DDTrace\Trace]`. Alternatively, you can import the namespace with `use DDTrace\Trace;` and use `#[Trace]`.
+if a namespace is present, you <strong>must</strong> use the fully qualified name of the attribute <code>#[\DDTrace\Trace]</code>. Alternatively, you can import the namespace with <code>use DDTrace\Trace;</code> and use <code>#[Trace]</code>.
 </div>
 
 ## Writing custom instrumentation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR:
- Updates manual logs injection snippets
  - The previous snippets were correct while 64-bit trace identifiers were still the defaults; however, this has changed in 0.94.0 and these snippets were no longer correct.
- Clarify Annotations usages
  - We've had multiple escalations related to these recently. Let's make it clear it the doc 🙏 



### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->