### PR TITLE
adding missing identifiers to menus.en.yaml

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1107,7 +1107,7 @@ main:
     identifier: infrastructure_process
     weight: 4
   - name: Increase Process Retention
-    identifier: infrastructure_process_increass_process_retention
+    identifier: infrastructure_process_increase_process_retention
     url: infrastructure/process/increase_process_retention/
     parent: infrastructure_process
     weight: 401
@@ -2995,7 +2995,7 @@ main:
     parent: log_collection
     weight: 106
   - name: C#
-    identifier: log_csharp
+    identifier: log_collection_csharp
     url: logs/log_collection/csharp/
     parent: log_collection
     weight: 107
@@ -3010,7 +3010,7 @@ main:
     identifier: log_collection_java
     weight: 109
   - name: NodeJS
-    identifier: log_nodejs
+    identifier: log_collection_nodejs
     url: logs/log_collection/nodejs/
     parent: log_collection
     weight: 110
@@ -3054,12 +3054,12 @@ main:
     parent: log_configuration
     weight: 202
   - name: Parsing
-    identifier: log_parsing
+    identifier: log_configuration_parsing
     url: logs/log_configuration/parsing/
     parent: log_configuration
     weight: 203
   - name: Pipeline Scanner
-    identifier: log_pipeline_scanner
+    identifier: log_configuration_pipeline_scanner
     url: logs/log_configuration/pipeline_scanner/
     parent: log_configuration
     weight: 204
@@ -3800,12 +3800,12 @@ main:
     identifier: synthetics_browser_tests
     weight: 3
   - name: Recording Steps
-    identifier: synthetics_recording_steps
+    identifier: synthetics_browser_tests_recording_steps
     url: synthetics/browser_tests/actions
     parent: synthetics_browser_tests
     weight: 301
   - name: Test Results
-    identifier: synthetics_test_results
+    identifier: synthetics_browser_tests_test_results
     url: synthetics/browser_tests/test_results
     parent: synthetics_browser_tests
     weight: 302
@@ -4540,7 +4540,7 @@ main:
     parent: custom_checks
     weight: 301
   - name: Writing a Custom OpenMetrics Check
-    identifier: custom_checks_prometheus
+    identifier: dev_tools_custom_checks_prometheus
     url: developers/custom_checks/prometheus/
     parent: custom_checks
     weight: 302

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -171,18 +171,22 @@ main:
     parent: getting_started_synthetics
     weight: 1703
   - name: Incident Management
+    identifier: getting_started_incident_management
     url: getting_started/incident_management/
     parent: getting_started
     weight: 18
   - name: Database Monitoring
+    identifier: getting_started_database_monitoring
     url: getting_started/database_monitoring/
     parent: getting_started
     weight: 19
   - name: Cloud Security Management
+    identifier: getting_started_cloud_security_management
     url: getting_started/cloud_security_management/
     parent: getting_started
     weight: 20
   - name: Cloud SIEM
+    identifier: getting_started_cloud_siem
     url: getting_started/cloud_siem/
     parent: getting_started
     weight: 21
@@ -202,10 +206,12 @@ main:
     parent: getting_started
     weight: 23
   - name: Learning Center
+    identifier: getting_started_learning_center
     url: getting_started/learning_center/
     parent: getting_started
     weight: 24
   - name: Support
+    identifier: getting_started_support
     url: getting_started/support/
     parent: getting_started
     weight: 25
@@ -338,14 +344,17 @@ main:
     parent: agent
     weight: 7
   - name: Advanced Configurations
+    identifier: agent_logs_advanced_log_collection
     url: agent/logs/advanced_log_collection
     parent: agent_logs
     weight: 701
   - name: Proxy
+    identifier: agent_logs_proxy
     url: agent/logs/proxy
     parent: agent_logs
     weight: 702
   - name: Transport
+    identifier: agent_logs_transport
     url: agent/logs/log_transport
     parent: agent_logs
     weight: 703
@@ -355,46 +364,57 @@ main:
     identifier: agent_configuration
     weight: 8
   - name: Commands
+    identifier: agent_configuration_commands
     url: agent/configuration/agent-commands/
     parent: agent_configuration
     weight: 801
   - name: Configuration Files
+    identifier: agent_configuration_files
     url: agent/configuration/agent-configuration-files/
     parent: agent_configuration
     weight: 802
   - name: Log Files
