### PR TITLE
Replace CD Visibility Tile with Test Visibility

### DIFF
--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -107,11 +107,11 @@ nav_sections:
       - title: CI Visibility
         link: continuous_integration/
         icon: ci
-        desc: See test metrics, build results, and pipeline executions for your CI pipeline
-      - title: CD Visibility
-        link: continuous_delivery/
-        icon: ci
-        desc: See deployment metrics, results, and insights for your CD provider
+        desc: Monitor the health and performance of your CI pipelines
+      - title: Test Visibility
+        link: tests/
+        icon: intelligent-test-runner
+        desc: Detect flaky tests and identify commits introducing flaky tests
       - title: Cloud Cost Management
         link: cloud_cost_management/
         icon: cloud-cost-management


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We're not charging customers for CD Visibility at the moment, we are charging customers for [Test Visibility & ITR](https://www.datadoghq.com/pricing/?product=test-visibility--intelligent-test-runner#products), so I am replacing the `CD Visibility` tile on the Docs Site landing page with a tile for `Test Visibility`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->