### PR TITLE
discourage multiple APM agents

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -249,6 +249,7 @@ Integrations can be enabled or disabled individually (overriding the default abo
 
 - Running the Java tracer in Bitbucket is not supported.
 - JDK 21 virtual threads are in [Beta](#levels-of-support).
+- Loading multiple Java agents that perform APM/tracing functions is not a recommended or supported configuration.
 
 ## Further Reading
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -249,7 +249,7 @@ Integrations can be enabled or disabled individually (overriding the default abo
 
 - Running the Java tracer in Bitbucket is not supported.
 - JDK 21 virtual threads are in [Beta](#levels-of-support).
-- Loading multiple Java agents that perform APM/tracing functions is not a recommended or supported configuration.
+- Loading multiple Java Agents that perform APM/tracing functions is not a recommended or supported configuration.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Discourages users from loading multiple simultaneous APM Java agents.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing