### PR TITLE
[DOCS-6572] Add iOS and Android to DD libraries page.

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/android.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/android.md
@@ -4,6 +4,9 @@ aliases:
 - /tracing/setup/android
 - /tracing/trace_collection/dd_libraries/android
 description: Collect traces from your Android applications.
+code_lang: android
+type: multi-code-lang
+code_lang_weight: 80
 further_reading:
 - link: https://github.com/DataDog/dd-sdk-android
   tag: GitHub
@@ -12,7 +15,7 @@ further_reading:
   tag: Documentation
   text: Explore your services, resources, and traces
 kind: documentation
-title: Android Trace Collection
+title: Tracing Android Applications
 ---
 Send [traces][1] to Datadog from your Android applications with [Datadog's `dd-sdk-android-trace` client-side tracing library][2] and leverage the following features:
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/ios.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/ios.md
@@ -1,11 +1,14 @@
 ---
-title: iOS Trace Collection
+title: Tracing iOS Applications
 kind: documentation
 aliases:
 - /tracing/setup_overview/setup/ios/
 - /tracing/setup/ios/
 - /tracing/trace_collection/dd_libraries/ios
 description: Collect traces from your iOS applications.
+code_lang: ios
+type: multi-code-lang
+code_lang_weight: 90
 further_reading:
 - link: https://github.com/DataDog/dd-sdk-ios
   tag: GitHub

--- a/layouts/partials/apm/apm-compatibility.html
+++ b/layouts/partials/apm/apm-compatibility.html
@@ -65,6 +65,24 @@
           </div>
         </a>
       </div>
+      <!-- Conditional Android and iOS cards (no compatibility or library_config pages for these as of 12/22/23) -->
+      {{ $currentURL := .Page.Permalink }}
+      {{ if and (not (in $currentURL "/compatibility/")) (not (in $currentURL "/library_config/")) }}
+      <div class="col">
+        <a class="card h-100" href="android">
+          <div class="card-body text-center py-2 px-1">
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/android.png" "class" "img-fluid" "alt" "Android" "width" "400") }}
+          </div>
+        </a>
+      </div>
+      <div class="col">
+        <a class="card h-100" href="ios">
+          <div class="card-body text-center py-2 px-1">
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/ios_large.svg" "class" "img-fluid" "alt" "iOS" "width" "400") }}
+          </div>
+        </a>
+      </div>
+      {{ end }}
     </div>
   </div>
 </div>

--- a/layouts/partials/apm/apm-languages.html
+++ b/layouts/partials/apm/apm-languages.html
@@ -65,6 +65,20 @@
           </div>
         </a>
       </div>
+      <div class="col">
+        <a class="card h-100" href="dd_libraries/android">
+          <div class="card-body text-center py-2 px-1">
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/android.png" "class" "img-fluid" "alt" "Android" "width" "400") }}
+          </div>
+        </a>
+      </div>
+      <div class="col">
+        <a class="card h-100" href="dd_libraries/ios">
+          <div class="card-body text-center py-2 px-1">
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/ios_large.svg" "class" "img-fluid" "alt" "iOS" "width" "400") }}
+          </div>
+        </a>
+      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The Tracing Android and iOS pages were not linked anywhere in the docs before.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->