### PR TITLE
Update C++ documentations

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -43,7 +43,7 @@ With these three tags, you can:
 | Language         | Minimum Tracer Version |
 |--------------|------------|
 | .NET    |  1.17.0+       |
-| C++    |  1.1.4+       |
+| C++    |  0.1.0+       |
 | Go         |  1.24.0+       |
 | Java   |  0.50.0+      |
 | Node    |  0.20.3+       |

--- a/content/en/tracing/guide/setting_up_APM_with_cpp.md
+++ b/content/en/tracing/guide/setting_up_APM_with_cpp.md
@@ -34,61 +34,40 @@ sudo apt-get update
 sudo apt-get -y install g++ cmake
 ```
 
-Run these two lines together to get the latest C++ version:
+Run these two lines together to get the latest C++ tracer version:
 
 ```cpp
 get_latest_release() {
-  wget -qO- "https://api.github.com/repos/$1/releases/latest" |
-    grep '"tag_name":' |
-    sed -E 's/.*"([^"]+)".*/\1/';
+  wget -qO- "https://api.github.com/repos/$1/releases/latest" | jq --raw-output .tag_name
 }
-DD_OPENTRACING_CPP_VERSION="$(get_latest_release DataDog/dd-opentracing-cpp)"
+DD_TRACE_CPP_VERSION="$(get_latest_release DataDog/dd-trace-cpp)"
 ```
 
 If you get a rate limited message from GitHub, wait a few minutes and run the command again. When the update is complete, confirm that this is successful by checking your C++ version with:
 
 ```shell
-echo $DD_OPENTRACING_CPP_VERSION
+echo $DD_TRACE_CPP_VERSION
 ```
 
-Then, download and install the `dd-opentracing-cpp` library with:
+Then, download and install the `dd-trace-cpp` library with:
 
 ```shell
-wget https://github.com/DataDog/dd-opentracing-cpp/archive/${DD_OPENTRACING_CPP_VERSION}.tar.gz -O dd-opentracing-cpp.tar.gz
+wget https://github.com/DataDog/dd-trace-cpp/archive/${DD_TRACE_CPP_VERSION}.tar.gz -O dd-trace-cpp.tar.gz
 ```
 
-After downloading the `tar` file, create a new directory and a `.build` file for the library:
-
-```shell
-mkdir -p dd-opentracing-cpp/.build
-```
-
-Then unzip it:
+After downloading the `tar` file, unzip it:
 
 ```bash
-tar zxvf dd-opentracing-cpp.tar.gz -C ./dd-opentracing-cpp/ --strip-components=1
+tar zxvf dd-trace-cpp.tar.gz -C ./dd-trace-cpp/ --strip-components=1
 ```
 
-You should see a list of the library contents in your console:
-
-```shell
-dd-opentracing-cpp-1.0.1/test/integration/nginx/nginx.conf
-dd-opentracing-cpp-1.0.1/test/integration/nginx/nginx_integration_test.sh
-```
-
-Next, go in your `.build` directory:
-
-```shell
-cd dd-opentracing-cpp/.build
-```
-
-Finally, install dependencies with:
+Finally, build and install the library:
 
 ```bash
-sudo ../scripts/install_dependencies.sh
-cmake ..
-make
-sudo make install
+cd dd-trace-cpp
+cmake -B build .
+cmake --build build -j
+cmake --install build
 ```
 
 ## Building a simple app
@@ -96,33 +75,44 @@ sudo make install
 Create a new file called `tracer_example.cpp` and populate it with the below code:
 
 ```cpp
-#include <datadog/opentracing.h>
+#include <datadog/tracer.h>
 #include <iostream>
 #include <string>
 
 int main(int argc, char* argv[]) {
-  datadog::opentracing::TracerOptions tracer_options{"localhost", 8126, "compiled-in example"};
-  auto tracer = datadog::opentracing::makeTracer(tracer_options);
+  datadog::tracing::TracerConfig tracer_config;
+  tracer_config.service = "compiled-in example";
+
+  const auto validated_config = dd::finalize_config(tracer_options);
+  if (!validated_config) {
+    std::cerr << validated_config.error() << '\n';
+    return 1;
+  }
+
+  dd::Tracer tracer{*validated_config};
 
   // Create some spans.
   {
-    auto span_a = tracer->StartSpan("A");
-    span_a->SetTag("tag", 123);
-    auto span_b = tracer->StartSpan("B", {opentracing::ChildOf(&span_a->context())});
-    span_b->SetTag("tag", "value");
+    datadog::tracing::SpanConfig options;
+    options.name = "A";
+    options.tags.emplace("tag", "123");
+    auto span_a = tracer.create_span(options);
+
+    auto span_b = span_a.create_child();
+    span_b.set_name("B");
+    span_b.set_tag("tag", "value");
   }
 
-  tracer->Close();
   return 0;
 }
 ```
 
 This creates a tracer that generates two spans, a parent span `span_a` and a child span `span_b`, and tags them.
 
-Then, link against `libdd_opentracing` and `libopentracing` with:
+Then, link against `libdd_trace_cpp` with:
 
 ```shell
-g++ -std=c++14 -o tracer_example tracer_example.cpp -ldd_opentracing -lopentracing
+g++ -std=c++17 -o tracer_example tracer_example.cpp -ldd_trace_cpp
 ```
 
 Finally, run the app with:
@@ -150,7 +140,7 @@ LD_LIBRARY_PATH=/usr/local/lib/ ./tracer_example
 On the Trace Agent tab, you will see something similar to:
 
 ```text
-2019-08-09 20:02:26 UTC | TRACE | INFO | (pkg/trace/info/stats.go:108 in LogStats) | [lang:cpp lang_version:201402 tracer_version:v1.0.1] -> traces received: 1, traces filtered: 0, traces amount: 363 bytes, events extracted: 0, events sampled: 0
+2019-08-09 20:02:26 UTC | TRACE | INFO | (pkg/trace/info/stats.go:108 in LogStats) | [lang:cpp lang_version:201402 tracer_version:0.2.0] -> traces received: 1, traces filtered: 0, traces amount: 363 bytes, events extracted: 0, events sampled: 0
 ```
 
 The service then shows up in the Service Catalog in Datadog.

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
@@ -13,7 +13,7 @@ code_lang: cpp
 type: multi-code-lang
 code_lang_weight: 50
 further_reading:
-- link: "https://github.com/DataDog/dd-opentracing-cpp"
+- link: "https://github.com/DataDog/dd-trace-cpp"
   tag: "Github"
   text: Source code
 - link: "/tracing/glossary/"
@@ -25,11 +25,11 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> C++ does not provide integrations for OOTB instrumentation, but it's used by Proxy tracing such as [Envoy][1] and [Nginx][2].
+  <strong>Note:</strong> C++ does not provide integrations for OOTB instrumentation, but it's used by Proxy tracing such as <a href="/tracing/setup/envoy/">Envoy</a> and <a href="/tracing/setup/nginx/">Nginx</a>.
 </div>
 
 ## Compatibility requirements
-The C++ tracing library requires C++17 to build. For a full list of Datadog's tracing library compatiblity requirements and processor architecture support, visit the [Compatibility Requirements][3] page.
+The C++ tracing library requires C++17 toolchain to build. For a full list of Datadog's tracing library compatiblity requirements and processor architecture support, visit the [Compatibility Requirements][3] page.
 
 ## Getting started
 Before you begin, make sure you have already [installed and configured the Agent][6].
@@ -131,7 +131,7 @@ wget https://github.com/DataDog/dd-trace-cpp/archive/${DD_TRACE_CPP_VERSION}.tar
 mkdir dd-trace-cpp && tar zxvf dd-trace-cpp.tar.gz -C ./dd-trace-cpp/ --strip-components=1
 cd dd-trace-cpp
 
-# Download and install the correct version of opentracing-cpp, & other deps.
+# Download and install the correct version of dd-trace-cpp.
 # Configure the project, build it, and install it.
 cmake -B build .
 cmake --build build -j
@@ -172,10 +172,10 @@ int main() {
 }
 ```
 
-Link against `libdd_trace_cpp`, making sure that they are both in your `LD_LIBRARY_PATH`:
+Link against `libdd_trace_cpp`, making sure the shared library is in `LD_LIBRARY_PATH`.
 
 ````bash
