### PR TITLE
Update SAML with Okta instructions and add identifiers to menu subitems

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -4581,38 +4581,47 @@ main:
     weight: 4
   - name: User Group Mapping
     url: account_management/saml/mapping/
+    identifier: account_management_saml_mapping
     parent: account_management_saml
     weight: 401
   - name: Active Directory
     url: account_management/saml/activedirectory/
+    identifier: account_management_saml_activedirectory
     parent: account_management_saml
     weight: 402
   - name: Auth0
     url: account_management/saml/auth0/
+    identifier: account_management_saml_auth0
     parent: account_management_saml
     weight: 403
   - name: Azure
     url: account_management/saml/azure/
+    identifier: account_management_saml_azure
     parent: account_management_saml
     weight: 404
   - name: Google
     url: account_management/saml/google/
+    identifier: account_management_saml_google
     parent: account_management_saml
     weight: 405
   - name: NoPassword
     url: account_management/saml/lastpass/
+    identifier: account_management_saml_lastpass
     parent: account_management_saml
     weight: 406
   - name: Okta
     url: account_management/saml/okta/
+    identifier: account_management_saml_okta
     parent: account_management_saml
     weight: 407
   - name: SafeNet
     url: account_management/saml/safenet/
+    identifier: account_management_saml_safenet
     parent: account_management_saml
     weight: 408
   - name: Troubleshooting
     url: account_management/saml/troubleshooting/
+    identifier: account_management_samle_troubleshooting
     parent: account_management_saml
     weight: 409
   - name: SCIM

--- a/content/en/account_management/saml/okta.md
+++ b/content/en/account_management/saml/okta.md
@@ -14,11 +14,8 @@ further_reading:
 
 ## Setup
 
-Follow Okta's [Create SAML app integrations][1] docs to configure Okta as a SAML IdP.
+Follow Okta's [add existing app integrations][1] instructions to configure Okta as a SAML IdP. Use the latest preconfigured Datadog application in the [Okta Integration Network (OIN)][2].
 
-**Note**: It's recommended that you set up Datadog as an Okta application manually, as opposed to using a `pre-configured` configuration.
-
-**Note**: US1 customers can use the preset configuration in Okta's [How to Configure SAML 2.0 for Datadog][2] docs to configure Okta as a SAML IdP.
 
 ## General details
 
@@ -63,8 +60,8 @@ In the event that you need to upload an `IDP.XML` file to Datadog before being a
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://help.okta.com/en-us/Content/Topics/Apps/Apps_App_Integration_Wizard_SAML.htm?cshid=ext_Apps_App_Integration_Wizard-saml
-[2]: https://saml-doc.okta.com/SAML_Docs/How-to-Configure-SAML-2.0-for-DataDog.html
+[1]: https://help.okta.com/en-us/content/topics/apps/apps-add-applications.htm
+[2]: https://www.okta.com/integrations/
 [3]: https://app.datadoghq.com/saml/saml_setup
 [4]: /account_management/saml/mapping
 [5]: /account_management/saml/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Datadog's new recommendation for configuring SAML with Okta is to use the pre-configured Datadog integration in Okta's application library. This PR updates our docs with the current recommendation. Requested in Slack by TEE Chris Choi.

While making the update, I noticed that the Azure and Okta SAML subpages don't show up in the left navigation. David and Heston figured out that the menu items are missing `identifier` tags, which they need to disambiguate from the other Azure and Okta menu items.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->