### PR TITLE
Remove mention of "remote config" from single step APM docs

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -19,7 +19,7 @@ The following examples show how it works on each infrastructure type.
 {{< tabs >}}
 {{% tab "Linux host or VM" %}}
 
-In one command, you can install, configure, and start the Agent with APM and [Remote Configuration][2] enabled, and set up automatic instrumentation of your services.
+With one command, you can install, configure, and start the Agent, while also instrumenting your services with APM.
 
 For an Ubuntu host:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
PM requested that we remove mention of remote configuration from single step instrumentation documentations. This was creating confusion for users.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->