### PR TITLE
[PROF-9132] document Go custom profiler annotations

### DIFF
--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -86,6 +86,26 @@ try (var scope = Profiling.get().newScope()) {
 {{< /code-block >}}
 
 
+## Isolate your own business logic (Go)
+
+The Go profiler supports custom annotations for your business logic as of version v1.60.0. To add annotations, use [profiler labels](https://pkg.go.dev/runtime/pprof#Do) like so:
+
+{{< code-block lang="go" >}}
+pprof.Do(ctx, pprof.Labels("customer_name", <value>), func(context.Context) {
+  /* customer-specific logic here */
+})
+{{< /code-block >}}
+
+Add the [WithCustomProfilerLabelKeys](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithCustomProfilerLabelKeys) option when starting the profiler to specify which label keys you want use for filtering:
+
+{{< code-block lang="go" >}}
+profiler.Start(
+  profiler.WithCustomProfilerLabelKeys("customer_name"),
+  /* other options */
+)
+{{< /code-block>}}
+
+Then, open CPU or goroutine profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
 
 
 ## Further reading

--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -88,7 +88,7 @@ try (var scope = Profiling.get().newScope()) {
 
 ## Isolate your own business logic (Go)
 
-The Go profiler supports custom annotations for your business logic as of version v1.60.0. To add annotations, use [profiler labels](https://pkg.go.dev/runtime/pprof#Do) like so:
+The Go profiler supports custom annotations for your business logic as of version v1.60.0. To add annotations, use [profiler labels][1] like so:
 
 {{< code-block lang="go" >}}
 pprof.Do(ctx, pprof.Labels("customer_name", <value>), func(context.Context) {
@@ -96,7 +96,7 @@ pprof.Do(ctx, pprof.Labels("customer_name", <value>), func(context.Context) {
 })
 {{< /code-block >}}
 
-Add the [WithCustomProfilerLabelKeys](https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithCustomProfilerLabelKeys) option when starting the profiler to specify which label keys you want use for filtering:
+To specify which label keys you want use for filtering, add the [WithCustomProfilerLabelKeys][2] option when starting the profiler:
 
 {{< code-block lang="go" >}}
 profiler.Start(
@@ -107,7 +107,9 @@ profiler.Start(
 
 Then, open CPU or goroutine profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
 
-
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://pkg.go.dev/runtime/pprof#Do
+[2]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithCustomProfilerLabelKeys

--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -77,10 +77,13 @@ In the previous image, notice that the `ModelTraining` operation is taking more 
 
 ## Isolate your own business logic
 
+Endpoint and operation isolation is available in your profiles by default, but you may want to isolate a different piece of logic. For example, if the monolith is sensitive to specific customers, you can add a custom filter to the profiles:
+
 {{< programming-lang-wrapper langs="java,go" >}}
 {{< programming-lang lang="java">}}
 
-Endpoint and operation isolation is available in your profiles by default, but you may want to isolate a different piece of logic. For example, if the monolith is sensitive to specific customers, you can add a custom filter to the profiles:
+
+Set a context value for the customer name like so:
 
 ```java
 try (var scope = Profiling.get().newScope()) {
@@ -88,6 +91,8 @@ try (var scope = Profiling.get().newScope()) {
    <logic goes here>
 }
 ```
+
+Then, open CPU, Exceptions or Wall Time profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
 
 
 {{< /programming-lang >}}

--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -74,42 +74,50 @@ The APM `Trace operation` attribute lets you filter and group a flame graph with
 
 In the previous image, notice that the `ModelTraining` operation is taking more CPU time than its primary use in the `GET /train` endpoint, so it must be used elsewhere. Click the operation name to determine where else it is used. In this case, `ModelTraining` is also use by `POST /update_model`.
 
-## Isolate your own business logic (Java)
+
+## Isolate your own business logic
+
+{{< programming-lang-wrapper langs="java,go" >}}
+{{< programming-lang lang="java">}}
 
 Endpoint and operation isolation is available in your profiles by default, but you may want to isolate a different piece of logic. For example, if the monolith is sensitive to specific customers, you can add a custom filter to the profiles:
 
-{{< code-block lang="java" >}}
+```java
 try (var scope = Profiling.get().newScope()) {
    scope.setContextValue("customer_name", <the customer name value>);
    <logic goes here>
 }
-{{< /code-block >}}
+```
 
 
-## Isolate your own business logic (Go)
+{{< /programming-lang >}}
+{{< programming-lang lang="go">}}
 
 The Go profiler supports custom annotations for your business logic as of version v1.60.0. To add annotations, use [profiler labels][1] like so:
 
-{{< code-block lang="go" >}}
+```go
 pprof.Do(ctx, pprof.Labels("customer_name", <value>), func(context.Context) {
   /* customer-specific logic here */
 })
-{{< /code-block >}}
+```
 
 To specify which label keys you want use for filtering, add the [WithCustomProfilerLabelKeys][2] option when starting the profiler:
 
-{{< code-block lang="go" >}}
+```go
 profiler.Start(
   profiler.WithCustomProfilerLabelKeys("customer_name"),
   /* other options */
 )
-{{< /code-block>}}
+```
 
 Then, open CPU or goroutine profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
+
+[1]: https://pkg.go.dev/runtime/pprof#Do
+[2]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithCustomProfilerLabelKeys
+{{< /programming-lang >}}
+{{< /programming-lang-wrapper >}}
+
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
-[1]: https://pkg.go.dev/runtime/pprof#Do
-[2]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithCustomProfilerLabelKeys

--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -92,7 +92,7 @@ try (var scope = Profiling.get().newScope()) {
 }
 ```
 
-Then, open CPU, Exceptions or Wall Time profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
+Then, open CPU, Exceptions, or Wall Time profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
 
 
 {{< /programming-lang >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We've added a public API to support user-provided annotations which
whill appear in Go CPU and goroutine profiles. Document how to use them.
The advice on the "Isolate Outliers in Monolothic Services" is relevant
to this, and most of it applies to Go just as much as Java. Put the
Go-specific bits there.

### Merge instructions

- [ ] Please merge after reviewing

### Additional notes
