### PR TITLE
Fixing reference to Application Vulnerability Management

### DIFF
--- a/content/en/getting_started/devsecops/_index.md
+++ b/content/en/getting_started/devsecops/_index.md
@@ -7,7 +7,7 @@ This guide introduces the DevSecOps bundles with links to setup instructions to 
 
 ## APM DevSecOps
 
-The APM DevSecOps bundles combine [Application Performance Monitoring (APM)][4] with the [Application Vulnerability Management][1] capabilities of [Application Security Management (ASM)][2].
+The APM DevSecOps bundles combine [Application Performance Monitoring (APM)][4] with the [Application Vulnerability Management][3] capabilities of [Application Security Management (ASM)][2].
 
 {{< tabs >}}
 {{% tab "APM DevSecOps" %}}
@@ -21,9 +21,9 @@ To get started with APM DevSecOps, [install and configure the Datadog Agent][5] 
 - [APM][6]
 - [Universal Service Monitoring][7]
 
-After you install the Agent, enable ASM for your environment.
+After you install the Agent, enable AVM for your environment.
 
-- [Application Security Management][8]
+- [Application Vulnerability Management][10]
 
 ### Next steps
 
@@ -42,6 +42,7 @@ Learn more about the features included with APM DevSecOps:
 [7]: /universal_service_monitoring/setup/
 [8]: /security/application_security/enabling/
 [9]: /tracing/metrics/
+[10]: /getting_started/application_security/vulnerability_management/
 
 {{% /tab %}}
 {{% tab "APM DevSecOps Pro" %}}
@@ -56,9 +57,9 @@ To get started with APM DevSecOps Pro, [install and configure the Datadog Agent]
 - [Universal Service Monitoring][8]
 - [Data Streams Monitoring][9]
 
-After you install the Agent, configure ASM for your environment.
+After you install the Agent, configure Application Vulnerability Management for your environment.
 
-- [Application Security Management][10]
+- [Application Vulnerability Management][10]
 
 #### Next steps
 
@@ -78,7 +79,7 @@ Learn more about the features included with APM DevSecOps Pro:
 [7]: /tracing/trace_collection/
 [8]: /universal_service_monitoring/setup/
 [9]: /data_streams/#setup
-[10]: /security/application_security/enabling/
+[10]: /getting_started/application_security/vulnerability_management/
 [11]: /tracing/metrics/
 
 {{% /tab %}}
@@ -97,7 +98,7 @@ To get started with APM DevSecOps Enterprise, [install and configure the Datadog
 
 After you install the Agent, configure ASM for your environment.
 
-- [Application Security Management][12]
+- [Application Security Management][14]
 
 ### Next steps
 
@@ -122,6 +123,7 @@ Learn more about the features included with APM DevSecOps Enterprise:
 [11]: /profiler/enabling
 [12]: /security/application_security/enabling/
 [13]: /tracing/metrics/
+[14]: /getting_started/application_security/vulnerability_management/
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/getting_started/devsecops/_index.md
+++ b/content/en/getting_started/devsecops/_index.md
@@ -7,7 +7,7 @@ This guide introduces the DevSecOps bundles with links to setup instructions to 
 
 ## APM DevSecOps
 
-The APM DevSecOps bundles combine [Application Performance Monitoring (APM)][4] with the [Application Vulnerability Management][3] capabilities of [Application Security Management (ASM)][2].
+The APM DevSecOps bundles combine [Application Performance Monitoring (APM)][4] with the [Application Vulnerability Management][10] capabilities of [Application Security Management (ASM)][2].
 
 {{< tabs >}}
 {{% tab "APM DevSecOps" %}}


### PR DESCRIPTION
The DevSecOps bundle include Application Vulnerability Management capabilities. The setup link takes the user to the ASM general setup page, which may lead to activations of Threat Management capabilities, which are not included in teh bundle

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->