### PR TITLE
Update expression-language.md for `@exception` and `instanceof`

### DIFF
--- a/content/en/dynamic_instrumentation/expression-language.md
+++ b/content/en/dynamic_instrumentation/expression-language.md
@@ -16,7 +16,7 @@ Probe conditions must evaluate to a Boolean, for example: `startsWith(user.name,
 
 Generally, the Expression Language supports:
 * Accessing local variables, method parameters, and deeply nested fields and attributes within objects.
-* Using comparison operators (`<`, `>`, `>=`, `<=`, `==`, `!=`) to compare variables, fields, and constants in your conditions, for example: `localVar1.field1.field2 != 15`.
+* Using comparison operators (`<`, `>`, `>=`, `<=`, `==`, `!=`, `instanceof`) to compare variables, fields, and constants in your conditions, for example: `localVar1.field1.field2 != 15`.
 * Using logical operators (`&&`, `||`, and `not` or `!`) to build complex Boolean conditions.
 * Using the `null` literal (equivalent to `nil` in Python).
 
@@ -33,6 +33,7 @@ The following sections summarize the variables and operations that the Dynamic I
 | `@return`   | Provides access to the return value                                        |
 | `@duration` | Provides access to the call execution duration                             |
 | `@it`       | Provides access to the current value in collection iterating operations    |
+| `@exception`| Provides access to the current uncaught exception                          |
 
 
 ## String operations


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
add `@exception` keyword for uncaught exception
add `instanceof` operator for type comparison

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->