### PR TITLE
addition AP1 to Open ports - Outbound (Agent v6 & v7)

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -279,7 +279,7 @@ See [logs endpoints][3] for other connection types.
 
 {{% /site-region %}}
 
-{{% site-region region="us3,us5,gov" %}}
+{{% site-region region="us3,us5,gov,ap1" %}}
 
 443/tcp
 : Port for most Agent data (Metrics, APM, Live Processes & Containers).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
There is no information about open ports in AP1.
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
https://docs.datadoghq.com/logs/log_collection/?tab=tcp
(DATADOG SITE: AP1)
>Custom log forwarding
>The TCP endpoint is not supported for this site.

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->