### PR TITLE
Add connections_read to App Builder auth page.

### DIFF
--- a/content/en/service_management/app_builder/auth.md
+++ b/content/en/service_management/app_builder/auth.md
@@ -26,13 +26,16 @@ For more information on configuring credentials, see [Connections][2]. App Build
 
 Use [role-based access control (RBAC)][4] to control access to your apps and connections. 
 
-The coarse permissions that apply to apps include `apps_run` and `apps_write`.
+The coarse permissions that apply to apps include `apps_run`, `apps_write`, and `connections_read`.
 
 `apps_write`
 : Can create and edit new and existing apps. Datadog Standard and Admin roles have write access to App Builder by default.
 
 `apps_run`
 : Can interact with apps. Datadog Standard and Admin roles have run access to App Builder by default.
+
+`connections_read`
+: Can list and view available connections. Datadog Read Only, Standard, and Admin roles have read access to connections by default.
 
 ### Restrict access to a specific connection
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds the `connections_read` permission and its description to the App Builder authorization page. It was omitted in error. Requested by an engineer.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->