### PR TITLE
Add Flutter GraphQL Integration

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/_index.md
@@ -19,19 +19,20 @@ This page lists integrated libraries you can use for the following applications:
 
 - Android & Android TV Monitoring
 - React Native
+- Flutter
 
 ## Android & Android TV Monitoring
- 
+
 ### Coil
- 
+
 If you use Coil to load images in your application, see Datadog's [dedicated Coil library][1].
- 
+
 ### Fresco
- 
+
 If you use Fresco to load images in your application, see Datadog's [dedicated Fresco library][2].
- 
+
 ### Glide
- 
+
 If you use Glide to load images in your application, see Datadog's [dedicated Glide library][3].
 
 ### Jetpack Compose
@@ -43,14 +44,14 @@ If you use Jetpack Compose in your application, see Datadog's [dedicated Jetpack
 If you use RxJava in your application, see Datadog's [dedicated RxJava library][8].
 
 ### Picasso
- 
+
 If you use Picasso, use it with the `OkHttpClient` that's been instrumented with the Datadog SDK for RUM and APM information about network requests made by Picasso.
 
 {{< tabs >}}
 {{% tab "Kotlin" %}}
    ```kotlin
        val picasso = Picasso.Builder(context)
-            .downloader(OkHttp3Downloader(okHttpClient)) 
+            .downloader(OkHttp3Downloader(okHttpClient))
             // …
             .build()
        Picasso.setSingletonInstance(picasso)
@@ -66,9 +67,9 @@ If you use Picasso, use it with the `OkHttpClient` that's been instrumented with
    ```
 {{% /tab %}}
 {{< /tabs >}}
- 
+
 ### Retrofit
- 
+
 If you use Retrofit, use it with the `OkHttpClient` that's been instrumented with the Datadog SDK for RUM and APM information about network requests made with Retrofit.
 
 {{< tabs >}}
@@ -89,16 +90,16 @@ If you use Retrofit, use it with the `OkHttpClient` that's been instrumented wit
    ```
 {{% /tab %}}
 {{< /tabs >}}
- 
+
 ### SQLDelight
- 
+
 If you use SQLDelight in your application, see Datadog's [dedicated SQLDelight library][4].
- 
+
 ### SQLite
- 
+
 Following SQLiteOpenHelper's [generated API documentation][5], you only have to provide the implementation of the
 `DatabaseErrorHandler` -> `DatadogDatabaseErrorHandler` in the constructor.
- 
+
 Doing this detects whenever a database is corrupted and sends a relevant
 RUM error event for it.
 
@@ -106,13 +107,13 @@ RUM error event for it.
 {{% tab "Kotlin" %}}
    ```kotlin
         class <YourOwnSqliteOpenHelper>: SqliteOpenHelper(
-                                        <Context>, 
-                                        <DATABASE_NAME>, 
-                                        <CursorFactory>, 
+                                        <Context>,
+                                        <DATABASE_NAME>,
+                                        <CursorFactory>,
                                         <DATABASE_VERSION>,
                                         DatadogDatabaseErrorHandler()) {
             // …
-        
+
         }
    ```
 {{% /tab %}}
@@ -130,9 +131,9 @@ RUM error event for it.
    ```
 {{% /tab %}}
 {{< /tabs >}}
- 
+
 ### Apollo (GraphQL)
- 
+
 If you use Apollo, use it with the `OkHttpClient` that's been instrumented with the Datadog SDK for RUM and APM information about all the queries performed through Apollo client.
 
 {{< tabs >}}
@@ -247,6 +248,46 @@ const viewNamePredicate: ViewNamePredicate = function customViewNamePredicate(ev
 DdRumReactNativeNavigationTracking.startTracking(viewNamePredicate);
 ```
 
+## Flutter
+
+### GraphQL (gql_link)
+
+Datadog provides [`datadog_gql_link`][14] for use with most GraphQL Flutter libraries, including `graphql_flutter` and `ferry`.
+
+#### Setup
+
+Add `datadog_gql_link` to your `pubspec.yaml` or by running `flutter pub add datadog_gql_link` from your terminal
+
+```yaml
+dependencies:
+  # Other dependencies
+  datadog_gql_link: ^1.0.0
+```
+
+When creating your GraphQL link, add the `DatadogGqlLink` above at a location above your terminating link. For example:
+
+```dart
+final graphQlUrl = "https://example.com/graphql";
+
+final link = Link.from([
+  DatadogGqlLink(DatadogSdk.instance, Uri.parse(graphQlUrl)),
+  HttpLink(graphQlUrl),
+]);
+```
+
+
+If you are tracking non-GraphQL network calls with `datadog_tracking_http_client`, you need to have the tracking plugin ignore requests to your GraphQL endpoint. Otherwise, GraphQL resources will be double reported, and APM traces may be broken. Ignore your GraphQL endpoint by using the `ignoreUrlPatterns` parameter added to `datadog_tracking_http_client` version 2.1.0.
+
+```dart
+final datadogConfig = DatadogConfiguration(
+    // Your configuration
+  )..enableHttpTracking(
+      ignoreUrlPatterns: [
+        RegExp('example.com/graphql'),
+      ],
+    );
+```
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -263,3 +304,4 @@ DdRumReactNativeNavigationTracking.startTracking(viewNamePredicate);
 [10]: https://github.com/Datadog/dd-sdk-android/tree/develop/integrations/dd-sdk-android-trace-coroutines
 [11]: https://wix.github.io/react-native-navigation/api/events/#componentdidappear
 [12]: https://reactnavigation.org/
+[14]: https://pub.dev/packages/datadog_gql_link


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Add information about using Flutter's new `datadog_gql_link` package for use with GraphQL.

This should probably be reviewed merged after the similar change for React Native: #21419

### Merge instructions

- [x] Please merge after reviewing
