### PR TITLE
Update RUM migration guide for Flutter

### DIFF
--- a/content/en/real_user_monitoring/guide/mobile-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/mobile-sdk-upgrade.md
@@ -772,6 +772,7 @@ Certain configuration properties have been moved or renamed to support modularit
 The following structures have been renamed:
 
 | `1.x` | `2.x` |
+|-------|-------|
 | `DdSdkConfiguration` | `DatadogConfiguration` |
 | `LoggingConfiguartion` | `DatadogLoggingConfiguration` |
 | `RumConfiguration` | `DatadogRumConfiguration` |
@@ -779,7 +780,7 @@ The following structures have been renamed:
 
 The following properties have changed:
 
-| `1.x` | `2.x` | Notes |
+| 1.x | 2.x | Notes |
 |-------|-------|-------|
 | `DdSdkConfiguration.trackingConsent`| Removed | Part of `Datadog.initialize` | |
 | `DdSdkConfiguration.customEndpoint` | Removed | Now configured per-feature | |
@@ -790,7 +791,7 @@ The following properties have changed:
 
 In addition, the following APIs have changed:
 
-| `1.x` | `2.x` | Notes |
+| 1.x | 2.x | Notes |
 |-------|-------|-------|
 | `Verbosity` | Removed | See `CoreLoggerLevel` or `LogLevel` |
 | `DdLogs DatadogSdk.logs` | `DatadogLogging DatadogSdk.logs` | Type changed |
@@ -802,7 +803,7 @@ In addition, the following APIs have changed:
 
 ## Flutter Web Changes
 
-Clients using Flutter Web should update to using the Datadog Browser SDK v5.  Change the following import in your `index.html`:
+Clients using Flutter Web should update to using the Datadog Browser SDK v5. Change the following import in your `index.html`:
 
 ```diff
 -  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
@@ -811,17 +812,17 @@ Clients using Flutter Web should update to using the Datadog Browser SDK v5.  Ch
 +  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script>
 ```
 
