### PR TITLE
Re-ordering Kubernetes Operator/Helm tabns

### DIFF
--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -422,22 +422,6 @@ The following instructions enables the image metadata collection and [Software B
 #### Containers
 
 {{< tabs >}}
-{{% tab "Kubernetes (Helm)" %}}
-
-If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
-Or, add the following to your `values.yaml` helm configuration file:
-
-```yaml
-datadog:
-  containerImageCollection:
-    enabled: true
-  sbom:
-    containerImage:
-      enabled: true
-```
-[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
-
-{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -460,6 +444,22 @@ spec:
 
 {{% /tab %}}
 
+{{% tab "Kubernetes (Helm)" %}}
+
+If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
+Or, add the following to your `values.yaml` helm configuration file:
+
+```yaml
+datadog:
+  containerImageCollection:
+    enabled: true
+  sbom:
+    containerImage:
+      enabled: true
+```
+[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
+
+{{% /tab %}}
 {{% tab "ECS EC2" %}}
 
 To enable container image vulnerability scanning on your [ECS EC2 instances][7], add the following environment variables to your `datadog-agent` container definition:
@@ -532,17 +532,6 @@ container_image:
 
 {{< tabs >}}
 
-{{% tab "Kubernetes (Helm)" %}}
-
-```yaml
-datadog:
-  sbom:
-    host:
-      enabled: true
-```
-
-{{% /tab %}}
-
 {{% tab "Kubernetes (Operator)" %}}
 
 Add the following to the spec section of your `values.yaml` file:
@@ -562,6 +551,17 @@ spec:
       host:
         enabled: true
 ```
+{{% /tab %}}
+
+{{% tab "Kubernetes (Helm)" %}}
+
+```yaml
+datadog:
+  sbom:
+    host:
+      enabled: true
+```
+
 {{% /tab %}}
 
 {{% tab "ECS EC2" %}}

--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -84,26 +84,7 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
 #### Configure the Agent
 
 {{< tabs >}}
-{{% tab "Kubernetes (Helm)" %}}
 
-1. Add the following to the `datadog` section of the `values.yaml` file:
-
-    ```yaml
-    # values.yaml file
-    datadog:
-      remoteConfiguration:
-        enabled: true
-      securityAgent:
-        runtime:
-          enabled: true
-        compliance:
-          enabled: true
-          host_benchmarks:
-            enabled: true
-    ```
-2. Restart the Agent.
-
-{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -123,6 +104,26 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
             enabled: true
     ```
 
+2. Restart the Agent.
+
+{{% /tab %}}
+{{% tab "Kubernetes (Helm)" %}}
+
+1. Add the following to the `datadog` section of the `values.yaml` file:
+
+    ```yaml
+    # values.yaml file
+    datadog:
+      remoteConfiguration:
+        enabled: true
+      securityAgent:
+        runtime:
+          enabled: true
+        compliance:
+          enabled: true
+          host_benchmarks:
+            enabled: true
+    ```
 2. Restart the Agent.
 
 [2]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
@@ -422,22 +423,6 @@ The following instructions enables the image metadata collection and [Software B
 #### Containers
 
 {{< tabs >}}
-{{% tab "Kubernetes (Helm)" %}}
-
-If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
-Or, add the following to your `values.yaml` helm configuration file:
-
-```yaml
-datadog:
-  containerImageCollection:
-    enabled: true
-  sbom:
-    containerImage:
-      enabled: true
-```
-[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
-
-{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -457,6 +442,21 @@ spec:
       containerImage:
         enabled: true
 ```
+{{% /tab %}}
+{{% tab "Kubernetes (Helm)" %}}
+
+If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
+Or, add the following to your `values.yaml` helm configuration file:
+
+```yaml
+datadog:
+  containerImageCollection:
+    enabled: true
+  sbom:
+    containerImage:
+      enabled: true
+```
+[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
 
 {{% /tab %}}
 
@@ -532,17 +532,6 @@ container_image:
 
 {{< tabs >}}
 
-{{% tab "Kubernetes (Helm)" %}}
-
-```yaml
-datadog:
-  sbom:
-    host:
-      enabled: true
-```
-
-{{% /tab %}}
-
 {{% tab "Kubernetes (Operator)" %}}
 
 Add the following to the spec section of your `values.yaml` file:
@@ -562,6 +551,17 @@ spec:
       host:
         enabled: true
 ```
+{{% /tab %}}
+
+{{% tab "Kubernetes (Helm)" %}}
+
+```yaml
+datadog:
+  sbom:
+    host:
+      enabled: true
+```
+
 {{% /tab %}}
 
 {{% tab "ECS EC2" %}}

--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -84,26 +84,6 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
 #### Configure the Agent
 
 {{< tabs >}}
-{{% tab "Kubernetes (Helm)" %}}
-
-1. Add the following to the `datadog` section of the `values.yaml` file:
-
-    ```yaml
-    # values.yaml file
-    datadog:
-      remoteConfiguration:
-        enabled: true
-      securityAgent:
-        runtime:
-          enabled: true
-        compliance:
-          enabled: true
-          host_benchmarks:
-            enabled: true
-    ```
-2. Restart the Agent.
-
-{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -126,6 +106,27 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
 2. Restart the Agent.
 
 [2]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
+
+{{% /tab %}}
+
+{{% tab "Kubernetes (Helm)" %}}
+
+1. Add the following to the `datadog` section of the `values.yaml` file:
+
+    ```yaml
+    # values.yaml file
+    datadog:
+      remoteConfiguration:
+        enabled: true
+      securityAgent:
+        runtime:
+          enabled: true
+        compliance:
+          enabled: true
+          host_benchmarks:
+            enabled: true
+    ```
+2. Restart the Agent.
 
 {{% /tab %}}
 

--- a/content/en/security/cloud_security_management/setup/csm_enterprise.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise.md
@@ -84,7 +84,26 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
 #### Configure the Agent
 
 {{< tabs >}}
+{{% tab "Kubernetes (Helm)" %}}
 
+1. Add the following to the `datadog` section of the `values.yaml` file:
+
+    ```yaml
+    # values.yaml file
+    datadog:
+      remoteConfiguration:
+        enabled: true
+      securityAgent:
+        runtime:
+          enabled: true
+        compliance:
+          enabled: true
+          host_benchmarks:
+            enabled: true
+    ```
+2. Restart the Agent.
+
+{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -104,26 +123,6 @@ To use Remote Configuration with CSM Threats, add the Remote Configuration scope
             enabled: true
     ```
 
-2. Restart the Agent.
-
-{{% /tab %}}
-{{% tab "Kubernetes (Helm)" %}}
-
-1. Add the following to the `datadog` section of the `values.yaml` file:
-
-    ```yaml
-    # values.yaml file
-    datadog:
-      remoteConfiguration:
-        enabled: true
-      securityAgent:
-        runtime:
-          enabled: true
-        compliance:
-          enabled: true
-          host_benchmarks:
-            enabled: true
-    ```
 2. Restart the Agent.
 
 [2]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md
@@ -423,6 +422,22 @@ The following instructions enables the image metadata collection and [Software B
 #### Containers
 
 {{< tabs >}}
+{{% tab "Kubernetes (Helm)" %}}
+
+If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
+Or, add the following to your `values.yaml` helm configuration file:
+
+```yaml
+datadog:
+  containerImageCollection:
+    enabled: true
+  sbom:
+    containerImage:
+      enabled: true
+```
+[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
+
+{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -442,21 +457,6 @@ spec:
       containerImage:
         enabled: true
 ```
-{{% /tab %}}
-{{% tab "Kubernetes (Helm)" %}}
-
-If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
-Or, add the following to your `values.yaml` helm configuration file:
-
-```yaml
-datadog:
-  containerImageCollection:
-    enabled: true
-  sbom:
-    containerImage:
-      enabled: true
-```
-[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
 
 {{% /tab %}}
 
@@ -532,6 +532,17 @@ container_image:
 
 {{< tabs >}}
 
+{{% tab "Kubernetes (Helm)" %}}
+
+```yaml
+datadog:
+  sbom:
+    host:
+      enabled: true
+```
+
+{{% /tab %}}
+
 {{% tab "Kubernetes (Operator)" %}}
 
 Add the following to the spec section of your `values.yaml` file:
@@ -551,17 +562,6 @@ spec:
       host:
         enabled: true
 ```
-{{% /tab %}}
-
-{{% tab "Kubernetes (Helm)" %}}
-
-```yaml
-datadog:
-  sbom:
-    host:
-      enabled: true
-```
-
 {{% /tab %}}
 
 {{% tab "ECS EC2" %}}

--- a/content/en/security/cloud_security_management/setup/csm_pro.md
+++ b/content/en/security/cloud_security_management/setup/csm_pro.md
@@ -60,21 +60,6 @@ Alternatively, use the following examples to enable CSM Vulnerabilities on your 
 
 
 {{< tabs >}}
-{{% tab "Kubernetes (Helm)" %}}
-
-If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
-Or, add the following to your `values.yaml` helm configuration file:
-
-```yaml
-datadog:
-  containerImageCollection:
-    enabled: true
-  sbom:
-    containerImage:
-      enabled: true
-```
-[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
-{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -95,6 +80,22 @@ spec:
         enabled: true
 ```
 
+{{% /tab %}}
+
+{{% tab "Kubernetes (Helm)" %}}
+
+If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
+Or, add the following to your `values.yaml` helm configuration file:
+
+```yaml
+datadog:
+  containerImageCollection:
+    enabled: true
+  sbom:
+    containerImage:
+      enabled: true
+```
+[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
 {{% /tab %}}
 
 {{% tab "ECS EC2" %}}

--- a/content/en/security/cloud_security_management/setup/csm_pro.md
+++ b/content/en/security/cloud_security_management/setup/csm_pro.md
@@ -60,6 +60,21 @@ Alternatively, use the following examples to enable CSM Vulnerabilities on your 
 
 
 {{< tabs >}}
+{{% tab "Kubernetes (Helm)" %}}
+
+If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
+Or, add the following to your `values.yaml` helm configuration file:
+
+```yaml
+datadog:
+  containerImageCollection:
+    enabled: true
+  sbom:
+    containerImage:
+      enabled: true
+```
+[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
+{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -79,23 +94,6 @@ spec:
       containerImage:
         enabled: true
 ```
-
-{{% /tab %}}
-
-{{% tab "Kubernetes (Helm)" %}}
-
-If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
-Or, add the following to your `values.yaml` helm configuration file:
-
-```yaml
-datadog:
-  containerImageCollection:
-    enabled: true
-  sbom:
-    containerImage:
-      enabled: true
-```
-[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
 
 {{% /tab %}}
 

--- a/content/en/security/cloud_security_management/setup/csm_pro.md
+++ b/content/en/security/cloud_security_management/setup/csm_pro.md
@@ -60,21 +60,6 @@ Alternatively, use the following examples to enable CSM Vulnerabilities on your 
 
 
 {{< tabs >}}
-{{% tab "Kubernetes (Helm)" %}}
-
-If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
-Or, add the following to your `values.yaml` helm configuration file:
-
-```yaml
-datadog:
-  containerImageCollection:
-    enabled: true
-  sbom:
-    containerImage:
-      enabled: true
-```
-[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
-{{% /tab %}}
 
 {{% tab "Kubernetes (Operator)" %}}
 
@@ -94,6 +79,23 @@ spec:
       containerImage:
         enabled: true
 ```
+
+{{% /tab %}}
+
+{{% tab "Kubernetes (Helm)" %}}
+
+If you are using helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
+Or, add the following to your `values.yaml` helm configuration file:
+
+```yaml
+datadog:
+  containerImageCollection:
+    enabled: true
+  sbom:
+    containerImage:
+      enabled: true
+```
+[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
 
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR re-orders the Kubernetes Operator tab to be first in the list to be consistent with containers docs as we are moving towards having Operator as the preferred installation method.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->