### PR TITLE
remove Node12-x and add Node20-x

### DIFF
--- a/content/en/security/application_security/enabling/serverless.md
+++ b/content/en/security/application_security/enabling/serverless.md
@@ -215,7 +215,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available RUNTIME options are `Node12-x`, `Node14-x`, `Node16-x` and         `Node18-x`.
+         Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available RUNTIME options are `Node14-x`, `Node16-x`, `Node18-x` and `Node20-x`.
 
    - **Java**: [Configure the layers][1] for your Lambda function using the ARN in one of the following formats, depending on where your Lambda is deployed. Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`:
      ```sh
@@ -279,7 +279,7 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available RUNTIME options are `Node12-x`, `Node14-x`, `Node16-x` and         `Node18-x`.
+         Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available RUNTIME options are `Node14-x`, `Node16-x`, `Node18-x` and `Node20-x`.
 
 
    - **Java**: [Configure the layers][1] for your Lambda function using the ARN in one of the following formats, depending on where your Lambda is deployed. Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`:

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -413,7 +413,7 @@ resource "aws_lambda_function" "lambda" {
       arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="node" >}}
       ```
 
-      Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `RUNTIME` options are `Node12-x`, `Node14-x`, `Node16-x` and `Node18-x`.
+      Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `RUNTIME` options are  `Node14-x`, `Node16-x`, `Node18-x` and `Node20-x`.
 
     - Option B: If you cannot use the prebuilt Datadog Lambda layer, alternatively you can install the packages `datadog-lambda-js` and `dd-trace` using your favorite package manager.
 

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -312,7 +312,7 @@ Fill in variables accordingly:
         </tr>
     </table>
 
-   In the ARN, replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. Replace `<RUNTIME>` with `Node14-x`, `Node16-x`, `Node18-x` or `Node20-x`.
+   In the ARN, replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. Replace `<RUNTIME>` with `Node16-x`, `Node18-x` or `Node20-x`.
 
 2. Replace `<DATADOG_EXTENSION_ARN>` with the ARN of the appropriate Datadog Lambda Extension for your region and architecture:
 
@@ -413,7 +413,7 @@ resource "aws_lambda_function" "lambda" {
       arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="node" >}}
       ```
 
-      Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `RUNTIME` options are  `Node14-x`, `Node16-x`, `Node18-x` and `Node20-x`.
+      Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `RUNTIME` options are `Node16-x`, `Node18-x` and `Node20-x`.
 
     - Option B: If you cannot use the prebuilt Datadog Lambda layer, alternatively you can install the packages `datadog-lambda-js` and `dd-trace` using your favorite package manager.
 

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -304,7 +304,7 @@ Fill in variables accordingly:
         </tr>
     </table>
 
-   In the ARN, replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. Replace `<RUNTIME>` with `Python37`, `Python38`, or `Python39`.
+   In the ARN, replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. Replace `<RUNTIME>` with `Python38`, `Python39`, `Python310`, `Python311` or `Python312`.
 
 2. Replace `<DATADOG_EXTENSION_ARN>` with the ARN of the appropriate Datadog Lambda Extension for your region and architecture:
 
@@ -397,7 +397,7 @@ resource "aws_lambda_function" "lambda" {
       arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:{{< latest-lambda-layer-version layer="python" >}}
       ```
 
-      Replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. The available `RUNTIME` options are `Python37`, `Python38`, `Python39`, `Python310`, and `Python311`.
+      Replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`. The available `RUNTIME` options are `Python38`, `Python39`, `Python310`, `Python311`, and `Python312`.
 
     - Option B: If you cannot use the prebuilt Datadog Lambda layer, alternatively install the `datadog-lambda` package and its dependencies locally to your function project folder using your favorite Python package manager, such as `pip`.
 

--- a/content/en/serverless/guide/datadog_forwarder_node.md
+++ b/content/en/serverless/guide/datadog_forwarder_node.md
@@ -262,7 +262,7 @@ arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION
 
 ```
 
