### PR TITLE
Add Operator and Helm instructions to Kubernetes Tag Extraction page

### DIFF
--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -106,11 +106,75 @@ com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
 
 ## Node labels as tags
 
-Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics emitted by all pods on this node:
+Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics emitted associated with this `host` in Datadog:
 
 {{< tabs >}}
-{{% tab "Containerized Agent" %}}
+{{% tab "Operator" %}}
+To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
 
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    nodeLabelsAsTags:
+      <NODE_LABEL>: <TAG_KEY>
+```
+
+For example, you could set up:
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    nodeLabelsAsTags:
+      kubernetes.io/arch: arch
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    nodeLabelsAsTags:
+      "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+
+```yaml
+datadog:
+  nodeLabelsAsTags:
+    <NODE_LABEL>: <TAG_KEY>
+```
+
+For example, you could set up:
+```yaml
+datadog:
+  nodeLabelsAsTags:
+    kubernetes.io/arch: arch
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+
+```yaml
+datadog:
+  nodeLabelsAsTags:
+    "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Containerized Agent" %}}
 To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -120,7 +184,7 @@ DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"<NODE_LABEL>": "<TAG_KEY>"}'
 For example, you could set up:
 
 ```bash
-DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"app":"kube_app"}'
+DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"kubernetes.io/arch":"arch"}'
 ```
 
 For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
@@ -128,38 +192,82 @@ For Agent v7.24.0+, use the following environment variable configuration to add 
 ```bash
 DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 ```
-
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][1] for more information.
-
-[1]: /account_management/billing/custom_metrics
-{{% /tab %}}
-{{% tab "Agent" %}}
-
-To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
-
-```yaml
-kubernetes_node_labels_as_tags:
-  <NODE_LABEL>: <TAG_KEY>
-```
-
-For example, you could set up:
-
-```yaml
-kubernetes_node_labels_as_tags:
-  app: kube_app
-```
-
-[1]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][4] for more information.
 
 ## Pod labels as tags
 
 Starting with Agent v6.0+, the Agent can collect labels for a given pod and use them as tags to attach to all metrics emitted by this pod:
 
 {{< tabs >}}
-{{% tab "Containerized Agent" %}}
+{{% tab "Operator" %}}
+To extract a given pod label `<POD_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
 
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    podLabelsAsTags:
+      <POD_LABEL>: <TAG_KEY>
+```
+
+For example, you could set up:
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    podLabelsAsTags:
+      app: kube_app
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    podLabelsAsTags:
+      "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+To extract a given pod label `<POD_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+
+```yaml
+datadog:
+  podLabelsAsTags:
+    <POD_LABEL>: <TAG_KEY>
+```
+
+For example, you could set up:
+```yaml
+datadog:
+  podLabelsAsTags:
+    app: kube_app
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+
+```yaml
+datadog:
+  podLabelsAsTags:
+    "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Containerized Agent" %}}
 To extract a given pod label `<POD_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -177,47 +285,82 @@ For Agent v6.8.0+, use the following environment variable configuration to add a
 ```bash
 DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 ```
-
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][1] for more information.
-
-[1]: /account_management/billing/custom_metrics
-{{% /tab %}}
-{{% tab "Agent" %}}
-
-To extract a given pod label `<POD_LABEL>` and transform it as a Tag Key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
-
-```yaml
-kubernetes_pod_labels_as_tags:
-  <POD_LABEL>: <TAG_KEY>
-```
-
-For example, you could set up:
-
-```yaml
-kubernetes_pod_labels_as_tags:
-  app: kube_app
-```
-
-For Agent v6.8.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tag names are prefixed by `<PREFIX>_`:
-
-```yaml
-kubernetes_pod_labels_as_tags:
-  *: <PREFIX>_%%label%%
-```
-
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
-
-[1]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][4] for more information.
 
 ## Pod annotations as tags
 
 Starting with Agent v6.0+, the Agent can collect annotations for a given pod and use them as tags to attach to all metrics emitted by this pod:
 
 {{< tabs >}}
-{{% tab "Containerized Agent" %}}
+{{% tab "Operator" %}}
+To extract a given pod annotation `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
 
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    podAnnotationsAsTags:
+      <POD_ANNOTATION>: <TAG_KEY>
+```
+
+For example, you could set up:
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    podAnnotationsAsTags:
+      app: kube_app
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all pod annotations as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    podAnnotationsAsTags:
+      "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+To extract a given pod annotation `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+
+```yaml
+datadog:
+  podAnnotationsAsTags:
+    <POD_LABEL>: <TAG_KEY>
+```
+
+For example, you could set up:
+```yaml
+datadog:
+  podAnnotationsAsTags:
+    app: kube_app
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all pod annotation as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+
+```yaml
+datadog:
+  podAnnotationsAsTags:
+    "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Containerized Agent" %}}
 To extract a given pod label `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -235,38 +378,82 @@ For Agent v7.24.0+, use the following environment variable configuration to add 
 ```bash
 DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS='{"*":"<PREFIX>_%%annotation%%"}'
 ```
-
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][1] for more information.
-
-[1]: /account_management/billing/custom_metrics
-{{% /tab %}}
-{{% tab "Agent" %}}
-
-To extract a given pod annotation `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
-
-```yaml
-kubernetes_pod_annotations_as_tags:
-  <POD_ANNOTATION>: <TAG_KEY>
-```
-
-For example, you could set up:
-
-```yaml
-kubernetes_pod_annotations_as_tags:
-  app: kube_app
-```
-
-[1]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][4] for more information.
 
 ## Namespace labels as tags
 
 Starting with Agent v7.27+, the Agent can collect labels for a given namespace and use them as tags to attach to all metrics emitted by all pods in this namespace:
 
 {{< tabs >}}
