### PR TITLE
Clarify container statement to avoid confusion about Fargate

### DIFF
--- a/content/en/account_management/billing/apm_tracing_profiler.md
+++ b/content/en/account_management/billing/apm_tracing_profiler.md
@@ -20,7 +20,7 @@ APM is available through three tiers: APM, APM Pro, and APM Enterprise. APM give
 | [Ingested span][5] | $.10 per GB Ingested Spans per month | Billed when usage is in excess of Ingested Spans included with every APM host | An Ingested span is an individual request against an individual service in your stack. Datadog charges based on the total number of gigabytes of spans ingested to Datadog at the end of the month. [More APM pricing information.][5]                                                                                          |
 
 **Notes**:  
-   - If you're using a container based environment, you get billed for the underlying host deploying the Datadog Agent.
+   - If you're using a non-Fargate container based environment, you get billed for the underlying host deploying the Datadog Agent.
    - One profiled container is a container that is running the Continuous Profiler service. This does not include containers that are not being profiled. For instance, a DNS service container that is NOT profiled, running concurrently with your application container that IS profiled, is not counted towards the four profiler containers allotment.
    - [Universal Service Monitoring][15] is included in all APM tiers (APM, APM Pro, APM Enterprise) at no additional cost.
 


### PR DESCRIPTION
Mitigate this question from Sales:

Hi Team, received the following question from a client looking to onboard Datadog: "I’m trying to get the most accurate info possible, specifically for the APM pricing for containers (ECS and EKS, no Fargate). On your APM Billing page I see If you’re using a container based environment, you get billed for the underlying host deploying the Datadog Agent. If we’re running say 450 containers on 10x EC2 instances – does that mean we’d be billed just for APM on the 10 hosts? Wouldn’t it be deployed as a sidecar/daemon for each pod?"

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->