### PR TITLE
docs only to review autogenerated api content

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 
 /assets/                  @DataDog/corpweb @DataDog/documentation
 /data/                    @DataDog/corpweb @DataDog/documentation
+/data/api/                @DataDog/documentation
 /local/                   @DataDog/corpweb @DataDog/documentation
 /layouts/                 @DataDog/corpweb @DataDog/documentation
 /src/                     @DataDog/corpweb @DataDog/documentation


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR updates codeowners to remove corpweb from the data/api reviews.

#### Motivation
These are autogenerated files and do not need review by our team. The codeowner assignment has caused some confusion for contributors to the spec repo thinking its blocked on us.  We should be looped in if there is an issue with autogeneration but beyond that these are editorial changes to review which are good in docs hands.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->