### PR TITLE
[DOCS-7081] TLS Ciphers deprecation notice

### DIFF
--- a/content/en/data_security/guide/_index.md
+++ b/content/en/data_security/guide/_index.md
@@ -14,4 +14,5 @@ cascade:
 {{< whatsnext desc="Deprecation notices:" >}}
     {{< nextlink href="data_security/guide/tls_deprecation_1_2" >}}TLS < 1.2 deprecation notice{{< /nextlink >}}
     {{< nextlink href="data_security/guide/tls_cert_chain_of_trust" >}}Changes to Datadog's TLS certificate chain of trust{{< /nextlink >}}
+    {{< nextlink href="data_security/guide/tls_ciphers_deprecation" >}}TLS ciphers deprecation notice{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/data_security/guide/tls_ciphers_deprecation.md
+++ b/content/en/data_security/guide/tls_ciphers_deprecation.md
@@ -1,0 +1,62 @@
+# Overview
+
+**Transport Layer Security (TLS)** is a critical security protocol used to protect web traffic. It provides confidentiality and integrity of data in transit between clients and servers exchanging information. During the establishment of a TLS session, both parties agree on a cipher suite which dictates the cryptographic algorithms used to secure the communication.
+
+As part of its ongoing commitment to the security and protection of its customer's data, **Datadog** is rolling out a more modern cryptographic engine across its systems which imposes some changes to the configurations it can accept.
+
+Beginning **April 1st, 2024**, Datadog is disabling support for the following cipher suites across its public-facing applications. If you use unsupported clients to connect to Datadog after the older protocols are disabled, you will receive connection error messages.
+
+## Disabled Cipher Suites
+
+| Code       | IANA Name                                |
+|------------|------------------------------------------|
+| 0xC0,0x27   | TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256    |
+| 0xC0,0x23   | TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256  |
+| 0xC0,0x28   | TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384    |
+| 0xC0,0x24   | TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384  |
+| 0x00,0x3C   | TLS_RSA_WITH_AES_128_CBC_SHA256          |
+| 0x00,0x3D   | TLS_RSA_WITH_AES_256_CBC_SHA256          |
+
+After this date, the following cipher suites will be accepted:
+
+## Accepted Cipher Suites
+
+| Code       | IANA Name                                       |
+|------------|-------------------------------------------------|
+| 0xC0,0x2B   | TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256        |
+| 0xC0,0x2F   | TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256          |
+| 0xC0,0x2C   | TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384        |
+| 0xC0,0x30   | TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384          |
+| 0xCC,0xA9   | TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 |
+| 0xCC,0xA8   | TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256   |
+| 0xC0,0x09   | TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA          |
+| 0xC0,0x13   | TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA            |
+| 0xC0,0x0A   | TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA          |
+| 0xC0,0x14   | TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA            |
+| 0x00,0x9C   | TLS_RSA_WITH_AES_128_GCM_SHA256               |
+| 0x00,0x9D   | TLS_RSA_WITH_AES_256_GCM_SHA384               |
+| 0x00,0x2F   | TLS_RSA_WITH_AES_128_CBC_SHA                 |
+| 0x00,0x35   | TLS_RSA_WITH_AES_256_CBC_SHA                 |
+| 0x13,0x01   | TLS_AES_128_GCM_SHA256                        |
+| 0x13,0x02   | TLS_AES_256_GCM_SHA384                        |
+| 0x13,0x03   | TLS_CHACHA20_POLY1305_SHA256                  |
+
+This change does not impact Datadog for Government site for which the accepted cipher suites remain the following:
+
+## Accepted Cipher Suites (Datadog for Government)
+
+| Code       | IANA Name                                |
+|------------|------------------------------------------|
+| 0xC0,0x2F   | TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256    |
+| 0xC0,0x30   | TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384    |
+| 0xC0,0x2B   | TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256  |
+| 0xC0,0x2C   | TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384  |
+
+# Client Compatibility
+
+Datadog's systems already require the use of **TLS 1.2** and compatible clients will be able to negotiate other cipher suites. However, specific client-side configurations may alter this behavior. Use the client of your choice to connect to [tls-config-test.datadoghq.com][3] which is configured with the target ciphers, or use [How's my SSL? API][1] to check the cipher suites it supports. For any additional questions, reach out to [Datadog support][2].
+
+
+[1]: https://www.howsmyssl.com/api/
+[2]: /help
+[3]: https://tls-config-test.datadoghq.com

--- a/content/en/data_security/guide/tls_ciphers_deprecation.md
+++ b/content/en/data_security/guide/tls_ciphers_deprecation.md
@@ -2,7 +2,7 @@
 
 **Transport Layer Security (TLS)** is a critical security protocol used to protect web traffic. It provides confidentiality and integrity of data in transit between clients and servers exchanging information. During the establishment of a TLS session, both parties agree on a cipher suite which dictates the cryptographic algorithms used to secure the communication.
 
-As part of its ongoing commitment to the security and protection of its customer's data, **Datadog** is rolling out a more modern cryptographic engine across its systems which imposes some changes to the configurations it can accept.
+As part of its ongoing commitment to the security and protection of its customer's data, Datadog is rolling out a more modern cryptographic engine across its systems which imposes some changes to the configurations it can accept.
 
 Beginning **April 1st, 2024**, Datadog is disabling support for the following cipher suites across its public-facing applications. If you use unsupported clients to connect to Datadog after the older protocols are disabled, you will receive connection error messages.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds information on the deprecation of TLS Cipher Suites
[DOCS-7081](https://datadoghq.atlassian.net/browse/DOCS-7081)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7081]: https://datadoghq.atlassian.net/browse/DOCS-7081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