### PR TITLE
Clarify statefulset

### DIFF
--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -109,7 +109,7 @@ The cost of an EBS volume has three components: IOPS, throughput, and storage. E
 - Workload idle: Cost of provisioned IOPS, throughput, or storage not being used by workloads. Storage cost is based on the maximum amount of storage used that day. IOPS and throughput costs are based on the average amount used that day. *Note: This tag is only available if you have enabled `Resource Collection` in your [**AWS Integration**][9]. To prevent being charged for `Cloud Security Posture Management`, ensure that during the `Resource Collection` setup, the `Cloud Security Posture Management` box is unchecked.*
 - Cluster idle: Cost of provisioned IOPS, throughput, or storage for volumes not claimed by any pods that day.
 
-**Note**: Persistent volume allocation is only supported in Kubernetes clusters, and not available for pods that are part of a Kubernetes Deployment.
+**Note**: Persistent volume allocation is only supported in Kubernetes clusters, and is only available for pods that are part of a Kubernetes StatefulSet.
 
 ## Cost metrics
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
To clarify that Persistent volume allocation is currently only supported for pods that are part of a `StatefulSet`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->