### PR TITLE
Data Jobs Monitoring - Add tags to EMR init script

### DIFF
--- a/static/resources/sh/data_jobs/datadog_emr_job_monitoring_init_v2.sh
+++ b/static/resources/sh/data_jobs/datadog_emr_job_monitoring_init_v2.sh
@@ -44,8 +44,10 @@ EOF
 
 # Adding tags
 echo "tags:" | sudo tee --append /etc/datadog-agent/datadog.yaml
+echo "  - \"init_script_version:1\"" | sudo tee --append /etc/datadog-agent/datadog.yaml
 echo "  - \"data_workload_monitoring_trial:true\"" | sudo tee --append /etc/datadog-agent/datadog.yaml
 echo "  - \"cluster_name:${CLUSTER_NAME}\"" | sudo tee --append /etc/datadog-agent/datadog.yaml
+echo "  - \"cluster_id:${JOB_FLOW_ID}\"" | sudo tee --append /etc/datadog-agent/datadog.yaml
 echo "  - \"job_flow_id:${JOB_FLOW_ID}\"" | sudo tee --append /etc/datadog-agent/datadog.yaml
 echo "  - \"is_master_node:${IS_MASTER}\"" | sudo tee --append /etc/datadog-agent/datadog.yaml
 echo "  - \"instance_group_id:${INSTANCE_GROUP_ID}\"" | sudo tee --append /etc/datadog-agent/datadog.yaml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adding the two tags:
- `init_script_version:1` to track which version of the script is used 
- `cluster_id` with the same value as `job_flow_id`, to have a unified tagging for cluster_id with other technologies

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->