### PR TITLE
PRODUCTSA-1134 Remove disk buffers from OPW quickstart configs

### DIFF
--- a/static/resources/yaml/observability_pipelines/quickstart/aws_eks.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/aws_eks.yaml
@@ -118,7 +118,7 @@ pipelineConfig:
       default_api_key: "${DD_API_KEY}"
       site: "${DD_SITE}"
       compression: gzip
-      ## We've omitted the disk buffer here to simplify quickstart setup.
+      ## We've omitted the disk buffer to simplify quickstart setup.
       ## Consider re-enabling and configuring before deploying to production environments.
       ## The disk buffer size is currently set to 144GB.
       #buffer:

--- a/static/resources/yaml/observability_pipelines/quickstart/aws_eks.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/aws_eks.yaml
@@ -43,9 +43,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 ## NOTE: If using the Quickstart use case, this load balancer will not be receiving
 ## inbound traffic because our Quickstart data source is a sample syslog generator.
-## However, we will still provision this load balancer so that it can be used 
-## once you update your configuration with a real data source. 
-## 
+## However, we will still provision this load balancer so that it can be used
+## once you update your configuration with a real data source.
+##
 ## In the meantime, beware of cost implications of running this LB!
 service:
   enabled: true
@@ -104,12 +104,6 @@ pipelineConfig:
   ## SINKS: Data output destinations
   ## console: Print JSON-formatted events to the console
   ## datadog: Ship logs to Datadog Logs
-  ##
-  ## This buffer configuration is split into 144GB buffers for both of the console and Datadog sinks.
-  ##
-  ## This should work for the vast majority of OP Worker deployments and should rarely
-  ## need to be adjusted. If you do change it, be sure to update the size of the persistence
-  ## block above.
   sinks:
     print_syslog:
       type: console
@@ -124,7 +118,9 @@ pipelineConfig:
       default_api_key: "${DD_API_KEY}"
       site: "${DD_SITE}"
       compression: gzip
-      buffer:
-          type: disk
-          max_size: 154618822656
-    
+      ## We've omitted the disk buffer here to simplify quickstart setup.
+      ## Consider re-enabling and configuring before deploying to production environments.
+      ## The disk buffer size is currently set to 144GB.
+      #buffer:
+      #    type: disk
+      #    max_size: 154618822656

--- a/static/resources/yaml/observability_pipelines/quickstart/azure_aks.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/azure_aks.yaml
@@ -43,9 +43,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 ## NOTE: If using the Quickstart use case, this load balancer will not be receiving
 ## inbound traffic because our Quickstart data source is a sample syslog generator.
-## However, we will still provision this load balancer so that it can be used 
-## once you update your configuration with a real data source. 
-## 
+## However, we will still provision this load balancer so that it can be used
+## once you update your configuration with a real data source.
+##
 ## In the meantime, beware of cost implications of running this LB!
 service:
   enabled: true
@@ -95,12 +95,6 @@ pipelineConfig:
   ## SINKS: Data output destinations
   ## console: Print JSON-formatted events to the console
   ## datadog: Ship logs to Datadog Logs
-  ##
-  ## This buffer configuration is split into 144GB buffers for both of the console and Datadog sinks.
-  ##
-  ## This should work for the vast majority of OP Worker deployments and should rarely
-  ## need to be adjusted. If you do change it, be sure to update the size of the persistence
-  ## block above.
   sinks:
     print_syslog:
       type: console
@@ -115,7 +109,9 @@ pipelineConfig:
       default_api_key: "${DD_API_KEY}"
       site: "${DD_SITE}"
       compression: gzip
-      buffer:
-          type: disk
-          max_size: 154618822656
-          
+      ## We've omitted the disk buffer here to simplify quickstart setup.
+      ## Consider re-enabling and configuring before deploying to production environments.
+      ## The disk buffer size is currently set to 144GB.
+      #buffer:
+      #    type: disk
+      #    max_size: 154618822656

--- a/static/resources/yaml/observability_pipelines/quickstart/google_gke.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/google_gke.yaml
@@ -111,7 +111,7 @@ pipelineConfig:
       default_api_key: "${DD_API_KEY}"
       site: "${DD_SITE}"
       compression: gzip
-      ## We've omitted the disk buffer here to simplify quickstart setup.
+      ## We've omitted the disk buffer to simplify quickstart setup.
       ## Consider re-enabling and configuring before deploying to production environments.
       ## The disk buffer size is currently set to 144GB.
       #buffer:

--- a/static/resources/yaml/observability_pipelines/quickstart/google_gke.yaml
+++ b/static/resources/yaml/observability_pipelines/quickstart/google_gke.yaml
@@ -43,9 +43,9 @@ affinity:
 ## This example configuration avoids cross-availability-zone costs where possible.
 ## NOTE: If using the Quickstart use case, this load balancer will not be receiving
 ## inbound traffic because our Quickstart data source is a sample syslog generator.
