### PR TITLE
[CIVIS-9204] Rename mentions of "metrics" to "measures" in CI docs

### DIFF
--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -57,7 +57,7 @@ Datadog integrates with the following CI providers to gather pipeline metrics wh
 
 </br>
 
-You can use the `datadog-ci` CLI to [trace commands][8] in your pipelines, as well as the [custom tags and metrics commands][9] to add user-defined text and numerical tags in your pipeline traces.
+You can use the `datadog-ci` CLI to [trace commands][8] in your pipelines, as well as the [custom tags and measures commands][9] to add user-defined text and numerical tags in your pipeline traces.
 
 ## Ready to start?
 
@@ -74,4 +74,4 @@ See [Pipeline Visibility][3] and [Test Visibility][4] for instructions on settin
 [6]: /monitors/types/ci/
 [7]: /continuous_integration/explorer/
 [8]: /continuous_integration/pipelines/custom_commands/
-[9]: /continuous_integration/pipelines/custom_tags_and_metrics/
+[9]: /continuous_integration/pipelines/custom_tags_and_measures/

--- a/content/en/continuous_integration/pipelines/_index.md
+++ b/content/en/continuous_integration/pipelines/_index.md
@@ -40,7 +40,7 @@ cascade:
     {{< nextlink href="continuous_integration/pipelines/teamcity" >}}TeamCity{{< /nextlink >}}
     {{< nextlink href="continuous_integration/pipelines/custom" >}}Other CI Providers{{< /nextlink >}}
     {{< nextlink href="continuous_integration/pipelines/custom_commands" >}}Custom Commands{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/pipelines/custom_tags_and_metrics" >}}Custom Tags and Metrics{{< /nextlink >}}
+    {{< nextlink href="continuous_integration/pipelines/custom_tags_and_measures" >}}Custom Tags and measures{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ### Terminology
@@ -168,7 +168,7 @@ If your CI provider is not supported, you can try setting up Pipeline Visibility
 | {{< ci-details title="Infrastructure metric correlation" >}}Correlation of host-level information for the Datadog Agent, CI pipelines, or job runners to CI pipeline execution data.{{< /ci-details >}} | {{< X >}} | {{< X >}} |  | {{< X >}} | {{< X >}} |  |  |  |  |  |
 | {{< ci-details title="Custom spans for traced commands using datadog-ci" >}}Support for sending command-level events to CI Visibility to be incorporated into pipeline flame graph visualization. You can then query and analyze <a href="https://docs.datadoghq.com/continuous_integration/pipelines/custom_commands/">these events</a>. {{< /ci-details >}} | {{< X >}} |  | {{< X >}} |  |  |  |  |  |  |  |
 | {{< ci-details title="Custom predefined tags" >}}Support for setting static pipeline tags in the CI provider that do not change between executions.{{< /ci-details >}} | {{< X >}} | {{< X >}} | {{< X >}} |  | {{< X >}} | {{< X >}} |  |  |  |  |
-| {{< ci-details title="Custom tags and metrics at runtime" >}}Support for adding <a href="https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/">user-defined text and numerical tags</a> to pipelines and jobs in CI Visibility.{{< /ci-details >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |  |  |  |  {{< X >}} |
+| {{< ci-details title="Custom tags and measures at runtime" >}}Support for adding <a href="https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_measures/">user-defined text and numerical tags</a> to pipelines and jobs in CI Visibility.{{< /ci-details >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |  |  |  |  {{< X >}} |
 | {{< ci-details title="Parameters" >}}Support for adding custom pipeline parameters that users set (for example, <code>DYNAMICS_IS_CHILD:true</code>). You can then search using these parameters in the <a href="https://docs.datadoghq.com/continuous_integration/explorer/?tab=pipelineexecutions">CI Visibility Explorer</a> to find all events with a specific parameter.{{< /ci-details >}} | {{< X >}} | {{< X >}} |  |  |  |  | {{< X >}} |  |  |  {{< X >}} |
 | {{< ci-details title="Pipeline failure reason" >}}Identification of a specific reason behind a pipeline or job failure.{{< /ci-details >}} | {{< X >}} | {{< X >}} |  |  |  |  | {{< X >}} | {{< X >}} | {{< X >}} |  {{< X >}} |
 

--- a/content/en/continuous_integration/pipelines/azure.md
+++ b/content/en/continuous_integration/pipelines/azure.md
@@ -10,9 +10,9 @@ further_reading:
     - link: "/continuous_integration/troubleshooting/"
       tag: "Documentation"
       text: "Troubleshooting CI"
-    - link: "/continuous_integration/pipelines/custom_tags_and_metrics/"
+    - link: "/continuous_integration/pipelines/custom_tags_and_measures/"
       tag: "Documentation"
-      text: "Extend Pipeline Visibility by adding custom tags and metrics"
+      text: "Extend Pipeline Visibility by adding custom tags and measures"
 ---
 
 <div class="alert alert-warning">
@@ -25,7 +25,7 @@ Azure DevOps Server is not officially supported.
 
 ## Compatibility
 
-- **Custom tags and metrics at runtime**: Configure [custom tags][6] and metrics at runtime
+- **Custom tags and measures at runtime**: Configure [custom tags][6] and measures at runtime
 
 ## Configure the Datadog integration
 
@@ -104,5 +104,5 @@ The [Pipelines][4] and [Pipeline Executions][5] pages populate with data after t
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions
-[6]: /continuous_integration/pipelines/custom_tags_and_metrics/?tab=linux
+[6]: /continuous_integration/pipelines/custom_tags_and_measures/?tab=linux
 [8]: https://marketplace.visualstudio.com/items?itemName=Datadog.ci-visibility

--- a/content/en/continuous_integration/pipelines/buildkite.md
+++ b/content/en/continuous_integration/pipelines/buildkite.md
@@ -71,7 +71,7 @@ The resulting pipeline looks as follows:
 
 {{< img src="ci/buildkite-custom-tags.png" alt="Buildkite pipeline trace with custom tags" style="width:100%;">}}
 
-Any metadata with a key starting with `dd-metrics.` and containing a numerical value will be set as
+Any metadata with a key starting with `dd-measures.` and containing a numerical value will be set as
 a metric tag that can be used to create numerical measures. You can use the `buildkite-agent meta-data set`
 command to create such tags. This can be used for example to measure the binary size in a pipeline:
 
@@ -79,7 +79,7 @@ command to create such tags. This can be used for example to measure the binary 
 steps:
   - commands:
     - go build -o dst/binary .
-    - ls -l dst/binary | awk '{print \$5}' | tr -d '\n' | buildkite-agent meta-data set "dd_metrics.binary_size"
+    - ls -l dst/binary | awk '{print \$5}' | tr -d '\n' | buildkite-agent meta-data set "dd_measures.binary_size"
     label: Go build
 ```
 

--- a/content/en/continuous_integration/pipelines/buildkite.md
+++ b/content/en/continuous_integration/pipelines/buildkite.md
@@ -10,9 +10,9 @@ further_reading:
     - link: "/continuous_integration/troubleshooting/"
       tag: "Documentation"
       text: "Troubleshooting CI"
-    - link: "/continuous_integration/pipelines/custom_tags_and_metrics/"
+    - link: "/continuous_integration/pipelines/custom_tags_and_measures/"
       tag: "Documentation"
-      text: "Extend Pipeline Visibility by adding custom tags and metrics"
+      text: "Extend Pipeline Visibility by adding custom tags and measures"
 ---
 
 {{< site-region region="gov" >}}
@@ -29,7 +29,7 @@ further_reading:
 
 - **Queue time**: View amount of time pipeline jobs sit in the queue before processing
 
-- **Custom tags and metrics at runtime**: Configure [custom tags][6] and metrics at runtime
+- **Custom tags and measures at runtime**: Configure [custom tags][6] and measures at runtime
 
 ## Configure the Datadog integration
 
@@ -127,6 +127,6 @@ These filters can also be applied through the facet panel on the left hand side 
 [3]: https://app.datadoghq.com/ci/pipelines
 [4]: https://app.datadoghq.com/ci/pipeline-executions
 [5]: https://docs.datadoghq.com/continuous_integration/pipelines/buildkite/#view-partial-and-downstream-pipelines
-[6]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_metrics/?tab=linux
+[6]: https://docs.datadoghq.com/continuous_integration/pipelines/custom_tags_and_measures/?tab=linux
 [7]: /agent/
 [8]: /continuous_integration/pipelines/buildkite/#correlate-infrastructure-metrics-to-jobs

--- a/content/en/continuous_integration/pipelines/circleci.md
+++ b/content/en/continuous_integration/pipelines/circleci.md
@@ -13,9 +13,9 @@ further_reading:
     - link: "/continuous_integration/troubleshooting/"
       tag: "Documentation"
       text: "Troubleshooting CI"
-    - link: "/continuous_integration/pipelines/custom_tags_and_metrics/"
+    - link: "/continuous_integration/pipelines/custom_tags_and_measures/"
       tag: "Documentation"
-      text: "Extend Pipeline Visibility by adding custom tags and metrics"
+      text: "Extend Pipeline Visibility by adding custom tags and measures"
 ---
 
 {{< site-region region="gov" >}}
@@ -32,7 +32,7 @@ further_reading:
 
 - **Custom pre-defined tags**: Set [custom tags][6] to all generated pipeline and job spans
 
-- **Custom tags and metrics at runtime**: Configure [custom tags][7] and metrics at runtime
+- **Custom tags and measures at runtime**: Configure [custom tags][7] and measures at runtime
 
 ## Configure the Datadog integration
 
@@ -105,7 +105,7 @@ The [Pipelines][4] and [Pipeline Executions][5] pages populate with data after t
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions
 [6]: /continuous_integration/pipelines/circleci/#set-custom-tags
-[7]: /continuous_integration/pipelines/custom_tags_and_metrics/?tab=linux
+[7]: /continuous_integration/pipelines/custom_tags_and_measures/?tab=linux
 [8]: /account_management/teams/
 [9]: https://raw.githubusercontent.com/DataDog/ci-visibility-circle-ci/main/service_hooks.py
 [10]: /continuous_integration/pipelines/circleci/#enable-log-collection

--- a/content/en/continuous_integration/pipelines/custom.md
+++ b/content/en/continuous_integration/pipelines/custom.md
@@ -22,7 +22,7 @@ further_reading:
 
 ## Compatibility
 
-- **Custom tags and metrics**: Attach custom tags and metrics to pipeline executions
+- **Custom tags and measures**: Attach custom tags and measures to pipeline executions
 
 - **Manual steps**: View manually triggered pipelines
 

--- a/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
+++ b/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
@@ -2,7 +2,7 @@
 title: Adding Custom Tags and Measures to Pipeline Traces
 kind: documentation
 aliases:
-  - /continuous_integration/pipelines/custom_tags_and_measures
+  - /continuous_integration/pipelines/custom_tags_and_metrics
   - /continuous_integration/setup_pipelines/custom_tags_and_metrics
 further_reading:
   - link: "/continuous_integration/troubleshooting/"

--- a/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
+++ b/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
@@ -1,7 +1,9 @@
 ---
-title: Adding Custom Tags and Metrics to Pipeline Traces
+title: Adding Custom Tags and Measures to Pipeline Traces
 kind: documentation
 aliases:
+  - /continuous_integration/pipelines/custom_tags_and_measures
+  - /continuous_integration/setup_pipelines/custom_tags_and_measures
   - /continuous_integration/setup_pipelines/custom_tags_and_metrics
 further_reading:
   - link: "/continuous_integration/troubleshooting/"
@@ -16,19 +18,19 @@ further_reading:
 <div class="alert alert-warning">CI Visibility is not available for the selected site ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-The custom tags and metrics commands provide a way to add user-defined text and numerical tags to your CI Visibility
+The custom tags and measures commands provide a way to add user-defined text and numerical tags to your CI Visibility
 pipeline traces.
 These tags can be used to create facets (string value tags) or measures (numerical value tags). Facets and measures
 can then be used to search, graph, or monitor the pipelines.
 
 ## Compatibility
 
-Custom tags and metrics work with the following CI providers:
+Custom tags and measures work with the following CI providers:
 
 - Buildkite
 - CircleCI
 - GitLab (SaaS or self-hosted >= 14.1)
-- GitHub.com (SaaS) **Note:** For adding tags and metrics to GitHub jobs, see the [section][6] below.
+- GitHub.com (SaaS) **Note:** For adding tags and measures to GitHub jobs, see the [section][6] below.
 - Jenkins **Note:** For Jenkins, follow [these instructions][5] to set up custom tags in your pipelines.
 - Azure DevOps Pipelines
 
@@ -101,12 +103,12 @@ and then click the **create facet** option.
 
 {{< img src="ci/custom-tags-create-facet.mp4" alt="Facet creation for custom tag" style="width:100%;" video="true">}}
 
-## Add metrics to pipeline traces
+## Add measures to pipeline traces
 
 To add numerical tags to the pipeline span or the job span, run:
 
 {{< code-block lang="shell" >}}
-datadog-ci metric [--level <pipeline|job>] [--metrics <metrics>]
+datadog-ci measure [--level <pipeline|job>] [--measures <measures>]
 {{< /code-block >}}
 
 You must specify a valid [Datadog API key][3] using the environment variable `DATADOG_API_KEY`.
@@ -116,24 +118,24 @@ You must specify the [Datadog site][1] using the environment variable `DATADOG_S
 [1]: /getting_started/site/
 {{< /site-region >}}
 
-The following example adds the metric `error_rate` to the pipeline span:
+The following example adds the measure `error_rate` to the pipeline span:
 
 {{< code-block lang="shell" >}}
-datadog-ci metric --level pipeline --metrics "error_rate:0.56"
+datadog-ci measure --level pipeline --measures "error_rate:0.56"
 {{< /code-block >}}
 
-The following example adds a metric `binary.size` to the span for the currently running job:
+The following example adds a measure `binary.size` to the span for the currently running job:
 
 {{< code-block lang="shell" >}}
-datadog-ci metric --level job --metrics "binary.size:`ls -l dst/binary | awk '{print \$5}' | tr -d '\n'`"
+datadog-ci measure --level job --measures "binary.size:`ls -l dst/binary | awk '{print \$5}' | tr -d '\n'`"
 {{< /code-block >}}
 
-To create a measure, click the gear icon next to the metrics name in the [pipeline executions page][4]
+To create a measure, click the gear icon next to the measures name in the [pipeline executions page][4]
 and then click the **create measure** option.
 
-## Add tags and metrics to GitHub jobs
+## Add tags and measures to GitHub jobs
 
-To add tags and metrics to GitHub jobs, `datadog-ci CLI` version `2.29.0` or higher is required.
+To add tags and measures to GitHub jobs, `datadog-ci CLI` version `2.29.0` or higher is required.
 If the job name does not match the entry defined in the workflow configuration file (the GitHub [job ID][7]),
 the `DD_GITHUB_JOB_NAME` environment variable needs to be exposed, pointing to the job name. For example:
 1. If the job name is changed using the [name property][8]:
@@ -171,7 +173,7 @@ within parenthesis. The `DD_GITHUB_JOB_NAME` environment variable should then be
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: https://app.datadoghq.com/ci/pipeline-executions
 [5]: /continuous_integration/pipelines/jenkins?tab=usingui#setting-custom-tags-for-your-pipelines
-[6]: /continuous_integration/pipelines/custom_tags_and_metrics/?tab=linux#add-tags-and-metrics-to-github-jobs
+[6]: /continuous_integration/pipelines/custom_tags_and_measures/?tab=linux#add-tags-and-measures-to-github-jobs
 [7]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_id
 [8]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#name
 [9]: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#using-a-matrix-strategy

--- a/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
+++ b/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
@@ -3,7 +3,6 @@ title: Adding Custom Tags and Measures to Pipeline Traces
 kind: documentation
 aliases:
   - /continuous_integration/pipelines/custom_tags_and_measures
-  - /continuous_integration/setup_pipelines/custom_tags_and_measures
   - /continuous_integration/setup_pipelines/custom_tags_and_metrics
 further_reading:
   - link: "/continuous_integration/troubleshooting/"

--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -10,9 +10,9 @@ further_reading:
     - link: "/continuous_integration/troubleshooting/"
       tag: "Documentation"
       text: "Troubleshooting CI"
-    - link: "/continuous_integration/pipelines/custom_tags_and_metrics/"
+    - link: "/continuous_integration/pipelines/custom_tags_and_measures/"
       tag: "Documentation"
-      text: "Extend Pipeline Visibility by adding custom tags and metrics"
+      text: "Extend Pipeline Visibility by adding custom tags and measures"
     - link: "https://www.datadoghq.com/blog/datadog-github-actions-ci-visibility/"
       tag: "blog"
       text: "Monitor your GitHub Actions workflows with Datadog CI Visibility"
@@ -35,7 +35,7 @@ further_reading:
 
 - **Infrastructure metric correlation**: [Correlate infrastructure metrics][11] to pipeline jobs for self-hosted GitHub runners
 
-- **Custom tags and metrics at runtime**: Configure custom tags and metrics at runtime
+- **Custom tags and measures at runtime**: Configure custom tags and measures at runtime
 
 - **Queue time**: View amount of time workflow jobs sit in the queue before processing
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -10,9 +10,9 @@ further_reading:
     - link: "/continuous_integration/troubleshooting/"
       tag: "Documentation"
       text: "Troubleshooting CI"
-    - link: "/continuous_integration/pipelines/custom_tags_and_metrics/"
+    - link: "/continuous_integration/pipelines/custom_tags_and_measures/"
       tag: "Documentation"
-      text: "Extend Pipeline Visibility by adding custom tags and metrics"
+      text: "Extend Pipeline Visibility by adding custom tags and measures"
 ---
 
 {{< site-region region="gov" >}}
@@ -40,7 +40,7 @@ further_reading:
 
 - **Custom pre-defined tags**: Configure [custom tags][10] to all generated pipeline, stages, and job spans
 
-- **Custom tags and metrics at runtime**: Configure [custom tags][13] and metrics at runtime
+- **Custom tags and measures at runtime**: Configure [custom tags][13] and measures at runtime
 
 - **Parameters**: Set custom `env` or `service` parameters
 
@@ -302,7 +302,7 @@ The storage must not have network restrictions, such as an IP range allowlist.</
 [10]: /continuous_integration/pipelines/gitlab/?tab=gitlabcom#set-custom-tags
 [11]: /continuous_integration/pipelines/gitlab/?tab=gitlabcom#partial-and-downstream-pipelines
 [12]: /continuous_integration/pipelines/gitlab/#enable-job-log-collection
-[13]: /continuous_integration/pipelines/custom_tags_and_metrics/?tab=linux
+[13]: /continuous_integration/pipelines/custom_tags_and_measures/?tab=linux
 [14]: /continuous_integration/pipelines/gitlab/?tab=gitlabcom#correlate-infrastructure-metrics-to-jobs
 [15]: /continuous_integration/pipelines/gitlab/?tab=gitlabcom#view-error-messages-for-pipeline-failures
 [16]: /account_management/teams/

--- a/content/en/continuous_integration/pipelines/jenkins.md
+++ b/content/en/continuous_integration/pipelines/jenkins.md
@@ -34,7 +34,7 @@ further_reading:
 
 - **Custom spans**: Configure custom spans
 
-- **Custom pre-defined tags**: Configure [custom tags][12] and metrics at runtime
+- **Custom pre-defined tags**: Configure [custom tags][12] and measures at runtime
 
 - **Parameters**: Set custom parameters such as default branch name and Git information
 
@@ -956,7 +956,7 @@ Failed to reinitialize Datadog-Plugin Tracer, Cannot enable traces collection vi
 [9]: https://plugins.jenkins.io/kubernetes/#plugin-content-pod-template
 [10]: /continuous_integration/pipelines/jenkins/?tab=linux#enable-job-log-collection
 [11]: /continuous_integration/pipelines/jenkins/?tab=linux#correlate-infrastructure-metrics
-[12]: /continuous_integration/pipelines/custom_tags_and_metrics/
+[12]: /continuous_integration/pipelines/custom_tags_and_measures/
 [14]: /agent/
 [15]: /account_management/teams/
 [16]: /continuous_integration/tests/

--- a/content/en/continuous_integration/search/_index.md
+++ b/content/en/continuous_integration/search/_index.md
@@ -82,4 +82,4 @@ Pipeline Visibility provides AI-generated explanations for pipeline errors based
 [4]: /continuous_integration/pipelines/gitlab/#enable-job-log-collection-beta
 [5]: /continuous_integration/pipelines/jenkins#enable-job-log-collection
 [6]: /account_management/teams/ 
-[7]: /continuous_integration/pipelines/custom_tags_and_metrics/?tab=linux
+[7]: /continuous_integration/pipelines/custom_tags_and_measures/?tab=linux


### PR DESCRIPTION
This PR renames the custom_tags_and_metrics.md page to custom_tags_and_measures.md (while maintaining an alias to the old path). We also rename every outdated mention of "metrics" to "measures" in the continous_integrations pages

Context: https://docs.google.com/document/d/1X9-0eiiNaDsfLMKlVYsGdQs4RDKGZx9jEqLX4NEPAxY

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->