### PR TITLE
Add downtime example with boolean OR across two different groups

### DIFF
--- a/content/en/monitors/downtimes/_index.md
+++ b/content/en/monitors/downtimes/_index.md
@@ -77,7 +77,7 @@ The Downtime scope query follows the same common [Search Syntax][19] that many o
 | `host:*-prod-cluster`       | Mutes any notification that relates to a host whose name is suffixed with `-prod-cluster`. |
 | `host:*-prod-cluster`       | Mutes any notification that relates to a host whose name is suffixed with `-prod-cluster`. |
 | `service:web-store AND -env:prod`       | Mutes any notification that relates to the `web-store` service that is **not** running on the `prod` environment. |
-| `service:web-store env:prod`       | Mutes any notification that relates to the `web-store` service **or** the `prod` host. |
+| `service:web-store env:prod`       | Mutes any notification that relates to the `web-store` service **or** the `prod` environment. |
 
 #### Downtime scope limitations
 There are a few limitations that are **not supported** which include:

--- a/content/en/monitors/downtimes/_index.md
+++ b/content/en/monitors/downtimes/_index.md
@@ -76,7 +76,8 @@ The Downtime scope query follows the same common [Search Syntax][19] that many o
 | `host:authentication-*`       | Mutes any notification that relates to a host whose name is prefixed with `authentication-`. |
 | `host:*-prod-cluster`       | Mutes any notification that relates to a host whose name is suffixed with `-prod-cluster`. |
 | `host:*-prod-cluster`       | Mutes any notification that relates to a host whose name is suffixed with `-prod-cluster`. |
-| `service:webstore AND -env:prod`       | Mutes any notification about the `web-store` service that is **not** running on the `prod` environment. |
+| `service:web-store AND -env:prod`       | Mutes any notification that relates to the `web-store` service that is **not** running on the `prod` environment. |
+| `service:web-store env:prod`       | Mutes any notification that relates to the `web-store` service **or** the `prod` host. |
 
 #### Downtime scope limitations
 There are a few limitations that are **not supported** which include:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This includes an additional example that shows how to perform a boolean or with 2 or more keys. OR is not needed in this scenario which may be confusing without an example.

Release notes on this feature: https://app.datadoghq.com/release-notes/tackle-expected-maintenance-periods-proactively-with-more-flexible-downtimes