### PR TITLE
Remove outdated Fed1 disclaimer from incident_details.md

### DIFF
--- a/content/en/service_management/incident_management/incident_details.md
+++ b/content/en/service_management/incident_management/incident_details.md
@@ -10,10 +10,6 @@ further_reading:
   text: "Incident Management Analytics"
 ---
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning">Incident Management is not available on the Datadog {{< region-param key="dd_site_name" >}} site.</div>
-{{< /site-region >}}
-
 ## Overview
 
 {{< img src="/service_management/incidents/incident_details/incident_overview_page.png" alt="Incident details page of an Active SEV-4 incident." style="width:100%;">}}


### PR DESCRIPTION
Removes a disclaimer in incident_details.md explaining that Incident Management is not available in Fed1 (it is).

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->