### PR TITLE
fix `deleteOneSelection` functionality

### DIFF
--- a/layouts/static-analysis/list.html
+++ b/layouts/static-analysis/list.html
@@ -133,14 +133,15 @@
                 acc[lang.toLowerCase()] = displayName
                 return acc
             }, {})
-
+            
             Array.from(url.searchParams.entries()).forEach(([key, value]) => {
                 if (key === 'search'){
                     this.searchValue = value
                 } else if ((key === 'languages') && validLangsArr.some(l => l.replace(/\;\w./, '').toLowerCase() === value.toLowerCase())){
                     const logoName = this.lang_aliases[value.toLowerCase()] ?? value
                     const displayName = langAliasMap[value.toLowerCase()] ?? value
-                    this.filterTypes[key].push(`${displayName},https://static.datadoghq.com/static/images/logos/${logoName.toLowerCase()}_avatar.svg`)
+                    const langLookupName = langAliasMap[value.toLowerCase()] ? `,${value}`: ''
+                    this.filterTypes[key].push(`${displayName},https://static.datadoghq.com/static/images/logos/${logoName.toLowerCase()}_avatar.svg${langLookupName}`)
                 } else if (key != 'languages'){
                     this.filterTypes[key]?.push(value)
                 }

--- a/layouts/static-analysis/list.html
+++ b/layouts/static-analysis/list.html
@@ -103,6 +103,7 @@
             let newURL = ''
             if(filterType){
                 if(!url.searchParams.getAll(filterType).includes(filterOption)){
+                    // add one key:value param
                     url.searchParams.append(filterType, filterOption)
                 }else{
                     // remove one key:value param
@@ -118,7 +119,7 @@
                     url.searchParams.delete('search')
                 }
             }
-      
+
             window.history.pushState(null,'', newURL || url.toString())
         },
         updateWithURLParams (validLangs) {
@@ -178,13 +179,16 @@
             })
         },
         deleteOneSelection (filterType, filterOption) {
-            // delete one filterOption at a time
+            // delete one filterOption from selections in filter toggler
 
             this.filterTypes[filterType] = this.filterTypes[filterType].filter(s => s !== filterOption)
-            this.pushState(filterType, filterOption.split(',')[0])
+
+            const [displayName,_,langLookupName] = filterOption.split(',')
+            const filterName = langLookupName || displayName
+            this.pushState(filterType, filterName)
         },
         deleteAllSelections (filterType) {
-            // delete all selections and url params of a filter type
+            // delete all selections of a filter type from filter toggler and url params
 
             this.filterTypes[filterType] = []
             this.openedFilterForm = null
@@ -369,12 +373,12 @@
                                 {{ $lang_lookup_name := index (split . ";") 0 }}
                                 {{ $display_name := (index (split . ";") 1) | default . }}
                                 {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $lang_lookup_name "variant" "avatar") }}
-                               
-                                {{/*  store int_logo with filter value if int_logo is present e.g. "Javascript,int_logo url" */}}
+
+                                {{/*  store int_logo with filter value if int_logo is present e.g. "Javascript,int_logo url,<alias name>" */}}
                                 <input 
                                 id="{{ $lang_lookup_name | anchorize }}" 
                                 type="checkbox" 
-                                value='{{ cond ($int_logo | not ) . (printf "%s,%s" $display_name $int_logo) }}' 
+                                value='{{ cond ($int_logo | not ) . (printf "%s,%s%s" $display_name $int_logo (cond (eq ((split . ";") | len) 2) (printf ",%s" $lang_lookup_name) "")) }}' 
                                 x-model="filterTypes['{{$filter_type}}']"
                                 @change="resetFilteredRulesets"
                                 @change.debounce="pushState('{{ $filter_type }}', '{{ $lang_lookup_name }}')"

--- a/layouts/static-analysis/list.html
+++ b/layouts/static-analysis/list.html
@@ -373,12 +373,12 @@
                                 {{ $lang_lookup_name := index (split . ";") 0 }}
                                 {{ $display_name := (index (split . ";") 1) | default . }}
                                 {{ $int_logo := partial "integrations-logo.html" (dict "context" $dot "basename" $lang_lookup_name "variant" "avatar") }}
-
-                                {{/*  store int_logo with filter value if int_logo is present e.g. "Javascript,int_logo url,<alias name>" */}}
+                                {{/*  store $int_logo and $lang_lookup_name with filter value if $int_logo is present. e.g. "Javascript,int_logo url,<alias name>" */}}
+                                {{ $value := (printf "%s,%s%s" $display_name $int_logo (cond (eq ((split . ";") | len) 2) (printf ",%s" $lang_lookup_name) ""))}}
                                 <input 
                                 id="{{ $lang_lookup_name | anchorize }}" 
                                 type="checkbox" 
-                                value='{{ cond ($int_logo | not ) . (printf "%s,%s%s" $display_name $int_logo (cond (eq ((split . ";") | len) 2) (printf ",%s" $lang_lookup_name) "")) }}' 
+                                value='{{ cond ($int_logo | not ) . $value }}' 
                                 x-model="filterTypes['{{$filter_type}}']"
                                 @change="resetFilteredRulesets"
                                 @change.debounce="pushState('{{ $filter_type }}', '{{ $lang_lookup_name }}')"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
uses the `language_alias` value to target url params that have a language_alias

preview: https://docs-staging.datadoghq.com/stefon.simmons/fix-delete-one-sa/static_analysis/rules/?languages=Docker&languages=Java&languages=CSharp
- clicking the **x** (delete) for the `C#` selection (not the checkbox), should remove the `CSharp` (alias) url param.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->