### PR TITLE
Removing banner for Holiday Chat Removal

### DIFF
--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -7,9 +7,6 @@ further_reading:
   text: "Agent Troubleshooting"
 ---
 
-{{< callout header="false" btn_hidden="true" >}}
-Our US offices are closed on Monday, February 19th for Presidents' Day. Support will be operating with limited staffing, and so Live Chat will not be available on Presidents' Day for Standard Support customers during normal US business hours. Premier Support customers retain access to chat 24x7x365. For urgent issues, contact us through the <a href="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/">Support Portal</a>.
-{{< /callout >}}
 ## Overview
 
 Datadog provides two primary channels for customers seeking support:


### PR DESCRIPTION
On President's Day, we removed Live Chat for Standard Support customers. We put up a banner on the support docs page to inform customers. This PR removes that banner now that the holiday is over.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes the banner informing customers about our chat schedule from the Monday holiday

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Discussed in this slack thread: https://dd.slack.com/archives/C0DESMBQU/p1707779550610169

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->