### PR TITLE
Add Team as a monitor notification target

### DIFF
--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -112,6 +112,11 @@ Disk space is low @ops-team@company.com
 
 {{% notifications-email %}}
 
+
+#### Teams
+
+If a [notification channel][17] is set, you can route notifications to a specific Team. Monitor alerts targeting @team-handle will be redirected to the selected communication channel.
+
 #### Integrations
 
 {{% notifications-integrations %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
When users are using Datadog Team they can set a notification channel for each team. Once the notification channel is set, the user can use the @ team-handle in a monitor to redirect monitor notification to that channel. 