### PR TITLE
[DOCS-6951] Update trace and span ID page to reflect 128-bit IDs

### DIFF
--- a/content/en/tracing/guide/send_traces_to_agent_by_api.md
+++ b/content/en/tracing/guide/send_traces_to_agent_by_api.md
@@ -42,6 +42,8 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource` and so on
 
 ### Model
 
+<div class="alert alert-info">Datadog tracing libraries support both 64-bit and 128-bit trace IDs. Read <a href="/tracing/guide/span_and_trace_id_format/">Span and Trace ID formats to learn more.</a></div>
+
 | Field      | Type    | Description                           |
 |------------|---------|---------------------------------------|
 | `duration`   | int64   | The duration of the request in nanoseconds. |
@@ -56,7 +58,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource` and so on
 | `service`    | string  | The service you are tracing. The service name must not be longer than 100 characters. |
 | `span_id`    | int64   | The span integer (64-bit unsigned) ID. |
 | `start`      | int64   | The start time of the request in nanoseconds from the UNIX epoch. |
-| `trace_id`   | int64   | The unique integer (64-bit unsigned) ID of the trace containing this span. |
+| `trace_id`   | int64 or int128   | The unique integer (64-bit unsigned or 128-bit unsigned) ID of the trace containing this span. |
 | `type`       | enum    | The type of request. Allowed enum values: `web`, `db`, `cache`, `custom` |
 
 

--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -20,7 +20,7 @@ This page details Datadog tracing library support for trace and span IDs.
 
 128-bit trace IDs are generated and accepted by default in the latest versions of Datadog tracing libraries.
 
-| Language   | Generated IDs             | Valid Accepted 128-bit int IDs |
+| Language   | Generated IDs             | Valid, Accepted 128-bit int IDs |
 | ---------- | --------------------------| ------------------------------ |
 | JavaScript | Unsigned [0, $2^128-1$]   |  Signed or unsigned            |
 | Java       | Unsigned [0, $2^128-1$]   |  Unsigned                      |
@@ -37,7 +37,7 @@ This page details Datadog tracing library support for trace and span IDs.
 
 Trace IDs are generated as 128-bit by default, and they are accepted as either 128-bit or 64-bit integers. To generate 64-bit trace IDs, set the environment variable `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` to `false`.
 
-| Language   | Generated IDs            | Valid Accepted 64-bit int IDs |
+| Language   | Generated IDs            | Valid, Accepted 64-bit int IDs |
 | ---------- | ------------------------ | ----------------------------- |
 | JavaScript | Unsigned  [$0, 2^64-1$]   | Signed or unsigned            |
 | Java       | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
@@ -52,7 +52,7 @@ Trace IDs are generated as 128-bit by default, and they are accepted as either 1
 
 Span IDs are limited to 64-bits in Datadog.
 
-| Language   | Generated IDs            | Valid Accepted 64-bit int IDs |
+| Language   | Generated IDs            | Valid, Accepted 64-bit int IDs |
 | ---------- | ------------------------ | ----------------------------- |
 | JavaScript | Unsigned [0, $2^63$]     | Signed or unsigned            |
 | Java       | Unsigned [1, $2^63-1$]   | Unsigned                      |

--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -18,35 +18,22 @@ This page details Datadog tracing library support for trace and span IDs.
 
 ## 128-bit trace IDs
 
-128-bit trace IDs are generated and accepted by default in the latest versions of Datadog tracing libraries.
+128-bit trace IDs are generated and accepted by default in the latest versions of Datadog tracing libraries:
 
-| Language   | Generated IDs             | Valid, Accepted 128-bit int IDs |
-| ---------- | --------------------------| ------------------------------ |
-| Node.js    | Unsigned [0, $2^128-1$]   |                                |
-| Java       | Unsigned [0, $2^128-1$]   |                                |
-| Go         | Unsigned [0, $2^128-1$]   |                                |
-| Python     | Unsigned [0, $2^128-1$]   |                                |
-| Ruby       | Unsigned [0, $2^128-1$]   |                                |
-| .NET       | Unsigned [0, $2^128-1$]   |                                |
-| PHP        | Unsigned [0, $2^128-1$]   |                                |
-| C++        | Unsigned [0, $2^128-1$]   |                                |
+- [Node.js][1]
+- [Java][2]   
+- [Go][3]     
+- [Python][4] 
+- [Ruby][5]   
+- [.NET][6]   
+- [PHP][7]    
+- [C++][8]   
 
 ## 64-bit trace and span IDs
 
 ### Trace IDs
 
 Trace IDs are generated as 128-bit by default, and they are accepted as either 128-bit or 64-bit integers. To generate 64-bit trace IDs, set the environment variable `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` to `false`.
