### PR TITLE
Fix YAML spacing for token/hpa

### DIFF
--- a/content/en/containers/kubernetes/configuration.md
+++ b/content/en/containers/kubernetes/configuration.md
@@ -309,7 +309,7 @@ spec:
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>
-  clusterAgentToken: <DATADOG_CLUSTER_AGENT_TOKEN>
+    clusterAgentToken: <DATADOG_CLUSTER_AGENT_TOKEN>
 ```
 
 Alternatively, you can specify this token by referencing the name of an existing `Secret` and the data key containing this token:
@@ -324,9 +324,9 @@ spec:
     credentials:
       apiKey: <DATADOG_API_KEY>
       appKey: <DATADOG_APP_KEY>
-  clusterAgentTokenSecret: 
-    secretName: <SECRET_NAME>
-    keyName: <KEY_NAME>
+    clusterAgentTokenSecret: 
+      secretName: <SECRET_NAME>
+      keyName: <KEY_NAME>
 ```
 
 **Note**: When set manually, this token must be 32 alphanumeric characters.
@@ -410,10 +410,10 @@ datadog:
   apiKey: <DATADOG_API_KEY>
   appKey: <DATADOG_APP_KEY>
 
-  clusterAgent:
+clusterAgent:
+  enabled: true
+  metricsProvider:
     enabled: true
-    metricsProvider:
-      enabled: true
 ```
 
 Then upgrade your Helm chart:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fix YAML spacing

- The Operator's Cluster Agent token rules go under `global`
- The Helm Metrics Provider/HPA goes under the root `clusterAgent` instead of `datadog.clusterAgent`

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->