### PR TITLE
Make it more clear the minimum Agent version for all CSM components

### DIFF
--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -32,6 +32,8 @@ further_reading:
 <div class="alert alert-warning">Cloud Security Management Misconfigurations is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
+## Overview
+
 Cloud Security Management (CSM) delivers real-time threat detection and continuous configuration audits across your entire cloud infrastructure, all in a unified view for seamless collaboration and faster remediation.
 
 CSM is available in three packages: [CSM Enterprise][1], [CSM Pro][2], and [CSM Workload Security][3]. For more information, see [Changes to Datadog Cloud Security Management][7]. Each package includes access to a specific set of **features**, as shown in the following table:
@@ -57,9 +59,17 @@ CSM is available in three packages: [CSM Enterprise][1], [CSM Pro][2], and [CSM 
 
 **Note**: You can enable features that aren't included in your package at any time by following the instructions on the [CSM Setup page][4].
 
-## Supported deployment types and features
+## Prerequsites
 
-| Type          | Agent Required (7.46+) | CSM Misconfigurations | CSM Threats | CSM Vulnerabilities | CSM Identity Risks |
+The following table summarizes the CSM features available relative to each deployment type.
+
+- The **minimum** Datadog Agent version required for CSM is `7.46` or higher.
+
+<div class="alert alert-info">For more details, click each of the CSM feature headings to review additional requirements for that feature.</div>
+
+### Supported deployment types and features
+
+| Type          | Agent Required (7.46+) | CSM Misconfigurations | [CSM Threats][8]| [CSM Vulnerabilities][9] | [CSM Identity Risks][10] |
 |---------------|------------------------|-----------------------|-------------|---------------------|--------------------|
 | Docker        | {{< X >}}              | {{< X >}}             | {{< X >}}   |                     |                    |
 | Kubernetes    | {{< X >}}              | {{< X >}}             | {{< X >}}   | {{< X >}}           |                    |
@@ -71,9 +81,50 @@ CSM is available in three packages: [CSM Enterprise][1], [CSM Pro][2], and [CSM 
 | Windows       | {{< X >}}              |                       | beta        |                     |                    |
 | AWS Fargate   | {{< X >}}              |                       | beta        |                     |                    |
 
-**Note**: The minimum Datadog Agent version required for all CSM components is `7.46` or higher.
+The following tables represent additional prerequisites relative to each CSM feature.
 
-{{% csm-prereqs %}}
+### CSM Threats
+
+CSM Threats supports the following Linux distributions:
+
+| Linux Distributions        | Supported Versions                    |
+| ---------------------------| --------------------------------------|
+| Ubuntu LTS                 | 18.04, 20.04, 22.04                   |
+| Debian                      | 10 or later                           |
+| Amazon Linux 2              | Kernels 4.15, 5.4, 5.10, and 2023      |
+| SUSE Linux Enterprise Server| 12 and 15                              |
+| Red Hat Enterprise Linux    | 7, 8, and 9                            |
+| Oracle Linux                | 7, 8, and 9                            |
+| CentOS                      | 7                                     |
+
+**Notes:**
+
+- Custom kernel builds are not supported.
+- For compatibility with a custom Kubernetes network plugin like Cilium or Calico, see the [Troubleshooting page][102].
+- Data collection is done using eBPF, so Datadog minimally requires platforms that have underlying Linux kernel versions of 4.15.0+ or have eBPF features backported.
+
+### CSM Vulnerabilities
+
+| Component                | Version/Requirement                     |
+| ------------------------ | ----------------------------------------|
+| [Helm Chart][103]            | v3.49.6 or later (Kubernetes only)      |
+| [containerd][104]              | v1.5.6 or later (Kubernetes and hosts only)|
+
+**Note**: CSM Vulnerabilities is **not** available for the following container runtimes:
+
+  - CRI-O runtime
+  - podman runtime
+
+### CSM Identity Risks
+
+<div class="alert alert-info"><strong>Note</strong>: At this time, CSM Identity Risks is available for AWS only.</div>
+
+To use CSM Identity Risks, you must [enable resource collection for AWS][105]. If you've already done this, no additional setup is required.
+
+**Notes**: 
+
+- If you've [enabled CSM Misconfigurations for your AWS accounts][106], you already have cloud resource collection enabled.
+- Although not required, when you [enable CloudTrail logs forwarding][107], you get additional insights based on the actual usage (or non-usage) of resources in your infrastructure, for example, users and roles with significant gaps between provisioned and used permissions.
 
 ## Next steps
 
@@ -90,4 +141,14 @@ To get started setting up CSM, navigate to the [**Security** > **Setup**][4] sec
 [5]: /security/identity_risks/#setup
 [6]: /security/cloud_security_management/setup/compatibility
 [7]: https://www.datadoghq.com/blog/cloud-security-management-changes/
+[8]: /security/cloud_security_management/setup/#csm-threats
+[9]: /security/cloud_security_management/setup/#csm-vulnerabilities
+[10]: /security/cloud_security_management/setup/#csm-identity-risks
+[102]: /security/cloud_security_management/troubleshooting
+[103]: /containers/kubernetes/installation/?tab=helm
+[104]: https://kubernetes.io/docs/tasks/administer-cluster/migrating-from-dockershim/find-out-runtime-you-use/
+[105]: /integrations/amazon_web_services/?tab=roledelegation#cloud-security-posture-management
+[106]: /security/cloud_security_management/setup/csm_enterprise?tab=aws#enable-resource-scanning-for-cloud-accounts
+[107]: /security/cloud_security_management/setup/csm_enterprise/?tab=aws#enable-cloudtrail-logs-forwarding
+
 

--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -71,6 +71,8 @@ CSM is available in three packages: [CSM Enterprise][1], [CSM Pro][2], and [CSM 
 | Windows       | {{< X >}}              |                       | beta        |                     |                    |
 | AWS Fargate   | {{< X >}}              |                       | beta        |                     |                    |
 
+**Note**: The minimum Datadog Agent version required for all CSM components is `7.46` or higher.
+
 {{% csm-prereqs %}}
 
 ## Next steps


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
A support ticket came in where the customer as well as the Support Engineer were not able to easily identify which version of the Agent is required at minimum for the CSM features. Adding additional information to make that more clear.

More work needs to be done on this page, but would like to get this small change published, as it's needed in the short term.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->