### PR TITLE
trace-agent log level can not be updated from cli

### DIFF
--- a/content/en/agent/troubleshooting/debug_mode.md
+++ b/content/en/agent/troubleshooting/debug_mode.md
@@ -65,7 +65,7 @@ For Agent v6.19+ / v7.19+, set the Agent log level at runtime using:
 agent config set log_level debug
 ```
 
-If the trace-agent is in a dedicated container, you **cannot** change the log level for the trace-agent container at runtime like you can do for the agent container. A redeployment after setting `dd_log_level` variable to `debug` is still necessary for the dedicated trace-agent container.
+You **cannot** change the log level for the trace-agent container at runtime like you can do for the agent container. A redeployment after setting `dd_log_level` variable to `debug` is still necessary for the dedicated trace-agent container.
 
 {{% /tab %}}
 {{% tab "Agent v5" %}}


### PR DESCRIPTION
This implies this config change is possible outside dedicated containers which isn't accurate.

The log level _can_ be changed by remote config but NOT via the CLI currently.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->