### PR TITLE
docs(php): Add `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` documentation

### DIFF
--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -185,6 +185,11 @@ The default app name.
 **Default**: `null`<br>
 Change the default name of an APM integration. Rename one or more integrations at a time, for example: `DD_SERVICE_MAPPING=pdo:payments-db,mysqli:orders-db` (see [Integration names](#integration-names)).
 
+`DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`
+: **INI**: `datadog.trace.128_bit_traceid_generation_enabled`<br>
+**Default**: `true`<br>
+When true, the tracer generates 128 bit Trace IDs, and encodes Trace IDs as 32 lowercase hexadecimal characters with zero padding.
+
 `DD_TRACE_128_BIT_TRACEID_LOGGING_ENABLED`
 : **INI**: `datadog.trace.128_bit_traceid_logging_enabled`<br>
 **Default**: `0`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Motivation: [This Slack Message](https://dd.slack.com/archives/C4WC8C39Q/p1711979945661959)

This PR adds the missing PHP configuration option `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED` to the public doc. It reuses Java's description.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->