+    identifier: agent_configuration_log_files
     url: agent/configuration/agent-log-files/
     parent: agent_configuration
     weight: 803
   - name: Status Page
+    identifier: agent_configuration_status_page
     url: agent/configuration/agent-status-page/
     parent: agent_configuration
     weight: 804
   - name: Network Traffic
+    identifier: agent_configuration_network_traffic
     url: agent/configuration/network/
     parent: agent_configuration
     weight: 805
   - name: Proxy Configuration
+    identifier: agent_configuration_proxy
     url: agent/configuration/proxy/
     parent: agent_configuration
     weight: 806
   - name: FIPS Compliance
+    identifier: agent_configuration_fips_compliance
     url: agent/configuration/agent-fips-proxy/
     parent: agent_configuration
     weight: 807
   - name: Dual Shipping
+    identifier: agent_configuration_dual_shipping
     url: agent/configuration/dual-shipping/
     parent: agent_configuration
     weight: 808
   - name: Secrets Management
+    identifier: agent_configuration_secrets_management
     url: agent/configuration/secrets-management/
     parent: agent_configuration
     weight: 809
   - name: Remote Configuration
+    identifier: agent_remote_configuration
     url: agent/remote_config
     parent: agent
     weight: 9
   - name: Fleet Automation
+    identifier: agent_fleet_automation
     url: agent/fleet_automation
     parent: agent
     weight: 10
@@ -404,14 +424,17 @@ main:
     identifier: agent_versions
     weight: 11
   - name: Upgrade to Agent v7
+    identifier: agent_versions_upgrade_to_agent_v7
     url: agent/versions/upgrade_to_agent_v7/
     parent: agent_versions
     weight: 1101
   - name: Upgrade to Agent v6
+    identifier: agent_versions_upgrade_to_agent_v6
     url: agent/versions/upgrade_to_agent_v6/
     parent: agent_versions
     weight: 1102
   - name: Upgrade Between Agent Minor Versions
+    identifier: agent_versions_upgrade_between_agent_minor_versions
     url: agent/versions/upgrade_between_agent_minor_versions
     parent: agent_versions
     weight: 1103
@@ -421,50 +444,62 @@ main:
     weight: 12
     identifier: agent_troubleshooting
   - name: Container Hostname Detection
+    identifier: agent_troubleshooting_hostname_containers
     url: agent/troubleshooting/hostname_containers/
     parent: agent_troubleshooting
     weight: 1201
   - name: Debug Mode
+    identifier: agent_troubleshooting_debug_mode
     url: agent/troubleshooting/debug_mode/
     parent: agent_troubleshooting
     weight: 1202
   - name: Agent Flare
+    identifier: agent_troubleshooting_agent_flare
     url: agent/troubleshooting/send_a_flare/
     parent: agent_troubleshooting
     weight: 1203
   - name: Agent Check Status
+    identifier: agent_troubleshooting_agent_check_status
     url: agent/troubleshooting/agent_check_status/
     parent: agent_troubleshooting
     weight: 1204
   - name: NTP Issues
+    identifier: agent_troubleshooting_ntp
     url: agent/troubleshooting/ntp/
     parent: agent_troubleshooting
     weight: 1205
   - name: Permission Issues
+    identifier: agent_troubleshooting_permissions
     url: agent/troubleshooting/permissions/
     parent: agent_troubleshooting
     weight: 1206
   - name: Integrations Issues
+    identifier: agent_troubleshooting_integrations
     url: agent/troubleshooting/integrations/
     parent: agent_troubleshooting
     weight: 1207
   - name: Site Issues
+    identifier: agent_troubleshooting_site
     url: agent/troubleshooting/site/
     parent: agent_troubleshooting
     weight: 1208
   - name: Autodiscovery Issues
+    identifier: agent_troubleshooting_autodiscovery
     url: agent/troubleshooting/autodiscovery/
     parent: agent_troubleshooting
     weight: 1209
   - name: Windows Container Issues
+    identifier: agent_troubleshooting_windows_containers
     url: agent/troubleshooting/windows_containers
     weight: 1210
     parent: agent_troubleshooting
   - name: Agent Runtime Configuration
+    identifier: agent_troubleshooting_runtime_configuration
     url: agent/troubleshooting/config
     weight: 1211
     parent: agent_troubleshooting
   - name: High CPU or Memory Consumption
