### PR TITLE
(asm) Update doc for protection navigation release

### DIFF
--- a/content/en/security/application_security/threats/inapp_waf_rules.md
+++ b/content/en/security/application_security/threats/inapp_waf_rules.md
@@ -58,13 +58,13 @@ An input represents which part of the request the operator is applied to. The fo
 
    <div class="alert alert-info">Custom in-app WAF rules is in beta.</div>
 
-Custom in-app WAF rules enable users to log specific types of requests to their applications. For example, you can use custom rules to monitor login success or failure. To get started, navigate to **Security** -> **Application Security** -> **Configuration** -> **In-App WAF** -> [**Custom Rules**][4].
+Custom in-app WAF rules enable users to log or block specific types of requests to their applications. For example, you can use custom rules to monitor login success or failure. To get started, navigate to **Security** -> **Application Security** -> **Protection** -> **In-App WAF** -> [**Custom Rules**][4].
 
 **Note:** Default rules in in-app WAF are read-only. To refine your in-app WAF behavior, modify the in-app WAF rules. Default rules cannot be modified, however, you can create a custom rule based on one of the default rules, and modify the match conditions to your needs. Be sure to disable the default rule so that you don't have two similar rules evaluating the same requests. 
 
 ## Configure an ASM In-App WAF rule
 
-Blocking on a service is defined through the policy rules. Three Datadog default policies are included in the in-app WAF: *Datadog Recommended*, *Datadog Monitoring*, which monitors attacks only, and *Datadog Block Attack tools*, which blocks attack tools and monitors all other attacks.
+Blocking on a service is defined through the policy rules. Three Datadog default policies are included in the in-app WAF: *Datadog Recommended*, *Datadog Monitoring-only*, which monitors attacks only, and *Datadog Block Attack tools*, which blocks attack tools and monitors all other attacks.
 
 Services using a policy are visible directly in the policy management page.
 
@@ -129,4 +129,4 @@ Next, [configure detection rules to create security signals][1] based on those s
 [1]: /security/application_security/custom_rules/
 [2]: https://app.datadoghq.com/security/appsec/in-app-waf
 [3]: /security/application_security/enabling/
-[4]: https://app.datadoghq.com/security/configuration/asm/in-app-waf?config_by=custom-rules
+[4]: https://app.datadoghq.com/security/appsec/in-app-waf?config_by=custom-rules

--- a/content/en/security/application_security/threats/protection.md
+++ b/content/en/security/application_security/threats/protection.md
@@ -34,7 +34,7 @@ From there, all ASM-protected services block incoming requests performed by the 
 
 In addition to manually blocking attackers, you can configure automation rules to have ASM automatically block attackers that are flagged in Security Signals. 
 
-To get started, navigate to **Security > Application Security > Configuration > [Detection Rules][14]**. You can create a new rule or edit an existing rule with type _Application security_. For example, you can create a rule to trigger `Critical` severity signals when Credential Stuffing attacks are detected, and automatically block the associated attackers' IP addresses for 30 minutes.
+To get started, navigate to **Security > Application Security > Protection > [Detection Rules][14]**. You can create a new rule or edit an existing rule with type _Application security_. For example, you can create a rule to trigger `Critical` severity signals when Credential Stuffing attacks are detected, and automatically block the associated attackers' IP addresses for 30 minutes.
 
 **Note**: You must instrument your services to be able to block authenticated attackers. See [User Monitoring and Protection][15] for more details.
 
@@ -77,11 +77,9 @@ View blocked security traces in the [Trace Explorer][11] by filtering on the fac
 
 1. [**Enable Remote Configuration**][2] so that your ASM-enabled services show up under In-App WAF. This is required to securely push In-App WAF configuration from your Datadog backend to the tracing library in your infrastructure. 
 
-2. **Associate your ASM/Remote Configuration-enabled services with a policy**. After Remote Configuration is enabled on a service, it appears under the _Datadog Recommended_ policy by default. Datadog Recommended is a managed policy and is read-only, meaning you cannot modify the status (monitoring, blocking, or disabled) for individual rules.
+2. **Associate your ASM/Remote Configuration-enabled services with a policy**. After Remote Configuration is enabled on a service, navigate to **Security > Protection > Application > [In-App WAF][9]**. The service will appears under the _Datadog Monitoring-only_ policy by default. Datadog Monitoring-only is a managed policy and is read-only, meaning you cannot modify the status (monitoring, blocking, or disabled) for individual rules.
 
-   If you need granular control, clone the _Datadog Recommended_ policy to create a custom policy where rule statuses can be modified. Associate one or more of your services with this custom policy.
-
-3. **Configure blocking for each service**. By default, no requests are blocked even if certain In-App WAF rule statuses are blocking. Navigate to **Security > Configuration > Application > [In-App WAF][13]** to turn on blocking mode for a service. See [In-app WAF rules][19] for more information.
+   If you need granular control, clone one of the available policy to create a custom policy where rule statuses can be modified. Associate one or more of your services with this custom policy.
 
 ## Customize protection behavior
 
@@ -91,7 +89,7 @@ View blocked security traces in the [Trace Explorer][11] by filtering on the fac
 
 {{< img src="/security/application_security/asm-blocking-page-html.png" alt="The page displayed as ASM blocks requests originating from blocked IPs" width="75%" >}}
 
