### PR TITLE
Update python.md with trace_id workaround while backend works on fix

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/python.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/python.md
@@ -89,7 +89,7 @@ If you are not using the standard library `logging` module, you can use the foll
 from ddtrace import tracer
 
 span = tracer.current_span()
-correlation_ids = (span.trace_id, span.span_id) if span else (None, None)
+correlation_ids = (str((1 << 64) - 1 & trace_id), span.span_id) if span else (None, None)
 ```
 As an illustration of this approach, the following example defines a function as a *processor* in `structlog` to add tracer fields to the log output:
 
@@ -102,7 +102,7 @@ import structlog
 def tracer_injection(logger, log_method, event_dict):
     # get correlation ids from current tracer context
     span = tracer.current_span()
-    trace_id, span_id = (span.trace_id, span.span_id) if span else (None, None)
+    trace_id, span_id = (str((1 << 64) - 1 & trace_id), span.span_id) if span else (None, None)
 
     # add ids to structlog event dictionary
     event_dict['dd.trace_id'] = str(trace_id or 0)


### PR DESCRIPTION
128-bit log correlation doesn't work yet, with that being the case we need customers to inject the 64-bit trace_id instead, until the backend work is complete.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->