-The available `RUNTIME` options are `Node14-x`, `Node16-x`, `Node18-x` and `Node20-x`. The latest `VERSION` is `{{< latest-lambda-layer-version layer="node" >}}`. For example:
+The available `RUNTIME` options are `Node16-x`, `Node18-x` and `Node20-x`. The latest `VERSION` is `{{< latest-lambda-layer-version layer="node" >}}`. For example:
 
 ```
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node16-x:{{< latest-lambda-layer-version layer="node" >}}

--- a/content/en/serverless/guide/datadog_forwarder_node.md
+++ b/content/en/serverless/guide/datadog_forwarder_node.md
@@ -262,7 +262,7 @@ arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION
 
 ```
 
-The available `RUNTIME` options are `Node12-x`, `Node14-x`, and `Node16-x`. The latest `VERSION` is `{{< latest-lambda-layer-version layer="node" >}}`. For example:
+The available `RUNTIME` options are `Node14-x`, `Node16-x`, `Node18-x` and `Node20-x`. The latest `VERSION` is `{{< latest-lambda-layer-version layer="node" >}}`. For example:
 
 ```
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node16-x:{{< latest-lambda-layer-version layer="node" >}}

--- a/content/en/serverless/guide/datadog_forwarder_python.md
+++ b/content/en/serverless/guide/datadog_forwarder_python.md
@@ -209,13 +209,13 @@ More information and additional parameters can be found in the [macro documentat
         }
     }
     ```
-1. Replace the placeholder `<AWS_REGION>`, `<RUNTIME>` and `<VERSION>` in the layer ARN with appropriate values. The available `RUNTIME` options are `Python27`, `Python36`, `Python37`, and `Python38`. The latest `VERSION` is `{{< latest-lambda-layer-version layer="python" >}}`. For example:
+1. Replace the placeholder `<AWS_REGION>`, `<RUNTIME>` and `<VERSION>` in the layer ARN with appropriate values. The available `RUNTIME` options are `Python38`, `Python39`, `Python310`, `Python311`, and `Python312`. The latest `VERSION` is `{{< latest-lambda-layer-version layer="python" >}}`. For example:
     ```
     # For regular regions
-    arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 
     # For us-gov regions
-    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
     ```
 1. If your Lambda function is configured to use code signing, add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][1].
 
@@ -334,10 +334,10 @@ arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
 arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-The available `RUNTIME` options are `Python27`, `Python36`, `Python37`, and `Python38`. The latest `VERSION` is `{{< latest-lambda-layer-version layer="python" >}}`. For example:
+The available `RUNTIME` options are `Python27`, `Python36`, `Python312`, and `Python38`. The latest `VERSION` is `{{< latest-lambda-layer-version layer="python" >}}`. For example:
 
 ```
-arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 ```
 
 If your Lambda function is configured to use code signing, you must add Datadog's Signing Profile ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) to your function's [Code Signing Configuration][9] before you can add the Datadog Lambda library as a layer.

--- a/content/fr/security/application_security/enabling/serverless.md
+++ b/content/fr/security/application_security/enabling/serverless.md
@@ -81,7 +81,7 @@ Pour installer et configurer le plug-in Serverless Framework Datadog :
           # Use this format for arm64-based Lambda deployed in AWS GovCloud regions
           arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:72
           ```
-          Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour `RUNTIME` sont `Python37`, `Python38` et `Python39`.
+          Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour `RUNTIME` sont `Python38`, `Python39`, `Python310`, `Python311` et `Python312`.
 
    - **Node**   
        ``` sh
@@ -91,7 +91,7 @@ Pour installer et configurer le plug-in Serverless Framework Datadog :
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```  
-         Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour RUNTIME sont `Node14-x`, `Node16-x`, `Node18-x` et `Node20-x`.
+         Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour RUNTIME sont `Node16-x`, `Node18-x` et `Node20-x`.
 
    - **Java** : [Configurez les couches][1] pour votre fonction Lambda à l'aide de l'ARN en respectant l'un des formats suivants, en fonction de l'endroit où votre fonction Lambda est déployée. Remplacez `<AWS_REGION>` par une région AWS valide telle que `us-east-1` :
      ```sh
@@ -145,7 +145,7 @@ Pour installer et configurer le plug-in Serverless Framework Datadog :
           # Use this format for arm64-based Lambda deployed in AWS GovCloud regions
           arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:72
           ```
-          Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour `RUNTIME` sont `Python37`, `Python38`, `Python39`, `Python310` et `Python311`.
+          Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour `RUNTIME` sont `Python38`, `Python39`, `Python310`, `Python311` et `Python312`.
 
    - **Node**   
        ``` sh
