### PR TITLE
[DOCS-7274] updating Network page to make IP Ranges easier to find

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -21,7 +21,7 @@ further_reading:
       tag: 'Documentation'
       text: 'Collect your traces'
 algolia:
-  tags: ['network traffic', 'destinations', 'ports', 'data buffering']
+  tags: ['network traffic', 'destinations', 'ports', 'data buffering', 'static IP addresses']
 ---
 
 ## Overview
@@ -174,6 +174,8 @@ Agent < v7.18.0 or 6.18.0: `app.`{{< region-param key="dd_site" code="true" >}}
 [Agent flare][12]
 : `<VERSION>-flare.agent.`{{< region-param key="dd_site" code="true" >}}<br>
 For example, Agent v7.31.0 sends flare data to `7-31-0-flare.agent.`{{< region-param key="dd_site" code="true" >}}. You must add `*.agent.`{{< region-param key="dd_site" code="true" >}} to your inclusion list in your firewall(s).<br>
+
+### Static IP addresses
 
 All of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at `https://ip-ranges.`{{< region-param key="dd_site" code="true" >}}.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Small update to the Agent - Network page to add an H3 for "Static IP addresses" as well as algolia search term to make this easier to find.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->