### PR TITLE
Update JDK 21 to GA

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -23,13 +23,13 @@ The Java Datadog Trace library is open source - view the [GitHub repository][1] 
 
 The Java Tracer supports automatic instrumentation for the following Oracle JDK and OpenJDK JVM runtimes.
 
-| Java versions | Operating Systems                                                               | Support level                       | Tracer version |
-| -------------| ------------------------------------------------------------------------------- | ----------------------------------- | -------------- |
-| 18 to 21     | Windows (x86, x86-64)<br>Linux (x86, x86-64, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#levels-of-support)               | Latest         |
-| 8 to 17      | Linux (arm64)<br>Mac (arm64)                                                    | [Beta](#levels-of-support)               | Latest         |
-| 7            | Linux (arm64)<br>Mac (arm64)                                                    | [End-of-life](#levels-of-support)         | v0             |
-| 8 to 17      | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [GA](#levels-of-support)                   | Latest         |
-| 7            | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [Maintenance](#levels-of-support) | v0             |
+| Java versions | Operating Systems                                                               | Support level                     | Tracer version |
+|---------------|---------------------------------------------------------------------------------|-----------------------------------|----------------|
+| 18 to 21      | Windows (x86, x86-64)<br>Linux (x86, x86-64, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#levels-of-support)        | Latest         |
+| 8 to 17       | Linux (arm64)<br>Mac (arm64)                                                    | [Beta](#levels-of-support)        | Latest         |
+| 7             | Linux (arm64)<br>Mac (arm64)                                                    | [End-of-life](#levels-of-support) | v0             |
+| 8 to 17       | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [GA](#levels-of-support)          | Latest         |
+| 7             | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [Maintenance](#levels-of-support) | v0             |
 
 Datadog does not officially support any early-access versions of Java.
 
@@ -57,31 +57,31 @@ Beta integrations are disabled by default but can be enabled individually:
 **Web Framework tracing provides:**
 
 - timing HTTP request to response
-- tags for the HTTP request (status code, method, etc)
+- tags for the HTTP request (status code, method, etc.)
 - error and stacktrace capturing
 - linking work created within a web request and Distributed Tracing
 
-| Server                  | Versions   | Support Type    | Instrumentation Names (used for configuration) |
-| ----------------------- | ---------- | --------------- | ---------------------------------------------- |
-| Akka-Http Server        | 10.0+      | Fully Supported | `akka-http`, `akka-http-server`                |
-| Finatra Web             | 2.9+       | Fully Supported | `finatra`                                      |
-| Grizzly                 | 2.0+       | Fully Supported | `grizzly`                                      |
-| Grizzly-HTTP            | 2.3.20+    | Fully Supported | `grizzly-filterchain`                          |
-| Java Servlet Compatible | 2.3+, 3.0+ | Fully Supported | `servlet`, `servlet-2`, `servlet-3`            |
-| Jax-RS Annotations      | JSR311-API | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-annotations`, `jax-rs-filter` |
-| Jetty                   | 7.0-12.x   | Fully Supported | `jetty`                                        |
-| Micronaut HTTP Server   | 2.x        | Fully Supported | `micronaut`                                    |
-| Mulesoft                | 4          | Fully Supported | `mule`                                         |
-| Netty HTTP Server       | 3.8+       | Fully Supported | `netty`, `netty-3.8`, `netty-4.0`, `netty-4.1` |
-| Play                    | 2.3-2.8    | Fully Supported | `play`, `play-action`                          |
-| Ratpack                 | 1.5+       | Fully Supported | `ratpack`                                      |
-| Restlet HTTP Server     | 2.2 - 2.4  | Fully Supported | `restlet-http`.                                |
-| Spark Java              | 2.3+       | [Beta](#framework-integrations-disabled-by-default) | `sparkjava` (requires `jetty`) |
-| Spring Boot             | 1.5        | Fully Supported | `spring-web` or `spring-webflux`               |
-| Spring Web (MVC)        | 4.0+       | Fully Supported | `spring-web`                                   |
-| Spring WebFlux          | 5.0+       | Fully Supported | `spring-webflux`                               |
-| Tomcat                  | 5.5+       | Fully Supported | `tomcat`                                       |
-| Vert.x                  | 3.4+       | Fully Supported | `vertx`, `vertx-3.4`, `vertx-3.9`, `vertx-4.0`  |
+| Server                  | Versions   | Support Type                                        | Instrumentation Names (used for configuration)           |
+|-------------------------|------------|-----------------------------------------------------|----------------------------------------------------------|
+| Akka-Http Server        | 10.0+      | Fully Supported                                     | `akka-http`, `akka-http-server`                          |
+| Finatra Web             | 2.9+       | Fully Supported                                     | `finatra`                                                |
+| Grizzly                 | 2.0+       | Fully Supported                                     | `grizzly`                                                |
+| Grizzly-HTTP            | 2.3.20+    | Fully Supported                                     | `grizzly-filterchain`                                    |
+| Java Servlet Compatible | 2.3+, 3.0+ | Fully Supported                                     | `servlet`, `servlet-2`, `servlet-3`                      |
+| Jax-RS Annotations      | JSR311-API | Fully Supported                                     | `jax-rs`, `jaxrs`, `jax-rs-annotations`, `jax-rs-filter` |
+| Jetty                   | 7.0-12.x   | Fully Supported                                     | `jetty`                                                  |
+| Micronaut HTTP Server   | 2.x        | Fully Supported                                     | `micronaut`                                              |
+| Mulesoft                | 4          | Fully Supported                                     | `mule`                                                   |
+| Netty HTTP Server       | 3.8+       | Fully Supported                                     | `netty`, `netty-3.8`, `netty-4.0`, `netty-4.1`           |
+| Play                    | 2.3-2.8    | Fully Supported                                     | `play`, `play-action`                                    |
+| Ratpack                 | 1.5+       | Fully Supported                                     | `ratpack`                                                |
+| Restlet HTTP Server     | 2.2 - 2.4  | Fully Supported                                     | `restlet-http`.                                          |
+| Spark Java              | 2.3+       | [Beta](#framework-integrations-disabled-by-default) | `sparkjava` (requires `jetty`)                           |
+| Spring Boot             | 1.5        | Fully Supported                                     | `spring-web` or `spring-webflux`                         |
+| Spring Web (MVC)        | 4.0+       | Fully Supported                                     | `spring-web`                                             |
+| Spring WebFlux          | 5.0+       | Fully Supported                                     | `spring-webflux`                                         |
+| Tomcat                  | 5.5+       | Fully Supported                                     | `tomcat`                                                 |
+| Vert.x                  | 3.4+       | Fully Supported                                     | `vertx`, `vertx-3.4`, `vertx-3.9`, `vertx-4.0`           |
 
 **Note**: Many application servers are Servlet compatible and are automatically covered by that instrumentation, such as Websphere, Weblogic, and JBoss.
 Also, frameworks like Spring Boot (version 3) inherently work because they usually use a supported embedded application server, such as Tomcat, Jetty, or Netty.
@@ -90,14 +90,14 @@ Also, frameworks like Spring Boot (version 3) inherently work because they usual
 
 The following instrumentations are disabled by default and can be enabled with the following settings:
 
-| Instrumentation         | To Enable 									  |
-| ----------------------- |---------------------------------------------- |
-| JAX-WS		              | `-Ddd.integration.jax-ws.enabled=true`|
-| Mulesoft		            | `-Ddd.integration.mule.enabled=true`, `-Ddd.integration.grizzly-client.enabled=true`, `-Ddd.integration.grizzly-filterchain.enabled=true`|
-| Grizzly                 | `-Ddd.integration.grizzly-client.enabled=true`|
-| Grizzly-HTTP            | `-Ddd.integration.grizzly-filterchain.enabled=true`|
-| Ning                    | `-Ddd.integration.ning.enabled=true`|
-| Spark Java              | `-Ddd.integration.sparkjava.enabled=true`|
+| Instrumentation | To Enable 									                                                                                                                       |
+|-----------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| JAX-WS		        | `-Ddd.integration.jax-ws.enabled=true`                                                                                                    |
+| Mulesoft		      | `-Ddd.integration.mule.enabled=true`, `-Ddd.integration.grizzly-client.enabled=true`, `-Ddd.integration.grizzly-filterchain.enabled=true` |
+| Grizzly         | `-Ddd.integration.grizzly-client.enabled=true`                                                                                            |
+| Grizzly-HTTP    | `-Ddd.integration.grizzly-filterchain.enabled=true`                                                                                       |
+| Ning            | `-Ddd.integration.ning.enabled=true`                                                                                                      |
+| Spark Java      | `-Ddd.integration.sparkjava.enabled=true`                                                                                                 |
 
 **Note**: JAX-WS integration instruments endpoints annotated with @WebService (JAX-WS 1.x) and @WebServiceProvider (JAX-WS 2.x).
 
@@ -114,31 +114,31 @@ Don't see your desired web frameworks? Datadog is continually adding additional 
 - error and stacktrace capturing
 - distributed tracing
 
-| Framework                | Versions    | Support Type    | Instrumentation Names (used for configuration) |
-| ------------------------ | ----------- | --------------- | ---------------------------------------------- |
-| Apache HTTP Client       | 4.0+        | Fully Supported | `httpclient`, `apache-httpclient`, `apache-http-client` |
-| Apache HTTP Async Client | 4.0+        | Fully Supported | `httpasyncclient`, `apache-httpasyncclient`    |
-| AWS Java SDK             | 1.11+, 2.2+ | Fully Supported | `aws-sdk`                                      |
-| Camel-OpenTelemetry      | 3.12.0+     | Beta            | [opentelemetry-1][5]                           |
-| Commons HTTP Client      | 2.0+        | Fully Supported | `commons-http-client`                          |
-| Google HTTP Client       | 1.19.0+     | Fully Supported | `google-http-client`                           |
-| Google Pub/Sub           | 1.116.0+    | Fully Supported | `google-pubsub`                                |
-| Grizzly HTTP Client      | 1.9+        | [Beta](#framework-integrations-disabled-by-default) | `grizzly-client`     |
-| gRPC                     | 1.5+        | Fully Supported | `grpc`, `grpc-client`, `grpc-server`           |
-| HttpURLConnection        | all         | Fully Supported | `httpurlconnection`, `urlconnection`           |
-| Kafka-Clients            | 0.11+       | Fully Supported | `kafka`                                        |
-| Kafka-Streams            | 0.11+       | Fully Supported | `kafka`, `kafka-streams`                       |
-| Java RMI                 | all         | Distributed Tracing Not Supported | `rmi`, `rmi-client`, `rmi-server`              |
-| Jax RS Clients           | 2.0+        | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-client`             |
-| Jersey Client            | 1.9-2.29    | Fully Supported | `jax-rs`, `jaxrs`, `jax-rs-client`             |
-| JMS                      | 1 and 2     | Fully Supported | `jms`, `jms-1`, `jms-2`                        |
-| Netty HTTP Client        | 4.0+        | Fully Supported | `netty`, `netty-4.0`, `netty-4.1`              |
-| Ning HTTP Client         | 1.9.0+      | [Beta](#framework-integrations-disabled-by-default) | `ning`               |
-| OkHTTP                   | 2.2+        | Fully Supported | `okhttp`, `okhttp-2`,`okhttp-3`                |
-| Play WSClient            | 1.0+        | Fully Supported | `play-ws`                                      |
-| Rabbit AMQP              | 2.7+        | Fully Supported | `amqp`, `rabbitmq`                             |
-| Spring SessionAwareMessageListener     | 3.1+            | Fully Supported | `spring-jms-3.1`             |
-| Spring WebClient         | 5.0+        | Fully Supported | `spring-webflux`, `spring-webflux-client`      |
+| Framework                          | Versions    | Support Type                                        | Instrumentation Names (used for configuration)          |
+|------------------------------------|-------------|-----------------------------------------------------|---------------------------------------------------------|
+| Apache HTTP Client                 | 4.0+        | Fully Supported                                     | `httpclient`, `apache-httpclient`, `apache-http-client` |
+| Apache HTTP Async Client           | 4.0+        | Fully Supported                                     | `httpasyncclient`, `apache-httpasyncclient`             |
+| AWS Java SDK                       | 1.11+, 2.2+ | Fully Supported                                     | `aws-sdk`                                               |
+| Camel-OpenTelemetry                | 3.12.0+     | Beta                                                | [opentelemetry-1][5]                                    |
+| Commons HTTP Client                | 2.0+        | Fully Supported                                     | `commons-http-client`                                   |
+| Google HTTP Client                 | 1.19.0+     | Fully Supported                                     | `google-http-client`                                    |
+| Google Pub/Sub                     | 1.116.0+    | Fully Supported                                     | `google-pubsub`                                         |
+| Grizzly HTTP Client                | 1.9+        | [Beta](#framework-integrations-disabled-by-default) | `grizzly-client`                                        |
+| gRPC                               | 1.5+        | Fully Supported                                     | `grpc`, `grpc-client`, `grpc-server`                    |
+| HttpURLConnection                  | all         | Fully Supported                                     | `httpurlconnection`, `urlconnection`                    |
+| Kafka-Clients                      | 0.11+       | Fully Supported                                     | `kafka`                                                 |
+| Kafka-Streams                      | 0.11+       | Fully Supported                                     | `kafka`, `kafka-streams`                                |
+| Java RMI                           | all         | Distributed Tracing Not Supported                   | `rmi`, `rmi-client`, `rmi-server`                       |
+| Jax RS Clients                     | 2.0+        | Fully Supported                                     | `jax-rs`, `jaxrs`, `jax-rs-client`                      |
+| Jersey Client                      | 1.9-2.29    | Fully Supported                                     | `jax-rs`, `jaxrs`, `jax-rs-client`                      |
+| JMS                                | 1 and 2     | Fully Supported                                     | `jms`, `jms-1`, `jms-2`                                 |
+| Netty HTTP Client                  | 4.0+        | Fully Supported                                     | `netty`, `netty-4.0`, `netty-4.1`                       |
+| Ning HTTP Client                   | 1.9.0+      | [Beta](#framework-integrations-disabled-by-default) | `ning`                                                  |
+| OkHTTP                             | 2.2+        | Fully Supported                                     | `okhttp`, `okhttp-2`,`okhttp-3`                         |
+| Play WSClient                      | 1.0+        | Fully Supported                                     | `play-ws`                                               |
+| Rabbit AMQP                        | 2.7+        | Fully Supported                                     | `amqp`, `rabbitmq`                                      |
+| Spring SessionAwareMessageListener | 3.1+        | Fully Supported                                     | `spring-jms-3.1`                                        |
+| Spring WebClient                   | 5.0+        | Fully Supported                                     | `spring-webflux`, `spring-webflux-client`               |
 
 **Kafka Note**: Datadog's Kafka integration works with Kafka version `0.11+`, which supports the Header API. This API is used to inject and extract trace context. If you are running a mixed version environment, the Kafka broker can incorrectly report the newer version of Kafka. This causes an issue when the tracer tries to inject headers that are not supported by the local producer. Additionally, older consumers are unable to consume the message because of the presence of headers. To prevent these issues, if you are running a mixed version Kafka environment with versions older than 0.11, disable context propagation with the environment variable: `DD_KAFKA_CLIENT_PROPAGATION_ENABLED=false`.
 
@@ -158,25 +158,25 @@ Don't see your desired networking framework? Datadog is continually adding addit
 - query info (for example, a sanitized query string)
 - error and stacktrace capturing
 
-| Database                | Versions | Support Type    | Instrumentation Names (used for configuration)                                           |
-| ----------------------- | -------- | --------------- | ---------------------------------------------------------------------------------------- |
-| Aerospike               | 4.0+     | Fully Supported | `aerospike`                                                                              |
-| Couchbase               | 2.0+     | Fully Supported | `couchbase`                                                                              |
-| Cassandra               | 3.0+     | Fully Supported | `cassandra`                                                                              |
-| Elasticsearch Transport | 2.0+     | Fully Supported | `elasticsearch`, `elasticsearch-transport`, `elasticsearch-transport-{2,5,6,7}` (pick one)|
-| Elasticsearch Rest      | 5.0+     | Fully Supported | `elasticsearch`, `elasticsearch-rest`, `elasticsearch-rest-{5,6,7}` (pick one)           |
-| JDBC                    | N/A      | Fully Supported | `jdbc`, `jdbc-datasource`                                                                |
-| Jedis                   | 1.4+     | Fully Supported | `jedis`, `redis`                                                                         |
-| Lettuce                 | 4.0+     | Fully Supported | `lettuce`, `lettuce-4-async`, `lettuce-5-rx`                                             |
-| MongoDB                 | 3.0-4.0+ | Fully Supported | `mongo`                                                                                  |
-| OpenSearch Rest         | 1.x-2.x  | Fully Supported | `opensearch`, `opensearch-rest`           |
-| OpenSearch Transport    | 1.0+     | Fully Supported | `opensearch`, `opensearch-transport`                                                     |
-| RediScala | 1.5+     | Fully Supported | `rediscala`, `redis`                                                                     |
-| Redisson | 2.x-3.x      | Fully Supported | `redisson`, `redis`                                                                     |
-| SpyMemcached            | 2.12+    | Fully Supported | `spymemcached`                                                                           |
-| Vert.x Cassandra Client | 3.9+		 | Fully Supported | `cassandra`																			  |
-| Vert.x Redis Client     | 3.9      | Fully Supported | `vertx-redis-client`                                                                     |
-| Vert.x MySQL Client     | 3.9+      | Fully Supported | `vertx-sql-client`																		  |
+| Database                | Versions | Support Type    | Instrumentation Names (used for configuration)                                             |
+|-------------------------|----------|-----------------|--------------------------------------------------------------------------------------------|
+| Aerospike               | 4.0+     | Fully Supported | `aerospike`                                                                                |
+| Couchbase               | 2.0+     | Fully Supported | `couchbase`                                                                                |
+| Cassandra               | 3.0+     | Fully Supported | `cassandra`                                                                                |
+| Elasticsearch Transport | 2.0+     | Fully Supported | `elasticsearch`, `elasticsearch-transport`, `elasticsearch-transport-{2,5,6,7}` (pick one) |
+| Elasticsearch Rest      | 5.0+     | Fully Supported | `elasticsearch`, `elasticsearch-rest`, `elasticsearch-rest-{5,6,7}` (pick one)             |
+| JDBC                    | N/A      | Fully Supported | `jdbc`, `jdbc-datasource`                                                                  |
+| Jedis                   | 1.4+     | Fully Supported | `jedis`, `redis`                                                                           |
+| Lettuce                 | 4.0+     | Fully Supported | `lettuce`, `lettuce-4-async`, `lettuce-5-rx`                                               |
+| MongoDB                 | 3.0-4.0+ | Fully Supported | `mongo`                                                                                    |
+| OpenSearch Rest         | 1.x-2.x  | Fully Supported | `opensearch`, `opensearch-rest`                                                            |
+| OpenSearch Transport    | 1.0+     | Fully Supported | `opensearch`, `opensearch-transport`                                                       |
+| RediScala               | 1.5+     | Fully Supported | `rediscala`, `redis`                                                                       |
+| Redisson                | 2.x-3.x  | Fully Supported | `redisson`, `redis`                                                                        |
+| SpyMemcached            | 2.12+    | Fully Supported | `spymemcached`                                                                             |
+| Vert.x Cassandra Client | 3.9+		   | Fully Supported | `cassandra`																			                                                             |
+| Vert.x Redis Client     | 3.9      | Fully Supported | `vertx-redis-client`                                                                       |
+| Vert.x MySQL Client     | 3.9+     | Fully Supported | `vertx-sql-client`																		                                                       |
 
 `dd-java-agent` is also compatible with common JDBC drivers including:
 
@@ -196,9 +196,9 @@ Don't see your desired networking framework? Datadog is continually adding addit
 
 The following instrumentations are disabled by default and can be enabled with the following settings:
 
-| Instrumentation         | To Enable 									  |
-| ----------------------- |---------------------------------------------- |
-| JDBC-Datasource		  | `-Ddd.integration.jdbc-datasource.enabled=true` |
+| Instrumentation   | To Enable 									                             |
+|-------------------|-------------------------------------------------|
+| JDBC-Datasource		 | `-Ddd.integration.jdbc-datasource.enabled=true` |
 
 Don't see your desired datastores? Datadog is continually adding additional support. Contact [Datadog support][2] if you need help.
 
@@ -206,21 +206,21 @@ Don't see your desired datastores? Datadog is continually adding additional supp
 
 `dd-java-agent` includes support for automatically tracing the following frameworks.
 
-| Framework         | Versions | Support Type    | Instrumentation Names (used for configuration) |
-| ----------------- | -------- | --------------- | ---------------------------------------------- |
-| Datanucleus JDO   | 4.0+     | Fully Supported | `datanucleus`                                  |
-| Dropwizard Views  | 0.7+     | Fully Supported | `dropwizard`, `dropwizard-view`                |
-| GraphQL         | 14.0+     | Fully Supported | `graphql-java`                  |
-| Hibernate         | 3.5+     | Fully Supported | `hibernate`, `hibernate-core`                  |
-| Hystrix           | 1.4+     | Fully Supported | `hystrix`                                      |
-| JSP Rendering     | 2.3+     | Fully Supported | `jsp`, `jsp-render`, `jsp-compile`             |
-| JUnit             | 4.1+, 5.3+ | Fully Supported | `junit`, `junit-4`, `junit-5`                 |       
-| Project Reactor   | 3.1+     | Fully Supported | `reactor-core`                                 |
-| Quartz            | 2.x      | Fully Supported | `quartz`                                       |
-| RxJava            | 2.x      | Fully Supported | `rxjava`                                       |
-| Spring Data       | 1.8+     | Fully Supported | `spring-data`                                  |
-| Spring Scheduling | 3.1+     | Fully Supported | `spring-scheduling`                            |
-| Twilio SDK        | < 8.0    | Fully Supported | `twilio-sdk`                                   |
+| Framework         | Versions   | Support Type    | Instrumentation Names (used for configuration) |
+|-------------------|------------|-----------------|------------------------------------------------|
+| Datanucleus JDO   | 4.0+       | Fully Supported | `datanucleus`                                  |
+| Dropwizard Views  | 0.7+       | Fully Supported | `dropwizard`, `dropwizard-view`                |
+| GraphQL           | 14.0+      | Fully Supported | `graphql-java`                                 |
+| Hibernate         | 3.5+       | Fully Supported | `hibernate`, `hibernate-core`                  |
+| Hystrix           | 1.4+       | Fully Supported | `hystrix`                                      |
+| JSP Rendering     | 2.3+       | Fully Supported | `jsp`, `jsp-render`, `jsp-compile`             |
+| JUnit             | 4.1+, 5.3+ | Fully Supported | `junit`, `junit-4`, `junit-5`                  |
+| Project Reactor   | 3.1+       | Fully Supported | `reactor-core`                                 |
+| Quartz            | 2.x        | Fully Supported | `quartz`                                       |
+| RxJava            | 2.x        | Fully Supported | `rxjava`                                       |
+| Spring Data       | 1.8+       | Fully Supported | `spring-data`                                  |
+| Spring Scheduling | 3.1+       | Fully Supported | `spring-scheduling`                            |
+| Twilio SDK        | < 8.0      | Fully Supported | `twilio-sdk`                                   |
 
 Don't see your desired frameworks? Datadog is continually adding additional support. To request a framework, contact our awesome [support team][2].
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -23,13 +23,14 @@ The Java Datadog Trace library is open source - view the [GitHub repository][1] 
 
 The Java Tracer supports automatic instrumentation for the following Oracle JDK and OpenJDK JVM runtimes.
 
-| Java versions | Operating Systems                                                               | Support level                     | Tracer version |
-|---------------|---------------------------------------------------------------------------------|-----------------------------------|----------------|
-| 18 to 21      | Windows (x86, x86-64)<br>Linux (x86, x86-64, arm64)<br>Mac (x86, x86-64, arm64) | [Beta](#levels-of-support)        | Latest         |
-| 8 to 17       | Linux (arm64)<br>Mac (arm64)                                                    | [Beta](#levels-of-support)        | Latest         |
-| 7             | Linux (arm64)<br>Mac (arm64)                                                    | [End-of-life](#levels-of-support) | v0             |
-| 8 to 17       | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [GA](#levels-of-support)          | Latest         |
-| 7             | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)               | [Maintenance](#levels-of-support) | v0             |
+| Java versions | Operating Systems                                                                                               | Support level                     | Tracer version |
+|---------------|-----------------------------------------------------------------------------------------------------------------|-----------------------------------|----------------|
+| 22+           | Windows (x86, x86-64)<br>Linux (x86, x86-64, arm64)<br>Mac (x86, x86-64, arm64)<br>Linux (arm64)<br>Mac (arm64) | [Beta](#levels-of-support)        | Latest         |
+| 18 to 21      | Windows (x86, x86-64)<br>Linux (x86, x86-64, arm64)<br>Mac (x86, x86-64, arm64)<br>Linux (arm64)<br>Mac (arm64) | [GA](#levels-of-support)          | Latest         |
+| 8 to 17       | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)                                               | [GA](#levels-of-support)          | Latest         |
+| 8 to 17       | Linux (arm64)<br>Mac (arm64)                                                                                    | [Beta](#levels-of-support)        | Latest         |
+| 7             | Windows (x86, x86-64)<br>Linux (x86, x86-64)<br>Mac (x86, x86-64)                                               | [Maintenance](#levels-of-support) | v0             |
+| 7             | Linux (arm64)<br>Mac (arm64)                                                                                    | [End-of-life](#levels-of-support) | v0             |
 
 Datadog does not officially support any early-access versions of Java.
 
@@ -246,7 +247,8 @@ Integrations can be enabled or disabled individually (overriding the default abo
 
 ### Known issues
 
-Running the Java tracer in Bitbucket is not supported.
+- Running the Java tracer in Bitbucket is not supported.
+- JDK 21 virtual threads are in [Beta](#levels-of-support).
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates support table to set JDK 21 to GA following testing in https://github.com/DataDog/dd-trace-java/pull/6483 and https://github.com/DataDog/dd-trace-java/pull/6542

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
The first commit reformats tables without changing any information
The second commit includes JDK 21 support

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->