### PR TITLE
(maint) Move local branch language in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ For more information on contributing, see the [contribution guidelines][18].
 ### Datadog Staff
 
 - Always branch off of master; never commit directly to master.
-- Name your branch `<SLACK_HANDLE>/<FEATURE_NAME>` if you would like to create a preview site and run tests.
-  - If you're collaborating on a branch with someone, you can have two names on the branch so you can both receive Slack notifications when a preview build finishes, e.g. `<SLACK_HANDLE_1>/<SLACK_HANDLE_2>/<FEATURE_NAME>`.
-- When you are ready to commit, create a new pull request to master from your branch.
+- Name your branch `<SLACK_HANDLE>/<FEATURE_NAME>`.
 - Consult our [contributing guidelines][8], and the [Documentation Build Wiki][7].
+- When you're ready to commit, create a new pull request to master from your branch.
 - Use GitHub's [draft pull request][15] feature and appropriate labels such as "Do Not Merge" or "Work in Progress" until your PR is ready to be merged and live on production.
-- If you need to run the build locally, see [Docs Build][20].
+- If you've named your branch correctly, a GitHub bot posts a link to the docs preview website for your PR. After the preview build completes, you can use the link to preview your changes.
+- To run the build locally, see [Docs Build][20]. This is an optional step and requires setup.
 
 ### Outside Contributors
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ For more information on contributing, see the [contribution guidelines][18].
 
 ### Datadog Staff
 
-- To run the build locally, see [Docs Build][20].
 - Always branch off of master; never commit directly to master.
 - Name your branch `<SLACK_HANDLE>/<FEATURE_NAME>` if you would like to create a preview site and run tests.
   - If you're collaborating on a branch with someone, you can have two names on the branch so you can both receive Slack notifications when a preview build finishes, e.g. `<SLACK_HANDLE_1>/<SLACK_HANDLE_2>/<FEATURE_NAME>`.
 - When you are ready to commit, create a new pull request to master from your branch.
 - Consult our [contributing guidelines][8], and the [Documentation Build Wiki][7].
 - Use GitHub's [draft pull request][15] feature and appropriate labels such as "Do Not Merge" or "Work in Progress" until your PR is ready to be merged and live on production.
+- If you need to run the build locally, see [Docs Build][20].
 
 ### Outside Contributors
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For more information on contributing, see the [contribution guidelines][18].
 
 - Always branch off of master; never commit directly to master.
 - Name your branch `<SLACK_HANDLE>/<FEATURE_NAME>`.
-- Consult our [contributing guidelines][8], and the [Documentation Build Wiki][7].
+- Consult our [contributing guidelines][8].
 - When you're ready to commit, create a new pull request to master from your branch.
 - Use GitHub's [draft pull request][15] feature and appropriate labels such as "Do Not Merge" or "Work in Progress" until your PR is ready to be merged and live on production.
 - If you've named your branch correctly, a GitHub bot posts a link to the docs preview website for your PR. After the preview build completes, you can use the link to preview your changes.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Moves the local branch step down in the README, as it's an optional step for most internal contributors and is likely to trip some people up. Also shuffled/reworded some of the other steps.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->