### PR TITLE
[SYNTH-12562] Update Synthetics Private Location `verbosity` option description

### DIFF
--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -232,7 +232,7 @@ Format log output between `"compact"`, `"pretty"`, `"pretty-compact"`, and `"jso
 `--verbosity`
 : **Type**: Number <br>
 **Default**: `3`<br>
-Verbosity level (for example, `-v`, `-vv`, and `-vvv`).
+Verbosity level from `1` (errors only) to `4` (debug logs and above). Setting the verbosity from the command line is done with `-v`, `-vv`, `-vvv`, and `-vvvv` arguments.
 
 `--help`
 : **Type**: Boolean <br>

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -232,7 +232,13 @@ Format log output between `"compact"`, `"pretty"`, `"pretty-compact"`, and `"jso
 `--verbosity`
 : **Type**: Number <br>
 **Default**: `3`<br>
-Verbosity level from `1` (errors only) to `4` (debug logs and above). Setting the verbosity from the command line is done with `-v`, `-vv`, `-vvv`, and `-vvvv` arguments.
+Verbosity level from `1` (errors only) to `4` (debug logs and above). Setting the verbosity from the command line is done with `-v`, `-vv`, `-vvv`, and `-vvvv` arguments.<br><br>
+Verbosity level | CLI argument | JSON config option
+-- | -- | --
+DEBUG | `-vvvv` | `"verbosity": 4`
+INFO (default) | `-vvv` | `"verbosity": 3`
+WARNING | `-vv` | `"verbosity": 2`
+ERROR | `-v` | `"verbosity": 1`
 
 `--help`
 : **Type**: Boolean <br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Update the misleading description of the `verbosity` option for Synthetics Private location to document how to set it through command line argument or the configuration file **which is not done in the same way**:

- When using the JSON configuration file, the `verbosity` option is a number from `1` to `4` (default `3`: info)
- When using CLI arguments the verbosity is set through `-v`, `-vv`, `-vvv`, `-vvvv` (number of `v`s = verbosity level)
- The default is info log level (`3`, `-vvv`)
- **The `--verbosity <level>` CLI argument option is not recognized**

Verbosity level | CLI argument | JSON config option
-- | -- | --
DEBUG | `-vvvv` | `"verbosity": 4`
INFO (default) | `-vvv` | `"verbosity": 3`
WARNING | `-vv` | `"verbosity": 2`
ERROR | `-v` | `"verbosity": 1`



### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->