### PR TITLE
Revert "Revert "[NO-TICKET] Update Ruby timeline prerequisites""

### DIFF
--- a/content/en/profiler/connect_traces_and_profiles.md
+++ b/content/en/profiler/connect_traces_and_profiles.md
@@ -61,9 +61,10 @@ Requires `dd-trace-py` version 0.44.0+.
 
 Code Hotspots identification is enabled by default when you [turn on profiling for your Ruby service][1].
 
-To enable the new [timeline feature](#span-execution-timeline-view) (beta):
-- upgrade to `dd-trace-rb` 1.15+
-- set `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=true`
+The new [timeline feature](#span-execution-timeline-view) (beta) is enabled by default in `dd-trace-rb` 1.21.1+.
+
+To additionally enable showing [GC in timeline](#span-execution-timeline-view):
+- set `DD_PROFILING_FORCE_ENABLE_GC=true`
 
 [1]: /profiler/enabling/ruby
 {{< /programming-lang >}}


### PR DESCRIPTION
Reverts DataDog/documentation#22357