### PR TITLE
Add missing attributes to otel semantic conventions mapping docs

### DIFF
--- a/content/en/opentelemetry/guide/semantic_mapping.md
+++ b/content/en/opentelemetry/guide/semantic_mapping.md
@@ -29,7 +29,7 @@ For more information, see [Unified Service Tagging][2].
 | `container.image.tag` | `image_tag` |
 | `container.runtime` | `runtime` |
 
-[Semantic conventions: containers](https://opentelemetry.io/docs/specs/semconv/resource/container/)
+Read more about [Semantic conventions: containers][3].
 
 Additional cloud provider specific attributes are also mapped.
 

--- a/content/en/opentelemetry/guide/semantic_mapping.md
+++ b/content/en/opentelemetry/guide/semantic_mapping.md
@@ -74,9 +74,13 @@ Additional cloud provider specific attributes are also mapped.
 
 ## Further reading
 
-[Implementation of these mappings](https://github.com/DataDog/opentelemetry-mapping-go/blob/main/pkg/otlp/attributes/attributes.go)
+* [Datadog: OpenTelemetry metric types][3]
+* [Datadog: OpenTelemetry Metric mappings][4]
+* [Implementation of these mappings in the exporter](https://github.com/DataDog/opentelemetry-mapping-go/blob/main/pkg/otlp/attributes/attributes.go)
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://opentelemetry.io/docs/concepts/semantic-conventions/
 [2]: /getting_started/tagging/unified_service_tagging
+[3]: /metrics/open_telemetry/otlp_metric_types
+[4]: /guide/metrics_mapping

--- a/content/en/opentelemetry/guide/semantic_mapping.md
+++ b/content/en/opentelemetry/guide/semantic_mapping.md
@@ -27,6 +27,11 @@ For more information, see [Unified Service Tagging][2].
 | `container.name` | `container_name` |
 | `container.image.name` | `image_name` |
 | `container.image.tag` | `image_tag` |
+| `container.runtime` | `runtime` |
+
+[Semantic conventions: containers](https://opentelemetry.io/docs/specs/semconv/resource/container/)
+
+Additional cloud provider specific attributes are also mapped.
 
 ### Cloud
 
@@ -60,8 +65,16 @@ For more information, see [Unified Service Tagging][2].
 | `k8s.cronjob.name` | `kube_cronjob` |
 | `k8s.namespace.name` | `kube_namespace` |
 | `k8s.pod.name` | `pod_name` |
+| `app.kubernetes.io/name` | `kube_app_name` |
+| `app.kubernetes.io/instance` | `kube_app_instance` |
+| `app.kubernetes.io/version` | `kube_app_version` |
+| `app.kuberenetes.io/component` | `kube_app_component` |
+| `app.kubernetes.io/part-of` | `kube_app_part_of` |
+| `app.kubernetes.io/managed-by` | `kube_app_managed_by` |
 
 ## Further reading
+
+[Implementation of these mappings](https://github.com/DataDog/opentelemetry-mapping-go/blob/main/pkg/otlp/attributes/attributes.go)
 
 {{< partial name="whats-next/whats-next.html" >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fix incomplete documentation on otel semantic conventions mappings.

The otel semantic conventions mapping docs are missing a variety of attributes.

I've added some of them here. More are missing; see https://github.com/DataDog/opentelemetry-mapping-go/blob/5432be02915e24c7e8a294cd4a17877016f9b73d/pkg/otlp/attributes/attributes.go#L56 

DD should really make sure this doc matches the implementation.

### Merge instructions

- [x] Please merge after reviewing

### Additional notes

It'd be best if you added the rest of the missing attributes on top of my PR.