### PR TITLE
[Container Images] Reorder "K8s (Operator)" to be the first tab for config

### DIFF
--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -42,22 +42,6 @@ The following instructions enable the container image metadata collection and [S
 
 
 {{< tabs >}}
-{{% tab "Kubernetes (Helm)" %}}
-
-If you are using Helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
-Or, add the following to your `values.yaml` Helm configuration file:
-
-```yaml
-datadog:
-  containerImageCollection:
-    enabled: true
-  sbom:
-    containerImage:
-      enabled: true
-```
-[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
-{{% /tab %}}
-
 {{% tab "Kubernetes (Operator)" %}}
 
 Image collection is enabled by default with Datadog Operator version `>= 1.3.0`.</br>
@@ -77,6 +61,22 @@ spec:
         enabled: true
 ```
 
+{{% /tab %}}
+
+{{% tab "Kubernetes (Helm)" %}}
+
+If you are using Helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
+Or, add the following to your `values.yaml` Helm configuration file:
+
+```yaml
+datadog:
+  containerImageCollection:
+    enabled: true
+  sbom:
+    containerImage:
+      enabled: true
+```
+[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
 {{% /tab %}}
 
 {{% tab "ECS EC2" %}}


### PR DESCRIPTION
* Reorder tabs so that the page defaults to Operator (preferred config method).
* Consistency with Containers and Orchestrator config pages.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->