### PR TITLE
[Source Code Integration] Improvements to GitLab tab

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -370,13 +370,48 @@ Setting up the GitHub integration also allows you to see inline code snippets in
 [107]: /security/application_security/
 
 {{% /tab %}}
+{{% tab "GitLab" %}}
+
+<div class="alert alert-warning">
+Repositories from self-managed GitLab instances are not supported out-of-the-box by the source code integration. To enable this feature, <a href="/help">contact Support</a>.
+</div>
+
+To link telemetry with your source code, upload your repository metadata with the [`datadog-ci git-metadata upload`][2] command.
+
+When you run `datadog-ci git-metadata upload` within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths.
+
+Run this command for every commit that you need to be synchronized with Datadog.
+
+If you are using [gitlab.com][1], this also allows you to see inline code snippets in [**Error Tracking**][3], [**Continuous Profiler**][4], [**Serverless Monitoring**][5], [**CI Visibility**][6], and [**Application Security Monitoring**][7].
+
+### Validation
+
+To ensure the data is being collected, run `datadog-ci git-metadata upload` in your CI pipeline.
+
+You can expect to see the following output:
+
+```
+Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@my-git-server.com:my-org/my-repository.git.
+180 tracked file paths will be reported.
+✅  Handled in 0.077 seconds.
+```
+
+[1]: https://gitlab.com
+[2]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata
+[3]: /logs/error_tracking/backend/?tab=serilog#setup
+[4]: /integrations/guide/source-code-integration/?tab=continuousprofiler#links-to-git-providers
+[5]: /serverless/aws_lambda/configuration/?tab=datadogcli#link-errors-to-your-source-code
+[6]: /tests/developer_workflows/#open-tests-in-github-and-your-ide
+[7]: /security/application_security/
+
+{{% /tab %}}
 {{% tab "Other Git Providers" %}}
 
 <div class="alert alert-warning">
 Repositories on self-hosted instances or private URLs are not supported out-of-the-box by the source code integration. To enable this feature, <a href="/help">contact Support</a>.
 </div>
 
-To link telemetry to your source code, you can upload your repository metadata with the [`datadog-ci git-metadata upload`][1] command.
+To link telemetry with your source code, upload your repository metadata with the [`datadog-ci git-metadata upload`][1] command.
 
 When you run `datadog-ci git-metadata upload` within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths.
 
@@ -389,27 +424,12 @@ To ensure the data is being collected, run `datadog-ci git-metadata upload` in y
 You can expect to see the following output:
 
 ```
-Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@github.com:my-org/my-repository.git.
+Reporting commit 007f7f466e035b052415134600ea899693e7bb34 from repository git@my-git-server.com:my-org/my-repository.git.
 180 tracked file paths will be reported.
 ✅  Handled in 0.077 seconds.
 ```
 
 [1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata
-{{% /tab %}}
-
-{{% tab "GitLab" %}}
-
-To link telemetry with your source code, upload your repository metadata with the [`datadog-ci git-metadata upload`][2] command. When you run `datadog-ci git-metadata upload` within a Git repository, Datadog receives the repository URL, the commit SHA of the current branch, and a list of tracked file paths. Run this command for every commit you need to be synchronized with Datadog. If you are using [gitlab.com][1], this also allows you to see inline code snippets in [Error Tracking][3], [Continuous Profiler][4], [Serverless Monitoring][5], [CI Visibility][6], and [Application Security Monitoring][7].
-
-[1]: https://gitlab.com
-[2]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/git-metadata
-[3]: /logs/error_tracking/backend/?tab=serilog#setup
-[4]: /integrations/guide/source-code-integration/?tab=continuousprofiler#links-to-git-providers
-[5]: /serverless/aws_lambda/configuration/?tab=datadogcli#link-errors-to-your-source-code
-[6]: /tests/developer_workflows/#open-tests-in-github-and-your-ide
-[7]: /security/application_security/
-
-
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Minor improvements on the SCI setup instructions:
- Move the GitLab tab in second position, so that "Other Git providers" comes last
- Add the "Validation" section in the GitLab tab as well, since it's relevant as well
- Make wording / spacing consistent with the "Other Git providers" tab
- Add the warning about self-managed instances, which require contacting support to enable
- Update the repository URL in the example to something that isn't GitHub, since the prefered way for GitHub is to use the GitHub Apps integration

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->