### PR TITLE
[CSPM] Document how to enable host benchmarks

### DIFF
--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -98,6 +98,8 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
           enabled: true
         compliance:
           enabled: true
+          host_benchmarks:
+            enabled: true
     ```
 2. Restart the Agent.
 
@@ -117,6 +119,8 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
           enabled: true
         cspm:
           enabled: true
+          hostBenchmarks:
+            enabled: true
     ```
 
 2. Restart the Agent.
@@ -152,6 +156,7 @@ docker run -d --name dd-agent \
   -v /sys/kernel/debug:/sys/kernel/debug \
   -v /etc/os-release:/etc/os-release \
   -e DD_COMPLIANCE_CONFIG_ENABLED=true \
+  -e DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED=true \
   -e DD_RUNTIME_SECURITY_CONFIG_ENABLED=true \
   -e DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED=true \
   -e HOST_ROOT=/host/root \
@@ -191,6 +196,8 @@ Add the following settings to the `env` section of `security-agent` and `system-
                 value: "true"
               - name: DD_COMPLIANCE_CONFIG_ENABLED
                 value: "true"
+              - name: DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED
+                value: "true"
           [...]
 ```
 
@@ -222,10 +229,12 @@ runtime_security_config:
   enabled: true
 
 compliance_config:
- ## @param enabled - boolean - optional - default: false
- ## Set to true to enable CIS benchmarks for CSPM.
- #
- enabled: true
+  ## @param enabled - boolean - optional - default: false
+  ## Set to true to enable CIS benchmarks for CSPM.
+  #
+  enabled: true
+  host_benchmarks:
+    enabled: true
 ```
 
 ```bash
@@ -236,10 +245,12 @@ runtime_security_config:
   enabled: true
 
 compliance_config:
- ## @param enabled - boolean - optional - default: false
- ## Set to true to enable CIS benchmarks for CSPM.
- #
- enabled: true
+  ## @param enabled - boolean - optional - default: false
+  ## Set to true to enable CIS benchmarks for CSPM.
+  #
+  enabled: true
+  host_benchmarks:
+    enabled: true
 ```
 
 ```bash
@@ -338,7 +349,11 @@ The following deployment can be used to start the Runtime Security Agent and `sy
                 {
                       "name": "DD_COMPLIANCE_CONFIG_ENABLED",
                       "value": "true"
-                  }
+                },
+                {
+                      "name": "DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED",
+                      "value": "true"
+                }
             ],
             "memory": 256,
             "dockerSecurityOptions": ["apparmor:unconfined"],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This change documents how to enable host benchmarks in Kubernetes (Helm and Operator), Docker, Daemonset and Host.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->