### PR TITLE
add instruction to disable log anomaly detection

### DIFF
--- a/content/en/watchdog/alerts/_index.md
+++ b/content/en/watchdog/alerts/_index.md
@@ -86,14 +86,14 @@ A `severe` anomaly is defined as:
 Watchdog requires some data to establish a baseline of expected behavior. For log anomalies, the minimum history is 24 hours. 
 Watchdog starts finding anomalies after the minimum required history is available, and Watchdog improves as history grows. Best performances are obtained with six weeks of history. 
 
-#### Disabling Log anomaly detection
+#### Disabling log anomaly detection
 
-To disable Log Anomaly detection, go to the [Log Management pipeline page][4] and turn off the toogle for Log Anomalies.
+To disable log anomaly detection, go to the [Log Management pipeline page][4] and click the Log Anomalies toggle.
 
 [1]: https://app.datadoghq.com/watchdog
 [2]: /monitors/types/watchdog/
 [3]: /watchdog/insights?tab=logmanagement#explore-insights
-[4]: /logs/log_configuration/
+[4]: https://app.datadoghq.com/logs/pipelines
 {{% /tab %}}
 {{% tab "APM" %}}
 

--- a/content/en/watchdog/alerts/_index.md
+++ b/content/en/watchdog/alerts/_index.md
@@ -86,9 +86,14 @@ A `severe` anomaly is defined as:
 Watchdog requires some data to establish a baseline of expected behavior. For log anomalies, the minimum history is 24 hours. 
 Watchdog starts finding anomalies after the minimum required history is available, and Watchdog improves as history grows. Best performances are obtained with six weeks of history. 
 
+#### Disabling Log anomaly detection
+
+To disable Log Anomaly detection, go to the [Log Management pipeline page][4] and turn off the toogle for Log Anomalies.
+
 [1]: https://app.datadoghq.com/watchdog
 [2]: /monitors/types/watchdog/
 [3]: /watchdog/insights?tab=logmanagement#explore-insights
+[4]: /logs/log_configuration/
 {{% /tab %}}
 {{% tab "APM" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
It is possible to disable log anomaly detection but the instruction were not documented.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->