### PR TITLE
[web-4682] partitioned `device_id` cookie

### DIFF
--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -14,6 +14,7 @@ const getRumDeviceId = () => {
 
 // Temporary solution attributing website page views w. dd app user
 const setRumDeviceId = () => {
+    console.log('in set rum device id')
     const deviceId = getRumDeviceId()
     const domain = window.location.hostname.split('.').slice(-2).join('.')
     const maxAge = 60 * 60 * 24 * 365
@@ -46,8 +47,8 @@ if (window.DD_RUM) {
         if (branch) {
             window.DD_RUM.addRumGlobalContext('branch', branch);
         }
-
-        if (env === 'live') {
+        // remove preview condition before merging
+        if (env === 'live' || env === 'preview') {
             setRumDeviceId()
         }
     }

--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -47,7 +47,7 @@ if (window.DD_RUM) {
             window.DD_RUM.addRumGlobalContext('branch', branch);
         }
 
-        if (env === 'live') {
+        if (env === 'live' || env === 'preview') {
             setRumDeviceId()
         }
     }

--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -14,7 +14,6 @@ const getRumDeviceId = () => {
 
 // Temporary solution attributing website page views w. dd app user
 const setRumDeviceId = () => {
-    console.log('in set rum device id')
     const deviceId = getRumDeviceId()
     const domain = window.location.hostname.split('.').slice(-2).join('.')
     const maxAge = 60 * 60 * 24 * 365
@@ -47,8 +46,8 @@ if (window.DD_RUM) {
         if (branch) {
             window.DD_RUM.addRumGlobalContext('branch', branch);
         }
-        // remove preview condition before merging
-        if (env === 'live' || env === 'preview') {
+
+        if (env === 'live') {
             setRumDeviceId()
         }
     }

--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -18,7 +18,7 @@ const setRumDeviceId = () => {
     const domain = window.location.hostname.split('.').slice(-2).join('.')
     const maxAge = 60 * 60 * 24 * 365
 
-    document.cookie = `_dd_device_id=${deviceId}; Domain=.${domain}; Max-Age=${maxAge}; Path=/; SameSite=None; Secure`
+    document.cookie = `_dd_device_id=${deviceId}; Domain=.${domain}; Max-Age=${maxAge}; Path=/; SameSite=None; Secure; Partitioned`
 
     window.DD_RUM.setUserProperty('device_id', deviceId)
 }

--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -47,7 +47,7 @@ if (window.DD_RUM) {
             window.DD_RUM.addRumGlobalContext('branch', branch);
         }
 
-        if (env === 'live' || env === 'preview') {
+        if (env === 'live') {
             setRumDeviceId()
         }
     }


### PR DESCRIPTION
### What does this PR do? What is the motivation?
adds `Partitioned` attribute when generating `_dd_device_id` cookie.   this is needed ahead of the end of 3rd party cookies due to the presence of `Same-Site=None` attribute

https://datadoghq.atlassian.net/browse/WEB-4682

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after websites reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

https://docs-staging.datadoghq.com/brian.deutsch/web-4682-device-id-partitioned/

- no console errors present.

