### PR TITLE
[DOCS-7390] Tracer must be initialized before configuration integrations

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/go.md
+++ b/content/en/tracing/trace_collection/compatibility/go.md
@@ -20,7 +20,10 @@ The Go Datadog Trace library is open source. View the [GitHub repository][1] for
 
 The Go Datadog Trace Library has a [version support policy][2] defined for Go versions. The two latest releases of Go are fully supported, while the third newest release is considered in [maintenance][3]. Older versions may function, but no support is provided by default. For special requests, [contact support][4]. 
 
-You must be running Datadog Agent v5.21.1+.
+### Requirements
+
+- Datadog Agent v5.21.1+.
+- [Add and initialize the Datadog Go tracer][77] before configuring integrations.
 
 ### Integrations
 
@@ -164,3 +167,4 @@ import "gopkg.in/DataDog/dd-trace-go.v1/contrib/<PACKAGE_DIR>/<PACKAGE_NAME>"
 [74]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib/bradfitz/gomemcache/memcache
 [75]: https://aws.github.io/aws-sdk-go-v2/docs/
 [76]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go-v2/aws
+[77]: /tracing/trace_collection/library_config/go/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Clarify for users that you need to initialize the Go tracer before configuring integrations.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->