### PR TITLE
Team handles can be used in montior notifcations

### DIFF
--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -112,6 +112,10 @@ Disk space is low @ops-team@company.com
 
 {{% notifications-email %}}
 
+#### Teams
+
+If a [notification channel][17] is set, you can route notifications to a specific Team. Monitor alerts targeting @team-handle will be redirected to the selected communication channel.
+
 #### Integrations
 
 {{% notifications-integrations %}}
@@ -202,3 +206,4 @@ Message variables auto-populate with a randomly selected group based on the scop
 [14]: /monitors/guide/how-to-set-up-rbac-for-monitors/
 [15]: /monitors/types
 [16]: /monitors/guide/recovery-thresholds/
+[17]: /account_management/teams/

--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -114,7 +114,7 @@ Disk space is low @ops-team@company.com
 
 #### Teams
 
-If a [notification channel][17] is set, you can route notifications to a specific Team. Monitor alerts targeting @team-handle will be redirected to the selected communication channel.
+If a notification channel is set, you can route notifications to a specific [Team][17]. Monitor alerts targeting @team-handle are redirected to the selected communication channel.
 
 #### Integrations
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Datadog teams can now support notification channels. When a notification channel is set and the team handle is used in a monitor message the notification will be redirected to that notification channel for that team
