### PR TITLE
Change to improve accuracy

### DIFF
--- a/content/en/monitors/guide/custom_schedules.md
+++ b/content/en/monitors/guide/custom_schedules.md
@@ -26,7 +26,7 @@ Monitor Custom Schedules are supported on events, logs, and metrics monitors wit
 
 Click **Add Custom Schedule** to configure your evaluation frequency. 
 
-<div class="alert alert-warning">After a custom schedule has been enabled on a monitor, the monitor cannot be disabled.
+<div class="alert alert-warning">After a custom schedule has been enabled on a monitor, the schedule cannot be disabled. Custom schedules can only be added or removed during monitor creation.
 </div>
 
 {{< tabs >}}


### PR DESCRIPTION
Updating from 
"After a custom schedule has been enabled on a monitor, the monitor cannot be disabled." to,
"After a custom schedule has been enabled on a monitor, the schedule cannot be disabled. Custom schedules can only be added or removed during monitor creation."

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Improving doc accuracy

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [√] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->