### PR TITLE
Swap pa11y runner

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -463,7 +463,7 @@ link_checks:on-schedule:
 # template for what runs in pa11y to avoid duplication
 .pa11y_live_template: &pa11y_live_template
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:pa11y-25121683
-  tags: ["runner:docker"]
+  tags: ["arch:amd64"]
   stage: post-deploy
   cache: []
   variables:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Migrate pa11y job to use K8s architecture

https://datadoghq.atlassian.net/browse/WEB-4531

Gitlab preview pa11y job started as expected https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/424944917

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->