### PR TITLE
Add docs on composite monitor enrichment

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -386,7 +386,9 @@ To retrieve the status of the sub-monitor `a` use:
 
 Possible values for the status are: `OK`, `Alert`, `Warn`, and `No Data`.
 
-Composite monitors also support tag variables in the same way as their underlying monitors. They follow the same format as other monitors, provided the underlying monitors are grouped by the same tag/facet. For instance,  if your composite monitor has sub-monitor `a`, given that `a` is a log monitor, you can include the value of any tag/facet of `a` with:
+Composite monitors also support tag variables in the same way as their underlying monitors. They follow the same format as other monitors, provided the underlying monitors are grouped by the same tag or facet.
+
+For instance, assume your composite monitor has a sub-monitor `a`, which is a Logs monitor. You can include the value of any tag or facet of `a` with:
 
 ```text
 {{ a.log.message }} or {{ a.log.my_facet }}

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -386,7 +386,11 @@ To retrieve the status of the sub-monitor `a` use:
 
 Possible values for the status are: `OK`, `Alert`, `Warn`, and `No Data`.
 
-Composite monitors also support tag variables in the same way as their underlying monitors. They follow the same format as other monitors, provided the underlying monitors are grouped by the same tag/facet.
+Composite monitors also support tag variables in the same way as their underlying monitors. They follow the same format as other monitors, provided the underlying monitors are grouped by the same tag/facet. For instance,  if your composite monitor has sub-monitor `a`, given that `a` is a log monitor, you can include the value of any tag/facet of `a` with:
+
+```text
+{{ a.log.message }} or {{ a.log.my_facet }}
+```
 
 ### Character escape
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Explain sub-monitor enrichment in docs (e.g. `{{a.log.message}}`).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->