### PR TITLE
Add table to list the different TrackingConsent values for the Mobile SDK

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/_index.md
@@ -48,7 +48,7 @@ To update the tracking consent after the SDK is initialized, call `Datadog.setTr
 - `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
 - `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
 
-Note that the values to use differ between the different SDK to follow common capitalization patterns:
+**Note**: The `TrackingConsent` values do not use the same capitalization patterns across the SDK languages:
 
 Android | iOS, React Native and Flutter | Unity
 --- | --- | ---

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/_index.md
@@ -48,6 +48,14 @@ To update the tracking consent after the SDK is initialized, call `Datadog.setTr
 - `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
 - `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
 
+Note that the values to use differ between the different SDK to follow common capitalization patterns:
+
+Android | iOS, React Native and Flutter | Unity
+--- | --- | ---
+`PENDING` | `pending` | `Pending`
+`GRANTED` | `granted` | `Granted`
+`NOT_GRANTED` | `not_granted` | `NotGranted`
+
 ### Sending data when device is offline
 
 RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The `TrackingConsent` values may differ from one SDK to the other as we are using common capitalisation rules for each language. This PR clarifies the different values in a table.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
None