### PR TITLE
Fix dd-trace-go description

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -281,7 +281,7 @@ Tracing:
       link: https://github.com/DataDog/dd-trace-go
       official: true
       authors: Datadog
-      notes: Go package 'tracer'.
+      notes: Go package is 'gopkg.in/DataDog/dd-trace-go.v1'.
     - name: dd-go-opentracing
       link: https://github.com/gchaincl/dd-go-opentracing
       authors: Gustavo Chaín


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Reading the full table you could think the go tracer package is named "tracer", which is false. Fixed this

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->