### PR TITLE
WEB-4382 - 4th level should be intentional only

### DIFF
--- a/layouts/partials/nav/left-nav.html
+++ b/layouts/partials/nav/left-nav.html
@@ -63,7 +63,7 @@
                                         </a>
                                         {{/* 4th level, hide */}}
                                         {{ if .HasChildren }}
-                                            <ul class="list-unstyled sub-menu">
+                                            <ul class="list-unstyled sub-menu {{ if not (in (slice "observability_pipelines_reference_processing_language" "observability_pipelines_vector_configuration") .Identifier) }}d-none{{ end }}">
                                             {{ range .Children }}
                                                 <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
                                                     {{ $url_without_anchor = (index (split .URL "#") 0) }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

4th level nav should be disabled except for special cases, this was removed recently when it shouldn't have been.
https://datadoghq.atlassian.net/browse/WEB-4382

### Merge instructions

- [ ] Please merge after reviewing

### Additional notes

introduced in https://github.com/DataDog/documentation/commit/398d4779f8291df8479b827006e3198f7efb31be#diff-dfdaa69dbf684b687cc5616b90c96c3a66145c1ff7c5e8cba24193b9ad3add0e

**Should not show 4th level java, .NET etc. under library compatibility**
https://docs-staging.datadoghq.com/david.jones/web-4382/security/application_security/enabling/compatibility/java/

**Should show 4th level (errors/functions)**
https://docs-staging.datadoghq.com/david.jones/web-4382/observability_pipelines/reference/processing_language/errors/