### PR TITLE
Update PHP ASM compatibility to include PHP 8.3 and ARM64

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/php.md
+++ b/content/en/security/application_security/enabling/compatibility/php.md
@@ -27,9 +27,9 @@ The minimum tracer version to get all supported ASM capabilities for PHP is 0.86
 ### Supported deployment types
 |Type | Threat Detection support | Vulnerability Management for OSS support |
 | ---           |   ---             |           ----            |
-| Docker        | {{< X >}}         |                           |
-| Kubernetes    | {{< X >}}         |                           |
-| Amazon ECS    | {{< X >}}         |                           |
+| Docker        | {{< X >}}         |  {{< X >}}                |
+| Kubernetes    | {{< X >}}         |  {{< X >}}                |
+| Amazon ECS    | {{< X >}}         |  {{< X >}}                |
 | AWS Fargate   |                   |                           |
 | AWS Lambda    |                   |                           |
 
@@ -42,6 +42,7 @@ It's recommended to use <a href="https://www.php.net/supported-versions">officia
 
 | PHP Version    | Support level                         | Package version |
 |:---------------|:--------------------------------------|:----------------|
+| 8.3.x          | General Availability                  | > `0.95.0+`     |
 | 8.2.x          | General Availability                  | > `0.82.0+`     |
 | 8.1.x          | General Availability                  | > `0.66.0+`     |
 | 8.0.x          | General Availability                  | > `0.52.0+`     |
@@ -68,6 +69,8 @@ PHP ASM supports the following architectures:
 | ------------------------------------------|-----------------------|----------------------------------------|
 | Linux GNU amd64 (`x86-64-linux-gnu`)      | GA                    | All                                    |
 | Linux MUSL amd64 (`x86-64-linux-musl`)    | GA                    | All                                    |
+| Linux GNU arm64 (aarch64-linux-gnu)       | GA                    | > `0.95.0`                             |
+| Linux MUSL arm64 (aarch64-linux-musl)     | GA                    | > `0.95.0`                             |
 
 The Datadog PHP library supports PHP version 7.0 and above on the following architectures:
 

--- a/content/en/security/application_security/enabling/compatibility/php.md
+++ b/content/en/security/application_security/enabling/compatibility/php.md
@@ -74,8 +74,8 @@ PHP ASM supports the following architectures:
 
 The Datadog PHP library supports PHP version 7.0 and above on the following architectures:
 
-- Linux (GNU) x86-64
-- Alpine Linux (musl) x86-64
+- Linux (GNU) x86-64 and arm64
+- Alpine Linux (musl) x86-64 and arm64
 
 The library supports the use of all PHP frameworks, and also the use of no framework.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Update the PHP ASM compatibility documentation to include PHP 8.3 and ARM64 support released in `0.95.0`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->