### PR TITLE
Remove box shadow on baseof - [WEB-4438]

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -49,7 +49,7 @@
       </div>
 
       <div class="mainContent-wrapper order-2 order-lg-0 col-12 {{ if eq .Params.disable_sidebar true }}col-lg-9{{ else }}col-lg-7{{ end }} main">
-        <div class='table-responsive-container {{ if and (eq $.Section "integrations") (eq $.Kind "page") }}integrations-single{{ end }}'
+        <div class='{{ if and (eq $.Section "integrations") (eq $.Kind "page") }}integrations-single{{ end }}'
           id="mainContent">
           {{ block "main" . }}{{ end }}
           {{ partial "page-edit.html" (dict "ctx" $ctx "type" "contribute") }}

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -8,5 +8,7 @@
         </div>
     </div>
     {{ partial "translate_status_banner/translate_status_banner.html" . }}
-    {{ .Content }}
+    
+    {{ $wrappedTable := printf "<div class=table-wrapper> ${1} </div>" }} 
+    {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
 {{ end }}

--- a/layouts/multi-code-lang/single.html
+++ b/layouts/multi-code-lang/single.html
@@ -21,6 +21,7 @@
 
     {{/* Add `table-wrapper` div to tables in imported markdown to fix overflow issues */}}
       
-    <div>{{ replaceRE `<\/table>` "</table></div>" (replaceRE `(<table>)` "<div class='table-wrapper'><table>" .Content) | safeHTML }}</div>
+    {{ $wrappedTable := printf "<div class=table-wrapper> ${1} </div>" }} 
+    {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
 
 {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

quick fix:
removes box shadow from docs baseof. 
- on viewports `<=575px`, a box shadow would appear on the right. 

applies `.table-wrapper` around markdown tables in `section` pages to enable horizontal scroll

jira: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-4438
previews:  
- https://docs-staging.datadoghq.com/stefon.simmons/rm-box-shadow-on-base/continuous_integration/pipelines/?tab=githubactions#alert-on-pipeline-data

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->