### PR TITLE
[DOCS-6645] Add note about trace IDs

### DIFF
--- a/content/en/logs/log_configuration/processors.md
+++ b/content/en/logs/log_configuration/processors.md
@@ -755,6 +755,8 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following trace remapper
 {{% /tab %}}
 {{< /tabs >}}
 
+**Note**: Trace IDs and span IDs are not displayed in your logs or log attributes in the UI.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel.md
+++ b/content/en/tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel.md
@@ -92,6 +92,8 @@ Once the IDs are properly injected and remapped to your logs, you can see the lo
 
 {{< img src="tracing/troubleshooting/trace_id_injection.png" alt="A trace page showing the logs section with correlated logs" style="width:90%;">}}
 
+**Note**: Trace IDs and span IDs are not displayed in your logs or log attributes in the UI.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds note about trace IDs and span IDs not displayed in logs. SE request.

[DOCS-6645](https://datadoghq.atlassian.net/browse/DOCS-6645)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6645]: https://datadoghq.atlassian.net/browse/DOCS-6645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