### PR TITLE
fix heading on k8s control plane page

### DIFF
--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -786,7 +786,7 @@ spec:
 {{< /tabs >}}
 
 
-## Kubernetes on Rancher Kubernetes Engine (\<v2.5) {#RKEBefore2_5}
+## Kubernetes on Rancher Kubernetes Engine (before v2.5) {#RKEBefore2_5}
 
 ### API Server, Controller Manager, and Scheduler
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Escaping the `<` isn't working, and the heading appears broken when rendered in the corpsite (heading says **Kubernetes on Rancher Kubernetes Engine (** and then the angle bracket breaks everything). Using the HTML escape `&lt;` also does not work, nor does enclosing `<` in backticks. Consequently, I've replaced the char with the word "before".

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->