### PR TITLE
add list of all Windows installers

### DIFF
--- a/content/en/agent/supported_platforms.md
+++ b/content/en/agent/supported_platforms.md
@@ -203,7 +203,6 @@ A check mark ({{< X >}}) indicates support for all minor and patch versions.
 [7]: /agent/basic_agent_usage/fedora/
 
 {{% /tab %}}
-
 {{% tab "Windows" %}}
 
 <table>
@@ -262,6 +261,8 @@ A check mark ({{< X >}}) indicates support for all minor and patch versions.
 </table>
 
 A check mark ({{< X >}}) indicates support for all minor and patch versions.
+
+To install a specific version of the Windows Agent, see the [installer list][8].
 
 {{% /tab %}}
 {{% tab "macOS" %}}
@@ -329,3 +330,4 @@ Agent 6 and 7 support the following [AIX][1] versions:
 
 
 [1]: /agent/basic_agent_usage/source/
+[8]: https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Customers that find that the latest Agent version doesn't support their OS platform/version will need to install a previous version of the Agent that is compatible. This PR just adds a link to the full list of previous installers.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->