### PR TITLE
Fix SBOM Upload Instructions

### DIFF
--- a/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
@@ -48,7 +48,7 @@ Provide the following inputs:
 ```bash
 # Set the Datadog site to send information to
 export DD_SITE="datadoghq.com"
-                        
+
 # Install dependencies
 npm install -g @datadog/datadog-ci
 

--- a/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
@@ -48,9 +48,12 @@ Provide the following inputs:
 ```bash
 # Set the Datadog site to send information to
 export DD_SITE="datadoghq.com"
-
+                        
 # Install dependencies
 npm install -g @datadog/datadog-ci
+
+# Output Trivy results
+trivy fs --output /tmp/trivy.json --format cyclonedx </path/to/code>
 
 # Upload results
 datadog-ci sbom upload --service "my-app" --env "ci" /tmp/trivy.json


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds a missing line to the Bash script for uploading an SBOM with a generic CI provider for the Code Analysis product.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->