### PR TITLE
DOCS-7137 - add Fargate link to serverless section

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -549,42 +549,42 @@ main:
     url: opentelemetry/collector_exporter/hostname_tagging/
     identifier: otel_gs_tagging
     parent: otel_gs_collector
-    weight: 101
+    weight: 201
   - name: OTLP Receiver
     url: opentelemetry/collector_exporter/otlp_receiver/
     identifier: otel_gs_otlp_receiver
     parent: otel_gs_collector
-    weight: 102
+    weight: 202
   - name: Host Metrics
     url: opentelemetry/collector_exporter/host_metrics/
     identifier: otel_gs_host_metrics
     parent: otel_gs_collector
-    weight: 103
+    weight: 203
   - name: Docker Metrics
     url: opentelemetry/collector_exporter/docker_metrics/
     identifier: otel_gs_docker_metrics
     parent: otel_gs_collector
-    weight: 104
+    weight: 204
   - name: Log Collection
     url: opentelemetry/collector_exporter/log_collection/
     identifier: otel_gs_log_collection
     parent: otel_gs_collector
-    weight: 105
+    weight: 205
   - name: Collector Health Metrics
     url: opentelemetry/collector_exporter/collector_health_metrics/
     identifier: otel_gs_coll_health
     parent: otel_gs_collector
-    weight: 106
+    weight: 206
   - name: Trace Metrics
     url: opentelemetry/collector_exporter/trace_metrics/
     identifier: otel_gs_trace_metrics
     parent: otel_gs_collector
-    weight: 107
+    weight: 207
   - name: Batch and Memory Settings
     url: opentelemetry/collector_exporter/collector_batch_memory/
     identifier: otel_gs_batch_memory
     parent: otel_gs_collector
-    weight: 108
+    weight: 208
   - name: OTLP Ingestion by the Datadog Agent
     url: opentelemetry/otlp_ingest_in_the_agent/
     identifier: otel_ingest_agent
@@ -599,22 +599,22 @@ main:
     url: opentelemetry/runtime_metrics/java
     identifier: otel_runtime_metrics_java
     parent: otel_runtime_metrics
-    weight: 301
+    weight: 401
   - name: .NET
     url: opentelemetry/runtime_metrics/dotnet
     identifier: otel_runtime_metrics_dotnet
     parent: otel_runtime_metrics
-    weight: 302
+    weight: 402
   - name: Go
     url: opentelemetry/runtime_metrics/go
     identifier: otel_runtime_metrics_go
     parent: otel_runtime_metrics
-    weight: 303
+    weight: 403
   - name: Guides
     url: opentelemetry/guide/
     identifier: otel_guides
     parent: opentelemetry_top_level
-    weight: 4
+    weight: 5
   - name: Developers
     url: developers/
     pre: dev-code
@@ -1864,46 +1864,51 @@ main:
     parent: serverless_step_functions
     identifier: serverless_step_functions_troubleshooting
     weight: 203
+  - name: AWS Fargate
+    identifier: serverless_aws_fargate
+    url: integrations/ecs_fargate
+    parent: serverless
+    weight: 3
   - name: Azure App Service
     url: serverless/azure_app_services
     parent: serverless
     identifier: serverless_app_services
-    weight: 3
+    weight: 4
   - name: Linux - Code
     identifier: serverless_azure_app_services_linux_code
     url: serverless/azure_app_services/azure_app_services_linux
     parent: serverless_app_services
-    weight: 301
+    weight: 401
   - name: Linux - Container
     identifier: serverless_azure_app_services_linux_container
     url: serverless/azure_app_services/azure_app_services_container
     parent: serverless_app_services
-    weight: 302
+    weight: 402
   - name: Windows - Code
     identifier: serverless_azure_app_services_windows_code
     url: serverless/azure_app_services/azure_app_services_windows
     parent: serverless_app_services
-    weight: 303
+    weight: 403
   - name: Azure Container Apps
     url: serverless/azure_container_apps
     parent: serverless
     identifier: serverless_container_apps
-    weight: 4
+    weight: 5
   - name: Google Cloud Run
     url: serverless/google_cloud_run
     parent: serverless
     identifier: serverless_gcr
-    weight: 5
+    weight: 6
   - name: Glossary
     url: serverless/glossary
     parent: serverless
     identifier: serverless_glossary
-    weight: 6
+    weight: 7
   - name: Guides
     url: serverless/guide/
     identifier: serverless_guides
     parent: serverless
-    weight: 7
+    weight: 8
   - name: Cloud Cost
     url: cloud_cost_management/
     identifier: cloud_cost_top_level
@@ -2337,7 +2342,8 @@ main:
     parent: tracing_troubleshooting
     weight: 1306
   - name: Correlated Logs
-    url: tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel
+    url: >-
+      tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel
     identifier: tracing_troubleshooting_correlated_logs
     parent: tracing_troubleshooting
     weight: 1307


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
PM asked that the Serverless section also link to the ECS Fargate integration, as is done in the Containers section.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->