@@ -155,7 +155,7 @@ Pour installer et configurer le plug-in Serverless Framework Datadog :
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```  
-         Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour RUNTIME sont `Node14-x`, `Node16-x`, `Node18-x` et `Node20-x`.
+         Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour RUNTIME sont `Node16-x`, `Node18-x` et `Node20-x`.
 
 
    - **Java** : [Configurez les couches][1] pour votre fonction Lambda à l'aide de l'ARN en respectant l'un des formats suivants, en fonction de l'endroit où votre fonction Lambda est déployée. Remplacez `<AWS_REGION>` par une région AWS valide telle que `us-east-1` :

--- a/content/fr/security/application_security/enabling/serverless.md
+++ b/content/fr/security/application_security/enabling/serverless.md
@@ -91,7 +91,7 @@ Pour installer et configurer le plug-in Serverless Framework Datadog :
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```  
-         Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour RUNTIME sont `Node12-x`, `Node14-x`, `Node16-x` et `Node18-x`.
+         Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour RUNTIME sont `Node14-x`, `Node16-x`, `Node18-x` et `Node20-x`.
 
    - **Java** : [Configurez les couches][1] pour votre fonction Lambda à l'aide de l'ARN en respectant l'un des formats suivants, en fonction de l'endroit où votre fonction Lambda est déployée. Remplacez `<AWS_REGION>` par une région AWS valide telle que `us-east-1` :
      ```sh
@@ -155,7 +155,7 @@ Pour installer et configurer le plug-in Serverless Framework Datadog :
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```  
-         Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour RUNTIME sont `Node12-x`, `Node14-x`, `Node16-x` et `Node18-x`.
+         Remplacez `<AWS_REGION>` par une région AWS valide, comme `us-east-1`. Les options disponibles pour RUNTIME sont `Node14-x`, `Node16-x`, `Node18-x` et `Node20-x`.
 
 
    - **Java** : [Configurez les couches][1] pour votre fonction Lambda à l'aide de l'ARN en respectant l'un des formats suivants, en fonction de l'endroit où votre fonction Lambda est déployée. Remplacez `<AWS_REGION>` par une région AWS valide telle que `us-east-1` :

--- a/content/fr/serverless/guide/datadog_forwarder_node.md
+++ b/content/fr/serverless/guide/datadog_forwarder_node.md
@@ -261,7 +261,7 @@ arn:aws:lambda:<RÉGION_AWS>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
 arn:aws-us-gov:lambda:<RÉGION_AWS>:002406178527:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-Les options `RUNTIME` disponibles sont `Node14-x`, `Node16-x`, `Node18-x` et `Node20-x`. La dernière `VERSION` est `{{< latest-lambda-layer-version layer="node" >}}`. Exemple :
+Les options `RUNTIME` disponibles sont `Node16-x`, `Node18-x` et `Node20-x`. La dernière `VERSION` est `{{< latest-lambda-layer-version layer="node" >}}`. Exemple :
 
 ```
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node16-x:{{< latest-lambda-layer-version layer="node" >}}

--- a/content/fr/serverless/guide/datadog_forwarder_node.md
+++ b/content/fr/serverless/guide/datadog_forwarder_node.md
@@ -261,7 +261,7 @@ arn:aws:lambda:<RÉGION_AWS>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
 arn:aws-us-gov:lambda:<RÉGION_AWS>:002406178527:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-Les options `RUNTIME` disponibles sont `Node12-x`, `Node14-x` et `Node16-x`. La dernière `VERSION` est `{{< latest-lambda-layer-version layer="node" >}}`. Exemple :
+Les options `RUNTIME` disponibles sont `Node14-x`, `Node16-x`, `Node18-x` et `Node20-x`. La dernière `VERSION` est `{{< latest-lambda-layer-version layer="node" >}}`. Exemple :
 
 ```
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node16-x:{{< latest-lambda-layer-version layer="node" >}}

