### PR TITLE
Update RUM Next.js guide to recommend CDN method for Next.js app router

### DIFF
--- a/content/en/real_user_monitoring/guide/monitor-your-nextjs-app-with-rum.md
+++ b/content/en/real_user_monitoring/guide/monitor-your-nextjs-app-with-rum.md
@@ -29,11 +29,11 @@ Follow the steps below to set up Datadog RUM browser monitoring.
 1. Choose your instrumentation type, then copy and paste the code snippet from the Datadog RUM UI into the appropriate file based on the instrumentation type.
 
    {{< tabs >}}
-   {{% tab "NPM" %}}
+   {{% tab "npm" %}}
 
-   If using NPM, you need to make a few small changes to the code snippet from the Datadog RUM UI before pasting it into either the root `layout.tsx` or custom `_app.tsx` file (Datadog supports both):
+   If using npm, you need to make a few small changes to the code snippet from the Datadog RUM UI before pasting it into either the root `layout.tsx` or custom `_app.tsx` file (Datadog supports both):
 
-   - If your application relies on the **newer** Next.js [App Router][1] (versions 13+), the initialization code must run in a [client component][5] so that it can collect telemetry from the client. You can achieve this without making your [`layout.tsx`][2] file itself a client component by following the example below to create an empty `<DatadogInit />` component with the RUM initialization code, and then rendering that `<DatadogInit />` component in your `layout.tsx`. Another option to avoid making your `layout.tsx` a client component is to use the CDN RUM instrumentation.
+   - If your application relies on the **newer** Next.js [App Router][1] (versions 13+), we recommend using the CDN RUM instrumentation to ensure that the RUM initialization occurs in the client. If you would prefer to use the npm package, the initialization code must run in a [client component][5] so that RUM can collect telemetry from the client. You can achieve this without making your [`layout.tsx`][2] file itself a client component by following the example below to create an empty `<DatadogInit />` component with the RUM initialization code, and then rendering that `<DatadogInit />` component in your `layout.tsx`.
    - If your Next.js application relies on the **older** Next.js [Page Router][3], you can paste the initialization snippet into the custom [`_app.tsx`][4] file without the `"use client"` directive and without a separate `<DatadogInit />` component.
 
    {{< code-block lang="javascript" filename="datadog-init.tsx" disable_copy="false" collapsible="true" >}}

--- a/content/en/real_user_monitoring/guide/monitor-your-nextjs-app-with-rum.md
+++ b/content/en/real_user_monitoring/guide/monitor-your-nextjs-app-with-rum.md
@@ -31,9 +31,9 @@ Follow the steps below to set up Datadog RUM browser monitoring.
    {{< tabs >}}
    {{% tab "npm" %}}
 
-   If using npm, you need to make a few small changes to the code snippet from the Datadog RUM UI before pasting it into either the root `layout.tsx` or custom `_app.tsx` file (Datadog supports both):
+   When using npm, you need to make a few small changes to the code snippet from the Datadog RUM UI before pasting it into either the root `layout.tsx` or custom `_app.tsx` file (Datadog supports both):
 
-   - If your application relies on the **newer** Next.js [App Router][1] (versions 13+), we recommend using the CDN RUM instrumentation to ensure that the RUM initialization occurs in the client. If you would prefer to use the npm package, the initialization code must run in a [client component][5] so that RUM can collect telemetry from the client. You can achieve this without making your [`layout.tsx`][2] file itself a client component by following the example below to create an empty `<DatadogInit />` component with the RUM initialization code, and then rendering that `<DatadogInit />` component in your `layout.tsx`.
+   - If your application relies on the **newer** Next.js [App Router][1] (versions 13+), Datadog recommends using the CDN RUM instrumentation to ensure that the RUM initialization occurs in the client. If you want to use the npm package, the initialization code must run in a [client component][5] so RUM can collect telemetry from the client. You can achieve this without making your [`layout.tsx`][2] file itself a client component by following the example below to create an empty `<DatadogInit />` component with the RUM initialization code, and then rendering that `<DatadogInit />` component in your `layout.tsx`.
    - If your Next.js application relies on the **older** Next.js [Page Router][3], you can paste the initialization snippet into the custom [`_app.tsx`][4] file without the `"use client"` directive and without a separate `<DatadogInit />` component.
 
    {{< code-block lang="javascript" filename="datadog-init.tsx" disable_copy="false" collapsible="true" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates the RUM Next.js doc to more strongly recommend that customers use the CDN method when using the Next.js app router

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->