### PR TITLE
Update values for max debug symbol file size

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/browser.md
+++ b/content/en/real_user_monitoring/error_tracking/browser.md
@@ -41,6 +41,15 @@ Error Tracking and RUM can use this information to correlate errors with your so
 
 For more information, see the [Datadog Source Code Integration][13].
 
+### Limitations
+
+{{< site-region region="us,us3,us5,eu,gov" >}}
+Source maps are limited to **500** MB each.
+{{< /site-region >}}
+{{< site-region region="ap1" >}}
+Source maps are limited to **500** MB each.
+{{< /site-region >}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/real_user_monitoring/error_tracking/mobile/android.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/android.md
@@ -157,12 +157,12 @@ For example:
 tasks["minify${variant}WithR8"].finalizedBy { tasks["uploadMapping${variant}"] }
 ```
 
-## Limitations
+### Limitations
 
-{{< site-region region="us,us3,us5,eu" >}}
-Mapping files are limited to **300** MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
+{{< site-region region="us,us3,us5,eu,gov" >}}
+Mapping files are limited to **500** MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
 {{< /site-region >}}
-{{< site-region region="ap1,gov" >}}
+{{< site-region region="ap1" >}}
 Mapping files are limited to **50** MB. If your project has a mapping file larger than this, use one of the following options to reduce the file size:
 {{< /site-region >}}
 

--- a/content/en/real_user_monitoring/error_tracking/mobile/expo.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/expo.md
@@ -110,7 +110,7 @@ You can disable some files from uploading by setting the `iosDsyms`, `iosSourcem
 }
 ```
 
-If you want to disable **all file uploads**, remove the `expo-datadog` from the list of plugins.
+If you want to disable **all file uploads**, remove `expo-datadog` from the list of plugins.
 
 
 ### Using with Sentry

--- a/content/en/real_user_monitoring/error_tracking/mobile/expo.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/expo.md
@@ -54,29 +54,6 @@ yarn add -D @datadog/datadog-ci
 
 Run `eas secret:create` to set `DATADOG_API_KEY` to your Datadog API key.
 
-### Disable file uploads
-
-You can disable some files from uploading by setting the `iosDsyms`, `iosSourcemaps`, `androidProguardMappingFiles`, or `androidSourcemaps` parameters to `false`.
-
-```json
-{
-    "expo": {
-        "plugins": [
-            [
-                "expo-datadog",
-                {
-                    "errorTracking": {
-                        "iosDsyms": false
-                    }
-                }
-            ]
-        ]
-    }
-}
-```
-
-If you want to disable **all file uploads**, remove the `expo-datadog` from the list of plugins.
-
 ### Add git repository data to your mapping files on Expo Application Services (EAS)
 
 If you are using EAS to build your Expo application, set `cli.requireCommit` to `true` in your `eas.json` file to add git repository data to your mapping files.
@@ -102,6 +79,39 @@ Run `eas secret:create` to set `DATADOG_SITE` to the host of your Datadog site, 
 | `androidSourcemaps`           | `true`  | Enables the uploading of JavaScript source maps on Android builds.                                                                 |
 | `androidProguardMappingFiles` | `true`  | Enables the uploading of Proguard mapping files to deobfuscate native Android crashes (is only applied if obfuscation is enabled). |
 | `datadogGradlePluginVersion`  | `"1.+"` | Version of `dd-sdk-android-gradle-plugin` used for uploading Proguard mapping files.     |
+
+### Limitations
+
+{{< site-region region="us,us3,us5,eu,gov" >}}
+Source maps, mapping files, and dSYM files are limited to **500** MB each.
+{{< /site-region >}}
+{{< site-region region="ap1" >}}
+Source maps, mapping files, and dSYM files  are limited to **500** MB each.
+{{< /site-region >}}
+
+### Disable file uploads
+
+You can disable some files from uploading by setting the `iosDsyms`, `iosSourcemaps`, `androidProguardMappingFiles`, or `androidSourcemaps` parameters to `false`.
+
+```json
+{
+    "expo": {
+        "plugins": [
+            [
+                "expo-datadog",
+                {
+                    "errorTracking": {
+                        "iosDsyms": false
+                    }
+                }
+            ]
+        ]
+    }
+}
+```
+
+If you want to disable **all file uploads**, remove the `expo-datadog` from the list of plugins.
+
 
 ### Using with Sentry
 

--- a/content/en/real_user_monitoring/error_tracking/mobile/flutter.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/flutter.md
@@ -49,7 +49,6 @@ DatadogSdk.instance.initialize(configuration);
 
 If your application suffers a fatal crash, after your application restarts, the Datadog Flutter SDK uploads a crash report to Datadog. For non-fatal errors, the Datadog Flutter SDK uploads these errors with other RUM data.
 
-
 ## Upload symbol files to Datadog
 
 Native iOS crash reports are collected in a raw format and mostly contain memory addresses. To map these addresses into legible symbol information, Datadog requires that you upload .dSYM files, which are generated in your application's build process.
@@ -79,6 +78,15 @@ datadog-ci flutter-symbols upload --service-name <your_service_name> --dart-symb
 **Note**: Re-uploading a source map does not override the existing one if the version has not changed.
 
 For a full list of options, see the `datadog-ci` [Flutter Symbols documentation][5].
+
+### Limitations
+
+{{< site-region region="us,us3,us5,eu,gov" >}}
+Source maps and dSYM files are limited to **500** MB each.
+{{< /site-region >}}
+{{< site-region region="ap1" >}}
+Source maps and dSYM files are limited to **500** MB each.
+{{< /site-region >}}
 
 ## Advanced Configuration - Flavors and Build Numbers
 

--- a/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -193,6 +193,15 @@ jobs:
 
 For more information, see [dSYMs commands][7].
 
+### Limitations
+
+{{< site-region region="us,us3,us5,eu,gov" >}}
+dSYM files are limited to **500** MB.
+{{< /site-region >}}
+{{< site-region region="ap1" >}}
+dSYM files are limited to **500** MB.
+{{< /site-region >}}
+
 ## Verify crash reports
 
 To verify your iOS Crash Reporting and Error Tracking configuration, issue a crash in your RUM application and confirm that the error appears in Datadog. 

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -107,7 +107,7 @@ payloadsize=$(($sourcemapsize + $bundlesize))
 echo "Size of source maps and bundle is $(($payloadsize / 1000000))MB"
 ```
 
