### PR TITLE
remove 'csp-report.' subdomain for CSP report intake URLs

### DIFF
--- a/content/en/integrations/content_security_policy_logs.md
+++ b/content/en/integrations/content_security_policy_logs.md
@@ -52,7 +52,7 @@ Before you add a directive to a CSP header, [generate a client token in your Dat
 You need a URL where browsers can send policy violation reports. The URL must have the following format:
 
 ```
-https://csp-report.{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client -token>&dd-evp-origin=content-security-policy&ddsource=csp-report
+https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report
 ```
 
 Optionally, add the `ddtags` key (service name, the environment, and service version) to the URL to set up [Unified Service Tagging][3]:
@@ -74,7 +74,7 @@ service%3AbillingService%2Cenv%3Aproduction
 And the final URL with tags would be:
 
 ```
-https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=<client -token>&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3AbillingService%2Cenv%3Aproduction
+https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report&ddtags=service%3AbillingService%2Cenv%3Aproduction
 ```
 
 ## Add the URL to the CSP
@@ -87,7 +87,7 @@ Datadog recommends embedding the Content Security Policy in an HTTP header. You 
 
 - If you're using the `report-uri` directive:
   ```bash
-  Content-Security-Policy: ...; report-uri https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=<client -token>&dd-evp-origin=content-security-policy&ddsource=csp-report
+  Content-Security-Policy: ...; report-uri https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report
   ```
 
 - If you're using the `report-to` directive:
@@ -96,7 +96,7 @@ Datadog recommends embedding the Content Security Policy in an HTTP header. You 
   Report-To: { "group": "browser-intake-datadoghq",
               "max_age": 10886400,
               "endpoints": [
-                  { "url": " https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=<client -token>&dd-evp-origin=content-security-policy&ddsource=csp-report" }
+                  { "url": " https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report" }
               ] }
   ```
 
@@ -106,7 +106,7 @@ You can also embed the URL in a `<meta>` HTML tag.
 
 ```html
 <meta http-equiv="Content-Security-Policy"
-    content="...; report-uri 'https://csp-report.browser-intake-datadoghq.com/api/v2/logs?dd-api-key=<client -token>&dd-evp-origin=content-security-policy&ddsource=csp-report'">
+    content="...; report-uri 'https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report'">
 ```
 ## Violation reports examples
 

--- a/content/en/integrations/content_security_policy_logs.md
+++ b/content/en/integrations/content_security_policy_logs.md
@@ -96,7 +96,7 @@ Datadog recommends embedding the Content Security Policy in an HTTP header. You 
   Report-To: { "group": "browser-intake-datadoghq",
               "max_age": 10886400,
               "endpoints": [
-                  { "url": " https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report" }
+                  { "url": "https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report" }
               ] }
   ```
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

* the `csp-report.` subdomain hasn't been setup when the AP1 region was created, so the doc is mentioning an inexistent domain `csp-report.browser-intake-ap1-datadoghq.com`

* starting from the latest major release, the Browser SDK doesn't use intake subdomain anymore (`logs.`, `rum.` and `replay.`)

  * this allows a simpler setup when deploying new regions
  * also it allows a simpler, more secure proxy setup, as all requests can be forwarded to a single domain

Given those two information let's remove the `csp-report.` subdomain as well. New regions will be easier to setup, and it will follow the same pattern as other intake usages.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->