### PR TITLE
[Update _index.md] kevin_gleeson

### DIFF
--- a/content/en/containers/troubleshooting/_index.md
+++ b/content/en/containers/troubleshooting/_index.md
@@ -16,7 +16,7 @@ There are three methods of deploying the Agent:
 
 2. In a **cloud environment**, such as [Amazon ECS][2], [Fargate in an Amazon ECS environment][3], or [Amazon EKS][4]
 
-3. In a [Kubernetes environment][2]
+3. In a [Kubernetes environment][16]
 
 These different methods present unique deployment challenges. Use this page as a starting point to resolve issues. If you continue to have trouble, reach out to [Datadog support][6] for further assistance. 
 
@@ -170,3 +170,4 @@ $ docker exec -it <AGENT_CONTAINER_ID> curl -k -v "<METRIC_ENDPOINT>"
 [13]: https://docs.datadoghq.com/integrations/eks_fargate/#log-collection
 [14]: https://docs.datadoghq.com/logs/guide/aws-eks-fargate-logs-with-kinesis-data-firehose/#overview
 [15]: https://docs.datadoghq.com/agent/troubleshooting/send_a_flare
+[16]: https://docs.datadoghq.com/containers/kubernetes/installation/?tab=operator


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- This PR fixes a link on the Container Troubleshooting page. The third option in the overview was linked to an Amazon ECS doc instead of installing the agent on Kubernetes. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->