### PR TITLE
[APM > Runtime Metrics > .NET] add .NET 8 as supported runtime

### DIFF
--- a/content/en/tracing/metrics/runtime_metrics/dotnet.md
+++ b/content/en/tracing/metrics/runtime_metrics/dotnet.md
@@ -29,6 +29,7 @@ further_reading:
 - .NET 5
 - .NET 6
 - .NET 7
+- .NET 8
  
 ## Automatic configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add .NET 8 to the list of supported runtime in the Runtime Metrics page for .NET.
We added general support for .NET 8 a few months ago and neglected to update this page. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
n/a

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->