### PR TITLE
Deprecating Oracle Python integration (DBMON-3776)

### DIFF
--- a/content/en/integrations/guide/_index.md
+++ b/content/en/integrations/guide/_index.md
@@ -69,7 +69,7 @@ cascade:
     {{< nextlink href="integrations/guide/jmx_integrations/" tag=" jmx" >}}Which integrations use Jmxfetch?{{< /nextlink >}}
 {{< /whatsnext >}}
 
-{{< whatsnext desc="SQL guides:" >}}
+{{< whatsnext desc="Database guides:" >}}
     {{< nextlink href="integrations/guide/collect-more-metrics-from-the-sql-server-integration" tag=" SQL Server" >}}Collect more metrics from the SQL Server integration{{< /nextlink >}}
     {{< nextlink href="integrations/guide/collect-sql-server-custom-metrics" tag=" SQL Server" >}}Collect SQL Server custom metrics{{< /nextlink >}}
     {{< nextlink href="integrations/guide/use-wmi-to-collect-more-sql-server-performance-metrics" tag=" SQL Server" >}}Use WMI to collect more SQL Server performance metrics{{< /nextlink >}}

--- a/content/en/integrations/guide/_index.md
+++ b/content/en/integrations/guide/_index.md
@@ -12,7 +12,7 @@ cascade:
 
 {{< whatsnext desc="General guides:" >}}
     {{< nextlink href="integrations/guide/requests" tag=" documentation" >}}Request Datadog integrations{{< /nextlink >}}
-    {{< nextlink href="/integrations/guide/reference-tables/" tag=" Documentation" >}}Add Custom Metadata with Reference Tables{{< /nextlink >}}   
+    {{< nextlink href="/integrations/guide/reference-tables/" tag=" Documentation" >}}Add Custom Metadata with Reference Tables{{< /nextlink >}}
     {{< nextlink href="integrations/guide/source-code-integration" tag=" Documentation" >}}Datadog Source Code Integration{{< /nextlink >}}
     {{< nextlink href="integrations/guide/cloud-metric-delay" tag=" cloud" >}}Cloud metric delay{{< /nextlink >}}
     {{< nextlink href="integrations/guide/add-event-log-files-to-the-win32-ntlogevent-wmi-class" tag=" Windows" >}}Add event log files to the `Win32_NTLogEvent` WMI class{{< /nextlink >}}
@@ -25,11 +25,11 @@ cascade:
     {{< nextlink href="integrations/guide/hcp-consul" tag=" Consul" >}}Monitoring HCP Consul with Datadog{{< /nextlink >}}
     {{< nextlink href="integrations/guide/agent-failed-to-retrieve-rmiserver-stub" tag=" kafka" >}}Agent failed to retrieve RMIServer stub{{< /nextlink >}}
     {{< nextlink href="integrations/guide/send-tcp-udp-host-metrics-to-the-datadog-api/" tag=" network" >}}Send TCP/UDP host metrics to the Datadog API{{< /nextlink >}}
