### PR TITLE
remove beta warning for JDK-21

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -277,7 +277,6 @@ Integrations can be enabled or disabled individually (overriding the default abo
 ### Known issues
 
 - Running the Java tracer in Bitbucket is not supported.
-- JDK 21 virtual threads are in [Beta](#levels-of-support).
 - Loading multiple Java Agents that perform APM/tracing functions is not a recommended or supported configuration.
 
 ## Further Reading


### PR DESCRIPTION
### What does this PR do? What is the motivation?
 
JDK-21 virtual threads are no longer in beta.  This remove the beta warning.

[x] Please merge after reviewing
