### PR TITLE
Fix first party hosts description for React Native

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
@@ -160,7 +160,7 @@ Enables native interaction tracking. Set to `true` if you want to track interact
 : Optional<br/>
 **Type**: List<br/>
 **Default**: `[]`<br/>
-Enables native views tracking. Set to `true` if you use a custom navigation system relying on native views. For more information, see [Connect RUM and Traces][12].
+List of your backends hosts to enable tracing with. For more information, see [Connect RUM and Traces][12].
 
 `telemetrySampleRate`
 : Optional<br/>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Fixes the description of the `firstPartyHosts` parameter for React Native configuration. It used to be a copy/paste from another parameter.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->