### PR TITLE
Update Test Visibility and ITR docs for Java: add Scalatest support, and other minor updates

### DIFF
--- a/content/en/continuous_integration/pipelines/jenkins.md
+++ b/content/en/continuous_integration/pipelines/jenkins.md
@@ -543,6 +543,8 @@ See the [Test Visibility documentation][17] for your language to make sure that 
 
 ### Enable with the Jenkins configuration UI
 
+UI-based Test Visibility configuration is available in Datadog Jenkins plugin v5.6.0 or newer.
+
 1. In your Jenkins instance web interface, go to the job or pipeline that you want to instrument and choose the **Configure** option.
 2. In the **General** configuration section, tick the **Enable Datadog Test Visibility** checkbox.
 3. Enter the name of the service or library being tested into the **Service Name** input. You can choose any value that makes sense to you.

--- a/content/en/intelligent_test_runner/setup/java.md
+++ b/content/en/intelligent_test_runner/setup/java.md
@@ -291,7 +291,7 @@ Feature: My Feature
 ```
 
 {{% /tab %}}
-{{% tab "Scalatest" %}}
+{{% tab "ScalaTest" %}}
 
 Create a `Tag` with the value `datadog_itr_unskippable` and tag your test case with it:
 

--- a/content/en/intelligent_test_runner/setup/java.md
+++ b/content/en/intelligent_test_runner/setup/java.md
@@ -8,7 +8,7 @@ code_lang_weight: 10
 aliases:
   - continuous_integration/intelligent_test_runner/java/
   - continuous_integration/intelligent_test_runner/setup/java/
-  
+
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"
@@ -22,13 +22,14 @@ further_reading:
 
 ## Compatibility
 
-Intelligent Test Runner is supported in `dd-java-agent >= 1.22.0`.
+Intelligent Test Runner is supported in `dd-java-agent >= 1.26.0`.
 
 The following test frameworks are supported:
 - JUnit >= 4.10 and >= 5.3
 - TestNG >= 6.4
 - Spock >= 2.0
 - Cucumber >= 5.4.0
+- Scalatest >= 3.0.8
 
 ## Setup
 
@@ -89,6 +90,7 @@ Unskippable tests are supported in the following versions and testing frameworks
 - TestNG >= 6.4
 - Spock >= 2.2
 - Cucumber >= 5.4.0
+- Scalatest >= 3.0.8
 
 ### Marking tests as unskippable
 
@@ -286,6 +288,24 @@ Feature: My Feature
 
   Scenario: My Scenario
     # ...
+```
+
+{{% /tab %}}
+{{% tab "Scalatest" %}}
+
+Create a `Tag` with the value `datadog_itr_unskippable` and tag your test case with it:
+
+```scala
+import org.scalatest.Tag
+import org.scalatest.flatspec.AnyFlatSpec
+
+object ItrUnskippableTag extends Tag("datadog_itr_unskippable")
+
+class MyTestSuite extends AnyFlatSpec {
+  "myTest" should "assert something" taggedAs ItrUnskippableTag in {
+    // ...
+  }
+}
 ```
 
 {{% /tab %}}

--- a/content/en/intelligent_test_runner/setup/java.md
+++ b/content/en/intelligent_test_runner/setup/java.md
@@ -22,7 +22,7 @@ further_reading:
 
 ## Compatibility
 
-Intelligent Test Runner is supported in `dd-java-agent >= 1.26.0`.
+Intelligent Test Runner is supported in `dd-java-agent >= 1.26.1`.
 
 The following test frameworks are supported:
 - JUnit >= 4.10 and >= 5.3

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -40,6 +40,7 @@ Supported test frameworks:
 | Spock | >= 2.0 |
 | Cucumber | >= 5.4.0 |
 | Karate | >= 1.0.0 |
+| Scalatest | >= 3.0.8 |
 | Scala MUnit | >= 0.7.28 |
 
 If your test framework is not supported, you can try instrumenting your tests using [Manual Testing API][1].
@@ -358,7 +359,7 @@ Ensure that you are using the latest version of the tracer.
 
 Verify that your build system and testing framework are supported by CI Visibility. See the list of [supported build systems and test frameworks](#compatibility).
 
-Ensure that the `dd.civisibility.enabled` property is set to `true` in the tracer arguments.
+Ensure that the `dd.civisibility.enabled` property (or `DD_CIVISIBILITY_ENABLED` environment variable) is set to `true` in the tracer arguments.
 
 Check the build output for any errors that indicate tracer misconfiguration, such as an unset `DD_API_KEY` environment variable.
 
@@ -370,7 +371,8 @@ The plugin is optional, as it only serves to reduce the performance overhead.
 
 Depending on the build configuration, adding the plugin can sometimes disrupt the compilation process.
 
-If the plugin interferes with the build, disable it by adding `dd.civisibility.compiler.plugin.auto.configuration.enabled=false` to the list of `-javaagent` arguments.
+If the plugin interferes with the build, disable it by adding `dd.civisibility.compiler.plugin.auto.configuration.enabled=false` to the list of `-javaagent` arguments
+(or by setting `DD_CIVISIBILITY_COMPILER_PLUGIN_AUTO_CONFIGURATION_ENABLED=false` environment variable).
 
 ### Tests fail when building a project with the tracer attached
 
@@ -384,7 +386,7 @@ They are enabled by default.
 To disable a specific integration, refer to the [Datadog Tracer Compatibility][7] table for the relevant configuration property names.
 For example, to disable `OkHttp3` client request integration, add `dd.integration.okhttp-3.enabled=false` to the list of `-javaagent` arguments.
 
-To disable all integrations, augment the list of `-javaagent` arguments with `dd.trace.enabled=false`.
+To disable all integrations, augment the list of `-javaagent` arguments with `dd.trace.enabled=false` (or set `DD_TRACE_ENABLED=false` environment variable).
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates Test Visibility documents for Java:
- Scalatest added to list of supported frameworks
- a note added that Jenkins plugin supports Test Visibility configuration starting with v5.6.0
- troubleshooting section now has environment variable names in addition to system property names for tracer config

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->