### PR TITLE
Fix typo in getSessionReplayLink function name

### DIFF
--- a/content/en/real_user_monitoring/guide/connect-session-replay-to-your-third-party-tools.md
+++ b/content/en/real_user_monitoring/guide/connect-session-replay-to-your-third-party-tools.md
@@ -38,7 +38,7 @@ datadogRum.init({
     ...
 });
 
-const url = datadogRum.getSessionReplayUrl();
+const url = datadogRum.getSessionReplayLink();
 ```
 
 {{% /tab %}}
@@ -53,7 +53,7 @@ window.DD_RUM.onReady(function() {
         subdomain: ''
         ...
     })
-    const url = DD_RUM.getSessionReplayUrl();
+    const url = DD_RUM.getSessionReplayLink();
 })
 
 ```
@@ -70,7 +70,7 @@ window.DD_RUM &&
         subdomain: ''
         ...
     });
-const url = DD_RUM && DD_RUM.getSessionReplayUrl();
+const url = DD_RUM && DD_RUM.getSessionReplayLink();
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes the name for the RUM Browser SDK public API method `getSessionReplayLink`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->