### PR TITLE
(maint) Add old files back to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,11 @@ content/en/static_analysis/github_actions.md
 content/en/static_analysis/circleci_orbs.md
 content/en/static_analysis/rules/*
 !content/en/static_analysis/rules/_index.md
+# Let's keep these so we don't accidentally re-add them to repo
+content/en/continuous_integration/static_analysis/github_actions.md
+content/en/continuous_integration/static_analysis/circleci_orbs.md
+content/en/continuous_integration/static_analysis/rules/
+
 
 # serverless
 content/en/serverless/libraries_integrations/plugin.md


### PR DESCRIPTION
Even though we've moved these files, we should keep ignoring them at least for a little while, cos anyone with files from an old build may accidentally add them back in.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->