### PR TITLE
Add troubleshooting steps for expo logs

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
@@ -197,6 +197,32 @@ const config = new DdSdkReactNativeConfiguration(/* your config */);
 DdSdkReactNative.initialize(config);
 ```
 
+## Troubleshooting
+
+### App produces a lot of /logs RUM Resources
+
+When Resource tracking is enabled and SDK verbosity is set to `DEBUG`, each RUM Resource will trigger a `/logs` call to the Expo dev server to print the log, which will itself create a new RUM resource, creating an infinite loop.
+The most common patterns of Expo dev server host URL are filtered by the SDK, therefore, you may not encounter this error in most situations.
+If this error occurs, add the following RUM Resource mapper to filter out the calls:
+
+```js
+import { DdSdkReactNativeConfiguration } from 'expo-datadog';
+import Constants from 'expo-constants';
+
+const config = new DdSdkReactNativeConfiguration(/* your config */);
+config.resourceEventMapper = event => {
+  if (
+    event.resourceContext?.responseURL ===
+    `http://${Constants.expoConfig.hostUri}/logs`
+  ) {
+    return null;
+  }
+  return event;
+};
+```
+
+
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Expo dev client makes `/logs` API calls to the packager every time there is a log. If we track RUM Resources and have SDK Verbosity set to `DEBUG` we end up in a loop creating infinite resources and logs.

We already filter out the most probable URLs for this call, but it can be custom. In that case, we add instructions for users to avoid creating this many calls.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->