### PR TITLE
Adding note about Browser Extensions

### DIFF
--- a/content/en/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/en/real_user_monitoring/browser/collecting_browser_errors.md
@@ -59,7 +59,7 @@ addError(
 );
 {{< /code-block >}}
 
-**Note**: The [Error Tracking][4] feature processes errors sent with source set to `custom` or `source` and that contain a stack trace. Errors sent with any other source (such as `console`), or sent from browser extensions, are not processed by Error Tracking.
+**Note**: The [Error Tracking][4] feature processes errors that are sent with the source set to `custom` or `source`, and contain a stack trace. Errors sent with any other source (such as `console`) or sent from browser extensions are not processed by Error Tracking.
 
 {{< tabs >}}
 {{% tab "NPM" %}}

--- a/content/en/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/en/real_user_monitoring/browser/collecting_browser_errors.md
@@ -59,7 +59,7 @@ addError(
 );
 {{< /code-block >}}
 
-**Note**: The [Error Tracking][4] feature processes errors sent with source set to `custom` or `source` and that contain a stack trace. Errors sent with any other source (such as `console`) are not processed by Error Tracking.
+**Note**: The [Error Tracking][4] feature processes errors sent with source set to `custom` or `source` and that contain a stack trace. Errors sent with any other source (such as `console`), or sent from browser extensions, are not processed by Error Tracking.
 
 {{< tabs >}}
 {{% tab "NPM" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds a note clarifying that Error Tracking does not process errors from Browser Extensions

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
