### PR TITLE
[Synthetics] Private Location: Document the behavior of reverse proxies with Datadog intake

### DIFF
--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -80,7 +80,7 @@ On browser tests, the DNS resolution is done directly by the browser, which usua
 **Default**: `none`<br>
 Proxy URL used by the private location to send requests to Datadog (for example, `--proxyDatadog=http://<YOUR_USER>:<YOUR_PWD>@<YOUR_IP>:<YOUR_PORT>`).
 
-**Note:** When setting up an HTTPS proxy, the `HTTP CONNECT` request made between the Private Location and the proxy establishes the initial TCP connection between the Private Location and Datadog. As such, reverse proxies like HAProxy that directs `HTTP CONNECT` request to Datadog are not supported, and a forward proxy should be set up to open the connection to Datadog on behalf of the Private Location.
+**Note:** When setting up an HTTPS proxy, the `HTTP CONNECT` request made to the proxy establishes the initial TCP connection between the Private Location and Datadog. As such, reverse proxies like HAProxy that directs `HTTP CONNECT` request to Datadog are not supported. A forward proxy should be set up to open the connection to Datadog on behalf of the Private Location.
 
 `proxyTestRequests`
 : **Type**: String <br>

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -80,6 +80,8 @@ On browser tests, the DNS resolution is done directly by the browser, which usua
 **Default**: `none`<br>
 Proxy URL used by the private location to send requests to Datadog (for example, `--proxyDatadog=http://<YOUR_USER>:<YOUR_PWD>@<YOUR_IP>:<YOUR_PORT>`).
 
+**Note:** When setting up an HTTPS proxy, the `HTTP CONNECT` request made between the Private Location and the proxy establishes the initial TCP connection between the Private Location and Datadog. As such, reverse proxies like HAProxy that directs `HTTP CONNECT` request to Datadog are not supported, and a forward proxy should be set up to open the connection to Datadog on behalf of the Private Location.
+
 `proxyTestRequests`
 : **Type**: String <br>
 **Default**: `none`<br>

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -80,7 +80,7 @@ On browser tests, the DNS resolution is done directly by the browser, which usua
 **Default**: `none`<br>
 Proxy URL used by the private location to send requests to Datadog (for example, `--proxyDatadog=http://<YOUR_USER>:<YOUR_PWD>@<YOUR_IP>:<YOUR_PORT>`).
 
-**Note:** When setting up an HTTPS proxy, the `HTTP CONNECT` request made to the proxy establishes the initial TCP connection between the Private Location and Datadog. As such, reverse proxies like HAProxy that directs `HTTP CONNECT` request to Datadog are not supported. A forward proxy should be set up to open the connection to Datadog on behalf of the Private Location.
+**Note:** When setting up an HTTPS proxy, the `HTTP CONNECT` request made to the proxy establishes the initial TCP connection between the private location and Datadog. As such, reverse proxies like HAProxy that direct an `HTTP CONNECT` request to Datadog are not supported. Set up a forward proxy to open the connection to Datadog on behalf of the private location.
 
 `proxyTestRequests`
 : **Type**: String <br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR adds a mention of the HTTPS proxies behavior in the Synthetics Private Location proxy configuration option:
- When using a HTTPS proxy, the Private Location sends an initial [HTTP CONNECT](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/CONNECT) request to the proxy
- A forward-proxy will initiate the tunnel connection to Datadog
- However some customers use a reverse-proxy, that instead forwards the `CONNECT` to Datadog and is not supported

We want to provide a note that reverse-proxies are not supported, and a forward proxy should be use in addition / instead.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->