### PR TITLE
Add Ruby rules to landing page.

### DIFF
--- a/content/en/code_analysis/static_analysis_rules/_index.md
+++ b/content/en/code_analysis/static_analysis_rules/_index.md
@@ -133,6 +133,26 @@ rulesets:
        - Hardcoded credentials
        - Shell injection
        - Unsafe deserialization
+  rails-best-practices:
+    title: "Patterns widely adopted by the Ruby on Rails community"
+    description: |
+      Best practices to write Ruby on Rails code.
+  ruby-best-practices:
+    title: "Follow best practices in Ruby"
+    description: |
+      Rules to enforce Ruby best practices.
+  ruby-code-style:
+    title: "Rules to enforce Ruby code style."
+    description: |
+      Code Analysis rules to write Ruby rules that follows established coding standards.
+  ruby-inclusive:
+    title: "Rules for inclusive Ruby code"
+    description: |
+      Write inclusive Ruby code
+  ruby-security:
+    title: "Security rules for Ruby"
+    description: |
+      Rules focused on finding security issues in your Ruby code.
   tsx-react:
     title: "TypeScript React code quality"
     description: |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds frontmatter for the Ruby rulesets.
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->