### PR TITLE
each searched word must be a part of rule

### DIFF
--- a/layouts/static-analysis/list.html
+++ b/layouts/static-analysis/list.html
@@ -84,7 +84,7 @@
             */
 
             const containsFilteredValue = filterValues.every(t => t.length ? t.some(f => ruleFilterInfo.includes(f.split(',')[0].toLowerCase())) : true ) // checks filter attrs match at least one filter value. allows for multiple selection of a filter type.
-            const containsSearchValues = searchValues.some(word => ruleSearchInfo.includes(word.toLowerCase())) // checks search attrs match a typed query
+            const containsSearchValues = searchValues.every(word => ruleSearchInfo.includes(word.toLowerCase())) // checks search attrs match a typed query
 
             this.shouldShowRuleSet(ruleEl.closest('.ruleset'), containsSearchValues && containsFilteredValue)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
fixes search functionality. should be able to search for a `ruleset id`, `rulset description`, `rule name`, or `rule id` to find a rule.

preview: https://docs-staging.datadoghq.com/stefon.simmons/fix-search-static-analysis/static_analysis/rules/?search=empty

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->