### PR TITLE
[DOCS-6979] updates to CSM troubleshooting vulnerabilities and moving page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3532,11 +3532,6 @@ main:
     parent: csm
     identifier: vulnerabilities
     weight: 18
-  - name: Troubleshooting
-    url: security/vulnerabilities/troubleshooting
-    parent: vulnerabilities
-    identifier: vulnerabilities_troubleshooting
-    weight: 101
   - name: Default Detection Rules
     url: security/default_rules/#cat-cloud-security-management
     parent: csm
@@ -3567,6 +3562,11 @@ main:
     parent: csm
     identifier: csm_troubleshooting
     weight: 30
+  - name: Vulnerabilities
+    url: security/cloud_security_management/troubleshooting/vulnerabilities/
+    parent: csm_troubleshooting
+    identifier: csm_troubleshooting_vulnerabilities
+    weight: 301
   - name: Application Security Management
     url: security/application_security/
     parent: security_platform_heading

--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -40,6 +40,7 @@ The following instructions enable the container image metadata collection and [S
 
 **Note**: The CSM Vulnerabilities feature is not available for AWS Fargate or Windows environments.
 
+
 {{< tabs >}}
 {{% tab "Kubernetes (Helm)" %}}
 
@@ -59,7 +60,8 @@ datadog:
 
 {{% tab "Kubernetes (Operator)" %}}
 
-Add the following to the spec section of your `values.yaml` file:
+Image collection is enabled by default with Datadog Operator version `>= 1.3.0`.</br>
+Or, add the following to the spec section of your `values.yaml` file:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1

--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -426,7 +426,8 @@ datadog:
 
 {{% tab "Kubernetes (Operator)" %}}
 
-Add the following to the spec section of your `values.yaml` file:
+Image collection is enabled by default with Datadog Operator version `>= 1.3.0`.</br>
+Or, add the following to the spec section of your `values.yaml` file:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1

--- a/content/en/security/cloud_security_management/setup/csm_pro.md
+++ b/content/en/security/cloud_security_management/setup/csm_pro.md
@@ -78,7 +78,8 @@ datadog:
 
 {{% tab "Kubernetes (Operator)" %}}
 
-Add the following to the spec section of your `values.yaml` file:
+Image collection is enabled by default with Datadog Operator version `>= 1.3.0`.</br>
+Or, add the following to the spec section of your `values.yaml` file:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1

--- a/content/en/security/cloud_security_management/troubleshooting/_index.md
+++ b/content/en/security/cloud_security_management/troubleshooting/_index.md
@@ -4,6 +4,11 @@ kind: documentation
 aliases:
   - /security_platform/cloud_workload_security/troubleshooting/
   - /security_platform/cloud_security_management/troubleshooting/
+  - /security/cloud_security_management/troubleshooting/
+further_reading:
+- link: "/security/cloud_security_management/troubleshooting/vulnerabilities"
+  tag: "Documentation"
+  text: "Troubleshooting CSM Vulnerabilities"
 ---
 
 ## Security Agent flare
@@ -76,5 +81,8 @@ datadog:
 ```bash
 DD_RUNTIME_SECURITY_CONFIG_NETWORK_ENABLED=false
 ```
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/troubleshooting/send_a_flare/?tab=agentv6v7

--- a/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
+++ b/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
@@ -1,6 +1,8 @@
 ---
 title: Troubleshooting Cloud Security Management Vulnerabilities
 kind: documentation
+aliases:
+  - /security/vulnerabilities/troubleshooting/
 further_reading:
 - link: "/security/cloud_security_management/setup/csm_pro/?tab=aws#configure-the-agent-for-containers"
   tag: "Documentation"
@@ -32,24 +34,30 @@ Ensure all the [prerequisites][5] are met for CSM Vulnerabilities:
 | Component                | Version/Requirement                     |
 | ------------------------ | ----------------------------------------|
 | [Helm Chart][6]            | v3.49.6 or later (Kubernetes only)      |
-| [containerd][7]              | v1.5.6 or later (Kubernetes and hosts only)|
+| [containerd][7]              | v1.5.6 or later (Kubernetes and hosts only)|</br>
 
 CSM Vulnerabilities is **not** available for the following environments:
 
   - Windows
   - AWS Fargate 
   - CRI-O runtime
+  - podman runtime
 
 ## Error messages
 
 ### Disk space requirements
 
-Ensure your free disk space is equal to the size of your largest container image. This space is needed for the Datadog Agent to scan the container image for vulnerabilities.
+Ensure your free disk space is equal to the size of your largest container image. This space is needed for the Datadog Agent to scan the container image for vulnerabilities (1GB by default).
 
 The resulting error appears as:
 ```sh
 Error: failed to check current disk usage: not enough disk space to safely collect sbom, 192108482560 available, 1073741824000 required
 ```
+
+Workaround: 
+
+- Increase the available disk space to at least 1GB. If your images are larger than 1GB, increase your disk space accordingly.
+- If all of your images are smaller than 1GB, you can decrease the Agent request disk space with the parameter: `sbom.container_image.min_available_disk` (default value 1GB).
 
 ### Uncompressed container image layers
 

--- a/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
+++ b/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
@@ -57,7 +57,7 @@ Error: failed to check current disk usage: not enough disk space to safely colle
 Workaround: 
 
 - Increase the available disk space to at least 1GB. If your images are larger than 1GB, increase your disk space accordingly.
-- If all of your images are smaller than 1GB, you can decrease the Agent request disk space with the parameter: `sbom.container_image.min_available_disk` (default value 1GB).
+- If all of your images are smaller than 1GB, you can decrease the default Agent request disk space with the environment variable: `DD_SBOM_CONTAINER_IMAGE_MIN_AVAILABLE_DISK` (default value 1GB).
 
 ### Uncompressed container image layers
 

--- a/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
+++ b/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
@@ -47,7 +47,7 @@ CSM Vulnerabilities is **not** available for the following environments:
 
 ### Disk space requirements
 
-Ensure your free disk space is equal to the size of your largest container image. This space is needed for the Datadog Agent to scan the container image for vulnerabilities (1GB by default).
+Ensure your free disk space is equal to the size of your largest container image. This space is needed for the Datadog Agent to scan the container image for vulnerabilities (1 GB by default).
 
 The resulting error appears as:
 ```sh
@@ -56,8 +56,8 @@ Error: failed to check current disk usage: not enough disk space to safely colle
 
 Workaround: 
 
-- Increase the available disk space to at least 1GB. If your images are larger than 1GB, increase your disk space accordingly.
-- If all of your images are smaller than 1GB, you can decrease the default Agent request disk space with the environment variable: `DD_SBOM_CONTAINER_IMAGE_MIN_AVAILABLE_DISK` (default value 1GB).
+- Increase the available disk space to at least 1 GB. If your images are larger than 1 GB, increase your disk space accordingly.
+- If all of your images are smaller than 1 GB, you can decrease the default Agent request disk space with the environment variable: `DD_SBOM_CONTAINER_IMAGE_MIN_AVAILABLE_DISK` (default value 1GB).
 
 ### Uncompressed container image layers
 

--- a/layouts/shortcodes/csm-prereqs-enterprise.md
+++ b/layouts/shortcodes/csm-prereqs-enterprise.md
@@ -28,7 +28,12 @@ CSM Threats supports the following Linux distributions:
 | [Helm Chart][103]            | v3.49.6 or later (Kubernetes only)      |
 | [containerd][104]              | v1.5.6 or later (Kubernetes and hosts only)|
 
-**Note**: CSM Vulnerabilities is not available for CRI-O runtime, Windows, or AWS Fargate environments.
+**Note**: CSM Vulnerabilities is **not** available for the following environments:
+
+  - Windows
+  - AWS Fargate 
+  - CRI-O runtime
+  - podman runtime
 
 ### CSM Identity Risks
 

--- a/layouts/shortcodes/csm-prereqs-pro.md
+++ b/layouts/shortcodes/csm-prereqs-pro.md
@@ -7,7 +7,12 @@ Datadog Agent `7.46` or later installed on your hosts or containers.
 | [Helm Chart][102]            | v3.49.6 or later (Kubernetes only)      |
 | [containerd][103]              | v1.5.6 or later (Kubernetes and hosts only)|
 
-**Note**: CSM Vulnerabilities is not available for CRI-O runtime, Windows, or AWS Fargate environments.
+**Note**: CSM Vulnerabilities is **not** available for the following environments:
+
+  - Windows
+  - AWS Fargate 
+  - CRI-O runtime
+  - podman runtime
 
 [102]: /containers/kubernetes/installation/?tab=helm
 [103]: https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds additional context in CSM vulnerabilities troubleshooting page and moves the page under the CSM - Troubleshooting on the left nav where it flows better. Also added default version for Datadog operator for image collection.
Check redirects, etc.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->