### PR TITLE
Link to data security from browser adv config

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -732,11 +732,11 @@ window.DD_RUM &&
 {{% /tab %}}
 {{< /tabs >}}
 
-For a sampled out session, all page views and associated telemetry for that session are not collected.
+For a sampled out session, all pageviews and associated telemetry for that session are not collected.
 
 ## User tracking consent
 
-To be compliant with GDPR, CCPA, and similar regulations, the RUM Browser SDK lets you provide the tracking consent value at initialization.
+To be compliant with GDPR, CCPA, and similar regulations, the RUM Browser SDK lets you provide the tracking consent value at initialization. For more information on tracking consent, see [Data Security][18].
 
 The `trackingConsent` initialization parameter can be one of the following values:
 
@@ -1005,7 +1005,7 @@ By default, global context and user context are stored in the current page memor
 
 To add them to all events of the session, they must be attached to every page.
 
-With the introduction of the `storeContextsAcrossPages` configuration option in the v4.49.0 of the browser SDK, those contexts can be stored in [`localStorage`][18], allowing the following behaviors:
+With the introduction of the `storeContextsAcrossPages` configuration option in the v4.49.0 of the browser SDK, those contexts can be stored in [`localStorage`][19], allowing the following behaviors:
 
 - Contexts are preserved after a full reload
 - Contexts are synchronized between tabs opened on the same origin
@@ -1037,4 +1037,5 @@ However, this feature comes with some **limitations**:
 [15]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum-core/src/rumEvent.types.ts
 [16]: /logs/log_configuration/attributes_naming_convention/#user-related-attributes
 [17]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v4130
-[18]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage
+[18]: /data_security/real_user_monitoring/#browser-rum-use-of-cookies
+[19]: https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds a link to the RUM Data Security page from the Browser Advanced Configuration page, as per request in [DOCS-7428](https://datadoghq.atlassian.net/browse/DOCS-7428)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7428]: https://datadoghq.atlassian.net/browse/DOCS-7428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