### PR TITLE
set supported versions for python remote configuration settings

### DIFF
--- a/content/en/tracing/trace_collection/runtime_config/_index.md
+++ b/content/en/tracing/trace_collection/runtime_config/_index.md
@@ -44,14 +44,14 @@ You can tell when the configuration changes have been successfully applied by re
 
 ## Supported configuration options
 
-The following options are supported with configuration at runtime. The required tracer version is listed for each language: 
+The following options are supported with configuration at runtime. The required tracer version is listed for each language:
 
 | Option                                                                                                                                 | Java      | Javascript              | Python   | .NET      | Ruby      | Go        |
 |----------------------------------------------------------------------------------------------------------------------------------------|-----------|-------------------------|----------|-----------|-----------|-----------|
 | <h5>Custom sampling rate</h5>Set a global sampling rate for the library using `DD_TRACE_SAMPLE_RATE`.                                  | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.4.0+` | `2.33.0+` | `1.13.0+` | `1.59.0+` |
-| <h5>Log injection</h5>Automatically inject trace correlation identifiers to correlate logs and traces by enabling `DD_LOGS_INJECTION`. | `1.17.0+` | `4.11+` `3.32+` `2.45+` |          | `2.33.0+` | `1.13.0+` |           |
-| <h5>HTTP header tags</h5>Add HTTP header values as tags on traces using `DD_TRACE_HEADER_TAGS`.                                        | `1.17.0+` | `4.11+` `3.32+` `2.45+` |          | `2.33.0+` | `1.13.0+` | `1.59.0+` |
-| <h5>Custom span tags</h5>Add specified tags to each span using `DD_TAGS`.                                                              |           | `4.23.0+` `3.44.0+`     |          | `2.44.0+` |           | `1.59.0+` |
+| <h5>Log injection</h5>Automatically inject trace correlation identifiers to correlate logs and traces by enabling `DD_LOGS_INJECTION`. | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.6.0+` | `2.33.0+` | `1.13.0+` |           |
+| <h5>HTTP header tags</h5>Add HTTP header values as tags on traces using `DD_TRACE_HEADER_TAGS`.                                        | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.6.0+` | `2.33.0+` | `1.13.0+` | `1.59.0+` |
+| <h5>Custom span tags</h5>Add specified tags to each span using `DD_TAGS`.                                                              |           | `4.23.0+` `3.44.0+`     | `2.5.0+` | `2.44.0+` |           | `1.59.0+` |
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This change updates the table of remote configuration settings version support to reflect the state of dd-trace-py.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->