### PR TITLE
[test-visibility] Change test visibility icon to "CI visibility" rather than intelligent test runner

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3197,7 +3197,7 @@ main:
     weight: 6
   - name: Test Visibility
     url: tests/
-    pre: intelligent-test-runner
+    pre: ci
     parent: software_delivery_heading
     identifier: tests
     weight: 20000

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -110,7 +110,7 @@ nav_sections:
         desc: Monitor the health and performance of your CI pipelines
       - title: Test Visibility
         link: tests/
-        icon: intelligent-test-runner
+        icon: ci
         desc: Detect flaky tests and identify commits introducing flaky tests
       - title: Cloud Cost Management
         link: cloud_cost_management/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The test visibility's icon shouldn't be that of intelligent test runner.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->