+    identifier: agent_troubleshooting_high_cpu_memory_consumption
     url: agent/troubleshooting/high_memory_usage/
     weight: 1212
     parent: agent_troubleshooting
@@ -595,14 +630,17 @@ main:
     parent: containers_cluster
     weight: 402
   - name: Cluster Checks
+    identifier: containers_cluster_agent_clusterchecks
     url: containers/cluster_agent/clusterchecks/
     parent: containers_cluster
     weight: 403
   - name: Endpoint Checks
+    identifier: containers_cluster_agent_endpoint_checks
     url: containers/cluster_agent/endpointschecks/
     parent: containers_cluster
     weight: 404
   - name: Admission Controller
+    identifier: containers_cluster_agent_admission_controller
     url: containers/cluster_agent/admission_controller/
     parent: containers_cluster
     weight: 405
@@ -750,6 +788,7 @@ main:
     parent: watchdog_top_level
     weight: 3
   - name: Insights
+    identifier: watchdog_insights
     url: watchdog/insights
     parent: watchdog_top_level
     weight: 4
@@ -770,6 +809,7 @@ main:
     identifier: dashboards_widgets
     weight: 1
   - name: Querying
+    identifier: dashboards_querying
     url: dashboards/querying/
     parent: dashboards
     weight: 2
@@ -779,54 +819,67 @@ main:
     identifier: dashboards_functions
     weight: 3
   - name: Algorithms
+    identifier: dashboards_functions_algorithms
     url: dashboards/functions/algorithms/
     parent: dashboards_functions
     weight: 301
   - name: Arithmetic
+    identifier: dashboards_functions_arithmetic
     url: dashboards/functions/arithmetic/
     parent: dashboards_functions
     weight: 302
   - name: Count
+    identifier: dashboards_functions_count
     url: dashboards/functions/count/
     parent: dashboards_functions
     weight: 303
   - name: Exclusion
+    identifier: dashboards_functions_exclusion
     url: dashboards/functions/exclusion/
     parent: dashboards_functions
     weight: 303
   - name: Interpolation
+    identifier: dashboards_functions_interpolation
     url: dashboards/functions/interpolation/
     parent: dashboards_functions
     weight: 304
   - name: Rank
+    identifier: dashboards_functions_rank
     url: dashboards/functions/rank/
     parent: dashboards_functions
     weight: 305
   - name: Rate
+    identifier: dashboards_functions_rate
     url: dashboards/functions/rate/
     parent: dashboards_functions
     weight: 306
   - name: Regression
+    identifier: dashboards_functions_regression
     url: dashboards/functions/regression/
     parent: dashboards_functions
     weight: 307
   - name: Rollup
+    identifier: dashboards_functions_rollup
     url: dashboards/functions/rollup/
     parent: dashboards_functions
     weight: 308
   - name: Smoothing
+    identifier: dashboards_functions_smoothing
     url: dashboards/functions/smoothing/
     parent: dashboards_functions
     weight: 309
   - name: Timeshift
+    identifier: dashboards_functions_timeshift
     url: dashboards/functions/timeshift/
     parent: dashboards_functions
     weight: 310
   - name: Beta
+    identifier: dashboards_functions_beta
     url: dashboards/functions/beta/
     parent: dashboards_functions
     weight: 311
   - name: Correlations
+    identifier: dashboards_correlations
     url: dashboards/correlations/
     parent: dashboards
     weight: 4
@@ -846,6 +899,7 @@ main:
     weight: 7
     identifier: dashboards_overlays
   - name: Sharing
+    identifier: dashboards_sharing
     url: dashboards/sharing/
     parent: dashboards
     weight: 8
@@ -941,14 +995,17 @@ main:
     identifier: serverless_app_services
     weight: 3
   - name: Linux - Code
+    identifier: serverless_azure_app_services_linux_code
     url: serverless/azure_app_services/azure_app_services_linux
     parent: serverless_app_services
     weight: 301
   - name: Linux - Container
+    identifier: serverless_azure_app_services_linux_container
     url: serverless/azure_app_services/azure_app_services_container
     parent: serverless_app_services
     weight: 302
   - name: Windows - Code
+    identifier: serverless_azure_app_services_windows_code
     url: serverless/azure_app_services/azure_app_services_windows
     parent: serverless_app_services
     weight: 303