-{{% tab "Containerized Agent" %}}
+{{% tab "Operator" %}}
+To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
 
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    namespaceLabelsAsTags:
+      <NAMESPACE_LABEL>: <TAG_KEY>
+```
+
+For example, you could set up:
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    namespaceLabelsAsTags:
+      app: kube_app
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all namespace labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    namespaceLabelsAsTags:
+      "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+
+```yaml
+datadog:
+  namespaceLabelsAsTags:
+    <NAMESPACE_LABEL>: <TAG_KEY>
+```
+
+For example, you could set up:
+```yaml
+datadog:
+  namespaceLabelsAsTags:
+    app: kube_app
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all namespace labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+
+```yaml
+datadog:
+  namespaceLabelsAsTags:
+    "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Containerized Agent" %}}
 To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -284,38 +471,70 @@ Use the following environment variable configuration to add all namespace labels
 ```bash
 DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 ```
-
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][1] for more information.
-
-[1]: /account_management/billing/custom_metrics
-{{% /tab %}}
-{{% tab "Agent" %}}
-
-To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
-
-```yaml
-kubernetes_namespace_labels_as_tags:
-  <NAMESPACE_LABEL>: <TAG_KEY>
-```
-
-For example, you could set up:
-
-```yaml
-kubernetes_namespace_labels_as_tags:
-  app: kube_app
-```
-
-[1]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][4] for more information.
 
 ## Container environment variables as tags
 
 Starting with Agent v7.32+, the Agent can collect container environment variables and use them as tags to attach to all metrics corresponding to the container. Both `docker` and `containerd` containers are supported:
 
 {{< tabs >}}
-{{% tab "Containerized Agent" %}}
+{{% tab "Operator" %}}
+To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
 
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  #(...)
+  override:
+    nodeAgent:
+      env: 
+        - name: DD_CONTAINER_ENV_AS_TAGS
+          value: '{"<ENV_VAR>": "<TAG_KEY>"}'
+```
+
+For example, you could set up:
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  #(...)
+  override:
+    nodeAgent:
+      env: 
+        - name: DD_CONTAINER_ENV_AS_TAGS
+          value: '{"app":"kube_app"}'
+```
+
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+
+```yaml
+datadog:
+  env:
+    - name: DD_CONTAINER_ENV_AS_TAGS
+      value: '{"<ENV_VAR>": "<TAG_KEY>"}'
+```
+
+For example, you could set up:
+```yaml
+datadog:
+  env:
+    - name: DD_CONTAINER_ENV_AS_TAGS
+      value: '{"app":"kube_app"}'
+```
+{{% /tab %}}
+
+{{% tab "Containerized Agent" %}}
 To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -328,29 +547,10 @@ For example:
 DD_CONTAINER_ENV_AS_TAGS='{"app":"kube_app"}'
 ```
 
