### PR TITLE
Removing mention of Custom Scorecards private beta

### DIFF
--- a/content/en/tracing/service_catalog/scorecards.md
+++ b/content/en/tracing/service_catalog/scorecards.md
@@ -43,10 +43,6 @@ To select which of the out-of-the-box rules are evaluated for each of the defaul
 
 ### Creating custom rules
 
-{{< callout url="https://forms.gle/8HCfQiuKM8FVceTG9" btn_hidden="false">}}
-Custom Scorecard rules are in private beta. Join the beta by requesting access.
-{{< /callout >}}
-
 To add custom rules to your Scorecards dashboard using the [Scorecards API][10]: 
 
 1. Specify the name of the rule, the scorecard it belongs to, a rule description, and an owner to pass to `/scorecard/rules`.


### PR DESCRIPTION
The feature is now in public beta, so removing call out to request access for private beta.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->