### PR TITLE
Update Timeline config for PHP

### DIFF
--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -226,7 +226,7 @@ Lanes on the top are garbage collector **runtime activities** that may add extra
 {{< programming-lang lang="php" >}}
 See [prerequisites](#prerequisites) to learn how to enable this feature for PHP.
 
-There is one lane for each PHP **thread** (in PHP NTS this is just one lane, in PHP ZTS there is one lane per **thread**). Fibers that run in this **thread** are represented in the same lane.
+There is one lane for each PHP **thread**. In PHP NTS, this is one lane; in PHP ZTS, there is one lane per **thread**. Fibers that run in this **thread** are represented in the same lane.
 
 Lanes on the top are runtime activities that may add extra latency to your request, due to file compilation and garbage collection.
 {{< /programming-lang >}}

--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -121,8 +121,8 @@ Code Hotspots identification is enabled by default when you [turn on profiling f
 Requires `dd-trace-php` version 0.71+.
 
 To enable the [timeline feature](#span-execution-timeline-view) (beta):
-- Upgrade to `dd-trace-php` version 0.89+.
-- Set the environment variable `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=1` or INI setting `datadog.profiling.experimental_timeline_enabled=1`
+- Upgrade to `dd-trace-php` version 0.98+.
+- Set the environment variable `DD_PROFILING_TIMELINE_ENABLED=1` or INI setting `datadog.profiling.timeline_enabled=1`
 
 [1]: /profiler/enabling/php
 {{< /programming-lang >}}
@@ -226,7 +226,7 @@ Lanes on the top are garbage collector **runtime activities** that may add extra
 {{< programming-lang lang="php" >}}
 See [prerequisites](#prerequisites) to learn how to enable this feature for PHP.
 
-There is one lane for the PHP **thread**. Fibers that run in this **thread** are represented in separate lanes that are grouped together.
+There is one lane for each PHP **thread** (in PHP NTS this is just one lane, in PHP ZTS there is one lane per **thread**). Fibers that run in this **thread** are represented in the same lane.
 
 Lanes on the top are runtime activities that may add extra latency to your request, due to file compilation and garbage collection.
 {{< /programming-lang >}}

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -156,7 +156,7 @@ Configure the sampling distance for exceptions. The higher the sampling distance
 `DD_PROFILING_TIMELINE_ENABLED`
 : **INI**: `datadog.profiling.timeline_enabled`. INI available since `0.98.0`.<br>
 **Default**: `1`<br>
-Enable the timeline profile type. Added in version `0.89.0`.
+Enable the timeline profile type. Added in version `0.89.0`.<br><br>
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable (`datadog.profiling.experimental_timeline_enabled` INI setting), which was available since `0.89` (default `0`). If both are set, this one takes precedence.
 
 `DD_PROFILING_LOG_LEVEL`

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -153,10 +153,11 @@ in version `0.96.0`.<br><br>
 Configure the sampling distance for exceptions. The higher the sampling distance, the fewer samples are created and the lower the overhead.<br><br>
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE` environment variable (`datadog.profiling.experimental_exception_sampling_distance` INI setting), which was available since `0.92`. If both are set, this one takes precedence.
 
-`DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED`
-: **INI**: `datadog.profiling.experimental_timeline_enabled`. INI available since `0.89.0`.<br>
-**Default**: `0`<br>
-Enable the experimental timeline profile type. Added in version `0.89.0`.
+`DD_PROFILING_TIMELINE_ENABLED`
+: **INI**: `datadog.profiling.timeline_enabled`. INI available since `0.98.0`.<br>
+**Default**: `1`<br>
+Enable the timeline profile type. Added in version `0.89.0`.
+**Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable (`datadog.profiling.experimental_timeline_enabled` INI setting), which was available since `0.89` (default `0`). If both are set, this one takes precedence.
 
 `DD_PROFILING_LOG_LEVEL`
 : **INI**: `datadog.profiling.log_level`. INI available since `0.82.0`.<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

With the [`0.98.0`](https://github.com/DataDog/dd-trace-php/releases/tag/0.98.0) release timeline is now default enabled as well as the `EXPERIMENTAL` removed.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->