### PR TITLE
Move widget specific information from landing page to widget page

### DIFF
--- a/content/en/dashboards/_index.md
+++ b/content/en/dashboards/_index.md
@@ -83,31 +83,7 @@ Screenboards are dashboards with free-form layouts which can include a variety o
 
 ## Configuring dashboards
 
-### Graph menu
-
-Click on any dashboard graph to open an options menu:
-
-| Option                 | Description                                                   |
-|------------------------|---------------------------------------------------------------|
-| Send snapshot          | Create and send a snapshot of your graph.                     |
-| Find correlated metrics| Find correlations from APM services, integrations, and dashboards. |
-| View in full screen    | View the graph in [full screen mode][5].                     |
-| Lock cursor            | Lock the cursor in place on the page.                         |
-| View related processes | Jump to the [Live Processes][6] page scoped to your graph.   |
-| View related hosts     | Jump to the [Host Map][7] page scoped to your graph.         |
-| View related logs      | Jump to the [Log Explorer][8] page scoped to your graph.     |
-| View related traces    | Populate a [Traces][9] panel scoped to your graph.           |
-| View related profiles  | Jump to the [Profiling][10] page scoped to your graph.        |
-
-### Global time selector
-
-To use the global time selector, at least one time-based widget must be set to use `Global Time`. Make the selection in the widget editor under **Set display preferences**, or add a widget (global time is the default time setting).
-
-The global time selector sets the same time frame for all widgets using the `Global Time` option on the same dashboard. Select a moving window in the past (for example, `Past 1 Hour` or `Past 1 Day`) or a fixed period with the `Select from calendar…` option or [enter a custom time frame][11]. If a moving window is chosen, the widgets are updated to move along with the time window.
-
-Widgets not linked to global time show the data for their local time frame as applied to the global window. For example, if the global time selector is set to January 1, 2019 through January 2, 2019, a widget set with the local time frame for `Past 1 Minute` shows the last minute of January 2, 2019 from 11:59 pm.
-
-#### Refresh rate
+### Refresh rate
 
 The refresh rate of a private dashboard depends on the time frame you are viewing. The shorter the time frame is, the more frequently the data is refreshed. Publicly shared dashboards refresh every thirty seconds, regardless of the selected time frame.
 

--- a/content/en/dashboards/sharing.md
+++ b/content/en/dashboards/sharing.md
@@ -122,7 +122,7 @@ Datadog has a [dedicated API][8] allowing you to interact with your shared graph
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /dashboards/#global-time-selector
+[1]: /dashboards/widgets/#global-time-selector
 [2]: https://app.datadoghq.com/dashboard/lists
 [3]: /dashboards/#timeboards
 [4]: /dashboards/#screenboards

--- a/content/en/dashboards/widgets/_index.md
+++ b/content/en/dashboards/widgets/_index.md
@@ -140,6 +140,14 @@ This is not an alternative for assigning units to your data.
     {{< nextlink href="/logs/explorer/facets/#units">}} Set units for Event-based queries{{< /nextlink >}}
 {{< /whatsnext >}}
 
+## Global time selector
+
+To use the global time selector, at least one time-based widget must be set to use `Global Time`. Make the selection in the widget editor under **Set display preferences**, or add a widget (global time is the default time setting).
+
+The global time selector sets the same time frame for all widgets using the `Global Time` option on the same dashboard. Select a moving window in the past (for example, `Past 1 Hour` or `Past 1 Day`) or a fixed period with the `Select from calendar…` option or [enter a custom time frame][11]. If a moving window is chosen, the widgets are updated to move along with the time window.
+
+Widgets not linked to global time show the data for their local time frame as applied to the global window. For example, if the global time selector is set to January 1, 2019 through January 2, 2019, a widget set with the local time frame for `Past 1 Minute` shows the last minute of January 2, 2019 from 11:59 pm.
+
 ## Copy and paste widgets
 
 <div class="alert alert-warning">You must have <a href="https://docs.datadoghq.com/account_management/rbac/permissions/#dashboards"><code>dashboard_public_share</code> permissions</a> and enable <a href="https://app.datadoghq.com/organization-settings/public-sharing/settings"><strong>Static Public Data Sharing</strong></a> in your Organization Settings to use this feature.</div>
@@ -163,15 +171,30 @@ To copy multiple screenboard widgets (edit mode only), `shift + click` on the wi
 
 **Note**: This only works when sharing within Datadog. It does not generate a preview image.
 
-## Export graphs
+## Widget graphs
 
-### PNG
+### Export
 
-To download a widget in PNG format, click the export button in the upper right hand side of the widget, and select **Download as PNG**.
+| Format | Instructions            |
+| -----  | ----------------------- |
+| PNG    | To download a widget in PNG format, click the export button in the upper right hand side of the widget, and select **Download as PNG**. |
+| CSV    | To download data from a timeseries, table, or top list widget in CSV format, click the export button in the upper right hand side of the widget, and select **Download as CSV**.|
 
-### CSV
+### Graph menu
 
-To download data from a timeseries, table, or top list widget in CSV format, click the export button in the upper right hand side of the widget, and select **Download as CSV**.
+Click on any dashboard graph to open an options menu:
+
+| Option                 | Description                                                        |
+|------------------------|--------------------------------------------------------------------|
+| Send snapshot          | Create and send a snapshot of your graph.                          |
+| Find correlated metrics| Find correlations from APM services, integrations, and dashboards. |
+| View in full screen    | View the graph in [full screen mode][5].                           |
+| Lock cursor            | Lock the cursor in place on the page.                              |
+| View related processes | Jump to the [Live Processes][6] page scoped to your graph.         |
+| View related hosts     | Jump to the [Host Map][7] page scoped to your graph.               |
+| View related logs      | Jump to the [Log Explorer][8] page scoped to your graph.           |
+| View related traces    | Populate a [Traces][9] panel scoped to your graph.                 |
+| View related profiles  | Jump to the [Profiling][10] page scoped to your graph.             |
 
 ## Further Reading
 

--- a/content/en/logs/guide/correlate-logs-with-metrics.md
+++ b/content/en/logs/guide/correlate-logs-with-metrics.md
@@ -59,5 +59,5 @@ To correlate logs and metrics on the [Metrics Explorer][7] page:
 [3]: /metrics/explorer/
 [4]: https://app.datadoghq.com/logs
 [5]: https://app.datadoghq.com/dashboard/lists
-[6]: /dashboards/#graph-menu
+[6]: /dashboards/widgets/#graph-menu
 [7]: https://app.datadoghq.com/metric/explorer


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Move `Graph menu` and `Global time selector` from Dashboard landing page to the Widget landing page.
- Part of Dashboard reorg work

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->