### PR TITLE
[DOCS-7215] Clarify Agent version requirements for regex filter tags.

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -32,10 +32,10 @@ The filter tags option requires an exact string match. If your use case requires
 You can specify span tags to require or reject by using a list of keys and values separated by spaces in environment variables:
 
 `DD_APM_FILTER_TAGS_REQUIRE`
-: Collects only traces that have root spans with an exact match for the specified span tags and values. If it does not match this rule, the trace is dropped. For example, `DD_APM_FILTER_TAGS_REQUIRE="key1:value1 key2:value2"`. Regular expression can be provided with `DD_APM_FILTER_TAGS_REGEX_REQUIRE`.
+: Collects only traces that have root spans with an exact match for the specified span tags and values. If it does not match this rule, the trace is dropped. For example, `DD_APM_FILTER_TAGS_REQUIRE="key1:value1 key2:value2"`. In Datadog Agent 7.49+, regular expressions can be provided with `DD_APM_FILTER_TAGS_REGEX_REQUIRE`.
 
 `DD_APM_FILTER_TAGS_REJECT`
-: Rejects traces that have root spans with an exact match for the specified span tags and values. If it matches this rule, the trace is dropped. For example, `DD_APM_FILTER_TAGS_REJECT="key1:value1 key2:value2"`. Regular expression can be provided with `DD_APM_FILTER_TAGS_REGEX_REJECT`.
+: Rejects traces that have root spans with an exact match for the specified span tags and values. If it matches this rule, the trace is dropped. For example, `DD_APM_FILTER_TAGS_REJECT="key1:value1 key2:value2"`. In Datadog Agent 7.49+, regular expressions can be provided with `DD_APM_FILTER_TAGS_REGEX_REJECT`.
 
 
 {{< tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
`DD_APM_FILTER_TAGS_REGEX_REQUIRE` and `DD_APM_FILTER_TAGS_REGEX_REJECT` require Datadog Agent 7.49+. This is confusing right now because this section starts by talking about `Datadog Agent 6.27.0/7.27.0` for `the **filter tags** option drops traces with root spans that match specified span tags`.

Adding a note next to the regular expression env variables to indicate the version to alleviate confusion.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->