### PR TITLE
Add documentation of JSON request and CSV file using the API

### DIFF
--- a/content/en/cloud_cost_management/custom.md
+++ b/content/en/cloud_cost_management/custom.md
@@ -29,7 +29,7 @@ Custom Cost is in public beta.
 
 ## Overview
 
-Custom Costs allow you to upload *any cost data source* to Datadog, so that you can understand the total cost of your services. 
+Custom Costs allow you to upload *any cost data source* to Datadog, so that you can understand the total cost of your services.
 
 Custom Costs accepts costs in pre-defined file structures (CSV or JSON). These files are aligned with the [FinOps FOCUS specification][2], and you can [upload multiple files in either format](#create-a-csv-or-json-file-with-required-fields). For example, you can upload a mix of CSV or JSON files as desired with 1+ line items (rows for CSV or objects for JSON).
 
@@ -156,8 +156,8 @@ Example of an invalid JSON file:
 
 {{% /tab %}}
 {{< /tabs >}}
-   
-### Add optional tags 
+
+### Add optional tags
 
 You can optionally add any number of tags to CSV or JSON files to allocate costs *after* the required fields as additional columns.
 
@@ -230,7 +230,7 @@ In this example, an additional `Tags` object property has been added with two ke
 
 ### Configure Custom Costs
 
-Once your data is formatted to the requirements above, upload your CSV and JSON files to Cloud Cost Management on [the **Custom Costs Uploaded Files** page][3] or programmatically by using the API. 
+Once your data is formatted to the requirements above, upload your CSV and JSON files to Cloud Cost Management on [the **Custom Costs Uploaded Files** page][3] or programmatically by using the API.
 
 {{< tabs >}}
 {{% tab "UI" %}}
@@ -242,9 +242,9 @@ Navigate to [**Cloud Costs** > **Settings** > **Uploaded Files**][101] and click
 [101]: https://app.datadoghq.com/cost/settings/cost-files
 
 {{% /tab %}}
-{{% tab "Programmatically" %}}
+{{% tab "API (file)" %}}
 
-To send a JSON file, use the `PUT api/v2/cost/custom_costs` API endpoint. 
+To send a file, use the `PUT api/v2/cost/custom_costs` API endpoint.
 
 Example with cURL:
 
@@ -256,9 +256,21 @@ curl -L -X PUT "api.datadoghq.com/api/v2/cost/custom_costs/" \
 -F "file=${file};type=text/json"
 ```
 {{% /tab %}}
+{{% tab "API (request)" %}}
+
+Send the content of the file though the API using the `PUT api/v2/cost/custom_costs` endpoint.
+
+```curl
+curl -L -X PUT "api.datadoghq.com/api/v2/cost/custom_costs/" \
+-H "Content-Type: application/json" \
+-H "DD-API-KEY: ${DD_API_KEY}" \
+-H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
+-d '${file_content}'
+```
+{{% /tab %}}
 {{< /tabs >}}
 
-Cost data appears after 24 hours. 
+Cost data appears after 24 hours.
 
 ## Cost metric types
 

--- a/content/en/cloud_cost_management/custom.md
+++ b/content/en/cloud_cost_management/custom.md
@@ -230,7 +230,7 @@ In this example, an additional `Tags` object property has been added with two ke
 
 ### Configure Custom Costs
 
-Once your data is formatted to the requirements above, upload your CSV and JSON files to Cloud Cost Management on [the **Custom Costs Uploaded Files** page][3] or programmatically by using the API.
+After your data is formatted to the requirements above, upload your CSV and JSON files to Cloud Cost Management on [the **Custom Costs Uploaded Files** page][3] or programmatically by using the API.
 
 {{< tabs >}}
 {{% tab "UI" %}}
@@ -258,7 +258,7 @@ curl -L -X PUT "api.datadoghq.com/api/v2/cost/custom_costs/" \
 {{% /tab %}}
 {{% tab "API (request)" %}}
 
-Send the content of the file though the API using the `PUT api/v2/cost/custom_costs` endpoint.
+Use the `PUT api/v2/cost/custom_costs` endpoint to send the content of the file with the API .
 
 ```curl
 curl -L -X PUT "api.datadoghq.com/api/v2/cost/custom_costs/" \


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We've recently added a way for customer to send cost file through the API using a request instead of a multi part file. This documentation change state this change

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

You can check the result here: https://docs-staging.datadoghq.com/julien.hemery/add-json-request-doc/cloud_cost_management/custom/?tab=csv