### PR TITLE
Move Service Catalog Docs Outside APM

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2112,52 +2112,53 @@ main:
     parent: trace_explorer
     weight: 607
   - name: Service Catalog
-    url: tracing/service_catalog/
-    parent: tracing
+    url: service_catalog/
+    pre: service-catalog
+    parent: platform_heading
     identifier: service_catalog
-    weight: 7
+    weight: 110000
   - name: Browsing
-    url: tracing/service_catalog/browsing
+    url: service_catalog/browsing
     parent: service_catalog
     identifier: service_catalog_browse
     weight: 701
   - name: Investigating a Service
-    url: tracing/service_catalog/investigating
+    url: service_catalog/investigating
     parent: service_catalog
     identifier: service_investigate
     weight: 702
   - name: Adding Entries to Service Catalog
-    url: tracing/service_catalog/setup
+    url: service_catalog/setup
     parent: service_catalog
     identifier: service_catalog_setup
     weight: 703
   - name: Adding Metadata
-    url: tracing/service_catalog/adding_metadata
+    url: service_catalog/adding_metadata
     parent: service_catalog
     identifier: service_metadata
     weight: 704
   - name: Service Catalog API
-    url: tracing/service_catalog/service_definition_api
+    url: service_catalog/service_definition_api
     parent: service_catalog
     identifier: service_catalog_api
     weight: 705
   - name: Service Scorecards
-    url: tracing/service_catalog/scorecards
+    url: service_catalog/scorecards
     parent: service_catalog
     identifier: service_catalog_scorecards
     weight: 706
   - name: Integrations
-    url: tracing/service_catalog/integrations
+    url: service_catalog/integrations
     parent: service_catalog
     identifier: service_catalog_integrations
     weight: 707
   - name: Troubleshooting
-    url: tracing/service_catalog/troubleshooting
+    url: service_catalog/troubleshooting
     parent: service_catalog
     identifier: service_catalog_troubleshooting
     weight: 708
   - name: Guides
-    url: tracing/service_catalog/guides
+    url: service_catalog/guides
     parent: service_catalog
     identifier: service_catalog_guides
     weight: 709

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -1439,6 +1439,57 @@ main:
     weight: 100
     parent: alerting
     identifier: alerting_guide
+  - name: Service Catalog
+    url: service_catalog/
+    pre: service-catalog
+    parent: platform_heading
+    identifier: service_catalog
+    weight: 110000
+  - name: Browsing
+    url: service_catalog/browsing
+    parent: service_catalog
+    identifier: service_catalog_browse
+    weight: 1
+  - name: Investigating a Service
+    url: service_catalog/investigating
+    parent: service_catalog
+    identifier: service_investigate
+    weight: 2
+  - name: Adding Entries to Service Catalog
+    url: service_catalog/setup
+    parent: service_catalog
+    identifier: service_catalog_setup
+    weight: 3
+  - name: Adding Metadata
+    url: service_catalog/adding_metadata
+    parent: service_catalog
+    identifier: service_metadata
+    weight: 4
+  - name: Service Catalog API
+    url: service_catalog/service_definition_api
+    parent: service_catalog
+    identifier: service_catalog_api
+    weight: 5
+  - name: Service Scorecards
+    url: service_catalog/scorecards
+    parent: service_catalog
+    identifier: service_catalog_scorecards
+    weight: 6
+  - name: Integrations
+    url: service_catalog/integrations
+    parent: service_catalog
+    identifier: service_catalog_integrations
+    weight: 7
+  - name: Troubleshooting
+    url: service_catalog/troubleshooting
+    parent: service_catalog
+    identifier: service_catalog_troubleshooting
+    weight: 8
+  - name: Guides
+    url: service_catalog/guides
+    parent: service_catalog
+    identifier: service_catalog_guides
+    weight: 9
   - name: Service Level Objectives
     url: service_management/service_level_objectives/
     pre: slos
@@ -2111,91 +2162,40 @@ main:
     url: tracing/trace_explorer/request_flow_map/
     parent: trace_explorer
     weight: 607
