### PR TITLE
[synthetics] Update documentation about Windows PL requirements

### DIFF
--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -70,9 +70,7 @@ You must install .NET version 4.7.2 or later on your computer before using the M
 
 {{< site-region region="gov" >}}
 
-FIPS compliance is not supported for private locations that report to `ddog-gov.com`. Please use the `--disableFipsCompliance` option to disable this behavior ([more information here][1]).
-
-[1]: https://docs.datadoghq.com/synthetics/private_locations/configuration/?tab=docker#all-configuration-options
+<div class="alert alert-danger">FIPS compliance is not supported for private locations that report to `ddog-gov.com`. To disable this behavior, use the <a href"="https://docs.datadoghq.com/synthetics/private_locations/configuration/?tab=docker#all-configuration-options"><code>--disableFipsCompliance</code> option</a>.</div>
 
 {{< /site-region >}}
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -70,7 +70,7 @@ You must install .NET version 4.7.2 or later on your computer before using the M
 
 {{< site-region region="gov" >}}
 
-<div class="alert alert-danger">FIPS compliance is not supported for private locations that report to `ddog-gov.com`. To disable this behavior, use the <a href"="https://docs.datadoghq.com/synthetics/private_locations/configuration/?tab=docker#all-configuration-options"><code>--disableFipsCompliance</code> option</a>.</div>
+<div class="alert alert-danger">FIPS compliance is not supported for private locations that report to <code>ddog-gov.com</code>. To disable this behavior, use the <a href"="https://docs.datadoghq.com/synthetics/private_locations/configuration/?tab=docker#all-configuration-options"><code>--disableFipsCompliance</code> option</a>.</div>
 
 {{< /site-region >}}
 

--- a/content/en/synthetics/private_locations/_index.md
+++ b/content/en/synthetics/private_locations/_index.md
@@ -68,6 +68,14 @@ This machine's requirements are listed in the table below. PowerShell scripting 
 
 You must install .NET version 4.7.2 or later on your computer before using the MSI installer. 
 
+{{< site-region region="gov" >}}
+
+FIPS compliance is not supported for private locations that report to `ddog-gov.com`. Please use the `--disableFipsCompliance` option to disable this behavior ([more information here][1]).
+
+[1]: https://docs.datadoghq.com/synthetics/private_locations/configuration/?tab=docker#all-configuration-options
+
+{{< /site-region >}}
+
 [101]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-1.43.0.amd64.msi
 
 {{% /tab %}}

--- a/content/en/synthetics/private_locations/configuration.md
+++ b/content/en/synthetics/private_locations/configuration.md
@@ -159,7 +159,7 @@ Proxy URL used by the private location to send requests to Datadog (for example,
 : **Type:** Boolean <br>
 **Default**: `false`<br>
 Disables the FIPS compliance for a private location using `ddog-gov.com`.
-By default, Private Locations reporting to `ddog-gov.com` communicate to Datadog using FIPS-compliant encryption. The communication complies on the use of FIPS 140-2 validated [Cryptographic Module - Certificate #4282][3].
+By default, Private Locations reporting to `ddog-gov.com` communicate to Datadog using FIPS-compliant encryption. The communication complies on the use of FIPS 140-2 validated [Cryptographic Module - Certificate #4282][3]. This option is required if you are using a Windows private location that reports to `ddog-gov.com`.
 
 `--dumpConfig`
 : **Type**: Boolean <br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The Synthetics Windows private location was made generally available a few weeks ago. We recently noticed that Windows private locations that report to `ddog-gov.com` could not start. This is due to a lack of support for FIPS compliance (for communications with Datadog) of this type of private location.

For now, we recommend using the `--disableFipsCompliance` config option to bypass the default behavior and fix their Windows private locations.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->