### PR TITLE
Update "Enabling the Ruby profiler" to use the new `ddprofrb` command

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -51,7 +51,7 @@ To begin profiling applications:
 2. Add the `ddtrace` gem to your `Gemfile` or `gems.rb` file:
 
     ```ruby
-    gem 'ddtrace', '~> 1.20'
+    gem 'ddtrace', '~> 1.21'
     ```
 
     If you're running a version of `ddtrace` older than 1.15.0, add the `google-protobuf` gem (version ~> 3.0) as a dependency.
@@ -103,7 +103,7 @@ end
 
     **Note**
 
-    If starting the application via `ddprofrb exec` is not an option (eg. when using the Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application entry point such as `config.ru` for a web application:
+    If starting the application with `ddprofrb exec` is not an option (for example, when using the Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application entry point (such as `config.ru`, for a web application):
 
     ```ruby
     require 'datadog/profiling/preload'

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -51,7 +51,7 @@ To begin profiling applications:
 2. Add the `ddtrace` gem to your `Gemfile` or `gems.rb` file:
 
     ```ruby
-    gem 'ddtrace', '~> 1.15'
+    gem 'ddtrace', '~> 1.20'
     ```
 
     If you're running a version of `ddtrace` older than 1.15.0, add the `google-protobuf` gem (version ~> 3.0) as a dependency.
@@ -87,21 +87,23 @@ end
 {{% /tab %}}
 {{< /tabs >}}
 
-4. Add the `ddtracerb exec` command to your Ruby application start command:
+4. Add the `ddprofrb exec` command to your Ruby application start command:
 
     ```shell
-    bundle exec ddtracerb exec ruby myapp.rb
+    bundle exec ddprofrb exec ruby myapp.rb
     ```
 
     Rails example:
 
     ```shell
-    bundle exec ddtracerb exec bin/rails s
+    bundle exec ddprofrb exec bin/rails s
     ```
+
+    If you're running a version of `ddtrace` older than 1.21.0, replace `ddprofrb exec` with `ddtracerb exec`.
 
     **Note**
 
-    If starting the application via `ddtracerb exec` is not an option (eg. when using the Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application entry point such as `config.ru` for a web application:
+    If starting the application via `ddprofrb exec` is not an option (eg. when using the Phusion Passenger web server), you can alternatively start the profiler by adding the following to your application entry point such as `config.ru` for a web application:
 
     ```ruby
     require 'datadog/profiling/preload'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates the "Enabling the Ruby profiler" page to use the `ddprofrb` command as a replacement for the `ddtracerb` command that was deprecated in https://github.com/DataDog/dd-trace-rb/pull/3501 .

The old command is still going to be kept around for a while longer, and emits a deprecation warning when used.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

The dd-trace-rb release containing this change fix (1.21.0) has not yet been released, so I'm queuing this documentation change but ask that we don't merge it yet, and I'll come back and leave a note once the release is out.

### Additional notes
<!-- Anything else we should know when reviewing?-->

N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->