### PR TITLE
adding blog link to data streams doc

### DIFF
--- a/content/en/data_streams/_index.md
+++ b/content/en/data_streams/_index.md
@@ -14,6 +14,9 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/data-streams-monitoring/'
       tag: 'Blog'
       text: 'Track and improve the performance of streaming data pipelines with Datadog Data Streams Monitoring'
+    - link: 'https://www.datadoghq.com/blog/data-streams-monitoring-apm-integration/'
+      tag: 'Blog'
+      text: 'Troubleshoot streaming data pipelines directly from APM with Datadog Data Streams Monitoring'
 cascade:
     algolia:
         rank: 70


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds the new blog "Troubleshoot streaming data pipelines directly from APM with Datadog Data Streams Monitoring" to the Data streams doc.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->