--- a/content/fr/serverless/guide/datadog_forwarder_python.md
+++ b/content/fr/serverless/guide/datadog_forwarder_python.md
@@ -209,13 +209,13 @@ Pour obtenir plus de détails ainsi que des paramètres supplémentaires, consul
         }
     }
     ```
-1. Remplacez les paramètres fictifs `<AWS_REGION>`, `<RUNTIME>` et `<VERSION>` dans l'ARN de couche par les valeurs appropriées. Les options `RUNTIME` disponibles sont `Python27`, `Python36`, `Python37` et `Python38`. La dernière `VERSION` disponible est `{{< latest-lambda-layer-version layer="python" >}}`. Exemple :
+1. Remplacez les paramètres fictifs `<AWS_REGION>`, `<RUNTIME>` et `<VERSION>` dans l'ARN de couche par les valeurs appropriées. Les options `RUNTIME` disponibles sont `Python38`, `Python39`, `Python310`, `Python311` et `Python312`. La dernière `VERSION` disponible est `{{< latest-lambda-layer-version layer="python" >}}`. Exemple :
     ```
     # For regular regions
-    arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 
     # For us-gov regions
-    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
     ```
 1. Si votre fonction Lambda est configurée de façon à utiliser la signature de code, ajoutez l'ARN du profil de signature de Datadog (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) à la [configuration de la signature de code][1] de votre fonction.
 
@@ -335,10 +335,10 @@ arn:aws:lambda:<RÉGION_AWS>:464622532012:layer:Datadog-<RUNTIME>:<VERSION>
 arn:aws-us-gov:lambda:<RÉGION_AWS>:002406178527:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-Les options `RUNTIME` disponibles sont `Python27`, `Python36`, `Python37` et `Python38`. La dernière `VERSION` est `{{< latest-lambda-layer-version layer="python" >}}`. Exemple :
+Les options `RUNTIME` disponibles sont `Python38`, `Python39`, `Python310`, `Python311` et `Python312`. La dernière `VERSION` est `{{< latest-lambda-layer-version layer="python" >}}`. Exemple :
 
 ```
-arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 ```
 
 Si votre fonction Lambda est configurée de façon à utiliser la signature de code, vous devez ajouter l'ARN du profil de signature de Datadog (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) à la [configuration de la signature de code][2] de votre fonction avant de pouvoir ajouter la bibliothèque Lambda Datadog en tant que couche.

--- a/content/fr/serverless/guide/serverless_package_too_large.md
+++ b/content/fr/serverless/guide/serverless_package_too_large.md
@@ -18,11 +18,11 @@ Datadog ajoute généralement deux couches Lambda pour l'instrumentation :
 - Une bibliothèque propre au langage qui instrumente le code de la fonction
 - L'extension qui agrège, met en mémoire tampon et transmet les données d'observabilité au backend Datadog
 
-Vérifiez le contenu et la taille des couches Lambda Datadog à l'aide de la commande AWS CLI [`aws lambda get-layer-version`][3]. Par exemple, les commandes ci-dessous fournissent des liens afin de télécharger les couches Lambda pour _la version 67 de Datadog-Node14-x_ et _la version 19 de Datadog-Extension et de vérifier leur taille non compressée (environ 30 Mo pour les couches). La taille non compressée varie selon les couches et les versions. Remplacez le nom de la couche et le numéro de version de l'exemple suivant par les valeurs pertinentes pour vos applications :
+Vérifiez le contenu et la taille des couches Lambda Datadog à l'aide de la commande AWS CLI [`aws lambda get-layer-version`][3]. Par exemple, les commandes ci-dessous fournissent des liens afin de télécharger les couches Lambda pour _la version 67 de Datadog-Node20-x_ et _la version 19 de Datadog-Extension et de vérifier leur taille non compressée (environ 30 Mo pour les couches). La taille non compressée varie selon les couches et les versions. Remplacez le nom de la couche et le numéro de version de l'exemple suivant par les valeurs pertinentes pour vos applications :
 
 ```
 aws lambda get-layer-version \
-  --layer-name arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node14-x \
+  --layer-name arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node20-x \
   --version-number 67
 
 aws lambda get-layer-version \

--- a/content/ja/security/application_security/enabling/serverless.md
+++ b/content/ja/security/application_security/enabling/serverless.md
@@ -101,7 +101,7 @@ Datadog Serverless Framework プラグインをインストールして構成す
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。RUNTIME オプションは、`Node12-x`、`Node14-x`、`Node16-x`、`Node18-x` が利用可能です。
+         `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。RUNTIME オプションは、`Node14-x`、`Node16-x`、`Node18-x`、`Node20-x` が利用可能です。
 
    - **Java**: Lambda がデプロイされている場所に応じて、以下のいずれかの形式の ARN を使用して Lambda 関数の[レイヤーを構成します][1]。`<AWS_REGION>` は `us-east-1` などの有効な AWS リージョンに置き換えてください。
      ```sh
