### PR TITLE
Add Session Replay support for native Android & iOS

### DIFF
--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -139,7 +139,7 @@ Agent (v7.36.1)
 
 #### Events
 
-In the Datadog UI, go to the Events Managment Page **Service Mgmt > Event Management**. The Agent sends events to Datadog when an Agent is started or restarted. The following message displays if your Agent successfully installs:
+In the Datadog UI, go to the Events Management Page **Service Mgmt > Event Management**. The Agent sends events to Datadog when an Agent is started or restarted. The following message displays if your Agent successfully installs:
 
 ```text
 Datadog agent (v. 7.XX.X) started on <Hostname>

--- a/content/en/infrastructure/containers/orchestrator_explorer.md
+++ b/content/en/infrastructure/containers/orchestrator_explorer.md
@@ -233,7 +233,7 @@ Additionally, resources contain a `kube_<api_kind>:<metadata.name>` tag. For exa
 > - Pods use `pod_name` instead.
 > - *VPAs: `verticalpodautoscaler`*.
 > - *VPHs: `horizontalpodautoscaler`*.
-> - *Persistant Volume Claims: `persistantvolumeclaim`*.
+> - *Persistent Volume Claims: `persistentvolumeclaim`*.
 
 Based on the labels attached to the resource, the following tags will also be extracted:
 
@@ -270,7 +270,7 @@ Pods are given the following tags:
 
 #### Workloads
 
-Workload resources (pods, deployments, stateful sets, etc.) will have the following tags, indiciating their support within the Resources Utilization page:
+Workload resources (pods, deployments, stateful sets, etc.) will have the following tags, indicating their support within the Resources Utilization page:
 
 - `resource_utilization` (`supported` or `unsupported`)
 - `missing_cpu_requests`
@@ -301,7 +301,7 @@ Some resources have specific tags that are extracted based on your cluster's env
 
 ### Resource Utilization Filters
 
-The following workload resouces are enriched with resource utilization metrics:
+The following workload resources are enriched with resource utilization metrics:
 
 - Clusters
 - Daemonsets
@@ -313,7 +313,7 @@ The following workload resouces are enriched with resource utilization metrics:
 
 These metrics are calculated at the time of collection, based on the average values over the last 15 minutes. You can filter by metric values like so: `metric#<metric_name><comparator><numeric_value>`.
 
-- `metric_name` is an availbale metric (see below)
+- `metric_name` is an available metric (see below)
 - `comparator` is a supported [comparator](#comparator)
 - and `numeric_value` is a floating poing value.
 

--- a/content/en/real_user_monitoring/_index.md
+++ b/content/en/real_user_monitoring/_index.md
@@ -99,7 +99,7 @@ The following table shows which RUM capabilities are supported on each platform:
 | Monitor platform-specific vitals | {{< X >}} | {{< X >}}  | {{< X >}}  | {{< X >}} | {{< X >}} |  |  |
 | Global context/attribute tracking in Logs  | {{< X >}} |  |  |  |  |  |  |
 | Client side tracing |  | {{< X >}} |  {{< X >}}|  |  |  |  |  |
-| Session Replay | {{< X >}} |  |  |  |  |  |  |
+| Session Replay | {{< X >}} | {{< X >}} | {{< X >}} |  |  |  | Mobile Session Replay is in public beta for native mobile apps. |
 | Heatmaps | {{< X >}} |  |  |  |  |  |  |
 | Frustration signals | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | Only partially supported for all **mobile** and **Roku** devices |
 

--- a/content/en/service_management/mobile/_index.md
+++ b/content/en/service_management/mobile/_index.md
@@ -232,7 +232,7 @@ You can also specify a dashboard that opens by default when you tap on an SLOs w
 - Long press on your home screen.
 - Tap the "+" button on the top left corner of the screen.
 - Search for "Datadog" widgets.
-- Select your prefered size (small shows one SLO and medium shows one SLO along with a visualized timeframe of its health).
+- Select your preferred size (small shows one SLO and medium shows one SLO along with a visualized timeframe of its health).
 - Drag the widget to your desired, on-screen location.
 
 
@@ -331,7 +331,7 @@ View your [monitors][16] from your home screen with Datadog widgets. Tap any cel
 - Long press on the home screen.
 - Tap the "+" button on the top left corner of the screen.
 - Search for "Datadog" widgets.
-- Select your prefered size (small shows two monitor saved views, medium allows up to three monitor saved views, and large up to six monitor saved views).
+- Select your preferred size (small shows two monitor saved views, medium allows up to three monitor saved views, and large up to six monitor saved views).
 - Drag the widget to your desired, on-screen location.
 
 
@@ -427,7 +427,7 @@ Long-press the app icon to display a quick-action sheet of your top five [Freque
 
 ## Shortcuts and Siri suggestions
 
-**Android**: Create shortcut icons for your dashboards by touching and holding the Datadog app icon, then lift your finger. If the app has shorcuts, it displays a list. Touch and hold the desired shortcut, then drag and drop it to another location on your screen to create a unique shortcut icon.
+**Android**: Create shortcut icons for your dashboards by touching and holding the Datadog app icon, then lift your finger. If the app has shortcuts, it displays a list. Touch and hold the desired shortcut, then drag and drop it to another location on your screen to create a unique shortcut icon.
 
 **iOS**: Create Siri Shortcuts for Datadog dashboards and monitors through the Shortcuts App. For a shortcut to be available for creation, you must execute the desired action at least once in the app. For example, to create an "Open AWS Overview Dashboard" shortcut, open the AWS Overview Dashboard in your mobile app at least once.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Session Replay has been available to public (at least public beta). I've tried it out myself using Datadog sample app and it works.

![session-replay-sample-app](https://github.com/DataDog/documentation/assets/5099600/648b963a-abab-4f74-a029-227cf7df903b)

There is also a documentation for Session Replay for Android & iOS here:
- https://docs.datadoghq.com/real_user_monitoring/session_replay/mobile/
- https://docs.datadoghq.com/real_user_monitoring/session_replay/mobile/setup_and_configuration/?tab=android
- https://docs.datadoghq.com/real_user_monitoring/session_replay/mobile/setup_and_configuration/?tab=ios

 I believe we can safely add this information in the index page of Real User Monitoring.

Additionally, I've also fixed some typos on several files to improve readability.

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
