### PR TITLE
Remove private beta designation for AP1 PrivateLink

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -14,10 +14,6 @@ further_reading:
 <div class="alert alert-warning">Datadog PrivateLink does not support the selected Datadog site.</div>
 {{% /site-region %}}
 
-{{% site-region region="ap1"%}}
-<div class="alert alert-primary">Datadog PrivateLink in AP1 is currently in private beta. To request access, contact <a href="https://docs.datadoghq.com/help/">Datadog support</a>.</div>
-{{% /site-region %}}
-
 {{% site-region region="us,ap1" %}}
 
 This guide walks you through how to configure [AWS PrivateLink][1] for use with Datadog.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

PrivateLink for AP1 is now generally available. As such, we can remove the banner indicating that it is in private beta.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->