### PR TITLE
Add merge label check

### DIFF
--- a/.github/workflows/merge_label_check.yml
+++ b/.github/workflows/merge_label_check.yml
@@ -1,0 +1,28 @@
+# Fail if the "Do Not Merge" label is present on a PR.
+name: Merge label check
+on: 
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+      - synchronize
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  new-check-for-merge-label:
+    runs-on: ubuntu-latest
+    name: "Merge is not allowed when 'Do Not Merge' label is present"
+    steps:
+      - name: Verify lack of "Do Not Merge" label
+        env:
+          DO_NOT_MERGE_LABEL_IS_PRESENT: ${{ contains( github.event.pull_request.labels.*.name, 'Do Not Merge') }}
+        run: |
+          if [[ $DO_NOT_MERGE_LABEL_IS_PRESENT == "true" ]]; then
+          exit 1
+          else
+          exit 0
+          fi


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds a check that fails if the "Do Not Merge" label is present. This is part of an ongoing rollout of merge safety features for the docs repo.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Demo PR that you can label/unlabel: [Demo PR](https://github.com/DataDog/jen.gilbert-actions-sandbox/pull/63)

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->