### PR TITLE
Fix DD_TRACE_RATE_LIMIT description

### DIFF
--- a/content/en/tracing/trace_collection/library_config/nodejs.md
+++ b/content/en/tracing/trace_collection/library_config/nodejs.md
@@ -107,8 +107,8 @@ Controls the ingestion sample rate (between 0.0 and 1.0) between the Agent and t
 
 `DD_TRACE_RATE_LIMIT`
 : **Configuration**: `rateLimit`<br>
-**Default**: `1.0` when `DD_TRACE_SAMPLE_RATE` is set. Otherwise, delegates rate limiting to the Datadog Agent.
-Ratio of spans to sample as a float between `0.0` and `1.0`. <br>
+**Default**: `100` when `DD_TRACE_SAMPLE_RATE` is set. Otherwise, delegates rate limiting to the Datadog Agent.
+The maximum number of traces per second per service instance.<br>
 
 `DD_TRACE_SAMPLING_RULES`
 : **Configuration**: `samplingRules`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- `DD_TRACE_RATE_LIMIT` config is incorrectly described as a ratio (0.0 -> 1.0).
- It should instead be N traces per second per service instance.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->