### PR TITLE
docs: PHP Tracer Windows Support

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/php.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/php.md
@@ -70,6 +70,10 @@ php datadog-setup.php --php-bin=all --enable-appsec
 php datadog-setup.php --php-bin=all --enable-profiling
 ```
 
+<div class="alert alert-danger">
+<strong>Note</strong>: Windows supports only APM. Do not use the <code>--enable-appsec</code> and <code>--enable-profiling</code> flags when tracing PHP applications on Windows.
+</div>
+
 This command installs the extension to all the PHP binaries found in the host or container. If `--php-bin` is omitted, the installer runs in interactive mode and asks the user to select the binaries for installation. The value of `--php-bin` can be a path to a specific binary in case `dd-trace-php` should be installed only to such binary.
 
 Restart PHP (PHP-FPM or the Apache SAPI) and visit a tracing-enabled endpoint of your application. To see the generated traces, go to the [APM Traces page][4].

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/php.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/php.md
@@ -71,7 +71,7 @@ php datadog-setup.php --php-bin=all --enable-profiling
 ```
 
 <div class="alert alert-danger">
-<strong>Note</strong>: Windows supports only APM. Do not use the <code>--enable-appsec</code> and <code>--enable-profiling</code> flags when tracing PHP applications on Windows.
+<strong>Note</strong>: Windows only supports APM. Do not use the <code>--enable-appsec</code> and <code>--enable-profiling</code> flags when tracing PHP applications on Windows.
 </div>
 
 This command installs the extension to all the PHP binaries found in the host or container. If `--php-bin` is omitted, the installer runs in interactive mode and asks the user to select the binaries for installation. The value of `--php-bin` can be a path to a specific binary in case `dd-trace-php` should be installed only to such binary.

--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -72,13 +72,13 @@ PHP APM supports the following SAPI's:
 
 PHP APM supports the following architectures:
 
-| Processor architectures                 | Support level     | Package version |
-|-----------------------------------------|-------------------|---------------|
-| Linux GNU amd64 (`x86-64-linux-gnu`)    | [GA](#support-ga) | All           |
-| Linux MUSL amd64 (`x86-64-linux-musl`)  | [GA](#support-ga) | All           |
-| Linux GNU arm64 (`aarch64-linux-gnu`)   | [GA](#support-ga) | > `0.78.0`    |
-| Linux MUSL arm64 (`aarch64-linux-musl`) | [GA](#support-ga) | > `0.78.0`    |
-| Windows amd64 (`x86_64-windows`)        | [GA](#support-ga) | > `0.98.0`    |
+| Processor architectures                 | Support level     | Package version | Support Type               |
+|-----------------------------------------|-------------------|---------------|----------------------------|
+| Linux GNU amd64 (`x86-64-linux-gnu`)    | [GA](#support-ga) | All           | All supported PHP versions |
+| Linux MUSL amd64 (`x86-64-linux-musl`)  | [GA](#support-ga) | All           | All supported PHP versions |
+| Linux GNU arm64 (`aarch64-linux-gnu`)   | [GA](#support-ga) | > `0.78.0`    | All supported PHP versions |
+| Linux MUSL arm64 (`aarch64-linux-musl`) | [GA](#support-ga) | > `0.78.0`    | All supported PHP versions |
+| Windows amd64 (`x86_64-windows`)        | [GA](#support-ga) | > `0.98.0`    | PHP 7.2+                   |
 
 ### Integrations
 

--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -72,12 +72,13 @@ PHP APM supports the following SAPI's:
 
 PHP APM supports the following architectures:
 
-| Processor architectures                   | Support level         | Package version                        |
-| ------------------------------------------|-----------------------|----------------------------------------|
-| Linux GNU amd64 (`x86-64-linux-gnu`)      | [GA](#support-ga)     | All                                    |
-| Linux MUSL amd64 (`x86-64-linux-musl`)    | [GA](#support-ga)     | All                                    |
-| Linux GNU arm64 (`aarch64-linux-gnu`)     | [GA](#support-ga)     | > `0.78.0`                             |
-| Linux MUSL arm64 (`aarch64-linux-musl`)   | [GA](#support-ga)     | > `0.78.0`                             |
+| Processor architectures                 | Support level     | Package version |
+|-----------------------------------------|-------------------|---------------|
+| Linux GNU amd64 (`x86-64-linux-gnu`)    | [GA](#support-ga) | All           |
+| Linux MUSL amd64 (`x86-64-linux-musl`)  | [GA](#support-ga) | All           |
+| Linux GNU arm64 (`aarch64-linux-gnu`)   | [GA](#support-ga) | > `0.78.0`    |
+| Linux MUSL arm64 (`aarch64-linux-musl`) | [GA](#support-ga) | > `0.78.0`    |
+| Windows amd64 (`x86_64-windows`)        | [GA](#support-ga) | > `0.98.0`    |
 
 ### Integrations
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Windows support has been released with the version [0.98.0](https://github.com/DataDog/dd-trace-php/releases/tag/0.98.0) of the tracer for PHP7.2+.

This PR adds related documentation and important notes while trying to trace PHP applications on Windows.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->