### PR TITLE
No Longer Sourcing Static Analysis Rules This Way

### DIFF
--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -69,15 +69,6 @@
 	]
 	},
 
-	"Further reading footer - static analysis rules": {
-		"prefix": ";;further",
-		"body": [
-			"## Default rules",
-			"",
-			"{{< partial name=\"continuous_integration/rule-type.html\" >}}"
-		]
-	},
-
 	"Alert box":{
 		"prefix": ";;alert",
 		"body": [


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We are no longer using the partial to render the Static Analysis rules, we can remove this from the `markdown.json` file!

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->