### PR TITLE
replace hardcoded timestamp - [WEB-4201]

### DIFF
--- a/content/en/api/v2/metrics/request.SubmitMetrics.json
+++ b/content/en/api/v2/metrics/request.SubmitMetrics.json
@@ -5,7 +5,7 @@
       "type": 0,
       "points": [
         {
-          "timestamp": 1636629071,
+          "timestamp": "${NOW}",
           "value": 0.7
         }
       ],


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
replaces hardcoded timestamp on `Submit metrics` api curl code example
 
jira: https://datadoghq.atlassian.net/browse/WEB-4201
preview: https://docs-staging.datadoghq.com/stefon.simmons/fix-api-metric-api-ex/api/latest/metrics/?code-lang=curl

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->