@@ -165,7 +165,7 @@ Datadog Serverless Framework プラグインをインストールして構成す
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。RUNTIME オプションは、`Node12-x`、`Node14-x`、`Node16-x`、`Node18-x` が利用可能です。
+         `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。RUNTIME オプションは、`Node14-x`、`Node16-x`、`Node18-x`、`Node20-x` が利用可能です。
 
 
    - **Java**: Lambda がデプロイされている場所に応じて、以下のいずれかの形式の ARN を使用して Lambda 関数の[レイヤーを構成します][1]。`<AWS_REGION>` は `us-east-1` などの有効な AWS リージョンに置き換えてください。

--- a/content/ja/security/application_security/enabling/serverless.md
+++ b/content/ja/security/application_security/enabling/serverless.md
@@ -91,7 +91,7 @@ Datadog Serverless Framework プラグインをインストールして構成す
           # Use this format for arm64-based Lambda deployed in AWS GovCloud regions
           arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:72
           ```
-          `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。`RUNTIME` オプションは、`Python37`、`Python38` または `Python39` が利用可能です。
+          `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。`RUNTIME` オプションは、`Python38`、`Python39`、`Python310`、`Python311` または `Python312` が利用可能です。
 
    - **Node**
        ``` sh
@@ -101,7 +101,7 @@ Datadog Serverless Framework プラグインをインストールして構成す
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。RUNTIME オプションは、`Node14-x`、`Node16-x`、`Node18-x`、`Node20-x` が利用可能です。
+         `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。RUNTIME オプションは、`Node16-x`、`Node18-x`、`Node20-x` が利用可能です。
 
    - **Java**: Lambda がデプロイされている場所に応じて、以下のいずれかの形式の ARN を使用して Lambda 関数の[レイヤーを構成します][1]。`<AWS_REGION>` は `us-east-1` などの有効な AWS リージョンに置き換えてください。
      ```sh
@@ -155,7 +155,7 @@ Datadog Serverless Framework プラグインをインストールして構成す
           # Use this format for arm64-based Lambda deployed in AWS GovCloud regions
           arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:72
           ```
-`<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えます。`RUNTIME` オプションは、`Python37`、`Python38`、`Python39`、`Python310`、`Python311` が利用可能です。
+`<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えます。`RUNTIME` オプションは、`Python38`、`Python39`、`Python310`、`Python311`、`Python312` が利用可能です。
 
    - **Node**
        ``` sh
@@ -165,7 +165,7 @@ Datadog Serverless Framework プラグインをインストールして構成す
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。RUNTIME オプションは、`Node14-x`、`Node16-x`、`Node18-x`、`Node20-x` が利用可能です。
+         `<AWS_REGION>` を `us-east-1` などの有効な AWS リージョンに置き換えてください。RUNTIME オプションは、`Node16-x`、`Node18-x`、`Node20-x` が利用可能です。
 
 
    - **Java**: Lambda がデプロイされている場所に応じて、以下のいずれかの形式の ARN を使用して Lambda 関数の[レイヤーを構成します][1]。`<AWS_REGION>` は `us-east-1` などの有効な AWS リージョンに置き換えてください。

--- a/content/ja/serverless/guide/datadog_forwarder_node.md
+++ b/content/ja/serverless/guide/datadog_forwarder_node.md
@@ -298,7 +298,7 @@ arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION
 arn:aws-us-gov:lambda:<AWS_REGION>:417141415827:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-使用できる `RUNTIME` オプションは、`Node12-x`、`Node14-x`、`Node16-x` です。最新の `VERSION` は `{{< latest-lambda-layer-version layer="node" >}}` です。例:
+使用できる `RUNTIME` オプションは、`Node14-x`、`Node16-x`、`Node18-x`、`Node20-x` です。最新の `VERSION` は `{{< latest-lambda-layer-version layer="node" >}}` です。例:
 
 {{< site-region region="us,us3,us5,eu,gov" >}}
 ```

