### PR TITLE
[DOCS-7242] adding scope of protection matrix and EKS support

### DIFF
--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -80,27 +80,10 @@ The following table summarizes the CSM features available relative to each deplo
 | Windows       | {{< X >}}              |                       | beta        |                     |                    |
 | AWS Fargate ECS/EKS  | {{< X >}}              |                       | beta        |                     |                    |
 
-The following table summarizes the scope of coverage relative to each CSM feature.
-
-## Scope of coverage
-| Resources types                         | CSM Misconfigurations | CSM Threats | CSM Vulnerabilities  | CSM Identity Risks | 
-| ----------------------------------------| --------------------- | ----------- | -------------------- | ------------------- |  
-| Resources in AWS Account                | {{< X >}}             |             |                      |                     |  
-| Resources in Azure Subscription         | {{< X >}}             |             |                      |                     | 
-| Resources in GCP Project                | {{< X >}}             |             |                      |                     |  
-| Kubernetes Cluster                      | {{< X >}}             | {{< X >}}   |                      |                     |  
-| Docker Host                             | {{< X >}}             |             |                      |                     |
-| Linux Host                              | {{< X >}}             | {{< X >}}   |    {{< X >}}         |                     |  
-| Docker Container                        |                       | {{< X >}}   |                      |                     |
-| Container Image                         |                       |             |    {{< X >}}         |                     |
-| IAM in AWS Account                      |                       |             |                      |  {{< X >}}          |
-
-**Note**: CSM Misconfigurations additionally monitors common resources used in your cloud accounts that are running Windows and AWS Fargate, such as EC2 instances, RDS, S3, and ELB.
-
 
 The following tables represent additional prerequisites relative to each CSM feature.
 
-## CSM Threats
+### CSM Threats 
 
 CSM Threats supports the following Linux distributions:
 
@@ -120,7 +103,7 @@ CSM Threats supports the following Linux distributions:
 - For compatibility with a custom Kubernetes network plugin like Cilium or Calico, see the [Troubleshooting page][102].
 - Data collection is done using eBPF, so Datadog minimally requires platforms that have underlying Linux kernel versions of 4.15.0+ or have eBPF features backported.
 
-## CSM Vulnerabilities
+### CSM Vulnerabilities 
 
 | Component                | Version/Requirement                     |
 | ------------------------ | ----------------------------------------|
@@ -132,7 +115,7 @@ CSM Threats supports the following Linux distributions:
   - CRI-O runtime
   - podman runtime
 
-## CSM Identity Risks
+### CSM Identity Risks 
 
 <div class="alert alert-info"><strong>Note</strong>: At this time, CSM Identity Risks is available for AWS only.</div>
 
@@ -142,6 +125,23 @@ To use CSM Identity Risks, you must [enable resource collection for AWS][105]. I
 
 - If you've [enabled CSM Misconfigurations for your AWS accounts][106], you already have cloud resource collection enabled.
 - Although not required, when you [enable CloudTrail logs forwarding][107], you get additional insights based on the actual usage (or non-usage) of resources in your infrastructure, for example, users and roles with significant gaps between provisioned and used permissions.
+
+The following table summarizes the scope of coverage available relative to each CSM feature.
+
+## Scope of coverage
+| Resources types                         | CSM Misconfigurations | CSM Threats | CSM Vulnerabilities  | CSM Identity Risks | 
+| ----------------------------------------| --------------------- | ----------- | -------------------- | ------------------- |  
+| Resources in AWS Account                | {{< X >}}             |             |                      |                     |  
+| Resources in Azure Subscription         | {{< X >}}             |             |                      |                     | 
+| Resources in GCP Project                | {{< X >}}             |             |                      |                     |  
+| Kubernetes Cluster                      | {{< X >}}             | {{< X >}}   |                      |                     |  
+| Docker Host                             | {{< X >}}             |             |                      |                     |
+| Linux Host                              | {{< X >}}             | {{< X >}}   |    {{< X >}}         |                     |  
+| Docker Container                        |                       | {{< X >}}   |                      |                     |
+| Container Image                         |                       |             |    {{< X >}}         |                     |
+| IAM in AWS Account                      |                       |             |                      |  {{< X >}}          |
+
+**Note**: CSM Misconfigurations additionally monitors common resources used in your cloud accounts that are running Windows and AWS Fargate, such as EC2 instances, RDS, S3, and ELB.
 
 ## Next steps
 

