### PR TITLE
[PRODUCTSA-1093] Refine K8S Helm chart values

### DIFF
--- a/static/resources/yaml/observability_pipelines/v2/setup/aws_eks.yaml
+++ b/static/resources/yaml/observability_pipelines/v2/setup/aws_eks.yaml
@@ -1,0 +1,47 @@
+datadog:
+  ## The site parameter is based on the Datadog site you are using.
+  ## For example, the site URL for US1 is "datadoghq.com". See Datadog Site
+  ## for more information: https://docs.datadoghq.com/getting_started/site/
+  site: "datadoghq.com"
+
+## Autoscaling
+##
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+## HorizontalPodAutoscaler (HPA) requires resource requests to function,
+## so this example configures several default values. Datadog recommends
+## that you change the values to match the actual size of the instances that
+## you are using.
+resources:
+  requests:
+    cpu: 1000m
+    memory: 512Mi
+
+
+## To prevent a single datacenter from causing a complete system failure,
+## the topologySpreadConstraints in this example controls how OP Worker pods
+## are spread across your cluster among availability zones.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - observability-pipelines-worker
+
+
+## Load Balancing
+##
+service:
+  enabled: true
+  type: "ClusterIP"

--- a/static/resources/yaml/observability_pipelines/v2/setup/azure_aks.yaml
+++ b/static/resources/yaml/observability_pipelines/v2/setup/azure_aks.yaml
@@ -1,0 +1,47 @@
+datadog:
+  ## The site parameter is based on the Datadog site you are using.
+  ## For example, the site URL for US1 is "datadoghq.com". See Datadog Site
+  ## for more information: https://docs.datadoghq.com/getting_started/site/
+  site: "datadoghq.com"
+
+## Autoscaling
+##
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+## HorizontalPodAutoscaler (HPA) requires resource requests to function,
+## so this example configures several default values. Datadog recommends
+## that you change the values to match the actual size of the instances that
+## you are using.
+resources:
+  requests:
+    cpu: 1000m
+    memory: 512Mi
+
+
+## To prevent a single datacenter from causing a complete system failure,
+## the topologySpreadConstraints in this example controls how OP Worker pods
+## are spread across your cluster among availability zones.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - observability-pipelines-worker
+
+
+## Load Balancing
+##
+service:
+  enabled: true
+  type: "ClusterIP"

--- a/static/resources/yaml/observability_pipelines/v2/setup/google_gke.yaml
+++ b/static/resources/yaml/observability_pipelines/v2/setup/google_gke.yaml
@@ -1,0 +1,47 @@
+datadog:
+  ## The site parameter is based on the Datadog site you are using.
+  ## For example, the site URL for US1 is "datadoghq.com". See Datadog Site
+  ## for more information: https://docs.datadoghq.com/getting_started/site/
+  site: "datadoghq.com"
+
+## Autoscaling
+##
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+## HorizontalPodAutoscaler (HPA) requires resource requests to function,
+## so this example configures several default values. Datadog recommends
+## that you change the values to match the actual size of the instances that
+## you are using.
+resources:
+  requests:
+    cpu: 1000m
+    memory: 512Mi
+
+
+## To prevent a single datacenter from causing a complete system failure,
+## the topologySpreadConstraints in this example controls how OP Worker pods
+## are spread across your cluster among availability zones.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - observability-pipelines-worker
+
+
+## Load Balancing
+##
+service:
+  enabled: true
+  type: "ClusterIP"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Refactor OP Helm chart values for OPW2.0:

- Remove `datadog.apiKey` and `datadog.pipelineId` from values file; these secrets should be injected via **set** param: `helm install --set datadog.apiKey=<API_KEY>`
- Remove mounted volumes and disk buffering configurations; disk buffering should be disabled by default
- Remove Network LoadBalancer configurations; basic k8s service (`ClusterIP`) is sufficient enough for the quickstart/example setup

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

This is OPW2.0 work-in-progress.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->