### PR TITLE
alias cleanup, leading slash

### DIFF
--- a/content/en/developers/integrations/create_a_tile.md
+++ b/content/en/developers/integrations/create_a_tile.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- developers/marketplace/offering
+- /developers/marketplace/offering
 description: Learn how to develop and publish an integration tile.
 further_reading:
 - link: https://www.datadoghq.com/blog/datadog-marketplace/
@@ -18,11 +18,11 @@ This page walks Technology Partners through creating the tile that represents an
 
 ## Integration tiles
 
-The tile serves as a point of entry where customers can learn about your offering, see setup instructions, and install or purchase your offering to unlock out-of-the-box dashboards and additional assets. 
+The tile serves as a point of entry where customers can learn about your offering, see setup instructions, and install or purchase your offering to unlock out-of-the-box dashboards and additional assets.
 
 {{< img src="developers/integrations/marketplace_or_integrations_tile.png" alt="An expanded tile modal of an example offering on the Integrations or Marketplace page" style="width:100%" >}}
 
-* For any offerings that **do not use** the Datadog Agent—including API-based integrations, professional services listings, and software licenses—you only need to create a tile and submit the tile-related files in order to publish your offering. This is called a _tile-only-listing_. Tile-ony listings apply in situations where Datadog does not host any of the code associated with the API-based integrations, and the other supported offering types do not require any code. 
+* For any offerings that **do not use** the Datadog Agent—including API-based integrations, professional services listings, and software licenses—you only need to create a tile and submit the tile-related files in order to publish your offering. This is called a _tile-only-listing_. Tile-ony listings apply in situations where Datadog does not host any of the code associated with the API-based integrations, and the other supported offering types do not require any code.
 
 * For **Agent-based integrations**, you must create a tile, and additionally, submit all of your integration-related code (as well as your tile-related files) in one pull request. For more information, see [Create an Agent-based integration][27].
 
@@ -36,7 +36,7 @@ The tile serves as a point of entry where customers can learn about your offerin
 
 To build a tile on the [**Integrations** page][103]:
 
-<div class="alert alert-warning">If you have already gone through the steps to create an Agent integration and have built out the scaffolding, you can skip directly to <a href="#complete-the-necessary-integration-asset-files">completing the necessary integration asset files</a>. 
+<div class="alert alert-warning">If you have already gone through the steps to create an Agent integration and have built out the scaffolding, you can skip directly to <a href="#complete-the-necessary-integration-asset-files">completing the necessary integration asset files</a>.
 </div>
 
 1. Create a `dd` directory:
@@ -44,7 +44,7 @@ To build a tile on the [**Integrations** page][103]:
    ```shell
    mkdir $HOME/dd
    ```
-   
+
    The Datadog Development Toolkit expects you to be working in the `$HOME/dd/` directory. This is not mandatory, but working in a different directory requires additional configuration steps.
 
 2. Fork the [`integrations-extras` repository][102].
