### PR TITLE
[DOCS-7243] updating source code integration

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -399,7 +399,16 @@ Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@gi
 
 {{% tab "Gitlab" %}}
 
-To link telemetry to your source code, you can upload your repository metadata with the `datadog-ci git-metadata upload` command. When you run datadog-ci git-metadata upload within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths. Run this command for every commit that you need to be synchronized with Datadog. If you are using gitlab.com, this will also allow you to see inline code snippets in Error Tracking, Continuous Profiler, Serverless Monitoring, CI Visibility, and Application Security Monitoring.
+To link telemetry to your source code, you can upload your repository metadata with the [`datadog-ci git-metadata upload`][2] command. When you run `datadog-ci git-metadata upload` within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths. Run this command for every commit that you need to be synchronized with Datadog. If you are using [gitlab.com][1], this will also allow you to see inline code snippets in [Error Tracking][3], [Continuous Profiler][4], [Serverless Monitoring][5], [CI Visibility][6], and [Application Security Monitoring][7].
+
+[1]: https://gitlab.com
+[2]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata
+[3]: /logs/error_tracking/backend/?tab=serilog#setup
+[4]: /integrations/guide/source-code-integration/?tab=continuousprofiler#links-to-git-providers
+[5]: /serverless/aws_lambda/configuration/?tab=datadogcli#link-errors-to-your-source-code
+[6]: /tests/developer_workflows/#open-tests-in-github-and-your-ide
+[7]: /security/application_security/
+
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -397,9 +397,9 @@ Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@gi
 [1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata
 {{% /tab %}}
 
-{{% tab "Gitlab" %}}
+{{% tab "GitLab" %}}
 
-To link telemetry to your source code, you can upload your repository metadata with the [`datadog-ci git-metadata upload`][2] command. When you run `datadog-ci git-metadata upload` within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths. Run this command for every commit that you need to be synchronized with Datadog. If you are using [gitlab.com][1], this will also allow you to see inline code snippets in [Error Tracking][3], [Continuous Profiler][4], [Serverless Monitoring][5], [CI Visibility][6], and [Application Security Monitoring][7].
+To link telemetry with your source code, upload your repository metadata with the [`datadog-ci git-metadata upload`][2] command. When you run `datadog-ci git-metadata upload` within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths. Run this command for every commit you need to be synchronized with Datadog. If you are using [gitlab.com][1], this also allows you to see inline code snippets in [Error Tracking][3], [Continuous Profiler][4], [Serverless Monitoring][5], [CI Visibility][6], and [Application Security Monitoring][7].
 
 [1]: https://gitlab.com
 [2]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -396,6 +396,12 @@ Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@gi
 
 [1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata
 {{% /tab %}}
+
+{{% tab "Gitlab" %}}
+
+To link telemetry to your source code, you can upload your repository metadata with the `datadog-ci git-metadata upload` command. When you run datadog-ci git-metadata upload within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths. Run this command for every commit that you need to be synchronized with Datadog. If you are using gitlab.com, this will also allow you to see inline code snippets in Error Tracking, Continuous Profiler, Serverless Monitoring, CI Visibility, and Application Security Monitoring.
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Usage


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds the Gitlab tab and related information to the Source Code integration per
[DOCS-7243](https://datadoghq.atlassian.net/browse/DOCS-7243)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7243]: https://datadoghq.atlassian.net/browse/DOCS-7243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