### PR TITLE
Update CODEOWNERS for Software delivery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,11 +103,10 @@ content/en/mobile_app_testing/*.md                              @Datadog/synthet
 
 # Software Delivery
 
-content/en/tests/**.md                                 @Datadog/ci-app-libraries @Datadog/documentation
-content/en/intelligent_test_runner/**.md               @Datadog/ci-app-libraries @Datadog/documentation
-content/en/continuous_integration/**.md                @Datadog/ci-app-backend @Datadog/documentation
-content/en/continuous_delivery/**.md                   @Datadog/ci-app-backend @Datadog/documentation
-content/en/dora_metrics/**.md                          @Datadog/ci-app-backend @Datadog/documentation
-content/en/code_analysis/**.md                         @Datadog/static-analysis @Datadog/documentation
-content/en/quality_gates/_index.md                    @Datadog/ci-app-backend @Datadog/documentation
-content/en/quality_gates/_index.md                    @Datadog/ci-app-backend @Datadog/documentation
+content/en/tests/                                 @Datadog/ci-app-libraries @Datadog/documentation
+content/en/intelligent_test_runner/               @Datadog/ci-app-libraries @Datadog/documentation
+content/en/continuous_integration/                @Datadog/ci-app-backend @Datadog/documentation
+content/en/continuous_delivery/                   @Datadog/ci-app-backend @Datadog/documentation
+content/en/dora_metrics/                          @Datadog/ci-app-backend @Datadog/documentation
+content/en/code_analysis/                         @Datadog/static-analysis @Datadog/documentation
+content/en/quality_gates/                         @Datadog/ci-app-backend @Datadog/documentation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The current codeowners don't match exactly what we want: I opened https://github.com/DataDog/documentation/pull/22369 which does not request a review from `ci-app-backend`. I am not sure why, though I don't think we should overcomplicate our codeowners file and we should simply match all files in subdirectories. In addition, this makes it consistent with the rest of the codeowners file.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->