### PR TITLE
[SEC-12866] Add documentation about events_matched template variables

### DIFF
--- a/content/en/security/notifications/variables.md
+++ b/content/en/security/notifications/variables.md
@@ -33,10 +33,10 @@ The following variables are available:
 | `{{last_seen_epoch}}`                              | Time the signal was most recently triggered, in milliseconds, since midnight, January 1, 1970.|
 | `{{rule_name}}`                                    | Name of the associated rule.                                                                  |
 | `{{case_name}}`                                    | Name of the triggering rule case.                                                             |
-| `{{events_matched}}`                               | Number of events which has matched the associated rule.                                       |
-| `{{events_matched_per_query.<name_of_the_query>}}` | Number of events which has matched the associated rule query `<name_of_the_query>`.           |
+| `{{events_matched}}`                               | Number of events that have matched the associated rule.                                       |
+| `{{events_matched_per_query.<name_of_the_query>}}` | Number of events that have matched the associated rule query `<name_of_the_query>`.           |
 
-When a high amount of logs match a rule, the rule title/message are not rendered for every new logs. Therefore, in this case, the rendered values of `{{events_matched}}` and `{{events_matched_per_query.<name_of_the_query>}}` could be below the values displayed in the Overview Tab of the Signal Side Panel.
+When a large number of logs match a rule, the rule's title and message are not rendered for every new log. In these cases, the rendered values of `{{events_matched}}` and `{{events_matched_per_query.<name_of_the_query>}}` could be below the values displayed in the Overview tab of the signal's side panel.
 
 ### Dynamic links
 

--- a/content/en/security/notifications/variables.md
+++ b/content/en/security/notifications/variables.md
@@ -22,17 +22,21 @@ Use template variables to inject dynamic context from triggered logs or traces d
 
 The following variables are available:
 
-| Variable              | Description                                                                                   |
-| --------------------- | --------------------------------------------------------------------------------------------- |
-| `{{severity}}`        | The severity of the triggering rule case (integer, 0-4).                                      |
-| `{{timestamp}}`       | Time the signal was created. For example, `Mon Jan 01 00:00:00 UTC 1970`.                     |
-| `{{timestamp_epoch}}` | Time the signal was created, in milliseconds since midnight, January 1, 1970.                 |
-| `{{first_seen}}`      | Time the signal was first seen. For example, `Mon Jan 01 00:00:00 UTC 1970`.                  |
-| `{{first_seen_epoch}}`| Time the signal was first seen, in milliseconds since midnight, January 1, 1970.              |
-| `{{last_seen}}`       | Time the signal was most recently triggered. For example, `Mon Jan 01 00:00:00 UTC 1970`.     |
-| `{{last_seen_epoch}}` | Time the signal was most recently triggered, in milliseconds, since midnight, January 1, 1970.|
-| `{{rule_name}}`       | Name of the associated rule.                                                                  |
-| `{{case_name}}`       | Name of the triggering rule case.                                                             |
+| Variable                                           | Description                                                                                   |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `{{severity}}`                                     | The severity of the triggering rule case (integer, 0-4).                                      |
+| `{{timestamp}}`                                    | Time the signal was created. For example, `Mon Jan 01 00:00:00 UTC 1970`.                     |
+| `{{timestamp_epoch}}`                              | Time the signal was created, in milliseconds since midnight, January 1, 1970.                 |
+| `{{first_seen}}`                                   | Time the signal was first seen. For example, `Mon Jan 01 00:00:00 UTC 1970`.                  |
+| `{{first_seen_epoch}}`                             | Time the signal was first seen, in milliseconds since midnight, January 1, 1970.              |
+| `{{last_seen}}`                                    | Time the signal was most recently triggered. For example, `Mon Jan 01 00:00:00 UTC 1970`.     |
+| `{{last_seen_epoch}}`                              | Time the signal was most recently triggered, in milliseconds, since midnight, January 1, 1970.|
+| `{{rule_name}}`                                    | Name of the associated rule.                                                                  |
+| `{{case_name}}`                                    | Name of the triggering rule case.                                                             |
+| `{{events_matched}}`                               | Number of events which has matched the associated rule.                                       |
+| `{{events_matched_per_query.<name_of_the_query>}}` | Number of events which has matched the associated rule query `<name_of_the_query>`.           |
+
+When a high amount of logs match a rule, the rule title/message are not rendered for every new logs. Therefore, in this case, the rendered values of `{{events_matched}}` and `{{events_matched_per_query.<name_of_the_query>}}` could be below the values displayed in the Overview Tab of the Signal Side Panel.
 
 ### Dynamic links
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
It adds the documentation for the new template variable added in this [PR](https://github.com/DataDog/logs-backend/pull/66505)

Example:
In the rule message:
![image](https://github.com/DataDog/documentation/assets/101127904/bf189b93-2426-47ed-9869-bae38745e7c0)

Rendered message:
![image](https://github.com/DataDog/documentation/assets/101127904/076c4b79-4d29-424c-8ea3-39e90cbd5da4)


### Merge instructions

- [ ] Please merge after reviewing
