### PR TITLE
istio tracing: remove table of version correspondence

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/_index.md
+++ b/content/en/tracing/trace_collection/proxy_setup/_index.md
@@ -570,17 +570,6 @@ spec:
         apm.datadoghq.com/env: '{ "DD_ENV": "prod", "DD_SERVICE": "my-service", "DD_VERSION": "v1.1"}'
 ```
 
-The available [environment variables][11] depend on the version of the C++ tracer embedded in the Istio sidecar's proxy.
-
-| Istio Version | C++ Tracer Version |
-|---------------|--------------------|
-| v1.9.x - v1.17.x | v1.2.1 |
-| v1.7.x - v1.8.x | v1.1.5 |
-| v1.6.x | v1.1.3 |
-| v1.3.x - v1.5.x | v1.1.1 |
-| v1.1.3 - v1.2.x | v0.4.2 |
-
-
 ## Deployment and service
 
 If the Agents on your cluster are running as a deployment and service instead of the default DaemonSet, then an additional option is required to specify the DNS address and port of the Agent.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
A recent correspondence with a customer over an issue with our Istio tracing integration brought to light that our documentation is outdated.

We have a project planned to rewrite our Istio tracing documentation entirely, but for now I think we can remove unnecessary out-of-date information.

This revision removes a table that related Istio's release version to the corresponding Datadog C++ tracing library release version. That correspondence is no longer relevant, the table was out of date, and the context about environment variables included a broken link.

Our support policy for Istio is "when a new Istio release comes out, we support it." I think it's best to leave that implicit, and avoid customers inferring it from a table about library versions.