### PR TITLE
[WEB-4425] Assetlib bump

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ placeholders: hugpython update_pre_build
 hugpython: local/etc/requirements3.txt
 	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<;\
 	if [[ "$(CI_COMMIT_REF_NAME)" != "" ]]; then \
-		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.23712458-py3-none-any.whl; \
+		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.25735200-py3-none-any.whl; \
 	fi
 
 update_pre_build: hugpython


### PR DESCRIPTION
### What does this PR do? What is the motivation?
bumps `assetlib` to latest version
https://datadoghq.atlassian.net/browse/WEB-4425

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/assetlib-bump/integrations

`Machine Learning & LLM` is no longer a listed category
`NVIDIA` tile falls under `AI/ML`