### PR TITLE
Add a callout for chat on US holiday

### DIFF
--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -7,8 +7,8 @@ further_reading:
   text: "Agent Troubleshooting"
 ---
 
-{{< callout url="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/" >}}
-Please note that our US offices will be closed on Monday, February 19th in honor of President’s Day. We will be operating with limited staffing, and as a result, Live Chat will not be available on President’s Day for Standard Support customers during normal US business hours. Premier Support customers will retain access to chat 24x7x365. For any urgent issues, please contact us through our Support Portal.
+{{< callout header="false" >}}
+Our US offices are closed on Monday, February 19th for Presidents' Day. Support will be operating with limited staffing, and so Live Chat will not be available on Presidents' Day for Standard Support customers during normal US business hours. Premier Support customers retain access to chat 24x7x365. For urgent issues, contact us through the <a href="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/">Support Portal</a>.
 {{< /callout >}}
 ## Overview
 

--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -7,6 +7,9 @@ further_reading:
   text: "Agent Troubleshooting"
 ---
 
+{{< callout url="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/" >}}
+Please note that our US offices will be closed on Monday, February 19th in honor of President’s Day. We will be operating with limited staffing, and as a result, Live Chat will not be available on President’s Day for Standard Support customers during normal US business hours. Premier Support customers will retain access to chat 24x7x365. For any urgent issues, please contact us through our Support Portal.
+{{< /callout >}}
 ## Overview
 
 Datadog provides two primary channels for customers seeking support:


### PR DESCRIPTION
Adding a banner to our Support page informing customers that Live Chat will not be available on President's Day, February 19th 2024.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR adds a callout box to the top of this article, informing our customers that we will not be offering chat during the US Holiday of President's Day. It's intended to be on this docs page only temporarily, and I will submit another PR to remove it immediately after the holiday.


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- I think this should be merged no earlier than Wed Feb 14th.

### Additional notes
<!-- Anything else we should know when reviewing?-->
I've reached out about this on slack here: https://dd.slack.com/archives/C0DESMBQU/p1707779550610169

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->