### PR TITLE
Code Hotspot: windows not compatible with java

### DIFF
--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -27,7 +27,10 @@ You can move directly from span information to profiling data on the Code Hotspo
 
 {{< programming-lang-wrapper langs="java,python,go,ruby,nodejs,dotnet,php" >}}
 {{< programming-lang lang="java" >}}
-Code Hotspots identification is enabled by default when you [turn on profiling for your Java service][1]. For manually instrumented code, continuous profiler requires scope activation of spans:
+Code Hotspots identification is enabled by default when you [turn on profiling for your Java service][1] on Linux and macOS. 
+The feature is not available on Windows.
+
+For manually instrumented code, continuous profiler requires scope activation of spans:
 
 ```java
 final Span span = tracer.buildSpan("ServicehandlerSpan").start();


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Add in the documentation that Code Hotspot is not available on windows for the Java Profiler for the moment.
Update motivated by a customer question in a support ticket