--- a/content/ja/serverless/guide/datadog_forwarder_node.md
+++ b/content/ja/serverless/guide/datadog_forwarder_node.md
@@ -298,7 +298,7 @@ arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION
 arn:aws-us-gov:lambda:<AWS_REGION>:417141415827:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-使用できる `RUNTIME` オプションは、`Node14-x`、`Node16-x`、`Node18-x`、`Node20-x` です。最新の `VERSION` は `{{< latest-lambda-layer-version layer="node" >}}` です。例:
+使用できる `RUNTIME` オプションは、`Node16-x`、`Node18-x`、`Node20-x` です。最新の `VERSION` は `{{< latest-lambda-layer-version layer="node" >}}` です。例:
 
 {{< site-region region="us,us3,us5,eu,gov" >}}
 ```

--- a/content/ja/serverless/guide/datadog_forwarder_python.md
+++ b/content/ja/serverless/guide/datadog_forwarder_python.md
@@ -237,13 +237,13 @@ Lambda 関数が、コード署名を使用するよう構成してある場合�
         }
     }
     ```
-1. レイヤー ARN のプレースホルダー `<AWS_REGION>`、`<RUNTIME>`、`<VERSION>` に適切な値を挿入します。`RUNTIME` には `Python27`、`Python36`、`Python37`、`Python38` のいずれかを使用できます。最新の `VERSION` は `{{< latest-lambda-layer-version layer="python" >}}` です。例:
+1. レイヤー ARN のプレースホルダー `<AWS_REGION>`、`<RUNTIME>`、`<VERSION>` に適切な値を挿入します。`RUNTIME` には `Python38`、`Python39`、`Python310`、`Python311`、`Python312` のいずれかを使用できます。最新の `VERSION` は `{{< latest-lambda-layer-version layer="python" >}}` です。例:
     ```
     # For regular regions
-    arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 
     # For us-gov regions
-    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
     ```
 1. Lambda 関数が、コード署名を使用するよう構成してある場合、Datadog の署名プロフィール ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) を関数の[コード署名コンフィギュレーション][1]に追加します。
 
@@ -265,13 +265,13 @@ Lambda 関数が、コード署名を使用するよう構成してある場合�
         }
     }
     ```
-1. レイヤー ARN のプレースホルダー `<AWS_REGION>`、`<RUNTIME>`、`<VERSION>` に適切な値を挿入します。`RUNTIME` には `Python27`、`Python36`、`Python37`、`Python38` のいずれかを使用できます。最新の `VERSION` は `{{< latest-lambda-layer-version layer="python" >}}` です。例:
+1. レイヤー ARN のプレースホルダー `<AWS_REGION>`、`<RUNTIME>`、`<VERSION>` に適切な値を挿入します。`RUNTIME` には `Python38`、`Python39`、`Python310`、`Python311`、`Python312` のいずれかを使用できます。最新の `VERSION` は `{{< latest-lambda-layer-version layer="python" >}}` です。例:
     ```
     # For regular regions
-    arn:aws:lambda:us-east-1:417141415827:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws:lambda:us-east-1:417141415827:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 
     # For us-gov regions
-    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
     ```
 1. Lambda 関数が、コード署名を使用するよう構成してある場合、Datadog の署名プロフィール ARN (`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`) を関数の[コード署名コンフィギュレーション][1]に追加します。
 
@@ -404,10 +404,10 @@ arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION
 arn:aws-us-gov:lambda:<AWS_REGION>:417141415827:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-使用できる `RUNTIME` オプションは、`Python27`、`Python36`、`Python37`、`Python38` です。最新の `VERSION` は `{{< latest-lambda-layer-version layer="python" >}}` です。例:
+使用できる `RUNTIME` オプションは、`Python38`、`Python39`、`Python310`、`Python311`、`Python312` です。最新の `VERSION` は `{{< latest-lambda-layer-version layer="python" >}}` です。例:
 
 ```
-arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 ```
 
 {{< site-region region="us,us3,us5,eu,gov" >}}

--- a/content/ko/security/application_security/enabling/serverless.md
+++ b/content/ko/security/application_security/enabling/serverless.md
@@ -205,7 +205,7 @@ Datadog CLI는 기존 Lambda 함수의 구성을 변경하여 새롭게 배포�
           # Use this format for arm64-based Lambda deployed in AWS GovCloud regions
           arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:72
           ```
