### PR TITLE
Add step to link git to EAS projects

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/expo.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/expo.md
@@ -77,6 +77,18 @@ You can disable some files from uploading by setting the `iosDsyms`, `iosSourcem
 
 If you want to disable **all file uploads**, remove the `expo-datadog` from the list of plugins.
 
+### Add git repository data to your mapping files on Expo Application Services (EAS)
+
+If you are using EAS to build your Expo application, set `cli.requireCommit` to `true` in your `eas.json` file to add git repository data to your mapping files.
+
+```json
+{
+    "cli": {
+        "requireCommit": true
+    }
+}
+```
+
 ### Setting the Datadog site
 
 Run `eas secret:create` to set `DATADOG_SITE` to the host of your Datadog site, for example: `datadoghq.eu`. By default, `datadoghq.com` is used.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Expo users see a `upload sourcemaps from your git repository` warning when looking at an unminified RUM error.
This is because they are uploading their file on the EAS CI tool, which by default does not setup git.

To setup git, an additional configuration option needs to be set.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->