### PR TITLE
Correcting the needed permissions for the agent user to tail logs

### DIFF
--- a/content/en/logs/guide/log-collection-troubleshooting-guide.md
+++ b/content/en/logs/guide/log-collection-troubleshooting-guide.md
@@ -79,7 +79,7 @@ If the Agent does not have the correct permissions, you might see one of the fol
 - Access is denied.
 - Could not find any file matching pattern `<path/to/filename>`, check that all its subdirectories are executable.
 
-To fix the error, give the Datadog Agent user read, write, and execute permissions to the log file and subdirectories.
+To fix the error, give the Datadog Agent user read and execute permissions to the log file and subdirectories.
 
 {{< tabs >}}
 {{% tab "Linux" %}}


### PR DESCRIPTION
The Datadog agent user only need the read and execute permissions to tail log files. The agent does not attempt to write anything to the logs files being tailed so it does not need the write permission. This also sends the wrong message to customers and may flag security concerns.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This was brought up in a slack conversation https://dd.slack.com/archives/C046YU1V0SK/p1702457801831989 
Which lead to creating this Jira escalation: https://datadoghq.atlassian.net/browse/AGENT-10762

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [√ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->