-Note that Datadog provides one CDN bundle per site. See the [Browser SDK README](https://github.com/DataDog/browser-sdk/#cdn-bundles) for a list of all site URLs.
+**Note**: Datadog provides one CDN bundle per site. See the [Browser SDK README](https://github.com/DataDog/browser-sdk/#cdn-bundles) for a list of all site URLs.
 
-## Logs Product Changes
+## Logs product changes
 
-As with `1.x`, Datadog Logging can be enabled by setting the `DatadogConfiguration.loggingConfiguration` member. However, unlike `1.x`, Datadog will not create a default logger for you. `DatadogSdk.logs` is now and instance of `DatadogLogging`, which can be used to create logs. Many options were moved to `DatadogLoggerConfiguration` to give developers more granular support over individual loggers.
+As with v1, Datadog Logging can be enabled by setting the `DatadogConfiguration.loggingConfiguration` member. However, unlike v1, Datadog does not create a default logger for you. `DatadogSdk.logs` is now an instance of `DatadogLogging`, which can be used to create logs. Many options were moved to `DatadogLoggerConfiguration` to give developers more granular support over individual loggers.
 
 The following APIs have changed:
 
-| `1.x` | `2.x` | Notes |
+| 1.x | 2.x | Notes |
 |-------|-------|-------|
-| `LoggingConfiguration` | `DatadogLoggingConfiguration` | Rename, most members are now on `DatadogLoggerConfiguration` |
+| `LoggingConfiguration` | `DatadogLoggingConfiguration` | Renamed most members are now on `DatadogLoggerConfiguration` |
 | `LoggingConfiguration.sendNetworkInfo` | `DatadogLoggerConfiguration.networkInfoEnabled` | |
 | `LoggingConfiguration.printLogsToConsole` | `DatadogLoggerConfiguration.customConsoleLogFunction` | |
 | `LoggingConfiguration.sendLogsToDatadog` | Removed. Use `remoteLogThreshold` instead | |
@@ -835,7 +836,7 @@ The following APIs have changed:
 
 The following APIs have changed:
 
-| `1.x` | `2.x` | Notes |
+| 1.x | 2.x | Notes |
 |-------|-------|-------|
 | `RumConfiguration` | `DatadogRumConfiguration` | Type renamed |
 | `RumConfiguration.vitalsUpdateFrequency` | `DatadogRumConfiguration.vitalsUpdateFrequency` | Set to `null` to disable vitals updates |

--- a/content/en/real_user_monitoring/guide/mobile-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/mobile-sdk-upgrade.md
@@ -39,6 +39,11 @@ SDK v2 enables the usage of [Mobile Session Replay][1] on Android and iOS applic
 The migration from v1 to v2 comes with improved performance.
 
 {{% /tab %}}
+{{% tab "Flutter" %}}
+
+The migration from v1 to v2 comes with improved performance and additional features supplied by the v2 Native SDKs.
+
+{{% /tab %}}
 {{< /tabs >}}
 ### Modules
 {{< tabs >}}
@@ -303,6 +308,43 @@ dependencies {
     }
 }
 ```
+
+{{% /tab %}}
+{{% tab "Flutter" %}}
+
+Update `datadog_flutter_plugin` in your pubspec.yaml:
+
+```yaml
+dependencies:
+  'datadog_flutter_plugin: ^2.0.0
+```
+
+## Troubleshooting
+
+### Duplicate interface (iOS)
+
+If you see this error while building iOS after upgrading to `datadog_flutter_plugin` v2.0:
+
+```
+Semantic Issue (Xcode): Duplicate interface definition for class 'DatadogSdkPlugin'
+/Users/exampleuser/Projects/test_app/build/ios/Debug-iphonesimulator/datadog_flutter_plugin/datadog_flutter_plugin.framework/Headers/DatadogSdkPlugin.h:6:0
+```
+
+Try performing `flutter clean` && `flutter pub get` and rebuilding. This usually resolves the issue.
+
+### Duplicate classes (Android)
+
+If you see this error while building Android after the upgrading to `datadog_flutter_plugin` v2.0:
+
+```
+FAILURE: Build failed with an exception.
+
+* What went wrong:
+Execution failed for task ':app:checkDebugDuplicateClasses'.
+> A failure occurred while executing com.android.build.gradle.internal.tasks.CheckDuplicatesRunnable
+```
+
+Make sure that you've updated your version of Kotlin to at least 1.8 in your `build.gradle` file.
 
 {{% /tab %}}
 
@@ -720,6 +762,102 @@ For instructions on setting up Mobile Session Replay, see [Mobile Session Replay
 No change in the SDK initialization is needed.
 
 {{% /tab %}}
+
+{{% tab "Flutter" %}}
+
+## SDK Configuration Changes
+
+Certain configuration properties have been moved or renamed to support modularity in Datadog's native SDKs.
+
+The following structures have been renamed:
+
+| `1.x` | `2.x` |
+| `DdSdkConfiguration` | `DatadogConfiguration` |
+| `LoggingConfiguartion` | `DatadogLoggingConfiguration` |
+| `RumConfiguration` | `DatadogRumConfiguration` |
+| `DdSdkExistingConfiguration` | `DatadogAttachConfiguration` |
+
+The following properties have changed:
+
+| `1.x` | `2.x` | Notes |
+|-------|-------|-------|
+| `DdSdkConfiguration.trackingConsent`| Removed | Part of `Datadog.initialize` | |
+| `DdSdkConfiguration.customEndpoint` | Removed | Now configured per-feature | |
+| `DdSdkConfiguration.serviceName` | `DatadogConfiguration.service` | |
+| `DdSdkConfiguration.logEventMapper` | `DatadogLoggingConfiguration.eventMapper` | |
+| `DdSdkConfiguration.customLogsEndpoint` | `DatadogLoggingConfiguration.customEndpoint` | |
+| `DdSdkConfiguration.telemetrySampleRate` | `DatadogRumConfiguration.telemetrySampleRate` | |
+
+In addition, the following APIs have changed:
+
+| `1.x` | `2.x` | Notes |
+|-------|-------|-------|
+| `Verbosity` | Removed | See `CoreLoggerLevel` or `LogLevel` |
+| `DdLogs DatadogSdk.logs` | `DatadogLogging DatadogSdk.logs` | Type changed |
+| `DdRum DatadogSdk.rum` | `DatadogRum DatadogSdk.rum` | Type changed
+| `Verbosity DatadogSdk.sdkVerbosity` | `CoreLoggerLevel DatadogSdk.sdkVerbosity` |
+| `DatadogSdk.runApp` | `DatadogSdk.runApp` | Added `trackingConsent` parameter |
+| `DatadogSdk.initialize` | `DatadogSdk.initialize` | Added `trackingConsent` parameter |
+| `DatadogSdk.createLogger` | `DatadogLogging.createLogger` | Moved |
+
+## Flutter Web Changes
+
+Clients using Flutter Web should update to using the Datadog Browser SDK v5.  Change the following import in your `index.html`:
+
+```diff
+-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-logs-v4.js"></script>
+-  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/datadog-rum-slim-v4.js"></script>
++  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-logs.js"></script>
++  <script type="text/javascript" src="https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum-slim.js"></script>
+```
+
+Note that Datadog provides one CDN bundle per site. See the [Browser SDK README](https://github.com/DataDog/browser-sdk/#cdn-bundles) for a list of all site URLs.
+
+## Logs Product Changes
+
+As with `1.x`, Datadog Logging can be enabled by setting the `DatadogConfiguration.loggingConfiguration` member. However, unlike `1.x`, Datadog will not create a default logger for you. `DatadogSdk.logs` is now and instance of `DatadogLogging`, which can be used to create logs. Many options were moved to `DatadogLoggerConfiguration` to give developers more granular support over individual loggers.
+
+The following APIs have changed:
+
+| `1.x` | `2.x` | Notes |
+|-------|-------|-------|
+| `LoggingConfiguration` | `DatadogLoggingConfiguration` | Rename, most members are now on `DatadogLoggerConfiguration` |
+| `LoggingConfiguration.sendNetworkInfo` | `DatadogLoggerConfiguration.networkInfoEnabled` | |
+| `LoggingConfiguration.printLogsToConsole` | `DatadogLoggerConfiguration.customConsoleLogFunction` | |
+| `LoggingConfiguration.sendLogsToDatadog` | Removed. Use `remoteLogThreshold` instead | |
+| `LoggingConfiguration.datadogReportingThreshold` | `DatadogLoggerConfiguration.remoteLogThreshold` | |
+| `LoggingConfiguration.bundleWithRum` | `DatadogLoggerConfiguration.bundleWithRumEnabled` | |
+| `LoggingConfiguration.bundleWithTrace` | `DatadogLoggerConfiguration.bundleWithTraceEnabled` | |
+| `LoggingConfiguration.loggerName` | `DatadogLoggerConfiguration.name` | |
+| `LoggingConfiguration.sampleRate` | `DatadogLoggerConfiguration.remoteSampleRate` | |
+
+## RUM Product Changes
+
+The following APIs have changed:
+
+| `1.x` | `2.x` | Notes |
+|-------|-------|-------|
+| `RumConfiguration` | `DatadogRumConfiguration` | Type renamed |
+| `RumConfiguration.vitalsUpdateFrequency` | `DatadogRumConfiguration.vitalsUpdateFrequency` | Set to `null` to disable vitals updates |
+| `RumConfiguration.tracingSampleRate` | `DatadogRumConfiguration.traceSampleRate` |
+| `RumConfiguration.rumViewEventMapper` | `DatadogRumConfiguration.viewEventMapper` |
+| `RumConfiguration.rumActionEventMapper` | `DatadogRumConfiguration.actionEventMapper` |
+| `RumConfiguration.rumResourceEventMapper` | `DatadogRumConfiguration.resourceEventMapper` |
+| `RumConfiguration.rumErrorEventMapper` | `DatadogRumConfiguration.rumErrorEventMapper` |
+| `RumConfiguration.rumLongTaskEventMapper` | `DatadogRumConfiguration.longTaskEventMapper` |
+| `RumUserActionType` | `RumActionType` | Type renamed |
+| `DdRum.addUserAction` | `DdRum.addAction` | |
+| `DdRum.startUserAction` | `DdRum.startAction` | |
+| `DdRum.stopUserAction` | `DdRum.stopAction` | |
+| `DdRum.startResourceLoading` | `DdRum.startResource` | |
+| `DdRum.stopResourceLoading` | `DdRum.stopResource` | |
+| `DdRum.stopResourceLoadingWithError` | `DdRum.stopResourceWithError` | |
+
+Additionally, event mappers no longer allow you to modify their view names. To rename a view, use a custom [`ViewInfoExtractor`](https://pub.dev/documentation/datadog_flutter_plugin/latest/datadog_flutter_plugin/ViewInfoExtractor.html) instead.
+
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Flutter v2 was released a bit back but the migration guide was not added to docs.

refs: RUM-3122

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
