### PR TITLE
(docs-build) Improve docs troubleshooting feedback

### DIFF
--- a/local/bin/py/build/actions/pull_and_push_folder.py
+++ b/local/bin/py/build/actions/pull_and_push_folder.py
@@ -29,6 +29,7 @@ def pull_and_push_folder(content, content_dir):
     """
 
     for file_name in chain.from_iterable(glob.iglob(pattern, recursive=True) for pattern in content["globs"]):
+        print(f'Processing: {file_name.replace("./integrations_data/extracted", "")}')
         source_comment = f"<!--  SOURCED FROM https://github.com/DataDog/{content['repo_name']} -->\n"
         with open(file_name, mode="r+", encoding="utf-8", errors="ignore") as f:
             file_name_path = Path(file_name)

--- a/local/bin/py/build/update_pre_build.py
+++ b/local/bin/py/build/update_pre_build.py
@@ -97,13 +97,9 @@ class Build:
 
             except Exception as e:
                 print(e)
-                if not getenv("CI_COMMIT_REF_NAME"):
-                    print(
-                        "\x1b[33mWARNING\x1b[0m: Unsuccessful processing of {}".format(content))
-                else:
-                    print(
-                        "\x1b[31mERROR\x1b[0m: Unsuccessful processing of {}".format(content))
-                    raise ValueError
+                print(
+                    "\x1b[31mERROR\x1b[0m: Unsuccessful processing of {}".format(content))
+                raise ValueError
 
         # Once all the content is processed integrations are merged according to the integration_merge.yaml
         # configuration file. This needs to happen after all content is processed to avoid flacky integration merge


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Local builds should always fail when an error is encountered while processing a single-sourced file. For the `pull_and_push_folder` action, we should always know which file the build failed on.

It sometimes takes us a while to chase down broken builds because:
- The local build doesn't always behave the same way as the prod build. It gives warnings instead of errors, which are more difficult to spot, and doesn't fail in the same way as the prod build
- It's not always clear which file the build is hanging on

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->