### PR TITLE
INA-5429: Update incident management documentation to remove notice about unavailability in us1-fed

### DIFF
--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -25,10 +25,6 @@ further_reading:
     text: "Automate common security tasks and stay ahead of threats with Datadog Workflows and Cloud SIEM"
 ---
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning">Incident Management is not available on the Datadog for Government site.</div>
-{{< /site-region >}}
-
 Any event that may lead to a disruption in your organization's services can be described as an incident, and it is often necessary to have a set framework for handling these events. Datadog's Incident Management feature provides a system through which your organization can effectively identify and mitigate incidents.
 
 Incidents live in Datadog alongside the metrics, traces, and logs you are collecting. You can view and filter incidents that are relevant to you.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR removes a notice in Incident Management's us1-fed documentation indicating that the product is not in that environment. The product _is_ available.

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
N/A
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->