### PR TITLE
APM datasecurity golang client query strings

### DIFF
--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -134,8 +134,7 @@ The table below describes the default behavior of each language tracing library 
 
 {{% tab "Go" %}}
 
-**Note:** Client IPs are not collected by default and must be enabled. Database statements and
-Client URIs are obfuscated by the Datadog Agent.
+**Note:** Client IPs are not collected by default and must be enabled. Database statements are obfuscated by the Datadog Agent.
 
 | Category                | Collected                       | Obfuscated                      |
 |:------------------------|:-------------------------------:|:-------------------------------:|
@@ -145,7 +144,7 @@ Client URIs are obfuscated by the Datadog Agent.
 | Database statements     | <i class="icon-check-bold"></i> |                                 |
 | Geographic location     |                                 |                                 |
 | Client URI path         | <i class="icon-check-bold"></i> |                                 |
-| Client URI query string | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
+| Client URI query string | <i class="icon-check-bold"></i> |                                 |
 | Server URI path         | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
 | Server URI query string | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
 | HTTP body               | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |


### PR DESCRIPTION
we don't obfuscate client query strings in the go tracer by default

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->