### PR TITLE
docs: add SUSE in supported platform for FIPS

### DIFF
--- a/content/en/agent/configuration/agent-fips-proxy.md
+++ b/content/en/agent/configuration/agent-fips-proxy.md
@@ -34,7 +34,7 @@ Supported platforms (64-bit x86):
 
 |||
 | ---  | ----------- |
-| Bare metal and VMs | RHEL >= 7<br>Debian >= 8<br>Ubuntu >= 14.04|
+| Bare metal and VMs | RHEL >= 7<br>Debian >= 8<br>Ubuntu >= 14.04<br>SUSE >= 12 (beta)|
 | Cloud and container| Amazon ECS<br>AWS EKS (Helm)|
 
 **Note**: arm64 architecture is available in beta


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Add a new supported platform for FIPS

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

https://docs-staging.datadoghq.com/nicolas.guerguadj/add-suse-as-supported-for-fips/agent/configuration/agent-fips-proxy/?tab=hostorvm#supported-platforms-and-limitations

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->