### PR TITLE
[NDM] Add documentation for ping

### DIFF
--- a/content/en/network_monitoring/devices/snmp_metrics.md
+++ b/content/en/network_monitoring/devices/snmp_metrics.md
@@ -172,7 +172,9 @@ snmp_listener:
 {{% /tab %}}
 {{< /tabs >}}
 
-#### Ping
+**Note**: The Datadog Agent automatically configures the SNMP check with each of the IPs that are discovered. A discovered device is an IP that responds successfully when being polled using SNMP.
+
+### Ping
 
 When configured, the SNMP check can also send ICMP pings to your devices. This can be configured for individual as well as autodiscovered devices.
 
@@ -193,11 +195,11 @@ To set up ping with Network Device Monitoring:
 
 	```yaml
 	    init_config:
-	      loader: core  # use core check implementation of SNMP integration. recommended
-	      use_device_id_as_hostname: true  # recommended
+	      loader: core
+	      use_device_id_as_hostname: true
 	    instances:
 	    - ip_address: '1.2.3.4'
-	      community_string: 'sample-string'  # enclose with single quote
+	      community_string: 'sample-string'
 	      tags:
 	        - 'key1:val1'
 	        - 'key2:val2'
@@ -217,16 +219,16 @@ To set up ping with Network Device Monitoring:
 	listeners:
 	  - name: snmp
 	snmp_listener:
-	  workers: 100  # number of workers used to discover devices concurrently
-	  discovery_interval: 3600  # interval between each autodiscovery in seconds
-	  loader: core  # use core check implementation of SNMP integration. recommended
-	  use_device_id_as_hostname: true  # recommended
+	  workers: 100
+	  discovery_interval: 3600
+	  loader: core
+	  use_device_id_as_hostname: true
 	  configs:
-	    - network_address: 10.10.0.0/24  # CIDR subnet
+	    - network_address: 10.10.0.0/24
 	      loader: core
 	      snmp_version: 2
 	      port: 161
-	      community_string: '***'  # enclose with single quote
+	      community_string: '***'
 	      tags:
 	      - "key1:val1"
 	      - "key2:val2"
@@ -249,8 +251,6 @@ Edit `/etc/datadog-agent/system-probe.yaml` to set the enable flag to true.
 ping:
   enabled: true
 ```
-
-**Note**: The Datadog Agent automatically configures the SNMP check with each of the IPs that are discovered. A discovered device is an IP that responds successfully when being polled using SNMP.
 
 ## Validation
 

--- a/content/en/network_monitoring/devices/snmp_metrics.md
+++ b/content/en/network_monitoring/devices/snmp_metrics.md
@@ -94,7 +94,7 @@ To expand your setup:
 
 ### Autodiscovery
 
-An alternative to specifying individual devices is to use autodiscovery to automatically discover all the devices on your network.
+An alternative to specifying individual devices is to use Autodiscovery to automatically discover all the devices on your network.
 
 Autodiscovery polls each IP on the configured subnet, and checks for a response from the device. Then, the Datadog Agent looks up the `sysObjectID` of the discovered device and maps it to one of [Datadog's device profiles][6]. The profiles contain lists of predefined metrics to collect for various types of devices.
 
@@ -213,7 +213,7 @@ To set up ping with Network Device Monitoring:
 
 {{% tab "Autodiscovery" %}}
 
-- To apply ping settings to all autodiscovery subnets, create ping configuration under the `snmp_listener` section.
+- To apply ping settings to all Autodiscovery subnets, create ping configuration under the `snmp_listener` section.
 
 	```yaml
 	listeners:

--- a/content/en/network_monitoring/devices/snmp_metrics.md
+++ b/content/en/network_monitoring/devices/snmp_metrics.md
@@ -176,17 +176,17 @@ snmp_listener:
 
 ### Ping
 
-When configured, the SNMP check can also send ICMP pings to your devices. This can be configured for individual as well as autodiscovered devices.
+When configured, the SNMP check can also send ICMP pings to your devices. This can be configured for individual as well as Autodiscovered devices.
 
 To set up ping with Network Device Monitoring:
 
 1. Install or upgrade the Datadog Agent to v7.52+. For platform specific instructions, see the [Datadog Agent][7] documentation.
 
-2. Edit the `snmp.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3] for individual devices or the [`datadog.yaml`][8] Agent configuration file for autodiscovery. See the [sample snmp.d/conf.yaml][4] for all available configuration options.
+2. Edit the `snmp.d/conf.yaml` file in the `conf.d/` folder at the root of your [Agent's configuration directory][3] for individual devices or the [`datadog.yaml`][8] Agent configuration file for Autodiscovery. See the [sample snmp.d/conf.yaml][4] for all available configuration options.
 
-3. **Linux Only**: If you're receiving errors when running ping, you may need to configure the integration to send pings using a raw socket. This requires elevated privileges and is done using the agent's system-probe. See `linux.use_raw_socket` agent configuration and system-probe configuration below.
+3. **Linux Only**: If you're receiving errors when running ping, you may need to configure the integration to send pings using a raw socket. This requires elevated privileges and is done using the Agent's system-probe. See the `linux.use_raw_socket` Agent configuration and system-probe configuration below.
 
-**Note**: For autodiscovery, if the device does not respond to SNMP, we will not ping it.
+**Note**: For Autodiscovery, Datadog does not ping devices that do not respond to SNMP.
 
 {{< tabs >}}
 {{% tab "Individual" %}}
@@ -241,9 +241,9 @@ To set up ping with Network Device Monitoring:
 {{% /tab %}}
 {{< /tabs >}}
 
-##### Use Raw Sockets (Linux Only)
+##### Use raw sockets (Linux only)
 
-If you're on Linux and want to use raw sockets for ping, you must also enable ping in the system-probe configuration file in addition to the agent configuration above.
+If you're on Linux and want to use raw sockets for ping, you must also enable ping in the system-probe configuration file in addition to the Agent configuration above.
 
 Edit `/etc/datadog-agent/system-probe.yaml` to set the enable flag to true.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
As of agent 7.52, Network Device Monitoring exposes the ability to send ICMP pings to devices as part of the SNMP check. This PR adds documentation on how to configure this functionality inside the agent.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->