### PR TITLE
Small update to Docker run command for Private Locations

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -182,7 +182,7 @@ Launch your private location on:
 Run this command to boot your private location worker by mounting your configuration file to the container. Ensure that your `<MY_WORKER_CONFIG_FILE_NAME>.json` file is in `/etc/docker`, not the root home folder:
 
 ```shell
-docker run --rm -d --restart unless-stopped -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker:latest
+docker run -d --restart unless-stopped -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetics-check-runner.json datadog/synthetics-private-location-worker:latest
 ```
 
 **Note:** If you have blocked reserved IPs, add the `NET_ADMIN` [Linux capabilities][1] to your private location container.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The current instructions to launch a private location using Docker includes both a `--rm` flag and a `--restart` flag in the command. These options are mutually exclusive and cannot be used together in a `docker run` command. 

The intent of the original change to include the `--restart` flag was to ensure the container restarts when it's not explicitly stopped, so I am removing the `--rm` flag so there is no conflict in the docker command.

As it stands currently, our example results in an error from docker:
>docker: Conflicting options: --restart and --rm.

### Merge instructions


- [x ] Please merge after reviewing

### Additional notes


<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->