### PR TITLE
Update best-practices-for-rum-sampling.md to give better visibility on how a RUM session is defined

### DIFF
--- a/content/en/real_user_monitoring/guide/best-practices-for-rum-sampling.md
+++ b/content/en/real_user_monitoring/guide/best-practices-for-rum-sampling.md
@@ -12,7 +12,7 @@ further_reading:
 
 Sampling in Datadog's Real User Monitoring product enables you to collect data from a certain percentage of user traffic.
 
-This guide walks you through best practices for RUM sampling so you can capture sessions and collect data based on your monitoring needs.
+This guide walks you through best practices for RUM sampling so you can capture sessions and collect data based on your monitoring needs. Learn more about how [sessions are defined][9] in RUM.
 
 ## Sampling configuration
 
@@ -33,7 +33,7 @@ The random sampling is by session, not by user.
 RUM metrics (such as Core Web Vitals and usage numbers) are calculated based on sessions that are sampled. For example, if the sampling rate is set to capture 60% of sessions, then the Core Web Vitals and total number of sessions are calculated based on 60% of those sessions. 
 
 ### Recommended sampling rate
-In terms of setting an ideal sampling rate, it depends on the amount of traffic you see and the data you are looking for. Datadog recommends starting with a sampling rate you are comfortable with based on your budget and estimated traffic, then tweaking it based on the data you need. Learn more about how [sessions are defined][9] in RUM.
+In terms of setting an ideal sampling rate, it depends on the amount of traffic you see and the data you are looking for. Datadog recommends starting with a sampling rate you are comfortable with based on your budget and estimated traffic, then tweaking it based on the data you need. 
 
 ### Sampling based on specific attributes
 Configuring sampling based on specific attributes, such as sampling 100% of sessions with errors and 5% otherwise, or only sampling sessions that go through the checkout flow, is not supported. If this feature is critical for your business needs, create a ticket with [Datadog Support][8].


### PR DESCRIPTION
### Description
The document mentions "sessions" in all sub sections, however, it lacks the definition of what is a session in the overall structure. 

### What does this PR do? 
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The present PR updates the document, to provide better visibility of what is a "session". By moving the Learn about what is a session to the Overview section.

### What is the motivation?
This will clarify a lot of pending question about when changing the sampling rate data will change affect the collection of errors. This because, in the documentation about a session it defines what is a session, so customers can understand it.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->