### PR TITLE
fix broken link to installers_v2

### DIFF
--- a/content/en/agent/supported_platforms.md
+++ b/content/en/agent/supported_platforms.md
@@ -264,6 +264,8 @@ A check mark ({{< X >}}) indicates support for all minor and patch versions.
 
 To install a specific version of the Windows Agent, see the [installer list][8].
 
+[8]: https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json
+
 {{% /tab %}}
 {{% tab "macOS" %}}
 
@@ -328,6 +330,4 @@ Agent 6 and 7 support the following [AIX][1] versions:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-
 [1]: /agent/basic_agent_usage/source/
-[8]: https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Fixes a link for the installers list on this page: https://docs.datadoghq.com/agent/supported_platforms/?tab=windows

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->