### PR TITLE
Rename integrations-tools-and-libraries to api-clients in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,8 @@ go.mod                    @DataDog/corpweb @DataDog/documentation
 go.sum                    @DataDog/corpweb @DataDog/documentation
 
 # SDK versions
-.github/workflows/bump_versions.yml   @DataDog/integrations-tools-and-libraries @DataDog/documentation
-/data/sdk_versions.json               @DataDog/integrations-tools-and-libraries @DataDog/documentation
+.github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation
+/data/sdk_versions.json               @DataDog/api-clients @DataDog/documentation
 
 # Serverless
 


### PR DESCRIPTION
Cleanup from a team rename that already went into effect in Workday. The new team has the same members as the old one, plus managers:

https://github.com/orgs/DataDog/teams/integrations-tools-and-libraries
https://github.com/orgs/DataDog/teams/api-clients

[APITL-857](https://datadoghq.atlassian.net/browse/APITL-857)

[APITL-857]: https://datadoghq.atlassian.net/browse/APITL-857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