### PR TITLE
[APM .NET Client Library] Add .NET 8 to list of supported runtimes

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -50,7 +50,7 @@ further_reading:
 
 ### Supported .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
+The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
 
 For a full list of Datadog's .NET Core library and processor architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -50,7 +50,7 @@ further_reading:
 
 ### Supported .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, 3.1, .NET 5, .NET 6, and .NET 7.
+The .NET Tracer supports instrumentation on .NET Core 2.1, 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
 
 For a full list of Datadog's .NET Core library and processor architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Tiny change to add .NET 8 to the list of supported runtimes. This was already updated in other pages. We have supported .NET 8 since release 2.42.0 of the .NET Client Library (aka tracer).


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->