### PR TITLE
[CI Visibility] Clarify Azure extension name

### DIFF
--- a/content/en/continuous_integration/pipelines/azure.md
+++ b/content/en/continuous_integration/pipelines/azure.md
@@ -31,7 +31,7 @@ Azure DevOps Server is not officially supported.
 
 The Datadog integration for [Azure Pipelines][1] works by using [service hooks][2] to send data to Datadog.
 
-1. Install the [Datadog CI Visibility][8] extension from the Azure Marketplace.
+1. Install the [Datadog CI Visibility][8] extension from the Azure Marketplace. There are several extensions starting with **Datadog**, make sure that you are installing the [Datadog CI Visibility][8] extension.
 
 2. For each project, go to **Project settings > Service hooks** in Azure DevOps and select the green plus (+) icon to create a subscription.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We very often get questions from customers installing extensions the "Datadog" extension instead of the "Datadog CI Visibility" extension. I tried to emphasize that adding a sentence, but this can be improved.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->