### PR TITLE
Update documentation related to customer data limit

### DIFF
--- a/content/en/real_user_monitoring/browser/troubleshooting.md
+++ b/content/en/real_user_monitoring/browser/troubleshooting.md
@@ -102,13 +102,15 @@ If an event or a request goes beyond any of the following limitations, it is rej
 | Maximum event size                       | 256 KB       |
 | Maximum intake payload size              | 5 MB         |
 
-## Customer data exceeds the recommended 3KiB warning
+## "Customer data exceeds the recommended threshold" warning
 
 The RUM browser SDK allows you to set [global context][9], [user information][10] and [feature flags][11] which are then included with the collected events.
 
 To minimize the user bandwidth impact, the RUM browser SDK throttles the data sent to the Datadog intake. However, sending large volumes of data can still impact the performance for users on slow internet connections.
 
 For the best user experience, Datadog recommends keeping the size of the global context, user information, and feature flags below 3KiB. If the data exceeds this limit, a warning is displayed: `The data exceeds the recommended 3KiB threshold.`
+
+Since v5.3.0, the RUM Browser SDK supports data compression via the `compressIntakeRequest` [initialization parameter][12]. When enabled, this recommended limit is extended from 3KiB to 16KiB.
 
 ## Cross origin read blocking warning
 
@@ -131,3 +133,4 @@ The warning is shown because the intake returns a non-empty JSON object. This be
 [9]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#global-context
 [10]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#user-session
 [11]: /real_user_monitoring/guide/setup-feature-flag-data-collection/?tab=browser
+[12]: /real_user_monitoring/browser/#initialization-parameters


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The Browser SDK is now capable of compressing data before sending it to Datadog. With this feature enabled, the limit to display customer data warning has been increased. This PR adjusts the documentation.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes

Related SDK PR: https://github.com/DataDog/browser-sdk/pull/2529