### PR TITLE
Add alias redirect for CSM Threats setup

### DIFF
--- a/content/en/security/cloud_security_management/setup/csm_cloud_workload_security/_index.md
+++ b/content/en/security/cloud_security_management/setup/csm_cloud_workload_security/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Setting up CSM Cloud Workload Security
 kind: documentation
+aliases:
+  - /security/cloud_security_management/setup/csm_workload_security/
 further_reading:
   - link: "/security/cloud_security_management/setup"
     tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds an alias redirect for the CSM Threats setup page. Requested by PM.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->