### PR TITLE
Remove incorrect '.' in environment variable example

### DIFF
--- a/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
@@ -214,7 +214,7 @@ There are many other environment variables and settings supported in the Datadog
 1. For the application container, set `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to point to the Datadog Agent container. For example:
 
    ```
-   OTEL_EXPORTER_OTLP_ENDPOINT=http://<datadog-agent>:4318.
+   OTEL_EXPORTER_OTLP_ENDPOINT=http://<datadog-agent>:4318
    ```
 
 2. Both containers must be defined in the same bridge network, which is handled automatically if you use Docker Compose. Otherwise, follow the Docker example in [Tracing Docker Applications][1] to set up a bridge network with the correct ports.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Noticed that we put a `.` at the end of `OTEL_EXPORTER_OTLP_ENDPOINT` which definitely doesn't seem correct (and does not match any of the other examples for setting this environment variable on the same page).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->