### PR TITLE
[WEB-4224] cmd + click opens in new tab from search results

### DIFF
--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -238,7 +238,12 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
                         const clickPosition = getSearchResultClickPosition(target.href, hitsArray, numHits, page)
                         sendSearchRumAction(search.helper.state.query, target.href, clickPosition);
                         window.history.pushState({}, '', target.href);
-                        window.location.reload();
+
+                        if (e.metaKey || e.ctrlKey) {
+                            window.open(target.href, "_blank")
+                        } else {
+                            window.location.reload()
+                        }
                     }
 
                     target = target.parentNode;


### PR DESCRIPTION
### What does this PR do? What is the motivation?
`cmd + click` on an item from the search results opens page in a new tab
https://datadoghq.atlassian.net/browse/WEB-4224

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/cmdclick/search/

- `cmd + click` on a search result link, it should open in a new tab
- regular click should open page in the current tab
- no console/JS errors are introduced
- i don't have a windows keyboard but the same should work using the `ctrl` key