@@ -100,15 +100,15 @@ For Datadog API integrations that will be available out-of-the-box on the [Integ
 
 {{< img src="developers/integrations/marketplace_tile.png" alt="A tile representing an example offering on the Marketplace page" style="width:25%" >}}
 
-To build a tile on the [**Marketplace** page][104]: 
+To build a tile on the [**Marketplace** page][104]:
 
-<div class="alert alert-warning">If you have already gone through the steps to create an Agent integration and have built out the scaffolding, you can skip directly to <a href="#complete-the-necessary-integration-asset-files">completing the necessary integration asset files</a>. 
+<div class="alert alert-warning">If you have already gone through the steps to create an Agent integration and have built out the scaffolding, you can skip directly to <a href="#complete-the-necessary-integration-asset-files">completing the necessary integration asset files</a>.
 </div>
 
 1. See [Build a Marketplace Offering][102] to request access to the [Marketplace repository][101].
 
 1. Create a `dd` directory:
-   
+
    ```shell
    mkdir $HOME/dd
    ```
@@ -116,7 +116,7 @@ To build a tile on the [**Marketplace** page][104]:
    The Datadog Development Toolkit command expects you to be working in the `$HOME/dd/` directory. This is not mandatory, but working in a different directory requires additional configuration steps.
 
 1. Once you have been granted access to the Marketplace repository, create the `dd` directory and clone the `marketplace` repository:
-   
+
    ```shell
    git clone git@github.com:DataDog/marketplace.git
    ```
@@ -255,8 +255,8 @@ ddev validate all <INTEGRATION_NAME>
 Complete the following steps:
 
 1. Commit all changes to your feature branch.
-2. Push your changes to the remote repository. 
-3. Open a pull request that contains your integration tile's asset files (including images) in the [`marketplace`][18] or [`integrations-extras`][26] repository. 
+2. Push your changes to the remote repository.
+3. Open a pull request that contains your integration tile's asset files (including images) in the [`marketplace`][18] or [`integrations-extras`][26] repository.
 
 After you've created your pull request, automatic checks run to verify that your pull request is in good shape and contains all the required content to be updated.
 
@@ -268,9 +268,9 @@ Once you have addressed the feedback and re-requested reviews, these reviewers a
 
 ## Troubleshoot errors
 
-Out-of-the-box integrations in the `integrations-extras` repository can run into validation errors when the forked repository is out of date with the origin. 
+Out-of-the-box integrations in the `integrations-extras` repository can run into validation errors when the forked repository is out of date with the origin.
 
-To resolve validation errors, update the forked repository on the GitHub web app: 
+To resolve validation errors, update the forked repository on the GitHub web app:
 
 1. In [GitHub][29], navigate to your forked `integrations-extras` repository.
 1. Click **Sync fork** and click **Update branch**.

--- a/content/en/developers/integrations/marketplace_offering.md
+++ b/content/en/developers/integrations/marketplace_offering.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-- developers/marketplace/
+- /developers/marketplace/
 further_reading:
 - link: https://www.datadoghq.com/partner/
   tag: Partner Network
@@ -20,13 +20,13 @@ description: Learn about the Datadog marketplace.
 ---
 ## Overview
 
-The [Datadog Marketplace][2] is a digital marketplace where Technology Partners can list their paid offerings to Datadog users.  
+The [Datadog Marketplace][2] is a digital marketplace where Technology Partners can list their paid offerings to Datadog users.
 
 While the **Integrations** page includes integrations built by both Datadog and Technology Partners at no cost, the **Marketplace** page is a commercial platform for Datadog customers and Technology Partners to buy and sell a variety of offerings, including Agent-based or API-based integrations, software licenses, and professional services.
 
 {{< img src="developers/marketplace/marketplace_overview.png" alt="The Datadog Marketplace page" style="width:100%" >}}
 
-## List an offering 
+## List an offering
 
 The following types of offerings are supported on the Datadog Marketplace:
 
@@ -39,11 +39,11 @@ Software licenses
 Professional services
 : Professional services enable you to offer your team's services for implementation, support, or management for a set period of time.
 
-## Join the Datadog Marketplace 
+## Join the Datadog Marketplace
 
 Marketplace Partners have unique benefits that are not available to Technology Partners who list out-of-the-box integrations:
- 
-- **Go-to-market collaboration** including a blog post, a quote for a press release, and social media amplification, with access to dedicated sales and marketing resources focused on accelerating partner growth. 
+
+- **Go-to-market collaboration** including a blog post, a quote for a press release, and social media amplification, with access to dedicated sales and marketing resources focused on accelerating partner growth.
 - **Training and support** for internal sales enablement.
 - **Exclusive opportunities to sponsor** conferences and events (such as [Datadog DASH][20]) at a discounted rate.
 - **Generate new leads** from user discovery.

--- a/content/en/integrations/adobe_experience_manager.md
+++ b/content/en/integrations/adobe_experience_manager.md
@@ -10,7 +10,7 @@ categories:
     - log collection
 doc_link: /integrations/adobe_experience_manager/
 aliases:
-    - logs/log_collection/adobe_experience_manager
+    - /logs/log_collection/adobe_experience_manager
 has_logo: true
 integration_title: Adobe Experience Manager
 is_public: true

--- a/content/en/integrations/kubernetes_audit_logs.md
+++ b/content/en/integrations/kubernetes_audit_logs.md
@@ -12,7 +12,7 @@ categories:
     - orchestration
 doc_link: /integrations/kubernetes_audit_logs/
 aliases:
-    - logs/log_collection/kubernetes_audit_logs
+    - /logs/log_collection/kubernetes_audit_logs
 has_logo: true
 integration_title: Kubernetes Audit Logs
 is_public: true

--- a/content/en/integrations/nxlog.md
+++ b/content/en/integrations/nxlog.md
@@ -8,7 +8,7 @@ categories:
     - log collection
 doc_link: /integrations/nxlog/
 aliases:
-    - logs/log_collection/nxlog
+    - /logs/log_collection/nxlog
 has_logo: true
 integration_title: nxlog
 is_public: true

--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -8,7 +8,7 @@ categories:
     - log collection
 doc_link: /integrations/rsyslog/
 aliases:
-    - logs/log_collection/rsyslog
+    - /logs/log_collection/rsyslog
 has_logo: true
 integration_title: rsyslog
 is_public: true
@@ -73,7 +73,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    # include the omhttp module
    module(load="omhttp")
 
-   ruleset(name="infiles") { 
+   ruleset(name="infiles") {
       action(type="omhttp" server="http-intake.logs.<site_url>" serverport="443" restpath="api/v2/logs" template="test_template" httpheaders=["DD-API-KEY: <API_KEY>", "Content-Type: application/json"])
    }
    ```
@@ -85,7 +85,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    ```
 
 5. Associate your logs with the host metrics and tags.
-   
+
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
    - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
    - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
@@ -107,7 +107,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
      ```
 
 7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
-   
+
    1. Add the following lines to your Rsyslog configuration file:
 
       ```conf
@@ -208,7 +208,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    # include the omhttp module
    module(load="omhttp")
 
-   ruleset(name="infiles") { 
+   ruleset(name="infiles") {
       action(type="omhttp" server="http-intake.logs.<site_url>" serverport="443" restpath="api/v2/logs" template="test_template" httpheaders=["DD-API-KEY: <API_KEY>", "Content-Type: application/json"])
    }
    ```
@@ -220,12 +220,12 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    ```
 
 5. Associate your logs with the host metrics and tags:
-   
+
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
    - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
    - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
 
-6. To get the best use out of your logs in Datadog, set a source for the logs. 
+6. To get the best use out of your logs in Datadog, set a source for the logs.
    - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
    - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
 
@@ -242,7 +242,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
      ```
 
 7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
-   
+
    1. Add the following two lines to your Rsyslog configuration file:
 
       ```conf
@@ -345,7 +345,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    # include the omhttp module
    module(load="omhttp")
 
-   ruleset(name="infiles") { 
+   ruleset(name="infiles") {
       action(type="omhttp" server="http-intake.logs.<site_url>" serverport="443" restpath="api/v2/logs" template="test_template" httpheaders=["DD-API-KEY: <API_KEY>", "Content-Type: application/json"])
    }
    ```
@@ -357,12 +357,12 @@ Configure Rsyslog to gather logs from your host, containers, and services.
    ```
 
 5. Associate your logs with the host metrics and tags:
-   
+
    To make sure that your logs are associated with the metrics and tags from the same host in your Datadog account, set the `HOSTNAME` in your `rsyslog.conf` to match the hostname of your Datadog metrics.
    - If you specified a hostname in `datadog.conf` or `datadog.yaml`, replace the `%HOSTNAME%` value in `rsyslog.conf` to match your hostname.
    - If you did not specify a hostname in `datadog.conf` or `datadog.yaml`, you do not need to change anything.
 
-6. To get the best use out of your logs in Datadog, set a source for the logs. 
+6. To get the best use out of your logs in Datadog, set a source for the logs.
    - If you [forward your logs to the Datadog Agent][1], you can set the source in the Agent configuration file.
    - If you're not forwarding your logs to the Datadog Agent, create a distinct configuration file for each source in `/etc/rsyslog.d/`:
 
@@ -379,7 +379,7 @@ Configure Rsyslog to gather logs from your host, containers, and services.
      ```
 
 7. (Optional) Datadog cuts inactive connections after a period of inactivity. Some versions of Rsyslog are not able to reconnect when necessary. To mitigate this issue, use time markers so the connection never stops:
-   
+
    1. Add the following two lines to your Rsyslog configuration file:
 
       ```conf

--- a/content/en/integrations/sinatra.md
+++ b/content/en/integrations/sinatra.md
@@ -7,7 +7,7 @@ short_description: 'Gather Sinatra application logs.'
 categories:
     - log collection
 aliases:
-    - logs/log_collection/nxlog
+    - /logs/log_collection/nxlog
 has_logo: true
 integration_title: Sinatra
 is_public: true

--- a/content/en/integrations/syslog_ng.md
+++ b/content/en/integrations/syslog_ng.md
@@ -8,7 +8,7 @@ categories:
     - log collection
 doc_link: /integrations/syslog_ng/
 aliases:
-    - logs/log_collection/syslog_ng
+    - /logs/log_collection/syslog_ng
 has_logo: true
 integration_title: syslog_ng
 is_public: true

--- a/content/en/intelligent_test_runner/setup/dotnet.md
+++ b/content/en/intelligent_test_runner/setup/dotnet.md
@@ -5,8 +5,8 @@ code_lang: dotnet
 type: multi-code-lang
 code_lang_weight: 0
 aliases:
-  - continuous_integration/intelligent_test_runner/dotnet/
-  - continuous_integration/intelligent_test_runner/setup/dotnet/
+  - /continuous_integration/intelligent_test_runner/dotnet/
+  - /continuous_integration/intelligent_test_runner/setup/dotnet/
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"

--- a/content/en/intelligent_test_runner/setup/java.md
+++ b/content/en/intelligent_test_runner/setup/java.md
@@ -5,8 +5,8 @@ code_lang: java
 type: multi-code-lang
 code_lang_weight: 10
 aliases:
-  - continuous_integration/intelligent_test_runner/java/
-  - continuous_integration/intelligent_test_runner/setup/java/
+  - /continuous_integration/intelligent_test_runner/java/
+  - /continuous_integration/intelligent_test_runner/setup/java/
 
 further_reading:
     - link: "/continuous_integration/tests"

--- a/content/en/intelligent_test_runner/setup/javascript.md
+++ b/content/en/intelligent_test_runner/setup/javascript.md
@@ -5,8 +5,8 @@ code_lang: javascript
 type: multi-code-lang
 code_lang_weight: 20
 aliases:
-  - continuous_integration/intelligent_test_runner/javascript/
-  - continuous_integration/intelligent_test_runner/setup/javascript/
+  - /continuous_integration/intelligent_test_runner/javascript/
+  - /continuous_integration/intelligent_test_runner/setup/javascript/
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"

--- a/content/en/intelligent_test_runner/setup/python.md
+++ b/content/en/intelligent_test_runner/setup/python.md
@@ -5,8 +5,8 @@ code_lang: python
 type: multi-code-lang
 code_lang_weight: 30
 aliases:
-  - continuous_integration/intelligent_test_runner/python/
-  - continuous_integration/intelligent_test_runner/setup/python/
+  - /continuous_integration/intelligent_test_runner/python/
+  - /continuous_integration/intelligent_test_runner/setup/python/
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"

--- a/content/en/intelligent_test_runner/setup/swift.md
+++ b/content/en/intelligent_test_runner/setup/swift.md
@@ -6,8 +6,8 @@ code_lang: swift
 type: multi-code-lang
 code_lang_weight: 40
 aliases:
-  - continuous_integration/intelligent_test_runner/swift/
-  - continuous_integration/intelligent_test_runner/setup/swift/
+  - /continuous_integration/intelligent_test_runner/swift/
+  - /continuous_integration/intelligent_test_runner/setup/swift/
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"

--- a/content/en/security/cloud_siem/signal_correlation_rules.md
+++ b/content/en/security/cloud_siem/signal_correlation_rules.md
@@ -2,7 +2,7 @@
 title: Signal Correlation Rules
 type: documentation
 aliases:
- - security_platform/cloud_siem/signal_correlation_rules
+ - /security_platform/cloud_siem/signal_correlation_rules
 further_reading:
 - link: "/cloud_siem/explorer/"
   tag: "Documentation"

--- a/content/en/tests/setup/_index.md
+++ b/content/en/tests/setup/_index.md
@@ -3,7 +3,7 @@ title: Configure Test Visibility
 kind: documentation
 type: multi-code-lang
 aliases:
-- continuous_integration/tests/setup/
+- /continuous_integration/tests/setup/
 ---
 
 For information about configuration options for [Test Visibility][1], choose your language:

--- a/content/en/tests/setup/dotnet.md
+++ b/content/en/tests/setup/dotnet.md
@@ -7,7 +7,7 @@ code_lang_weight: 0
 aliases:
   - /continuous_integration/setup_tests/dotnet
   - /continuous_integration/tests/dotnet
-  - continuous_integration/tests/setup/dotnet
+  - /continuous_integration/tests/setup/dotnet
 further_reading:
     - link: "/continuous_integration/tests/containers/"
       tag: "Documentation"

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -7,7 +7,7 @@ code_lang_weight: 10
 aliases:
   - /continuous_integration/setup_tests/java
   - /continuous_integration/tests/java
-  - continuous_integration/tests/setup/java
+  - /continuous_integration/tests/setup/java
 further_reading:
     - link: "/continuous_integration/tests/containers/"
       tag: "Documentation"

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -7,7 +7,7 @@ code_lang_weight: 20
 aliases:
   - /continuous_integration/setup_tests/javascript
   - /continuous_integration/tests/javascript
-  - continuous_integration/tests/setup/javascript
+  - /continuous_integration/tests/setup/javascript
 further_reading:
     - link: "/continuous_integration/tests/containers/"
       tag: "Documentation"

--- a/content/en/tests/setup/junit_xml.md
+++ b/content/en/tests/setup/junit_xml.md
@@ -7,7 +7,7 @@ code_lang_weight: 60
 aliases:
   - /continuous_integration/setup_tests/junit_upload
   - /continuous_integration/tests/junit_upload
-  - continuous_integration/tests/setup/junit_xml
+  - /continuous_integration/tests/setup/junit_xml
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"
@@ -347,11 +347,11 @@ As a result, the JUnit XML tests have a `test.codeowners` tag with the owner of 
 To automatically add the `test.codeowners` tag to your tests, you need to:
 1. Have a `CODEOWNERS` file [in one of the allowed locations][15] in your repository.
 2. Provide the tests source file in your JUnit XML report. The following plugins do this automatically and add the `file` attribute to the `<testcase>` or `<testsuite>` elements in the XML report:
-    
+
     * phpunit
     * Most Python plugins (pytest, unittest)
     * Most Ruby plugins (ruby minitest)
-    
+
     If the XML does not have the `file` attribute, you need to [provide the source file manually](#manually-providing-the-testsourcefile-tag).
    Example of a valid report:
 

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -7,7 +7,7 @@ code_lang_weight: 30
 aliases:
   - /continuous_integration/setup_tests/python
   - /continuous_integration/tests/python
-  - continuous_integration/tests/setup/python
+  - /continuous_integration/tests/setup/python
 further_reading:
     - link: "/continuous_integration/tests/containers/"
       tag: "Documentation"

--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -7,7 +7,7 @@ code_lang_weight: 40
 aliases:
   - /continuous_integration/setup_tests/ruby
   - /continuous_integration/tests/ruby
-  - continuous_integration/tests/setup/ruby
+  - /continuous_integration/tests/setup/ruby
 further_reading:
     - link: "/continuous_integration/tests/containers/"
       tag: "Documentation"

--- a/content/en/tests/setup/swift.md
+++ b/content/en/tests/setup/swift.md
@@ -7,7 +7,7 @@ code_lang_weight: 50
 aliases:
   - /continuous_integration/setup_tests/swift
   - /continuous_integration/tests/swift
-  - continuous_integration/tests/setup/swift
+  - /continuous_integration/tests/setup/swift
 further_reading:
     - link: "/continuous_integration/tests"
       tag: "Documentation"

--- a/content/en/tests/swift_tests.md
+++ b/content/en/tests/swift_tests.md
@@ -5,7 +5,7 @@ description: Learn how to use CI Visibility and RUM to connect your Swift test r
 aliases:
 - /continuous_integration/guides/rum_swift_integration
 - /continuous_integration/integrate_tests/swift_tests
-- continuous_integration/tests/swift_tests
+- /continuous_integration/tests/swift_tests
 further_reading:
 - link: "/continuous_integration/tests"
   tag: "Documentation"
@@ -32,7 +32,7 @@ The CI Visibility - RUM integration is available for these versions of `dd-sdk-s
 
 ## Connect Swift tests and RUM
 
-If you link `dd-sdk-swift-testing` for your UI tests and the application being tested is instrumented using [Real User Monitoring][1], your test results and their generated RUM browser sessions and session replays are automatically linked. 
+If you link `dd-sdk-swift-testing` for your UI tests and the application being tested is instrumented using [Real User Monitoring][1], your test results and their generated RUM browser sessions and session replays are automatically linked.
 
 A **RUM Sessions** tab appears in the Test Visibility test detail side panel.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

In relation to #21896 we discovered we can get in a temporary state of 404 links between redirect passes that run.
This PR fixes current aliases without a leading slash.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->