### PR TITLE
[profiling] Fix missing instructions for Java custom context

### DIFF
--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -92,11 +92,11 @@ try (var scope = Profiling.get().newScope()) {
 }
 ```
 
-Then inform the Datadog backend of your intent to filter by this context key by setting the `profiling.context.attributes` configuration with one of:
+Then, inform the Datadog backend of your intent to filter by this context key; set the `profiling.context.attributes` configuration with one of the following:
 * Environment variable: `DD_PROFILING_CONTEXT_ATTRIBUTES=customer_name`
 * System setting: `-Ddd.profiling.context.attributes=customer_name`
 
-If you have several such context keys you should use a comma-separated string for the configuration (`-Ddd.profiling.context.attributes=customer_name,customer_group` for example).
+If you have multiple context keys, use a comma-separated string for the configuration (for example,`-Ddd.profiling.context.attributes=customer_name,customer_group`).
 
 Then, open CPU, Exceptions, or Wall Time profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
 

--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -92,7 +92,7 @@ try (var scope = Profiling.get().newScope()) {
 }
 ```
 
-Then, inform the Datadog backend of your intent to filter by this context key; set the `profiling.context.attributes` configuration with one of the following:
+To specify which label keys you want to use for filtering, set the `profiling.context.attributes` configuration with one of the following:
 * Environment variable: `DD_PROFILING_CONTEXT_ATTRIBUTES=customer_name`
 * System setting: `-Ddd.profiling.context.attributes=customer_name`
 
@@ -111,7 +111,7 @@ pprof.Do(ctx, pprof.Labels("customer_name", <value>), func(context.Context) {
 })
 ```
 
-To specify which label keys you want use for filtering, add the [WithCustomProfilerLabelKeys][2] option when starting the profiler:
+To specify which label keys you want to use for filtering, add the [WithCustomProfilerLabelKeys][2] option when starting the profiler:
 
 ```go
 profiler.Start(

--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -92,11 +92,11 @@ try (var scope = Profiling.get().newScope()) {
 }
 ```
 
-Then inform the Datadog backend of your intent to filter by this context key by setting the `profiling.context.attributes` configuration via one of:
+Then inform the Datadog backend of your intent to filter by this context key by setting the `profiling.context.attributes` configuration with one of:
 * Environment variable: `DD_PROFILING_CONTEXT_ATTRIBUTES=customer_name`
 * System setting: `-Ddd.profiling.context.attributes=customer_name`
 
-If you have several such context keys you should use a comma-separated string for the configuration (e.g. `-Ddd.profiling.context.attributes=customer_name,customer_group`).
+If you have several such context keys you should use a comma-separated string for the configuration (`-Ddd.profiling.context.attributes=customer_name,customer_group` for example).
 
 Then, open CPU, Exceptions, or Wall Time profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
 

--- a/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
+++ b/content/en/profiler/guide/isolate-outliers-in-monolithic-services.md
@@ -92,8 +92,13 @@ try (var scope = Profiling.get().newScope()) {
 }
 ```
 
-Then, open CPU, Exceptions, or Wall Time profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
+Then inform the Datadog backend of your intent to filter by this context key by setting the `profiling.context.attributes` configuration via one of:
+* Environment variable: `DD_PROFILING_CONTEXT_ATTRIBUTES=customer_name`
+* System setting: `-Ddd.profiling.context.attributes=customer_name`
 
+If you have several such context keys you should use a comma-separated string for the configuration (e.g. `-Ddd.profiling.context.attributes=customer_name,customer_group`).
+
+Then, open CPU, Exceptions, or Wall Time profiles for your service and select the `customer_name` value you're interested in under the `CPU time by` dropdown.
 
 {{< /programming-lang >}}
 {{< programming-lang lang="go">}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Instructions for specifying custom context in Java profiles were missing the required step of telling the backend which of the instrumented context keys to analyze at intake.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->