### PR TITLE
Add blog link to Exception Replay page

### DIFF
--- a/content/en/tracing/error_tracking/exception_replay.md
+++ b/content/en/tracing/error_tracking/exception_replay.md
@@ -10,6 +10,9 @@ further_reading:
 - link: '/tracing/error_tracking'
   tag: 'Documentation'
   text: 'Learn about Error Tracking for Backend Services'
+- link: 'https://www.datadoghq.com/blog/exception-replay-datadog/'
+  tag: 'Blog'
+  text: 'Simplify production debugging with Datadog Exception Replay'
 aliases:
   - /tracing/error_tracking/executional_context
   - /tracing/error_tracking/execution_replay/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
https://www.datadoghq.com/blog/exception-replay-datadog/

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->