### PR TITLE
Add events usage metrics

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -62,7 +62,7 @@ Estimated usage metrics are generally available for the following usage types:
 | CI Visibility Test Committers | `datadog.estimated_usage.ci_visibility.test.committers` | Test committers seen from (calendar) month-to-date. |
 | IOT devices                   | `datadog.estimated_usage.iot.devices` | Unique IoT devices seen in the last hour. |
 | Observability Pipelines Ingested Bytes | `datadog.estimated_usage.observability_pipelines.ingested_bytes` | Volume of data ingested by Observability Pipelines. |
-| Events Custom Events                   | `datadog.estimated_usage.events.custom_events` | Volume of custom events submitted. |
+| Custom Events                   | `datadog.estimated_usage.events.custom_events` | Volume of custom events submitted. |
 | Events Ingested                        | `datadog.estimated_usage.events.ingested_events` | Volume of data ingested by Events. |
 
 {{< img src="account_management/billing/usage-metrics-02.png" alt="Metric Names" >}}

--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -62,7 +62,8 @@ Estimated usage metrics are generally available for the following usage types:
 | CI Visibility Test Committers | `datadog.estimated_usage.ci_visibility.test.committers` | Test committers seen from (calendar) month-to-date. |
 | IOT devices                   | `datadog.estimated_usage.iot.devices` | Unique IoT devices seen in the last hour. |
 | Observability Pipelines Ingested Bytes | `datadog.estimated_usage.observability_pipelines.ingested_bytes` | Volume of data ingested by Observability Pipelines. |
-
+| Events Custom Events                   | `datadog.estimated_usage.events.custom_events` | Volume of custom events submitted. |
+| Events Ingested                        | `datadog.estimated_usage.events.ingested_events` | Volume of data ingested by Events. |
 
 {{< img src="account_management/billing/usage-metrics-02.png" alt="Metric Names" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- [DOCS-7206](https://datadoghq.atlassian.net/browse/DOCS-7206)
- Add Events usage metrics to the estimated usage metrics table

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing


[DOCS-7206]: https://datadoghq.atlassian.net/browse/DOCS-7206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