### PR TITLE
Add In-App Release Notes Link for Software Delivery

### DIFF
--- a/content/en/code_analysis/_index.md
+++ b/content/en/code_analysis/_index.md
@@ -4,6 +4,9 @@ kind: documentation
 description: Learn how to use Datadog Code Analysis to address maintainability issues, bugs, and security vulnerabilities in development to prevent customer impact.
 is_beta: true
 further_reading:
+- link: "https://app.datadoghq.com/release-notes?category=Software%20Delivery"
+  tag: "Release Notes"
+  text: "Check out the latest Software Delivery releases! (App login required)"
 - link: "https://www.datadoghq.com/blog/monitor-ci-pipelines/"
   tag: "Blog"
   text: "Monitor all your CI pipelines with Datadog"

--- a/content/en/continuous_delivery/_index.md
+++ b/content/en/continuous_delivery/_index.md
@@ -2,9 +2,9 @@
 title: Continuous Delivery Visibility
 kind: documentation
 further_reading:
-- link: "https://app.datadoghq.com/release-notes?category=CI%20Visibility"
+- link: "https://app.datadoghq.com/release-notes?category=Software%20Delivery"
   tag: "Release Notes"
-  text: "Check out the latest CI/CD Visibility releases! (App login required)"
+  text: "Check out the latest Software Delivery releases! (App login required)"
 - link: "continuous_delivery/deployments"
   tag: "Documentation"
   text: "Learn how to set up Deployment Visibility"

--- a/content/en/continuous_integration/_index.md
+++ b/content/en/continuous_integration/_index.md
@@ -4,9 +4,9 @@ kind: documentation
 aliases:
   - /ci
 further_reading:
-  - link: "https://app.datadoghq.com/release-notes?category=CI%20Visibility"
+  - link: "https://app.datadoghq.com/release-notes?category=Software%20Delivery"
     tag: "Release Notes"
-    text: "Check out the latest CI Visibility releases! (App login required)"
+    text: "Check out the latest Software Delivery releases! (App login required)"
   - link: "https://www.datadoghq.com/blog/circleci-monitoring-datadog/"
     tag: "Blog"
     text: "Monitor your CircleCI environment with Datadog"

--- a/content/en/dora_metrics/_index.md
+++ b/content/en/dora_metrics/_index.md
@@ -6,6 +6,9 @@ aliases:
 - /continuous_integration/dora_metrics
 is_beta: true
 further_reading:
+- link: "https://app.datadoghq.com/release-notes?category=Software%20Delivery"
+  tag: "Release Notes"
+  text: "Check out the latest Software Delivery releases! (App login required)"
 - link: "/continuous_integration/tests"
   tag: "Documentation"
   text: "Learn about Test Visibility"

--- a/content/en/intelligent_test_runner/_index.md
+++ b/content/en/intelligent_test_runner/_index.md
@@ -4,6 +4,9 @@ kind: documentation
 aliases:
 - /continuous_integration/intelligent_test_runner/
 further_reading:
+  - link: "https://app.datadoghq.com/release-notes?category=Software%20Delivery"
+    tag: "Release Notes"
+    text: "Check out the latest Software Delivery releases! (App login required)"
   - link: "https://www.datadoghq.com/blog/streamline-ci-testing-with-datadog-intelligent-test-runner/"
     tag: "Blog"
     text: "Streamline CI testing with Datadog Intelligent Test Runner"

--- a/content/en/quality_gates/_index.md
+++ b/content/en/quality_gates/_index.md
@@ -4,6 +4,9 @@ kind: documentation
 description: Learn how to use Quality Gates to enable your team to control what code makes it to production.
 is_beta: true
 further_reading:
+- link: "https://app.datadoghq.com/release-notes?category=Software%20Delivery"
+  tag: "Release Notes"
+  text: "Check out the latest Software Delivery releases! (App login required)"
 - link: "/quality_gates/search"
   tag: "Documentation"
   text: "Learn how to search for Quality Gate rules"

--- a/content/en/tests/_index.md
+++ b/content/en/tests/_index.md
@@ -7,6 +7,9 @@ aliases:
   - /continuous_integration/integrate_tests/
   - /continuous_integration/tests/
 further_reading:
+    - link: "https://app.datadoghq.com/release-notes?category=Software%20Delivery"
+      tag: "Release Notes"
+      text: "Check out the latest Software Delivery releases! (App login required)"
     - link: "/monitors/types/ci/"
       tag: "Documentation"
       text: "Creating CI Test Monitors"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Replace deprecated CI Visibility link with Software Delivery link, flagged in #ci-visibility-feedback on Slack.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->