### PR TITLE
[WEB-4324] adds default subcategory for search results hierarchy

### DIFF
--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -15,9 +15,18 @@
             {{ $title := $page.Params.integration_title | default $page.Title }}
             {{ $content := $page.Plain | htmlUnescape | safeHTML | truncate 10000 }}
             {{ $tags := $page.Params.algolia.tags }}
-            {{ $category := $page.Params.algolia.category | default "Documentation" }}
-            {{ $subcategory := $page.Params.algolia.subcategory | default $page.Title }}
             {{ $rank := $page.Params.algolia.rank | default 70 }}
+            {{ $category := $page.Params.algolia.category | default "Documentation" }}
+            {{ $subcategory := $page.Params.algolia.subcategory }}
+
+            {{- /* Fallback to page's ancestor if subcategory isnt set in Params. */ -}}
+            {{ if not $subcategory }}
+                {{ if eq (lower $page.FirstSection.Title) ("service_managements") }}
+                    {{ $subcategory = $page.CurrentSection.Title }}
+                {{ else }}
+                    {{ $subcategory = $page.FirstSection.Title }}
+                {{ end }}
+            {{ end }}
 
             {{- /* record for each individual section (split by h2 header) */ -}}
             {{ partial "algolia/page-sections.json" (dict "context" $hugo_context "page" $page "title" $title "category" $category "subcategory" $subcategory "rank" $rank) }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
adds a more sensible default for `subcategory` when indexing docs pages.   previously we used the page's title as default, which [caused confusion in at least one case](https://dd.slack.com/archives/C0DESMBQU/p1701277316279959?thread_ts=1701271042.707909&cid=C0DESMBQU).   this update adds more context to the categorical hierarchy when we display search results.

https://datadoghq.atlassian.net/browse/WEB-4324

### Merge instructions

- [ ] Please merge after websites reviewing

### Additional notes
QA the search results and confirm nothing looks incorrect: https://docs-staging.datadoghq.com/brian.deutsch/search-results-subcategories/search/?s=dashboards

no errors in the indexing job: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/388358669