### PR TITLE
Add stable OTel JVM metric mappings

### DIFF
--- a/content/en/opentelemetry/integrations/runtime_metrics/java.md
+++ b/content/en/opentelemetry/integrations/runtime_metrics/java.md
@@ -27,29 +27,29 @@ The following table lists the Datadog runtime metrics that are supported by mapp
 
 | Datadog metric | Description |  OpenTelemetry counterpart |
 | --- | --- | --- |
-| `jvm.heap_memory` | The total Java heap memory used. | `process.runtime.jvm.memory.usage` |
-| `jvm.heap_memory_committed` | The total Java heap memory committed to be used. | `process.runtime.jvm.memory.committed` |
-| `jvm.heap_memory_init` | The initial Java heap memory allocated. | `process.runtime.jvm.memory.init` |
-| `jvm.heap_memory_max` | The maximum Java heap memory available. | `process.runtime.jvm.memory.limit` |
-| `jvm.non_heap_memory` | The total Java non-heap memory used. Non-heap memory is: `Metaspace + CompressedClassSpace + CodeCache`. | `process.runtime.jvm.memory.usage` |
-| `jvm.non_heap_memory_committed` | The total Java non-heap memory committed to be used. | `process.runtime.jvm.memory.committed` |
-| `jvm.non_heap_memory_init` | The initial Java non-heap memory allocated. | `process.runtime.jvm.memory.init` |
-| `jvm.non_heap_memory_max` | The maximum Java non-heap memory available. | `process.runtime.jvm.memory.limit` |
-| `jvm.gc.old_gen_size` | | `process.runtime.jvm.memory.usage` |
-| `jvm.gc.eden_size` | | `process.runtime.jvm.memory.usage` |
-| `jvm.gc.survivor_size` | | `process.runtime.jvm.memory.usage` |
-| `jvm.gc.metaspace_size` | | `process.runtime.jvm.memory.usage` |
-| `jvm.thread_count` | The number of live threads. | `process.runtime.jvm.threads.count` |
-| `jvm.loaded_classes` | Number of classes currently loaded. | `process.runtime.jvm.classes.current_loaded` |
-| `jvm.cpu_load.system` | Recent CPU utilization for the whole system. | `process.runtime.jvm.system.cpu.utilization` |
-| `jvm.cpu_load.process` | Recent CPU utilization for the process. | `process.runtime.jvm.cpu.utilization` |
-| `jvm.buffer_pool.direct.used` | Measure of memory used by direct buffers. | `process.runtime.jvm.buffer.usage` |
-| `jvm.buffer_pool.direct.count` | Number of direct buffers in the pool. | `process.runtime.jvm.buffer.count` |
-| `jvm.buffer_pool.direct.capacity` | Measure of total memory capacity of direct buffers. | `process.runtime.jvm.buffer.limit` |
-| `jvm.buffer_pool.mapped.used` | Measure of memory used by mapped buffers. | `process.runtime.jvm.buffer.usage` |
-| `jvm.buffer_pool.mapped.count` | Number of mapped buffers in the pool. | `process.runtime.jvm.buffer.count` |
-| `jvm.buffer_pool.mapped.capacity` | Measure of total memory capacity of mapped buffers. | `process.runtime.jvm.buffer.limit` |
-| `jvm.gc.parnew.time` | The approximate accumulated garbage collection time elapsed. | `process.runtime.jvm.gc.duration` |
+| `jvm.heap_memory` | The total Java heap memory used. | `process.runtime.jvm.memory.usage` <br> `jvm.memory.used` |
+| `jvm.heap_memory_committed` | The total Java heap memory committed to be used. | `process.runtime.jvm.memory.committed` <br> `jvm.memory.committed` |
+| `jvm.heap_memory_init` | The initial Java heap memory allocated. | `process.runtime.jvm.memory.init` <br> `jvm.memory.init` |
+| `jvm.heap_memory_max` | The maximum Java heap memory available. | `process.runtime.jvm.memory.limit` <br> `jvm.memory.limit` |
+| `jvm.non_heap_memory` | The total Java non-heap memory used. Non-heap memory is: `Metaspace + CompressedClassSpace + CodeCache`. | `process.runtime.jvm.memory.usage` <br> `jvm.memory.used` |
+| `jvm.non_heap_memory_committed` | The total Java non-heap memory committed to be used. | `process.runtime.jvm.memory.committed` <br> `jvm.memory.committed` |
+| `jvm.non_heap_memory_init` | The initial Java non-heap memory allocated. | `process.runtime.jvm.memory.init` <br> `jvm.memory.init` |
+| `jvm.non_heap_memory_max` | The maximum Java non-heap memory available. | `process.runtime.jvm.memory.limit` <br> `jvm.memory.limit` |
+| `jvm.gc.old_gen_size` | | `process.runtime.jvm.memory.usage` <br> `jvm.memory.used` |
+| `jvm.gc.eden_size` | | `process.runtime.jvm.memory.usage` <br> `jvm.memory.used` |
+| `jvm.gc.survivor_size` | | `process.runtime.jvm.memory.usage` <br> `jvm.memory.used` |
+| `jvm.gc.metaspace_size` | | `process.runtime.jvm.memory.usage` <br> `jvm.memory.used` |
+| `jvm.thread_count` | The number of live threads. | `process.runtime.jvm.threads.count` <br> `jvm.thread.count` |
+| `jvm.loaded_classes` | Number of classes currently loaded. | `process.runtime.jvm.classes.current_loaded` <br> `jvm.class.count` |
+| `jvm.cpu_load.system` | Recent CPU utilization for the whole system. | `process.runtime.jvm.system.cpu.utilization` <br> `jvm.system.cpu.utilization` |
+| `jvm.cpu_load.process` | Recent CPU utilization for the process. | `process.runtime.jvm.cpu.utilization` <br> `jvm.cpu.recent_utilization` |
+| `jvm.buffer_pool.direct.used` | Measure of memory used by direct buffers. | `process.runtime.jvm.buffer.usage` <br> `jvm.buffer.memory.usage` |
+| `jvm.buffer_pool.direct.count` | Number of direct buffers in the pool. | `process.runtime.jvm.buffer.count`<br> `jvm.buffer.count` |
+| `jvm.buffer_pool.direct.limit` | Measure of total memory capacity of direct buffers. | `process.runtime.jvm.buffer.limit` <br> `jvm.buffer.memory.limit` |
+| `jvm.buffer_pool.mapped.used` | Measure of memory used by mapped buffers. | `process.runtime.jvm.buffer.usage`<br> `jvm.buffer.memory.usage` |
+| `jvm.buffer_pool.mapped.count` | Number of mapped buffers in the pool. | `process.runtime.jvm.buffer.count`<br> `jvm.buffer.count` |
+| `jvm.buffer_pool.mapped.limit` | Measure of total memory capacity of mapped buffers. | `process.runtime.jvm.buffer.limit` <br> `jvm.buffer.memory.limit` |
+| `jvm.gc.parnew.time` | The approximate accumulated garbage collection time elapsed. | N/A |
 |	`jvm.gc.cms.count` | The total number of garbage collections that have occurred. | N/A |
 |	`jvm.gc.major_collection_count` | The rate of major garbage collections. Set `new_gc_metrics: true` to receive this metric. | N/A |
 |	`jvm.gc.minor_collection_count` | The rate of minor garbage collections. Set `new_gc_metrics: true` to receive this metric. | N/A |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add documentation for runtime metric mappings introduced in v2.0.0 of OpenTelemetry Java: https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.0.0

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->