### PR TITLE
fix: call trace_id off of span

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/python.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/python.md
@@ -89,7 +89,7 @@ If you are not using the standard library `logging` module, you can use the foll
 from ddtrace import tracer
 
 span = tracer.current_span()
-correlation_ids = (str((1 << 64) - 1 & trace_id), span.span_id) if span else (None, None)
+correlation_ids = (str((1 << 64) - 1 & span.trace_id), span.span_id) if span else (None, None)
 ```
 As an illustration of this approach, the following example defines a function as a *processor* in `structlog` to add tracer fields to the log output:
 
@@ -102,7 +102,7 @@ import structlog
 def tracer_injection(logger, log_method, event_dict):
     # get correlation ids from current tracer context
     span = tracer.current_span()
-    trace_id, span_id = (str((1 << 64) - 1 & trace_id), span.span_id) if span else (None, None)
+    trace_id, span_id = (str((1 << 64) - 1 & span.trace_id), span.span_id) if span else (None, None)
 
     # add ids to structlog event dictionary
     event_dict['dd.trace_id'] = str(trace_id or 0)


### PR DESCRIPTION
### What does this PR do? What is the motivation?
When trying to implement the code snippet from the docs, `trace_id` was not defined. Looking through git history, it looks like calling `trace_id` off of span was accidentally dropped off in [this PR](https://github.com/DataDog/documentation/pull/21565/files).

### Merge instructions

- [X] Please merge after reviewing