### PR TITLE
Make it more clear than enterprise account means Infra Enterprise SKU

### DIFF
--- a/content/en/account_management/scim/_index.md
+++ b/content/en/account_management/scim/_index.md
@@ -29,7 +29,7 @@ Datadog supports using SCIM with the Azure Active Directory (Azure AD) and Okta 
 
 ### Prerequisites
 
-Using SCIM with Datadog requires an enterprise account.
+Using SCIM with Datadog requires an Infrastructure Enterprise account.
 
 This documentation assumes your organization manages user identities using an identity provider.
 

--- a/content/en/account_management/scim/_index.md
+++ b/content/en/account_management/scim/_index.md
@@ -29,7 +29,7 @@ Datadog supports using SCIM with the Azure Active Directory (Azure AD) and Okta 
 
 ### Prerequisites
 
-Using SCIM with Datadog requires an Infrastructure Enterprise account.
+SCIM in Datadog is an advanced feature included in the Enterprise plan.
 
 This documentation assumes your organization manages user identities using an identity provider.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

A customer has to be on Infra Enterprise (aka paying for Enterprise hosts) to have the SCIM feature available (We consider SCIM under Advanced Administrative Tools on https://www.datadoghq.com/pricing/?product=infrastructure#products)

One customer expressed confusion because they thought it was required to be in the "enterprise sales segment" which is just how many employees their company has and not related to how much they pay for Datadog. So I want to clarify that.

I think maybe it's better to say Enterprise plan over account: another enterprise-only feature Usage Attribution is called out here, so my thought is to make it more consistent btwn these 2 pages https://docs.datadoghq.com/account_management/billing/usage_attribution/

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->