### PR TITLE
Revert "Add downtime example with boolean OR across two different groups"

### DIFF
--- a/content/en/monitors/downtimes/_index.md
+++ b/content/en/monitors/downtimes/_index.md
@@ -76,8 +76,7 @@ The Downtime scope query follows the same common [Search Syntax][19] that many o
 | `host:authentication-*`       | Mutes any notification that relates to a host whose name is prefixed with `authentication-`. |
 | `host:*-prod-cluster`       | Mutes any notification that relates to a host whose name is suffixed with `-prod-cluster`. |
 | `host:*-prod-cluster`       | Mutes any notification that relates to a host whose name is suffixed with `-prod-cluster`. |
-| `service:web-store AND -env:prod`       | Mutes any notification that relates to the `web-store` service that is **not** running on the `prod` environment. |
-| `service:web-store env:prod`       | Mutes any notification that relates to the `web-store` service **or** the `prod` environment. |
+| `service:webstore AND -env:prod`       | Mutes any notification about the `web-store` service that is **not** running on the `prod` environment. |
 
 #### Downtime scope limitations
 There are a few limitations that are **not supported** which include:


### PR DESCRIPTION
Reverts DataDog/documentation#21639

Found out that this is not supported, this example evaluates as an AND not an OR. 
`Top level ORs are not supported, for example, service:A OR host:X. This requires two separate Downtimes.`