-  - name: Service Catalog
-    url: service_catalog/
-    pre: service-catalog
-    parent: platform_heading
-    identifier: service_catalog
-    weight: 110000
-  - name: Browsing
-    url: service_catalog/browsing
-    parent: service_catalog
-    identifier: service_catalog_browse
-    weight: 701
-  - name: Investigating a Service
-    url: service_catalog/investigating
-    parent: service_catalog
-    identifier: service_investigate
-    weight: 702
-  - name: Adding Entries to Service Catalog
-    url: service_catalog/setup
-    parent: service_catalog
-    identifier: service_catalog_setup
-    weight: 703
-  - name: Adding Metadata
-    url: service_catalog/adding_metadata
-    parent: service_catalog
-    identifier: service_metadata
-    weight: 704
-  - name: Service Catalog API
-    url: service_catalog/service_definition_api
-    parent: service_catalog
-    identifier: service_catalog_api
-    weight: 705
-  - name: Service Scorecards
-    url: service_catalog/scorecards
-    parent: service_catalog
-    identifier: service_catalog_scorecards
-    weight: 706
-  - name: Integrations
-    url: service_catalog/integrations
-    parent: service_catalog
-    identifier: service_catalog_integrations
-    weight: 707
-  - name: Troubleshooting
-    url: service_catalog/troubleshooting
-    parent: service_catalog
-    identifier: service_catalog_troubleshooting
-    weight: 708
-  - name: Guides
-    url: service_catalog/guides
-    parent: service_catalog
-    identifier: service_catalog_guides
-    weight: 709
   - name: Service Observability
     url: tracing/services/
     parent: tracing
     identifier: tracing_services
     weight: 8
-  - name: Service Page
-    url: tracing/services/service_page/
-    parent: tracing_services
-    identifier: tracing_service_page
-    weight: 801
-  - name: Resource Page
-    url: tracing/services/resource_page/
-    parent: tracing_services
-    identifier: tracing_resource_page
-    weight: 802
-  - name: Deployment Tracking
-    url: tracing/services/deployment_tracking/
-    parent: tracing_services
-    identifier: tracing_deployment_tracking
-    weight: 803
-  - name: Service Map
-    url: tracing/services/services_map/
-    parent: tracing_services
-    identifier: tracing_service_map
-    weight: 804
-  - name: APM Monitors
-    url: /monitors/create/types/apm/
-    parent: tracing_services
-    identifier: tracing_apm_monitors
-    weight: 805
   - name: List of Services
     url: /service_catalog/
     parent: tracing_services
     identifier: tracing_service_catalog
+    weight: 801
+  - name: Service Page
+    url: tracing/services/service_page/
+    parent: tracing_services
+    identifier: tracing_service_page
+    weight: 802
+  - name: Resource Page
+    url: tracing/services/resource_page/
+    parent: tracing_services
+    identifier: tracing_resource_page
+    weight: 803
+  - name: Deployment Tracking
+    url: tracing/services/deployment_tracking/
+    parent: tracing_services
+    identifier: tracing_deployment_tracking
+    weight: 804
+  - name: Service Map
+    url: tracing/services/services_map/
+    parent: tracing_services
+    identifier: tracing_service_map
+    weight: 805
+  - name: APM Monitors
+    url: /monitors/create/types/apm/
+    parent: tracing_services
+    identifier: tracing_apm_monitors
     weight: 806
   - name: API Catalog
     url: /tracing/api_catalog/

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -2192,6 +2192,11 @@ main:
     parent: tracing_services
     identifier: tracing_apm_monitors
     weight: 805
+  - name: List of Services
+    url: /service_catalog/
+    parent: tracing_services
+    identifier: tracing_service_catalog
+    weight: 806
   - name: API Catalog
     url: /tracing/api_catalog/
     identifier: api_catalog

--- a/content/en/service_catalog/_index.md
+++ b/content/en/service_catalog/_index.md
@@ -5,6 +5,7 @@ aliases:
   - /tracing/faq/service_catalog/
   - /tracing/services/services_list/
   - /tracing/visualization/services_list/
+  - /tracing/service_catalog/
 further_reading:
 - link: "/tracing/service_catalog/service_definition_api/"
   tag: "Documentation"

--- a/content/en/service_catalog/adding_metadata.md
+++ b/content/en/service_catalog/adding_metadata.md
@@ -12,7 +12,8 @@ further_reading:
   tag: "GitHub"
   text: "Service Definition Schema"
 aliases:
-  - tracing/service_catalog/service_metadata_structure
+  - /tracing/service_catalog/service_metadata_structure
+  - /tracing/service_catalog/adding_metadata
 ---
 
 ## Overview

--- a/content/en/service_catalog/browsing.md
+++ b/content/en/service_catalog/browsing.md
@@ -1,6 +1,8 @@
 ---
 title: Browsing the Service Catalog
 kind: documentation
+aliases:
+  - /tracing/service_catalog/browsing
 further_reading:
 - link: "/tracing/service_catalog/service_definition_api/"
   tag: "Documentation"

--- a/content/en/service_catalog/guides/_index.md
+++ b/content/en/service_catalog/guides/_index.md
@@ -2,6 +2,8 @@
 title: Service Catalog Guides
 kind: guide
 private: true
+aliases:
+  - /tracing/service_catalog/guides/
 ---
 
 

