### PR TITLE
[DOCS-7348] upating prometheus host collection 

### DIFF
--- a/content/en/integrations/guide/prometheus-host-collection.md
+++ b/content/en/integrations/guide/prometheus-host-collection.md
@@ -40,7 +40,7 @@ To collect your exposed metrics:
     init_config:
 
     instances:
-        - prometheus_url: 'localhost:<PORT>/<ENDPOINT>'
+        - openmetrics_endpoint: 'localhost:<PORT>/<ENDPOINT>'
           namespace: '<NAMESPACE>'
           metrics:
               - '<METRIC_TO_FETCH>': '<DATADOG_METRIC_NAME>'
@@ -64,10 +64,10 @@ Find below the full list of parameters that can be used for your `instances`:
 
 | Name                                    | Type                                    | Necessity | Default value | Description                                                                                                                                                                                                                                                          |
 | --------------------------------------- | --------------------------------------- | --------- | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `prometheus_url`                        | string                                  | required  | none          | The URL where your application metrics are exposed by Prometheus/OpenMetrics.                                                                                                                                                                                        |
+| `openmetrics_endpoint`                        | string                                  | required  | none          | The URL exposing metrics in the OpenMetrics format.                                                                           |
 | `namespace`                             | string                                  | required  | none          | The namespace to be appended before all metrics namespaces. Your metrics are collected in the form `namespace.metric_name`.                                                                                                                                          |
 | `metrics`                               | list of strings or `key:value` elements | required  | none          | List of `<METRIC_TO_FETCH>: <NEW_METRIC_NAME>` pairs for metrics to be fetched from the Prometheus endpoint.<br> `<NEW_METRIC_NAME>` is optional. It transforms the name in Datadog if set. This list should contain at least one metric.                            |
-| `prometheus_metrics_prefix`             | string                                  | optional  | none          | Prefix for exposed Prometheus/OpenMetrics metrics.                                                                                                                                                                                                                   |
+| `raw_metric_prefix`             | string                                  | optional  | none          | A prefix that is removed from all exposed metric names, if present.                                                                                                                 |
 | `health_service_check`                  | boolean                                 | optional  | true          | Send a service check reporting on the health of the Prometheus endpoint. The check is named `<NAMESPACE>.prometheus.health`.                                                                                                                                         |
 | `label_to_hostname`                     | string                                  | optional  | none          | Override the hostname with the value of one label.                                                                                                                                                                                                                   |
 | `label_joins`                           | object                                  | optional  | none          | The label join allows you to target a metric and retrieve its label using a 1:1 mapping.                                                                                                                                                                               |
@@ -106,7 +106,7 @@ To get started with collecting metrics exposed by Prometheus, follow these steps
     init_config:
 
     instances:
-        - prometheus_url: http://localhost:9090/metrics
+        - openmetrics_endpoint: http://localhost:9090/metrics
           namespace: 'documentation_example'
           metrics:
               - promhttp_metric_handler_requests_total: prometheus.handler.requests.total


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR updates 2 `prometheus.` metrics references in  the prometheus host collection guide that are now super-ceded by new metrics.
Namely, `prometheus_url` has been replaced by `openmetrics_endpoint` and `prometheus_metrics_prefix` has been replaced by `raw_metric_prefix`.

https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example#L49-L52

https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example#L59

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->