### PR TITLE
Update instructions to enable Orchestrator for Agent v7.51+

### DIFF
--- a/content/en/infrastructure/faq/set-up-orchestrator-explorer-daemonset.md
+++ b/content/en/infrastructure/faq/set-up-orchestrator-explorer-daemonset.md
@@ -100,11 +100,22 @@ This page contains instructions for setting up the Orchestrator Explorer using a
 3. The Process Agent, which runs in the Agent DaemonSet, must be enabled and running (it doesn't need to run the process collection), and configured with the following options:
 
     ```yaml
-    - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
-      value: "true"
+    containers:
+        - name: process-agent
+          env:
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"
+    ```
+    For Agent versions 7.51.0+, the orchestrator check runs on the Agent container instead of the Process Agent container so configure the following on the Agent container instead:
+    ```yaml
+    containers:
+        - name: agent
+          env:
+          - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+            value: "true"
     ```
 
-4. (Optional) Set collectors under instances section to specify the resources to be collected. Create `orchestrator.yaml` in ConfigMap. Sample configuration:
+5. (Optional) Set collectors under instances section to specify the resources to be collected. Create `orchestrator.yaml` in ConfigMap. Sample configuration:
 
      ```yaml
       apiVersion: v1

--- a/content/en/infrastructure/faq/set-up-orchestrator-explorer-daemonset.md
+++ b/content/en/infrastructure/faq/set-up-orchestrator-explorer-daemonset.md
@@ -106,7 +106,7 @@ This page contains instructions for setting up the Orchestrator Explorer using a
           - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
             value: "true"
     ```
-    For Agent versions 7.51.0+, the orchestrator check runs on the Agent container instead of the Process Agent container so configure the following on the Agent container instead:
+    For Agent versions 7.51.0+, the orchestrator check runs on the Agent container instead of the Process Agent container. To configure the Agent container:
     ```yaml
     containers:
         - name: agent

--- a/content/en/infrastructure/faq/set-up-orchestrator-explorer-daemonset.md
+++ b/content/en/infrastructure/faq/set-up-orchestrator-explorer-daemonset.md
@@ -115,7 +115,7 @@ This page contains instructions for setting up the Orchestrator Explorer using a
             value: "true"
     ```
 
-5. (Optional) Set collectors under instances section to specify the resources to be collected. Create `orchestrator.yaml` in ConfigMap. Sample configuration:
+4. (Optional) Set collectors under instances section to specify the resources to be collected. Create `orchestrator.yaml` in ConfigMap. Sample configuration:
 
      ```yaml
       apiVersion: v1


### PR DESCRIPTION
Updates instructions for changes introduced in Agent v7.51.0. Orchestrator runs on the main agent container instead of the process-agent container.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->