### PR TITLE
Generated by websites-modules - add api-catalog icon

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.5.2-0.20240205171032-4c4fd1df8b1d // indirect
+require github.com/DataDog/websites-modules v1.4.113 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/colin.cole/webops/websites-modules

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.4.112 // indirect
+require github.com/DataDog/websites-modules v1.5.2-0.20240205171032-4c4fd1df8b1d // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/colin.cole/webops/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.5.2-0.20240205171032-4c4fd1df8b1d h1:gEYoP+2a+TMa5wXIeOCXjOS+pS5Y3UhSFuRRQEm6aKU=
-github.com/DataDog/websites-modules v1.5.2-0.20240205171032-4c4fd1df8b1d/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.4.113 h1:6m4vZjO3Hf5iIJXHSTm2mJGlODoZ9/CSTvP9h0e8qsE=
+github.com/DataDog/websites-modules v1.4.113/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.4.112 h1:BKMDG8zrw8xxc27nVtpe1EVgIXDXutguBYtJYFUg/Bs=
-github.com/DataDog/websites-modules v1.4.112/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.5.2-0.20240205171032-4c4fd1df8b1d h1:gEYoP+2a+TMa5wXIeOCXjOS+pS5Y3UhSFuRRQEm6aKU=
+github.com/DataDog/websites-modules v1.5.2-0.20240205171032-4c4fd1df8b1d/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
enable access to `api-catalog` icon from [websites-modules](https://github.com/DataDog/websites-modules/pull/286)

preview: https://docs-staging.datadoghq.com/websites-modules/generated/286/
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->