### PR TITLE
[Hackathon Q1 2024] Improve Line Highlight Style for Code Blocks

### DIFF
--- a/assets/styles/vendor/_chroma-styles.scss
+++ b/assets/styles/vendor/_chroma-styles.scss
@@ -2,7 +2,7 @@
 /* Error */ .chroma .err { color: #000000 }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
-/* LineHighlight */ .chroma .hl { display: block; width: 100%; border-left: 4px solid #632ca6; background-color: #c987ff1d; }
+/* LineHighlight */ .chroma .hl { display: block; width: 100%; box-shadow: inset 4px 0 0 #632ca6; background-color: #c987ff1d; }
 /* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* Keyword */ .chroma .k { color: #a90d91 }

--- a/assets/styles/vendor/_chroma-styles.scss
+++ b/assets/styles/vendor/_chroma-styles.scss
@@ -2,7 +2,7 @@
 /* Error */ .chroma .err { color: #000000 }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
-/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
+/* LineHighlight */ .chroma .hl { display: block; width: 100%; border-left: 4px solid #632ca6; background-color: #c987ff1d; }
 /* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* Keyword */ .chroma .k { color: #a90d91 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The Docs team has been using the code highlight shortcode more and more often. This is really useful, but the default style looks out of place from our normal color scheme. This update tweaks the style look better and more consistent.

**Before**:
![image](https://github.com/DataDog/documentation/assets/84536271/282e2dbb-bfea-42c6-9b2c-c87bf7975fed)

**After**:
![image](https://github.com/DataDog/documentation/assets/84536271/3bef82c5-e1d9-4737-b345-7b6b38dc8008)

[Preview](https://docs-staging.datadoghq.com/brett0000FF/code-hl-style/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=kubernetes)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->