### PR TITLE
Postman: Mention that Save needs to be clicked ...

### DIFF
--- a/content/en/getting_started/api/_index.md
+++ b/content/en/getting_started/api/_index.md
@@ -67,6 +67,8 @@ Follow these steps to set up your environment:
 
 3. Edit the **Datadog Authentication** environment to add in your Datadog [API key][2] as the initial value and current value for the `api_key` variable, and add your Datadog [application key][2] as the initial value and current value for the `application_key` variable.
 
+4. Click **Save**.
+
 #### Switch the API endpoint
  
 If you are accessing a Datadog site other than `https://api.datadoghq.com`, you need to switch the Postman collection to access a different endpoint URL.


### PR DESCRIPTION
... when updating the API and app keys in the Datadog Authentication environment.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Tiny addition: Adds a step to the authentication setup for Postman on the API getting started page to clarify that the "Save" button needs to be clicked after adding API/app keys.

It might have taken us a little bit of time to notice that button and click on it while we were testing the API collection. On the upside, @jryszko412 and I have a better understanding of how Postman and the Datadog collection works. :)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->