### PR TITLE
Add Operator Path to APM Single Step Instrumentation

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -173,8 +173,8 @@ docker run -d --name dd-agent \
 
 You can enable APM by installing the Agent with either:
 
-- [Datadog Operator](#installing-with-datadog-operator)
-- [Datadog Helm chart](#installing-with-helm)
+- Datadog Operator
+- Datadog Helm chart
 
 <div class="alert alert-info">Single Step Instrumentation doesn't instrument applications in the namespace where you install the Datadog Agent. It's recommended to install the Agent in a separate namespace in your cluster where you don't run your applications.</div>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Split Kubernetes tab into Helm and Operator.
- Add content for Operator.

Preview: https://docs-staging.datadoghq.com/brett0000FF/ssi-k8operator/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=kubernetes

TODO
- [x] Verify code snippets for new Operator instructions.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->