### PR TITLE
Update python.md release support table

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -22,8 +22,8 @@ Two release branches are supported:
 
 | Release    | Support level        |
 |------------|----------------------|
-| `<1`       | Maintenance           |
-| `>=1.0,<2` | General Availability |
+| `>=1.0,<2` | Maintenance          |
+| `>=2.0,<3` | General Availability |
 
 And the library supports the following runtimes:
 


### PR DESCRIPTION
Updated the release support table in our public docs to match those in our ddtrace docs https://ddtrace.readthedocs.io/en/stable/versioning.html#release-support

This notes that version 1.x of the tracer is in Maintenance level of support . Our public docs are not updated with this information and state that v1.x is still in General Availability support.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates the release support table in our Python compatibilities doc.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->