### PR TITLE
Temporarily make JSON property Tags required

### DIFF
--- a/content/en/cloud_cost_management/custom.md
+++ b/content/en/cloud_cost_management/custom.md
@@ -56,7 +56,7 @@ To use Custom Costs in Datadog, you must [configure Cloud Cost Management][1] fo
 |`BilledCost`| The amount being charged. |10.00 |NaN | Number-based decimal. |
 |`BillingCurrency` | Currency of billed cost. | USD| EUR | Must be USD. |
 
-#### Optional Tags within JSON Files
+#### Optional tags within JSON files
 
 For JSON files only, an additional `Tags` property is required, but its contents are optional.
 

--- a/content/en/cloud_cost_management/custom.md
+++ b/content/en/cloud_cost_management/custom.md
@@ -60,7 +60,7 @@ To use Custom Costs in Datadog, you must [configure Cloud Cost Management][1] fo
 
 For JSON files only, an additional `Tags` property is required, but its contents are optional.
 
-To tag a JSON line item with tags like `team:web` and `service:ops`, then add:
+To tag a JSON line item with tags like `team:web` and `service:ops`, add:
 ```
 "Tags": {
     "team": "web",
@@ -68,7 +68,7 @@ To tag a JSON line item with tags like `team:web` and `service:ops`, then add:
 }
 ```
 
-If a line item does _not_ contain additional tags, then add:
+If a line item does _not_ contain additional tags, add:
 ```
 "Tags": {}
 ```

--- a/content/en/cloud_cost_management/custom.md
+++ b/content/en/cloud_cost_management/custom.md
@@ -56,6 +56,23 @@ To use Custom Costs in Datadog, you must [configure Cloud Cost Management][1] fo
 |`BilledCost`| The amount being charged. |10.00 |NaN | Number-based decimal. |
 |`BillingCurrency` | Currency of billed cost. | USD| EUR | Must be USD. |
 
+#### Optional Tags within JSON Files
+
+For JSON files only, an additional `Tags` property is required, but its contents are optional.
+
+To tag a JSON line item with tags like `team:web` and `service:ops`, then add:
+```
+"Tags": {
+    "team": "web",
+    "service": "ops"
+}
+```
+
+If a line item does _not_ contain additional tags, then add:
+```
+"Tags": {}
+```
+
 ### Create a CSV or JSON file with required fields
 
 You can upload multiple CSV and JSON files, in either or both formats. Ensure that you don't upload the same file twice, since the cost will appear as doubled in the product.
@@ -131,8 +148,9 @@ Example of a valid JSON file:
         "ChargeDescription": "Video Usage",
         "ChargePeriodStart": "2023-01-01",
         "ChargePeriodEnd": "2023-12-31",
-        "BilledCost": 100,
-        "BillingCurrency": "USD"
+        "BilledCost": 100.00,
+        "BillingCurrency": "USD",
+        "Tags": {}
     }
 ]
 ```
@@ -146,8 +164,9 @@ Example of an invalid JSON file:
         "chargedescription": "Video Usage",
         "chargeperiodstart": "2023-01-01",
         "chargeperiodend": "2023-12-31",
-        "billedcost": 100,
-        "billingcurrency": "USD"
+        "billedcost": 100.00,
+        "billingcurrency": "USD",
+        "tags": {}
     }
 ]
 ```
@@ -213,7 +232,7 @@ Example of a valid JSON file:
         "ChargeDescription": "Video Usage",
         "ChargePeriodStart": "2023-01-01",
         "ChargePeriodEnd": "2023-12-31",
-        "BilledCost": 100,
+        "BilledCost": 100.00,
         "BillingCurrency": "USD",
         "Tags": {
             "team": "web",


### PR DESCRIPTION
### Change

To temporarily mitigate a Public Beta issue with Custom Costs JSON file uploads, make `Tags` a required JSON property that can be empty.

<img width="837" alt="image" src="https://github.com/DataDog/documentation/assets/17853509/674ff457-1d1c-4caa-8267-22bf24217bc7">