-The default HTTP response status code while serving the deny page to attackers is `403 FORBIDDEN`. To customize the response, navigate to **Security > Application Security > Configuration > [Protection][16]**.
+The default HTTP response status code while serving the deny page to attackers is `403 FORBIDDEN`. To customize the response, navigate to **Security > Application Security > Protection > [Global Settings][16]**.
 
 You can optionally mask the fact that the attacker has been detected and blocked by overriding the response code to be `200 OK` or `404 NOT FOUND` when the deny page is served.
 
@@ -99,9 +97,9 @@ You can also optionally redirect attackers to a custom deny page and away from y
 
 ### Disable protection across all services (Disabling protection mode)
 
-Protection mode is **on** by default and is a toggle available to quickly disable blocking across **all** your services. Requests can be blocked from two sections in Datadog: all attacker requests from Security Signals, and security traces from In-App WAF. The latter also requires you to configure blocking per service in In-App WAF. 
+Protection mode is **on** by default and is a toggle available to quickly disable blocking across **all** your services. Requests can be blocked from two sections in Datadog: all attacker requests from Security Signals, and security traces from In-App WAF.
 
-As important as it is for you to be able to apply protection granularly and reduce the likelihood of legitimate users getting blocked, you sometimes need a simple off switch to quickly stop **all** blocking across **all** services. To turn off protection, navigate to **Security > Application Security > Configuration > [Protection][16]** and toggle **Protection mode** to off.
+As important as it is for you to be able to apply protection granularly and reduce the likelihood of legitimate users getting blocked, you sometimes need a simple off switch to quickly stop **all** blocking across **all** services. To turn off protection, navigate to **Security > Application Security > Protection > [Global Settings][16]** and toggle **Protection mode** to off.
 
 ## Further reading
 
@@ -119,11 +117,9 @@ As important as it is for you to be able to apply protection granularly and redu
 [10]: /security/application_security/threats/inapp_waf_rules/
 [11]: https://app.datadoghq.com/security/appsec/traces
 [12]: /security/application_security/enabling/compatibility/
-[13]: https://app.datadoghq.com/security/configuration/asm/in-app-waf?config_by=services
-[14]: https://app.datadoghq.com/security/configuration/asm/rules
+[14]: https://app.datadoghq.com/security/appsec/detection-rules
 [15]: /security/application_security/threats/add-user-info/?tab=set_user#adding-authenticated-user-information-to-traces-and-enabling-user-blocking-capability
-[16]: https://app.datadoghq.com/security/configuration/asm/protection-behaviour
+[16]: https://app.datadoghq.com/security/appsec/protection-settings
 [17]: https://docs.datadoghq.com/service_management/workflows/
 [18]: https://app.datadoghq.com/workflow/blueprints?selected_category=SECURITY
-[19]: /security/application_security/threats/inapp_waf_rules/
 [20]: /security/application_security/threats/security_signals/

--- a/content/en/security/application_security/threats/protection.md
+++ b/content/en/security/application_security/threats/protection.md
@@ -81,6 +81,8 @@ View blocked security traces in the [Trace Explorer][11] by filtering on the fac
 
    If you need granular control, clone one of the available policy to create a custom policy where rule statuses can be modified. Associate one or more of your services with this custom policy.
 
+   If you would like to change the policy applied by default to your services, you can update your default policy. From the In-App-WAF, click on the policy you would like to set as default, then click on "Actions" > "Set this policy as default".
+
 ## Customize protection behavior
 
 ### Customize response to blocked requests

--- a/content/en/security/application_security/threats/protection.md
+++ b/content/en/security/application_security/threats/protection.md
@@ -77,11 +77,11 @@ View blocked security traces in the [Trace Explorer][11] by filtering on the fac
 
 1. [**Enable Remote Configuration**][2] so that your ASM-enabled services show up under In-App WAF. This is required to securely push In-App WAF configuration from your Datadog backend to the tracing library in your infrastructure. 
 
-2. **Associate your ASM/Remote Configuration-enabled services with a policy**. After Remote Configuration is enabled on a service, navigate to **Security > Protection > Application > [In-App WAF][9]**. The service will appears under the _Datadog Monitoring-only_ policy by default. Datadog Monitoring-only is a managed policy and is read-only, meaning you cannot modify the status (monitoring, blocking, or disabled) for individual rules.
+2. **Associate your ASM/Remote Configuration-enabled services with a policy**. After Remote Configuration is enabled on a service, navigate to **Security > Protection > Application > [In-App WAF][9]**. The service appears under the _Datadog Monitoring-only_ policy by default. Datadog Monitoring-only is a managed policy and is read-only, meaning you cannot modify the status (monitoring, blocking, or disabled) for individual rules.
 
-   If you need granular control, clone one of the available policy to create a custom policy where rule statuses can be modified. Associate one or more of your services with this custom policy.
+   If you need granular control, clone one of the available policies to create a custom policy where rule statuses can be modified. Associate one or more of your services with this custom policy.
 
-   If you would like to change the policy applied by default to your services, you can update your default policy. From the In-App-WAF, click on the policy you would like to set as default, then click on "Actions" > "Set this policy as default".
+   To change the policy applied by default to your services, you can update your default policy. From the In-App-WAF, click the policy you would like to set as default, then click **Actions** > **Set this policy as default**.
 
 ## Customize protection behavior
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Following the release of the new navigation we want to update the different links we have in ASM threats

Configuration for In App Waf will now be in ASM -> Protection main menu


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after release of the new navigation (ETA this week)
- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->