-    {{< nextlink href="integrations/guide/snmp-commonly-used-compatible-oids/" tag=" snmp" >}}SNMP commonly used and compatible OIDs{{< /nextlink >}}    
-    {{< nextlink href="integrations/guide/versions-for-openmetrics-based-integrations" tag=" openmetrics" >}}Versioning for OpenMetrics-based integrations{{< /nextlink >}}     
-    {{< nextlink href="integrations/guide/cloud-foundry-setup" tag=" pivotal cloud foundry" >}}Pivotal Cloud Foundry manual setup{{< /nextlink >}}     
-    {{< nextlink href="integrations/guide/application-monitoring-vmware-tanzu" tag=" VMWare Tanzu" >}}Datadog Application Monitoring for VMware Tanzu{{< /nextlink >}} 
-    {{< nextlink href="integrations/guide/cluster-monitoring-vmware-tanzu" tag=" VMWare Tanzu" >}}Datadog Cluster Monitoring for VMware Tanzu{{< /nextlink >}} 
+    {{< nextlink href="integrations/guide/snmp-commonly-used-compatible-oids/" tag=" snmp" >}}SNMP commonly used and compatible OIDs{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/versions-for-openmetrics-based-integrations" tag=" openmetrics" >}}Versioning for OpenMetrics-based integrations{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/cloud-foundry-setup" tag=" pivotal cloud foundry" >}}Pivotal Cloud Foundry manual setup{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/application-monitoring-vmware-tanzu" tag=" VMWare Tanzu" >}}Datadog Application Monitoring for VMware Tanzu{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/cluster-monitoring-vmware-tanzu" tag=" VMWare Tanzu" >}}Datadog Cluster Monitoring for VMware Tanzu{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="AWS guides:" >}}
@@ -75,5 +75,6 @@ cascade:
     {{< nextlink href="integrations/guide/use-wmi-to-collect-more-sql-server-performance-metrics" tag=" SQL Server" >}}Use WMI to collect more SQL Server performance metrics{{< /nextlink >}}
     {{< nextlink href="integrations/guide/connection-issues-with-the-sql-server-integration" tag=" SQL Server" >}}Connection issues with the SQL Server integration{{< /nextlink >}}
     {{< nextlink href="integrations/guide/mysql-custom-queries" tag=" MySQL" >}}MySQL custom queries{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/deprecated-oracle-integration" tag=" Oracle" >}}Configuring Oracle integration on the Agent versions lower than 7.53{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/integrations/guide/_index.md
+++ b/content/en/integrations/guide/_index.md
@@ -75,6 +75,6 @@ cascade:
     {{< nextlink href="integrations/guide/use-wmi-to-collect-more-sql-server-performance-metrics" tag=" SQL Server" >}}Use WMI to collect more SQL Server performance metrics{{< /nextlink >}}
     {{< nextlink href="integrations/guide/connection-issues-with-the-sql-server-integration" tag=" SQL Server" >}}Connection issues with the SQL Server integration{{< /nextlink >}}
     {{< nextlink href="integrations/guide/mysql-custom-queries" tag=" MySQL" >}}MySQL custom queries{{< /nextlink >}}
-    {{< nextlink href="integrations/guide/deprecated-oracle-integration" tag=" Oracle" >}}Configuring Oracle integration on the Agent versions lower than 7.53{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/deprecated-oracle-integration" tag=" Oracle" >}}Configuring Oracle integration on the Agent versions lower than 7.50.1{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/integrations/guide/deprecated-oracle-integration.md
+++ b/content/en/integrations/guide/deprecated-oracle-integration.md
@@ -1,0 +1,534 @@
+---
+title: Configuring Oracle integration on the Agent versions lower than 7.50.1
+kind: guide
+aliases:
+  - integrations/guide/deprecated-oracle-integration
+---
+
+# Oracle Integration
+
+![Oracle Dashboard][1]
+
+## Overview
+
+The Oracle integration provides health and performance metrics for your Oracle database in near real-time. Visualize these metrics with the provided [dashboard][21] and create monitors to alert your team on Oracle states.
+
+Enable [Database Monitoring][22] (DBM) for enhanced insights into query performance and database health. In addition to the standard integration, Datadog DBM provides query-level metrics, live and historical query snapshots, wait event analysis, database load, query explain plans, and blocking query insights.
+
+## Setup
+
+### Installation
+
+#### Prerequisite
+
+To use the Oracle integration you can either use the native client (no additional install steps required), or the Oracle Instant Client.
+
+##### Oracle Instant Client
+
+<!-- xxx tabs xxx -->
+
+<!-- xxx tab "Linux" xxx -->
+###### Linux
+
+1. Follow the [Oracle Instant Client installation for Linux][17].
+
+2. Verify the following:
+    - Both the *Instant Client Basic* and *SDK* packages are installed. Find them on Oracle's [download page][18].
+
+        After the Instant Client libraries are installed, ensure the runtime linker can find the libraries. For example, using `ldconfig`:
+
+       ```shell
+       # Put the library location in an ld configuration file.
+
+       sudo sh -c "echo /usr/lib/oracle/12.2/client64/lib > \
+           /etc/ld.so.conf.d/oracle-instantclient.conf"
+
+       # Update the bindings.
+
+       sudo ldconfig
+       ```
+
+    - Both packages are decompressed into a single directory that is available to all users on the given machine (for example, `/opt/oracle`):
+       ```shell
+       mkdir -p /opt/oracle/ && cd /opt/oracle/
+       unzip /opt/oracle/instantclient-basic-linux.x64-12.1.0.2.0.zip
+       unzip /opt/oracle/instantclient-sdk-linux.x64-12.1.0.2.0.zip
+       ```
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "Windows" xxx -->
+###### Windows
+
+1. Follow the [Oracle Windows installation guide][19] to configure your Oracle Instant Client.
+
+2. Verify the following:
+    - The [Microsoft Visual Studio 2017 Redistributable][20] or the appropriate version is installed for the Oracle Instant Client.
+
+    - Both the *Instant Client Basic* and *SDK* packages from Oracle's [download page][18] are installed.
+
+    - Both packages are extracted into a single directory that is available to all users on the given machine (for example, `C:\oracle`).
+
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
+
+##### JDBC driver
+
+*NOTE*: This method only works on Linux.
+
+Java 8 or higher is required on your system for JPype, one of the libraries used by the Agent when using JDBC driver.
+
+Once it is installed, complete the following steps:
+
+1. [Download the JDBC Driver][4] JAR file.
+2. Add the path to the downloaded file in your `$CLASSPATH` or the check configuration file under `jdbc_driver_path` (see the [sample oracle.yaml][5]).
+
+#### Datadog user creation
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Stand Alone" xxx -->
+
+Create a read-only `datadog` user with proper access to your Oracle Database Server. Connect to your Oracle database with an administrative user, such as `SYSDBA` or `SYSOPER`, and run:
+
+```text
+-- Enable Oracle Script.
+ALTER SESSION SET "_ORACLE_SCRIPT"=true;
+
+-- Create the datadog user. Replace the password placeholder with a secure password.
+CREATE USER datadog IDENTIFIED BY <PASSWORD>;
+
+-- Grant access to the datadog user.
+GRANT CONNECT TO datadog;
+GRANT SELECT ON GV_$PROCESS TO datadog;
+GRANT SELECT ON gv_$sysmetric TO datadog;
+GRANT SELECT ON sys.dba_data_files TO datadog;
+GRANT SELECT ON sys.dba_tablespaces TO datadog;
+GRANT SELECT ON sys.dba_tablespace_usage_metrics TO datadog;
+```
+
+**Note**: If you're using Oracle 11g, there's no need to run the following line:
+
+```text
+ALTER SESSION SET "_ORACLE_SCRIPT"=true;
+```
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "Multitenant" xxx -->
+
+##### Oracle 12c or 19c
+
+Log in to the root database as an Administrator to create a `datadog` user and grant permissions:
+
+```text
+alter session set container = cdb$root;
+CREATE USER c##datadog IDENTIFIED BY password CONTAINER=ALL;
+GRANT CREATE SESSION TO c##datadog CONTAINER=ALL;
+Grant select any dictionary to c##datadog container=all;
+GRANT SELECT ON GV_$PROCESS TO c##datadog CONTAINER=ALL;
+GRANT SELECT ON gv_$sysmetric TO c##datadog CONTAINER=ALL;
+```
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
+
+### Configuration
+
+<!-- xxx tabs xxx -->
+<!-- xxx tab "Host" xxx -->
+
+#### Host
+
+To configure this check for an Agent running on a host:
+
+1. Edit the `oracle.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6]. Update the `server` and `port` to set the masters to monitor. See the [sample oracle.d/conf.yaml][5] for all available configuration options.
+
+   ```yaml
+   init_config:
+
+   instances:
+      ## @param server - string - required
+      ## The IP address or hostname of the Oracle Database Server.
+      #
+      - server: localhost:1521
+
+        ## @param service_name - string - required
+        ## The Oracle Database service name. To view the services available on your server,
+        ## run the following query: `SELECT value FROM v$parameter WHERE name='service_names'`
+        #
+        service_name: <SERVICE_NAME>
+
+        ## @param username - string - required
+        ## The username for the Datadog user account.
+        #
+        username: <USERNAME>
+
+        ## @param password - string - required
+        ## The password for the Datadog user account.
+        #
+        password: <PASSWORD>
+   ```
+
+2. [Restart the Agent][7].
+
+
+#### Only custom queries
+
+To skip default metric checks for an instance and only run custom queries with an existing metrics gathering user, insert the tag `only_custom_queries` with a value of `true`. This allows a configured instance of the Oracle integration to skip the system, process, and tablespace metrics from running, and allows custom queries to be run without having the permissions described in the [Datadog user creation](#datadog-user-creation) section. If this configuration entry is omitted, the user you specify is required to have those table permissions to run a custom query.
+
+```yaml
+init_config:
+
+instances:
+  ## @param server - string - required
+  ## The IP address or hostname of the Oracle Database Server.
+  #
+  - server: localhost:1521
+
+    ## @param service_name - string - required
+    ## The Oracle Database service name. To view the services available on your server,
+    ## run the following query:
+    ## `SELECT value FROM v$parameter WHERE name='service_names'`
+    #
+    service_name: "<SERVICE_NAME>"
+
+    ## @param username - string - required
+    ## The username for the user account.
+    #
+    username: <USER>
+
+    ## @param password - string - required
+    ## The password for the user account.
+    #
+    password: "<PASSWORD>"
+
+    ## @param only_custom_queries - string - optional
+    ## Set this parameter to any value if you want to only run custom
+    ## queries for this instance.
+    #
+    only_custom_queries: true
+```
+
+#### Connect to Oracle through TCPS
+
+1. To connect to Oracle through TCPS (TCP with SSL), uncomment the `protocol` configuration option and select `TCPS`. Update the `server` option to set the TCPS server to monitor.
+
+    ```yaml
+    init_config:
+
+    instances:
+      ## @param server - string - required
+      ## The IP address or hostname of the Oracle Database Server.
+      #
+      - server: localhost:1522
+
+        ## @param service_name - string - required
+        ## The Oracle Database service name. To view the services available on your server,
+        ## run the following query:
+        ## `SELECT value FROM v$parameter WHERE name='service_names'`
+        #
+        service_name: "<SERVICE_NAME>"
+
+        ## @param username - string - required
+        ## The username for the user account.
+        #
+        username: <USER>
+
+        ## @param password - string - required
+        ## The password for the user account.
+        #
+        password: "<PASSWORD>"
+
+        ## @param protocol - string - optional - default: TCP
+        ## The protocol to connect to the Oracle Database Server. Valid protocols include TCP and TCPS.
+        ##
+        ## When connecting to Oracle Database via JDBC, `jdbc_truststore` and `jdbc_truststore_type` are required.
+        ## More information can be found from Oracle Database's whitepaper:
+        ##
+        ## https://www.oracle.com/technetwork/topics/wp-oracle-jdbc-thin-ssl-130128.pdf
+        #
+        protocol: TCPS
+    ```
+
+2. Update the `sqlnet.ora`, `listener.ora`, and `tnsnames.ora` to allow TCPS connections on your Oracle Database.
+
+##### TCPS through Oracle without JDBC
+
+If you are not using JDBC, verify that the Datadog Agent is able to connect to your database. Use the `sqlplus` command line tool with the information inputted in your configuration options:
+
+```shell
+sqlplus <USER>/<PASSWORD>@(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCPS)(HOST=<HOST>)(PORT=<PORT>))(SERVICE_NAME=<SERVICE_NAME>)))
+```
+
+When using the [Oracle Instant Client][16] connection, move three files to the `network/admin` directory of the client libraries used by your application:
+  * `tnsnames.ora`: Maps net service names used for application connection strings to your database services.
+  * `sqlnet.ora`: Configures Oracle Network settings.
+  * `cwallet.sso`: Enables SSL or TLS connections. Keep this file secure.
+
+##### TCPS through JDBC
+
+If you are connecting to Oracle Database using JDBC, you also need to specify `jdbc_truststore_path`, `jdbc_truststore_type`, and `jdbc_truststore_password` (optional) if there is a password on the truststore.
+
+**Note**: `SSO` truststores don't require passwords.
+
+```yaml
+    # In the `instances:` section
+    ...
+
+    ## @param jdbc_truststore_path - string - optional
+    ## The JDBC truststore file path.
+    #
+    jdbc_truststore_path: /path/to/truststore
+
+    ## @param jdbc_truststore_type - string - optional
+    ## The JDBC truststore file type. Supported truststore types include JKS, SSO, and PKCS12.
+    #
+    jdbc_truststore_type: SSO
+
+    ## @param jdbc_truststore_password - string - optional
+    ## The password for the truststore when connecting via JDBC.
+    #
+    # jdbc_truststore_password: <JDBC_TRUSTSTORE_PASSWORD>
+```
+
+For more information about connecting to the Oracle Database through TCPS on JDBC, see the official [Oracle whitepaper][15].
+
+<!-- xxz tab xxx -->
+<!-- xxx tab "Containerized" xxx -->
+
+#### Containerized
+
+For containerized environments, see the [Autodiscovery Integration Templates][8] for guidance on applying the parameters below.
+
+| Parameter            | Value                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------- |
+| `<INTEGRATION_NAME>` | `oracle`                                                                                                  |
+| `<INIT_CONFIG>`      | blank or `{}`                                                                                             |
+| `<INSTANCE_CONFIG>`  | `{"server": "%%host%%:1521", "service_name":"<SERVICE_NAME>", "username":"datadog", "password":"<PASSWORD>"}` |
+
+
+<!-- xxz tab xxx -->
+<!-- xxz tabs xxx -->
+
+### Validation
+
+[Run the Agent's status subcommand][9] and look for `oracle` under the Checks section.
+
+## Custom query
+
+Providing custom queries is also supported. Each query must have two parameters:
+
+| Parameter       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `query`         | This is the SQL to execute. It can be a simple statement or a multi-line script. All rows of the result are evaluated.                                                                                                                                                                                                                                                                                                                        |
+| `columns`       | This is a list representing each column, ordered sequentially from left to right. There are two required pieces of data: <br> a. `type` - This is the submission method (`gauge`, `count`, etc.). <br> b. name - This is the suffix used to form the full metric name. If `type` is `tag`, this column is instead considered as a tag which is applied to every metric collected by this particular query. |
+
+Optionally use the `tags` parameter to apply a list of tags to each metric collected.
+
+The following:
+
+```python
+self.gauge('oracle.custom_query.metric1', value, tags=['tester:oracle', 'tag1:value'])
+self.count('oracle.custom_query.metric2', value, tags=['tester:oracle', 'tag1:value'])
+```
+
+is what the following example configuration would become:
+
+```yaml
+- query: | # Use the pipe if you require a multi-line script.
+    SELECT columns
+    FROM tester.test_table
+    WHERE conditions
+  columns:
+    # Put this for any column you wish to skip:
+    - {}
+    - name: metric1
+      type: gauge
+    - name: tag1
+      type: tag
+    - name: metric2
+      type: count
+  tags:
+    - tester:oracle
+```
+
+See the [sample oracle.d/conf.yaml][5] for all available configuration options.
+
+### Example
+
+Create a query configuration to help identify database locks:
+
+1. To include a custom query, modify `conf.d\oracle.d\conf.yaml`. Uncomment the `custom_queries` block, add the required queries and columns, and restart the Agent.
+
+```yaml
+  init_config:
+  instances:
+      - server: localhost:1521
+        service_name: orcl11g.us.oracle.com
+        username: datadog
+        password: xxxxxxx
+        jdbc_driver_path: /u01/app/oracle/product/11.2/dbhome_1/jdbc/lib/ojdbc6.jar
+        tags:
+          - db:oracle
+        custom_queries:
+          - query: |
+              select blocking_session, username, osuser, sid, serial# as serial, wait_class, seconds_in_wait
+              from v_$session
+              where blocking_session is not NULL order by blocking_session
+            columns:
+              - name: blocking_session
+                type: gauge
+              - name: username
+                type: tag
+              - name: osuser
+                type: tag
+              - name: sid
+                type: tag
+              - name: serial
+                type: tag
+              - name: wait_class
+                type: tag
+              - name: seconds_in_wait
+                type: tag
+```
+
+2. To access `v_$session`, give permission to `DATADOG` and test the permissions.
+
+```text
+SQL> grant select on sys.v_$session to datadog;
+
+##connecting with the DD user to validate the access:
+
+
+SQL> show user
+USER is "DATADOG"
+
+
+##creating a synonym to make the view visible
+SQL> create synonym datadog.v_$session for sys.v_$session;
+
+
+Synonym created.
+
+
+SQL> select blocking_session,username,osuser, sid, serial#, wait_class, seconds_in_wait from v_$session
+where blocking_session is not NULL order by blocking_session;
+```
+
+3. Once configured, you can create a [monitor][10] based on `oracle.custom_query.locks` metrics.
+
+## Data Collected
+
+### Metrics
+
+See [metadata.csv][11] for a list of metrics provided by this integration.
+
+### Events
+
+The Oracle Database check does not include any events.
+
+### Service Checks
+
+See [service_checks.json][12] for a list of service checks provided by this integration.
+
+## Troubleshooting
+
+### Common problems
+
+#### Oracle Native Client
+- If you encounter a `DPY-6000: cannot connect to database`:
+  ```text
+  Failed to connect to Oracle DB, error: DPY-6000: cannot connect to database. Listener refused connection. (Similar to ORA-12660)
+  ```
+ - Ensure Native Network Encryption or Checksumming are not enabled. If they are enabled, you must use the Instant Client method by setting `use_instant_client: true`.
+
+For more information about setting up the Oracle Instant Client, see the [Oracle integration documentation][3].
+
+#### Oracle Instant Client
+- Verify that both the Oracle Instant Client and SDK files are located in the same directory.
+The structure of the directory should look similar:
+  ```text
+  |___ BASIC_LITE_LICENSE
+  |___ BASIC_LITE_README
+  |___ adrci
+  |___ genezi
+  |___ libclntsh.so -> libclntsh.so.19.1
+  |___ libclntsh.so.10.1 -> libclntsh.so.19.1
+  |___ libclntsh.so.11.1 -> libclntsh.so.19.1
+  |___ libclntsh.so.12.1 -> libclntsh.so.19.1
+  |___ libclntsh.so.18.1 -> libclntsh.so.19.1
+  |___ libclntsh.so.19.1
+  |___ libclntshcore.so.19.1
+  |___ libipc1.so
+  |___ libmql1.so
+  |___ libnnz19.so
+  |___ libocci.so -> libocci.so.19.1
+  |___ libocci.so.10.1 -> libocci.so.19.1
+  |___ libocci.so.11.1 -> libocci.so.19.1
+  |___ libocci.so.12.1 -> libocci.so.19.1
+  |___ libocci.so.18.1 -> libocci.so.19.1
+  |___ libocci.so.19.1
+  |___ libociicus.so
+  |___ libocijdbc19.so
+  |___ liboramysql19.so
+  |___ listener.ora
+  |___ network
+  |   `___ admin
+  |       |___ README
+  |       |___ cwallet.sso
+  |       |___ sqlnet.ora
+  |       `___ tnsnames.ora
+  |___ ojdbc8.jar
+  |___ ucp.jar
+  |___ uidrvci
+  `___ xstreams.jar
+  ```
+
+#### JDBC driver (Linux only)
+- If you encounter a `JVMNotFoundException`:
+
+    ```text
+    JVMNotFoundException("No JVM shared library file ({jpype._jvmfinder.JVMNotFoundException: No JVM shared library file (libjvm.so) found. Try setting up the JAVA_HOME environment variable properly.})"
+    ```
+
+    - Ensure that the `JAVA_HOME` environment variable is set and pointing to the correct directory.
+    - Add the environment variable to `/etc/environment`:
+        ```text
+        JAVA_HOME=/path/to/java
+        ```
+    - Then restart the Agent.
+
+- If you encounter this error `Unsupported major.minor version 52.0` it means that you're running a Java version that
+is too old. You need to either update your system Java or additionally install a newer version and point your `JAVA_HOME`
+variable to the new install as explained above.
+
+- Verify your environment variables are set correctly by running the following command from the Agent.
+Ensure the displayed output matches the correct value.
+
+    ```shell script
+      sudo -u dd-agent -- /opt/datadog-agent/embedded/bin/python -c "import os; print(\"JAVA_HOME:{}\".format(os.environ.get(\"JAVA_HOME\")))"
+    ```
+
+Need help? Contact [Datadog support][14].
+
+[1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/oracle/images/oracle_dashboard.png
+[2]: https://oracle.github.io/python-oracledb/
+[3]: https://github.com/DataDog/integrations-core/tree/7.41.x/oracle#oracle-instant-client
+[4]: https://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html
+[5]: https://github.com/DataDog/integrations-core/blob/master/oracle/datadog_checks/oracle/data/conf.yaml.example
+[6]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
+[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[8]: https://docs.datadoghq.com/agent/kubernetes/integrations/
+[9]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
+[10]: https://docs.datadoghq.com/monitors/monitor_types/metric/?tab=threshold
+[11]: https://github.com/DataDog/integrations-core/blob/master/oracle/metadata.csv
+[12]: https://github.com/DataDog/integrations-core/blob/master/oracle/assets/service_checks.json
+[13]: https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html
+[14]: https://docs.datadoghq.com/help/
+[15]: https://www.oracle.com/technetwork/topics/wp-oracle-jdbc-thin-ssl-130128.pdf
+[16]: https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#install-the-wallet-and-network-configuration-files
+[17]: https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html
+[18]: https://www.oracle.com/technetwork/database/features/instant-client/index.htm
+[19]: https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html#ic_winx64_inst
+[20]: https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0
+[21]: https://app.datadoghq.com/dash/integration/30990/
+[22]: https://docs.datadoghq.com/database_monitoring/

--- a/content/en/integrations/guide/deprecated-oracle-integration.md
+++ b/content/en/integrations/guide/deprecated-oracle-integration.md
@@ -5,8 +5,6 @@ kind: guide
 
 # Oracle Integration
 
-![Oracle Dashboard][1]
-
 ## Overview
 
 This guide describes setting up the Oracle integration on versions of the Datadog Agent lower than 7.50.1. For more information on the Oracle integration, including setting it up on newer Agent versions, see the [Oracle integration documentation][1].
@@ -506,7 +504,7 @@ Ensure the displayed output matches the correct value.
 
 Need help? Contact [Datadog support][14].
 
-[1]: https://raw.githubusercontent.com/DataDog/integrations-core/master/oracle/images/oracle_dashboard.png
+[1]: https://docs.datadoghq.com/integrations/oracle/?tab=linux
 [2]: https://oracle.github.io/python-oracledb/
 [3]: https://github.com/DataDog/integrations-core/tree/7.41.x/oracle#oracle-instant-client
 [4]: https://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html

--- a/content/en/integrations/guide/deprecated-oracle-integration.md
+++ b/content/en/integrations/guide/deprecated-oracle-integration.md
@@ -1,8 +1,6 @@
 ---
 title: Configuring the Oracle integration on Agent versions lower than 7.50.1
 kind: guide
-aliases:
-  - integrations/guide/deprecated-oracle-integration
 ---
 
 # Oracle Integration

--- a/content/en/integrations/guide/deprecated-oracle-integration.md
+++ b/content/en/integrations/guide/deprecated-oracle-integration.md
@@ -1,9 +1,7 @@
 ---
-title: Configuring the Oracle integration on Agent versions lower than 7.50.1
+title: Configuring the Oracle Integration on Agent Versions Lower than 7.50.1
 kind: guide
 ---
-
-# Oracle Integration
 
 ## Overview
 
@@ -19,15 +17,12 @@ To use the Oracle integration you can either use the native client (no additiona
 
 ##### Oracle Instant Client
 
-<!-- xxx tabs xxx -->
-
-<!-- xxx tab "Linux" xxx -->
-###### Linux
-
-1. Follow the [Oracle Instant Client installation for Linux][17].
+{{< tabs >}}
+{{% tab "Linux" %}}
+1. Follow the [Oracle Instant Client installation for Linux][1].
 
 2. Verify the following:
-    - Both the *Instant Client Basic* and *SDK* packages are installed. Find them on Oracle's [download page][18].
+    - Both the *Instant Client Basic* and *SDK* packages are installed. Find them on Oracle's [download page][2].
 
         After the Instant Client libraries are installed, ensure the runtime linker can find the libraries. For example, using `ldconfig`:
 
@@ -49,22 +44,24 @@ To use the Oracle integration you can either use the native client (no additiona
        unzip /opt/oracle/instantclient-sdk-linux.x64-12.1.0.2.0.zip
        ```
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "Windows" xxx -->
-###### Windows
+[1]: https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html
+[2]: https://www.oracle.com/technetwork/database/features/instant-client/index.htm
+{{% /tab %}}
 
-1. Follow the [Oracle Windows installation guide][19] to configure your Oracle Instant Client.
+{{% tab "Windows" %}}
+1. Follow the [Oracle Windows installation guide][1] to configure your Oracle Instant Client.
 
 2. Verify the following:
-    - The [Microsoft Visual Studio 2017 Redistributable][20] or the appropriate version is installed for the Oracle Instant Client.
+    - The [Microsoft Visual Studio 2017 Redistributable][2] or the appropriate version is installed for the Oracle Instant Client.
 
     - Both the *Instant Client Basic* and *SDK* packages from Oracle's [download page][18] are installed.
 
     - Both packages are extracted into a single directory that is available to all users on the given machine (for example, `C:\oracle`).
 
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
+[1]: https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html#ic_winx64_inst
+[2]: https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0
+{{% /tab %}}
+{{< /tabs >}}
 
 ##### JDBC driver
 
@@ -79,9 +76,8 @@ Once it is installed, complete the following steps:
 
 #### Datadog user creation
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Stand Alone" xxx -->
-
+{{< tabs >}}
+{{% tab "Standalone" %}}
 Create a read-only `datadog` user with proper access to your Oracle Database Server. Connect to your Oracle database with an administrative user, such as `SYSDBA` or `SYSOPER`, and run:
 
 ```text
@@ -105,10 +101,9 @@ GRANT SELECT ON sys.dba_tablespace_usage_metrics TO datadog;
 ```text
 ALTER SESSION SET "_ORACLE_SCRIPT"=true;
 ```
+{{% /tab %}}
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "Multitenant" xxx -->
-
+{{% tab "Multi-tenant" %}}
 ##### Oracle 12c or 19c
 
 Log in to the root database as an Administrator to create a `datadog` user and grant permissions:
@@ -121,20 +116,16 @@ Grant select any dictionary to c##datadog container=all;
 GRANT SELECT ON GV_$PROCESS TO c##datadog CONTAINER=ALL;
 GRANT SELECT ON gv_$sysmetric TO c##datadog CONTAINER=ALL;
 ```
-
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Configuration
 
-<!-- xxx tabs xxx -->
-<!-- xxx tab "Host" xxx -->
-
-#### Host
-
+{{< tabs >}}
+{{% tab "Host" %}}
 To configure this check for an Agent running on a host:
 
-1. Edit the `oracle.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][6]. Update the `server` and `port` to set the masters to monitor. See the [sample oracle.d/conf.yaml][5] for all available configuration options.
+1. Edit the `oracle.d/conf.yaml` file, in the `conf.d/` folder at the root of your [Agent's configuration directory][2]. Update the `server` and `port` to set the masters to monitor. See the [sample oracle.d/conf.yaml][1] for all available configuration options.
 
    ```yaml
    init_config:
@@ -162,12 +153,12 @@ To configure this check for an Agent running on a host:
         password: <PASSWORD>
    ```
 
-2. [Restart the Agent][7].
+2. [Restart the Agent][3].
 
 
 #### Only custom queries
 
-To skip default metric checks for an instance and only run custom queries with an existing metrics gathering user, insert the tag `only_custom_queries` with a value of `true`. This allows a configured instance of the Oracle integration to skip the system, process, and tablespace metrics from running, and allows custom queries to be run without having the permissions described in the [Datadog user creation](#datadog-user-creation) section. If this configuration entry is omitted, the user you specify is required to have those table permissions to run a custom query.
+To skip default metric checks for an instance and only run custom queries with an existing metrics-gathering user, insert the tag `only_custom_queries` with a value of `true`. This allows a configured instance of the Oracle integration to prevent the system, process, and tablespace metrics from running, and allows custom queries to be run without having the permissions described in the [Datadog user creation](#datadog-user-creation) section. If this configuration entry is omitted, the user you specify must have those table permissions to run a custom query.
 
 ```yaml
 init_config:
@@ -253,7 +244,7 @@ If you are not using JDBC, verify that the Datadog Agent is able to connect to y
 sqlplus <USER>/<PASSWORD>@(DESCRIPTION=(ADDRESS_LIST=(ADDRESS=(PROTOCOL=TCPS)(HOST=<HOST>)(PORT=<PORT>))(SERVICE_NAME=<SERVICE_NAME>)))
 ```
 
-When using the [Oracle Instant Client][16] connection, move three files to the `network/admin` directory of the client libraries used by your application:
+When using the [Oracle Instant Client][5] connection, move three files to the `network/admin` directory of the client libraries used by your application:
   * `tnsnames.ora`: Maps net service names used for application connection strings to your database services.
   * `sqlnet.ora`: Configures Oracle Network settings.
   * `cwallet.sso`: Enables SSL or TLS connections. Keep this file secure.
@@ -284,14 +275,18 @@ If you are connecting to Oracle Database using JDBC, you also need to specify `j
     # jdbc_truststore_password: <JDBC_TRUSTSTORE_PASSWORD>
 ```
 
-For more information about connecting to the Oracle Database through TCPS on JDBC, see the official [Oracle whitepaper][15].
+For more information about connecting to the Oracle Database through TCPS on JDBC, see the official [Oracle whitepaper][4].
 
-<!-- xxz tab xxx -->
-<!-- xxx tab "Containerized" xxx -->
+[1]: https://github.com/DataDog/integrations-core/blob/master/oracle/datadog_checks/oracle/data/conf.yaml.example
+[2]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
+[3]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
+[4]: https://www.oracle.com/technetwork/topics/wp-oracle-jdbc-thin-ssl-130128.pdf
+[5]: https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#install-the-wallet-and-network-configuration-files
 
-#### Containerized
+{{% /tab %}}
 
-For containerized environments, see the [Autodiscovery Integration Templates][8] for guidance on applying the parameters below.
+{{% tab "Containerized" %}}
+For containerized environments, see the [Autodiscovery Integration Templates][1] for guidance on applying the parameters below.
 
 | Parameter            | Value                                                                                                     |
 | -------------------- | --------------------------------------------------------------------------------------------------------- |
@@ -299,9 +294,10 @@ For containerized environments, see the [Autodiscovery Integration Templates][8]
 | `<INIT_CONFIG>`      | blank or `{}`                                                                                             |
 | `<INSTANCE_CONFIG>`  | `{"server": "%%host%%:1521", "service_name":"<SERVICE_NAME>", "username":"datadog", "password":"<PASSWORD>"}` |
 
+[1]: https://docs.datadoghq.com/agent/kubernetes/integrations/
 
-<!-- xxz tab xxx -->
-<!-- xxz tabs xxx -->
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Validation
 
@@ -491,9 +487,7 @@ The structure of the directory should look similar:
         ```
     - Then restart the Agent.
 
-- If you encounter this error `Unsupported major.minor version 52.0` it means that you're running a Java version that
-is too old. You need to either update your system Java or additionally install a newer version and point your `JAVA_HOME`
-variable to the new install as explained above.
+- If you encounter this error `Unsupported major.minor version 52.0` it means you're running a Java version that is too old. You need to either update your system Java or additionally install a newer version and point your `JAVA_HOME` variable to the new install as explained above.
 
 - Verify your environment variables are set correctly by running the following command from the Agent.
 Ensure the displayed output matches the correct value.
@@ -509,20 +503,9 @@ Need help? Contact [Datadog support][14].
 [3]: https://github.com/DataDog/integrations-core/tree/7.41.x/oracle#oracle-instant-client
 [4]: https://www.oracle.com/technetwork/database/application-development/jdbc/downloads/index.html
 [5]: https://github.com/DataDog/integrations-core/blob/master/oracle/datadog_checks/oracle/data/conf.yaml.example
-[6]: https://docs.datadoghq.com/agent/guide/agent-configuration-files/#agent-configuration-directory
-[7]: https://docs.datadoghq.com/agent/guide/agent-commands/#start-stop-and-restart-the-agent
-[8]: https://docs.datadoghq.com/agent/kubernetes/integrations/
 [9]: https://docs.datadoghq.com/agent/guide/agent-commands/#agent-status-and-information
 [10]: https://docs.datadoghq.com/monitors/monitor_types/metric/?tab=threshold
 [11]: https://github.com/DataDog/integrations-core/blob/master/oracle/metadata.csv
 [12]: https://github.com/DataDog/integrations-core/blob/master/oracle/assets/service_checks.json
-[13]: https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html
 [14]: https://docs.datadoghq.com/help/
-[15]: https://www.oracle.com/technetwork/topics/wp-oracle-jdbc-thin-ssl-130128.pdf
-[16]: https://python-oracledb.readthedocs.io/en/latest/user_guide/connection_handling.html#install-the-wallet-and-network-configuration-files
-[17]: https://docs.oracle.com/en/database/oracle/oracle-database/21/lacli/install-instant-client-using-zip.html
 [18]: https://www.oracle.com/technetwork/database/features/instant-client/index.htm
-[19]: https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html#ic_winx64_inst
-[20]: https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0
-[21]: https://app.datadoghq.com/dash/integration/30990/dbm-oracle-database-overview
-[22]: https://docs.datadoghq.com/database_monitoring/

--- a/content/en/integrations/guide/deprecated-oracle-integration.md
+++ b/content/en/integrations/guide/deprecated-oracle-integration.md
@@ -530,5 +530,5 @@ Need help? Contact [Datadog support][14].
 [18]: https://www.oracle.com/technetwork/database/features/instant-client/index.htm
 [19]: https://www.oracle.com/database/technologies/instant-client/winx64-64-downloads.html#ic_winx64_inst
 [20]: https://support.microsoft.com/en-us/topic/the-latest-supported-visual-c-downloads-2647da03-1eea-4433-9aff-95f26a218cc0
-[21]: https://app.datadoghq.com/dash/integration/30990/
+[21]: https://app.datadoghq.com/dash/integration/30990/dbm-oracle-database-overview
 [22]: https://docs.datadoghq.com/database_monitoring/

--- a/content/en/integrations/guide/deprecated-oracle-integration.md
+++ b/content/en/integrations/guide/deprecated-oracle-integration.md
@@ -1,5 +1,5 @@
 ---
-title: Configuring Oracle integration on the Agent versions lower than 7.50.1
+title: Configuring the Oracle integration on Agent versions lower than 7.50.1
 kind: guide
 aliases:
   - integrations/guide/deprecated-oracle-integration

--- a/content/en/integrations/guide/deprecated-oracle-integration.md
+++ b/content/en/integrations/guide/deprecated-oracle-integration.md
@@ -406,20 +406,6 @@ where blocking_session is not NULL order by blocking_session;
 
 3. Once configured, you can create a [monitor][10] based on `oracle.custom_query.locks` metrics.
 
-## Data Collected
-
-### Metrics
-
-See [metadata.csv][11] for a list of metrics provided by this integration.
-
-### Events
-
-The Oracle Database check does not include any events.
-
-### Service Checks
-
-See [service_checks.json][12] for a list of service checks provided by this integration.
-
 ## Troubleshooting
 
 ### Common problems

--- a/content/en/integrations/guide/deprecated-oracle-integration.md
+++ b/content/en/integrations/guide/deprecated-oracle-integration.md
@@ -9,9 +9,7 @@ kind: guide
 
 ## Overview
 
-The Oracle integration provides health and performance metrics for your Oracle database in near real-time. Visualize these metrics with the provided [dashboard][21] and create monitors to alert your team on Oracle states.
-
-Enable [Database Monitoring][22] (DBM) for enhanced insights into query performance and database health. In addition to the standard integration, Datadog DBM provides query-level metrics, live and historical query snapshots, wait event analysis, database load, query explain plans, and blocking query insights.
+This guide describes setting up the Oracle integration on versions of the Datadog Agent lower than 7.50.1. For more information on the Oracle integration, including setting it up on newer Agent versions, see the [Oracle integration documentation][1].
 
 ## Setup
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The Oracle Python integration will be deprecated in the next Agent release. This document preserves the configuration steps for the older Agent releases.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->