### PR TITLE
Add example for composite monitor combination table

### DIFF
--- a/content/en/monitors/types/composite.md
+++ b/content/en/monitors/types/composite.md
@@ -125,19 +125,21 @@ Consider a composite monitor that uses two individual monitors: `A` and `B`. The
 | Monitor A   | Monitor B   | Condition   | Notify No Data   | Composite status | Alert triggered? |
 |-------------|-------------|-------------|------------------|------------------|------------------|
 | Alert (T)   | Warn (T)    | `A && B`    |                  | Warn (T)         | {{< X >}}        |
-| Alert (T)   | Warn (T)    | `A \|\| B`    |                  | Alert (T)        | {{< X >}}        |
+| Alert (T)   | Warn (T)    | `A \|\| B`  |                  | Alert (T)        | {{< X >}}        |
+| Alert (T)   | Ok (F)      | `A && B`    |                  | OK (F)           |                  |
+| Alert (T)   | Ok (F)      | `A \|\| B`  |                  | Alert (T)        | {{< X >}}        |
 | Warn (T)    | Ok (F)      | `A && B`    |                  | OK (F)           |                  |
-| Warn (T)    | Ok (F)      | `A \|\| B`    |                  | Warn (T)         | {{< X >}}        |
+| Warn (T)    | Ok (F)      | `A \|\| B`  |                  | Warn (T)         | {{< X >}}        |
 | No Data (T) | Warn (T)    | `A && B`    | True             | No Data (T)      | {{< X >}}        |
-| No Data (T) | Warn (T)    | `A \|\| B`    | True             | Warn (T)         | {{< X >}}        |
+| No Data (T) | Warn (T)    | `A \|\| B`  | True             | Warn (T)         | {{< X >}}        |
 | No Data (T) | Warn (T)    | `A && B`    | False            | Last known       |                  |
-| No Data (T) | Warn (T)    | `A \|\| B`    | False            | Warn (T)         | {{< X >}}        |
+| No Data (T) | Warn (T)    | `A \|\| B`  | False            | Warn (T)         | {{< X >}}        |
 | No Data (T) | OK (F)      | `A && B`    | False            | OK (F)           |                  |
-| No Data (T) | OK (F)      | `A \|\| B`    | False            | Last known       |                  |
+| No Data (T) | OK (F)      | `A \|\| B`  | False            | Last known       |                  |
 | No Data (T) | OK (F)      | `A && B`    | True             | OK (F)           |                  |
-| No Data (T) | OK (F)      | `A \|\| B`    | True             | No Data (T)      | {{< X >}}        |
+| No Data (T) | OK (F)      | `A \|\| B`  | True             | No Data (T)      | {{< X >}}        |
 | No Data (T) | No Data (T) | `A && B`    | True             | No Data (T)      | {{< X >}}        |
-| No Data (T) | No Data (T) | `A \|\| B`    | True             | No Data (T)      | {{< X >}}        |
+| No Data (T) | No Data (T) | `A \|\| B`  | True             | No Data (T)      | {{< X >}}        |
 
 **Note**: When the composite has `notify_no_data` to false, and the result of the evaluation of the sub-monitors should end up on a `No Data` status for the composite, the composite uses the last known state instead.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Add combination example of `ALERT && OK` and `ALERT || OK`
- Fixed the table alignment
- [DOCS-7250](https://datadoghq.atlassian.net/browse/DOCS-7250)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7250]: https://datadoghq.atlassian.net/browse/DOCS-7250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