### PR TITLE
(DOCS-7297)(Srvce-mngmnt) Clarify support

### DIFF
--- a/content/en/service_management/events/guides/email.md
+++ b/content/en/service_management/events/guides/email.md
@@ -7,6 +7,10 @@ aliases:
 - /events/guides/email
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Events with email is not supported on {{< region-param key=dd_datacenter code="true" >}}</div>
+{{< /site-region >}}
+
 If your application does not have an existing [Datadog integration][1], and you don't want to create a [custom Agent check][2], you can send events with email. This can also be done with messages published to an Amazon SNS topic; read the [Create Datadog Events from Amazon SNS Emails][6] guide for more information.
 
 ## Setup


### PR DESCRIPTION
Events API emails is unsupported on GovCloud (US1-FED)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->