### PR TITLE
Fix configmap name in autodiscovery confirmap example in integration.md

### DIFF
--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -454,7 +454,7 @@ The following ConfigMap defines the integration template for `redis` containers:
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: redis-config-map
+  name: redisdb-config-map
   namespace: default
 data:
   redisdb-config: |-


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Configmap name from the `volumes` part of the pod definition does not match the example configmap name in the `configmap` definition. Taking the example as is does not work.

Current example :

`Configmap` definition example : 

```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: redis-config-map (note the confirmap name here)
```

`pod` definition update example :

```yaml
volumes:
      # [...]
        - name: redisdb-config-map
          configMap:
            name: redisdb-config-map (note the configmap name here)
```



### Merge instructions

- [X] Please merge after reviewing