-
-| Language   | Generated IDs            | Valid, Accepted int IDs |
-| ---------- | ------------------------ | ----------------------------- |
-| Node.js    | Unsigned  [$0, 2^64-1$]   |                        |
-| Java       | Unsigned  [$0, 2^64-1$]   |                        |
-| Go         | Unsigned  [$0, 2^64-1$]   |                        |
-| Python     | Unsigned  [$0, 2^64-1$]   |                        |
-| Ruby       | Unsigned  [$0, 2^64-1$]   |                        |
-| .NET       | Unsigned  [$0, 2^64-1$]   |                        |
-| PHP        | Unsigned  [$0, 2^64-1$]   |                        |
-| C++        | Unsigned  [$0, 2^64-1$]   |                        |
 
 ### Span IDs
 
@@ -66,3 +53,12 @@ Span IDs are limited to 64-bits in Datadog.
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/dd-trace-js/releases
+[2]: https://github.com/DataDog/dd-trace-java/releases
+[3]: https://github.com/DataDog/dd-trace-go/releases
+[4]: https://github.com/DataDog/dd-trace-py/releases
+[5]: https://github.com/DataDog/dd-trace-rb/releases
+[6]: https://github.com/DataDog/dd-trace-dotnet/releases
+[7]: https://github.com/DataDog/dd-trace-php/releases
+[8]: https://github.com/DataDog/dd-trace-cpp/releases

--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -3,12 +3,54 @@ title: Trace and Span ID Formats
 kind: guide
 aliases:
   - /tracing/faq/span_and_trace_id_format/
+further_reading:
+  - link: /tracing/other_telemetry/connect_logs_and_traces/
+    tag: documentation
+    text: Correlating logs and traces
+
 ---
 {{< jqmath-vanilla >}}
 
-If you write code that interacts directly with Datadog tracing spans and traces, here's what you need to know about how span IDs and trace IDs are generated and accepted by Datadog tracing libraries.
+This page details Datadog tracing library support for trace and span IDs.
 
-Generally, the libraries generate IDs that are 64-bit unsigned integers. Specifics and exceptions noted below:
+- **Generated IDs**: By default, all tracing libraries generate 128-bit trace IDs and 64-bit span IDs.  
+- **Accepted IDs**: Datadog accepts 128-bit or 64-bit trace IDs, and 64-bit span IDs.
+
+## 128-bit trace IDs
+
+128-bit trace IDs are generated and accepted by default in the latest versions of Datadog tracing libraries.
+
+| Language   | Generated IDs             | Valid Accepted 128-bit int IDs |
+| ---------- | --------------------------| ------------------------------ |
+| JavaScript | Unsigned [0, $2^128-1$]   |  Signed or unsigned            |
+| Java       | Unsigned [0, $2^128-1$]   |  Unsigned                      |
+| Go         | Unsigned [0, $2^128-1$]   |  Signed or unsigned            |
+| Python     | Unsigned [0, $2^128-1$]   |  Unsigned                      |
+| Ruby       | Unsigned [0, $2^128-1$]   |  Unsigned                      |
+| .NET       | Unsigned [0, $2^128-1$]   |  Unsigned                      |
+| PHP        | Unsigned [0, $2^128-1$]   |  Unsigned                      |
+| C++        | Unsigned [0, $2^128-1$]   |  Unsigned                      |
+
+## 64-bit trace and span IDs
+
+### Trace IDs
+
+Trace IDs are generated as 128-bit by default, and they are accepted as either 128-bit or 64-bit integers. To generate 64-bit trace IDs, set the environment variable `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` to `false`.
+
+| Language   | Generated IDs            | Valid Accepted 64-bit int IDs |
+| ---------- | ------------------------ | ----------------------------- |
+| JavaScript | Unsigned  [$0, 2^64-1$]   | Signed or unsigned            |
+| Java       | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
+| Go         | Unsigned  [$0, 2^64-1$]   | Signed or unsigned            |
+| Python     | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
+| Ruby       | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
+| .NET       | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
+| PHP        | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
+| C++        | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
+
+## Span IDs
+
+Span IDs are limited to 64-bits in Datadog.
 
 | Language   | Generated IDs            | Valid Accepted 64-bit int IDs |
 | ---------- | ------------------------ | ----------------------------- |
@@ -20,3 +62,7 @@ Generally, the libraries generate IDs that are 64-bit unsigned integers. Specifi
 | .NET       | Unsigned [0, $2^63-1$]   | Unsigned                      |
 | PHP        | Unsigned [1, $2^64-1$]   | Unsigned                      |
 | C++        | Unsigned [0, $2^63-1$]   | Unsigned                      |
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -22,7 +22,7 @@ This page details Datadog tracing library support for trace and span IDs.
 
 | Language   | Generated IDs             | Valid, Accepted 128-bit int IDs |
 | ---------- | --------------------------| ------------------------------ |
-| JavaScript | Unsigned [0, $2^128-1$]   |                                |
+| Node.js    | Unsigned [0, $2^128-1$]   |                                |
 | Java       | Unsigned [0, $2^128-1$]   |                                |
 | Go         | Unsigned [0, $2^128-1$]   |                                |
 | Python     | Unsigned [0, $2^128-1$]   |                                |
@@ -39,7 +39,7 @@ Trace IDs are generated as 128-bit by default, and they are accepted as either 1
 
 | Language   | Generated IDs            | Valid, Accepted int IDs |
 | ---------- | ------------------------ | ----------------------------- |