-g++ -std=c++17 -o tracer_example tracer_example.cpp -ldd_trace_cpp
+clang -std=c++17 -o tracer_example tracer_example.cpp -ldd_trace_cpp
 ./tracer_example
 DATADOG TRACER CONFIGURATION - {"collector":{"config":{"event_scheduler":{"type":"datadog::tracing::ThreadedEventScheduler" ... }}}
 ````

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
@@ -25,7 +25,7 @@ further_reading:
 ---
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> C++ does not provide integrations for OOTB instrumentation, but it's used by Proxy tracing such as <a href="/tracing/setup/envoy/">Envoy</a> and <a href="/tracing/setup/nginx/">Nginx</a>.
+  <strong>Note:</strong> C++ does not provide integrations for automatic instrumentation, but it's used by Proxy tracing such as <a href="/tracing/setup/envoy/">Envoy</a> and <a href="/tracing/setup/nginx/">Nginx</a>.
 </div>
 
 ## Compatibility requirements

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
@@ -56,7 +56,7 @@ FetchContent_MakeAvailable(dd-trace-cpp)
 add_executable(tracer_example tracer_example.cpp)
 
 # Statically link against `dd-trace-cpp`
-# To dynamically link agains `dd-trace-cpp` use the `dd_trace_cpp_shared` target
+# NOTE: To dynamically link against `dd-trace-cpp` use the `dd_trace_cpp_shared` target
 target_link_libraries(cpp-parametric-http-test dd_trace_cpp-objects)
 ````
 
@@ -144,9 +144,6 @@ cmake --install build
 #include <datadog/tracer.h>
 #include <datadog/tracer_config.h>
 
-#include <iostream>
-#include <string>
-
 namespace dd = datadog::tracing;
 
 int main() {
@@ -162,9 +159,10 @@ int main() {
   dd::Tracer tracer{*validated_config};
   // Create some spans.
   {
-    auto span_a = tracer.create_span();
-    span_a.set_name("A");
-    span_a.set_tag("tag", "123");
+    dd::SpanConfig options;
+    options.name = "A";
+    options.tags.emplace("tag", "123");
+    auto span_a = tracer.create_span(options);
     auto span_b = span_a.create_child();
     span_b.set_name("B");
     span_b.set_tag("tag", "value");

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
@@ -39,6 +39,7 @@ Before you begin, make sure you have already [installed and configured the Agent
 {{< tabs >}}
 
 {{% tab "CMake" %}}
+To integrate the `dd-trace-cpp` library into your C++ project using CMake, follow these steps:
 ````CMake
 include(FetchContent)
 
@@ -59,7 +60,7 @@ add_executable(tracer_example tracer_example.cpp)
 # NOTE: To dynamically link against `dd-trace-cpp` use the `dd_trace_cpp_shared` target
 target_link_libraries(tracer_example dd_trace_cpp-static)
 ````
-
+Here's an example of how to use the dd-trace-cpp library in your C++ code to create spans and traces:
 ```cpp
 // tracer_example.cpp
 #include <datadog/span_config.h>
@@ -107,7 +108,7 @@ DATADOG TRACER CONFIGURATION - {"collector":{"config":{"event_scheduler":{"type"
 {{% /tab %}}
 
 {{% tab "Manual" %}}
-
+To manually download and install the dd-trace-cpp library, run the following bash script:
 ```bash
 # Requires the "jq" command, which can be installed via
 # the package manager:
@@ -137,7 +138,7 @@ cmake -B build .
 cmake --build build -j
 cmake --install build
 ```
-
+After installing the `dd-trace-cpp` library, you can use it in your C++ code to create spans and traces. Here's an example:
 ```cpp
 // tracer_example.cpp
 #include <datadog/span_config.h>

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/cpp.md
@@ -45,7 +45,7 @@ include(FetchContent)
 FetchContent_Declare(
   dd-trace-cpp
   GIT_REPOSITORY https://github.com/DataDog/dd-trace-cpp
-  GIT_TAG        ${DD_TRACE_CPP_COMMIT}"
+  GIT_TAG        v0.2.0
   GIT_SHALLOW    ON
   GIT_PROGRESS   ON
 )
@@ -57,7 +57,7 @@ add_executable(tracer_example tracer_example.cpp)
 
 # Statically link against `dd-trace-cpp`
 # NOTE: To dynamically link against `dd-trace-cpp` use the `dd_trace_cpp_shared` target
-target_link_libraries(cpp-parametric-http-test dd_trace_cpp-objects)
+target_link_libraries(tracer_example dd_trace_cpp-static)
 ````
 
 ```cpp
@@ -73,7 +73,7 @@ namespace dd = datadog::tracing;
 
 int main() {
   dd::TracerConfig config;
-  config.defaults.service = "my-service";
+  config.service = "my-service";
 
   const auto validated_config = dd::finalize_config(config);
   if (!validated_config) {
@@ -97,7 +97,7 @@ int main() {
 ```
 
 ```bash
-cmake -B build -DDD_TRACE_VERSION=v0.1.12 .
+cmake -B build .
 cmake --build build --target tracer_example -j
 
 ./build/tracer_example
@@ -144,11 +144,14 @@ cmake --install build
 #include <datadog/tracer.h>
 #include <datadog/tracer_config.h>
 
+#include <iostream>
+#include <string>
+
 namespace dd = datadog::tracing;
 
 int main() {
   dd::TracerConfig config;
-  config.defaults.service = "my-service";
+  config.service = "my-service";
 
   const auto validated_config = dd::finalize_config(config);
   if (!validated_config) {
@@ -172,7 +175,7 @@ int main() {
 }
 ```
 
-Link against `libdd_trace_cpp`, making sure the shared library is in `LD_LIBRARY_PATH`.
+Link against `libdd_trace_cpp.so`, making sure the shared library is in `LD_LIBRARY_PATH`.
 
 ````bash
 clang -std=c++17 -o tracer_example tracer_example.cpp -ldd_trace_cpp
@@ -198,4 +201,3 @@ If needed, configure the tracing library to send application performance telemet
 [4]: https://app.datadoghq.com/apm/service-setup
 [5]: /tracing/trace_collection/library_config/cpp/
 [6]: /tracing/trace_collection/automatic_instrumentation/?tab=datadoglibraries#install-and-configure-the-agent
-[7]: TODO

--- a/content/en/tracing/trace_collection/compatibility/cpp.md
+++ b/content/en/tracing/trace_collection/compatibility/cpp.md
@@ -18,15 +18,13 @@ further_reading:
 
 The C++ Datadog Trace library is open source - view the [GitHub repository][1] for more information.
 
-This library requires C++14 to build, but if you use [dynamic loading][2], then OpenTracing requires [C++11 or later][3].
+This library requires C++17 to build.
 
-Supported platforms include Linux and Mac. To request Windows support, [contact Datadog support][4].
+Supported platforms include Linux and Mac. To request Windows support, [contact Datadog support][2].
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/dd-opentracing-cpp
-[2]: /tracing/setup/cpp/#dynamic-loading
-[3]: https://github.com/opentracing/opentracing-cpp/#cc98
-[4]: /help/
+[1]: https://github.com/DataDog/dd-trace-cpp
+[2]: /help/

--- a/content/en/tracing/trace_collection/compatibility/cpp.md
+++ b/content/en/tracing/trace_collection/compatibility/cpp.md
@@ -18,9 +18,13 @@ further_reading:
 
 The C++ Datadog Trace library is open source - view the [GitHub repository][1] for more information.
 
-This library requires C++17 to build.
+This library requires C++17 compiler to build.
 
-Supported platforms include Linux and Mac. To request Windows support, [contact Datadog support][2].
+Supported platforms include:
+- `x86_64` and `arm64` Linux. 
+- `arm64` macOS.
+
+To request Windows support, [contact Datadog support][2].
 
 ## Further Reading
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
@@ -23,7 +23,7 @@ If you have not yet read the setup instructions, start with the <a href="https:/
 
 ## Creating spans
 
-### Manually instrument a method
+To manually instrument a method:
 
 ```cpp
 {

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
@@ -56,8 +56,6 @@ Note that the Datadog tags are necessary for [unified service tagging][5].
 Add [tags][1] directly to a [span][2] object by calling `Span::set_tag`. For example:
 
 ```cpp
-auto tracer = ...
-
 // Add tags directly to a span by calling `Span::set_tag`
 auto span = tracer->create_span();
 span->set_tag("key must be string", "value must also be a string");
@@ -105,30 +103,23 @@ span. For example:
 span.set_error(true);
 ```
 
-Or, alternatively:
-
-```cpp
-span.set_error_message("error");
-span.set_error_type("propagation");
-span.set_error_stack(stack);
-```
-
-Add more specific information about the error by setting any combination of the
-`error.msg`, `error.stack`, or `error.type` tags. See [Error Tracking][7] for
-more information about error tags.
+Add more specific information about the error by setting any combination of `error.msg`, `error.stack`, or `error.type` by using respectively `Span::set_error_message`, `Span::set_error_stack` and `Span::set_error_type`. See [Error Tracking][7] for more information about error tags.
 
 An example of adding a combination of error tags:
 
 ```cpp
 // Associate this span with the "bad file descriptor" error from the standard
 // library.
+span.set_error_message("error");
 span.set_error_stack("[EBADF] invalid file");
 span.set_error_type("errno");
 ```
 
-Using any of the `Span::set_error_stack`, `Span::set_error_type` or `Span::set_error_message` sets tags `error` to the value `true`.
+<div class="alert alert-info">
+Using any of the `Span::set_error_*` result in an underlying call to `Span::set_error(true)`.
+</div>
 
-To unset an error on a span, set the `error` tag to value `false`, which removes any previously set `error.msg`, `error.stack`, or `error.type` tags.
+To unset an error on a span, set the `error` tag to value `false`, which removes any previously combination of `Span::set_error_stack`, `Span::set_error_type` or `Span::set_error_message`.
 
 ```cpp
 // Clear any error information associated with this span.

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
@@ -21,35 +21,80 @@ further_reading:
 If you have not yet read the setup instructions, start with the <a href="https://docs.datadoghq.com/tracing/setup/cpp/">C++ Setup Instructions</a>.
 </div>
 
-## Add tags
+## Creating spans
+
+### Manually instrument a method
+
+```cpp
+{
+  // Create a root span for the current request.
+  auto root_span = tracer.create_span();
+  root_span.set_name("get_ingredients");
+  // Set a resource name for the root span.
+  root_span.set_resource("bologna_sandwich");
+  // Create a child span with the root span as its parent.
+  auto child_span = root_span.create_child();
+  child_span.set_name("cache_lookup");
+  // Set a resource name for the child span.
+  child_span.set_resource_name("ingredients.bologna_sandwich");
+  // Spans can be finished at an explicit time ...
+  child_span.set_end_time(std::chrono::steady_clock::now());
+} // ... or implicitly when the destructor is invoked.
+  // For example, root_span finishes here.
+```
+
+## Adding tags
 
 Add custom [span tags][1] to your [spans][2] to customize your observability within Datadog. The span tags are applied to your incoming traces, allowing you to correlate observed behavior with code-level information such as merchant tier, checkout amount, or user ID.
 
-C++ tracing uses "common tags". These tags can be sourced from both [Datadog specific tags][3] or [OpenTracing tags][4], and included like this:
-
-```cpp
-#include <opentracing/ext/tags.h>
-#include <datadog/tags.h>
-```
-
 Note that the Datadog tags are necessary for [unified service tagging][5].
 
-### Add custom span tags
+{{< tabs >}}
 
-Add [tags][1] directly to a [span][2] object by calling `Span::SetTag`. For example:
+{{% tab "Locally" %}}
+
+Add [tags][1] directly to a [span][2] object by calling `Span::set_tag`. For example:
 
 ```cpp
 auto tracer = ...
-auto span = tracer->StartSpan("operation_name");
-span->SetTag("key must be string", "Values are variable types");
-span->SetTag("key must be string", 1234);
+
+// Add tags directly to a span by calling `Span::set_tag`
+auto span = tracer->create_span();
+span->set_tag("key must be string", "value must also be a string");
+
+// Or, add tags by providing a `SpanConfig`
+datadog::tracing::SpanConfig opt;
+opt.tag.emplace("team", "apm-proxy");
+auto span2 = tracer->create_span(opts);
 ```
 
-Values are of [variable type][6] and can be complex objects. Values are serialized as JSON, with the exception of a string value being serialized bare (without extra quotation marks).
+{{% /tab %}}
 
-### Adding tags globally to all spans
+{{% tab "Globally" %}}
+
+There is two ways to set tags across all your spans.
+
+### Environment variable
 
 To set tags across all your spans, set the `DD_TAGS` environment variable as a list of `key:value` pairs separated by commas.
+
+### Manually
+
+```cpp
+const datadog::tracing::TracerConfig tracer_config;
+tracer_config.tags.emplace("team", "apm-proxy");
+tracer_config.tags.emplace("apply", "on all spans");
+
+const auto validated_config = validate_config(tracer_config);
+auto tracer = datadog::trace::Tracer(*validated_config);
+
+// New spans will have all tags defined in `tracer_config.tags`
+auto span = tracer.create_tags();
+```
+
+{{% /tab %}}
+
+{{< /tabs >}}
 
 ### Set errors on a span
 
@@ -57,13 +102,15 @@ To associate a span with an error, set one or more error-related tags on the
 span. For example:
 
 ```cpp
-span->SetTag(opentracing::ext::error, true);
+span.set_error(true);
 ```
 
 Or, alternatively:
 
 ```cpp
-span->SetTag("error", true);
+span.set_error_message("error");
+span.set_error_type("propagation");
+span.set_error_stack(stack);
 ```
 
 Add more specific information about the error by setting any combination of the
@@ -75,45 +122,18 @@ An example of adding a combination of error tags:
 ```cpp
 // Associate this span with the "bad file descriptor" error from the standard
 // library.
-span->SetTag("error.msg", "[EBADF] invalid file");
-span->SetTag("error.type", "errno");
+span.set_error_stack("[EBADF] invalid file");
+span.set_error_type("errno");
 ```
 
-Adding any of the `error.msg`, `error.stack`, or `error.type` tags sets
-`error` to the value `true`.
+Using any of the `Span::set_error_stack`, `Span::set_error_type` or `Span::set_error_message` sets tags `error` to the value `true`.
 
-To unset an error on a span, set the `error` tag to value `false`, which removes
-any previously set `error.msg`, `error.stack`, or `error.type` tags.
+To unset an error on a span, set the `error` tag to value `false`, which removes any previously set `error.msg`, `error.stack`, or `error.type` tags.
 
 ```cpp
 // Clear any error information associated with this span.
-span->SetTag("error", false);
+span.set_error(false);
 ```
-
-## Adding spans
-
-### Manually instrument a method
-
-To manually instrument your code, install the tracer as in the [setup examples][8], and then use the tracer object to create [spans][2].
-
-```cpp
-{
-  // Create a root span for the current request.
-  auto root_span = tracer->StartSpan("get_ingredients");
-  // Set a resource name for the root span.
-  root_span->SetTag(datadog::tags::resource_name, "bologna_sandwich");
-  // Create a child span with the root span as its parent.
-  auto child_span = tracer->StartSpan(
-      "cache_lookup",
-      {opentracing::ChildOf(&root_span->context())});
-  // Set a resource name for the child span.
-  child_span->SetTag(datadog::tags::resource_name, "ingredients.bologna_sandwich");
-  // Spans can be finished at an explicit time ...
-  child_span->Finish();
-} // ... or implicitly when the destructor is invoked.
-  // For example, root_span finishes here.
-```
-
 
 ## Propagating context with headers extraction and injection
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
@@ -45,36 +45,40 @@ If you have not yet read the setup instructions, start with the <a href="https:/
 
 ## Adding tags
 
-Add custom [span tags][1] to your [spans][2] to customize your observability within Datadog. The span tags are applied to your incoming traces, allowing you to correlate observed behavior with code-level information such as merchant tier, checkout amount, or user ID.
+Add custom [span tags][1] to your [spans][2] to customize your observability within Datadog. Span tags are applied to your incoming traces, allowing you to correlate observed behavior with code-level information such as merchant tier, checkout amount, or user ID.
 
-Note that the Datadog tags are necessary for [unified service tagging][5].
+Note that some Datadog tags are necessary for [unified service tagging][5].
 
 {{< tabs >}}
 
 {{% tab "Locally" %}}
 
-Add [tags][1] directly to a [span][2] object by calling `Span::set_tag`. For example:
+### Manually
+
+Add tags directly to a span object by calling `Span::set_tag`. For example:
 
 ```cpp
 // Add tags directly to a span by calling `Span::set_tag`
 auto span = tracer->create_span();
-span->set_tag("key must be string", "value must also be a string");
+span.set_tag("key must be string", "value must also be a string");
 
-// Or, add tags by providing a `SpanConfig`
+// Or, add tags by setting a `SpanConfig`
 datadog::tracing::SpanConfig opt;
 opt.tag.emplace("team", "apm-proxy");
-auto span2 = tracer->create_span(opts);
+auto span2 = tracer.create_span(opts);
 ```
 
 {{% /tab %}}
 
 {{% tab "Globally" %}}
 
-There is two ways to set tags across all your spans.
-
 ### Environment variable
 
 To set tags across all your spans, set the `DD_TAGS` environment variable as a list of `key:value` pairs separated by commas.
+
+```
+export DD_TAGS=team:apm-proxy,key:value
+```
 
 ### Manually
 
@@ -86,8 +90,8 @@ tracer_config.tags.emplace("apply", "on all spans");
 const auto validated_config = validate_config(tracer_config);
 auto tracer = datadog::trace::Tracer(*validated_config);
 
-// New spans will have all tags defined in `tracer_config.tags`
-auto span = tracer.create_tags();
+// All new spans will have contains tags defined in `tracer_config.tags`
+auto span = tracer.create_span();
 ```
 
 {{% /tab %}}
@@ -119,7 +123,7 @@ span.set_error_type("errno");
 Using any of the `Span::set_error_*` result in an underlying call to `Span::set_error(true)`.
 </div>
 
-To unset an error on a span, set the `error` tag to value `false`, which removes any previously combination of `Span::set_error_stack`, `Span::set_error_type` or `Span::set_error_message`.
+To unset an error on a span, set `Span::set_error` to `false`, which removes any  combination of `Span::set_error_stack`, `Span::set_error_type` or `Span::set_error_message`.
 
 ```cpp
 // Clear any error information associated with this span.

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
@@ -31,7 +31,7 @@ If you have not yet read the setup instructions, start with the <a href="https:/
   auto root_span = tracer.create_span();
   root_span.set_name("get_ingredients");
   // Set a resource name for the root span.
-  root_span.set_resource("bologna_sandwich");
+  root_span.set_resource_name("bologna_sandwich");
   // Create a child span with the root span as its parent.
   auto child_span = root_span.create_child();
   child_span.set_name("cache_lookup");
@@ -59,12 +59,12 @@ Add tags directly to a span object by calling `Span::set_tag`. For example:
 
 ```cpp
 // Add tags directly to a span by calling `Span::set_tag`
-auto span = tracer->create_span();
+auto span = tracer.create_span();
 span.set_tag("key must be string", "value must also be a string");
 
 // Or, add tags by setting a `SpanConfig`
-datadog::tracing::SpanConfig opt;
-opt.tag.emplace("team", "apm-proxy");
+datadog::tracing::SpanConfig opts;
+opts.tags.emplace("team", "apm-proxy");
 auto span2 = tracer.create_span(opts);
 ```
 
@@ -83,12 +83,14 @@ export DD_TAGS=team:apm-proxy,key:value
 ### Manually
 
 ```cpp
-const datadog::tracing::TracerConfig tracer_config;
-tracer_config.tags.emplace("team", "apm-proxy");
-tracer_config.tags.emplace("apply", "on all spans");
+datadog::tracing::TracerConfig tracer_config;
+tracer_config.tags = {
+  {"team", "apm-proxy"},
+  {"apply", "on all spans"}
+};
 
-const auto validated_config = validate_config(tracer_config);
-auto tracer = datadog::trace::Tracer(*validated_config);
+const auto validated_config = datadog::tracing::finalize_config(tracer_config);
+auto tracer = datadog::tracing::Tracer(*validated_config);
 
 // All new spans will have contains tags defined in `tracer_config.tags`
 auto span = tracer.create_span();

--- a/content/en/tracing/trace_collection/library_config/cpp.md
+++ b/content/en/tracing/trace_collection/library_config/cpp.md
@@ -55,9 +55,9 @@ Sets the port where traces are sent (the port where the Agent is listening for c
 `DD_TRACE_AGENT_URL` 
 : **Since**: v0.1.0 <br>
 **Default**: `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>` if they are set, or `http://localhost:8126`.
-**Examples**:
-  - HTTP URL: `http://localhost:8126`
-  - Unix Domain Socket: `unix:///var/run/datadog/apm.socket`
+**Examples**: <br>
+HTTP URL: `http://localhost:8126` <br>
+Unix Domain Socket: `unix:///var/run/datadog/apm.socket` <br><br>
 Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. This URL supports HTTP, HTTPS, and Unix address schemes. <br>
 If the [Agent configuration][3] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then `DD_TRACE_AGENT_PORT` or `DD_TRACE_AGENT_URL` must match it.
 
@@ -68,42 +68,50 @@ Maximum number of traces allowed to be submitted per second.
 
 `DD_TRACE_SAMPLE_RATE`
 : **Since**: 0.1.0 <br>
-**Default**: The Datadog Agent default rates or `1.0`. <br>
+**Default**: The Datadog Agent default rate or `1.0`. <br>
 Sets the sampling rate for all generated traces. The value must be between `0.0` and `1.0` (inclusive). By default, the sampling rate is delegated to the Datadog Agent. If no sampling rate is set by the Datadog Agent, then the default is `1.0`.
 
 `DD_TRACE_SAMPLING_RULES` 
 : **Since**: v0.1.0 <br>
 **Default**: `null` <br>
-A JSON array of objects. Each object must have a `sample_rate`, and the `name` and `service` fields are optional. The `sample_rate` value must be between 0.0 and 1.0 (inclusive). Rules are applied in configured order to determine the trace's sample rate.
+**Examples:**<br>
+Set the sample rate to 20%: `[{"sample_rate": 0.2}]` <br>
+Set the span sample rate to 50% for the service `my-service` and operation name `http.request`, up to 50 traces per second: `'[{"service": "my-service", "name": "http.request", "sample_rate":0.5, "max_per_second": 50}]'` <br><br>
+A JSON array of objects. Each object must have a `sample_rate`, and the `name` and `service` fields are optional. The `sample_rate` value must be between 0.0 and 1.0 (inclusive). Rules are applied in configured order to determine the trace's sample rate. <br>
+For more information, see [Ingestion Mechanisms][2].<br>
 
 `DD_SPAN_SAMPLING_RULES`
 : **Version**: v0.1.0 <br>
 **Default**: `null`<br>
-**Example:**<br>
-  - Set the sample rate to 20%: `[{"sample_rate": 0.2}]`
-  - Set the span sample rate to 50% for the service `my-service` and operation name `http.request`, up to 50 traces per second: `'[{"service": "my-service", "name": "http.request", "sample_rate":0.5, "max_per_second": 50}]'` <br>
 A JSON array of objects. Rules are applied in configured order to determine the span's sample rate. The `sample_rate` value must be between 0.0 and 1.0 (inclusive).
-For more information, see [Ingestion Mechanisms][2].<br>
+
+`DD_SPAN_SAMPLING_RULES_FILE`
+: **Since**: 0.1.0 <br>
+Points to a JSON file that contains the span sampling rules. See `DD_SPAN_SAMPLING_RULES` for the rule format.
+
+`DD_PROPAGATION_STYLE`
+: **Since**: 0.1.0 <br>
+Comma separated list of propagation style(s) to use when extracting and injecting tracing context. <br>
+When multiple values are given, the order of matching is based on the order of values.
 
 `DD_TRACE_PROPAGATION_STYLE_INJECT` 
 : **Since**: v0.1.6 <br>
 **Default**: `datadog,tracecontext` <br>
 **Accepted values**: `datadog`, `tracecontext`, `b3` <br>
-Propagation style(s) to use when injecting tracing headers.
+Comma separated list of propagation styles to use when injecting tracing context.
 When multiple values are given, the order of matching is based on the order of values.
-TODO: write incompatibilities
 
 `DD_TRACE_PROPAGATION_STYLE_EXTRACT` 
 : **Since**: v0.1.6 <br>
 **Default**: `datadog,tracecontext` <br>
 **Accepted values**: `datadog`, `tracecontext`, `b3` <br>
-Propagation style(s) to use when extracting tracing headers. 
+Comma separated list of propagation style to use when extracting tracing context. 
 When multiple values are given, the order of matching is based on the order of values.
 TODO: Ditto!
 
 `DD_TRACE_ENABLED`
 : **Since**: 0.1.0 <br>
-**Default**: `true`
+**Default**: `true` <br>
 Submit or not traces to the Datadog Agent. <br>
 When `false`, the library stop sending traces to the Datadog Agent. However, the library continues to generate traces, report telemetry and poll for remote configuration updates.
 
@@ -128,48 +136,22 @@ If `false`, the tracer will generate legacy 64-bit trace IDs.
 **Default**: `true` <br>
 Datadog may collect [environmental and diagnostic information about your system][4] to improve the product. When `false`, this telemetry data will not be collected.
 
+`DD_REMOTE_CONFIGURATION_ENABLED`
+: **Since**: 0.2.0 <br>
+**Default**: `true` <br>
+Enable the capability that allows you to remotely configure and change the behavior of the tracer. <br>
+When `false` this feature is disabled.
+For more information, see [Remote Configuration][5]
+
 `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`
-: **Since**: 0.1.13 (NOT RELEASE YET) <br>
+: **Since**: 0.2.0 <br>
 **Default**: `5` <br>
 Sets how often, in seconds, the Datadog Agent is queried for Remote Configuration updates.
 
 `DD_TRACE_DELEGATE_SAMPLING`
-: **Version**: 0.1.13 (NOT RELEASE YET) <br>
+: **Version**: 0.2.0 <br>
 **Default**: `false` <br>
 If `true`, delegate trace sampling decision to a child service and prefer the resulting decision over its own, if appropriate.
-
---- 
-TODO
-
-`DD_PROPAGATION_STYLE_EXTRACT`
-: **Since**: 0.1.0 <br>
-**Default**: `datadog,tracecontext`
-
-`DD_PROPAGATION_STYLE_INJECT`
-: **Since**: 0.1.0 <br>
-**Default**: `datadog,tracecontext`
-
-`DD_PROPAGATION_STYLE`
-: **Since**: 0.1.0 <br>
-Propagation style(s) to use when extracting and injecting tracing headers. <br>
-When multiple values are given, the order of matching is based on the order of values.
-
-`DD_SPAN_SAMPLING_RULES_FILE`
-: **Since**: 0.1.0 <br>
-
-`DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH`
-?? 
-
-## Deprecated (should we still mention them?)
-
-`DD_TRACE_ANALYTICS_ENABLED` 
-: ***Deprecated*** <br>
-**Default**: `false` <br>
-Enable App Analytics globally for the application.
-
-`DD_TRACE_ANALYTICS_SAMPLE_RATE` 
-: ***Deprecated*** <br>
-Sets the App Analytics sampling rate. Overrides `DD_TRACE_ANALYTICS_ENABLED` if set. A floating point number between `0.0` and `1.0`.
 
 
 ## Further Reading
@@ -180,3 +162,4 @@ Sets the App Analytics sampling rate. Overrides `DD_TRACE_ANALYTICS_ENABLED` if 
 [2]: /tracing/trace_pipeline/ingestion_mechanisms/
 [3]: /agent/configuration/network/#configure-ports
 [4]: /tracing/configure_data_security#telemetry-collection
+[5]: /agent/remote_config

--- a/content/en/tracing/trace_collection/library_config/cpp.md
+++ b/content/en/tracing/trace_collection/library_config/cpp.md
@@ -83,7 +83,7 @@ For more information, see [Ingestion Mechanisms][2].<br>
 `DD_SPAN_SAMPLING_RULES`
 : **Version**: v0.1.0 <br>
 **Default**: `null`<br>
-A JSON array of objects. Rules are applied in configured order to determine the span's sample rate. The `sample_rate` value must be between 0.0 and 1.0 (inclusive).
+A JSON array of objects. Rules are applied in configured order to determine the span's sample rate. The `sample_rate` value must be between `0.0` and `1.0` (inclusive).
 
 `DD_SPAN_SAMPLING_RULES_FILE`
 : **Since**: 0.1.0 <br>
@@ -107,7 +107,6 @@ When multiple values are given, the order of matching is based on the order of v
 **Accepted values**: `datadog`, `tracecontext`, `b3` <br>
 Comma separated list of propagation style to use when extracting tracing context. 
 When multiple values are given, the order of matching is based on the order of values.
-TODO: Ditto!
 
 `DD_TRACE_ENABLED`
 : **Since**: 0.1.0 <br>
@@ -134,13 +133,13 @@ If `false`, the tracer will generate legacy 64-bit trace IDs.
 `DD_INSTRUMENTATION_TELEMETRY_ENABLED`
 : **Since**: 0.1.12 <br>
 **Default**: `true` <br>
-Datadog may collect [environmental and diagnostic information about your system][4] to improve the product. When `false`, this telemetry data will not be collected.
+Datadog may collect [environmental and diagnostic information about your system][4] to improve the product. When `false`, telemetry data are not be collected.
 
 `DD_REMOTE_CONFIGURATION_ENABLED`
 : **Since**: 0.2.0 <br>
 **Default**: `true` <br>
-Enable the capability that allows you to remotely configure and change the behavior of the tracer. <br>
-When `false` this feature is disabled.
+Enable the capability that allows to remotely configure and change the behavior of the tracer. <br>
+When `false` this feature is disabled. <br>
 For more information, see [Remote Configuration][5]
 
 `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`

--- a/content/en/tracing/trace_collection/library_config/cpp.md
+++ b/content/en/tracing/trace_collection/library_config/cpp.md
@@ -18,12 +18,14 @@ further_reading:
 
 After you set up the tracing library with your code and configure the Agent to collect APM data, optionally configure the tracing library as desired, including setting up [Unified Service Tagging][1].
 
-It is recommended to use `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` to set `env`, `service` and `version` for your services. Refer to the [Unified Service Tagging][1] docummentation recommendations on which value to set for environment variables
+It is recommended to use `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` to set `env`, `service` and `version` for your services. Refer to the [Unified Service Tagging][1] docummentation recommendations on which value to set for environment variables.
+
 ## Environment variables
+To configure the tracer using environment variables, set the variables before launching the instrumented application.
 
 `DD_SERVICE` 
 : **Since**: v0.1.0 <br>
-Sets the default service name.
+Sets the service name.
 
 `DD_ENV`
 : **Since**: v0.1.0 <br>
@@ -33,12 +35,12 @@ Adds the `env` tag with the specified value to all generated spans.
 `DD_VERSION` 
 : **Since**: v0.1.0 <br>
 **Example**: `1.2.3`, `6c44da20`, `2020.02.13` <br>
-Sets the service's version to all generated spans.
+Sets the version of the service.
 
 `DD_TAGS` 
 : **Since**: v0.1.0 <br>
 **Example**: `team:intake,layer:api,foo:bar` <br>
-A comma separated list of default `key:value` pairs to be added to all generated spans.
+A comma separated list of `key:value` pairs to be added to all generated spans.
 
 `DD_AGENT_HOST` 
 : **Since**: v0.1.0 <br>
@@ -52,29 +54,33 @@ Sets the port where traces are sent (the port where the Agent is listening for c
 
 `DD_TRACE_AGENT_URL` 
 : **Since**: v0.1.0 <br>
+**Default**: `http://<DD_AGENT_HOST>:<DD_TRACE_AGENT_PORT>` if they are set, or `http://localhost:8126`.
 **Examples**:
   - HTTP URL: `http://localhost:8126`
-  - Unix Domain Socket: `unix:///var/run/datadog/apm.socket` <br>
-Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. This URL supports HTTP, HTTPS, and Unix address schemes. If the [Agent configuration][3] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then `DD_TRACE_AGENT_PORT` or `DD_TRACE_AGENT_URL` must match it.
+  - Unix Domain Socket: `unix:///var/run/datadog/apm.socket`
+Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. This URL supports HTTP, HTTPS, and Unix address schemes. <br>
+If the [Agent configuration][3] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then `DD_TRACE_AGENT_PORT` or `DD_TRACE_AGENT_URL` must match it.
 
 `DD_TRACE_RATE_LIMIT`
 : **Since**: 0.1.0 <br>
 **Default**: `200` <br>
-Maximum number of spans to sample per-second.
+Maximum number of traces allowed to be submitted per second.
 
 `DD_TRACE_SAMPLE_RATE`
 : **Since**: 0.1.0 <br>
+**Default**: The Datadog Agent default rates or `1.0`. <br>
 Sets the sampling rate for all generated traces. The value must be between `0.0` and `1.0` (inclusive). By default, the sampling rate is delegated to the Datadog Agent. If no sampling rate is set by the Datadog Agent, then the default is `1.0`.
 
 `DD_TRACE_SAMPLING_RULES` 
 : **Since**: v0.1.0 <br>
-**Default**: `[]` <br>
+**Default**: `null` <br>
 A JSON array of objects. Each object must have a `sample_rate`, and the `name` and `service` fields are optional. The `sample_rate` value must be between 0.0 and 1.0 (inclusive). Rules are applied in configured order to determine the trace's sample rate.
 
 `DD_SPAN_SAMPLING_RULES`
 : **Version**: v0.1.0 <br>
-**Default**: `[]`<br>
+**Default**: `null`<br>
 **Example:**<br>
+  - Set the sample rate to 20%: `[{"sample_rate": 0.2}]`
   - Set the span sample rate to 50% for the service `my-service` and operation name `http.request`, up to 50 traces per second: `'[{"service": "my-service", "name": "http.request", "sample_rate":0.5, "max_per_second": 50}]'` <br>
 A JSON array of objects. Rules are applied in configured order to determine the span's sample rate. The `sample_rate` value must be between 0.0 and 1.0 (inclusive).
 For more information, see [Ingestion Mechanisms][2].<br>
@@ -110,10 +116,6 @@ Adds the `hostname` tag with the result of `gethostname`.
 : **Since**: 0.1.0 <br>
 **Default**: `true` <br>
 Log the tracer configuration once the tracer is fully initialized. <br>
-**Log Example**: <br>
-````
-DATADOG TRACER CONFIGURATION - {"collector":{"config":{"event_scheduler":{"type":"datadog::tracing::ThreadedEventScheduler"},"flush_interval_milliseconds":2000,"http_client":{"type":"datadog::tracing::Curl"},"remote_configuration_url":"unix:///apm.sock/v0.7/config","request_timeout_milliseconds":2000,"shutdown_timeout_milliseconds":2000,"telemetry_url":"unix:///apm.sock/telemetry/proxy/api/v2/apmtelemetry","traces_url":"unix:///apm.sock/v0.4/traces"},"type":"datadog::tracing::DatadogAgent"},"default":{"environment":"dmehala-dev","service":"dd-trace-cpp-example","service_type":"web"},"environment_variables":{"DD_ENV":"dmehala-dev","DD_TRACE_AGENT_URL":"unix:///apm.sock"},"extraction_styles":["Datadog","tracecontext"],"injection_styles":["Datadog","tracecontext"],"report_traces":true,"runtime_id":"d71b5215-ec13-4e1f-b670-332a91a48b26","span_sampler":{"rules":[]},"tags_header_size":512,"trace_sampler":{"max_per_second":200.0,"rules":[]},"version":"[dd-trace-cpp version v0.1.12]"
-````
 
 `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`
 : **Since**: 0.1.6 <br>
@@ -124,7 +126,7 @@ If `false`, the tracer will generate legacy 64-bit trace IDs.
 `DD_INSTRUMENTATION_TELEMETRY_ENABLED`
 : **Since**: 0.1.12 <br>
 **Default**: `true` <br>
-Generates and submit telemetry metrics to the Datadog Agent when enabled. If `false`, telemetry metrics are not generated and also not be submitted.
+Datadog may collect [environmental and diagnostic information about your system][4] to improve the product. When `false`, this telemetry data will not be collected.
 
 `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`
 : **Since**: 0.1.13 (NOT RELEASE YET) <br>
@@ -177,3 +179,4 @@ Sets the App Analytics sampling rate. Overrides `DD_TRACE_ANALYTICS_ENABLED` if 
 [1]: /getting_started/tagging/unified_service_tagging/
 [2]: /tracing/trace_pipeline/ingestion_mechanisms/
 [3]: /agent/configuration/network/#configure-ports
+[4]: /tracing/configure_data_security#telemetry-collection

--- a/content/en/tracing/trace_collection/library_config/cpp.md
+++ b/content/en/tracing/trace_collection/library_config/cpp.md
@@ -55,7 +55,6 @@ Sets the port where traces are sent (the port where the Agent is listening for c
 **Examples**:
   - HTTP URL: `http://localhost:8126`
   - Unix Domain Socket: `unix:///var/run/datadog/apm.socket`
-
 Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. This URL supports HTTP, HTTPS, and Unix address schemes. If the [Agent configuration][3] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then `DD_TRACE_AGENT_PORT` or `DD_TRACE_AGENT_URL` must match it.
 
 `DD_TRACE_RATE_LIMIT`
@@ -77,7 +76,6 @@ A JSON array of objects. Each object must have a `sample_rate`, and the `name` a
 **Default**: `nil`<br>
 **Example:**<br>
   - Set the span sample rate to 50% for the service `my-service` and operation name `http.request`, up to 50 traces per second: `'[{"service": "my-service", "name": "http.request", "sample_rate":0.5, "max_per_second": 50}]'`
-
 A JSON array of objects. Rules are applied in configured order to determine the span's sample rate. The `sample_rate` value must be between 0.0 and 1.0 (inclusive).
 For more information, see [Ingestion Mechanisms][2].<br>
 
@@ -85,7 +83,6 @@ For more information, see [Ingestion Mechanisms][2].<br>
 : **Since**: v0.1.6 <br>
 **Default**: `datadog,tracecontext` <br>
 **Accepted values**: `datadog`, `tracecontext`, `b3`
-
 Propagation style(s) to use when injecting tracing headers.
 When multiple values are given, the order of matching is based on the order of values.
 TODO: write incompatibilities
@@ -101,8 +98,7 @@ TODO: Ditto!
 `DD_TRACE_ENABLED`
 : **Since**: 0.1.0 <br>
 **Default**: `true`
-Submit or not traces to the Datadog Agent.
-
+Submit or not traces to the Datadog Agent. <br>
 When `false`, the library stop sending traces to the Datadog Agent. However, the library continues to generate traces, report telemetry and poll for remote configuration updates.
 
 `DD_TRACE_REPORT_HOSTNAME`
@@ -114,22 +110,18 @@ Adds the `hostname` tag with the result of `gethostname`.
 : **Since**: 0.1.0 <br>
 **Default**: `true` <br>
 Log the tracer configuration once the tracer is fully initialized. 
-
 **Log Example**: <br>
 `DATADOG TRACER CONFIGURATION - {"collector":{"config":{"event_scheduler":{"type":"datadog::tracing::ThreadedEventScheduler"},"flush_interval_milliseconds":2000,"http_client":{"type":"datadog::tracing::Curl"},"remote_configuration_url":"unix:///apm.sock/v0.7/config","request_timeout_milliseconds":2000,"shutdown_timeout_milliseconds":2000,"telemetry_url":"unix:///apm.sock/telemetry/proxy/api/v2/apmtelemetry","traces_url":"unix:///apm.sock/v0.4/traces"},"type":"datadog::tracing::DatadogAgent"},"default":{"environment":"dmehala-dev","service":"dd-trace-cpp-example","service_type":"web"},"environment_variables":{"DD_ENV":"dmehala-dev","DD_TRACE_AGENT_URL":"unix:///apm.sock"},"extraction_styles":["Datadog","tracecontext"],"injection_styles":["Datadog","tracecontext"],"report_traces":true,"runtime_id":"d71b5215-ec13-4e1f-b670-332a91a48b26","span_sampler":{"rules":[]},"tags_header_size":512,"trace_sampler":{"max_per_second":200.0,"rules":[]},"version":"[dd-trace-cpp version v0.1.12]"`
 
 `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`
 : **Since**: 0.1.6 <br>
 **Default**: `true` <br>
-
-If `true`, the tracer will generate 128-bit trace IDs.
-
+If `true`, the tracer will generate 128-bit trace IDs. <br>
 If `false`, the tracer will generate legacy 64-bit trace IDs.
 
 `DD_INSTRUMENTATION_TELEMETRY_ENABLED`
 : **Since**: 0.1.12 <br>
 **Default**: `true` <br>
-
 Generates and submit telemetry metrics to the Datadog Agent when enabled. If `false`, telemetry metrics are not generated and also not be submitted.
 
 `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`
@@ -155,8 +147,7 @@ TODO
 
 `DD_PROPAGATION_STYLE`
 : **Since**: 0.1.0 <br>
-Propagation style(s) to use when extracting and injecting tracing headers.
-
+Propagation style(s) to use when extracting and injecting tracing headers. <br>
 When multiple values are given, the order of matching is based on the order of values.
 
 `DD_SPAN_SAMPLING_RULES_FILE`

--- a/content/en/tracing/trace_collection/library_config/cpp.md
+++ b/content/en/tracing/trace_collection/library_config/cpp.md
@@ -54,16 +54,16 @@ Sets the port where traces are sent (the port where the Agent is listening for c
 : **Since**: v0.1.0 <br>
 **Examples**:
   - HTTP URL: `http://localhost:8126`
-  - Unix Domain Socket: `unix:///var/run/datadog/apm.socket`
+  - Unix Domain Socket: `unix:///var/run/datadog/apm.socket` <br>
 Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. This URL supports HTTP, HTTPS, and Unix address schemes. If the [Agent configuration][3] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then `DD_TRACE_AGENT_PORT` or `DD_TRACE_AGENT_URL` must match it.
 
 `DD_TRACE_RATE_LIMIT`
 : **Since**: 0.1.0 <br>
-**Default**: 200 <br>
+**Default**: `200` <br>
 Maximum number of spans to sample per-second.
 
 `DD_TRACE_SAMPLE_RATE`
-: **Since*: 0.1.0 <br>
+: **Since**: 0.1.0 <br>
 Sets the sampling rate for all generated traces. The value must be between `0.0` and `1.0` (inclusive). By default, the sampling rate is delegated to the Datadog Agent. If no sampling rate is set by the Datadog Agent, then the default is `1.0`.
 
 `DD_TRACE_SAMPLING_RULES` 
@@ -73,16 +73,16 @@ A JSON array of objects. Each object must have a `sample_rate`, and the `name` a
 
 `DD_SPAN_SAMPLING_RULES`
 : **Version**: v0.1.0 <br>
-**Default**: `nil`<br>
+**Default**: `[]`<br>
 **Example:**<br>
-  - Set the span sample rate to 50% for the service `my-service` and operation name `http.request`, up to 50 traces per second: `'[{"service": "my-service", "name": "http.request", "sample_rate":0.5, "max_per_second": 50}]'`
+  - Set the span sample rate to 50% for the service `my-service` and operation name `http.request`, up to 50 traces per second: `'[{"service": "my-service", "name": "http.request", "sample_rate":0.5, "max_per_second": 50}]'` <br>
 A JSON array of objects. Rules are applied in configured order to determine the span's sample rate. The `sample_rate` value must be between 0.0 and 1.0 (inclusive).
 For more information, see [Ingestion Mechanisms][2].<br>
 
 `DD_TRACE_PROPAGATION_STYLE_INJECT` 
 : **Since**: v0.1.6 <br>
 **Default**: `datadog,tracecontext` <br>
-**Accepted values**: `datadog`, `tracecontext`, `b3`
+**Accepted values**: `datadog`, `tracecontext`, `b3` <br>
 Propagation style(s) to use when injecting tracing headers.
 When multiple values are given, the order of matching is based on the order of values.
 TODO: write incompatibilities
@@ -90,7 +90,7 @@ TODO: write incompatibilities
 `DD_TRACE_PROPAGATION_STYLE_EXTRACT` 
 : **Since**: v0.1.6 <br>
 **Default**: `datadog,tracecontext` <br>
-**Accepted values**: `datadog`, `tracecontext`, `b3`
+**Accepted values**: `datadog`, `tracecontext`, `b3` <br>
 Propagation style(s) to use when extracting tracing headers. 
 When multiple values are given, the order of matching is based on the order of values.
 TODO: Ditto!
@@ -109,9 +109,11 @@ Adds the `hostname` tag with the result of `gethostname`.
 `DD_TRACE_STARTUP_LOGS`
 : **Since**: 0.1.0 <br>
 **Default**: `true` <br>
-Log the tracer configuration once the tracer is fully initialized. 
+Log the tracer configuration once the tracer is fully initialized. <br>
 **Log Example**: <br>
-`DATADOG TRACER CONFIGURATION - {"collector":{"config":{"event_scheduler":{"type":"datadog::tracing::ThreadedEventScheduler"},"flush_interval_milliseconds":2000,"http_client":{"type":"datadog::tracing::Curl"},"remote_configuration_url":"unix:///apm.sock/v0.7/config","request_timeout_milliseconds":2000,"shutdown_timeout_milliseconds":2000,"telemetry_url":"unix:///apm.sock/telemetry/proxy/api/v2/apmtelemetry","traces_url":"unix:///apm.sock/v0.4/traces"},"type":"datadog::tracing::DatadogAgent"},"default":{"environment":"dmehala-dev","service":"dd-trace-cpp-example","service_type":"web"},"environment_variables":{"DD_ENV":"dmehala-dev","DD_TRACE_AGENT_URL":"unix:///apm.sock"},"extraction_styles":["Datadog","tracecontext"],"injection_styles":["Datadog","tracecontext"],"report_traces":true,"runtime_id":"d71b5215-ec13-4e1f-b670-332a91a48b26","span_sampler":{"rules":[]},"tags_header_size":512,"trace_sampler":{"max_per_second":200.0,"rules":[]},"version":"[dd-trace-cpp version v0.1.12]"`
+````
+DATADOG TRACER CONFIGURATION - {"collector":{"config":{"event_scheduler":{"type":"datadog::tracing::ThreadedEventScheduler"},"flush_interval_milliseconds":2000,"http_client":{"type":"datadog::tracing::Curl"},"remote_configuration_url":"unix:///apm.sock/v0.7/config","request_timeout_milliseconds":2000,"shutdown_timeout_milliseconds":2000,"telemetry_url":"unix:///apm.sock/telemetry/proxy/api/v2/apmtelemetry","traces_url":"unix:///apm.sock/v0.4/traces"},"type":"datadog::tracing::DatadogAgent"},"default":{"environment":"dmehala-dev","service":"dd-trace-cpp-example","service_type":"web"},"environment_variables":{"DD_ENV":"dmehala-dev","DD_TRACE_AGENT_URL":"unix:///apm.sock"},"extraction_styles":["Datadog","tracecontext"],"injection_styles":["Datadog","tracecontext"],"report_traces":true,"runtime_id":"d71b5215-ec13-4e1f-b670-332a91a48b26","span_sampler":{"rules":[]},"tags_header_size":512,"trace_sampler":{"max_per_second":200.0,"rules":[]},"version":"[dd-trace-cpp version v0.1.12]"
+````
 
 `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`
 : **Since**: 0.1.6 <br>

--- a/content/en/tracing/trace_collection/library_config/cpp.md
+++ b/content/en/tracing/trace_collection/library_config/cpp.md
@@ -17,29 +17,155 @@ further_reading:
 ---
 
 After you set up the tracing library with your code and configure the Agent to collect APM data, optionally configure the tracing library as desired, including setting up [Unified Service Tagging][1].
+
+It is recommended to use `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` to set `env`, `service` and `version` for your services. Refer to the [Unified Service Tagging][1] docummentation recommendations on which value to set for environment variables
 ## Environment variables
 
+`DD_SERVICE` 
+: **Since**: v0.1.0 <br>
+Sets the default service name.
+
+`DD_ENV`
+: **Since**: v0.1.0 <br>
+**Example**: `prod`, `pre-prod`, or `staging` <br> 
+Adds the `env` tag with the specified value to all generated spans.
+
+`DD_VERSION` 
+: **Since**: v0.1.0 <br>
+**Example**: `1.2.3`, `6c44da20`, `2020.02.13` <br>
+Sets the service's version to all generated spans.
+
+`DD_TAGS` 
+: **Since**: v0.1.0 <br>
+**Example**: `team:intake,layer:api,foo:bar` <br>
+A comma separated list of default `key:value` pairs to be added to all generated spans.
+
 `DD_AGENT_HOST` 
-: **Version**: v0.3.6 <br>
+: **Since**: v0.1.0 <br>
 **Default**: `localhost` <br>
 Sets the host where traces are sent (the host running the Agent). Can be a hostname or an IP address. Ignored if `DD_TRACE_AGENT_URL` is set.
 
 `DD_TRACE_AGENT_PORT` 
-: **Version**: v0.3.6 <br>
+: **Since**: v0.1.0 <br>
 **Default**: `8126` <br>
 Sets the port where traces are sent (the port where the Agent is listening for connections). Ignored if `DD_TRACE_AGENT_URL` is set. If the [Agent configuration][3] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then `DD_TRACE_AGENT_PORT` or `DD_TRACE_AGENT_URL` must match it.
 
 `DD_TRACE_AGENT_URL` 
-: **Version**: v1.1.4 <br>
+: **Since**: v0.1.0 <br>
+**Examples**:
+  - HTTP URL: `http://localhost:8126`
+  - Unix Domain Socket: `unix:///var/run/datadog/apm.socket`
+
 Sets the URL endpoint where traces are sent. Overrides `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set. This URL supports HTTP, HTTPS, and Unix address schemes. If the [Agent configuration][3] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then `DD_TRACE_AGENT_PORT` or `DD_TRACE_AGENT_URL` must match it.
 
-`DD_ENV` 
-: **Version**: v1.0.0 <br>
-If specified, adds the `env` tag with the specified value to all generated spans.
+`DD_TRACE_RATE_LIMIT`
+: **Since**: 0.1.0 <br>
+**Default**: 200 <br>
+Maximum number of spans to sample per-second.
 
-`DD_SERVICE` 
-: **Version**: v1.1.4 <br>
-If specified, sets the default service name. Otherwise, the service name must be provided via TracerOptions or JSON configuration.
+`DD_TRACE_SAMPLE_RATE`
+: **Since*: 0.1.0 <br>
+Sets the sampling rate for all generated traces. The value must be between `0.0` and `1.0` (inclusive). By default, the sampling rate is delegated to the Datadog Agent. If no sampling rate is set by the Datadog Agent, then the default is `1.0`.
+
+`DD_TRACE_SAMPLING_RULES` 
+: **Since**: v0.1.0 <br>
+**Default**: `[]` <br>
+A JSON array of objects. Each object must have a `sample_rate`, and the `name` and `service` fields are optional. The `sample_rate` value must be between 0.0 and 1.0 (inclusive). Rules are applied in configured order to determine the trace's sample rate.
+
+`DD_SPAN_SAMPLING_RULES`
+: **Version**: v0.1.0 <br>
+**Default**: `nil`<br>
+**Example:**<br>
+  - Set the span sample rate to 50% for the service `my-service` and operation name `http.request`, up to 50 traces per second: `'[{"service": "my-service", "name": "http.request", "sample_rate":0.5, "max_per_second": 50}]'`
+
+A JSON array of objects. Rules are applied in configured order to determine the span's sample rate. The `sample_rate` value must be between 0.0 and 1.0 (inclusive).
+For more information, see [Ingestion Mechanisms][2].<br>
+
+`DD_TRACE_PROPAGATION_STYLE_INJECT` 
+: **Since**: v0.1.6 <br>
+**Default**: `datadog,tracecontext` <br>
+**Accepted values**: `datadog`, `tracecontext`, `b3`
+
+Propagation style(s) to use when injecting tracing headers.
+When multiple values are given, the order of matching is based on the order of values.
+TODO: write incompatibilities
+
+`DD_TRACE_PROPAGATION_STYLE_EXTRACT` 
+: **Since**: v0.1.6 <br>
+**Default**: `datadog,tracecontext` <br>
+**Accepted values**: `datadog`, `tracecontext`, `b3`
+Propagation style(s) to use when extracting tracing headers. 
+When multiple values are given, the order of matching is based on the order of values.
+TODO: Ditto!
+
+`DD_TRACE_ENABLED`
+: **Since**: 0.1.0 <br>
+**Default**: `true`
+Submit or not traces to the Datadog Agent.
+
+When `false`, the library stop sending traces to the Datadog Agent. However, the library continues to generate traces, report telemetry and poll for remote configuration updates.
+
+`DD_TRACE_REPORT_HOSTNAME`
+: **Since**: 0.1.0 <br>
+**Default**: `false` <br>
+Adds the `hostname` tag with the result of `gethostname`.
+
+`DD_TRACE_STARTUP_LOGS`
+: **Since**: 0.1.0 <br>
+**Default**: `true` <br>
+Log the tracer configuration once the tracer is fully initialized. 
+
+**Log Example**: <br>
+`DATADOG TRACER CONFIGURATION - {"collector":{"config":{"event_scheduler":{"type":"datadog::tracing::ThreadedEventScheduler"},"flush_interval_milliseconds":2000,"http_client":{"type":"datadog::tracing::Curl"},"remote_configuration_url":"unix:///apm.sock/v0.7/config","request_timeout_milliseconds":2000,"shutdown_timeout_milliseconds":2000,"telemetry_url":"unix:///apm.sock/telemetry/proxy/api/v2/apmtelemetry","traces_url":"unix:///apm.sock/v0.4/traces"},"type":"datadog::tracing::DatadogAgent"},"default":{"environment":"dmehala-dev","service":"dd-trace-cpp-example","service_type":"web"},"environment_variables":{"DD_ENV":"dmehala-dev","DD_TRACE_AGENT_URL":"unix:///apm.sock"},"extraction_styles":["Datadog","tracecontext"],"injection_styles":["Datadog","tracecontext"],"report_traces":true,"runtime_id":"d71b5215-ec13-4e1f-b670-332a91a48b26","span_sampler":{"rules":[]},"tags_header_size":512,"trace_sampler":{"max_per_second":200.0,"rules":[]},"version":"[dd-trace-cpp version v0.1.12]"`
+
+`DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`
+: **Since**: 0.1.6 <br>
+**Default**: `true` <br>
+
+If `true`, the tracer will generate 128-bit trace IDs.
+
+If `false`, the tracer will generate legacy 64-bit trace IDs.
+
+`DD_INSTRUMENTATION_TELEMETRY_ENABLED`
+: **Since**: 0.1.12 <br>
+**Default**: `true` <br>
+
+Generates and submit telemetry metrics to the Datadog Agent when enabled. If `false`, telemetry metrics are not generated and also not be submitted.
+
+`DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`
+: **Since**: 0.1.13 (NOT RELEASE YET) <br>
+**Default**: `5` <br>
+Sets how often, in seconds, the Datadog Agent is queried for Remote Configuration updates.
+
+`DD_TRACE_DELEGATE_SAMPLING`
+: **Version**: 0.1.13 (NOT RELEASE YET) <br>
+**Default**: `false` <br>
+If `true`, delegate trace sampling decision to a child service and prefer the resulting decision over its own, if appropriate.
+
+--- 
+TODO
+
+`DD_PROPAGATION_STYLE_EXTRACT`
+: **Since**: 0.1.0 <br>
+**Default**: `datadog,tracecontext`
+
+`DD_PROPAGATION_STYLE_INJECT`
+: **Since**: 0.1.0 <br>
+**Default**: `datadog,tracecontext`
+
+`DD_PROPAGATION_STYLE`
+: **Since**: 0.1.0 <br>
+Propagation style(s) to use when extracting and injecting tracing headers.
+
+When multiple values are given, the order of matching is based on the order of values.
+
+`DD_SPAN_SAMPLING_RULES_FILE`
+: **Since**: 0.1.0 <br>
+
+`DD_TRACE_TAGS_PROPAGATION_MAX_LENGTH`
+?? 
+
+## Deprecated (should we still mention them?)
 
 `DD_TRACE_ANALYTICS_ENABLED` 
 : ***Deprecated*** <br>
@@ -50,36 +176,6 @@ Enable App Analytics globally for the application.
 : ***Deprecated*** <br>
 Sets the App Analytics sampling rate. Overrides `DD_TRACE_ANALYTICS_ENABLED` if set. A floating point number between `0.0` and `1.0`.
 
-`DD_TRACE_SAMPLING_RULES` 
-: **Version**: v1.1.4 <br>
-**Default**: `[{"sample_rate": 1.0}]` <br>
-A JSON array of objects. Each object must have a `sample_rate`, and the `name` and `service` fields are optional. The `sample_rate` value must be between 0.0 and 1.0 (inclusive). Rules are applied in configured order to determine the trace's sample rate.
-
-`DD_SPAN_SAMPLING_RULES`
-: **Version**: v1.3.3 <br>
-**Default**: `nil`<br>
-A JSON array of objects. Rules are applied in configured order to determine the span's sample rate. The `sample_rate` value must be between 0.0 and 1.0 (inclusive).
-For more information, see [Ingestion Mechanisms][2].<br>
-**Example:**<br>
-  - Set the span sample rate to 50% for the service `my-service` and operation name `http.request`, up to 50 traces per second: `'[{"service": "my-service", "name": "http.request", "sample_rate":0.5, "max_per_second": 50}]'`
-
-`DD_VERSION` 
-: **Version**: v1.1.4 <br>
-If specified, adds the `version` tag with the specified value to all generated spans.
-
-`DD_TAGS` 
-: **Version**: v1.1.4 <br>
-If specified, will add tags to all generated spans. A comma-separated list of `key:value` pairs.
-
-`DD_TRACE_PROPAGATION_STYLE_INJECT` 
-: **Version**: v0.4.1 <br>
-**Default**: `Datadog` <br>
-Propagation style(s) to use when injecting tracing headers. `Datadog`, `B3`, or `Datadog B3`.
-
-`DD_TRACE_PROPAGATION_STYLE_EXTRACT` 
-: **Version**: v0.4.1 <br>
-**Default**: `Datadog` <br>
-Propagation style(s) to use when extracting tracing headers. `Datadog`, `B3`, or `Datadog B3`.
 
 ## Further Reading
 

--- a/content/en/tracing/trace_collection/library_config/cpp.md
+++ b/content/en/tracing/trace_collection/library_config/cpp.md
@@ -91,7 +91,7 @@ Points to a JSON file that contains the span sampling rules. See `DD_SPAN_SAMPLI
 
 `DD_PROPAGATION_STYLE`
 : **Since**: 0.1.0 <br>
-Comma separated list of propagation style(s) to use when extracting and injecting tracing context. <br>
+Comma separated list of propagation styles to use when extracting and injecting tracing context. <br>
 When multiple values are given, the order of matching is based on the order of values.
 
 `DD_TRACE_PROPAGATION_STYLE_INJECT` 
@@ -105,7 +105,7 @@ When multiple values are given, the order of matching is based on the order of v
 : **Since**: v0.1.6 <br>
 **Default**: `datadog,tracecontext` <br>
 **Accepted values**: `datadog`, `tracecontext`, `b3` <br>
-Comma separated list of propagation style to use when extracting tracing context. 
+Comma separated list of propagation styles to use when extracting tracing context. 
 When multiple values are given, the order of matching is based on the order of values.
 
 `DD_TRACE_ENABLED`
@@ -133,14 +133,14 @@ If `false`, the tracer will generate legacy 64-bit trace IDs.
 `DD_INSTRUMENTATION_TELEMETRY_ENABLED`
 : **Since**: 0.1.12 <br>
 **Default**: `true` <br>
-Datadog may collect [environmental and diagnostic information about your system][4] to improve the product. When `false`, telemetry data are not be collected.
+Datadog may collect [environmental and diagnostic information about your system][4] to improve the product. When `false`, telemetry data are not collected.
 
 `DD_REMOTE_CONFIGURATION_ENABLED`
 : **Since**: 0.2.0 <br>
 **Default**: `true` <br>
 Enable the capability that allows to remotely configure and change the behavior of the tracer. <br>
 When `false` this feature is disabled. <br>
-For more information, see [Remote Configuration][5]
+For more information, see [Remote Configuration][5].
 
 `DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS`
 : **Since**: 0.2.0 <br>

--- a/content/en/tracing/trace_collection/runtime_config/_index.md
+++ b/content/en/tracing/trace_collection/runtime_config/_index.md
@@ -46,12 +46,12 @@ You can tell when the configuration changes have been successfully applied by re
 
 The following options are supported with configuration at runtime. The required tracer version is listed for each language:
 
-| Option                                                                                                                                 | Java      | Javascript              | Python   | .NET      | Ruby      | Go        |
-|----------------------------------------------------------------------------------------------------------------------------------------|-----------|-------------------------|----------|-----------|-----------|-----------|
-| <h5>Custom sampling rate</h5>Set a global sampling rate for the library using `DD_TRACE_SAMPLE_RATE`.                                  | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.4.0+` | `2.33.0+` | `1.13.0+` | `1.59.0+` |
-| <h5>Log injection</h5>Automatically inject trace correlation identifiers to correlate logs and traces by enabling `DD_LOGS_INJECTION`. | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.6.0+` | `2.33.0+` | `1.13.0+` |           |
-| <h5>HTTP header tags</h5>Add HTTP header values as tags on traces using `DD_TRACE_HEADER_TAGS`.                                        | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.6.0+` | `2.33.0+` | `1.13.0+` | `1.59.0+` |
-| <h5>Custom span tags</h5>Add specified tags to each span using `DD_TAGS`.                                                              | `1.31.0+` | `4.23.0+` `3.44.0+`     | `2.5.0+` | `2.44.0+` |           | `1.59.0+` |
+| Option                                                                                                                                 | Java      | Javascript              | Python   | .NET      | Ruby      | Go        | C++ |
+|----------------------------------------------------------------------------------------------------------------------------------------|-----------|-------------------------|----------|-----------|-----------|-----------|-|
+| <h5>Custom sampling rate</h5>Set a global sampling rate for the library using `DD_TRACE_SAMPLE_RATE`.                                  | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.4.0+` | `2.33.0+` | `1.13.0+` | `1.59.0+` | `0.2.0+` |
+| <h5>Log injection</h5>Automatically inject trace correlation identifiers to correlate logs and traces by enabling `DD_LOGS_INJECTION`. | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.6.0+` | `2.33.0+` | `1.13.0+` |           | |
+| <h5>HTTP header tags</h5>Add HTTP header values as tags on traces using `DD_TRACE_HEADER_TAGS`.                                        | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.6.0+` | `2.33.0+` | `1.13.0+` | `1.59.0+` | |
+| <h5>Custom span tags</h5>Add specified tags to each span using `DD_TAGS`.                                                              | `1.31.0+` | `4.23.0+` `3.44.0+`     | `2.5.0+` | `2.44.0+` |           | `1.59.0+` | `0.2.0+` |
 
 ## Further reading
 

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -199,7 +199,7 @@ Read more about sampling controls in the [PHP tracing library documentation][1].
 [1]: /tracing/trace_collection/dd_libraries/php
 {{% /tab %}}
 {{% tab "C++" %}}
-Starting in version version [v0.1.0][1], the Datadog C++ library supports the following configurations:
+Starting in [v0.1.0][1], the Datadog C++ library supports the following configurations:
 - Global sampling rate: `DD_TRACE_SAMPLE_RATE` environment variable
 - Sampling rates by service: `DD_TRACE_SAMPLING_RULES` environment variable.
 - Rate limit setting: `DD_TRACE_RATE_LIMIT` environment variable.

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -585,15 +585,16 @@ Manually keep a trace:
 ```cpp
 ...
 #include <datadog/tags.h>
+#include <datadog/trace_segment.h>
+#include <datadog/sampling_priority.h>
 ...
 
-auto tracer = ...
-datadog::tracing::SpanConfig span_cfg;
+dd::SpanConfig span_cfg;
 span_cfg.resource = "operation_name";
 
 auto span = tracer.create_span(span_cfg);
 // Always keep this trace
-span.trace_segment.override_sampling_priority(datadog::tracing::SamplingPriority::USER_KEEP);
+span.trace_segment().override_sampling_priority(int(dd::SamplingPriority::USER_KEEP));
 //method impl follows
 ```
 
@@ -602,15 +603,18 @@ Manually drop a trace:
 ```cpp
 ...
 #include <datadog/tags.h>
+#include <datadog/trace_segment.h>
+#include <datadog/sampling_priority.h>
 ...
 
-auto tracer = ...
-datadog::tracing::SpanConfig span_cfg;
+using namespace dd = datadog::tracing;
+
+dd::SpanConfig span_cfg;
 span_cfg.resource = "operation_name";
 
 auto another_span = tracer.create_span(span_cfg);
 // Always drop this trace
-span.trace_segment.override_sampling_priority(datadog::tracing::SamplingPriority::USER_DROP);
+span.trace_segment().override_sampling_priority(int(dd::SamplingPriority::USER_DROP));
 //method impl follows
 ```
 

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -211,7 +211,7 @@ export DD_TRACE_SAMPLE_RATE=0.1
 export DD_TRACE_SAMPLING_RULES='[{"service": "my-service", "sample_rate": 0.5}]'
 ```
 
-C++ does not provide integrations for out-of-the-box instrumentation, but it's used by proxy tracing such as Envoy, Nginx, or Istio. Read more about how to configure sampling for proxies in [Tracing proxies][2].
+C++ does not provide integrations for automatic instrumentation, but it's used by proxy tracing such as Envoy, Nginx, or Istio. Read more about how to configure sampling for proxies in [Tracing proxies][2].
 
 [1]: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.1.0
 [2]: /tracing/trace_collection/proxy_setup

--- a/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
+++ b/content/en/tracing/trace_pipeline/ingestion_mechanisms.md
@@ -199,7 +199,7 @@ Read more about sampling controls in the [PHP tracing library documentation][1].
 [1]: /tracing/trace_collection/dd_libraries/php
 {{% /tab %}}
 {{% tab "C++" %}}
-Starting in version version `1.3.2`, the Datadog C++ library supports the following configurations:
+Starting in version version [v0.1.0][1], the Datadog C++ library supports the following configurations:
 - Global sampling rate: `DD_TRACE_SAMPLE_RATE` environment variable
 - Sampling rates by service: `DD_TRACE_SAMPLING_RULES` environment variable.
 - Rate limit setting: `DD_TRACE_RATE_LIMIT` environment variable.
@@ -211,9 +211,10 @@ export DD_TRACE_SAMPLE_RATE=0.1
 export DD_TRACE_SAMPLING_RULES='[{"service": "my-service", "sample_rate": 0.5}]'
 ```
 
-C++ does not provide integrations for out-of-the-box instrumentation, but it's used by proxy tracing such as Envoy, Nginx, or Istio. Read more about how to configure sampling for proxies in [Tracing proxies][1].
+C++ does not provide integrations for out-of-the-box instrumentation, but it's used by proxy tracing such as Envoy, Nginx, or Istio. Read more about how to configure sampling for proxies in [Tracing proxies][2].
 
-[1]: /tracing/trace_collection/proxy_setup
+[1]: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.1.0
+[2]: /tracing/trace_collection/proxy_setup
 {{% /tab %}}
 {{% tab ".NET" %}}
 For .NET applications, set a global sampling rate for the library using the `DD_TRACE_SAMPLE_RATE` environment variable. Set by-service sampling rates with the `DD_TRACE_SAMPLING_RULES` environment variable.
@@ -587,9 +588,12 @@ Manually keep a trace:
 ...
 
 auto tracer = ...
-auto span = tracer->StartSpan("operation_name");
+datadog::tracing::SpanConfig span_cfg;
+span_cfg.resource = "operation_name";
+
+auto span = tracer.create_span(span_cfg);
 // Always keep this trace
-span->SetTag(datadog::tags::manual_keep, {});
+span.trace_segment.override_sampling_priority(datadog::tracing::SamplingPriority::USER_KEEP);
 //method impl follows
 ```
 
@@ -601,10 +605,12 @@ Manually drop a trace:
 ...
 
 auto tracer = ...
-auto another_span = tracer->StartSpan("operation_name");
-// Always drop this trace
+datadog::tracing::SpanConfig span_cfg;
+span_cfg.resource = "operation_name";
 
-another_span->SetTag(datadog::tags::manual_drop, {});
+auto another_span = tracer.create_span(span_cfg);
+// Always drop this trace
+span.trace_segment.override_sampling_priority(datadog::tracing::SamplingPriority::USER_DROP);
 //method impl follows
 ```
 
@@ -719,7 +725,7 @@ Read more about sampling controls in the [PHP tracing library documentation][2].
 [2]: /tracing/trace_collection/dd_libraries/php
 {{% /tab %}}
 {{% tab "C++" %}}
-Starting from version [v1.3.3][1], for C++ applications, set by-service and by-operation name **span** sampling rules with the `DD_SPAN_SAMPLING_RULES` environment variable.
+Starting from version [v0.1.0][1], for C++ applications, set by-service and by-operation name **span** sampling rules with the `DD_SPAN_SAMPLING_RULES` environment variable.
 
 For example, to collect `100%` of the spans from the service named `my-service`, for the operation `http.request`, up to `50` spans per second:
 
@@ -727,7 +733,7 @@ For example, to collect `100%` of the spans from the service named `my-service`,
 @env DD_SPAN_SAMPLING_RULES=[{"service": "my-service", "name": "http.request", "sample_rate":1.0, "max_per_second": 50}]
 ```
 
-[1]: https://github.com/DataDog/dd-opentracing-cpp/releases/tag/v1.3.3
+[1]: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.1.0
 {{% /tab %}}
 {{% tab ".NET" %}}
 Starting from version [v2.18.0][1], for .NET applications, set by-service and by-operation name **span** sampling rules with the `DD_SPAN_SAMPLING_RULES` environment variable.

--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -262,6 +262,11 @@ Classic:
       api: true
       authors: Jacob Aronoff
 Tracing:
+  - C++:
+    - name: dd-trace-cpp
+      link: https://github.com/DataDog/dd-trace-cpp
+      official: true
+      authors: Datadog
   - .NET:
     - name: dd-trace-dotnet
       link: https://github.com/DataDog/dd-trace-dotnet


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Historically, the C++ implementation was based on OpenTracing. Since late 2022, we developed our Datadog tracer for C++ that are now in use for all our proxy integrations. The goal of this PR is to replace any mention and code related to [dd-opentracing-cpp](https://github.com/DataDog/dd-opentracing-cpp) to [dd-trace-cpp](https://github.com/DataDog/dd-trace-cpp).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
🚀