### PR TITLE
[STAL-992] Add C# rulesets to frontmatter

### DIFF
--- a/content/en/static_analysis/_index.md
+++ b/content/en/static_analysis/_index.md
@@ -18,7 +18,7 @@ further_reading:
 
 {{% site-region region="us,us3,us5,eu,ap1" %}}
 <div class="alert alert-warning">
-  Static Analysis is in private beta. Python, JavaScript, TypeScript, and Docker are the only supported languages. To request access, <a href="/help">contact Support</a>.
+  Static Analysis is in private beta. Python, JavaScript, TypeScript, Java, C#, and Docker are the only supported languages. To request access, <a href="/help">contact Support</a>.
 </div>
 {{% /site-region %}}
 

--- a/content/en/static_analysis/_index.md
+++ b/content/en/static_analysis/_index.md
@@ -18,7 +18,7 @@ further_reading:
 
 {{% site-region region="us,us3,us5,eu,ap1" %}}
 <div class="alert alert-warning">
-  Static Analysis is in private beta. Python, JavaScript, TypeScript, Java, C#, and Docker are the only supported languages. To request access, <a href="/help">contact Support</a>.
+  Static Analysis is in private beta. Python, Java, C#, JavaScript, TypeScript, and Docker are the only supported languages. To request access, <a href="/help">contact Support</a>.
 </div>
 {{% /site-region %}}
 

--- a/content/en/static_analysis/rules/_index.md
+++ b/content/en/static_analysis/rules/_index.md
@@ -8,6 +8,22 @@ is_beta: true
 type: static-analysis
 
 rulesets:
+  csharp-best-practices:
+    title: "Best Practices for C#"
+    description: |
+      Rules to enforce C# best practices.
+  csharp-code-style:
+    title: "Follow C# code style patterns"
+    description: |
+      Rules to enforce C# code style.
+  csharp-inclusive:
+    title: "Use inclusive language in C#"
+    description: |
+      Rules to make your C# code more inclusive.
+  csharp-security:
+    title: "Write safe and secure C# code"
+    description: |
+      Rules focused on finding security issues in your C# code.
   docker-best-practices:
     title: "Follow best practices with using Docker"
     description: |

--- a/content/en/static_analysis/rules/_index.md
+++ b/content/en/static_analysis/rules/_index.md
@@ -163,7 +163,7 @@ further_reading:
 
 {{% site-region region="us,us3,us5,eu,ap1" %}}
 <div class="alert alert-warning">
-  Static Analysis is in private beta. Python, Java, JavaScript, TypeScript, and Docker are the only supported languages. To request access, <a href="/help">contact Support</a>.
+  Static Analysis is in private beta. Python, Java, C#, JavaScript, TypeScript, and Docker are the only supported languages. To request access, <a href="/help">contact Support</a>.
 </div>
 {{% /site-region %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds the new C# rulesets that were added to the rule index page frontmatter section.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->