### PR TITLE
[DOCS-6803] updating Helm version in CSM vulnerabilities prereqs

### DIFF
--- a/content/en/security/vulnerabilities/troubleshooting.md
+++ b/content/en/security/vulnerabilities/troubleshooting.md
@@ -31,7 +31,7 @@ Ensure all the [prerequisites][5] are met for CSM Vulnerabilities:
 
 | Component                | Version/Requirement                     |
 | ------------------------ | ----------------------------------------|
-| [Helm Chart][6]            | v3.33.6 or later (Kubernetes only)      |
+| [Helm Chart][6]            | v3.49.6 or later (Kubernetes only)      |
 | [containerd][7]              | v1.5.6 or later (Kubernetes and hosts only)|
 
 CSM Vulnerabilities is **not** available for the following environments:

--- a/layouts/shortcodes/csm-prereqs-enterprise.md
+++ b/layouts/shortcodes/csm-prereqs-enterprise.md
@@ -25,7 +25,7 @@ CSM Threats supports the following Linux distributions:
 
 | Component                | Version/Requirement                     |
 | ------------------------ | ----------------------------------------|
-| [Helm Chart][103]            | v3.33.6 or later (Kubernetes only)      |
+| [Helm Chart][103]            | v3.49.6 or later (Kubernetes only)      |
 | [containerd][104]              | v1.5.6 or later (Kubernetes and hosts only)|
 
 **Note**: CSM Vulnerabilities is not available for CRI-O runtime, Windows, or AWS Fargate environments.

--- a/layouts/shortcodes/csm-prereqs-pro.md
+++ b/layouts/shortcodes/csm-prereqs-pro.md
@@ -4,7 +4,7 @@ Datadog Agent `7.46` or later installed on your hosts or containers.
 
 | Component                | Version/Requirement                     |
 | ------------------------ | ----------------------------------------|
-| [Helm Chart][102]            | v3.33.6 or later (Kubernetes only)      |
+| [Helm Chart][102]            | v3.49.6 or later (Kubernetes only)      |
 | [containerd][103]              | v1.5.6 or later (Kubernetes and hosts only)|
 
 **Note**: CSM Vulnerabilities is not available for CRI-O runtime, Windows, or AWS Fargate environments.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR bumps the minimum required Helm version for CSM vulnerabilities due to a bug that was fixed in the helm chart.
[DOCS-6803](https://datadoghq.atlassian.net/browse/DOCS-6803)
https://github.com/DataDog/helm-charts/pull/1259

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6803]: https://datadoghq.atlassian.net/browse/DOCS-6803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