### PR TITLE
[PROCS-3870] Add contimage and contlcycle endpoints to Network Traffic doc

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -459,4 +459,4 @@ To avoid running out of storage space, the Agent stores the metrics on disk only
 [10]: /network_monitoring/devices
 [11]: /getting_started/site/
 [12]: /agent/troubleshooting/send_a_flare
-[13]: infrastructure/containers/container_images
+[13]: /infrastructure/containers/container_images

--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -38,6 +38,9 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 : `trace.agent.`{{< region-param key="dd_site" code="true" >}}<br>
 `instrumentation-telemetry-intake.`{{< region-param key="dd_site" code="true" >}}
 
+[Container Images][13]
+: `contimage-intake.`{{< region-param key="dd_site" code="true" >}}
+
 [Live Containers][3] & [Live Process][4]
 : `process.`{{< region-param key="dd_site" code="true" >}}
 
@@ -47,7 +50,8 @@ All Agent traffic is sent over SSL. The destination is dependent on the Datadog 
 `ndmflow-intake.`{{< region-param key="dd_site" code="true" >}}
 
 [Orchestrator][5]
-: `orchestrator.`{{< region-param key="dd_site" code="true" >}}
+: `orchestrator.`{{< region-param key="dd_site" code="true" >}}<br>
+`contlcycle-intake.`{{< region-param key="dd_site" code="true" >}}
 
 [Profiling][7]
 : `intake.profile.`{{< region-param key="dd_site" code="true" >}}
@@ -455,3 +459,4 @@ To avoid running out of storage space, the Agent stores the metrics on disk only
 [10]: /network_monitoring/devices
 [11]: /getting_started/site/
 [12]: /agent/troubleshooting/send_a_flare
+[13]: infrastructure/containers/container_images


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Add the contimage-intake.datadoghq.com & contlcycle-intake.datadoghq.com endpoints to the [Network Traffic](https://docs.datadoghq.com/agent/configuration/network/?tab=agentv6v7) public documentation.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->