### PR TITLE
disables preview cache flag

### DIFF
--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
### What does this PR do? What is the motivation?
temporarily disables the preview caching mechanism to determine if some transient preview build errors are being caused by this functionality

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
transient build errors have been reported by the docs team, for example here reported by @hestonhoffman and @aliciascott https://dd.slack.com/archives/C3CT8QA11/p1705515891633269.

it seems the issues are contained to preview builds which could indicate a problem with the caching.