### PR TITLE
PCI audit trail req

### DIFF
--- a/layouts/shortcodes/pci-apm.md
+++ b/layouts/shortcodes/pci-apm.md
@@ -1,5 +1,5 @@
 1. Contact [Datadog support][101] or your [Customer Success Manager][102] to request that the org be configured as a PCI-compliant org and discuss the necessary paperwork to complete the PCI requirements.
-1. Enable [Audit Trail][103] in the new org. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
+1. [Audit Trail][103] will automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
 1. After Datadog support or Customer Success confirms that the org is PCI DSS compliant, configure the Agent configuration file to send spans to the dedicated PCI-compliant endpoint (`https://trace-pci.agent.datadoghq.com`):
     ```
     apm_config:

--- a/layouts/shortcodes/pci-apm.md
+++ b/layouts/shortcodes/pci-apm.md
@@ -1,5 +1,5 @@
 1. Contact [Datadog support][101] or your [Customer Success Manager][102] to request that the org be configured as a PCI-compliant org and discuss the necessary paperwork to complete the PCI requirements.
-1. [Audit Trail][103] will automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
+1. If not already enabled, [Audit Trail][103] will automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
 1. After Datadog support or Customer Success confirms that the org is PCI DSS compliant, configure the Agent configuration file to send spans to the dedicated PCI-compliant endpoint (`https://trace-pci.agent.datadoghq.com`):
     ```
     apm_config:

--- a/layouts/shortcodes/pci-apm.md
+++ b/layouts/shortcodes/pci-apm.md
@@ -1,5 +1,5 @@
 1. Contact [Datadog support][101] or your [Customer Success Manager][102] to request that the org be configured as a PCI-compliant org and discuss the necessary paperwork to complete the PCI requirements.
-1. If not already enabled, [Audit Trail][103] will automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
+1. If not already enabled, [Audit Trail][103] is automatically enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
 1. After Datadog support or Customer Success confirms that the org is PCI DSS compliant, configure the Agent configuration file to send spans to the dedicated PCI-compliant endpoint (`https://trace-pci.agent.datadoghq.com`):
     ```
     apm_config:

--- a/layouts/shortcodes/pci-logs.md
+++ b/layouts/shortcodes/pci-logs.md
@@ -1,5 +1,5 @@
 1. Contact [Datadog support][101] or your [Customer Success Manager][102] to request that the org be configured as a PCI-compliant org and discuss the necessary paperwork to complete the PCI requirements.
-1. [Audit Trail][103] will automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
+1. If not already enabled, [Audit Trail][103] will automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
 1. After Datadog support or Customer Success confirms that the org is PCI DSS compliant, configure the Agent configuration file to send logs to the dedicated PCI-compliant endpoint (`agent-http-intake-pci.logs.datadoghq.com`):
     ```
     logs_config:

--- a/layouts/shortcodes/pci-logs.md
+++ b/layouts/shortcodes/pci-logs.md
@@ -1,5 +1,5 @@
 1. Contact [Datadog support][101] or your [Customer Success Manager][102] to request that the org be configured as a PCI-compliant org and discuss the necessary paperwork to complete the PCI requirements.
-1. [Audit Trail][103] will be automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
+1. [Audit Trail][103] will automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
 1. After Datadog support or Customer Success confirms that the org is PCI DSS compliant, configure the Agent configuration file to send logs to the dedicated PCI-compliant endpoint (`agent-http-intake-pci.logs.datadoghq.com`):
     ```
     logs_config:

--- a/layouts/shortcodes/pci-logs.md
+++ b/layouts/shortcodes/pci-logs.md
@@ -1,5 +1,5 @@
 1. Contact [Datadog support][101] or your [Customer Success Manager][102] to request that the org be configured as a PCI-compliant org and discuss the necessary paperwork to complete the PCI requirements.
-1. Enable [Audit Trail][103] in the new org. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
+1. [Audit Trail][103] will be automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
 1. After Datadog support or Customer Success confirms that the org is PCI DSS compliant, configure the Agent configuration file to send logs to the dedicated PCI-compliant endpoint (`agent-http-intake-pci.logs.datadoghq.com`):
     ```
     logs_config:

--- a/layouts/shortcodes/pci-logs.md
+++ b/layouts/shortcodes/pci-logs.md
@@ -1,5 +1,5 @@
 1. Contact [Datadog support][101] or your [Customer Success Manager][102] to request that the org be configured as a PCI-compliant org and discuss the necessary paperwork to complete the PCI requirements.
-1. If not already enabled, [Audit Trail][103] will automatically be enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
+1. If not already enabled, [Audit Trail][103] is automatically enabled when the org is configured as PCI-compliant. Audit Trail *must* be enabled and remain enabled for PCI DSS compliance.
 1. After Datadog support or Customer Success confirms that the org is PCI DSS compliant, configure the Agent configuration file to send logs to the dedicated PCI-compliant endpoint (`agent-http-intake-pci.logs.datadoghq.com`):
     ```
     logs_config:


### PR DESCRIPTION
Clarified Audit Trail requirement for PCI in Logs and APM to be automatically turned on when PCI is enabled for a given org, if not already turned on.