### PR TITLE
rm trailing spaces/new lines after links - [WEB-4392] 

### DIFF
--- a/layouts/integrations/_markup/render-link.html
+++ b/layouts/integrations/_markup/render-link.html
@@ -1,1 +1,2 @@
 <a href="{{ .Destination | safeURL }}" {{ if hasSuffix .Destination ".xml" }}download{{ end }}>{{ .Text | safeHTML }}</a>
+{{- /*  Do not add extra empty lines or spaces to this render hook. will cause a space to render after anchor */ -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
removes trailing spaces / new lines after anchors generated by the `render-link` render hook.

jira: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-4392

should only effect pages using the `/integrations` layout
preview: https://docs-staging.datadoghq.com/stefon.simmons/remove-unexpected-space-web-4392/integrations/guide/azure-manual-setup/?tab=armtemplate#integrating-through-the-azure-portal

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->