-If a `build` directory does not already exist, create it first by running `mkdir build`. Then run the command above.
+If a `build` directory does not already exist, create it first by running `mkdir build`, then run the command above.
 
 ## Test your implementation of crash reporting
 

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -52,34 +52,6 @@ const config = new DdSdkReactNativeConfiguration(
 config.nativeCrashReportEnabled = true; // enable native crash reporting
 ```
 
-## Limitations
-
-{{< site-region region="us,us3,us5,eu" >}}
-Datadog can accept uploads up to **300** MB.
-{{< /site-region >}}
-{{< site-region region="ap1,gov" >}}
-Datadog can accept uploads up to **50** MB.
-{{< /site-region >}}
-
-To compute the size of your source maps and bundle, run the following command:
-
-```shell
-npx react-native bundle \
-  --dev false \
-  --platform ios \
-  --entry-file index.js \
-  --bundle-output build/main.jsbundle \
-  --sourcemap-output build/main.jsbundle.map
-
-sourcemapsize=$(wc -c build/main.jsbundle.map | awk '{print $1}')
-bundlesize=$(wc -c build/main.jsbundle | awk '{print $1}')
-payloadsize=$(($sourcemapsize + $bundlesize))
-
-echo "Size of source maps and bundle is $(($payloadsize / 1000000))MB"
-```
-
-If a `build` directory does not already exist, create it first by running `mkdir build`. Then run the command above.
-
 ## Symbolicate crash reports
 
 In order to make your application's size smaller, its code is minified when it is built for release. To link errors to your actual code, you need to upload the following symbolication files:
@@ -108,6 +80,34 @@ project.ext.datadog = [
 ### On iOS using the `datadog-ci react-native xcode` command
 
 Options for the `datadog-ci react-native xcode` command are available on the [command documentation page][12].
+
+### Limitations
+
+{{< site-region region="us,us3,us5,eu,gov" >}}
+Source maps, mapping files, and dSYM files are limited to **500** MB each.
+{{< /site-region >}}
+{{< site-region region="ap1" >}}
+Source maps, mapping files, and dSYM files are limited to **500** MB each.
+{{< /site-region >}}
+
+To compute the size of your source maps and bundle, run the following command:
+
+```shell
+npx react-native bundle \
+  --dev false \
+  --platform ios \
+  --entry-file index.js \
+  --bundle-output build/main.jsbundle \
+  --sourcemap-output build/main.jsbundle.map
+
+sourcemapsize=$(wc -c build/main.jsbundle.map | awk '{print $1}')
+bundlesize=$(wc -c build/main.jsbundle | awk '{print $1}')
+payloadsize=$(($sourcemapsize + $bundlesize))
+
+echo "Size of source maps and bundle is $(($payloadsize / 1000000))MB"
+```
+
+If a `build` directory does not already exist, create it first by running `mkdir build`. Then run the command above.
 
 ## Test your implementation of crash reporting
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We have bumped the limit of file size for source maps to 500 MB – on all DC but AP1 – with the PR [#55048](https://github.com/DataDog/datacenter-config/pull/55048) on the datacenter config and the PR [#65065](https://github.com/DataDog/logs-backend/pull/65065) on the Logs back-end to increase the timeout related to the upload step and accommodate larger files.

After a few weeks of testing and polishing, we are now confident in sharing this information with all customers.

This PR:
- Updates the RUM / Error Tracking pages for Browser and Mobile SDKs to display the correct limitations
- Add limitations on pages where it was missing
- Make the placement of this limitation consistent across pages

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->