### PR TITLE
Data Jobs Monitoring - Additional tracer options for EMR init script

### DIFF
--- a/static/resources/sh/data_jobs/datadog_emr_job_monitoring_init_v2.sh
+++ b/static/resources/sh/data_jobs/datadog_emr_job_monitoring_init_v2.sh
@@ -36,6 +36,10 @@ additional_environment_variables:
     value: false
   - key: DD_INTEGRATION_SPARK_ENABLED
     value: true
+  - key: DD_TRACE_AGENT_URL
+    value: http://localhost:8126
+  - key: DD_TRACE_EXPERIMENTAL_LONG_RUNNING_ENABLED
+    value: true
 EOF
 
 # Adding tags


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adding those two new options:
- DD_TRACE_AGENT_URL=http://localhost:8126 to force http protocol. Not using http caused some issues on ARM
- DD_TRACE_EXPERIMENTAL_LONG_RUNNING_ENABLED=true to enable long running traces by default

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->