### PR TITLE
Pally Image Update

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -466,8 +466,6 @@ link_checks:on-schedule:
   tags: ["runner:docker"]
   stage: post-deploy
   cache: []
-  dependencies:
-    - build_live
   variables:
     GIT_STRATEGY: none
   script:
@@ -481,6 +479,8 @@ link_checks:on-schedule:
 
 run_pa11y:schedule:
   <<: *pa11y_live_template
+  dependencies:
+    - build_live
   rules:
     - if: $CI_COMMIT_BRANCH == "master" && $CI_PIPELINE_SOURCE == "schedule"
       when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -462,7 +462,7 @@ link_checks:on-schedule:
 
 # template for what runs in pa11y to avoid duplication
 .pa11y_live_template: &pa11y_live_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:pa11y-latest
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:pa11y-25121683
   tags: ["runner:docker"]
   stage: post-deploy
   cache: []

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -462,7 +462,7 @@ link_checks:on-schedule:
 
 # template for what runs in pa11y to avoid duplication
 .pa11y_live_template: &pa11y_live_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:pa11y-devin.ford_pally-update
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:pa11y-latest
   tags: ["runner:docker"]
   stage: post-deploy
   cache: []

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -470,7 +470,6 @@ link_checks:on-schedule:
     GIT_STRATEGY: none
   script:
     - unset NODE_OPTIONS
-    - ls -la
     - cp -r ${ARTIFACT_RESOURCE} /app # copy the artifact to the working diretory of this docker container
     - cd /app # go into working directory
     - export CI_PROJECT_DIR="." # override project dir so pa11y script can locate the generated csv and push to s3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -462,7 +462,7 @@ link_checks:on-schedule:
 
 # template for what runs in pa11y to avoid duplication
 .pa11y_live_template: &pa11y_live_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:pa11y-17812916
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:pa11y-devin.ford_pally-update
   tags: ["runner:docker"]
   stage: post-deploy
   cache: []

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -472,6 +472,7 @@ link_checks:on-schedule:
     GIT_STRATEGY: none
   script:
     - unset NODE_OPTIONS
+    - ls -la
     - cp -r ${ARTIFACT_RESOURCE} /app # copy the artifact to the working diretory of this docker container
     - cd /app # go into working directory
     - export CI_PROJECT_DIR="." # override project dir so pa11y script can locate the generated csv and push to s3


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates the pally image job settings so we can run pally on preview branches if/when needed. A new image was pushed that was tested to exclude the `ko` directory which was causing the job to timeout when it ran on schedule

Successful pipeline run on preview that excludes `ko`
https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/390116141
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->