### PR TITLE
[PROF-9147] Document workaround for Ruby gc_finalize_deferred

### DIFF
--- a/content/en/profiler/profiler_troubleshooting/ruby.md
+++ b/content/en/profiler/profiler_troubleshooting/ruby.md
@@ -75,7 +75,7 @@ Doing this enables Datadog to add them to the auto-detection list, and to work w
 
 ## Segmentation faults in `gc_finalize_deferred` in Ruby versions 2.6 to 3.2
 
-A workaround for this issue is automatically applied since [`dd-trace-rb` version 1.21.0][3]. We recommend upgrading to this version or later to fix this issue.
+A workaround for this issue is automatically applied since [`dd-trace-rb` version 1.21.0][3]. Datadog recommends upgrading to this version or later to fix this issue.
 
 Prior to version 1.21.0, in rare situations the profiler could trigger [Ruby VM Bug #19991][12] that manifests itself as a "Segmentation fault" with a crash stack trace including the `gc_finalize_deferred` function.
 

--- a/content/en/profiler/profiler_troubleshooting/ruby.md
+++ b/content/en/profiler/profiler_troubleshooting/ruby.md
@@ -75,9 +75,11 @@ Doing this enables Datadog to add them to the auto-detection list, and to work w
 
 ## Segmentation faults in `gc_finalize_deferred` in Ruby versions 2.6 to 3.2
 
-In rare situations, the profiler can trigger [Ruby VM Bug #19991][12] that manifests itself as a "Segmentation fault" with a crash stack trace including the `gc_finalize_deferred` function.
+A workaround for this issue is automatically applied since [`dd-trace-rb` version 1.21.0][3]. We recommend upgrading to this version or later to fix this issue.
 
-This bug has been fixed for Ruby 3.3 and above. For older Ruby versions, you can use the "no signals" workaround to resolve this issue.
+Prior to version 1.21.0, in rare situations the profiler could trigger [Ruby VM Bug #19991][12] that manifests itself as a "Segmentation fault" with a crash stack trace including the `gc_finalize_deferred` function.
+
+This bug has been fixed for Ruby 3.3 and above. For older Ruby versions (and prior to dd-trace-rb 1.21.0), you can use the "no signals" workaround to resolve this issue.
 
 To enable this workaround, set the `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED` environment variable to `true`, or in code:
 
@@ -94,7 +96,7 @@ end
 
 [1]: /tracing/troubleshooting/#tracer-debug-logs
 [2]: /help/
-[3]: https://github.com/DataDog/dd-trace-rb/releases/tag/v0.54.0
+[3]: https://github.com/datadog/dd-trace-rb/releases/tag/v1.21.0
 [4]: https://github.com/resque/resque
 [5]: https://github.com/resque/resque/blob/v2.0.0/docs/HOOKS.md#worker-hooks
 [6]: https://bugs.ruby-lang.org/issues/18073


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR updates the Ruby troubleshooting documentation, now that a new workaround exists and is auto-applied (<https://github.com/DataDog/dd-trace-rb/pull/3473>).

This clarifies that using the "no signals" workaround is no longer the recommended way to solve this issue.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

The dd-trace-rb release containing the fix (1.21.0) has not yet been released, so I'm queuing this documentation change but ask that we don't merge it yet, and I'll come back and leave a note once the release is out. 

### Additional notes
<!-- Anything else we should know when reviewing?-->

N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->