### PR TITLE
Add banner to warn the users that suppression queries will be deprecated soon.

### DIFF
--- a/content/en/security/cloud_siem/log_detection_rules.md
+++ b/content/en/security/cloud_siem/log_detection_rules.md
@@ -83,6 +83,8 @@ Click **Add Query** to add additional queries.
 
 ## Exclude benign activity with suppression queries
 
+<div class="alert alert-warning"> <a href="https://docs.datadoghq.com/security/suppressions/"> Suppression rules</a> are replacing suppression queries in detection rules. The legacy suppression queries will be deprecated on April 1, 2024. See <a href="#migrate-legacy-suppression-queries-to-suppression-rules">Migrate legacy suppression queries to suppression rules</a> for more information. </div>
+
 In the **Only generate a signal if there is a match** field, you have the option to enter a query so that a trigger is only generated when a value is met.
 
 In the **This rule will not generate a signal if there is a match** field, you have the option to enter suppression queries so that a trigger is not generated when the values are met. For example, if a user called `john.doe` is triggering a signal, but their actions are benign and you no longer want signals triggered from this user, input a logs query that excludes `@user.username: john.doe`.

--- a/content/en/security/cloud_siem/log_detection_rules.md
+++ b/content/en/security/cloud_siem/log_detection_rules.md
@@ -83,7 +83,7 @@ Click **Add Query** to add additional queries.
 
 ## Exclude benign activity with suppression queries
 
-<div class="alert alert-warning"> <a href="https://docs.datadoghq.com/security/suppressions/"> Suppression rules</a> are replacing suppression queries in detection rules. The legacy suppression queries will be deprecated on April 1, 2024. See <a href="#migrate-legacy-suppression-queries-to-suppression-rules">Migrate legacy suppression queries to suppression rules</a> for more information. </div>
+<div class="alert alert-warning"> <a href="https://docs.datadoghq.com/security/suppressions/"> Suppression rules</a> are replacing suppression queries in detection rules. The legacy suppression queries will be deprecated on April 1, 2024. See <a href="https://docs.datadoghq.com/security/suppressions/#migrate-legacy-suppression-queries-to-suppression-rules">Migrate legacy suppression queries to suppression rules</a> for more information. </div>
 
 In the **Only generate a signal if there is a match** field, you have the option to enter a query so that a trigger is only generated when a value is met.
 


### PR DESCRIPTION
…cated soon

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? 
Add a banner to warn the users that suppression queries will be deprecated soon. 

What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
To make the users aware that suppression queries will be deprecated so they might be encouraged to either migrate their suppression queries or use global Suppressions feature. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
I copied the banner and the wording that is already available on https://docs.datadoghq.com/security/suppressions/. I am not sure if the migrating part needs to be removed. Please let me know. Thanks 

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->