### PR TITLE
[NO-TICKET] Update Ruby profile types

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -160,7 +160,7 @@ Wall Time
 
 Allocations (beta, v1.21.1+)
 : The number of objects allocated by each method during the profiling period (default: 60s), including allocations which were subsequently freed. This is useful for investigating garbage collection load.<br />
-_Requires: [Manual enablement][3]
+_Requires:_ [Manual enablement][3]
 
 Heap Live Objects (alpha, v1.21.1+)
 : The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -158,20 +158,21 @@ CPU
 Wall Time
 : The elapsed time used by each function. Elapsed time includes time when code is running on CPU, waiting for I/O, and anything else that happens while the function is running.
 
-Allocations (alpha, v1.19.0+)
+Allocations (beta, v1.21.1+)
 : The number of objects allocated by each method during the profiling period (default: 60s), including allocations which were subsequently freed. This is useful for investigating garbage collection load.<br />
-_Requires: Ruby 2.7+_ and [needs to be enabled][2]
+_Requires: [Enabling manually][3]
 
-Heap Live Objects (alpha, v1.19.0+)
+Heap Live Objects (alpha, v1.21.1+)
 : The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
 _Requires: Ruby 2.7+_ and [needs to be enabled][2]
 
-Heap Live Size (alpha, v1.19.0+)
+Heap Live Size (alpha, v1.21.1+)
 : The amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
 _Requires: Ruby 2.7+_ and [needs to be enabled][2]
 
 [1]: /profiler/enabling/ruby/#requirements
 [2]: https://github.com/DataDog/dd-trace-rb/releases/tag/v1.19.0#:~:text=You%20can%20enable%20these%20features%3A
+[3]: https://github.com/DataDog/dd-trace-rb/releases/tag/v1.21.0
 {{< /programming-lang >}}
 {{< programming-lang lang="nodejs" >}}
 

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -160,15 +160,15 @@ Wall Time
 
 Allocations (beta, v1.21.1+)
 : The number of objects allocated by each method during the profiling period (default: 60s), including allocations which were subsequently freed. This is useful for investigating garbage collection load.<br />
-_Requires: [Enabling manually][3]
+_Requires: [Manual enablement][3]
 
 Heap Live Objects (alpha, v1.21.1+)
 : The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
-_Requires: Ruby 2.7+_ and [needs to be enabled][2]
+_Requires: Ruby 2.7+_ and [manual enablement][2]
 
 Heap Live Size (alpha, v1.21.1+)
 : The amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
-_Requires: Ruby 2.7+_ and [needs to be enabled][2]
+_Requires: Ruby 2.7+_ and [manual enablement][2]
 
 [1]: /profiler/enabling/ruby/#requirements
 [2]: https://github.com/DataDog/dd-trace-rb/releases/tag/v1.19.0#:~:text=You%20can%20enable%20these%20features%3A


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR updates the Ruby profile types documentation to match the same changes in https://github.com/DataDog/documentation/pull/22301:

* Allocation is now in beta
* Bumped the minimum versions to v1.21.1+
* Allocation works in all Rubies

In the past few releases we did a number of important performance improvements, so I'm bumping the minimum versions we state for allocation + heap + timeline as otherwise running older versions means running with known performance pitfalls.

Finally, I've clarified that allocation profiling actually works on all Rubies we support, not only Ruby 2.7. This was an oversight on my earlier PR to add this documentation, and doesn't actually reflect the code. Oops :)

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
N/A
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->