--- a/content/en/service_catalog/guides/streamlining-development-lifecycle-with-ci-visibility.md
+++ b/content/en/service_catalog/guides/streamlining-development-lifecycle-with-ci-visibility.md
@@ -1,6 +1,8 @@
 ---
 title: Streamlining the Development Lifecycle with CI Visibility
 kind: guide
+aliases:
+  - /tracing/service_catalog/guides/streamlining-development-lifecycle-with-ci-visibility
 further_reading:
 - link: "/tracing/service_catalog/"
   tag: "Documentation"

--- a/content/en/service_catalog/guides/understanding-service-configuration.md
+++ b/content/en/service_catalog/guides/understanding-service-configuration.md
@@ -1,6 +1,8 @@
 ---
 title: Understanding Your Service Configuration
 kind: guide
+aliases:
+  - /tracing/service_catalog/guides/understanding-service-configuration
 further_reading:
 - link: "/tracing/service_catalog/"
   tag: "Documentation"

--- a/content/en/service_catalog/guides/upstream-downstream-dependencies.md
+++ b/content/en/service_catalog/guides/upstream-downstream-dependencies.md
@@ -1,6 +1,8 @@
 ---
 title: See Upstream and Downstream Dependencies During an Active Incident
 kind: guide
+aliases:
+  - /tracing/service_catalog/guides/upstream-downstream-dependencies
 further_reading:
 - link: "/tracing/service_catalog/"
   tag: "Documentation"

--- a/content/en/service_catalog/guides/validating-service-definition.md
+++ b/content/en/service_catalog/guides/validating-service-definition.md
@@ -1,6 +1,8 @@
 ---
 title: Validating Service Definition YAMLs
 kind: guide
+aliases:
+  - /tracing/service_catalog/guides/validating-service-definition
 further_reading:
 - link: "/tracing/service_catalog/"
   tag: "Documentation"

--- a/content/en/service_catalog/integrations.md
+++ b/content/en/service_catalog/integrations.md
@@ -1,6 +1,8 @@
 ---
 title: Using Integrations with Service Catalog
 kind: documentation
+aliases:
+  - /tracing/service_catalog/integrations
 further_reading:
 - link: "/tracing/service_catalog/service_definition_api/"
   tag: "Documentation"

--- a/content/en/service_catalog/investigating.md
+++ b/content/en/service_catalog/investigating.md
@@ -1,6 +1,8 @@
 ---
 title: Investigating a Service
 kind: documentation
+aliases:
+  - /tracing/service_catalog/investigating
 further_reading:
 - link: "/tracing/service_catalog/service_definition_api/"
   tag: "Documentation"

--- a/content/en/service_catalog/scorecards.md
+++ b/content/en/service_catalog/scorecards.md
@@ -1,6 +1,8 @@
 ---
 title: Service Scorecards
 kind: documentation
+aliases:
+  - /tracing/service_catalog/scorecards
 further_reading:
 - link: "/tracing/service_catalog/"
   tag: "Documentation"

--- a/content/en/service_catalog/service_definition_api.md
+++ b/content/en/service_catalog/service_definition_api.md
@@ -2,7 +2,8 @@
 title: Service Catalog API
 kind: documentation
 aliases:
-- /tracing/faq/service_definition_api/
+  - /tracing/faq/service_definition_api/
+  - /tracing/service_catalog/service_definition_api
 further_reading:
 - link: "/tracing/service_catalog/"
   tag: "Documentation"

--- a/content/en/service_catalog/setup.md
+++ b/content/en/service_catalog/setup.md
@@ -1,6 +1,8 @@
 ---
 title: Adding Entries to Service Catalog
 kind: documentation
+aliases:
+  - /tracing/service_catalog/setup
 further_reading:
 - link: "/tracing/service_catalog/adding_metadata"
   tag: "Documentation"

--- a/content/en/service_catalog/troubleshooting.md
+++ b/content/en/service_catalog/troubleshooting.md
@@ -1,6 +1,8 @@
 ---
 title: Troubleshooting Service Catalog
 kind: documentation
+aliases:
+  - /tracing/service_catalog/troubleshooting
 further_reading:
 - link: "/tracing/service_catalog/setup/"
   tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
[DOCS-6960](https://datadoghq.atlassian.net/jira/software/projects/DOCS/boards/199?assignee=712020%3A0c2a9bb8-dcff-4533-8eb8-9e0bd4696037&selectedIssue=DOCS-6960)
* Move Service Catalog docs [here](https://a.cl.ly/bLuQY1ng?method=GET).
* Update aliases to all pages.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6960]: https://datadoghq.atlassian.net/browse/DOCS-6960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