-**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][1] for more details.
-
-[1]: /account_management/billing/custom_metrics
-{{% /tab %}}
-{{% tab "Agent" %}}
-
-To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
-
-```yaml
-container_env_as_tags:
-  <ENV_VAR>: <TAG_KEY>
-```
-
-For example:
-
-```yaml
-container_env_as_tags:
-  app: kube_app
-```
-
-[1]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][4] for more details.
 
 ## Container labels as tags
 
@@ -358,8 +558,60 @@ Starting with Agent v7.33+, the Agent can collect container labels and use them 
 The Agent can generate tags from container labels for both `docker` and `containerd` containers. In the case of `containerd`, the minimum supported version is v1.5.6, because previous releases do not propagate labels correctly.
 
 {{< tabs >}}
-{{% tab "Containerized Agent" %}}
+{{% tab "Operator" %}}
+To extract a given container label `<CONTAINER_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
 
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  #(...)
+  override:
+    nodeAgent:
+      env: 
+        - name: DD_CONTAINER_LABELS_AS_TAGS
+          value: '{"<CONTAINER_LABEL>": "<TAG_KEY>"}'
+```
+
+For example, you could set up:
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  #(...)
+  override:
+    nodeAgent:
+      env: 
+        - name: DD_CONTAINER_LABELS_AS_TAGS
+          value: '{"app":"kube_app"}'
+```
+
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+To extract a given container label `<CONTAINER_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+
+```yaml
+datadog:
+  env:
+    - name: DD_CONTAINER_LABELS_AS_TAGS
+      value: '{"<CONTAINER_LABEL>": "<TAG_KEY>"}'
+```
+
+For example, you could set up:
+```yaml
+datadog:
+  env:
+    - name: DD_CONTAINER_LABELS_AS_TAGS
+      value: '{"app":"kube_app"}'
+```
+{{% /tab %}}
+
+{{% tab "Containerized Agent" %}}
 To extract a given container label `<CONTAINER_LABEL>` and transform it to a tag key `<TAG_KEY>`, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -371,30 +623,10 @@ For example:
 ```bash
 DD_CONTAINER_LABELS_AS_TAGS='{"app":"kube_app"}'
 ```
-
-**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][1] for more details.
-
-[1]: /account_management/billing/custom_metrics
-{{% /tab %}}
-{{% tab "Agent" %}}
-
-To extract a given container label `<CONTAINER_LABEL>` and transform it to a tag key `<TAG_KEY>`, add the following configuration block in the [Agent `datadog.yaml` configuration file][1]:
-
-```yaml
-container_labels_as_tags:
-  <CONTAINER_LABEL>: <TAG_KEY>
-```
-
-For example:
-
-```yaml
-container_labels_as_tags:
-  app: kube_app
-```
-
-[1]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 {{% /tab %}}
 {{< /tabs >}}
+
+**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][4] for more details.
 
 ## Further Reading
 
@@ -403,3 +635,4 @@ container_labels_as_tags:
 [1]: /getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
 [2]: /getting_started/tagging/unified_service_tagging
 [3]: /agent/kubernetes/tag/?tab=agent#extract-labels-as-tags
+[4]: /account_management/billing/custom_metrics

--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -16,7 +16,7 @@ further_reading:
   text: "Limit data collection to a subset of containers only"
 ---
 
-The Agent can create and assign tags to all metrics, traces, and logs, traces, and logs emitted by a Pod, based on its labels or annotations.
+The Agent can create and assign tags to all metrics, traces, and logs emitted by a Pod, based on its labels or annotations.
 
 If you are running the Agent as a binary on a host, configure your tag extractions with the [Agent](?tab=agent) tab instructions. If you are running the Agent as a container in your Kubernetes cluster, configure your tag extraction with the [Containerized Agent](?tab=containerizedagent) tab instructions.
 
@@ -78,7 +78,7 @@ The Agent can attach Kubernetes environment information as "host tags".
 
 </div>
 
