### PR TITLE
fixing name in left nav

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3424,10 +3424,10 @@ main:
     parent: security_platform
     identifier: security_inbox
     weight: 10
-  - name: Threat Intel
-    url: security/threat_intel
+  - name: Threat Intelligence
+    url: security/threat_intelligence
     parent: security_platform
-    idenfier: security_threat_intel
+    idenfier: security_threat_intelligence
     weight: 11
   - name: Audit Trail
     url: security/audit_trail

--- a/content/en/security/threat_intelligence.md
+++ b/content/en/security/threat_intelligence.md
@@ -1,6 +1,8 @@
 ---
 title: Threat Intelligence
 kind: documentation
+aliases:
+    - /security/threat_intel
 description: "Threat Intelligence at Datadog"
 further_reading:
   - link: "/security/application_security/threats/threat-intelligence/"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
changing the name in the left nav from Threat Intel to Threat Intelligence for continuity

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->