### PR TITLE
MNTS-90344 Clarify Downtime V1 output

### DIFF
--- a/data/api/v1/full_spec.yaml
+++ b/data/api/v1/full_spec.yaml
@@ -23383,7 +23383,7 @@ paths:
         type: safe
   /api/v1/downtime:
     get:
-      description: Get all scheduled downtimes.
+      description: Get all V1 scheduled downtimes (and currently active V2 downtimes). To retrieve all V1 and V2 scheduled downtimes, use Downtimes V2.
       operationId: ListDowntimes
       parameters:
       - description: Only return downtimes that are active when the request is made.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR clarifies that the Downtimes V1 api will only return V1 downtimes (and currently active V2 downtimes)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->