### PR TITLE
Adding two glossary terms

### DIFF
--- a/content/en/glossary/terms/parallelization.md
+++ b/content/en/glossary/terms/parallelization.md
@@ -1,0 +1,9 @@
+---
+# Glossary Term
+title: parallelization
+core_product:
+  - synthetic monitoring
+related_terms:
+  - test run
+---
+In Datadog Synthetic Monitoring, parallelization allows you to execute multiple tests in your CI/CD pipelines simultaneously rather than sequentially to help speed up your building, testing, and deployment processes. For more information, <a href="/continuous_testing/settings/#parallelization">see the documentation</a>.

--- a/content/en/glossary/terms/test_batch.md
+++ b/content/en/glossary/terms/test_batch.md
@@ -1,0 +1,7 @@
+---
+# Glossary Term
+title: test batch
+core_product:
+  - synthetic monitoring
+---
+In Datadog Synthetic Monitoring, a test batch is a batch of CI jobs running in your CI pipelines. For more information, <a href="/continuous_testing/explorer/search/">see the documentation</a>.

--- a/content/en/glossary/terms/test_run.md
+++ b/content/en/glossary/terms/test_run.md
@@ -1,0 +1,7 @@
+---
+# Glossary Term
+title: test run
+core_product:
+  - synthetic monitoring
+---
+In Datadog Synthetic Monitoring, a test run is an executed set of tests on software to ensure its functionality. A browser test run is a simulation of a web transaction, up to 25 steps. For more information, <a href="/continuous_testing/explorer/search_runs/">see the documentation</a>.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds two glossary terms related to Continuous Testing: parallelization and test runs.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ x ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->