### PR TITLE
product and source names match - standard attributes - [WEB-4573]

### DIFF
--- a/layouts/standard-attributes/list.html
+++ b/layouts/standard-attributes/list.html
@@ -109,7 +109,7 @@
                 {{ range $idx, $el := .product_source }}
                   {{ if in . "icon-"}}
                     {{ $product := (substr . 5) }}
-                    {{ partial "icon" (dict "name" $product "size" "18px" "color" "#7c3eb9" "title" (cond (eq $product "log") (printf "%s management" $product) $product) )}}
+                    {{ partial "icon" (dict "name" $product "size" "18px" "color" "#7c3eb9" "title" ((cond (eq $product "log") (printf "%s management" $product) $product) | upper) )}}
 
                   {{ else if in (slice "android" "ios" "flutter" "roku") . }}
                     {{/*  Local partial */}}
@@ -118,13 +118,13 @@
                     {{/*  Get integration logos for android, ios, roku, and flutter  */}}
                     {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" . "variant" "avatar") . "avatar" }}
                     {{ if $int_logo }}
-                      <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}" title='{{ printf "rum %s" . }}' data-bs-toggle="tooltip" data-bs-placement="top"/>
+                      <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}" title='{{ (printf "rum %s" .) | upper }}' data-bs-toggle="tooltip" data-bs-placement="top"/>
                     {{ end }}
                   {{ else if eq . "browser" }}
                     {{/*  Local partial */}}
                     {{ partial "throw-error" (dict "ctx_product_source" $ctx_product_source "ctx_file_path" $ctx.File.Path) }}
 
-                    {{ partial "icon" (dict "name" . "size" "18px" "color" "#7c3eb9" "title" (printf "rum %s" .))}}
+                    {{ partial "icon" (dict "name" . "size" "18px" "color" "#7c3eb9" "title" ((printf "rum %s" .) | upper))}}
 
                   {{ end }}
                 {{ end }}

--- a/layouts/standard-attributes/list.html
+++ b/layouts/standard-attributes/list.html
@@ -61,7 +61,7 @@
       // Determines table-row display
       // Compares search values and filter values against attributes info (dataset)
       const datasetArr = dataset.split(';')
-      const productValues = datasetArr[0].replaceAll('icon-', '').replace('log', 'logs')
+      const productValues = datasetArr[0].replaceAll('icon-', '').replace('log', 'log management')
       const searchValues = this.searchValue.split(' ')
 
       const containsFilteredValue = productValues.includes(this.filterValue) // checks product attrs in dataset
@@ -109,7 +109,7 @@
                 {{ range $idx, $el := .product_source }}
                   {{ if in . "icon-"}}
                     {{ $product := (substr . 5) }}
-                    {{ partial "icon" (dict "name" $product "size" "18px" "color" "#7c3eb9" "title" (cond (eq $product "log") (printf "%ss" $product) $product) )}}
+                    {{ partial "icon" (dict "name" $product "size" "18px" "color" "#7c3eb9" "title" (cond (eq $product "log") (printf "%s management" $product) $product) )}}
 
                   {{ else if in (slice "android" "ios" "flutter" "roku") . }}
                     {{/*  Local partial */}}
@@ -118,13 +118,13 @@
                     {{/*  Get integration logos for android, ios, roku, and flutter  */}}
                     {{ $int_logo := partialCached "integrations-logo.html" (dict "context" $ctx "basename" . "variant" "avatar") . "avatar" }}
                     {{ if $int_logo }}
-                      <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}" title="{{ . }}" data-bs-toggle="tooltip" data-bs-placement="top"/>
+                      <img src="{{ $int_logo }}" height="18" alt="{{$int_logo}}" title='{{ printf "rum %s" . }}' data-bs-toggle="tooltip" data-bs-placement="top"/>
                     {{ end }}
                   {{ else if eq . "browser" }}
                     {{/*  Local partial */}}
                     {{ partial "throw-error" (dict "ctx_product_source" $ctx_product_source "ctx_file_path" $ctx.File.Path) }}
 
-                    {{ partial "icon" (dict "name" . "size" "18px" "color" "#7c3eb9" "title" .)}}
+                    {{ partial "icon" (dict "name" . "size" "18px" "color" "#7c3eb9" "title" (printf "rum %s" .))}}
 
                   {{ end }}
                 {{ end }}
@@ -154,7 +154,7 @@
         {{ end }}
         {{ $sortedProduct := (split (replaceRE `icon-` "" (delimit $products " ")) " ") | sort }}
         {{ range $sortedProduct }}
-            {{ $product := cond (eq . "log") (printf "%ss" .) .}}
+            {{ $product := cond (eq . "log") (printf "%s management" .) .}}
             <button
             @click="filterValue = '{{ $product }}'; pushState()"
             class="filter-btn mb-1 me-1 btn btn-sm-tag btn-outline-secondary"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

updates the standard attributes pg to make the **product** filter button and **source** tooltip names match.

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-4573
preview: https://docs-staging.datadoghq.com/stefon.simmons/update-standard-attributes-source-names/standard-attributes/
   - hover over the **SOURCE** column icons. the tooltips should match the product filter button names
   - filtering via the buttons should still work

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->