### PR TITLE
Update Specifying library versions section for k8s

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -262,9 +262,9 @@ To disable instrumentation for specific namespaces, add the `disabledNamespaces`
 
 ### Specifying tracing library versions
 
-<div class="alert alert-info">Injecting specific tracing libraries is only available for Datadog Cluster Agent version 7.52.0+.</div>
+<div class="alert alert-info">Starting with Datadog Cluster Agent v7.52.0+, you can inject a subset of tracing libraries into your applications.</div>
 
-Specify Datadog tracing library versions to control which versions and libraries are injected into your applications. You can configure this in two ways, which are applied in the following order of precedence:
+Specify Datadog tracing libraries and their versions to inject into your applications. You can configure this in two ways, which are applied in the following order of precedence:
 
 1. [Specify at the service level](#specifying-at-the-service-level), or
 2. [Specify at the cluster level](#specifying-at-the-cluster-level).
@@ -293,8 +293,6 @@ Replace <CONTAINER IMAGE TAG> with the desired library version. Available versio
 
 <div class="alert alert-warning">Exercise caution when using the <code>latest</code> tag, as major library releases may introduce breaking changes.</div>
 
-If an application is already instrumented using a different library version, the version loaded first takes precedence. Library injection happens at the admission controller level before runtime, so it overrides manually configured libraries.
-
 For example, to inject a Java library:
 
 {{< highlight yaml "hl_lines=12" >}}
@@ -315,6 +313,8 @@ spec:
         - # ...
 {{< /highlight >}}
 
+If an application is already instrumented using a different library version, the version loaded first takes precedence. Library injection happens at the admission controller level before runtime, so it overrides manually configured libraries.
+
 #### Specifying at the cluster level
 
 If you don't inject tracing libraries from the pod spec, you can specify tracing libraries for the entire cluster with Single Step Instrumentation configuration. When `apm.instrumentation.libVersions` is set, only the specified libraries and versions are injected.
@@ -328,7 +328,7 @@ For example, add the following configuration to your `datadog-values.yaml` file:
      apm:
        instrumentation:
          enabled: true
-         libVersions: # Add any versions you want to set
+         libVersions: # Add any libraries and versions you want to set
             dotnet: v2.46.0
             python: v1.20.6
             java: v1.22.0

--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -262,9 +262,11 @@ To disable instrumentation for specific namespaces, add the `disabledNamespaces`
 
 ### Specifying tracing library versions
 
-You can optionally set specific tracing libraries and versions to use. If you don't specify a library in `libVersions`, it isn't included.
+You can optionally set specific tracing libraries and versions to use. Only libraries specified in `libVersions` are included. However, if `apm.instrumentation.enabled=true` and you don't set anything in `apm.instrumentation.libVersions`, the latest version of all five libraries are included.
 
-For example, add the following configuration to your `datadog-values.yaml` file:
+**Note**: Injecting specific tracing libraries is only available for Datadog Cluster Agent version 7.52.0+.
+
+To specify libraries and versions, add the following configuration to your `datadog-values.yaml` file:
 {{< highlight yaml "hl_lines=7-12" >}}
    datadog:
      apiKeyExistingSecret: datadog-secret
@@ -280,7 +282,7 @@ For example, add the following configuration to your `datadog-values.yaml` file:
             ruby: v1.15.0
 {{< /highlight >}}
 
-Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see [Changing your container registry][30].
+You can also overwrite libraries and their versions for specific deployments using the annotation `admission.datadoghq.com/<language>-lib.version`.
 
 Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and Amazon ECR:
 
@@ -291,6 +293,8 @@ Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and Am
 | Python     | [gcr.io/datadoghq/dd-lib-python-init][21] | [hub.docker.com/r/datadog/dd-lib-python-init][22] | [gallery.ecr.aws/datadog/dd-lib-python-init][23] |
 | .NET       | [gcr.io/datadoghq/dd-lib-dotnet-init][24] | [hub.docker.com/r/datadog/dd-lib-dotnet-init][25] | [gallery.ecr.aws/datadog/dd-lib-dotnet-init][26] |
 | Ruby       | [gcr.io/datadoghq/dd-lib-ruby-init][27] | [hub.docker.com/r/datadog/dd-lib-ruby-init][28] | [gallery.ecr.aws/datadog/dd-lib-ruby-init][29] |
+
+Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see [Changing your container registry][30].
 
 The `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` environment variable in the Datadog Cluster Agent configuration specifies the registry used by the Admission Controller. The default value is `gcr.io/datadoghq`.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -280,8 +280,6 @@ For example, add the following configuration to your `datadog-values.yaml` file:
             ruby: v1.15.0
 {{< /highlight >}}
 
-If you include a library but don't specify its version, it defaults to the latest version.
-
 Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see [Changing your container registry][30].
 
 Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and Amazon ECR:

--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -262,9 +262,9 @@ To disable instrumentation for specific namespaces, add the `disabledNamespaces`
 
 ### Specifying tracing library versions
 
-You can optionally set specific tracing library versions to use. If you don't specify a version, it defaults to the latest version. To find the latest version for a library, go to **Releases** in the dd-trace-&lt;language&gt; GitHub repo. For example, [dd-trace-dotnet releases][15].
+You can optionally set specific tracing libraries and versions to use. If you don't specify a library in `libVersions`, it isn't included.
 
-To set specific tracing library versions, add the following configuration to your `datadog-values.yaml` file:
+For example, add the following configuration to your `datadog-values.yaml` file:
 {{< highlight yaml "hl_lines=7-12" >}}
    datadog:
      apiKeyExistingSecret: datadog-secret
@@ -280,13 +280,17 @@ To set specific tracing library versions, add the following configuration to you
             ruby: v1.15.0
 {{< /highlight >}}
 
-Supported languages include:
+If you include a library but don't specify its version, it defaults to the latest version. See the links in the following table to find the latest versions of Datadog tracing libraries on gcr.io, Docker Hub, and Amazon ECR:
 
-- .NET (`dotnet`)
-- Python (`python`)
-- Java (`java`)
-- Node.js (`js`)
-- Ruby (`ruby`)
+| Language   | gcr.io                              | hub.docker.com                              | gallery.ecr.aws                            |
+|------------|-------------------------------------|---------------------------------------------|-------------------------------------------|
+| Java       | [gcr.io/datadoghq/dd-lib-java-init][15]   | [hub.docker.com/r/datadog/dd-lib-java-init][16]   | [gallery.ecr.aws/datadog/dd-lib-java-init][17]   |
+| JavaScript | [gcr.io/datadoghq/dd-lib-js-init][18]     | [hub.docker.com/r/datadog/dd-lib-js-init][19]     | [gallery.ecr.aws/datadog/dd-lib-js-init][20]     |
+| Python     | [gcr.io/datadoghq/dd-lib-python-init][21] | [hub.docker.com/r/datadog/dd-lib-python-init][22] | [gallery.ecr.aws/datadog/dd-lib-python-init][23] |
+| .NET       | [gcr.io/datadoghq/dd-lib-dotnet-init][24] | [hub.docker.com/r/datadog/dd-lib-dotnet-init][25] | [gallery.ecr.aws/datadog/dd-lib-dotnet-init][26] |
+| Ruby       | [gcr.io/datadoghq/dd-lib-ruby-init][27] | [hub.docker.com/r/datadog/dd-lib-ruby-init][28] | [gallery.ecr.aws/datadog/dd-lib-ruby-init][29] |
+
+The `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` environment variable in the Datadog Cluster Agent configuration specifies the registry used by the Admission Controller. The default value is `gcr.io/datadoghq`.
 
 ### Tagging observability data by environment {#env-k8}
 
@@ -304,7 +308,22 @@ For example, add the following configuration to your `datadog-values.yaml` file:
          enabled: true
 {{< /highlight >}}
 
-[15]: https://github.com/DataDog/dd-trace-dotnet/releases
+[15]: http://gcr.io/datadoghq/dd-lib-java-init
+[16]: http://hub.docker.com/r/datadog/dd-lib-java-init
+[17]: http://gallery.ecr.aws/datadog/dd-lib-java-init
+[18]: http://gcr.io/datadoghq/dd-lib-js-init
+[19]: http://hub.docker.com/r/datadog/dd-lib-js-init
+[20]: http://gallery.ecr.aws/datadog/dd-lib-js-init
+[21]: http://gcr.io/datadoghq/dd-lib-python-init
+[22]: http://hub.docker.com/r/datadog/dd-lib-python-init
+[23]: http://gallery.ecr.aws/datadog/dd-lib-python-init
+[24]: http://gcr.io/datadoghq/dd-lib-dotnet-init
+[25]: http://hub.docker.com/r/datadog/dd-lib-dotnet-init
+[26]: http://gallery.ecr.aws/datadog/dd-lib-dotnet-init
+[27]: http://gcr.io/datadoghq/dd-lib-ruby-init
+[28]: http://hub.docker.com/r/datadog/dd-lib-ruby-init
+[29]: http://gallery.ecr.aws/datadog/dd-lib-ruby-init
+
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -269,7 +269,7 @@ Specify Datadog tracing libraries and their versions to inject into your applica
 1. [Specify at the service level](#specifying-at-the-service-level), or
 2. [Specify at the cluster level](#specifying-at-the-cluster-level).
 
-If you don't specify any library versions and `apm.instrumentation.enabled=true`, the latest version of all supported tracing libraries are injected.
+**Default**: If you don't specify any library versions and `apm.instrumentation.enabled=true`, the latest version of all supported tracing libraries are injected.
 
 #### Specifying at the service level
 
@@ -295,7 +295,7 @@ Replace <CONTAINER IMAGE TAG> with the desired library version. Available versio
 
 For example, to inject a Java library:
 
-{{< highlight yaml "hl_lines=12" >}}
+{{< highlight yaml "hl_lines=10" >}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -304,8 +304,6 @@ metadata:
 spec:
   template:
     metadata:
-      labels:
-        admission.datadoghq.com/enabled: "true"
       annotations:
         admission.datadoghq.com/java-lib.version: "<CONTAINER IMAGE TAG>"
     spec:
@@ -313,13 +311,11 @@ spec:
         - # ...
 {{< /highlight >}}
 
-If an application is already instrumented using a different library version, the version loaded first takes precedence. Library injection happens at the admission controller level before runtime, so it overrides manually configured libraries.
-
 #### Specifying at the cluster level
 
 If you don't inject tracing libraries from the pod spec, you can specify tracing libraries for the entire cluster with Single Step Instrumentation configuration. When `apm.instrumentation.libVersions` is set, only the specified libraries and versions are injected.
 
-For example, add the following configuration to your `datadog-values.yaml` file:
+For example, to instrument .NET, Python, and Javascript applications, add the following configuration to your `datadog-values.yaml` file:
 
 {{< highlight yaml "hl_lines=7-12" >}}
    datadog:
@@ -331,9 +327,7 @@ For example, add the following configuration to your `datadog-values.yaml` file:
          libVersions: # Add any libraries and versions you want to set
             dotnet: v2.46.0
             python: v1.20.6
-            java: v1.22.0
             js: v4.17.0
-            ruby: v1.15.0
 {{< /highlight >}}
 
 #### Container registries
@@ -348,9 +342,11 @@ Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and Am
 | .NET       | [gcr.io/datadoghq/dd-lib-dotnet-init][24] | [hub.docker.com/r/datadog/dd-lib-dotnet-init][25] | [gallery.ecr.aws/datadog/dd-lib-dotnet-init][26] |
 | Ruby       | [gcr.io/datadoghq/dd-lib-ruby-init][27] | [hub.docker.com/r/datadog/dd-lib-ruby-init][28] | [gallery.ecr.aws/datadog/dd-lib-ruby-init][29] |
 
-Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see [Changing your container registry][30].
-
 The `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_CONTAINER_REGISTRY` environment variable in the Datadog Cluster Agent configuration specifies the registry used by the Admission Controller. The default value is `gcr.io/datadoghq`.
+
+You can pull the tracing library from a different registry by changing it to `docker.io/datadog`, `public.ecr.aws/datadog`, or another URL if you are hosting the images in a local container registry.
+
+For instructions on changing your container registry, see [Changing Your Container Registry][30].
 
 ### Tagging observability data by environment {#env-k8}
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -280,7 +280,11 @@ For example, add the following configuration to your `datadog-values.yaml` file:
             ruby: v1.15.0
 {{< /highlight >}}
 
-If you include a library but don't specify its version, it defaults to the latest version. See the links in the following table to find the latest versions of Datadog tracing libraries on gcr.io, Docker Hub, and Amazon ECR:
+If you include a library but don't specify its version, it defaults to the latest version.
+
+Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see [Changing your container registry][30].
+
+Datadog publishes instrumentation libraries images on gcr.io, Docker Hub, and Amazon ECR:
 
 | Language   | gcr.io                              | hub.docker.com                              | gallery.ecr.aws                            |
 |------------|-------------------------------------|---------------------------------------------|-------------------------------------------|
@@ -323,6 +327,7 @@ For example, add the following configuration to your `datadog-values.yaml` file:
 [27]: http://gcr.io/datadoghq/dd-lib-ruby-init
 [28]: http://hub.docker.com/r/datadog/dd-lib-ruby-init
 [29]: http://gallery.ecr.aws/datadog/dd-lib-ruby-init
+[30]: /containers/guide/changing_container_registry/
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The latest Agent release changed behavior of `libVersions`.

Previously, all tracing libraries were injected, even if only one library was configured in `libVersions`. Now, only the libraries a user configures are injected.

Updated docs to reflect the new functionality. Additionally, moved container registry table from Injecting libraries locally so users can find the latest versions better.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after @vidurkhannadatadog approves

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->