### PR TITLE
asm: go: fix build notes placement

### DIFF
--- a/content/en/security/application_security/enabling/go.md
+++ b/content/en/security/application_security/enabling/go.md
@@ -44,19 +44,20 @@ You can monitor application security for Go apps running in Docker, Kubernetes, 
    $ go build -v -tags appsec my-program
    ```
 
+  **Notes**:
+  - The Go build tag `appsec` is not necessary if CGO is enabled with `CGO_ENABLED=1`.
+  - Datadog WAF needs the following shared libraries on Linux: `libc.so.6` and `libpthread.so.0`.
+  - When using the build tag `appsec` and CGO is disabled, the produced binary is still linked dynamically to these libraries.
+
 4. **Redeploy your Go service and enable ASM** by setting the `DD_APPSEC_ENABLED` environment variable to `true`:
    ```console
    $ env DD_APPSEC_ENABLED=true ./my-program
    ```
-   Or one of the following methods, depending on where your application runs:
 
-   {{< tabs >}}
+    Or one of the following methods, depending on where your application runs:
+
+    {{< tabs >}}
 {{% tab "Docker CLI" %}}
-
-**Note**:
-- The Go build tag `appsec` is not necessary if CGO is enabled with `CGO_ENABLED=1`.
-- Datadog WAF needs the following shared libraries on Linux: `libc.so.6` and `libpthread.so.0`.
-- When using the build tag `appsec` and CGO is disabled, the produced binary is still linked dynamically to these libraries.
 
 Add the following environment variable value to your Docker command line:
 

--- a/content/en/security/application_security/enabling/go.md
+++ b/content/en/security/application_security/enabling/go.md
@@ -44,19 +44,19 @@ You can monitor application security for Go apps running in Docker, Kubernetes, 
    $ go build -v -tags appsec my-program
    ```
 
-  **Notes**:
-  - The Go build tag `appsec` is not necessary if CGO is enabled with `CGO_ENABLED=1`.
-  - Datadog WAF needs the following shared libraries on Linux: `libc.so.6` and `libpthread.so.0`.
-  - When using the build tag `appsec` and CGO is disabled, the produced binary is still linked dynamically to these libraries.
+   **Notes**:
+   - The Go build tag `appsec` is not necessary if CGO is enabled with `CGO_ENABLED=1`.
+   - Datadog WAF needs the following shared libraries on Linux: `libc.so.6` and `libpthread.so.0`.
+   - When using the build tag `appsec` and CGO is disabled, the produced binary is still linked dynamically to these libraries.
 
 4. **Redeploy your Go service and enable ASM** by setting the `DD_APPSEC_ENABLED` environment variable to `true`:
    ```console
    $ env DD_APPSEC_ENABLED=true ./my-program
    ```
 
-    Or one of the following methods, depending on where your application runs:
+   Or one of the following methods, depending on where your application runs:
 
-    {{< tabs >}}
+   {{< tabs >}}
 {{% tab "Docker CLI" %}}
 
 Add the following environment variable value to your Docker command line:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Fix the placement of the notes I wrote in #22256 because I did not know what `{{< tabs >}}` meant

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->