### PR TITLE
Update locked deprecation guide

### DIFF
--- a/content/en/monitors/guide/how-to-set-up-rbac-for-monitors.md
+++ b/content/en/monitors/guide/how-to-set-up-rbac-for-monitors.md
@@ -128,13 +128,13 @@ Before Datadog released the feature allowing restriction of monitor editing to s
 
 {{< img src="/monitors/guide/monitor_rbac_locked.jpg" alt="RBAC Locked Monitor" style="width:70%;">}}
 
-Locked monitors are deprecated and will no longer be supported after March 27, 2024. Datadog requires to use the role restriction option, which gives you more flexibility to define the users allowed to edit monitors.
+Locked monitors are deprecated and will no longer be supported after March 27, 2024. Instead, use the role restriction option, which gives you more flexibility to define which users are allowed to edit monitors.
 
 The sections below describe how to migrate from the locked mechanism to restricted roles, depending on the way you manage your monitors.
 
 ### API
 
-The `locked` parameter corresponding to the above mentioned locked mechanism will no longer be supported after March 27, 2024. This means you need to update the definition of your monitors managed through API or Terraform to stop using `locked` and start using `restricted_roles` (parameter attached with the new role restriction option).
+The `locked` parameter corresponding to the above mentioned locking mechanism will no longer be supported after March 27, 2024. This means you must update the definition of your monitors managed through API or Terraform to stop using `locked` and start using `restricted_roles` (parameter attached with the new role restriction option).
 
 For more information on how to update your monitors' definitions, see [Edit a monitor API endpoint][3] and [Monitor API Options][4].
 

--- a/content/en/monitors/guide/how-to-set-up-rbac-for-monitors.md
+++ b/content/en/monitors/guide/how-to-set-up-rbac-for-monitors.md
@@ -128,15 +128,13 @@ Before Datadog released the feature allowing restriction of monitor editing to s
 
 {{< img src="/monitors/guide/monitor_rbac_locked.jpg" alt="RBAC Locked Monitor" style="width:70%;">}}
 
-Locked monitors are deprecated. Datadog recommends using the role restriction option, which gives you more flexibility to define the users allowed to edit monitors.
-
-Your organization may have existing locked monitors. Datadog still supports locked monitors. Editing of locked monitors is restricted to users with the [Datadog Admin Role][2] and the monitor's creator.
+Locked monitors are deprecated and will no longer be supported after March 27, 2024. Datadog requires to use the role restriction option, which gives you more flexibility to define the users allowed to edit monitors.
 
 The sections below describe how to migrate from the locked mechanism to restricted roles, depending on the way you manage your monitors.
 
 ### API
 
-Although deprecated, the `locked` parameter corresponding to the above mentioned locked mechanism is still supported. This means you can progressively update the definition of your monitors managed through API or Terraform to stop using `locked` and start using `restricted_roles` (parameter attached with the new role restriction option).
+The `locked` parameter corresponding to the above mentioned locked mechanism will no longer be supported after March 27, 2024. This means you need to update the definition of your monitors managed through API or Terraform to stop using `locked` and start using `restricted_roles` (parameter attached with the new role restriction option).
 
 For more information on how to update your monitors' definitions, see [Edit a monitor API endpoint][3] and [Monitor API Options][4].
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
As we are moving on with the locked deprecation, we updated the public doc explaining that locked monitors will no longer be supported after March 27, 2024.