-## Tag Autodiscovery
+## Tag autodiscovery
 
 Starting with Agent v6.10+, the Agent can autodiscover tags from Pod annotations. It allows the Agent to associate tags to all data emitted by the entire pods or an individual container within this pod.
 
@@ -104,10 +104,10 @@ Starting with Agent v7.17+, the Agent can Autodiscover tags from Docker labels. 
 com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
 ```
 
-## Tag Extraction
+## Tag extraction
 ### Node labels as tags
 
-Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics, traces, and logs, traces, and logs emitted associated with this `host` in Datadog:
+Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics, traces, and logs emitted associated with this `host` in Datadog:
 
 {{< tabs >}}
 {{% tab "Operator" %}}

--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -136,7 +136,7 @@ spec:
       kubernetes.io/arch: arch
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -166,7 +166,7 @@ datadog:
     kubernetes.io/arch: arch
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```yaml
 datadog:
@@ -188,7 +188,7 @@ For example, you could set up:
 DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"kubernetes.io/arch":"arch"}'
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```bash
 DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
@@ -229,7 +229,7 @@ spec:
       app: kube_app
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -259,7 +259,7 @@ datadog:
     app: kube_app
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all pod labels as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```yaml
 datadog:

--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -16,7 +16,7 @@ further_reading:
   text: "Limit data collection to a subset of containers only"
 ---
 
-The Agent can create and assign tags to all metrics, traces, and logs emitted by a Pod, based on its labels or annotations.
+The Agent can create and assign tags to all metrics, traces, and logs, traces, and logs emitted by a Pod, based on its labels or annotations.
 
 If you are running the Agent as a binary on a host, configure your tag extractions with the [Agent](?tab=agent) tab instructions. If you are running the Agent as a container in your Kubernetes cluster, configure your tag extraction with the [Containerized Agent](?tab=containerizedagent) tab instructions.
 
@@ -98,15 +98,16 @@ annotations:
   ad.datadoghq.com/<CONTAINER_IDENTIFIER>.tags: '{"<TAG_KEY>": "<TAG_VALUE>","<TAG_KEY_1>": "<TAG_VALUE_1>"}'
 ```
 
-Starting with Agent v7.17+, the Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container, without [modifying the Agent `datadog.yaml` file][3].
+Starting with Agent v7.17+, the Agent can Autodiscover tags from Docker labels. This process allows the Agent to associate custom tags to all data emitted by a container, without modifying the Agent configuration.
 
 ```yaml
 com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
 ```
 
-## Node labels as tags
+## Tag Extraction
+### Node labels as tags
 
-Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics emitted associated with this `host` in Datadog:
+Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics, traces, and logs, traces, and logs emitted associated with this `host` in Datadog:
 
 {{< tabs >}}
 {{% tab "Operator" %}}
@@ -195,11 +196,11 @@ DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][4] for more information.
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
-## Pod labels as tags
+### Pod labels as tags
 
-Starting with Agent v6.0+, the Agent can collect labels for a given pod and use them as tags to attach to all metrics emitted by this pod:
+Starting with Agent v6.0+, the Agent can collect labels for a given pod and use them as tags to attach to all metrics, traces, and logs emitted by this pod:
 
 {{< tabs >}}
 {{% tab "Operator" %}}
@@ -288,11 +289,11 @@ DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][4] for more information.
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
-## Pod annotations as tags
+### Pod annotations as tags
 
-Starting with Agent v6.0+, the Agent can collect annotations for a given pod and use them as tags to attach to all metrics emitted by this pod:
+Starting with Agent v6.0+, the Agent can collect annotations for a given pod and use them as tags to attach to all metrics, traces, and logs emitted by this pod:
 
 {{< tabs >}}
 {{% tab "Operator" %}}
@@ -381,11 +382,11 @@ DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS='{"*":"<PREFIX>_%%annotation%%"}'
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][4] for more information.
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
-## Namespace labels as tags
+### Namespace labels as tags
 
-Starting with Agent v7.27+, the Agent can collect labels for a given namespace and use them as tags to attach to all metrics emitted by all pods in this namespace:
+Starting with Agent v7.27+, the Agent can collect labels for a given namespace and use them as tags to attach to all metrics, traces, and logs emitted by all pods in this namespace:
 
 {{< tabs >}}
 {{% tab "Operator" %}}
@@ -474,11 +475,11 @@ DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Custom metrics may impact billing. See the [custom metrics billing page][4] for more information.
+**Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
-## Container environment variables as tags
+### Container environment variables as tags
 
-Starting with Agent v7.32+, the Agent can collect container environment variables and use them as tags to attach to all metrics corresponding to the container. Both `docker` and `containerd` containers are supported:
+Starting with Agent v7.32+, the Agent can collect container environment variables and use them as tags to attach to all metrics, traces, and logs corresponding to the container. Both `docker` and `containerd` containers are supported:
 
 {{< tabs >}}
 {{% tab "Operator" %}}
@@ -493,7 +494,7 @@ spec:
   #(...)
   override:
     nodeAgent:
-      env: 
+      env:
         - name: DD_CONTAINER_ENV_AS_TAGS
           value: '{"<ENV_VAR>": "<TAG_KEY>"}'
 ```
