### PR TITLE
Fix link to fleet automation in shortcode

### DIFF
--- a/layouts/shortcodes/remote-flare.md
+++ b/layouts/shortcodes/remote-flare.md
@@ -6,4 +6,4 @@ To send a remote flare:
 1. Enable **Debug mode** to allow Datadog support staff to troubleshoot your issue faster. The log level is reset to its previous configuration after you send the flare.
 1. Click **Send Ticket**.
 
-[fleet-automation]:  https://app.datadoghq.com/fleet
+[fleet-automation]: https://app.datadoghq.com/fleet

--- a/layouts/shortcodes/remote-flare.md
+++ b/layouts/shortcodes/remote-flare.md
@@ -1,7 +1,9 @@
 To send a remote flare:
-1. From the [Fleet Automation][1] page, select an Agent that requires support.
+1. From the [Fleet Automation][fleet-automation] page, select an Agent that requires support.
 1. Click **Support**.
 1. Click **Send Support Ticket**.
 1. Provide an existing Zendesk support ticket number. If you don't provide a ticket number, one is created on your behalf.
 1. Enable **Debug mode** to allow Datadog support staff to troubleshoot your issue faster. The log level is reset to its previous configuration after you send the flare.
 1. Click **Send Ticket**.
+
+[fleet-automation]:  https://app.datadoghq.com/fleet


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Fix a broken link. Need to test it in the main fleet automation page as well to make sure it works

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->