### PR TITLE
set `site` param to selected region - [WEB-4546]

### DIFF
--- a/assets/scripts/region-redirects.js
+++ b/assets/scripts/region-redirects.js
@@ -19,7 +19,6 @@ document.addEventListener('DOMContentLoaded', () => {
     hideTOCItems()
 
     if (regionSelector) {
-        regionOnChangeHandler(currentUserSavedRegion)
         const options = regionSelector.querySelectorAll('.dropdown-item');
 
         options.forEach(option => {
@@ -60,6 +59,7 @@ function replaceButtonInnerText(value) {
 
 function regionOnChangeHandler(region) {
     const queryParams = new URLSearchParams(window.location.search);
+
     // on change, if query param exists, update the param
     if (config.allowedRegions.includes(queryParams.get('site') || region)) {
         queryParams.set('site', region);

--- a/assets/scripts/region-redirects.js
+++ b/assets/scripts/region-redirects.js
@@ -19,6 +19,7 @@ document.addEventListener('DOMContentLoaded', () => {
     hideTOCItems()
 
     if (regionSelector) {
+        regionOnChangeHandler(currentUserSavedRegion)
         const options = regionSelector.querySelectorAll('.dropdown-item');
 
         options.forEach(option => {
@@ -59,9 +60,8 @@ function replaceButtonInnerText(value) {
 
 function regionOnChangeHandler(region) {
     const queryParams = new URLSearchParams(window.location.search);
-
     // on change, if query param exists, update the param
-    if (config.allowedRegions.includes(queryParams.get('site'))) {
+    if (config.allowedRegions.includes(queryParams.get('site') || region)) {
         queryParams.set('site', region);
 
         window.history.replaceState(
@@ -70,10 +70,6 @@ function regionOnChangeHandler(region) {
             `${window.location.pathname}?${queryParams}`
         );
 
-        showRegionSnippet(region);
-        replaceButtonInnerText(region);
-        Cookies.set('site', region, { path: '/' });
-    } else if (config.allowedRegions.includes(region)) {
         showRegionSnippet(region);
         replaceButtonInnerText(region);
         Cookies.set('site', region, { path: '/' });


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

set `site` url param with selected region whether the param already exists or not.

motivation: https://datadoghq.atlassian.net/browse/WEB-4546
preview: https://docs-staging.datadoghq.com/stefon.simmons/update-site-region-url-state/account_management/saml/
   - select a region from the region dropdown on the right.
   - the `site` param should be appended to the url and the `site` Cookie should be set to the selected region
   - the `site` param should not persist when navigating othes pages but the Cookie and dropdown should.
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->