### PR TITLE
Update dotnet.md

### DIFF
--- a/content/en/serverless/aws_lambda/installation/dotnet.md
+++ b/content/en/serverless/aws_lambda/installation/dotnet.md
@@ -278,7 +278,6 @@ Fill in variables accordingly:
 
 4. Replace `<API_KEY>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, use `DD_API_KEY` instead of `DD_API_KEY_SECRET_ARN` and set the value to your Datadog API key in plaintext.
 
-5. Replace `<LAMBDA_HANDLER>` with your original handler. For example, `myfunc.handler`.
 
 #### Full example
 
@@ -294,7 +293,6 @@ resource "aws_lambda_function" "lambda" {
     "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:45"
   ]
 
-  handler = "/opt/nodejs/node_modules/datadog-lambda-js/handler.handler"
 
   environment {
     variables = {


### PR DESCRIPTION
Removed the nodejs instructions with the handler from the .NET page

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
In the Terraform instruction for .NET we can see two lines mentioning setting node js handlers and <LAMBDA_HANDLER> env var. This seems like the instructions for [NodeJS](url) 
<img width="1499" alt="image" src="https://github.com/DataDog/documentation/assets/79512613/317f9cd8-04df-4751-aa63-4e037974c16a">

This PR would remove these two lines from the .NET instructions
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->