### PR TITLE
Fix React Native connect RUM and traces example

### DIFF
--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -462,8 +462,7 @@ RUM supports several propagator types to connect resources with backends that ar
         // ...
     );
     config.firstPartyHosts = [
-        {match: "example.com", propagatorTypes: PropagatorType.TRACECONTEXT},
-        {match: "example.com", propagatorTypes: PropagatorType.DATADOG}
+        {match: "example.com", propagatorTypes: [PropagatorType.TRACECONTEXT, PropagatorType.DATADOG]}
     ];
     ```
 

--- a/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
+++ b/content/en/real_user_monitoring/connect_rum_and_traces/_index.md
@@ -461,9 +461,13 @@ RUM supports several propagator types to connect resources with backends that ar
     const config = new DatadogProviderConfiguration(
         // ...
     );
-    config.firstPartyHosts = [
-        {match: "example.com", propagatorTypes: [PropagatorType.TRACECONTEXT, PropagatorType.DATADOG]}
-    ];
+    config.firstPartyHosts = [{ 
+        match: "example.com", 
+        propagatorTypes: [
+            PropagatorType.TRACECONTEXT, 
+            PropagatorType.DATADOG
+        ]
+    }];
     ```
 
     `PropagatorType` is an enum representing the following tracing header types:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Fix the React Native 'Connect RUM and traces' example. 
This is the type used for the `firstPartyHosts` props:
```typescript
export declare type FirstPartyHost = {
    match: string;
    propagatorTypes: PropagatorType[];
};

```
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing