### PR TITLE
[ci-visibility] Add known limitation around jest's `forceExit` option

### DIFF
--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -602,7 +602,7 @@ Cucumber's [parallel mode][16] is not supported. Tests run in parallel mode are 
 Jest's [test.concurrent][17] is not supported.
 
 ### Jest's `--forceExit`
-Jest's [--forceExit][21] option might cause data to be lost. We try to send data as soon as possible after your tests finish, but shutting down the process abruptly can cause some requests to fail. Use `--forceExit` with caution.
+Jest's [--forceExit][21] option may cause data loss. Datadog tries to send data immediately after your tests finish, but shutting down the process abruptly can cause some requests to fail. Use `--forceExit` with caution.
 
 ## Best practices
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Add a known limitation section around jest's [--forceExit](https://jestjs.io/docs/cli#--forceexit) option. This should help users troubleshoot potential issues with `dd-trace`.

### Merge instructions

- [x] Please merge after reviewing

### Additional notes

Preview: https://docs-staging.datadoghq.com/juan-fernandez/add-force-exit-limitation/tests/setup/javascript/?tab=cloudciprovideragentless#jests---forceexit
