### PR TITLE
Note how method parameters are named in the expression language

### DIFF
--- a/content/en/dynamic_instrumentation/expression-language.md
+++ b/content/en/dynamic_instrumentation/expression-language.md
@@ -15,7 +15,7 @@ In log templates and tag values, expressions are delimited from the static parts
 Probe conditions must evaluate to a Boolean, for example: `startsWith(user.name, "abc")`, `len(str) > 20` or `a == b`.
 
 Generally, the Expression Language supports:
-* Accessing local variables, method parameters, and deeply nested fields and attributes within objects.
+* Accessing local variables, method parameters (`p0`, `p1`, etc.), and deeply nested fields and attributes within objects.
 * Using comparison operators (`<`, `>`, `>=`, `<=`, `==`, `!=`, `instanceof`) to compare variables, fields, and constants in your conditions, for example: `localVar1.field1.field2 != 15`.
 * Using logical operators (`&&`, `||`, and `not` or `!`) to build complex Boolean conditions.
 * Using the `null` literal (equivalent to `nil` in Python).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The documentation suggests that method parameters can be accessed, but does not state now this done in the expression langauage.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Please have some familiar with the expression language and/or implementation review this as _I have familiarity with neither_ . I only discovered method parameters appeared to be named by using "Capture method parameters and local variables" on a log probe.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->