### PR TITLE
Fix link in Session Replay docs

### DIFF
--- a/content/en/real_user_monitoring/session_replay/_index.md
+++ b/content/en/real_user_monitoring/session_replay/_index.md
@@ -103,6 +103,6 @@ Learn more about the [Session Replay for Mobile][5].
 [1]: https://github.com/DataDog/browser-sdk
 [2]: https://www.rrweb.io/
 [3]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum/BROWSER_SUPPORT.md
-[4]: /real_user_monitoring/session_replay/
+[4]: /real_user_monitoring/browser/
 [5]: /real_user_monitoring/session_replay/mobile/
 [6]: https://www.datadoghq.com/pricing/?product=real-user-monitoring--session-replay#real-user-monitoring--session-replay


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Under "Setup," "Datadog RUM Browser Monitoring" currently links to https://docs.datadoghq.com/real_user_monitoring/session_replay/ - bringing you back to the top of the page.  
This changes the link to https://docs.datadoghq.com/real_user_monitoring/browser/

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->