@@ -1015,6 +1072,7 @@ main:
     weight: 1
     identifier: infrastructure_host_map
   - name: Infrastructure List
+    identifier: infrastructure_list
     url: infrastructure/list/
     parent: infrastructure
     weight: 2
@@ -1049,6 +1107,7 @@ main:
     identifier: infrastructure_process
     weight: 4
   - name: Increase Process Retention
+    identifier: infrastructure_process_increass_process_retention
     url: infrastructure/process/increase_process_retention/
     parent: infrastructure_process
     weight: 401
@@ -1074,10 +1133,12 @@ main:
     identifier: metrics_explorer
     weight: 1
   - name: Metrics Units
+    identifier: metrics_units
     url: metrics/units/
     parent: metrics_explorer
     weight: 101
   - name: Summary
+    identifier: metrics_summary
     url: metrics/summary/
     parent: metrics_top_level
     weight: 2
@@ -1092,6 +1153,7 @@ main:
     identifier: metrics_distributions
     weight: 4
   - name: Metrics Without Limits™
+    identifier: metrics_without_limits
     url: metrics/metrics-without-limits/
     parent: metrics_top_level
     weight: 5
@@ -1991,10 +2053,12 @@ main:
     identifier: visualize_spans
     weight: 604
   - name: Trace View
+    identifier: tracing_trace_explorer_trace_view
     url: tracing/trace_explorer/trace_view/
     parent: trace_explorer
     weight: 605
   - name: Request Flow Map
+    identifier: tracing_trace_explorer_request_flow_map
     url: tracing/trace_explorer/request_flow_map/
     parent: trace_explorer
     weight: 606
@@ -2931,6 +2995,7 @@ main:
     parent: log_collection
     weight: 106
   - name: C#
+    identifier: log_csharp
     url: logs/log_collection/csharp/
     parent: log_collection
     weight: 107
@@ -2945,6 +3010,7 @@ main:
     identifier: log_collection_java
     weight: 109
   - name: NodeJS
+    identifier: log_nodejs
     url: logs/log_collection/nodejs/
     parent: log_collection
     weight: 110
@@ -2988,18 +3054,22 @@ main:
     parent: log_configuration
     weight: 202
   - name: Parsing
+    identifier: log_parsing
     url: logs/log_configuration/parsing/
     parent: log_configuration
     weight: 203
   - name: Pipeline Scanner
+    identifier: log_pipeline_scanner
     url: logs/log_configuration/pipeline_scanner/
     parent: log_configuration
     weight: 204
   - name: Attributes and Aliasing
+    identifier: log_collection_attributes_and_aliasing
     url: logs/log_collection/?tab=host#attributes-and-tags
     parent: log_processing
     weight: 205
   - name: Attributes and Aliasing
+    identifier: log_configuration_attributes_and_aliasing
     url: logs/log_configuration/attributes_naming_convention/
     parent: log_configuration
     weight: 206
@@ -3024,10 +3094,12 @@ main:
     identifier: log_archives
     weight: 210
   - name: Rehydrate from Archives
+    identifier: log_configuration_rehydrating
     url: logs/log_configuration/rehydrating
     parent: log_configuration
     weight: 211
   - name: Forwarding
+    identifier: log_configuration_forwarding
     url: logs/log_configuration/forwarding_custom_destinations/
     parent: log_configuration
     weight: 212
@@ -3042,14 +3114,17 @@ main:
     identifier: log_explorer
     weight: 5
   - name: Live Tail
+    identifier: log_explorer_live_tail
     url: logs/explorer/live_tail/
     parent: log_explorer
     weight: 501
   - name: Search Logs
+    identifier: log_explorer_search_logs
     url: logs/explorer/search/
     parent: log_explorer
     weight: 502
   - name: Search Syntax
+    identifier: log_explorer_search_syntax
     url: logs/explorer/search_syntax/
     parent: log_explorer
     weight: 503
@@ -3059,38 +3134,47 @@ main:
     identifier: log_explorer_advanced_search
     weight: 504
   - name: Facets
+    identifier: log_explorer_facets
     url: logs/explorer/facets/
     parent: log_explorer
     weight: 505
   - name: Analytics
+    identifier: log_explorer_analytics
     url: logs/explorer/analytics/
     parent: log_explorer
     weight: 506
   - name: Patterns
+    identifier: log_explorer_patterns
     url: logs/explorer/analytics/patterns/
     parent: log_explorer
     weight: 507
   - name: Transactions
