### PR TITLE
Cloudcraft doc - Add public endpoint requirement for eks scanning

### DIFF
--- a/content/en/cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft.md
+++ b/content/en/cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft.md
@@ -13,8 +13,7 @@ To learn more about RBAC configuration and IAM entities, see [Managing users or 
 
 ## Prerequisites
 
-<div class="alert alert-info">Scanning EKS clusters requires public endpoints. Read <a href="https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html">Amazon EKS cluster endpoint access control
-</a> for endpoint access options.</div>
+<div class="alert alert-info">Scanning EKS clusters requires public endpoints. For more information, see <a href="https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html">Amazon EKS cluster endpoint access control.</a></div>
 
 Before connecting your Amazon EKS clusters with Cloudcraft, you must connect your AWS account and generate diagrams that include your clusters.
 

--- a/content/en/cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft.md
+++ b/content/en/cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft.md
@@ -13,6 +13,9 @@ To learn more about RBAC configuration and IAM entities, see [Managing users or 
 
 ## Prerequisites
 
+<div class="alert alert-info">Scanning EKS clusters requires public endpoints. Read <a href="https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html">Amazon EKS cluster endpoint access control
+</a> for endpoint access options.</div>
+
 Before connecting your Amazon EKS clusters with Cloudcraft, you must connect your AWS account and generate diagrams that include your clusters.
 
 To connect your AWS account and familiarize yourself with Cloudcraft, see the following articles:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates the Cloudcraft documentation for connecting to an Amazon EKS cluster to note that public cluster endpoints are required to scan.
In-app connection flow warns of the requirement / fails if private, however the docs do not.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->