### PR TITLE
Specify hosts pattern matching for webview tracking

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
@@ -125,7 +125,7 @@ To disable Web View Tracking:
 WebViewTracking.disable(webView: webView)
 ```
 
-`allowedHosts` will match the given hosts and their subdomain. No regular expression is allowed.
+`allowedHosts` matches the given hosts and their subdomain. No regular expression is allowed.
 
 {{% /tab %}}
 {{% tab "Flutter" %}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
@@ -153,7 +153,7 @@ webViewController = WebViewController()
 ```
 
 Note that `JavaScriptMode.unrestricted` is required for tracking to work on Android.
-`allowedHosts` will match the given hosts and their subdomain. No regular expression is allowed.
+`allowedHosts` matches the given hosts and their subdomain. No regular expression is allowed.
 
 
 [1]: https://pub.dev/packages/webview_flutter

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
@@ -100,6 +100,8 @@ DatadogWebViewTracking.xcframework
      WebViewTracking.enable(webView, allowedHosts)
    ```
 
+`allowedHosts` will match the given hosts and their subdomain. No regular expression is allowed.
+
 [1]: https://search.maven.org/artifact/com.datadoghq/dd-sdk-android-rum
 [2]: /real_user_monitoring/android/?tab=kotlin#setup
 [3]: https://search.maven.org/artifact/com.datadoghq/dd-sdk-android-logs
@@ -122,6 +124,8 @@ To disable Web View Tracking:
 ```swift
 WebViewTracking.disable(webView: webView)
 ```
+
+`allowedHosts` will match the given hosts and their subdomain. No regular expression is allowed.
 
 {{% /tab %}}
 {{% tab "Flutter" %}}
@@ -149,6 +153,8 @@ webViewController = WebViewController()
 ```
 
 Note that `JavaScriptMode.unrestricted` is required for tracking to work on Android.
+`allowedHosts` will match the given hosts and their subdomain. No regular expression is allowed.
+
 
 [1]: https://pub.dev/packages/webview_flutter
 [2]: https://pub.dev/packages/datadog_webview_tracking
@@ -176,6 +182,8 @@ Note that `JavaScriptMode.unrestricted` is required for tracking to work on Andr
        allowedHosts={['example.com']}
    />
    ```
+
+`allowedHosts` will match the given hosts and their subdomain. No regular expression is allowed.
 
 [1]: https://github.com/react-native-webview/react-native-webview/blob/master/docs/Getting-Started.md
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
@@ -100,7 +100,7 @@ DatadogWebViewTracking.xcframework
      WebViewTracking.enable(webView, allowedHosts)
    ```
 
-`allowedHosts` will match the given hosts and their subdomain. No regular expression is allowed.
+`allowedHosts` matches the given hosts and their subdomain. No regular expression is allowed.
 
 [1]: https://search.maven.org/artifact/com.datadoghq/dd-sdk-android-rum
 [2]: /real_user_monitoring/android/?tab=kotlin#setup

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
@@ -183,7 +183,7 @@ Note that `JavaScriptMode.unrestricted` is required for tracking to work on Andr
    />
    ```
 
-`allowedHosts` will match the given hosts and their subdomain. No regular expression is allowed.
+`allowedHosts` matches the given hosts and their subdomain. No regular expression is allowed.
 
 [1]: https://github.com/react-native-webview/react-native-webview/blob/master/docs/Getting-Started.md
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
We had a few users confused about whether they could use regular expressions and if subdomains were being matched with webview tracking.
Looking at the [browser SDK implementation](https://github.com/DataDog/browser-sdk/blob/fd44db8f0a9e6b0e08396deb182eebf69a3ef4d3/packages/core/src/transport/eventBridge.ts#L54), we allow subdomains but not regex.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->