### PR TITLE
Fix yaml syntax on operator/pause container option

### DIFF
--- a/content/en/containers/guide/autodiscovery-management.md
+++ b/content/en/containers/guide/autodiscovery-management.md
@@ -176,7 +176,7 @@ spec:
       apiKey: <DATADOG_API_KEY>
   override:
     nodeAgent:
-    env:
+      env:
       - name: DD_EXCLUDE_PAUSE_CONTAINER
         value: "false"
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fix minor yaml issue. The `env` should be nested under the `nodeAgent` instead to apply to all of the node Agent's containers. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->