### PR TITLE
[WEB-4486] Disables build parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # make
 SHELL = /bin/bash
-MAKEFLAGS := --jobs=$(shell nproc)
-MAKEFLAGS += --output-sync --no-print-directory
+# MAKEFLAGS := --jobs=$(shell nproc)
+# MAKEFLAGS += --output-sync --no-print-directory
 .PHONY: help clean-all clean dependencies server start start-no-pre-build start-docker stop-docker all-examples clean-examples placeholders update_pre_build config derefs source-dd-source vector_data
 .DEFAULT_GOAL := help
 PY3=$(shell if [ `which pyenv` ]; then \

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/update_pre_build.py
+++ b/local/bin/py/build/update_pre_build.py
@@ -147,13 +147,10 @@ def main(disable_cache_on_retry=False):
     # 2. Load all configuration needed to build the doc
     # 3. Retrieve the list of content to work with and updates it based of the configuration specification
     # 4. Actually build the documentation with the udpated list of content.
-    try:
-        build = Build(temp_directory)
-        build.load_config(build_configuration_file_path, integration_merge_configuration_file_path, disable_cache_on_retry)
-        build.get_list_of_content(build.build_configuration)
-        build.build_documentation()
-    except Exception as err:
-        print(err)
+    build = Build(temp_directory)
+    build.load_config(build_configuration_file_path, integration_merge_configuration_file_path, disable_cache_on_retry)
+    build.get_list_of_content(build.build_configuration)
+    build.build_documentation()
 
 
 if __name__ == "__main__":

--- a/local/bin/py/build/update_pre_build.py
+++ b/local/bin/py/build/update_pre_build.py
@@ -147,10 +147,13 @@ def main(disable_cache_on_retry=False):
     # 2. Load all configuration needed to build the doc
     # 3. Retrieve the list of content to work with and updates it based of the configuration specification
     # 4. Actually build the documentation with the udpated list of content.
-    build = Build(temp_directory)
-    build.load_config(build_configuration_file_path, integration_merge_configuration_file_path, disable_cache_on_retry)
-    build.get_list_of_content(build.build_configuration)
-    build.build_documentation()
+    try:
+        build = Build(temp_directory)
+        build.load_config(build_configuration_file_path, integration_merge_configuration_file_path, disable_cache_on_retry)
+        build.get_list_of_content(build.build_configuration)
+        build.build_documentation()
+    except Exception as err:
+        print(err)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Disable jobs building in parallel temporarily, trying to confirm this is the root cause of some transient preview build errors seen in the Docs gitlab recently.    This also re-enables the preview cache mechanism.

https://datadoghq.atlassian.net/browse/WEB-4486

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
Running build jobs in parallel was a good performance win but may have been causing a race condition which led to random build errors.    We can revisit the parallelism (or alternative approaches to build performance) later on if we can confirm this was the cause.   As a result we may see preview build times creeping back up in the interim.

https://docs-staging.datadoghq.com/brian.deutsch/cache-debug

- make sure site looks good and dynamically built content exists (i.e. integrations, workflows, etc)