-| JavaScript | Unsigned  [$0, 2^64-1$]   |                        |
+| Node.js    | Unsigned  [$0, 2^64-1$]   |                        |
 | Java       | Unsigned  [$0, 2^64-1$]   |                        |
 | Go         | Unsigned  [$0, 2^64-1$]   |                        |
 | Python     | Unsigned  [$0, 2^64-1$]   |                        |
@@ -54,7 +54,7 @@ Span IDs are limited to 64-bits in Datadog.
 
 | Language   | Generated IDs            | Valid, Accepted 64-bit int IDs |
 | ---------- | ------------------------ | ----------------------------- |
-| JavaScript | Unsigned [0, $2^63$]     | Signed or unsigned            |
+| Node.js    | Unsigned [0, $2^63$]     | Signed or unsigned            |
 | Java       | Unsigned [1, $2^63-1$]   | Unsigned                      |
 | Go         | Unsigned [0, $2^63-1$]   | Signed or unsigned            |
 | Python     | Unsigned [0, $2^64-1$]   | Unsigned                      |

--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -48,7 +48,7 @@ Trace IDs are generated as 128-bit by default, and they are accepted as either 1
 | PHP        | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
 | C++        | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
 
-## Span IDs
+### Span IDs
 
 Span IDs are limited to 64-bits in Datadog.
 

--- a/content/en/tracing/guide/span_and_trace_id_format.md
+++ b/content/en/tracing/guide/span_and_trace_id_format.md
@@ -22,14 +22,14 @@ This page details Datadog tracing library support for trace and span IDs.
 
 | Language   | Generated IDs             | Valid, Accepted 128-bit int IDs |
 | ---------- | --------------------------| ------------------------------ |
-| JavaScript | Unsigned [0, $2^128-1$]   |  Signed or unsigned            |
-| Java       | Unsigned [0, $2^128-1$]   |  Unsigned                      |
-| Go         | Unsigned [0, $2^128-1$]   |  Signed or unsigned            |
-| Python     | Unsigned [0, $2^128-1$]   |  Unsigned                      |
-| Ruby       | Unsigned [0, $2^128-1$]   |  Unsigned                      |
-| .NET       | Unsigned [0, $2^128-1$]   |  Unsigned                      |
-| PHP        | Unsigned [0, $2^128-1$]   |  Unsigned                      |
-| C++        | Unsigned [0, $2^128-1$]   |  Unsigned                      |
+| JavaScript | Unsigned [0, $2^128-1$]   |                                |
+| Java       | Unsigned [0, $2^128-1$]   |                                |
+| Go         | Unsigned [0, $2^128-1$]   |                                |
+| Python     | Unsigned [0, $2^128-1$]   |                                |
+| Ruby       | Unsigned [0, $2^128-1$]   |                                |
+| .NET       | Unsigned [0, $2^128-1$]   |                                |
+| PHP        | Unsigned [0, $2^128-1$]   |                                |
+| C++        | Unsigned [0, $2^128-1$]   |                                |
 
 ## 64-bit trace and span IDs
 
@@ -37,16 +37,16 @@ This page details Datadog tracing library support for trace and span IDs.
 
 Trace IDs are generated as 128-bit by default, and they are accepted as either 128-bit or 64-bit integers. To generate 64-bit trace IDs, set the environment variable `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` to `false`.
 
-| Language   | Generated IDs            | Valid, Accepted 64-bit int IDs |
+| Language   | Generated IDs            | Valid, Accepted int IDs |
 | ---------- | ------------------------ | ----------------------------- |
-| JavaScript | Unsigned  [$0, 2^64-1$]   | Signed or unsigned            |
-| Java       | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
-| Go         | Unsigned  [$0, 2^64-1$]   | Signed or unsigned            |
-| Python     | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
-| Ruby       | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
-| .NET       | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
-| PHP        | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
-| C++        | Unsigned  [$0, 2^64-1$]   | Unsigned                      |
+| JavaScript | Unsigned  [$0, 2^64-1$]   |                        |
+| Java       | Unsigned  [$0, 2^64-1$]   |                        |
+| Go         | Unsigned  [$0, 2^64-1$]   |                        |
+| Python     | Unsigned  [$0, 2^64-1$]   |                        |
+| Ruby       | Unsigned  [$0, 2^64-1$]   |                        |
+| .NET       | Unsigned  [$0, 2^64-1$]   |                        |
+| PHP        | Unsigned  [$0, 2^64-1$]   |                        |
+| C++        | Unsigned  [$0, 2^64-1$]   |                        |
 
 ### Span IDs
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
All Datadog tracing libraries now generate 128-bit IDs by default. Update the Trace and Span ID Formats page to reflect the new paradigm.

- By default, all tracing libraries generate 128-bit trace IDs and 64-bit span IDs. 
- Datadog accepts 128-bit or 64-bit trace IDs, and 64-bit span IDs.
- Trace ID range should be 0, 2^64-1 for all languages (differing from span IDs).

Edit: Removed ID ranges from the new sections after discussing with js team.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->