-          `<AWS_REGION>`을  `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 `RUNTIME` 옵션은 `Python37`, `Python38`, `Python39`입니다.
+          `<AWS_REGION>`을  `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 `RUNTIME` 옵션은 `Python38`, `Python39`, `Python310`, `Python311`,`Python312`입니다.
 
    - **Node**
        ``` sh
@@ -215,7 +215,7 @@ Datadog CLI는 기존 Lambda 함수의 구성을 변경하여 새롭게 배포�
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 런타임 옵션은 `Node14-x`, `Node16-x`, `Node18-x`, `Node20-x`입니다.
+         `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 런타임 옵션은 `Node16-x`, `Node18-x`, `Node20-x`입니다.
 
    - **Java**: Lambda가 배포된 위치에 따라 다음 형식 중 하나의 ARN을 사용해 Lambda 함수의 [레이어를 구성][1]하세요. `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 바꾸세요.
      ```sh
@@ -269,7 +269,7 @@ Datadog CLI는 기존 Lambda 함수의 구성을 변경하여 새롭게 배포�
           # Use this format for arm64-based Lambda deployed in AWS GovCloud regions
           arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>-ARM:72
           ```
-          `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 `RUNTIME` 옵션은 `Python37`, `Python38`, `Python39`, `Python310`, `Python311`입니다.
+          `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 `RUNTIME` 옵션은 `Python38`, `Python39`, `Python310`, `Python311`, `Python312`입니다.
 
    - **Node**
        ``` sh
@@ -279,7 +279,7 @@ Datadog CLI는 기존 Lambda 함수의 구성을 변경하여 새롭게 배포�
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 런타임 옵션은 `Node14-x`, `Node16-x`, `Node18-x`, `Node20-x`입니다.
+         `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 런타임 옵션은 `Node16-x`, `Node18-x`, `Node20-x`입니다.
 
 
    - **Java**: Lambda가 배포된 위치에 따라 다음 형식 중 하나의 ARN을 사용해 Lambda 함수의 [레이어를 구성][1]하세요. `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 바꾸세요.

--- a/content/ko/security/application_security/enabling/serverless.md
+++ b/content/ko/security/application_security/enabling/serverless.md
@@ -215,7 +215,7 @@ Datadog CLI는 기존 Lambda 함수의 구성을 변경하여 새롭게 배포�
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 런타임 옵션은 `Node12-x`, `Node14-x`, `Node16-x`, `Node18-x`입니다.
+         `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 런타임 옵션은 `Node14-x`, `Node16-x`, `Node18-x`, `Node20-x`입니다.
 
    - **Java**: Lambda가 배포된 위치에 따라 다음 형식 중 하나의 ARN을 사용해 Lambda 함수의 [레이어를 구성][1]하세요. `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 바꾸세요.
      ```sh
@@ -279,7 +279,7 @@ Datadog CLI는 기존 Lambda 함수의 구성을 변경하여 새롭게 배포�
          # Use this format for AWS GovCloud regions
          arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:91
          ```
-         `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 런타임 옵션은 `Node12-x`, `Node14-x`, `Node16-x`, `Node18-x`입니다.
+         `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 변경하세요. 사용할 수 있는 런타임 옵션은 `Node14-x`, `Node16-x`, `Node18-x`, `Node20-x`입니다.
 
 
    - **Java**: Lambda가 배포된 위치에 따라 다음 형식 중 하나의 ARN을 사용해 Lambda 함수의 [레이어를 구성][1]하세요. `<AWS_REGION>`을 `us-east-1`와 같은 유효 AWS 리전으로 바꾸세요.

--- a/content/ko/serverless/guide/datadog_forwarder_node.md
+++ b/content/ko/serverless/guide/datadog_forwarder_node.md
@@ -262,7 +262,7 @@ arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION
 
 ```
 
-사용 가능한 `RUNTIME`옵션은 `Node12-x`, `Node14-x`, `Node16-x`입니다. 최신 `VERSION`은 `{{< latest-lambda-layer-version layer="node" >}}`입니다. 다음 예를 참고하세요.
+사용 가능한 `RUNTIME`옵션은 `Node16-x`, `Node18-x`, `Node20-x`입니다. 최신 `VERSION`은 `{{< latest-lambda-layer-version layer="node" >}}`입니다. 다음 예를 참고하세요.
 
 ```
 arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Node16-x:{{< latest-lambda-layer-version layer="node" >}}

