### PR TITLE
DOCS-7478: add gov region warning to logs guide

### DIFF
--- a/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
+++ b/content/en/logs/guide/sending-events-and-logs-to-datadog-with-amazon-eventbridge-api-destinations.md
@@ -7,6 +7,10 @@ further_reading:
   text: "AWS Blog with example API destination use cases"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">The Datadog for Government site does not support Amazon EventBridge.</div>
+{{< /site-region >}}
+
 Amazon EventBridge is a serverless event bus that enables you to build event-driven applications. EventBridge can integrate with your AWS services, but the API destinations feature lets you push and pull data from outside of AWS using APIs. This guide gives steps for sending your events and logs from EventBridge to Datadog. For more information about pushing your events from Datadog to EventBridge, [see the EventBridge integration docs][1].
 
 ## Setup


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds a note that Amazon EventBridge is unsupported on GovCloud. Request from support. Complement to https://github.com/DataDog/dogweb/pull/116270

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->