### PR TITLE
skip opening certain menu items - [WEB-4530]

### DIFF
--- a/assets/scripts/components/mobile-nav.js
+++ b/assets/scripts/components/mobile-nav.js
@@ -87,7 +87,7 @@ export function setMobileNav () {
     }else{
         const hash = window.location.hash
         const  hrefSelector = hash ? `[href$="${hash}"]`: ''
-        mobileSelection = document.querySelector(`#mobile-nav a[data-path="${pathName}"]${hrefSelector}`) || false
+        mobileSelection = document.querySelector(`#mobile-nav a[data-path="${pathName}"][data-skip="false"]${hrefSelector}`) || false
     }
 
     const subMenu = document.querySelector(`#mobile-nav a[data-path="${pathName}"] + ul.d-none`)

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -130,8 +130,8 @@ DOMReady(doOnLoad);
 function getVisibleParentPath(ancestralEl, path){
     // returns the closest visible parent path
     // of a child path not visible in the left nav (anything more than 4 levels deep)
-
-    let el = document.querySelector(`${ancestralEl} [data-path="${path}"]`)
+    
+    let el = document.querySelector(`${ancestralEl} [data-path="${path}"][data-skip="false"]`)
     // account for preview branch name in url
     let endIdx = env === 'preview' ? 6 : 4
 
@@ -169,6 +169,7 @@ function getPathElement(event = null) {
     let path = window.location.pathname;
     const activeMenus = document.querySelectorAll('.side .sidenav-nav-main .active, header .sidenav-nav-main .active');
 
+    // remove active class from all sidenav links to close all open menus
     for (let i = 0; i < activeMenus.length; i++) {
         activeMenus[i]?.classList.remove('active');
     }

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3607,6 +3607,8 @@ main:
     url: data_security/pci_compliance/
     parent: log_management
     weight: 3
+    params: 
+      skip: true
   - name: Connect Logs and Traces
     url: tracing/other_telemetry/connect_logs_and_traces/
     parent: log_management

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.5.2-0.20240305171928-abc3e9e59b63 // indirect
+require github.com/DataDog/websites-modules v1.4.122 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/colin.cole/webops/websites-modules

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.14
 
-require github.com/DataDog/websites-modules v1.4.121 // indirect
+require github.com/DataDog/websites-modules v1.5.2-0.20240305171928-abc3e9e59b63 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/colin.cole/webops/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.5.2-0.20240305171928-abc3e9e59b63 h1:LW6O549cJCFoT6e6Ov3iqo87N+Wzsu1uHa7DS6hErVE=
-github.com/DataDog/websites-modules v1.5.2-0.20240305171928-abc3e9e59b63/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.4.122 h1:HWvZ5S6nMlQ6pLotW9KQPv3fkpsEm0Uv9PJJfRwbfOw=
+github.com/DataDog/websites-modules v1.4.122/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.4.121 h1:k5sWyFX8KRTpaqBGFaQx+SzJCgeNeh0ehJheVArbmiY=
-github.com/DataDog/websites-modules v1.4.121/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.5.2-0.20240305171928-abc3e9e59b63 h1:LW6O549cJCFoT6e6Ov3iqo87N+Wzsu1uHa7DS6hErVE=
+github.com/DataDog/websites-modules v1.5.2-0.20240305171928-abc3e9e59b63/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=

--- a/layouts/partials/nav/left-nav.html
+++ b/layouts/partials/nav/left-nav.html
@@ -32,7 +32,7 @@
                 <li class="nav-top-level {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}
                 {{ if $currentPage.HasMenuCurrent "main" . }}active{{ end }}">
                     {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                    <a href="{{ .URL | relLangURL }}" class="d-flex align-items-center" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                    <a href="{{ .URL | relLangURL }}" class="d-flex align-items-center" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}" data-skip="{{ .Params.skip | not | not }}">
                         {{ if .Pre }}
                         {{ partial "icon" (dict "name" .Pre "size" "18px" )}}
                         {{ end }}
@@ -45,7 +45,7 @@
                         {{ range .Children }}
                             <li class="{{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }} {{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }}">
                                 {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                                <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                                <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}" data-skip="{{ .Params.skip | not | not }}">
                                     {{ if .Pre }}
                                     {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
                                     {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
@@ -58,7 +58,7 @@
                                 {{ range .Children }}
                                     <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
                                         {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                                        <a href="{{ .URL | relLangURL }}" data-type="{{- with site.GetPage .URL -}}{{- .Type -}}{{- end -}}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                                        <a href="{{ .URL | relLangURL }}" data-type="{{- with site.GetPage .URL -}}{{- .Type -}}{{- end -}}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}" data-skip="{{ .Params.skip | not | not }}">
                                             {{ if .Pre }}
                                             {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
                                             {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
@@ -71,7 +71,7 @@
                                             {{ range .Children }}
                                                 <li class="{{ if $currentPage.IsMenuCurrent "main" . }}active{{ end }} {{ if (not (or (in $excludeAsyc .Identifier) (and (in .URL "api/") (not (in .URL "_api/")) (not (in .URL "-api/"))))) }} js-load {{ end }}" >
                                                     {{ $url_without_anchor = (index (split .URL "#") 0) }}
-                                                    <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}">
+                                                    <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}" data-skip="{{ .Params.skip | not | not }}">
                                                         {{ if .Pre }}
                                                         {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
                                                         {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

1. adds a menu param (`skip`). used in the `datadog-docs` script to only query and select menu items we want to open. 
     - two menu items purposefully have the same `url` param value (i.e. `data_security/pci_compliance/`). In order for the script to select a menu item after the first, we use the `skip` param to ignore certain menu items for opening.

2. includes auto-generated webistes-modules ref update

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-4530
preview: https://docs-staging.datadoghq.com/websites-modules/generated/295/logs/
   - select **PCI Compliance** under **Log Management > Log Management**. the url should still read `data_security/pci_compliance`, the Log Management menu should close and the **Administration > Data Security** menu should open to **PCI Compliance** instead

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->