### PR TITLE
[WEB-4281] Fix duplicate objectIDs being generated in Algolia indexing job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,7 +241,7 @@ algolia_sync_preview:manual:
     - yarn run prebuild
     - build_site
     # end build
-    - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/brian.deutsch/dup-objects/atomic-algolia-v1.0.3.tgz
+    - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v1.0.2.tgz
     - >
       ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id')
       ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key')

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -241,7 +241,7 @@ algolia_sync_preview:manual:
     - yarn run prebuild
     - build_site
     # end build
-    - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/atomic-algolia-v1.0.2.tgz
+    - yarn add atomic-algolia@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/brian.deutsch/dup-objects/atomic-algolia-v1.0.3.tgz
     - >
       ALGOLIA_APP_ID=$(get_secret 'algolia_preview_application_id')
       ALGOLIA_ADMIN_KEY=$(get_secret 'algolia_preview_api_key')

--- a/layouts/partials/algolia/page-sections.json
+++ b/layouts/partials/algolia/page-sections.json
@@ -46,7 +46,7 @@
               {{- if gt (len $c) 2 -}}
                   {{- $full_url := print $page.Permalink "#" ($section_header | anchorize) -}}
                   {{- $relpermalink := print $page.RelPermalink "#" ($section_header | anchorize) -}}
-                  {{- $object_id := (print $page.File.UniqueID "_" $page.File.Lang "_" ($section_header | anchorize) "_" $i) -}}
+                  {{- $object_id := (print $page.File.UniqueID "_" $page.File.Lang "_" ($section_header | anchorize) "_" $i "_" $order) -}}
                   {{- $hugo_context.Scratch.Add "algoliaindex" (
                       dict "objectID" $object_id
                       "title" $title


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Fixes a bug in the Algolia indexing job where duplicate objectIDs are being generated.   This results in a) job duration increase and b) certain records being overwritten on each run.   [An example can be seen in any master pipeline](https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/385086072#L196) - where the job output indicates 500+ records are being updated every time it runs.

https://datadoghq.atlassian.net/browse/WEB-4281

### Merge instructions
- [ ] Please merge after websites reviews

### Additional notes
- QA the search results and confirm nothing looks broken: https://docs-staging.datadoghq.com/brian.deutsch/dup-object-ids/search/?s=azure

- [check the latest algolia preview job](https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/385580652#L560), only 4 records are being updated (as opposed to 500+).   these will be handled in follow up work.