@@ -508,7 +509,7 @@ spec:
   #(...)
   override:
     nodeAgent:
-      env: 
+      env:
         - name: DD_CONTAINER_ENV_AS_TAGS
           value: '{"app":"kube_app"}'
 ```
@@ -550,11 +551,12 @@ DD_CONTAINER_ENV_AS_TAGS='{"app":"kube_app"}'
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][4] for more details.
+**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][3] for more details.
 
-## Container labels as tags
+### Container labels as tags
 
-Starting with Agent v7.33+, the Agent can collect container labels and use them as tags. The agent attaches the tags to all metrics associated with the container.
+Starting with Agent v7.33+, the Agent can collect container labels and use them as tags. The agent attaches the tags to all metrics, traces, and logs associated with the container.
+
 The Agent can generate tags from container labels for both `docker` and `containerd` containers. In the case of `containerd`, the minimum supported version is v1.5.6, because previous releases do not propagate labels correctly.
 
 {{< tabs >}}
@@ -570,7 +572,7 @@ spec:
   #(...)
   override:
     nodeAgent:
-      env: 
+      env:
         - name: DD_CONTAINER_LABELS_AS_TAGS
           value: '{"<CONTAINER_LABEL>": "<TAG_KEY>"}'
 ```
@@ -585,7 +587,7 @@ spec:
   #(...)
   override:
     nodeAgent:
-      env: 
+      env:
         - name: DD_CONTAINER_LABELS_AS_TAGS
           value: '{"app":"kube_app"}'
 ```
@@ -626,7 +628,7 @@ DD_CONTAINER_LABELS_AS_TAGS='{"app":"kube_app"}'
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][4] for more details.
+**Note**: Custom metrics may impact billing. See [Custom Metrics Billing][3] for more details.
 
 ## Further Reading
 
@@ -634,5 +636,4 @@ DD_CONTAINER_LABELS_AS_TAGS='{"app":"kube_app"}'
 
 [1]: /getting_started/tagging/assigning_tags/?tab=containerizedenvironments#environment-variables
 [2]: /getting_started/tagging/unified_service_tagging
-[3]: /agent/kubernetes/tag/?tab=agent#extract-labels-as-tags
-[4]: /account_management/billing/custom_metrics
+[3]: /account_management/billing/custom_metrics

--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -78,7 +78,7 @@ The Agent can attach Kubernetes environment information as "host tags".
 
 </div>
 
-## Tag autodiscovery
+## Tag Autodiscovery
 
 Starting with Agent v6.10+, the Agent can autodiscover tags from Pod annotations. It allows the Agent to associate tags to all data emitted by the entire pods or an individual container within this pod.
 
@@ -110,8 +110,8 @@ com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
 Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics, traces, and logs emitted associated with this `host` in Datadog:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
-To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
+{{% tab "Datadog Operator" %}}
+To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -151,7 +151,7 @@ spec:
 {{% /tab %}}
 
 {{% tab "Helm" %}}
-To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `datadog-values.yaml` file:
 
 ```yaml
 datadog:
@@ -203,8 +203,8 @@ DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 Starting with Agent v6.0+, the Agent can collect labels for a given pod and use them as tags to attach to all metrics, traces, and logs emitted by this pod:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
-To extract a given pod label `<POD_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
+{{% tab "Datadog Operator" %}}
+To extract a given pod label `<POD_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -244,7 +244,7 @@ spec:
 {{% /tab %}}
 
 {{% tab "Helm" %}}
