### PR TITLE
Move call to set dd_service annotation

### DIFF
--- a/content/en/continuous_delivery/deployments/argocd.md
+++ b/content/en/continuous_delivery/deployments/argocd.md
@@ -111,34 +111,23 @@ metadata:
   annotations:
     notifications.argoproj.io/subscribe.cd-visibility-trigger.cd-visibility-webhook: ""
     dd_env: <YOUR_ENV>
+    dd_service: <YOUR_SERVICE>
 ```
 
-There are two annotations:
+There are three annotations:
 1. The notifications annotation subscribes the Argo CD application to the notification setup created above.
 2. The `dd_env` annotation configures the environment of the application. Replace `YOUR_ENV` above with the environment
    to which this application is deploying (for example: `staging` or `prod`). If you don't set this annotation,
    the environment defaults to `none`.
+3. The `dd_service` annotation configures the service of the application. Replace `YOUR_SERVICE` above with the service
+   that the Argo CD application is deploying (for example: `transaction-service`). When this annotation is used, the service
+   name is added to all the deployment executions generated from the application. Moreover, if your service is
+   registered in [Service Catalog][13], the team name is also added to all the deployment executions. Omit this annotation
+   if your Argo CD application is configured to deploy more than one service.
 
 See the [Argo CD official guide][12] for more details on applications subscriptions.
 
 After this final step is completed, you can start monitoring your Argo CD deployments in Datadog.
-
-## Adding service information to deployment executions
-
-The `dd_service` annotation can be used to map an Argo CD application to the service that it deploys. For example:
-
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  annotations:
-    notifications.argoproj.io/subscribe.cd-visibility-trigger.cd-visibility-webhook: ""
-    dd_env: <YOUR_ENV>
-    dd_service: transaction-service
-```
-
-Using this annotation adds the service name to all the deployment executions generated from the application.
-Moreover, if your service is registered in [Service Catalog][13], the team name is also added to all the deployment executions.
 
 ## Adding custom tags to deployment executions
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Setting the service is a very important part of the setup for Argo CD applications monitoring in Datadog. Currently, it's in a separate section after the default setup. This PR moves it to be part of the main setup to ensure that customers know about it and try to set it when possible.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->