### PR TITLE
[Error Tracking] Clarify error count monitor creation

### DIFF
--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -44,9 +44,7 @@ Choose **Count** to alert on issues with a high number of errors and **New Issue
 {{< tabs >}}
 {{% tab "Count" %}}
 
-Select **Web and Mobile Apps** from the dropdown menu. If you select **Backend Services** or **Logs**, only the **Error Occurrences** option is available.
-
-1. Choose what metric you want to monitor: a count, facet, or measure.
+1. Select **RUM Events**, **Traces**, or **Logs** from the dropdown menu and choose what metric you want to monitor: a count, facet, or measure.
    - For error occurrences, monitor over an overall count based on the issue ID.
    - For impacted users, monitor over a unique count of user emails based on the issue ID or over a measure.
    - For impacted sessions, monitor over a unique count of session IDs based on the issue ID.
@@ -57,6 +55,8 @@ Select **Web and Mobile Apps** from the dropdown menu. If you select **Backend S
    - **Error Occurrences**: Triggers when the error count is `above` or `above or equal to`.
    - **Impacted Users**: Triggers when the number of impacted user emails is `above` or `above or equal to`.
    - **Impacted Sessions**: Triggers when the number of impacted session IDs is `above` or `above or equal to`.
+
+   If you select **Traces** or **Logs** from the dropdown menu, only the **Error Occurrences** option is available.
 
 2. Construct a search query using the same logic as a [RUM Explorer search][1], [APM Explorer search][3], or [Log Explorer search][4] for the issues' error occurrences.
 3. Optionally, configure the alerting grouping strategy. For more information, see [Monitor Configuration][2].
@@ -78,7 +78,7 @@ Triggers when the error count is `above` or `above or equal to`. An alert is tri
 The list of new issues might display older issues that are considered new in the selected time frame, such as the past 24 hours or the past week.
 
 1. Select or input a custom time period for the monitor to consider an issue as new after its first occurrence. The selected threshold is evaluated in the given time frame. After the specific time period, the monitor stops alerting and turns green.
-2. Select **Web and Mobile Apps**, **Backend Services**, or **Logs** and choose to monitor over a count or [measure][1].
+2. Select **RUM Events**, **Traces**, or **Logs** and choose to monitor over a count or [measure][1].
    - Monitor the count of occurrences for a specific issue ID.
    - Monitor over a measure. If you select a measure, the monitor alerts over the numerical value of the RUM or APM facet (similar to a metric monitor). Select an aggregation type (`min`, `avg`, `sum`, `median`, `pc75`, `pc90`, `pc95`, `pc98`, `pc99`, or `max`).
 3. Construct a search query using the same logic as a [RUM Explorer search][2], [APM Explorer search][3], or [Log Explorer search][5] for the issues' error occurrences.

--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -76,6 +76,8 @@ Triggers when the error count is `above` or `above or equal to`. An alert is tri
 {{% tab "New Issue" %}}
 
 1. Select or input a custom time period for the monitor to consider an issue as new after its first occurrence. The selected threshold is evaluated in the given time frame. After the specific time period, the monitor stops alerting and turns green.
+
+   The list of issues on top has a separate time frame selector. It can be used to find which issues would be considered new in this time frame.
 2. Select **RUM Events**, **Traces**, or **Logs** and choose to monitor over a count or [measure][1].
    - Monitor the count of occurrences for a specific issue ID.
    - Monitor over a measure. If you select a measure, the monitor alerts over the numerical value of the RUM or APM facet (similar to a metric monitor). Select an aggregation type (`min`, `avg`, `sum`, `median`, `pc75`, `pc90`, `pc95`, `pc98`, `pc99`, or `max`).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR updates the docs for Error Tracking monitors:
- Renames the mentioned "Web and Mobile Apps" and "Backend Services" dropdown menu items to "RUM Events" and "Traces" respectively. They have been renamed in the UI a while back:
![Screenshot 2024-01-11 at 14 17 30](https://github.com/DataDog/documentation/assets/1335341/05992e29-327a-42ea-8b56-0b798691c0a2)
- The doc currently starts with "Select Web and Mobile Apps from the dropdown menu". This makes it seem like selecting another option is not right. Changing the text to start step 1 with "Select .... from the dropdown menu". This is similar to how it's said in step 2 of the New Issue monitor (on line 81)

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->