### PR TITLE
Document GraalVM Native Image support for Java

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -292,6 +292,8 @@ Use the latest versions of:
 
 ### Setup
 
+{{< tabs >}}
+{{% tab "GraalVM" %}}
 To set up the Datadog Java tracer with GraalVM Native Image, follow these steps:
 
 1. Instrument your application, following the steps described on [Tracing Java Applications][6].
@@ -302,7 +304,11 @@ To set up the Datadog Java tracer with GraalVM Native Image, follow these steps:
 3. (Optional) Enable the profiler integration by adding the following argument:
 `-J-Ddd.profiling.enabled=true –enable-monitoring=jfr`.
 
-#### Quarkus Native builds
+[6]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
+{{% /tab %}}
+
+{{% tab "Quarkus Native" %}}
+To set up the Datadog Java tracer with Quarkus Native, follow these steps:
 
 1. Instrument your application, following the steps described in [Tracing Java Applications][6].
 2. When you build a native executable, use the `quarkus.native.additional-build-args` property. For example:
@@ -312,7 +318,11 @@ To set up the Datadog Java tracer with GraalVM Native Image, follow these steps:
 3. (Optional) Enable the profiler integration by adding the following argument:
 `-J-Ddd.profiling.enabled=true –enable-monitoring=jfr`.
 
-#### Spring Native builds
+[6]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
+{{% /tab %}}
+
+{{% tab "Spring Native" %}}
+To set up the Datadog Java tracer with Spring Native, follow these steps:
 
 1. Instrument your application, following the steps described on [Tracing Java Applications][6].
 2. For Spring Native builds based on Buildpacks, add the [Paketo Buildpack for Datadog][8] and enable it using `BP_DATADOG_ENABLED=true`.
@@ -345,14 +355,19 @@ To set up the Datadog Java tracer with GraalVM Native Image, follow these steps:
    - Alternatively, you can use the `pack build` command with `--buildpack gcr.io/paketo-buildpacks/datadog` option to add the Datadog buildpack and use the `--env BP_DATADOG_ENABLED=true` option to enable it.
 3. (Optional) Enable the profiler integration by setting the environment variable `BP_NATIVE_IMAGE_BUILD_ARGUMENTS=’-J-Ddd.profiling.enabled=true –enable-monitoring=jfr’`.
 
+[6]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
+[8]: https://github.com/paketo-buildpacks/datadog
+{{% /tab %}}
+
+{{< /tabs >}}
+
 #### Usage
 
 After completing the setup, the service should send traces to Datadog.
 
 You can view traces using the [Trace Explorer][9].
 
-#### Troubleshooting
-
+{{% collapse-content title="Troubleshooting" level="h4" %}}
 ##### Native-image buildpack versions older than 5.12.2
 
 Older native-image buildpack versions expose the following option: `USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM`.
@@ -384,6 +399,8 @@ paketo-buildpacks_datadog/helper/exec.d/toggle': exit status 1
 
 The solution to this issue is to upgrade to version 4.6.0 or later.
 
