### PR TITLE
Add algolia tags for metrics submission

### DIFF
--- a/content/en/metrics/_index.md
+++ b/content/en/metrics/_index.md
@@ -9,6 +9,7 @@ aliases:
 cascade:
     algolia:
         rank: 70
+        tags: ["submit metrics", "metrics submission"]
 ---
 This is an introduction to Metrics in Datadog and why they're useful. This section includes the following topics: 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Add algolia tags for "submit metrics" and "metrics submission" to the Metrics landing page.
- Entering "submit metrics datadog" sometimes points users to the Workflows Submit Metrics or other pages that are tangentially related.
- Bumping the main Metrics page as the main starting point for users.
- https://datadoghq.atlassian.net/browse/DOCS-7232
- https://datadoghq.atlassian.net/browse/WEB-3535

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->