### PR TITLE
docs: Add Laravel 11.x support

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -94,28 +94,28 @@ The following table enumerates some of the frameworks and versions Datadog succe
 
 **Web frameworks**:
 
-| Module         | Versions                          | Support Type               | Instrumentation level           |
-|:---------------|:----------------------------------|:---------------------------|:--------------------------------|
-| CakePHP        | 2.x                               | All supported PHP versions | Framework-level instrumentation |
-| CodeIgniter    | 2.x                               | PHP 7+                     | Framework-level instrumentation |
-| CodeIgniter    | 3.x                               | PHP 7+                     | Generic web tracing             |
-| Drupal         |                                   | All supported PHP versions | Framework-level instrumentation |
-| FuelPHP        | 1.1                               | PHP 7+                     | Generic web tracing             |
-| Laminas        |                                   | All supported PHP versions | Framework-level instrumentation |
-| Laravel        | 4.2, 5.x, 6.x                     | All supported PHP versions | Framework-level instrumentation |
-| Laravel 8+     | 8.x, 9.x, 10.x (tracer `0.52.0+`) | All supported PHP versions | Framework-level instrumentation |
-| Lumen          | 5.2+                              | All supported PHP versions | Framework-level instrumentation |
-| Magento        | 1                                 | All supported PHP versions | Generic web tracing             |
-| Magento        | 2                                 | PHP 7+                     | Framework-level instrumentation |
-| Neos Flow      | 1.1                               | All supported PHP versions | Generic web tracing             |
-| Phalcon        | 1.3, 3.4                          | All supported PHP versions | Generic web tracing             |
-| RoadRunner     | 2.x                               | All supported PHP versions | Framework-level instrumentation |
-| Slim           | 2.x, 3.x, 4.x                     | All supported PHP versions | Framework-level instrumentation |
-| Symfony        | 2.x, 3.3, 3.4, 4.x, 5.x, 6.x, 7.x | All supported PHP versions | Framework-level instrumentation |
-| WordPress      | 4.x, 5.x, 6.x                     | PHP 7+                     | Framework-level instrumentation |
-| Yii            | 1.1, 2.0                          | All supported PHP versions | Framework-level instrumentation |
-| Zend Framework | 1.12, 1.21                        | All supported PHP versions | Framework-level instrumentation |
-| Zend Framework | 2.x                               | All supported PHP versions | Generic web tracing             |
+| Module         | Versions                                | Support Type               | Instrumentation level           |
+|:---------------|:----------------------------------------|:---------------------------|:--------------------------------|
+| CakePHP        | 2.x                                     | All supported PHP versions | Framework-level instrumentation |
+| CodeIgniter    | 2.x                                     | PHP 7+                     | Framework-level instrumentation |
+| CodeIgniter    | 3.x                                     | PHP 7+                     | Generic web tracing             |
+| Drupal         |                                         | All supported PHP versions | Framework-level instrumentation |
+| FuelPHP        | 1.1                                     | PHP 7+                     | Generic web tracing             |
+| Laminas        |                                         | All supported PHP versions | Framework-level instrumentation |
+| Laravel        | 4.2, 5.x, 6.x                           | All supported PHP versions | Framework-level instrumentation |
+| Laravel 8+     | 8.x, 9.x, 10.x, 11.x (tracer `0.52.0+`) | All supported PHP versions | Framework-level instrumentation |
+| Lumen          | 5.2+                                    | All supported PHP versions | Framework-level instrumentation |
+| Magento        | 1                                       | All supported PHP versions | Generic web tracing             |
+| Magento        | 2                                       | PHP 7+                     | Framework-level instrumentation |
+| Neos Flow      | 1.1                                     | All supported PHP versions | Generic web tracing             |
+| Phalcon        | 1.3, 3.4                                | All supported PHP versions | Generic web tracing             |
+| RoadRunner     | 2.x                                     | All supported PHP versions | Framework-level instrumentation |
+| Slim           | 2.x, 3.x, 4.x                           | All supported PHP versions | Framework-level instrumentation |
+| Symfony        | 2.x, 3.3, 3.4, 4.x, 5.x, 6.x, 7.x       | All supported PHP versions | Framework-level instrumentation |
+| WordPress      | 4.x, 5.x, 6.x                           | PHP 7+                     | Framework-level instrumentation |
+| Yii            | 1.1, 2.0                                | All supported PHP versions | Framework-level instrumentation |
+| Zend Framework | 1.12, 1.21                              | All supported PHP versions | Framework-level instrumentation |
+| Zend Framework | 2.x                                     | All supported PHP versions | Generic web tracing             |
 
 Note that even if you don't see your web framework in this list, it is supported out of the box with the latest release of the tracer.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Laravel 11.X compatibility is now tested through DataDog/dd-trace-php#2606.

This PR updates the public doc accordingly.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->