### PR TITLE
Add Custom Pipelines in Left Hand Nav

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3150,6 +3150,11 @@ main:
     parent: pipeline_visibility
     identifier: ci_custom_tags_and_measures
     weight: 111
+  - name: Custom Pipelines
+    url: continuous_integration/pipelines/custom/
+    parent: pipeline_visibility
+    identifier: ci_custom
+    weight: 112
   - name: Search and Manage
     url: continuous_integration/search/
     parent: ci

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3150,7 +3150,7 @@ main:
     parent: pipeline_visibility
     identifier: ci_custom_tags_and_measures
     weight: 111
-  - name: Custom Pipelines
+  - name: Other Providers (Programmmatically)
     url: continuous_integration/pipelines/custom/
     parent: pipeline_visibility
     identifier: ci_custom

--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3150,7 +3150,7 @@ main:
     parent: pipeline_visibility
     identifier: ci_custom_tags_and_measures
     weight: 111
-  - name: Other Providers (Programmmatically)
+  - name: Custom Pipelines API
     url: continuous_integration/pipelines/custom/
     parent: pipeline_visibility
     identifier: ci_custom


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We have this list of [Setup pages](https://docs.datadoghq.com/continuous_integration/pipelines/?tab=githubactions#setup) on the Pipeline Visibility landing page, and we want to add the [Custom Pipelines child page](https://docs.datadoghq.com/continuous_integration/pipelines/custom/) in the left hand navigation. 

Requested by Will McMullen on Slack.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->