### PR TITLE
Update config.go link after file was moved

### DIFF
--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -116,6 +116,6 @@ From Datadog Agent 7.45, the Datadog Agent service (`datadog-agent.service` unit
 [3]: /agent/configuration/proxy/#environment-variables
 [4]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/setup/config.go
 [5]: https://docs.datadoghq.com/agent/docker/apm/#docker-apm-agent-environment-variables
-[6]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/apm.go
-[7]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/process.go
+[6]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/setup/apm.go
+[7]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/setup/process.go
 [8]: https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Environment

--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -114,7 +114,7 @@ From Datadog Agent 7.45, the Datadog Agent service (`datadog-agent.service` unit
 [1]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 [2]: /getting_started/tagging/unified_service_tagging
 [3]: /agent/configuration/proxy/#environment-variables
-[4]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config.go
+[4]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/setup/config.go
 [5]: https://docs.datadoghq.com/agent/docker/apm/#docker-apm-agent-environment-variables
 [6]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/apm.go
 [7]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/process.go


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Update broken agent config links after [config.go was moved a couple months ago](https://github.com/DataDog/datadog-agent/commit/00b27d48c0dfb3cf41d05ee30c9fd43b647b88b4#diff-a7b6619528f155e64cefe12cc4ba753eb7688c87fdf9d96e1052a12eeb519df5) along with other files.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->