### PR TITLE
[monitors] Remove link to outdated blog post

### DIFF
--- a/content/en/monitors/guide/reduce-alert-flapping.md
+++ b/content/en/monitors/guide/reduce-alert-flapping.md
@@ -11,7 +11,7 @@ aliases:
 
 A frequent issue or pain point can be alert fatigue, or when alerts 'flap' (rapidly switching from an 'ok' to an 'alert' status).
 
-Your individual Datadog alerts with groups [have notification][1] rollups on by default, but there is functionality within Datadog that often leads to less noisy, more meaningful alerts.
+There is functionality within Datadog that often leads to less noisy, more meaningful alerts.
 
 * Re-Evaluate the Alert Threshold Value
     * The easiest way to reduce flapping when the alert <-> ok or state changes are frequent could be to increase/decrease the threshold condition.
@@ -37,7 +37,6 @@ If the issue is alert routing, [template variables][4] and the separation of **w
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://www.datadoghq.com/blog/alert-rollup
 [2]: /monitors/types/anomaly/
 [3]: /monitors/types/outlier/
 [4]: /monitors/notify/variables/?tab=is_alert#template-variables


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

"Avalanche control" has not been active on monitors for a couple of years (at least) it depended on ASN's sharding scheme which changed.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->