+    identifier: log_explorer_transactions
     url: logs/explorer/analytics/transactions/
     parent: log_explorer
     weight: 508
   - name: Visualize
+    identifier: log_explorer_visualize
     url: logs/explorer/visualize/
     parent: log_explorer
     weight: 509
   - name: Log Side Panel
+    identifier: log_explorer_side_panel
     url: logs/explorer/side_panel/
     parent: log_explorer
     weight: 510
   - name: Export
+    identifier: log_explorer_export
     url: logs/explorer/export/
     parent: log_explorer
     weight: 511
   - name: Watchdog Insights for Logs
+    identifier: log_explorer_watchdog_insights
     url: logs/explorer/watchdog_insights/
     parent: log_explorer
     weight: 512
   - name: Saved Views
+    identifier: log_explorer_saved_views
     url: logs/explorer/saved_views/
     parent: log_explorer
     weight: 513
@@ -3100,14 +3184,17 @@ main:
     identifier: log_management_error_tracking
     weight: 6
   - name: Error Tracking Explorer
+    identifier: log_management_error_tracking_explorer
     url: logs/error_tracking/explorer
     parent: log_management_error_tracking
     weight: 601
   - name: Track Browser and Mobile Errors
+    identifier: log_management_error_tracking_browser_and_mobile
     url: logs/error_tracking/browser_and_mobile
     parent: log_management_error_tracking
     weight: 602
   - name: Track Backend Errors
+    identifier: log_management_error_tracking_backend
     url: logs/error_tracking/backend
     parent: log_management_error_tracking
     weight: 603
@@ -3148,14 +3235,17 @@ main:
     identifier: observability_pipelines_setup
     weight: 1
   - name: Datadog
+    identifier: observability_pipelines_setup_datadog
     url: observability_pipelines/setup/datadog
     parent: observability_pipelines_setup
     weight: 101
   - name: Datadog with Archiving
+    identifier: observability_pipelines_setup_datadog_with_archiving
     url: observability_pipelines/setup/datadog_with_archiving
     parent: observability_pipelines_setup
     weight: 102
   - name: Splunk
+    identifier: observability_pipelines_setup_splunk
     url: observability_pipelines/setup/splunk
     parent: observability_pipelines_setup
     weight: 110
@@ -3660,34 +3750,42 @@ main:
     weight: 1
     identifier: api_tests
   - name: HTTP
+    identifier: synthetics_api_tests_http
     url: synthetics/api_tests/http_tests
     parent: api_tests
     weight: 101
   - name: SSL
+    identifier: synthetics_api_tests_ssl
     url: synthetics/api_tests/ssl_tests
     parent: api_tests
     weight: 102
   - name: DNS
+    identifier: synthetics_api_tests_dns
     url: synthetics/api_tests/dns_tests
     parent: api_tests
     weight: 103
   - name: WebSocket
+    identifier: synthetics_api_tests_websocket
     url: synthetics/api_tests/websocket_tests
     parent: api_tests
     weight: 104
   - name: TCP
+    identifier: synthetics_api_tests_tcp
     url: synthetics/api_tests/tcp_tests
     parent: api_tests
     weight: 105
   - name: UDP
+    identifier: synthetics_api_tests_udp
     url: synthetics/api_tests/udp_tests
     parent: api_tests
     weight: 106
   - name: ICMP
+    identifier: synthetics_api_tests_icmp
     url: synthetics/api_tests/icmp_tests
     parent: api_tests
     weight: 107
   - name: GRPC
+    identifier: synthetics_api_tests_grpc
     url: synthetics/api_tests/grpc_tests
     parent: api_tests
     weight: 108
@@ -3702,14 +3800,17 @@ main:
     identifier: synthetics_browser_tests
     weight: 3
   - name: Recording Steps
+    identifier: synthetics_recording_steps
     url: synthetics/browser_tests/actions
     parent: synthetics_browser_tests
     weight: 301
   - name: Test Results
+    identifier: synthetics_test_results
     url: synthetics/browser_tests/test_results
     parent: synthetics_browser_tests
     weight: 302
   - name: Advanced Options for Steps
+    identifier: synthetics_browser_tests_advanced_options
     url: synthetics/browser_tests/advanced_options
     parent: synthetics_browser_tests
     weight: 303
