### PR TITLE
Remove beta callout

### DIFF
--- a/content/en/monitors/guide/custom_schedules.md
+++ b/content/en/monitors/guide/custom_schedules.md
@@ -14,10 +14,6 @@ further_reading:
   text: "Cumulative time windows"
 ---
 
-{{< beta-callout url="https://docs.datadoghq.com/help/" btn_hidden="false" >}}
-The monitor custom schedule feature is in private beta. To request access, contact Datadog Support.
-{{< /beta-callout >}}
-
 ## Overview 
 
 Set a specific evaluation time and control the evaluation frequency for monitors to track the execution of critical jobs running in your environment. Monitor Custom Schedules enable you to alert on systems and processes that do not need to be continuously monitored, such as cron jobs.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Removing beta callout from the custom schedule guide since we are moving to a public beta.