### PR TITLE
[DOCS-7375] adding support for SNMP v3

### DIFF
--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -39,7 +39,7 @@ network_devices:
       authKey: myAuthKey
       authProtocol: "SHA"
       privKey: myPrivKey
-      privProtocol: "AES"
+      privProtocol: "AES" # choices: MD5, SHA, SHA224, SHA256, SHA384, SHA512
     - user: "user"
       authKey: myAuthKey
       authProtocol: "MD5"
@@ -49,7 +49,7 @@ network_devices:
       authKey: myAuthKey2
       authProtocol: "SHA"
       privKey: myPrivKey2
-      privProtocol: "AES"
+      privProtocol: "AES" # choices: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
 ```
 
 **Note**: Multiple v3 users and passwords are supported as of Datadog Agent `7.51` or higher.

--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -34,15 +34,25 @@ network_devices:
       - <STRING_1>
       - <STRING_2>
     bind_host: 0.0.0.0
-    users: # limited to only a single v3 user
-      - username: 'user'
-        authKey: 'fakeKey'
-        authProtocol: 'SHA' # choices: MD5, SHA, SHA224, SHA256, SHA384, SHA512
-        privKey: 'fakePrivKey'
-        privProtocol: 'AES' # choices: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
+    users: # SNMP v3
+    - user: "user"
+      authKey: myAuthKey
+      authProtocol: "SHA"
+      privKey: myPrivKey
+      privProtocol: "AES"
+    - user: "user"
+      authKey: myAuthKey
+      authProtocol: "MD5"
+      privKey: myPrivKey
+      privProtocol: "DES"
+    - user: "user2"
+      authKey: myAuthKey2
+      authProtocol: "SHA"
+      privKey: myPrivKey2
+      privProtocol: "AES"
 ```
 
-**Note**: Multiple v3 users and passwords are not supported. If this is a requirement in your environment, contact [Datadog support][2].
+**Note**: Multiple v3 users and passwords are supported as of Datadog Agent `7.50` or higher.
 
 ## Device namespaces
 

--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -52,7 +52,7 @@ network_devices:
       privProtocol: "AES"
 ```
 
-**Note**: Multiple v3 users and passwords are supported as of Datadog Agent `7.50` or higher.
+**Note**: Multiple v3 users and passwords are supported as of Datadog Agent `7.51` or higher.
 
 ## Device namespaces
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
[DOCS-7375](https://datadoghq.atlassian.net/browse/DOCS-7375)

Removing example stating “limited to only a single v3 user” , and adding new example for multi-user v3, with note this is now supported in Agent `7.51` and higher 
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7375]: https://datadoghq.atlassian.net/browse/DOCS-7375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