### PR TITLE
[.NET] [AAS] Update supported framework versions

### DIFF
--- a/content/en/serverless/azure_app_services/azure_app_services_windows.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_windows.md
@@ -57,6 +57,7 @@ The Datadog extension for Azure App Service provides additional monitoring capab
     - .NET 5
     - .NET 6
     - .NET 7
+    - .NET 8
 
 4. Datadog recommends doing regular updates to the latest version of the extension to ensure optimal performance, stability, and availability of features. Note that both the initial install and subsequent updates require your web app to be fully stopped in order to install/update successfully.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds .NET 8 to the list of supported frameworks for the AAS extension. Noticed the error while browsing generally.

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->