--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -60,13 +60,13 @@ CSM is available in three packages: [CSM Enterprise][1], [CSM Pro][2], and [CSM 
 
 ## Prerequsites
 
-The following table summarizes the CSM features available relative to each deployment type.
-
 - The **minimum** Datadog Agent version required for CSM is `7.46` or higher.
 
-<div class="alert alert-info">For more details, click each of the CSM feature headings to review additional requirements for that feature.</div>
-
 ### Supported deployment types and features
+
+The following table summarizes the CSM features available relative to each deployment type.
+
+<div class="alert alert-info">For more details, click each of the CSM feature headings to review additional requirements for that feature.</div>
 
 | Type          | Agent Required (7.46+) | CSM Misconfigurations | [CSM Threats][8]| [CSM Vulnerabilities][9] | [CSM Identity Risks][10] |
 |---------------|------------------------|-----------------------|-------------|---------------------|--------------------|
@@ -125,10 +125,11 @@ To use CSM Identity Risks, you must [enable resource collection for AWS][105]. I
 
 - If you've [enabled CSM Misconfigurations for your AWS accounts][106], you already have cloud resource collection enabled.
 - Although not required, when you [enable CloudTrail logs forwarding][107], you get additional insights based on the actual usage (or non-usage) of resources in your infrastructure, for example, users and roles with significant gaps between provisioned and used permissions.
-
-The following table summarizes the scope of coverage available relative to each CSM feature.
+</br>
 
 ## Scope of coverage
+
+The following table summarizes the scope of coverage available relative to each CSM feature.
 | Resources types                         | CSM Misconfigurations | CSM Threats | CSM Vulnerabilities  | CSM Identity Risks | 
 | ----------------------------------------| --------------------- | ----------- | -------------------- | ------------------- |  
 | Resources in AWS Account                | {{< X >}}             |             |                      |                     |  

--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -73,16 +73,34 @@ The following table summarizes the CSM features available relative to each deplo
 | Docker        | {{< X >}}              | {{< X >}}             | {{< X >}}   |                     |                    |
 | Kubernetes    | {{< X >}}              | {{< X >}}             | {{< X >}}   | {{< X >}}           |                    |
 | Linux         | {{< X >}}              | {{< X >}}             | {{< X >}}   | {{< X >}}           |                    |
-| Amazon ECS    | {{< X >}}              | {{< X >}}             | {{< X >}}   | {{< X >}}           |                    |
+| Amazon ECS/EKS    | {{< X >}}              | {{< X >}}             | {{< X >}}   | {{< X >}}           |                    |
 | AWS Account   |                        | {{< X >}}             |             |                     | {{< X >}}          |
 | Azure Account |                        | {{< X >}}             |             |                     |                    |
 | GCP Account   |                        | {{< X >}}             |             |                     |                    |
 | Windows       | {{< X >}}              |                       | beta        |                     |                    |
-| AWS Fargate   | {{< X >}}              |                       | beta        |                     |                    |
+| AWS Fargate ECS/EKS  | {{< X >}}              |                       | beta        |                     |                    |
+
+The following table summarizes the scope of coverage relative to each CSM feature.
+
+## Scope of coverage
+| Resources types                         | CSM Misconfigurations | CSM Threats | CSM Vulnerabilities  | CSM Identity Risks | 
+| ----------------------------------------| --------------------- | ----------- | -------------------- | ------------------- |  
+| Resources in AWS Account                | {{< X >}}             |             |                      |                     |  
+| Resources in Azure Subscription         | {{< X >}}             |             |                      |                     | 
+| Resources in GCP Project                | {{< X >}}             |             |                      |                     |  
+| Kubernetes Cluster                      | {{< X >}}             | {{< X >}}   |                      |                     |  
+| Docker Host                             | {{< X >}}             |             |                      |                     |
+| Linux Host                              | {{< X >}}             | {{< X >}}   |    {{< X >}}         |                     |  
+| Docker Container                        |                       | {{< X >}}   |                      |                     |
+| Container Image                         |                       |             |    {{< X >}}         |                     |
+| IAM in AWS Account                      |                       |             |                      |  {{< X >}}          |
+
+**Note**: CSM Misconfigurations additionally monitors common resources used in your cloud accounts that are running Windows and AWS Fargate, such as EC2 instances, RDS, S3, and ELB.
+
 
 The following tables represent additional prerequisites relative to each CSM feature.
 
-### CSM Threats
+## CSM Threats
 
 CSM Threats supports the following Linux distributions:
 
@@ -102,7 +120,7 @@ CSM Threats supports the following Linux distributions:
 - For compatibility with a custom Kubernetes network plugin like Cilium or Calico, see the [Troubleshooting page][102].
 - Data collection is done using eBPF, so Datadog minimally requires platforms that have underlying Linux kernel versions of 4.15.0+ or have eBPF features backported.
 
-### CSM Vulnerabilities
+## CSM Vulnerabilities
 
 | Component                | Version/Requirement                     |
 | ------------------------ | ----------------------------------------|
@@ -114,7 +132,7 @@ CSM Threats supports the following Linux distributions:
   - CRI-O runtime
   - podman runtime
 
-### CSM Identity Risks
+## CSM Identity Risks
 
 <div class="alert alert-info"><strong>Note</strong>: At this time, CSM Identity Risks is available for AWS only.</div>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR aims to expand on the CSM Setup page to help customers identify their scope of protection (resource types) when they enable certain CSM features .


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->