### PR TITLE
Rule removals

### DIFF
--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -105,6 +105,9 @@ def security_rules(content, content_dir):
             if not message_file_name.exists():
                 continue
 
+        # get path relative to the repo root for comparisons
+        relative_path = str(p.parent).split(f"/{content['repo_name']}/")[1]
+
         is_enabled = bool(data.get("isEnabled", True))
         is_beta = bool(data.get("isBeta", False))
 
@@ -118,9 +121,9 @@ def security_rules(content, content_dir):
         is_past_deprecation_date = date(*[int(x) for x in deprecation_date.split('-')]) < date.today() if deprecation_date else False
         # 3. general flags we should respect for removal. At least one true to cause removal
         is_removed = (data.get('isShadowDeployed', False) or data.get('isDeleted', False) or data.get('isDeprecated', False))
-        # 4. If rule not enabled and under infrastructure-monitoring directory lets remove the rule
-        # this is to cover the case where some rules exist that haven't been evaluated for use.
-        is_disabled_and_infra = not is_enabled and 'infrastructure-monitoring' in p.parent
+        # 4. If rule not enabled and under posture-management/infrastructure-monitoring directory lets remove the rule
+        # this is to cover the case where some rules were inherited that haven't been evaluated completely..
+        is_disabled_and_infra = not is_enabled and 'posture-management' in relative_path
 
         if is_restricted_and_not_beta or is_removed or is_past_deprecation_date or is_disabled_and_infra:
             if p.exists():
@@ -153,8 +156,6 @@ def security_rules(content, content_dir):
                 "is_beta": is_beta
             }
 
-            # get path relative to the repo root for comparisons
-            relative_path = str(p.parent).split(f"/{content['repo_name']}/")[1]
             # lets build up this categorization for filtering purposes
 
             tags = data.get('tags', [])

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Some rules are displaying which don't currently in the app e.g [cis-kubernetes-1.5.1-5.2.7](https://docs.datadoghq.com/security/default_rules/cis-kubernetes-1.5.1-5.2.7/)
Currently the best indicator for whether we should show or hide these is the isEnabled flag. So this PR specifically checks posture-management for this flag for display.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes

These rules are likely to be re-evaluated soon and potentially removed or flagged in otherways. So potentially this logic could be removed in the future.

This rule shouldn't exist
https://docs-staging.datadoghq.com/david.jones/rules/security/default_rules/cis-kubernetes-1.5.1-5.2.7/

This should populate with rules still but searching for something like NET_RAW shouldn't return any results
https://docs-staging.datadoghq.com/david.jones/rules/security/default_rules/