### PR TITLE
DatadogAgent v1alpha1 deprecation warning

### DIFF
--- a/content/en/containers/guide/datadogoperator_migration.md
+++ b/content/en/containers/guide/datadogoperator_migration.md
@@ -1,5 +1,12 @@
 ## Migrating to version 1.0 of the Datadog Operator
 
+<div class="alert alert-warning">
+The <code>v1alpha1</code> DatadogAgent reconciliation in the Operator is deprecated since v1.2.0+ and will be removed in v1.7.0. Once removed, the Datadog Operator cannot be configured to reconcile the <code>v1alpha1</code> DatadogAgent CRD. However, you will still be able to apply a <code>v1alpha1</code> manifest with the conversion webhook enabled (using <code>datadogCRDs.migration.datadogAgents.conversionWebhook.enabled</code>).
+
+DatadogAgent <code>v1alpha1</code> and the conversion webhook will be removed in v1.8.0. You will not be able to migrate thereafter unless you use earlier version of the Operator.
+</div>
+
+
 Datadog Operator v0.X uses `v1alpha1` of the DatadogAgent custom resource. Datadog Operator v1.X reconciles `v2alpha1`.
 
 This guide describes how to migrate to the `v2alpha1/DatadogAgent` custom resource from `v1alpha1/DatadogAgent`.

--- a/content/en/containers/guide/datadogoperator_migration.md
+++ b/content/en/containers/guide/datadogoperator_migration.md
@@ -1,9 +1,11 @@
 ## Migrating to version 1.0 of the Datadog Operator
 
 <div class="alert alert-warning">
-The <code>v1alpha1</code> DatadogAgent reconciliation in the Operator is deprecated since v1.2.0+ and will be removed in v1.7.0. Once removed, the Datadog Operator cannot be configured to reconcile the <code>v1alpha1</code> DatadogAgent CRD. However, you will still be able to apply a <code>v1alpha1</code> manifest with the conversion webhook enabled (using <code>datadogCRDs.migration.datadogAgents.conversionWebhook.enabled</code>).
+The <code>v1alpha1</code> <code>DatadogAgent</code> reconciliation in the Operator is deprecated since v1.2.0+ and will be removed in v1.7.0. After it's removed, you will not be able to configure the Datadog Operator to reconcile the <code>v1alpha1</code> <code>DatadogAgent</code> CRD. However, you will still be able to apply a <code>v1alpha1</code> manifest with the conversion webhook enabled using <code>datadogCRDs.migration.datadogAgents.conversionWebhook.enabled</code>.
+</div>
 
-DatadogAgent <code>v1alpha1</code> and the conversion webhook will be removed in v1.8.0. You will not be able to migrate thereafter unless you use earlier version of the Operator.
+<div class="alert alert-warning">
+<code>DatadogAgent</code> <code>v1alpha1</code> and the conversion webhook will be removed in v1.8.0. After it's removed, you will not be able to migrate unless you use earlier version of the Operator.
 </div>
 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds a deprecation warning for DatadogAgent `v1alpha1` version, similar warning was added to helm charts and the binary
https://github.com/DataDog/helm-charts/pull/1332
https://github.com/DataDog/datadog-operator/pull/1099

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->