### PR TITLE
added security rules

### DIFF
--- a/content/en/data_security/logs.md
+++ b/content/en/data_security/logs.md
@@ -45,7 +45,7 @@ These features are not available to customers who have signed Datadog's BAA:
 * You cannot [share][5] logs, security signals, or traces from the Datadog explorer.
 * Security rules cannot include triggering group-by values in notification title.
 * Security rules cannot include message template variables.
-* Security rules cannot notify via webhooks.
+* Security rules cannot notify through webhooks.
 
 If you have any questions about how the Log Management Service satisfies the applicable requirements under HIPAA, contact your account manager. HIPAA-enabled customers do not need to use specific endpoints to submit logs to enforce specific encryptions. The encryptions are enabled on all log submission endpoints.
 

--- a/content/en/data_security/logs.md
+++ b/content/en/data_security/logs.md
@@ -43,6 +43,9 @@ These features are not available to customers who have signed Datadog's BAA:
 
 * Users cannot request support through chat.
 * You cannot [share][5] logs, security signals, or traces from the Datadog explorer.
+* Security rules cannot include triggering group-by values in notification title.
+* Security rules cannot include message template variables.
+* Security rules cannot notify via webhooks.
 
 If you have any questions about how the Log Management Service satisfies the applicable requirements under HIPAA, contact your account manager. HIPAA-enabled customers do not need to use specific endpoints to submit logs to enforce specific encryptions. The encryptions are enabled on all log submission endpoints.
 

--- a/content/en/data_security/logs.md
+++ b/content/en/data_security/logs.md
@@ -43,7 +43,7 @@ These features are not available to customers who have signed Datadog's BAA:
 
 * Users cannot request support through chat.
 * You cannot [share][5] logs, security signals, or traces from the Datadog explorer.
-* Security rules cannot include triggering group-by values in notification title.
+* Security rules cannot include triggering group-by values in the notification title.
 * Security rules cannot include message template variables.
 * Security rules cannot notify through webhooks.
 


### PR DESCRIPTION
Added the below security rules to the documentation due to recent Cloud SIEM code changes cc @nimishaaa and @clementgbcn 

* Security rules cannot include triggering group-by values in notification title.
* Security rules cannot include message template variables.
* Security rules cannot notify via webhooks.