### PR TITLE
update config at runtime java tracer version for tags

### DIFF
--- a/content/en/tracing/trace_collection/runtime_config/_index.md
+++ b/content/en/tracing/trace_collection/runtime_config/_index.md
@@ -19,7 +19,7 @@ Configuration at runtime lets you modify APM library configuration from the Data
 
 - [Datadog Agent][2] 7.41.1 or higher.
 - [Remote Configuration][1] is enabled for your Agent.
-- `APM Remote Configuration Read` and `APM Remote Configuration Write` [permissions][4].  
+- `APM Remote Configuration Read` and `APM Remote Configuration Write` [permissions][4].
   **Note**: If you don't have these permissions, ask your Datadog Admin to update your permissions from your Organization Settings.
 
 ## Using configuration at runtime
@@ -51,7 +51,7 @@ The following options are supported with configuration at runtime. The required 
 | <h5>Custom sampling rate</h5>Set a global sampling rate for the library using `DD_TRACE_SAMPLE_RATE`.                                  | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.4.0+` | `2.33.0+` | `1.13.0+` | `1.59.0+` |
 | <h5>Log injection</h5>Automatically inject trace correlation identifiers to correlate logs and traces by enabling `DD_LOGS_INJECTION`. | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.6.0+` | `2.33.0+` | `1.13.0+` |           |
 | <h5>HTTP header tags</h5>Add HTTP header values as tags on traces using `DD_TRACE_HEADER_TAGS`.                                        | `1.17.0+` | `4.11+` `3.32+` `2.45+` | `2.6.0+` | `2.33.0+` | `1.13.0+` | `1.59.0+` |
-| <h5>Custom span tags</h5>Add specified tags to each span using `DD_TAGS`.                                                              |           | `4.23.0+` `3.44.0+`     | `2.5.0+` | `2.44.0+` |           | `1.59.0+` |
+| <h5>Custom span tags</h5>Add specified tags to each span using `DD_TAGS`.                                                              | `1.31.0+` | `4.23.0+` `3.44.0+`     | `2.5.0+` | `2.44.0+` |           | `1.59.0+` |
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
With the latest Java tracer release it now supports custom tags for config at runtime. Updating the docs to reflect current support.
https://github.com/DataDog/dd-trace-java/releases/tag/v1.31.0
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->