### PR TITLE
[RUM-2436][Browser SDK] Document `usePartitionedCrossSiteSessionCookie` config parameter

### DIFF
--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -364,11 +364,12 @@ The following parameters are available to configure the Datadog browser logs SDK
 
 Options that must have a matching configuration when using the `RUM` SDK:
 
-| Parameter                      | Type    | Required | Default | Description                                                                                                                                                  |
-| ------------------------------ | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `trackSessionAcrossSubdomains` | Boolean | No       | `false` | Preserve the session across subdomains for the same site.                                                                                                    |
-| `useSecureSessionCookie`       | Boolean | No       | `false` | Use a secure session cookie. This disables logs sent on insecure (non-HTTPS) connections.                                                                    |
-| `useCrossSiteSessionCookie`    | Boolean | No       | `false` | Use a secure cross-site session cookie. This allows the logs SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`. |
+| Parameter                              | Type    | Required | Default | Description                                                                                                                                                              |
+|----------------------------------------| ------- | -------- | ------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `trackSessionAcrossSubdomains`         | Boolean | No       | `false` | Preserve the session across subdomains for the same site.                                                                                                                |
+| `useSecureSessionCookie`               | Boolean | No       | `false` | Use a secure session cookie. This disables logs sent on insecure (non-HTTPS) connections.                                                                                |
+| `usePartitionedCrossSiteSessionCookie` | Boolean | No       | `false` | Use a partitioned secure cross-site session cookie. This allows the logs SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`. |
+| `useCrossSiteSessionCookie`            | Boolean | No       | `false` | **Deprecated**, see `usePartitionedCrossSiteSessionCookie`.                                                                                                              |
 
 ## Usage
 

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -1846,11 +1846,17 @@ Preserve the session across subdomains for the same site.
 **Default**: `false`<br/>
 Use a secure session cookie. This disables RUM events sent on insecure (non-HTTPS) connections.
 
-`useCrossSiteSessionCookie`
+`usePartitionedCrossSiteSessionCookie`
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**:`false`<br/>
-Use a secure cross-site session cookie. This allows the RUM Browser SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`.
+Use a partitioned secure cross-site session cookie. This allows the RUM Browser SDK to run when the site is loaded from another one (iframe). Implies `useSecureSessionCookie`.
+
+`useCrossSiteSessionCookie`
+: Optional - **Deprecated**<br/>
+**Type**: Boolean<br/>
+**Default**:`false`<br/>
+See `usePartitionedCrossSiteSessionCookie`.
 
 `allowFallbackToLocalStorage`
 : Optional<br/>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Document the new config parameter allowing to configure the session cookie as partitioned to address the phasing out of third-party cookies by google.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->