### PR TITLE
add MWAA to the table of AWS services with supported logs

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -48,6 +48,7 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 | [VPC][40]                          | [Enable Amazon VPC logs][41]                                                                                   | [Manual][42] log collection.                                                                                                 |
 | [Step Functions][52]               | [Enable Amazon Step Functions logs][53]                                                                        | [Manual][54] log collection.                                                                                                 |
 | [Web Application Firewall][49]     | [Enable Amazon WAF logs][50]                                                                                   | [Manual][51] log collection.                                                                                                 |
+| [MWAA][55]                         | [Enable Amazon MWAA logs][56]                                                                                  | [Manual][56] log collection.                                                                                                 |
 
 
 ## Set up triggers
@@ -310,3 +311,5 @@ You can also exclude or send only those logs that match a specific pattern by us
 [52]: /integrations/amazon_step_functions/
 [53]: /integrations/amazon_step_functions/#log-collection
 [54]: /integrations/amazon_step_functions/#send-logs-to-datadog
+[55]: /integrations/amazon_mwaa/
+[56]: /integrations/amazon_mwaa/#log-collection


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adding MWAA to the array of supported services.
This links to a new section in the MWAA doc that I added in https://github.com/DataDog/dogweb/pull/113595

### Merge instructions

should not be merged before changes from https://github.com/DataDog/dogweb/pull/113595 are reflected online.

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->