### PR TITLE
Watchdog Cross-Product Insights in Log Management

### DIFF
--- a/content/en/logs/explorer/watchdog_insights.md
+++ b/content/en/logs/explorer/watchdog_insights.md
@@ -41,6 +41,8 @@ Every insight comes with embedded interactions and a side panel with troubleshoo
 
 ## Insight Types
 
+The [Watchdog Insights][8] carousel surfaces anomalies and outliers detected on specific tags, enabling you to investigate the root cause of an issue. [Insights][9] are discovered from APM, Continuous Profiler, Log Management, and Infrastructure data that include the service tag. Two Insights Types are specific to Log Management:
+
 ### Log Anomaly Detection
 
 Ingested logs are analyzed at the intake level where Watchdog performs aggregations on detected patterns as well as `environment`, `service`, `source` and `status` tags.
@@ -103,3 +105,5 @@ In the **full side panel** view, you can see:
 [5]: /logs/explorer/analytics/patterns
 [6]: https://app.datadoghq.com/watchdog
 [7]: /monitors/types/watchdog/
+[8]: /watchdog/
+[9]: /watchdog/insights/?tab=logmanagement#outlier-types

--- a/content/en/logs/explorer/watchdog_insights.md
+++ b/content/en/logs/explorer/watchdog_insights.md
@@ -41,7 +41,10 @@ Every insight comes with embedded interactions and a side panel with troubleshoo
 
 ## Insight Types
 
-The [Watchdog Insights][8] carousel surfaces anomalies and outliers detected on specific tags, enabling you to investigate the root cause of an issue. [Insights][9] are discovered from APM, Continuous Profiler, Log Management, and Infrastructure data that include the service tag. Two Insights Types are specific to Log Management:
+[Watchdog Insights][8] surfaces anomalies and outliers detected on specific tags, enabling you to investigate the root cause of an issue. [Insights][9] are discovered from APM, Continuous Profiler, Log Management, and infrastructure data that include the `service` tag. The two types of insights specific to Log Management are:
+
+- [Log Anomaly Detection](#log-anomaly-detection)
+- [Error Outliers](#error-outliers)
 
 ### Log Anomaly Detection
 


### PR DESCRIPTION
Add details to make it explicit that Insights found in the Log Explorer are now not only log but can come from other products.

### Merge instructions
- Do not merge yet, as we're still writing the release notes.