### PR TITLE
Removing TCP mentions from Network Standard Attributes

### DIFF
--- a/content/en/logs/log_configuration/attributes_naming_convention.md
+++ b/content/en/logs/log_configuration/attributes_naming_convention.md
@@ -102,10 +102,10 @@ The following attributes are related to the data used in network communication. 
 
 | **Fullname**               | **Type** | **Description**                                                                          |
 | :------------------------- | :------- | :--------------------------------------------------------------------------------------- |
-| `network.client.ip`        | `string` | The IP address of the client that initiated the TCP connection.                          |
+| `network.client.ip`        | `string` | The IP address of the client that initiated the connection.                          |
 | `network.destination.ip`   | `string` | The IP address the client connected to.                                                  |
 | `network.client.port`      | `number` | The port of the client that initiated the connection.                                    |
-| `network.destination.port` | `number` | The TCP port the client connected to.                                                    |
+| `network.destination.port` | `number` | The port the client connected to.                                                    |
 | `network.bytes_read`       | `number` | Total number of bytes transmitted from the client to the server when the log is emitted. |
 | `network.bytes_written`    | `number` | Total number of bytes transmitted from the server to the client when the log is emitted. |
 


### PR DESCRIPTION
The fields `network.client.ip` and `network.client.port` currently refers explicitly to TCP connection, but other integrations could be using this field more globally. Suggesting removing TCP mentions to make it more generic.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing