### PR TITLE
Making default_zero description more accurate

### DIFF
--- a/content/en/dashboards/functions/interpolation.md
+++ b/content/en/dashboards/functions/interpolation.md
@@ -43,7 +43,7 @@ The `default_zero()` function fills empty time intervals using the value 0 or, i
 The `default_zero()` function is intended to address the following use cases (though it may also work for other use cases):
 
 - Aligning gauges as 0 when performing arithmetic on sparse metrics (note: `COUNT` or `RATE` type metrics queried `as_count()` or `as_rate()` are _always_ aligned as 0, so using `default_zero()` does not change how they are aligned; it only affects `GAUGE` type metrics).
-- Resolving monitors from a no-data condition. This works for both simple and multi alerts, but the value 0 must not cause the monitor to trigger. For example, this would not work for a monitor with the query `avg(last_10m):avg:system.cpu.idle{*} < 10` because this monitor triggers (instead of resolving) when it evaluates to 0. Avoid using this function for error rate monitors with `as_count()` queries. See the [as_count() in Monitor Evaluations guide][3] for more details.
+- Resolving monitors before they enter a no-data condition. This works for both simple and multi alerts, but the value 0 must not cause the monitor to trigger. For example, this would not work for a monitor with the query `avg(last_10m):avg:system.cpu.idle{*} < 10` because this monitor triggers (instead of resolving) when it evaluates to 0. Avoid using this function for error rate monitors with `as_count()` queries. See the [as_count() in Monitor Evaluations guide][3] for more details.
 - Filling in empty intervals in sparse (but nonempty) series for visual reasons or to affect the min/max/average of a timeseries in a monitor evaluation. If the evaluation window doesn't contain any points of data, `default_zero()` has no effect.
 - Showing the value 0 on the timeseries widget when there is no data.
 


### PR DESCRIPTION
Changing "Resolving monitors from a no-data state" to "Resolving monitors before they enter a no-data state"

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The doc previously said that a use case for default_zero is "Resolving monitors from a no-data state" but this is not accurate. Once a monitor is in No Data, default_zero will have no effect, as it only fills the time from the last datapoint until the end of the evaluation window.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [√] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->