--- a/content/ko/serverless/guide/datadog_forwarder_python.md
+++ b/content/ko/serverless/guide/datadog_forwarder_python.md
@@ -237,13 +237,13 @@ class CdkStack(core.Stack):
         }
     }
     ```
-1. 레이어 ARN에서 자리표시자 `<AWS_REGION>`, `<RUNTIME>`, `<VERSION>`을 적합한 값으로 대체하세요. 사용 가능한 `RUNTIME` 옵션은 `Python27`, `Python36`, `Python37`, `Python38`입니다. 최신 `VERSION`은 `{{< latest-lambda-layer-version layer="python" >}}`입니다. 예시: 
+1. 레이어 ARN에서 자리표시자 `<AWS_REGION>`, `<RUNTIME>`, `<VERSION>`을 적합한 값으로 대체하세요. 사용 가능한 `RUNTIME` 옵션은 `Python38`, `Python39`, `Python310`, `Python311`, `Python312`입니다. 최신 `VERSION`은 `{{< latest-lambda-layer-version layer="python" >}}`입니다. 예시: 
     ```
     # For regular regions
-    arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 
     # For us-gov regions
-    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
     ```
 1. 람바 함수가 코드 서명을 사용하도록 설정된 경우 Datadog 서명 프로필 ARN(`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`)을 함수의 [코드 서명 설정][1]에 추가하세요.
 
@@ -265,13 +265,13 @@ class CdkStack(core.Stack):
         }
     }
     ```
-1. 레이어 ARN에서 자리표시자 `<AWS_REGION>`, `<RUNTIME>`, `<VERSION>`을 적합한 값으로 대체하세요. 사용 가능한 `RUNTIME` 옵션은 `Python27`, `Python36`, `Python37`, `Python38`입니다. 최신 `VERSION`은 `{{< latest-lambda-layer-version layer="python" >}}`입니다. 예시: 
+1. 레이어 ARN에서 자리표시자 `<AWS_REGION>`, `<RUNTIME>`, `<VERSION>`을 적합한 값으로 대체하세요. 사용 가능한 `RUNTIME` 옵션은 `Python38`, `Python39`, `Python310`, `Python311`, `Python312`입니다. 최신 `VERSION`은 `{{< latest-lambda-layer-version layer="python" >}}`입니다. 예시: 
     ```
     # For regular regions
-    arn:aws:lambda:us-east-1:417141415827:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws:lambda:us-east-1:417141415827:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 
     # For us-gov regions
-    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+    arn:aws-us-gov:lambda:us-gov-east-1:002406178527:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
     ```
 1. 람바 함수가 코드 서명을 사용하도록 설정된 경우 Datadog 서명 프로필 ARN(`arn:aws:signer:us-east-1:464622532012:/signing-profiles/DatadogLambdaSigningProfile/9vMI9ZAGLc`)을 함수의 [코드 서명 설정][1]에 추가하세요.
 
@@ -404,10 +404,10 @@ arn:aws-us-gov:lambda:<AWS_REGION>:002406178527:layer:Datadog-<RUNTIME>:<VERSION
 arn:aws-us-gov:lambda:<AWS_REGION>:417141415827:layer:Datadog-<RUNTIME>:<VERSION>
 ```
 
-사용 가능한 `RUNTIME` 옵션은 `Python27`, `Python36`, `Python37`, `Python38`입니다. 최신 `VERSION`은 `{{< latest-lambda-layer-version layer="python" >}}`입니다. 예시:
+사용 가능한 `RUNTIME` 옵션은 `Python38`, `Python39`, `Python310`, `Python311`, `Python312`입니다. 최신 `VERSION`은 `{{< latest-lambda-layer-version layer="python" >}}`입니다. 예시:
 
 ```
-arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python37:{{< latest-lambda-layer-version layer="python" >}}
+arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Python312:{{< latest-lambda-layer-version layer="python" >}}
 ```
 
 {{< site-region region="us,us3,us5,eu,gov" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Remove Node12-x and Node14-x layer references and add Node20-x references.
Remove old python versions too and add Python312.

I'm favoring [PR-21886](https://github.com/DataDog/documentation/pull/21886/files#diff-273c23a68b141b4065c74fdfd99fa46d6e5f5e468570b0e80f219ac1bc6c5d23) over this one. 


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->