### PR TITLE
fix left nav deeper children - [WEB-4403]

### DIFF
--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -166,7 +166,7 @@ function getPathElement(event = null) {
     path = path.replace(/^\//, '');
     path = path.replace(/\/$/, '');
 
-    let sideNavPathElement = document.querySelector(`.side [data-path^="${getVisibleParentPath(path)}"]`) || document.querySelector(`.side [data-path="${path}"]`);
+    let sideNavPathElement = document.querySelector(`.side [data-path="${getVisibleParentPath(path)}"]`)
     let mobileNavPathElement = document.querySelector(`header [data-path="${path}"]`);
 
     // Select sidenav/mobile links by data-path attribute to ensure active class is set correctly on specific sub-pages

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -130,7 +130,15 @@ DOMReady(doOnLoad);
 function getVisibleParentPath(path){
     // returns the closest visible parent path
     // of a child path not visible in the left nav (anything more than 4 levels deep)
-    return path.split('/').slice(0,4).join('/')
+    let startIdx = 0
+    let endIdx = 4
+    if(env === 'preview'){
+        // account for preview branch name in url
+        startIdx += 2
+        endIdx += 2
+    }
+    console.log(path.split('/').slice(startIdx,endIdx).join('/'))
+    return path.split('/').slice(startIdx,endIdx).join('/')
 }
 
 // Get sidebar

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -127,9 +127,14 @@ const doOnLoad = () => {
 
 DOMReady(doOnLoad);
 
+function getVisibleParentPath(path){
+    // returns the closest visible parent path
+    // of a child path not visible in the left nav (anything more than 4 levels deep)
+    return path.split('/').slice(0,4).join('/')
+}
+
 // Get sidebar
 function hasParentLi(el) {
-    const els = [];
     while (el) {
         if (el.classList) {
             if (el.classList.contains('sidenav-nav-main')) {
@@ -146,7 +151,6 @@ function hasParentLi(el) {
             }
         }
 
-        els.unshift(el);
         el = el.parentNode;
     }
 }
@@ -162,7 +166,7 @@ function getPathElement(event = null) {
     path = path.replace(/^\//, '');
     path = path.replace(/\/$/, '');
 
-    let sideNavPathElement = document.querySelector(`.side [data-path="${path}"]`);
+    let sideNavPathElement = document.querySelector(`.side [data-path^="${getVisibleParentPath(path)}"]`) || document.querySelector(`.side [data-path="${path}"]`);
     let mobileNavPathElement = document.querySelector(`header [data-path="${path}"]`);
 
     // Select sidenav/mobile links by data-path attribute to ensure active class is set correctly on specific sub-pages

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -130,15 +130,11 @@ DOMReady(doOnLoad);
 function getVisibleParentPath(path){
     // returns the closest visible parent path
     // of a child path not visible in the left nav (anything more than 4 levels deep)
-    let startIdx = 0
-    let endIdx = 4
-    if(env === 'preview'){
-        // account for preview branch name in url
-        startIdx += 2
-        endIdx += 2
-    }
-    console.log(path.split('/').slice(startIdx,endIdx).join('/'))
-    return path.split('/').slice(startIdx,endIdx).join('/')
+
+    // account for preview branch name in url
+    const endIdx = env === 'preview' ? 6 : 4
+
+    return path.split('/').slice(0,endIdx).join('/')
 }
 
 // Get sidebar

--- a/layouts/partials/nav/left-nav.html
+++ b/layouts/partials/nav/left-nav.html
@@ -24,9 +24,11 @@
 {{ $currentPage := . }}
 {{ range $menu }}
     {{ if .HasChildren }}
+        {{/*  HEADER  */}}
         <p class="h5 text-uppercase fw-bold">{{.Name}}</p>
         <ul class="list-unstyled">
             {{ range .Children }}
+                {{/*  LEVEL 1  */}}
                 <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}
                 {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
                     {{ $url_without_anchor = (index (split .URL "#") 0) }}
@@ -39,6 +41,7 @@
                         </div>
                     </a>
                     <ul class="list-unstyled sub-menu {{ if (or (eq .Name "Guides") (eq .Name "Widgets")) }} d-none {{ end }}">
+                        {{/*  LEVEL 2  */}}
                         {{ range .Children }}
                             <li class="{{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
                                 {{ $url_without_anchor = (index (split .URL "#") 0) }}
@@ -51,6 +54,7 @@
                                 </a>
                             {{ if .HasChildren }}
                                 <ul class="list-unstyled sub-menu {{ if (or (eq .Name "Guides") (eq .Name "Widgets")) }} d-none {{ end }}">
+                                {{/*  LEVEL 3  */}}
                                 {{ range .Children }}
                                     <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
                                         {{ $url_without_anchor = (index (split .URL "#") 0) }}
@@ -61,9 +65,9 @@
                                             {{ end }}
                                             <span>{{ .Name }}</span>
                                         </a>
-                                        {{/* 4th level, hide */}}
                                         {{ if .HasChildren }}
                                             <ul class="list-unstyled sub-menu {{ if not (in (slice "automatic_instrumentation" "custom_instrumentation" "observability_pipelines_reference_processing_language" "observability_pipelines_vector_configuration") .Identifier) }}d-none{{ end }}">
+                                            {{/*  LEVEL 4, hide  */}}
                                             {{ range .Children }}
                                                 <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
                                                     {{ $url_without_anchor = (index (split .URL "#") 0) }}

--- a/layouts/partials/nav/left-nav.html
+++ b/layouts/partials/nav/left-nav.html
@@ -67,7 +67,7 @@
                                         </a>
                                         {{ if .HasChildren }}
                                             <ul class="list-unstyled sub-menu {{ if not (in (slice "automatic_instrumentation" "custom_instrumentation" "observability_pipelines_reference_processing_language" "observability_pipelines_vector_configuration") .Identifier) }}d-none{{ end }}">
-                                            {{/*  LEVEL 4, hide  */}}
+                                            {{/*  LEVEL 4 */}}
                                             {{ range .Children }}
                                                 <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
                                                     {{ $url_without_anchor = (index (split .URL "#") 0) }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

keeps left nav open at appropriate place for children (page) paths greater than 4 levels deep.


jira: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-4403

preview:  https://docs-staging.datadoghq.com/stefon.simmons/fix-left-nav-deeper-children/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->