### PR TITLE
[CAP-668] Update the minimum agent versions required for the orchestration explorer to work since we are using `container.*` metrics

### DIFF
--- a/content/en/infrastructure/containers/configuration.md
+++ b/content/en/infrastructure/containers/configuration.md
@@ -84,27 +84,27 @@ The following table presents the list of collected resources and the minimal Age
 
 | Resource | Minimal Agent version | Minimal Cluster Agent version* | Minimal Helm chart version | Minimal Kubernetes version |
 |---|---|---|---|---|
-| ClusterRoleBindings | 7.27.0 | 1.19.0 | 2.30.9 | 1.14.0 |
-| ClusterRoles | 7.27.0 | 1.19.0 | 2.30.9 | 1.14.0 |
-| Clusters | 7.27.0 | 1.12.0 | 2.10.0 | 1.17.0 |
-| CronJobs | 7.27.0 | 7.40.0 | 2.15.5 | 1.16.0 |
-| DaemonSets | 7.27.0 | 1.14.0 | 2.16.3 | 1.16.0 |
-| Deployments | 7.27.0 | 1.11.0 | 2.10.0 | 1.16.0 |
-| HorizontalPodAutoscalers | 7.27.0 | 7.51.0 | 2.10.0 | 1.1.1 |
-| Ingresses | 7.27.0 | 1.22.0 | 2.30.7 | 1.21.0 |
-| Jobs | 7.27.0 | 1.13.1 | 2.15.5 | 1.16.0 |
-| Namespaces | 7.27.0 | 7.41.0 | 2.30.9 | 1.17.0 |
-| Nodes | 7.27.0 | 1.11.0 | 2.10.0 | 1.17.0 |
-| PersistentVolumes | 7.27.0 | 1.18.0 | 2.30.4 | 1.17.0 |
-| PersistentVolumeClaims | 7.27.0 | 1.18.0 | 2.30.4 | 1.17.0 |
-| Pods | 7.27.0 | 1.11.0 | 2.10.0 | 1.17.0 |
-| ReplicaSets | 7.27.0 | 1.11.0 | 2.10.0 | 1.16.0 |
-| RoleBindings | 7.27.0 | 1.19.0 | 2.30.9 | 1.14.0 |
-| Roles | 7.27.0 | 1.19.0 | 2.30.9 | 1.14.0 |
-| ServiceAccounts | 7.27.0 | 1.19.0 | 2.30.9 | 1.17.0 |
-| Services | 7.27.0 | 1.11.0 | 2.10.0 | 1.17.0 |
-| Statefulsets | 7.27.0 | 1.15.0 | 2.20.1 | 1.16.0 |
-| VerticalPodAutoscalers | 7.27.0 | 7.46.0 | 3.6.8 | 1.16.0 |
+| ClusterRoleBindings | 7.33.0 | 1.19.0 | 2.30.9 | 1.14.0 |
+| ClusterRoles | 7.33.0 | 1.19.0 | 2.30.9 | 1.14.0 |
+| Clusters | 7.33.0 | 1.18.0 | 2.10.0 | 1.17.0 |
+| CronJobs | 7.33.0 | 7.40.0 | 2.15.5 | 1.16.0 |
+| DaemonSets | 7.33.0 | 1.18.0 | 2.16.3 | 1.16.0 |
+| Deployments | 7.33.0 | 1.18.0 | 2.10.0 | 1.16.0 |
+| HorizontalPodAutoscalers | 7.33.0 | 7.51.0 | 2.10.0 | 1.1.1 |
+| Ingresses | 7.33.0 | 1.22.0 | 2.30.7 | 1.21.0 |
+| Jobs | 7.33.0 | 1.18.0 | 2.15.5 | 1.16.0 |
+| Namespaces | 7.33.0 | 7.41.0 | 2.30.9 | 1.17.0 |
+| Nodes | 7.33.0 | 1.18.0 | 2.10.0 | 1.17.0 |
+| PersistentVolumes | 7.33.0 | 1.18.0 | 2.30.4 | 1.17.0 |
+| PersistentVolumeClaims | 7.33.0 | 1.18.0 | 2.30.4 | 1.17.0 |
+| Pods | 7.33.0 | 1.18.0 | 3.9.0 | 1.17.0 |
+| ReplicaSets | 7.33.0 | 1.18.0 | 2.10.0 | 1.16.0 |
+| RoleBindings | 7.33.0 | 1.19.0 | 2.30.9 | 1.14.0 |
+| Roles | 7.33.0 | 1.19.0 | 2.30.9 | 1.14.0 |
+| ServiceAccounts | 7.33.0 | 1.19.0 | 2.30.9 | 1.17.0 |
+| Services | 7.33.0 | 1.18.0 | 2.10.0 | 1.17.0 |
+| Statefulsets | 7.33.0 | 1.15.0 | 2.20.1 | 1.16.0 |
+| VerticalPodAutoscalers | 7.33.0 | 7.46.0 | 3.6.8 | 1.16.0 |
 
 **Note**: After version 1.22, Cluster Agent version numbering follows Agent release numbering, starting with version 7.39.0.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

In the Kubernetes product, we are now using `container.*` metrics to display CPU and memory usage instead of `kubernetes.*`. Since those metrics have been made GA with the datadog-agent `7.33.0`, I'm updating the minimum agent versions required for the orchestration explorer to work.
More context here: https://github.com/DataDog/web-ui/pull/125848

### Merge instructions

- [x] Please merge after reviewing

### Additional notes|

None, minor change