+{{% /collapse-content %}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -393,7 +410,5 @@ The solution to this issue is to upgrade to version 4.6.0 or later.
 [3]: /tracing/manual_instrumentation/java
 [4]: https://github.com/DataDog/documentation#outside-contributors
 [5]: /tracing/trace_collection/otel_instrumentation/java/
-[6]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
 [7]: https://www.graalvm.org/downloads/
-[8]: https://github.com/paketo-buildpacks/datadog
 [9]: /tracing/trace_explorer/

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -325,7 +325,7 @@ To set up the Datadog Java tracer with Quarkus Native, follow these steps:
 To set up the Datadog Java tracer with Spring Native, follow these steps:
 
 1. Instrument your application, following the steps described on [Tracing Java Applications][6].
-2. For Spring Native builds based on Buildpacks, add the [Paketo Buildpack for Datadog][8] and enable it using `BP_DATADOG_ENABLED=true`.
+2. For Spring Native builds based on Buildpacks, enable the [Paketo Buildpack for Datadog][8] using `BP_DATADOG_ENABLED=true`.
    - You can do this at the build tool level, like Maven:
      ```yaml
      <build>
@@ -336,11 +336,6 @@ To set up the Datadog Java tracer with Spring Native, follow these steps:
          <configuration>
            <image>
              ...
-             <buildpacks>
-               ...
-               <buildpack>gcr.io/paketo-buildpacks/datadog</buildpack>
-               ...
-             </buildpacks>
              <env>
                ...
                <BP_DATADOG_ENABLED>true</BP_DATADOG_ENABLED>
@@ -352,7 +347,7 @@ To set up the Datadog Java tracer with Spring Native, follow these steps:
      </plugins>
      </build>
      ```
-   - Alternatively, you can use the `pack build` command with `--buildpack gcr.io/paketo-buildpacks/datadog` option to add the Datadog buildpack and use the `--env BP_DATADOG_ENABLED=true` option to enable it.
+   - Alternatively, you can use the `pack build` command with `--env BP_DATADOG_ENABLED=true` option to enable the Datadog buildpack.
 3. (Optional) Enable the profiler integration by setting the environment variable `BP_NATIVE_IMAGE_BUILD_ARGUMENTS=’-J-Ddd.profiling.enabled=true –enable-monitoring=jfr’`.
 
 [6]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -297,9 +297,9 @@ Use the latest versions of:
 To set up the Datadog Java tracer with GraalVM Native Image, follow these steps:
 
 1. Instrument your application, following the steps described on [Tracing Java Applications][6].
-2. When you build a native executable with the `native-image` command, add the following argument:
+2. When you build a native executable with the `native-image` command, add the `-J-javaagent:/path/to/dd-java-agent.jar` argument. For example:
    ```shell
-   -J-javaagent:/path/to/dd-java-agent.jar
+   native-image -J-javaagent:/path/to/dd-java-agent.jar -jar App.jar
    ```
 3. (Optional) Enable the profiler integration by adding the following argument:
 `-J-Ddd.profiling.enabled=true –enable-monitoring=jfr`.

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -342,7 +342,7 @@ To set up the Datadog Java tracer with GraalVM Native Image, follow these steps:
      </plugins>
      </build>
      ```
-   - Alternatively, you can use the `pack build` command with `--buildpack gcr.io/paketo-buildpacks/datadog` option to add Datadog buildpack and `--env BP_DATADOG_ENABLED=true` option to enable it.
+   - Alternatively, you can use the `pack build` command with `--buildpack gcr.io/paketo-buildpacks/datadog` option to add the Datadog buildpack and use the `--env BP_DATADOG_ENABLED=true` option to enable it.
 3. (Optional) Enable the profiler integration by setting the environment variable `BP_NATIVE_IMAGE_BUILD_ARGUMENTS=’-J-Ddd.profiling.enabled=true –enable-monitoring=jfr’`.
 
 #### Usage
@@ -382,7 +382,7 @@ ERROR: failed to launch: exec.d: failed to execute exec.d file at path '/layers
 paketo-buildpacks_datadog/helper/exec.d/toggle': exit status 1
 ```
 
-The solution to this issue is to upgrade to version 4.6.0 or newer.
+The solution to this issue is to upgrade to version 4.6.0 or later.
 
 ## Further Reading
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -21,7 +21,7 @@ The Java Datadog Trace library is open source - view the [GitHub repository][1] 
 
 ### Supported Java runtimes
 
-The Java Tracer supports automatic instrumentation for the following Oracle JDK and OpenJDK JVM runtimes.
+The Java Tracer supports automatic instrumentation for the following Oracle JDK, OpenJDK JVM, and [GraalVM](#graalvm-native-image-support) runtimes.
 
 #### Java Tracer v1 (latest)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
DOCS-7386
- Java tracer support for GraalVM Native Image is coming out of beta.
- Documenting this on Java Compatibility page after discussion with @tushar-datadog .

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->