-## However, we will still provision this load balancer so that it can be used 
-## once you update your configuration with a real data source. 
-## 
+## However, we will still provision this load balancer so that it can be used
+## once you update your configuration with a real data source.
+##
 ## In the meantime, beware of cost implications of running this LB!
 service:
   enabled: true
@@ -97,12 +97,6 @@ pipelineConfig:
   ## SINKS: Data output destinations
   ## console: Print JSON-formatted events to the console
   ## datadog: Ship logs to Datadog Logs
-  ##
-  ## This buffer configuration is split into 144GB buffers for both of the console and Datadog sinks.
-  ##
-  ## This should work for the vast majority of OP Worker deployments and should rarely
-  ## need to be adjusted. If you do change it, be sure to update the size of the persistence
-  ## block above.
   sinks:
     print_syslog:
       type: console
@@ -117,7 +111,9 @@ pipelineConfig:
       default_api_key: "${DD_API_KEY}"
       site: "${DD_SITE}"
       compression: gzip
-      buffer:
-          type: disk
-          max_size: 154618822656
-          
+      ## We've omitted the disk buffer here to simplify quickstart setup.
+      ## Consider re-enabling and configuring before deploying to production environments.
+      ## The disk buffer size is currently set to 144GB.
+      #buffer:
+      #    type: disk
+      #    max_size: 154618822656

--- a/static/resources/yaml/observability_pipelines/quickstart/terraform_opw.tf
+++ b/static/resources/yaml/observability_pipelines/quickstart/terraform_opw.tf
@@ -67,7 +67,7 @@ transforms:
       .tags.opw_aggregator = get_hostname!()
 
 ## SINKS: Data output destinations
-## datadog_logs: Ship logs to Datadog Logs
+## datadog_logs: Ship logs to Datadog Log Management
 ## datadog_metrics: Publish metric events to Datadog
 sinks:
   datadog_logs:

--- a/static/resources/yaml/observability_pipelines/quickstart/terraform_opw.tf
+++ b/static/resources/yaml/observability_pipelines/quickstart/terraform_opw.tf
@@ -66,14 +66,9 @@ transforms:
       .tags.sender = "observability_pipelines_worker"
       .tags.opw_aggregator = get_hostname!()
 
-## This buffer configuration is split into the following, totaling the 288GB
-## provisioned automatically by the Terraform module:
-## - 240GB buffer for logs
-## - 48GB buffer for metrics
-##
-## This should work for the vast majority of OP Worker deployments and should rarely
-## need to be adjusted. If you do change it, be sure to update the `ebs-drive-size-gb`
-## parameter.
+## SINKS: Data output destinations
+## datadog_logs: Ship logs to Datadog Logs
+## datadog_metrics: Publish metric events to Datadog
 sinks:
   datadog_logs:
     type: datadog_logs
@@ -81,16 +76,22 @@ sinks:
       - logs_finish_ddtags
     default_api_key: "$${DD_API_KEY}"
     compression: gzip
-    buffer:
-       type: disk
-       max_size: 257698037760
+    ## We've omitted the disk buffer here to simplify quickstart setup.
+    ## Consider re-enabling and configuring before deploying to production environments.
+    ## The disk buffer size is currently set to 240GB.
+    #buffer:
+    #   type: disk
+    #   max_size: 257698037760
   datadog_metrics:
     type: datadog_metrics
     inputs:
       - metrics_add_dd_tags
     default_api_key: "$${DD_API_KEY}"
-    buffer:
-      type: disk
-      max_size: 51539607552
+    ## We've omitted the disk buffer here to simplify quickstart setup.
+    ## Consider re-enabling and configuring before deploying to production environments.
+    ## The disk buffer size is currently set to 48GB.
+    #buffer:
+    #  type: disk
+    #  max_size: 51539607552
 EOT
 }

--- a/static/resources/yaml/observability_pipelines/quickstart/terraform_opw.tf
+++ b/static/resources/yaml/observability_pipelines/quickstart/terraform_opw.tf
@@ -87,7 +87,7 @@ sinks:
     inputs:
       - metrics_add_dd_tags
     default_api_key: "$${DD_API_KEY}"
-    ## We've omitted the disk buffer here to simplify quickstart setup.
+    ## We've omitted the disk buffer to simplify quickstart setup.
     ## Consider re-enabling and configuring before deploying to production environments.
     ## The disk buffer size is currently set to 48GB.
     #buffer:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Remove disk buffers from OPW quickstart configs.

Data buffering in general (and disk buffers in particular) is an advanced topic and should be removed from quickstart configs. So far we've seen too many examples of customers struggling with this configs on an early stages of OPW adoption. The goal is to keep quickstart configs straightforward and simple.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->