### PR TITLE
Fix link conflict in Audit Trail Events doc because of reuse shortcode links

### DIFF
--- a/layouts/shortcodes/audit-trail-asm.md
+++ b/layouts/shortcodes/audit-trail-asm.md
@@ -1,15 +1,15 @@
 | Name                         | Description of audit event                                                                  | Query in audit explorer                                               |
 |------------------------------|---------------------------------------------------------------------------------------------|-----------------------------------------------------------------------|
-| [One-click Activation][24]   | A user activated or de-activated ASM on a service.                                          | `@evt.name:"Application Security" @asset.type:compatible_services`    |
-| [Protection][23]             | A user enabled or disabled the ASM protection.                                              | `@evt.name:"Application Security" @asset.type:blocking_configuration` |
-| [Denylist][22]               | A user blocked, unblocked, or extended the blocking duration of an IP address or a user ID. | `@evt.name:"Application Security" @asset.type:ip_user_denylist`       |
-| [Passlist][81]               | A user added, modified, or deleted an entry to the passlist.                                | `@evt.name:"Application Security" @asset.type:passlist_entry`         |
-| [In-App WAF Policy][82]      | A user created, modified, or deleted an In-App WAF policy.                                  | `@evt.name:"Application Security" @asset.type:policy_entry`           |
-| [In-App WAF Custom Rule][83] | A user validated, created, modified, or deleted an In-App WAF custom rule.                  | `@evt.name:"Application Security" @asset.type:waf_custom_rule`        |
+| [One-click Activation][1001]   | A user activated or de-activated ASM on a service.                                          | `@evt.name:"Application Security" @asset.type:compatible_services`    |
+| [Protection][102]             | A user enabled or disabled the ASM protection.                                              | `@evt.name:"Application Security" @asset.type:blocking_configuration` |
+| [Denylist][1003]               | A user blocked, unblocked, or extended the blocking duration of an IP address or a user ID. | `@evt.name:"Application Security" @asset.type:ip_user_denylist`       |
+| [Passlist][1004]               | A user added, modified, or deleted an entry to the passlist.                                | `@evt.name:"Application Security" @asset.type:passlist_entry`         |
+| [In-App WAF Policy][1005]      | A user created, modified, or deleted an In-App WAF policy.                                  | `@evt.name:"Application Security" @asset.type:policy_entry`           |
+| [In-App WAF Custom Rule][1006] | A user validated, created, modified, or deleted an In-App WAF custom rule.                  | `@evt.name:"Application Security" @asset.type:waf_custom_rule`        |
 
-[22]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Application%20Security%22%20%40asset.type%3Aip_user_denylist
-[23]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Application%20Security%22%20%40asset.type%3Ablocking_configuration
-[24]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A"Application%20Security"%20%40asset.type%3Acompatible_services
-[81]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A"Application%20Security"%20%40asset.type%3Apasslist_entry
-[82]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A"Application%20Security"%20%40asset.type%3Apolicy_entry
-[83]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A"Application%20Security"%20%40asset.type%3Awaf_custom_rule
+[1001]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Application%20Security%22%20%40asset.type%3Aip_user_denylist
+[1002]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Application%20Security%22%20%40asset.type%3Ablocking_configuration
+[1003]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A"Application%20Security"%20%40asset.type%3Acompatible_services
+[1004]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A"Application%20Security"%20%40asset.type%3Apasslist_entry
+[1005]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A"Application%20Security"%20%40asset.type%3Apolicy_entry
+[1006]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A"Application%20Security"%20%40asset.type%3Awaf_custom_rule


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

For general reuse shortcodes, index numbers must be unique within the combined page. There was a conflict with the links in the main page and the shortcode links.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->