-To extract a given pod label `<POD_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+To extract a given pod label `<POD_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `datadog-values.yaml` file:
 
 ```yaml
 datadog:
@@ -296,8 +296,8 @@ DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 Starting with Agent v6.0+, the Agent can collect annotations for a given pod and use them as tags to attach to all metrics, traces, and logs emitted by this pod:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
-To extract a given pod annotation `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
+{{% tab "Datadog Operator" %}}
+To extract a given pod annotation `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -322,7 +322,7 @@ spec:
       app: kube_app
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all pod annotations as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all pod annotations as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -337,7 +337,7 @@ spec:
 {{% /tab %}}
 
 {{% tab "Helm" %}}
-To extract a given pod annotation `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+To extract a given pod annotation `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `datadog-values.yaml` file:
 
 ```yaml
 datadog:
@@ -352,7 +352,7 @@ datadog:
     app: kube_app
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all pod annotation as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all pod annotation as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```yaml
 datadog:
@@ -389,8 +389,8 @@ DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS='{"*":"<PREFIX>_%%annotation%%"}'
 Starting with Agent v7.27+, the Agent can collect labels for a given namespace and use them as tags to attach to all metrics, traces, and logs emitted by all pods in this namespace:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
-To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
+{{% tab "Datadog Operator" %}}
+To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -415,7 +415,7 @@ spec:
       app: kube_app
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all namespace labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all namespace labels as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -430,7 +430,7 @@ spec:
 {{% /tab %}}
 
 {{% tab "Helm" %}}
-To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `datadog-values.yaml` file:
 
 ```yaml
 datadog:
@@ -445,7 +445,7 @@ datadog:
     app: kube_app
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all namespace labels as tags to your metrics. In this example, the tags names are prefixed by `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all namespace labels as tags to your metrics. In this example, the tags' names are prefixed by `<PREFIX>_`:
 
 ```yaml
 datadog:
@@ -482,8 +482,8 @@ DD_KUBERNETES_NAMESPACE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 Starting with Agent v7.32+, the Agent can collect container environment variables and use them as tags to attach to all metrics, traces, and logs corresponding to the container. Both `docker` and `containerd` containers are supported:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
-To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
+{{% tab "Datadog Operator" %}}
+To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -517,7 +517,7 @@ spec:
 {{% /tab %}}
 
 {{% tab "Helm" %}}
-To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `datadog-values.yaml` file:
 
 ```yaml
 datadog:
@@ -560,8 +560,8 @@ Starting with Agent v7.33+, the Agent can collect container labels and use them 
 The Agent can generate tags from container labels for both `docker` and `containerd` containers. In the case of `containerd`, the minimum supported version is v1.5.6, because previous releases do not propagate labels correctly.
 
 {{< tabs >}}
-{{% tab "Operator" %}}
-To extract a given container label `<CONTAINER_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration:
+{{% tab "Datadog Operator" %}}
+To extract a given container label `<CONTAINER_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -595,7 +595,7 @@ spec:
 {{% /tab %}}
 
 {{% tab "Helm" %}}
-To extract a given container label `<CONTAINER_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `values.yaml` file:
+To extract a given container label `<CONTAINER_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following configuration to your Helm `datadog-values.yaml` file:
 
 ```yaml
 datadog:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds instructions for Operator and Helm for all the tag extraction rules to use instead of the plain "Containerized Agent". Keeping the "Containerized Agent" instructions but removed the core "Agent" instructions as these were relative to modifying the `datadog.yaml` for host-installs. Which is pretty rare for these types of environments. 

Additionally moved all the extraction options (`xxxAsTags`) down to the the level 3 `###` header and put a new level 2 `##` header for "Tag Extraction" to help group these together. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
- Validated with sample deployments for all options. 
- It may make sense in the future to: 
  - adjust all the options so they aren't all using a `{"app": "kube_app"}` mapping. Like I've done here for the Node Labels As Tags option. 
  - double check and add any more automatically extracted tags, such as `kube_node`

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->