### PR TITLE
[rsyslogd] Fix the clear-text port, it should be 10514 as 10516 is the TLS one

### DIFF
--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -53,7 +53,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
 
    ruleset(name="infiles") {
-   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10516" template="DatadogFormat")
+   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10514" template="DatadogFormat")
    }
    ```
 
@@ -188,7 +188,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
 
    ruleset(name="infiles") {
-   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10516" template="DatadogFormat")
+   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10514" template="DatadogFormat")
    }
    ```
 
@@ -325,7 +325,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
 
    ruleset(name="infiles") {
-   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10516" template="DatadogFormat")
+   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10514" template="DatadogFormat")
    }
    ```
 

--- a/content/ja/integrations/rsyslog.md
+++ b/content/ja/integrations/rsyslog.md
@@ -53,7 +53,7 @@ Rsyslog を構成して、ホスト、コンテナ、サービスからログを
    $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
 
    ruleset(name="infiles") {
-   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10516" template="DatadogFormat")
+   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10514" template="DatadogFormat")
    }
    ```
 
@@ -188,7 +188,7 @@ Rsyslog を構成して、ホスト、コンテナ、サービスからログを
    $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
 
    ruleset(name="infiles") {
-   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10516" template="DatadogFormat")
+   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10514" template="DatadogFormat")
    }
    ```
 
@@ -325,7 +325,7 @@ Rsyslog を構成して、ホスト、コンテナ、サービスからログを
    $template DatadogFormat,"<DATADOG_API_KEY> <%pri%>%protocol-version% %timestamp:::date-rfc3339% %HOSTNAME% %app-name% - - - %msg%\n"
 
    ruleset(name="infiles") {
-   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10516" template="DatadogFormat")
+   action(type="omfwd" protocol="tcp" target="intake.logs.<site_url>" port="10514" template="DatadogFormat")
    }
    ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->