### PR TITLE
fix invalid json in docker run for prom container, metric formatting …

### DIFF
--- a/content/en/containers/docker/prometheus.md
+++ b/content/en/containers/docker/prometheus.md
@@ -146,8 +146,20 @@ labels:
 {{% tab "Docker run command" %}}
 
 ```shell
--l com.datadoghq.ad.check_names='["openmetrics"]' -l com.datadoghq.ad.init_configs='[{}]' -l com.datadoghq.ad.instances='["{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT> \",\"namespace\":\"<NAMESPACE>\",\"metrics\":[{\"<METRIC_TO_FETCH>\": \"<NEW_METRIC_NAME>\"}]}"]'
+# single metric
+-l com.datadoghq.ad.check_names='["openmetrics"]' -l com.datadoghq.ad.init_configs='[{}]' -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>\",\"namespace\":\"<NAMESPACE>\",\"metrics\":[{\"<METRIC_TO_FETCH>\": \"<NEW_METRIC_NAME>\"}]}]"
 ```
+
+Notes on metrics formatting in com.datadoghq.ad.instances:
+
+# multiple metrics
+-l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>\",\"namespace\":\"<NAMESPACE>\",\"metrics\":[{\"<METRIC_TO_FETCH>\": \"<NEW_METRIC_NAME>\"}, {\"<METRIC_TO_FETCH>\": \"<NEW_METRIC_NAME>\"}]}]"
+
+# all metrics of a base type
+-l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>\",\"namespace\":\"<NAMESPACE>\",\"metrics\":[\"<METRIC_BASE_TO_FETCH>.*\"]}]"
+
+# all metrics
+-l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>\",\"namespace\":\"<NAMESPACE>\",\"metrics\":[\".*\"]}]"
 
 **Multiple endpoints example**:
 

--- a/content/en/containers/docker/prometheus.md
+++ b/content/en/containers/docker/prometheus.md
@@ -150,7 +150,7 @@ labels:
 -l com.datadoghq.ad.check_names='["openmetrics"]' -l com.datadoghq.ad.init_configs='[{}]' -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>\",\"namespace\":\"<NAMESPACE>\",\"metrics\":[{\"<METRIC_TO_FETCH>\": \"<NEW_METRIC_NAME>\"}]}]"
 ```
 
-Notes on metrics formatting in com.datadoghq.ad.instances:
+**Examples of metrics formatting in `com.datadoghq.ad.instances`**
 
 ```shell
 # multiple metrics

--- a/content/en/containers/docker/prometheus.md
+++ b/content/en/containers/docker/prometheus.md
@@ -152,14 +152,20 @@ labels:
 
 Notes on metrics formatting in com.datadoghq.ad.instances:
 
+```shell
 # multiple metrics
 -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>\",\"namespace\":\"<NAMESPACE>\",\"metrics\":[{\"<METRIC_TO_FETCH>\": \"<NEW_METRIC_NAME>\"}, {\"<METRIC_TO_FETCH>\": \"<NEW_METRIC_NAME>\"}]}]"
+```
 
+```shell
 # all metrics of a base type
 -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>\",\"namespace\":\"<NAMESPACE>\",\"metrics\":[\"<METRIC_BASE_TO_FETCH>.*\"]}]"
+```
 
+```shell
 # all metrics
 -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:<PROMETHEUS_PORT>/<PROMETHEUS_ENDPOINT>\",\"namespace\":\"<NAMESPACE>\",\"metrics\":[\".*\"]}]"
+```
 
 **Multiple endpoints example**:
 


### PR DESCRIPTION
…examples

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
fix invalid json in docker run cmd and add examples for one, multiple, .* and all metrics

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
tests:

# one metric
docker run -d -l com.datadoghq.ad.check_names='["openmetrics"]' -l com.datadoghq.ad.init_configs='[{}]' -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:%%port%%/metrics\",\"namespace\":\"test\",\"metrics\":[{\"promhttp_metric_handler_requests_in_flight\": \"promhttp_metric_handler_requests_in_flight_new\"}]}]" -p 9090:9090 prom/prometheus

   openmetrics (4.1.0)
    -------------------
      Instance ID: openmetrics:test:9bc61bc4faa35290 [OK]
      Configuration Source: container:docker://9faa7777759ebd41396bcc07c54ba81d8398218dbf0b92e1f656018b06725ba4
      Total Runs: 1
      Metric Samples: Last Run: 1, Total: 1

———

# two metrics
docker run -d -l com.datadoghq.ad.check_names='["openmetrics"]' -l com.datadoghq.ad.init_configs='[{}]' -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:%%port%%/metrics\",\"namespace\":\"test\",\"metrics\":[{\"prometheus_tsdb_wal_storage_size_bytes\": \"prometheus_tsdb_wal_storage_size_bytes_new\"}, {\"promhttp_metric_handler_requests_in_flight\": \"promhttp_metric_handler_requests_in_flight_new\"}]}]" -p 9090:9090 prom/prometheus

    openmetrics (4.1.0)
    -------------------
      Instance ID: openmetrics:test:ede4dfab64c4184f [OK]
      Configuration Source: container:docker://08e89e8c851f3893f9f896ef59685aed9790877f94138f05a4f1832c2d099735
      Total Runs: 1
      Metric Samples: Last Run: 2, Total: 2

——

# all metrics from a base metrics
docker run -d -l com.datadoghq.ad.check_names='["openmetrics"]' -l com.datadoghq.ad.init_configs='[{}]' -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:9090/metrics\",\"namespace\":\"test\",\"metrics\":[\"prometheus_tsdb.*\"]}]" -p 9090:9090 prom/prometheus

    openmetrics (4.1.0)
    -------------------
      Instance ID: openmetrics:test:81934cf5cc989bb3 [OK]
      Configuration Source: container:docker://3a1bde88df566e6f9d9206d4e7101c7e34c1cb3bd0d55d6f188cef0d998a6ae6
      Total Runs: 1
      Metric Samples: Last Run: 133, Total: 133

——

# all metrics
docker run -d -l com.datadoghq.ad.check_names='["openmetrics"]' -l com.datadoghq.ad.init_configs='[{}]' -l com.datadoghq.ad.instances="[{\"openmetrics_endpoint\":\"http://%%host%%:9090/metrics\",\"namespace\":\"test\",\"metrics\":[\".*\"]}]" -p 9090:9090 prom/prometheus

    openmetrics (4.1.0)
    -------------------
      Instance ID: openmetrics:test:9317f0d382f3c368 [OK]
      Configuration Source: container:docker://0bf60653383235bc0e6b7bb2ef72408d47ea1fce8753a5de92c6982f2120425a
      Total Runs: 1
      Metric Samples: Last Run: 360, Total: 360

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->