### PR TITLE
Update _index.md with correct Docker Hub URL

### DIFF
--- a/content/en/serverless/azure_container_apps/_index.md
+++ b/content/en/serverless/azure_container_apps/_index.md
@@ -22,7 +22,7 @@ You can instrument your application in one of two ways: [Dockerfile](#dockerfile
 
 Datadog publishes new releases of the serverless-init container image to Google’s gcr.io, AWS’ ECR, and on Docker Hub:
 
-| dockerhub.io | gcr.io | public.ecr.aws |
+| hub.docker.com | gcr.io | public.ecr.aws |
 | ---- | ---- | ---- |
 | datadog/serverless-init | gcr.io/datadoghq/serverless-init | public.ecr.aws/datadog/serverless-init |
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR fixes the wrong URL to DockerHub in the documentation of Azure Container Apps for the image `datadog/serverless-init`.