### PR TITLE
[NO-TICKET] Update Ruby timeline prerequisites

### DIFF
--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -61,9 +61,10 @@ Requires `dd-trace-py` version 0.44.0+.
 
 Code Hotspots identification is enabled by default when you [turn on profiling for your Ruby service][1].
 
-To enable the new [timeline feature](#span-execution-timeline-view) (beta):
-- upgrade to `dd-trace-rb` 1.15+
-- set `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=true`
+The new [timeline feature](#span-execution-timeline-view) (beta) is enabled by default in `dd-trace-rb` 1.21.1+.
+
+To additionally enable showing [GC in timeline](#span-execution-timeline-view):
+- set `DD_PROFILING_FORCE_ENABLE_GC=true`
 
 [1]: /profiler/enabling/ruby
 {{< /programming-lang >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR tweaks the Ruby timeline prerequisites section to:
1. Mention that it's enabled starting from `dd-trace-rb` 1.21.1+ (See https://github.com/DataDog/dd-trace-rb/releases#:~:text=Profiler%20timeline%20feature%20is%20now%20on%20by%20default for details)
2. Drop the outdated mention for how to enable it on older versions. In particular, I don't think we should keep it since we've since made a number of performance improvements, so we really want to encourage folks to move to 1.21.1 instead of trying the feature with known performance pitfalls.
3. Document how to enable showing GC information in timeline. (See https://github.com/DataDog/dd-trace-rb/releases#:~:text=Performance%20improvements%20to%20Garbage%20Collection%20Profiling%20%2B%20Timeline%20view%20support for details)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
N/A
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->