### PR TITLE
WEB-4682 | Update image (redirect metadata work)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -544,7 +544,6 @@ set_redirect_metadata_preview:
   dependencies:
     - build_preview
   script:
-    - export EXTENDED_ROLE_DURATION="1800"
     - in-isolation run_update_redirect_metadata
   interruptible: true
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -538,13 +538,13 @@ set_redirect_metadata_preview:
   variables:
     BUCKET: "datadog-docs-preview"
     SET_REDIRECTS_PREVIEW: "true"
-    EXTENDED_ROLE_DURATION: "1800" # 30 minutes
   stage: post-deploy
   cache: []
   environment: "preview"
   dependencies:
     - build_preview
   script:
+    - export EXTENDED_ROLE_DURATION="1800"
     - in-isolation run_update_redirect_metadata
   interruptible: true
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-devin.ford_assume-duration-update
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-29301854
   tags:
     - "arch:amd64"
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-23395142
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/websites-images:webops-site-build-devin.ford_assume-duration-update
   tags:
     - "arch:amd64"
   rules:
@@ -538,6 +538,7 @@ set_redirect_metadata_preview:
   variables:
     BUCKET: "datadog-docs-preview"
     SET_REDIRECTS_PREVIEW: "true"
+    EXTENDED_ROLE_DURATION: "1800" # 30 minutes
   stage: post-deploy
   cache: []
   environment: "preview"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates the image to a new pointer that has work to increase the assumed role timeout for the redirect metadata job to `30` minutes from `15`. 
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
https://datadoghq.atlassian.net/browse/WEB-4628

Nothing really to test but you can check [this pipeline](https://gitlab.ddbuild.io/DataDog/documentation/-/pipelines/29306185) for a successful run on this image
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->