### PR TITLE
[WEB-4519] Fix subnav menu URL path to include trailing slash

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -4158,7 +4158,7 @@ main:
     identifier: rum_mobile_setup
     weight: 201
   - name: Advanced Configuration
-    url: real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration
+    url: real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/
     parent: mobile_and_tv_monitoring
     identifier: rum_mobile_advanced
     weight: 202


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Updates menu path where there isn't a trailing slash, causing relative URLs to return a 404

### Merge instructions

- [ ] Please merge after reviewing

### Additional notes
https://datadoghq.atlassian.net/browse/WEB-4519

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->