### PR TITLE
Remove outdated beta notice for Go and Java api clients

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -82,7 +82,6 @@ Classic:
       official: true
       api: true
       authors: Datadog
-      notes: Client library in beta and subject to change.
     - name: godspeed
       link: https://github.com/theckman/godspeed
       dogstatsd: true
@@ -112,7 +111,6 @@ Classic:
       official: true
       api: true
       authors: Datadog
-      notes: Client library in beta and subject to change.
     - name: Lassie
       link: https://github.com/bazaarvoice/lassie
       api: true


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
removes the note saying the Go and Java client is in beta

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->