@@ -3799,14 +3900,17 @@ main:
     identifier: synthetics_apm
     weight: 9
   - name: Settings
+    identifier: synthetics_settings
     url: synthetics/settings/
     parent: synthetics
     weight: 10
   - name: Metrics
+    identifier: synthetics_metrics
     url: synthetics/metrics/
     parent: synthetics
     weight: 11
   - name: Data Security
+    identifier: data_security_synthetics
     url: data_security/synthetics/
     parent: synthetics
     weight: 12
@@ -4284,6 +4388,7 @@ main:
     identifier: rum_guides
     weight: 13
   - name: Data Security
+    identifier: data_security_real_user_monitoring
     url: data_security/real_user_monitoring/
     parent: rum
     weight: 16
@@ -4400,22 +4505,27 @@ main:
     identifier: dev_tools_dogstatsd
     weight: 2
   - name: Datagram Format
+    identifier: dev_tools_dogstatsd_datagram_format
     url: developers/dogstatsd/datagram_shell
     parent: dev_tools_dogstatsd
     weight: 201
   - name: Unix Domain Socket
+    identifier: dev_tools_dogstatsd_unix_socket
     url: /developers/dogstatsd/unix_socket
     parent: dev_tools_dogstatsd
     weight: 202
   - name: High Throughput Data
+    identifier: dev_tools_dogstatsd_high_throughput
     url: developers/dogstatsd/high_throughput/
     parent: dev_tools_dogstatsd
     weight: 203
   - name: Data Aggregation
+    identifier: dev_tools_dogstatsd_data_agregation
     url: developers/dogstatsd/data_aggregation/
     parent: dev_tools_dogstatsd
     weight: 204
   - name: DogStatsD Mapper
+    identifier: dev_tools_dogstatsd_mapper
     url: developers/dogstatsd/dogstatsd_mapper/
     parent: dev_tools_dogstatsd
     weight: 205
@@ -4425,10 +4535,12 @@ main:
     identifier: custom_checks
     weight: 3
   - name: Writing a Custom Agent Check
+    identifier: dev_tools_write_agent_check
     url: developers/custom_checks/write_agent_check/
     parent: custom_checks
     weight: 301
   - name: Writing a Custom OpenMetrics Check
+    identifier: custom_checks_prometheus
     url: developers/custom_checks/prometheus/
     parent: custom_checks
     weight: 302
@@ -4438,18 +4550,22 @@ main:
     identifier: dev_tools_integrations
     weight: 4
   - name: Create an Agent-based Integration
+    identifier: dev_tools_integrations_agent
     url: developers/integrations/agent_integration/
     parent: dev_tools_integrations
     weight: 401
   - name: Create an API Integration
+    identifier: dev_tools_integrations_api
     url: developers/integrations/api_integration/
     parent: dev_tools_integrations
     weight: 402
   - name: Create a Log Integration
+    identifier: dev_tools_integrations_log
     url: developers/integrations/log_integration/
     parent: dev_tools_integrations
     weight: 403
   - name: Integration Assets Reference
+    identifier: dev_tools_integrations_check_references
     url: developers/integrations/check_references/
     parent: dev_tools_integrations
     weight: 404
@@ -4464,22 +4580,27 @@ main:
     identifier: dev_tools_integrations_tile
     weight: 406
   - name: Create an Integration Dashboard
+    identifier: dev_tools_integrations_dashboard
     url: developers/integrations/create-an-integration-dashboard
     parent: dev_tools_integrations
     weight: 407
   - name: Create a Recommended Monitor
+    identifier: dev_tools_integrations_recommended_monitor
     url: developers/integrations/create-an-integration-recommended-monitor
     parent: dev_tools_integrations
     weight: 408
   - name: Create a Cloud SIEM Detection Rule
+    identifier: dev_tools_integrations_cloud_siem_detection_rule
     url: developers/integrations/create-a-cloud-siem-detection-rule
     parent: dev_tools_integrations
     weight: 409
   - name: OAuth for Integrations
+    identifier: dev_tools_integrations_oauth
     url: developers/integrations/oauth_for_integrations
     parent: dev_tools_integrations
     weight: 410
   - name: Install Agent Integration Developer Tool
+    identifier: dev_tools_integrations_install_developer_tool
     url: developers/integrations/python/
     parent: dev_tools_integrations
     weight: 411
