### PR TITLE
Fix Cloudcraft's SSO documentation

### DIFF
--- a/content/en/cloudcraft/account-management/enable-sso-with-generic-idp.md
+++ b/content/en/cloudcraft/account-management/enable-sso-with-generic-idp.md
@@ -41,8 +41,8 @@ For more general information on using SSO with Cloudcraft, check out [Enable SSO
 
 {{< img src="cloudcraft/account-management/enable-sso-with-generic-idp/upload-metadata.png" alt="Successfully configured SAML Single Sign-On status with identity provider URL visible in security settings interface." responsive="true" style="width:100%;">}}
 
-10. Toggle the **SAML Single Sign-On is enabled** option. 
-11.  If you prefer to have your users access Cloudcraft only via Azure AD, enable the **Strict mode** option.
+10. Toggle the **SAML Single Sign-On is enabled** option.
+11.  If you prefer to have your users access Cloudcraft only via your identity provider, enable the **Strict mode** option.
 
 [1]: /cloudcraft/account-management/enable-sso-with-azure-ad/
 [2]: /cloudcraft/account-management/enable-sso-with-okta/

--- a/content/en/cloudcraft/account-management/enable-sso.md
+++ b/content/en/cloudcraft/account-management/enable-sso.md
@@ -3,7 +3,7 @@ title: Enable SSO
 kind: documentation
 ---
 
-Enabling Single Sign-On (SSO) with Azure AD as your identity provider allows you to simplify authentication and login access to Cloudcraft.
+Enabling Single Sign-On (SSO) for your account allows you to simplify authentication and login access to Cloudcraft.
 
 Cloudcraft supports SSO via two methods:
 
@@ -27,7 +27,7 @@ This article is all about SAML Enterprise SSO and how to set it up in your accou
 {{< img src="cloudcraft/account-management/enable-sso/service-provider-details.png" alt="Image provider metadata modal" responsive="true" style="width:100%;">}}
 
 4. After creating the application, navigate back to Cloudcraft and upload the metadata file from your identity provider.
-5. Toggle the **SAML Single Sign-On is enabled** option. 
+5. Toggle the **SAML Single Sign-On is enabled** option.
 6. If you prefer to have your users access Cloudcraft only via your identity provider, enable the **Strict mode** option.
 
 ## Additional features


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Seems like when rewriting Cloudcraft's SSO documentation we made a copy/paste mistake by refering to Azure AD on the overall documentation. This PR fixes that.

### Merge instructions
- [x] Please merge after reviewing