### PR TITLE
Minor Update to Single Step APM Instrumentation

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -208,8 +208,10 @@ To enable single step instrumentation with Helm:
 
 4. Run the following command:
    ```bash
-   helm install datadog-agent -f datadog-values.yaml
+   helm install datadog-agent -f datadog-values.yaml datadog/datadog
    ```
+5. Do a rolling restart on your applications for instrumentation to take effect.
+     
 
 [7]: https://v3.helm.sh/docs/intro/install/
 [8]: https://kubernetes.io/docs/tasks/tools/install-kubectl/


### PR DESCRIPTION
This PR fixes the helm install command in Single Step APM Instrumentation document. (currently missing datadog/datadog)

It also adds a step 5 after that to prompt users to do a rolling restart on applications for instrumentation to take place in k8 cluster

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Fixes helm install command in the Single Step APM Instrumentation document.
- Adds additional step for rolling restart of k8s application in order for instrumentation to take place.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->