### PR TITLE
Flamegraphs retention 15 days --> 30 days

### DIFF
--- a/content/en/tracing/faq/trace_sampling_and_storage.md
+++ b/content/en/tracing/faq/trace_sampling_and_storage.md
@@ -377,7 +377,7 @@ Note that trace priority should be manually controlled only before any context p
 
 ## Trace storage
 
-Individual traces are stored for 15 days. This means that all **sampled** traces are retained for a period of 15 days and at the end of the 15th day, the entire set of expired traces is deleted. In addition, once a trace has been viewed by opening a full page, it continues to be available by using its trace ID in the URL: `{{< region-param key="dd_full_site" >}}/apm/trace/<TRACE_ID>`. This is true even if it "expires" from the UI. This behavior is independent of the UI retention time buckets.
+Individual traces are stored for 30 days. This means that all **sampled** traces are retained for a period of 30 days and at the end of the 30th day, the entire set of expired traces is deleted. In addition, once a trace has been viewed by opening a full page, it continues to be available by using its trace ID in the URL: `{{< region-param key="dd_full_site" >}}/apm/trace/<TRACE_ID>`. This is true even if it "expires" from the UI. This behavior is independent of the UI retention time buckets.
 
 {{< img src="tracing/guide/trace_sampling_and_storage/trace_id.png" alt="Trace ID" >}}
 


### PR DESCRIPTION


### What does this PR do? What is the motivation?
Flamegraphs retention 15 days --> 30 days so it's consistent with the information in https://docs.datadoghq.com/developers/guide/data-collection-resolution-retention/#pagetitle



- [ x] Please merge after reviewing
