### PR TITLE
Update Collector configuration

### DIFF
--- a/content/en/getting_started/opentelemetry/_index.md
+++ b/content/en/getting_started/opentelemetry/_index.md
@@ -144,7 +144,7 @@ service:
     logs:
       exporters: [datadog]
 {{< /code-block >}}  
-4. Set `exporters.datadog.api.site` to your [Datadog site][16]. Otherwise, it defaults to US1.
+3. Set `exporters.datadog.api.site` to your [Datadog site][16]. Otherwise, it defaults to US1.
 
 This configuration allows the Datadog Exporter to send runtime metrics, traces, and logs to Datadog. However, sending infrastructure metrics requires additional configuration.
 

--- a/content/en/getting_started/opentelemetry/_index.md
+++ b/content/en/getting_started/opentelemetry/_index.md
@@ -130,16 +130,21 @@ exporters:
     api:
       key: ${DD_API_KEY}
       site: datadoghq.com
+   
+connectors:
+    datadog/connector:
+
 service:
   pipelines:
     metrics:
+      receivers: [otlp, datadog/connector] # <- update this line
       exporters: [datadog]
     traces:
-      exporters: [datadog]
+      exporters: [datadog, datadog/connector]
     logs:
       exporters: [datadog]
 {{< /code-block >}}  
-3. Set `exporters.datadog.api.site` to your [Datadog site][16]. Otherwise, it defaults to US1.
+4. Set `exporters.datadog.api.site` to your [Datadog site][16]. Otherwise, it defaults to US1.
 
 This configuration allows the Datadog Exporter to send runtime metrics, traces, and logs to Datadog. However, sending infrastructure metrics requires additional configuration.
 
@@ -187,7 +192,7 @@ receivers:
 service:
   pipelines:
     metrics:
-      receivers: [otlp, docker_stats] # <- update this line
+      receivers: [otlp, datadog/connector, docker_stats] # <- update this line
 {{< /code-block >}}
 
 This configuration allows the Calendar application to send container metrics to Datadog for you to explore in Datadog.


### PR DESCRIPTION
With OTel Collector `0.95.0` the Datadog connector is required.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR adds the Datadog connector to the OTel collector configuration.
Since OTel Collector version `0.95.0` this component is required in order to have stats calculation.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing
