### PR TITLE
Added example permission policy

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -83,7 +83,7 @@ For example:
         "kinesis:PutRecord",
         "kinesis:PutRecords"
       ],
-      "Resource": "arn:aws:firehose:us-east-1:123456789012:deliverystream/<DELIVERY_STREAM>"
+      "Resource": "arn:aws:firehose:<REGION>:<ACCOUNT_ID>:deliverystream/<DELIVERY_STREAM>"
     }
   ]
 }

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -70,6 +70,24 @@ Subscribe your new Kinesis stream to the CloudWatch log groups you want to inges
 Create an IAM role and permissions policy to enable CloudWatch Logs to put data into your Kinesis stream. 
    - Ensure that `logs.amazonaws.com` or `logs.<region>.amazonaws.com` is configured as the service principal in the role's **Trust relationships**.
    - Ensure that the role's attached permissions policy allows the `firehose:PutRecord` `firehose:PutRecordBatch`, `kinesis:PutRecord`, and `kinesis:PutRecords` actions.
+For example:
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "firehose:PutRecord",
+        "firehose:PutRecordBatch",
+        "kinesis:PutRecord",
+        "kinesis:PutRecords"
+      ],
+      "Resource": "arn:aws:firehose:us-east-1:123456789012:deliverystream/<DELIVERY_STREAM>"
+    }
+  ]
+}
+```
 
 Use the [Subscription filters with Kinesis][2] example (steps 3 to 6) for an example of setting this up with the AWS CLI.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The referenced AWS documentation does not provide a specific example for configuring a Datadog destination, and the patching instructions here still require some trial and error to get right. This PR provides a working example that I have used.

### Merge instructions
- [X ] Please merge after reviewing


<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->