### PR TITLE
Update Getting Started with OTel

### DIFF
--- a/content/en/getting_started/opentelemetry/_index.md
+++ b/content/en/getting_started/opentelemetry/_index.md
@@ -122,17 +122,14 @@ The Datadog Exporter sends data collected by the OTLP Receiver to the Datadog ba
 
    {{< code-block lang="yaml" filename="otelcol-config.yaml" collapsible="true" disable_copy="true" >}}
 exporters:
-  logging:
-    verbosity: detailed
   datadog:
     traces:
       span_name_as_resource_name: true
+      trace_buffer: 500
     hostname: "otelcol-docker"
     api:
       key: ${DD_API_KEY}
       site: datadoghq.com
-traces:
-  trace_buffer: 500
 service:
   pipelines:
     metrics:


### PR DESCRIPTION
Moved `trace_buffer` to the correct place.
And also removed `exporters.logging` as it was not being used.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->