### PR TITLE
product availability identifier - [WEB-4445]

### DIFF
--- a/assets/styles/components/_product-availability-labels.scss
+++ b/assets/styles/components/_product-availability-labels.scss
@@ -7,8 +7,15 @@
     }
     p {
         margin-left: 4px;
-        span{
+        .product {
             white-space: nowrap;
+            &:hover {
+                color: $ddpurple;
+            }
+            i {
+                position: relative;
+                top: 1.5px;
+            }
         }
     }
 }

--- a/assets/styles/components/_product-availability-labels.scss
+++ b/assets/styles/components/_product-availability-labels.scss
@@ -7,7 +7,7 @@
     }
     p {
         margin-left: 4px;
-        span {
+        span{
             white-space: nowrap;
         }
     }

--- a/assets/styles/components/_product-availability-labels.scss
+++ b/assets/styles/components/_product-availability-labels.scss
@@ -1,0 +1,14 @@
+.product-availability {
+    strong, p {
+        font-size: 18px;
+    }
+    strong {
+        white-space: nowrap;
+    }
+    p {
+        margin-left: 4px;
+        span {
+            white-space: nowrap;
+        }
+    }
+}

--- a/assets/styles/style.scss
+++ b/assets/styles/style.scss
@@ -49,6 +49,7 @@ $baseImgURL: '{{.Site.Params.img_url}}';
 @import 'components/global-modals';
 @import 'components/header';
 @import 'components/integration-labels';
+@import 'components/product-availability-labels';
 @import 'components/breadcrumbs';
 @import 'components/integrations';
 @import 'components/platforms';

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -17,7 +17,7 @@ products:
 
 {{< product-availability >}}
 
-<div class="alert alert-warning">Suppressions are available for Cloud Security Management Threats and Cloud SIEM.</div>
+<!-- <div class="alert alert-warning">Suppressions are available for Cloud Security Management Threats and Cloud SIEM.</div> -->
 
 ## Overview
 

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -6,9 +6,14 @@ further_reading:
 - link: "security/detection_rules/"
   tag: "Documentation"
   text: "Learn more about detection rules"
+products:
+- name: Cloud SIEM
+  url: /security/cloud_siem/
+- name: CSM Threats
+  url: /security/threats/
 ---
 
-{{< product-availability "Cloud SIEM" "CSM Threats">}}
+{{< product-availability >}}
 
 <div class="alert alert-warning">Suppressions are available for Cloud Security Management Threats and Cloud SIEM.</div>
 

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -9,8 +9,10 @@ further_reading:
 products:
 - name: Cloud SIEM
   url: /security/cloud_siem/
+  icon: siem
 - name: CSM Threats
   url: /security/threats/
+  icon: cloud-security-management
 ---
 
 {{< product-availability >}}

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -8,6 +8,8 @@ further_reading:
   text: "Learn more about detection rules"
 ---
 
+{{< product-availability "Cloud SIEM" "CSM Threats">}}
+
 <div class="alert alert-warning">Suppressions are available for Cloud Security Management Threats and Cloud SIEM.</div>
 
 ## Overview

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -363,5 +363,8 @@
   },
   "source" : {
     "other": "Source"
+  },
+  "available_for": {
+    "other": "Available for"
   }
 }

--- a/layouts/shortcodes/product-availability.html
+++ b/layouts/shortcodes/product-availability.html
@@ -1,12 +1,31 @@
+{{/*  
+    Uses the "products" frontmatter (list)
+
+    *EXAMPLE* 
+    products: 
+        - name: "Product 1"
+          url: "https://www.example.com/product-1"
+          icon: "product-icon-1"
+        - name: "Product 2"
+          url: "https://www.example.com/product-2"
+          icon: "product-icon-2"
+        - name: "Product 3"
+          url: "https://www.example.com/product-3"
+          icon: "product-icon-3"
+*/}}
+
 <div class="product-availability container mb-3 p-0">
     <div class="d-flex">
         <strong class="p-0">{{ i18n "available_for"}}:</strong>
         <p class="mb-0 p-0">
             {{ $len := len .Page.Params.products}}
             {{ range $idx, $product := .Page.Params.products }}
-            <span>
-                <a class="border border-0" href="{{$product.url}}">{{$product.name}}</a>{{ if ne $idx (sub $len 1) }} | {{ end }}
-            </span>
+                <span class="product position-relative">
+                    {{ partial "icon" (dict "name" $product.icon "size" "14px")}}
+                    <span>{{$product.name}}</span>
+                    <a class="border border-0 stretched-link" href="{{$product.url}}"></a>
+                    <span>{{ if ne $idx (sub $len 1) }}, {{ end }}</span>
+                </span>
             {{ end }}
         </p>
     </div>

--- a/layouts/shortcodes/product-availability.html
+++ b/layouts/shortcodes/product-availability.html
@@ -1,0 +1,11 @@
+<div class="product-availability container mb-3 p-0">
+    <div class="d-flex">
+        <strong class="p-0">{{ i18n "available_for"}}:</strong>
+        <p class="mb-0 p-0">
+            {{ $len := len .Params}}
+            {{ range $idx, $product := .Params }}
+                <span>{{$product}}{{ if ne $idx (sub $len 1) }} | {{ end }}</span>
+            {{ end }}
+        </p>
+    </div>
+</div>

--- a/layouts/shortcodes/product-availability.html
+++ b/layouts/shortcodes/product-availability.html
@@ -2,9 +2,11 @@
     <div class="d-flex">
         <strong class="p-0">{{ i18n "available_for"}}:</strong>
         <p class="mb-0 p-0">
-            {{ $len := len .Params}}
-            {{ range $idx, $product := .Params }}
-                <span>{{$product}}{{ if ne $idx (sub $len 1) }} | {{ end }}</span>
+            {{ $len := len .Page.Params.products}}
+            {{ range $idx, $product := .Page.Params.products }}
+            <span>
+                <a class="border border-0" href="{{$product.url}}">{{$product.name}}</a>{{ if ne $idx (sub $len 1) }} | {{ end }}
+            </span>
             {{ end }}
         </p>
     </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

creates a shortcode `{{< product-availability >}}` that can be placed on any page. 

The shortcode uses a `products` list defined in the page frontmatter:

```yml
products:
- name: <product name>
  url: <product url>
  icon: <product icon name>
- name: <product name>
  url: <product url>
  icon: <product icon name>
```

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-4445
preview: https://docs-staging.datadoghq.com/stefon.simmons/product-availability-identifier/security/suppressions/#suppression-rules

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb reviews
 
### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->