@@ -4534,10 +4655,12 @@ main:
     identifier: dev_community
     weight: 8
   - name: Libraries
+    identifier: dev_community_libraries
     url: developers/community/libraries/
     parent: dev_community
     weight: 801
   - name: Community Office Hours
+    identifier: dev_community_office_hours
     url: developers/community/office_hours/
     parent: dev_community
     weight: 802
@@ -4570,6 +4693,7 @@ main:
     parent: administration_heading
     weight: 270000
   - name: Switching Between Orgs
+    identifier: account_management_org_switching
     url: account_management/org_switching/
     parent: account_management
     weight: 1
@@ -4589,18 +4713,22 @@ main:
     identifier: login_methods
     weight: 202
   - name: OAuth Apps
+    identifier: account_management_org_settings_oauth_apps
     url: account_management/org_settings/oauth_apps
     parent: organization_settings
     weight: 203
   - name: Custom Organization Landing Page
+    identifier: account_management_org_settings_custom_landing
     url: account_management/org_settings/custom_landing
     parent: organization_settings
     weight: 204
   - name: Service Accounts
+    identifier: account_management_org_settings_service_accounts
     url: account_management/org_settings/service_accounts
     parent: organization_settings
     weight: 205
   - name: IP Allowlist
+    identifier: account_management_org_settings_ip_allowlist
     url: account_management/org_settings/ip_allowlist
     parent: organization_settings
     weight: 206
@@ -4675,22 +4803,27 @@ main:
     identifier: account_management_scim
     weight: 5
   - name: Okta
+    identifier: account_management_scim_okta
     url: account_management/scim/okta
     parent: account_management_scim
     weight: 501
   - name: Azure
+    identifier: account_management_scim_azure
     url: account_management/scim/azure
     parent: account_management_scim
     weight: 502
   - name: API and Application Keys
+    identifier: account_management_api_app_keys
     url: account_management/api-app-keys/
     parent: account_management
     weight: 6
   - name: Teams
+    identifier: account_management_teams
     url: account_management/teams/
     parent: account_management
     weight: 7
   - name: Multi-Factor Authentication
+    identifier: account_management_mfa
     url: account_management/multi-factor_authentication/
     parent: account_management
     weight: 8
@@ -4715,22 +4848,27 @@ main:
     identifier: account_management_plan_and_usage
     weight: 10
   - name: Usage Details
+    identifier: account_management_usage_details
     url: account_management/plan_and_usage/usage_details/
     parent: account_management_plan_and_usage
     weight: 1001
   - name: Cost Details
+    identifier: account_management_cost_details
     url: account_management/plan_and_usage/cost_details/
     parent: account_management_plan_and_usage
     weight: 902
   - name: Billing
+    identifier: account_management_billing
     url: account_management/billing/
     parent: account_management
     weight: 11
   - name: Multi-org Accounts
+    identifier: account_management_multi_org_accounts
     url: account_management/multi_organization/
     parent: account_management
     weight: 12
   - name: Guides
+    identifier: account_management_guides
     url: account_management/guide/
     parent: account_management
     weight: 13
@@ -4741,30 +4879,37 @@ main:
     parent: administration_heading
     weight: 270000
   - name: Agent
+    identifier: data_security_agent
     url: data_security/agent/
     parent: data_security
     weight: 1
   - name: Tracing
+    identifier: data_security_tracing
     url: /tracing/configure_data_security/
     parent: data_security
     weight: 2
   - name: Log Management
+    identifier: data_security_log_management
     url: data_security/logs/
     parent: data_security
     weight: 3
   - name: Kubernetes
+    identifier: data_security_kubernetes
     url: data_security/kubernetes
     parent: data_security
     weight: 4
   - name: Synthetic Monitoring
+    identifier: data_security_synthetic_monitoring
     url: data_security/synthetics/
     parent: data_security
     weight: 5
   - name: Real User Monitoring
+    identifier: data_security_real_user_monitoring
     url: data_security/real_user_monitoring/
     parent: data_security
     weight: 6
   - name: Guides
+    identifier: data_security_guide
     url: data_security/guide/
     parent: data_security
     weight: 7


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
some items in menus.en.yaml did not have identifiers
it isn't breaking, but ambiguity can lead to unexpected consequences
in the future we should lint for this, but for now this fixes the baseline

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

preview:
https://docs-staging.datadoghq.com/cswatt/menu-linting/agent/