### PR TITLE
Document Ruby memory-related profile types

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -160,17 +160,18 @@ Wall Time
 
 Allocations (alpha, v1.19.0+)
 : The number of objects allocated by each method during the profiling period (default: 60s), including allocations which were subsequently freed. This is useful for investigating garbage collection load.<br />
-_Requires: Ruby 2.7+_
+_Requires: Ruby 2.7+_ and [needs to be enabled][2]
 
 Heap Live Objects (alpha, v1.19.0+)
 : The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
-_Requires: Ruby 2.7+_
+_Requires: Ruby 2.7+_ and [needs to be enabled][2]
 
 Heap Live Size (alpha, v1.19.0+)
 : The amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
-_Requires: Ruby 2.7+_
+_Requires: Ruby 2.7+_ and [needs to be enabled][2]
 
 [1]: /profiler/enabling/ruby/#requirements
+[2]: https://github.com/DataDog/dd-trace-rb/releases/tag/v1.19.0#:~:text=You%20can%20enable%20these%20features%3A
 {{< /programming-lang >}}
 {{< programming-lang lang="nodejs" >}}
 

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -158,6 +158,18 @@ CPU
 Wall Time
 : The elapsed time used by each function. Elapsed time includes time when code is running on CPU, waiting for I/O, and anything else that happens while the function is running.
 
+Allocations (alpha, v1.19.0+)
+: The number of objects allocated by each method during the profiling period (default: 60s), including allocations which were subsequently freed. This is useful for investigating garbage collection load.<br />
+_Requires: Ruby 2.7+_
+
+Heap Live Objects (alpha, v1.19.0+)
+: The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
+_Requires: Ruby 2.7+_
+
+Heap Live Size (alpha, v1.19.0+)
+: The amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
+_Requires: Ruby 2.7+_
+
 [1]: /profiler/enabling/ruby/#requirements
 {{< /programming-lang >}}
 {{< programming-lang lang="nodejs" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The upcoming dd-trace-rb 1.19.0 release introduces three new profile types for Ruby. These are similar to other profilers, and I've mostly borrowed their description for these profile types, with minimal tweaks.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Ideally, this PR should only be merged after we release 1.19.0, which we plan to do this week. I'll drop a note on this PR once the release is out so it can be merged :)

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->