### PR TITLE
[ci-visibility] Cypress `after:run` improvements

### DIFF
--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -307,7 +307,7 @@ module.exports = defineConfig({
 })
 {{< /code-block >}}
 
-#### Cypress after:run event
+#### Cypress `after:run` event
 Datadog requires the [`after:run`][10] Cypress event to work, and Cypress does not allow multiple handlers for that event. If you defined handlers for `after:run` already, add the Datadog handler manually by importing `'dd-trace/ci/cypress/after-run'`:
 
 {{< code-block lang="javascript" filename="cypress.config.js" >}}
@@ -339,7 +339,7 @@ These are the instructions if you're using a version older than `cypress@10`. Se
 }
 {{< /code-block >}}
 
-If you've already defined a `pluginsFile`, you can still initialize the instrumentation with:
+If you already defined a `pluginsFile`, initialize the instrumentation with:
 {{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
 module.exports = (on, config) => {
   // your previous code is before this line
@@ -356,7 +356,7 @@ require('dd-trace/ci/cypress/support')
 // Cypress.Commands.add('login', (email, pw) => {})
 {{< /code-block >}}
 
-#### Cypress after:run event
+#### Cypress `after:run` event
 Datadog requires the [`after:run`][10] Cypress event to work, and Cypress does not allow multiple handlers for that event. If you defined handlers for `after:run` already, add the Datadog handler manually by importing `'dd-trace/ci/cypress/after-run'`:
 
 {{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -306,36 +306,70 @@ module.exports = defineConfig({
   }
 })
 {{< /code-block >}}
-<div class="alert alert-warning"> Datadog requires the <a href="#cypress-afterrun-event">after:run</a> Cypress event to work, and Cypress does not allow multiple <a href="">'after:run'</a> handlers. If you are using this event, dd-trace will not work properly.</div>
+
+#### Cypress after:run event
+Datadog requires the [`after:run`][10] Cypress event to work, and Cypress does not allow multiple handlers for that event. If you defined handlers for `after:run` already, add the Datadog handler manually by importing `'dd-trace/ci/cypress/after-run'`:
+
+{{< code-block lang="javascript" filename="cypress.config.js" >}}
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  e2e: {
+    setupNodeEvents(on, config) {
+      require('dd-trace/ci/cypress/plugin')(on, config)
+      // other plugins
+      on('after:run', (details) => {
+        // other 'after:run' handlers
+        // important that this function call is returned
+        return require('dd-trace/ci/cypress/after-run')(details)
+      })
+    }
+  }
+})
+{{< /code-block >}}
 
 ### Cypress before version 10
 
 These are the instructions if you're using a version older than `cypress@10`. See the [Cypress documentation][9] for more information about migrating to a newer version.
 
 1. Set [`pluginsFile`][2] to `"dd-trace/ci/cypress/plugin"`, for example, through [`cypress.json`][3]:
-   {{< code-block lang="json" filename="cypress.json" >}}
-   {
-     "pluginsFile": "dd-trace/ci/cypress/plugin"
-   }
-   {{< /code-block >}}
+{{< code-block lang="json" filename="cypress.json" >}}
+{
+  "pluginsFile": "dd-trace/ci/cypress/plugin"
+}
+{{< /code-block >}}
 
-   If you've already defined a `pluginsFile`, you can still initialize the instrumentation with:
-   {{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
-   module.exports = (on, config) => {
-     // your previous code is before this line
-     require('dd-trace/ci/cypress/plugin')(on, config)
-   }
-   {{< /code-block >}}
-   <div class="alert alert-warning"> Datadog requires the <a href="#cypress-afterrun-event">'after:run'</a> Cypress event to work, and Cypress does not allow multiple <a href="">'after:run'</a> handlers. If you are using this event, dd-trace will not work properly.</div>
+If you've already defined a `pluginsFile`, you can still initialize the instrumentation with:
+{{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
+module.exports = (on, config) => {
+  // your previous code is before this line
+  require('dd-trace/ci/cypress/plugin')(on, config)
+}
+{{< /code-block >}}
 
 2. Add the following line to the **top level** of your [`supportFile`][4]:
-   {{< code-block lang="javascript" filename="cypress/support/index.js" >}}
-   // Your code can be before this line
-   // require('./commands')
-   require('dd-trace/ci/cypress/support')
-   // Your code can also be after this line
-   // Cypress.Commands.add('login', (email, pw) => {})
-   {{< /code-block >}}
+{{< code-block lang="javascript" filename="cypress/support/index.js" >}}
+// Your code can be before this line
+// require('./commands')
+require('dd-trace/ci/cypress/support')
+// Your code can also be after this line
+// Cypress.Commands.add('login', (email, pw) => {})
+{{< /code-block >}}
+
+#### Cypress after:run event
+Datadog requires the [`after:run`][10] Cypress event to work, and Cypress does not allow multiple handlers for that event. If you defined handlers for `after:run` already, add the Datadog handler manually by importing `'dd-trace/ci/cypress/after-run'`:
+
+{{< code-block lang="javascript" filename="cypress/plugins/index.js" >}}
+module.exports = (on, config) => {
+  // your previous code is before this line
+  require('dd-trace/ci/cypress/plugin')(on, config)
+  on('after:run', (details) => {
+    // other 'after:run' handlers
+    // important that this function call is returned
+    return require('dd-trace/ci/cypress/after-run')(details)
+  })
+}
+{{< /code-block >}}
 
 
 Run your tests as you normally do, specifying the environment where test are being run (for example, `local` when running tests on a developer workstation, or `ci` when running them on a CI provider) in the `DD_ENV` environment variable. For example:
@@ -400,6 +434,7 @@ If the browser application being tested is instrumented using [Browser Monitorin
 [7]: /real_user_monitoring/browser/#setup
 [8]: /continuous_integration/guides/rum_integration/
 [9]: https://docs.cypress.io/guides/references/migration-guide#Migrating-to-Cypress-100
+[10]: https://docs.cypress.io/api/plugins/after-run-api
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -589,10 +624,6 @@ If you want visibility into the browser process, consider using [RUM & Session R
 
 Cypress interactive mode (which you can enter by running `cypress open`) is not supported by CI Visibility because some cypress events, such as [`before:run`][12], are not fired. If you want to try it anyway, pass `experimentalInteractiveRunEvents: true` to the [cypress configuration file][13].
 
-### Cypress `after:run` event
-
-Datadog requires usage of the Cypress [`after:run` event][14]. Cypress only allows a single listener for this event, so if your custom Cypress plugin requires `after:run`, it is incompatible with `dd-trace`.
-
 ### Mocha parallel tests
 Mocha's [parallel mode][15] is not supported. Tests run in parallel mode are not instrumented by CI Visibility.
 
@@ -662,7 +693,6 @@ When you use this approach, both the testing framework and CI Visibility can tel
 [11]: /continuous_integration/guides/rum_integration/
 [12]: https://docs.cypress.io/api/plugins/before-run-api
 [13]: https://docs.cypress.io/guides/references/configuration#Configuration-File
-[14]: https://docs.cypress.io/api/plugins/after-run-api
 [15]: https://mochajs.org/#parallel-tests
 [16]: https://github.com/cucumber/cucumber-js/blob/63f30338e6b8dbe0b03ddd2776079a8ef44d47e2/docs/parallel.md
 [17]: https://jestjs.io/docs/api#testconcurrentname-fn-timeout


### PR DESCRIPTION
### What does this PR do? What is the motivation?

After https://github.com/DataDog/dd-trace-js/pull/4090 we have more flexibility with the `after:run` event in Cypress. The objective of this PR is to let the user know.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes

https://docs-staging.datadoghq.com/juan-fernandez/cypress-after-run/tests/setup/javascript/?tab=cypress#cypress-afterrun-event