### PR TITLE
Update "How to use Terraform to restrict the editing of a dashboard"

### DIFF
--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -24,7 +24,7 @@ resource "datadog_dashboard" "example" {
 Please note that the `is_read_only` attribute is deprecated. It is recommended to use the `restricted_roles` attribute or Restriction Policies to manage access to your dashboards.
 </div>
 
-## [Private Beta] Restricting a dashboard using a restriction policy
+## Restricting a dashboard using a restriction policy
 
 <div class="alert alert-info">
 Please reach out to your Datadog contact or support to enable the feature.

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -9,7 +9,7 @@ aliases:
 
 ## Restricting a dashboard using the restricted_roles attribute
 
-The `restricted_roles` attribute can be used to restrict editing of the dashboard to specific roles. The field takes a list of IDs of roles whose associated users will be authorized.
+The `restricted_roles` attribute can be used to restrict editing of the dashboard to specific roles. The field takes a list of IDs of roles, and authorizes any associated users.
 
 Example usage:
 

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -26,9 +26,7 @@ The `is_read_only` attribute is deprecated. It is recommended to use the `restri
 
 ## Restricting a dashboard using a restriction policy
 
-{{< callout url="https://www.datadoghq.com/support/" >}}
-Restriction policies are in beta. Reach out to Datadog support to enable the feature.
-{{< /callout >}} 
+<div class="alert alert-warning">Restriction policies are in private beta. Contact <a href="/help/">Datadog Support</a> or your Customer Success Manager for access.</div>
 
 [Restriction Policies][1] allow you to restrict the editing of dashboards and other resources to specific principals, including roles, teams, users, and service accounts.
 

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -20,6 +20,10 @@ resource "datadog_dashboard" "example" {
 }
 ```
 
+<div class="alert alert-warning">
+Please note that the `is_read_only` attribute is deprecated. It is recommended to use the `restricted_roles` attribute or Restriction Policies to manage access to your dashboards.
+</div>
+
 ## [Private Beta] Restricting a dashboard using a restriction policy
 
 <div class="alert alert-info">

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -55,11 +55,11 @@ resource "datadog_restriction_policy" "example" {
 
 Role IDs can be retrieved from the [Roles API][2], [Roles UI][5], or by using the role ID defined in Terraform for [datadog_role][3] resources.
 
-Org ID can be obtained from the [Get user details API][4].
+Org ID can be obtained from the [GET /api/v2/org API][4].
 
 
 [1]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/restriction_policy
 [2]: /api/latest/roles/#list-roles
 [3]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/role
-[4]: https://docs.datadoghq.com/api/latest/users/#get-user-details
+[4]: https://app.datadoghq.com/api/v2/org
 [5]: https://app.datadoghq.com/organization-settings/roles

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -21,7 +21,7 @@ resource "datadog_dashboard" "example" {
 ```
 
 <div class="alert alert-warning">
-Please note that the `is_read_only` attribute is deprecated. It is recommended to use the `restricted_roles` attribute or Restriction Policies to manage access to your dashboards.
+The `is_read_only` attribute is deprecated. It is recommended to use the `restricted_roles` attribute or Restriction Policies to manage access to your dashboards.
 </div>
 
 ## Restricting a dashboard using a restriction policy

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -51,7 +51,9 @@ resource "datadog_restriction_policy" "example" {
 
 Role IDs can be retrieved from the [Roles API][2], [Roles UI][5], or by using the role ID defined in Terraform for [datadog_role][3] resources.
 
-Org ID can be obtained from the [GET /api/v2/current_user API][4].
+Org ID can be obtained from the [GET /api/v2/current_user API][4] request. Find it in the `data.relationships.org.data.id` field. 
+
+
 
 
 [1]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/restriction_policy

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -30,7 +30,7 @@ The `is_read_only` attribute is deprecated. It is recommended to use the `restri
 Restriction policies are in beta. Reach out to Datadog support to enable the feature.
 {{< /callout >}} 
 
-[Restriction Policies][1] allow restricting resources to various principals including Roles, Teams, Users, and Service Accounts.
+[Restriction Policies][1] allow you to restrict the editing of dashboards and other resources to specific principals, including roles, teams, users, and service accounts.
 
 Example usage:
 

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -53,7 +53,7 @@ resource "datadog_restriction_policy" "example" {
 }
 ```
 
-Role IDs can be retrieved from the [Roles APIs][2] or Roles UI, or referring to role ID as defined in Terraform for [Terraform managed Roles][3].
+Role IDs can be retrieved from the [Roles API][2], [Roles UI][5], or by using the role ID defined in Terraform for [datadog_role][3] resources.
 
 Org ID can be obtained from the [Get user details API][4].
 

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -26,9 +26,9 @@ The `is_read_only` attribute is deprecated. It is recommended to use the `restri
 
 ## Restricting a dashboard using a restriction policy
 
-<div class="alert alert-info">
-Please reach out to your Datadog contact or support to enable the feature.
-</div>
+{{< callout url="https://www.datadoghq.com/support/" >}}
+Restriction policies are in beta. Reach out to Datadog support to enable the feature.
+{{< /callout >}} 
 
 [Restriction Policies][1] allow restricting resources to various principals including Roles, Teams, Users, and Service Accounts.
 

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -20,9 +20,7 @@ resource "datadog_dashboard" "example" {
 }
 ```
 
-<div class="alert alert-warning">
-The `is_read_only` attribute is deprecated. It is recommended to use the `restricted_roles` attribute or Restriction Policies to manage access to your dashboards.
-</div>
+**Note**: The `is_read_only` attribute is deprecated. It is recommended to use the `restricted_roles` attribute or restriction policies to manage access to your dashboards.
 
 ## Restricting a dashboard using a restriction policy
 

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -51,11 +51,11 @@ resource "datadog_restriction_policy" "example" {
 
 Role IDs can be retrieved from the [Roles API][2], [Roles UI][5], or by using the role ID defined in Terraform for [datadog_role][3] resources.
 
-Org ID can be obtained from the [GET /api/v2/org API][4].
+Org ID can be obtained from the [GET /api/v2/current_user API][4].
 
 
 [1]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/restriction_policy
 [2]: /api/latest/roles/#list-roles
 [3]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/role
-[4]: https://app.datadoghq.com/api/v2/org
+[4]: https://app.datadoghq.com/api/v2/current_user
 [5]: https://app.datadoghq.com/organization-settings/roles

--- a/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
+++ b/content/en/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit.md
@@ -62,3 +62,4 @@ Org ID can be obtained from the [Get user details API][4].
 [2]: /api/latest/roles/#list-roles
 [3]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/role
 [4]: https://docs.datadoghq.com/api/latest/users/#get-user-details
+[5]: https://app.datadoghq.com/organization-settings/roles


### PR DESCRIPTION
### What does this PR do? What is the motivation?
* We released https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/restriction_policy - got a note there that dashboard support is in private beta.
* For dashboards, existing customers that use is_read_only or restricted_roles need to be careful and not use both at the same time, so we offer some additional guidance through Support for now.
* Main goal here is to note document that Terraform Restriction Policies for dashboards are currently in private beta.

Drive-by change - refresh old docs:
1. `is_read_only` has been deprecated years ago, `restricted_roles` is marked as deprecated now too: https://docs.datadoghq.com/api/latest/dashboards/#create-a-new-dashboard
2. So, removing the old `is_read_only` -> `restricted_roles` migration guidance.