### PR TITLE
Remove beta callout from Error Tracking Logs docs

### DIFF
--- a/content/en/logs/error_tracking/_index.md
+++ b/content/en/logs/error_tracking/_index.md
@@ -18,12 +18,6 @@ further_reading:
     text: 'Create an Error Tracking monitor'
 ---
 
-{{< callout btn_hidden="true" >}}
-  Error Tracking for Logs is in beta.
-
-  Billing begins in March 2024. The pricing plan starts at $0.25 per 1k error events, per month.
-{{< /callout >}} 
-
 ## Overview
 
 It is critical for your system's health to consistently monitor the errors collected by Datadog. When there are many individual error events, it becomes hard to prioritize errors for troubleshooting. By tracking, triaging, and debugging logs, you can minimize the impact of fatal errors on your browser, mobile, and backend services.


### PR DESCRIPTION
Remove beta callout from docs

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->