### PR TITLE
[RUM] remove relative time from add timing API

### DIFF
--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -174,7 +174,7 @@ Once the timing is sent, the timing is accessible as `@view.custom_timings.<timi
 
 For single-page applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing is equal to `8-5 = 3` seconds.
 
-If you are using an asynchronous setup, you can provide your own timing (the number of milliseconds relative to the start of the current RUM view or the UNIX epoch timestamp) as a second parameter.
+If you are using an asynchronous setup, you can provide your own timing (as an UNIX epoch timestamp) as a second parameter.
 
 For example:
 

--- a/content/en/real_user_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/browser/monitoring_page_performance.md
@@ -174,7 +174,7 @@ Once the timing is sent, the timing is accessible as `@view.custom_timings.<timi
 
 For single-page applications, the `addTiming` API issues a timing relative to the start of the current RUM view. For example, if a user lands on your application (initial load), then goes on a different page after 5 seconds (route change) and finally triggers `addTiming` after 8 seconds, the timing is equal to `8-5 = 3` seconds.
 
-If you are using an asynchronous setup, you can provide your own timing (as an UNIX epoch timestamp) as a second parameter.
+If you are using an asynchronous setup, you can provide your own timing (as a UNIX epoch timestamp) as a second parameter.
 
 For example:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Remove the mention of providing a relative time to the addTiming API since customer can't really provide a relative time that will be relative to the current view start.
They should favour using epoch timestamp instead.
cf https://github.com/DataDog/browser-sdk/issues/2552

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->