### PR TITLE
Fix typo missing `s` in `enableStepFunctionsTracing`

### DIFF
--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -39,7 +39,7 @@ For developers using [Serverless Framework][4] to deploy serverless applications
         site: <DATADOG_SITE>
         apiKeySecretArn: <DATADOG_API_KEY_SECRET_ARN>
         forwarderArn: <FORWARDER_ARN>
-        enableStepFunctionTracing: true
+        enableStepFunctionsTracing: true
     ```
     - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your [Datadog API key][3] is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use `apiKey` and set the Datadog API key in plaintext.


### PR DESCRIPTION
There should be an `s`.
source code: https://github.com/DataDog/serverless-plugin-datadog/blob/main/src/env.ts#L116