### PR TITLE
[CIVIS] fix CI providers terminology

### DIFF
--- a/content/en/continuous_integration/pipelines/_index.md
+++ b/content/en/continuous_integration/pipelines/_index.md
@@ -50,12 +50,11 @@ While the concept of a CI pipeline may vary depending on your provider, see how 
 {{< tabs >}}
 {{% tab "GitHub Actions" %}}
 
-| Datadog | GitHub Actions |
-|---|---|
-| Pipeline | Workflow |
-| Stage |  |
-| Job | Job |
-| Step | Step |
+| Datadog  | GitHub Actions |
+|----------|----------------|
+| Pipeline | Workflow       |
+| Job      | Job            |
+| Step     | Step           |
 
 {{% /tab %}}
 {{% tab "GitLab" %}}

--- a/content/en/continuous_integration/pipelines/_index.md
+++ b/content/en/continuous_integration/pipelines/_index.md
@@ -60,93 +60,78 @@ While the concept of a CI pipeline may vary depending on your provider, see how 
 {{% /tab %}}
 {{% tab "GitLab" %}}
 
-| Datadog | GitLab |
-|---|---|
-| Pipeline | Pipeline |
-| Stage | Stage |
-| Job | Job |
-| Step* | Script |
-
-_\*A pipeline's step granularity is not available in Datadog._
+| Datadog                    | GitLab   |
+|----------------------------|----------|
+| Pipeline                   | Pipeline |
+| Stage                      | Stage    |
+| Job                        | Job      |
+| _Not available in Datadog_ | Script   |
 
 {{% /tab %}}
 {{% tab "Jenkins" %}}
 
-| Datadog | Jenkins |
-|---|---|
+| Datadog  | Jenkins  |
+|----------|----------|
 | Pipeline | Pipeline |
-| Stage | Stage |
-| Job | Step |
-| Step |  |
+| Stage    | Stage    |
+| Job      | Step     |
 
 {{% /tab %}}
 {{% tab "CircleCI" %}}
 
-| Datadog | CircleCI |
-|---|---|
-| Pipeline | Pipeline |
-| Stage | Workflow |
-| Job | Job |
-| Step* | Step |
-
-_\*A pipeline's step granularity is not available in Datadog._
+| Datadog                    | CircleCI  |
+|----------------------------|-----------|
+| Pipeline                   | Workflow  |
+| Job                        | Job       |
+| _Not available in Datadog_ | Step      |
 
 {{% /tab %}}
 {{% tab "Buildkite" %}}
 
-| Datadog | Buildkite |
-|---|---|
-| Pipeline | Pipeline |
-| Stage |  |
-| Job | Job |
-| Step* | Step |
-
-_\*A pipeline's step granularity is not available in Datadog._
+| Datadog                    | Buildkite |
+|----------------------------|-----------|
+| Pipeline                   | Pipeline  |
+| Job                        | Job       |
+| _Not available in Datadog_ | Step      |
 
 {{% /tab %}}
 {{% tab "TeamCity" %}}
 
-| Datadog | TeamCity |
-|---|---|
-| Pipeline | Build Chain |
-| Stage |  |
-| Job | Build |
-| Step* | Step |
-
-_\*A pipeline's step granularity is not available in Datadog._
+| Datadog                    | TeamCity    |
+|----------------------------|-------------|
+| Pipeline                   | Build Chain |
+| Job                        | Build       |
+| _Not available in Datadog_ | Step        |
 
 {{% /tab %}}
 {{% tab "Azure Pipelines" %}}
 
-| Datadog | Azure Pipelines |
-|---|---|
-| Pipeline | Pipeline |
-| Stage | Stage |
-| Job | Job |
-| Step* | Step |
-
-_\*A pipeline's step granularity is not available in Datadog._
+| Datadog                    | Azure Pipelines |
+|----------------------------|-----------------|
+| Pipeline                   | Pipeline        |
+| Stage                      | Stage           |
+| Job                        | Job             |
+| _Not available in Datadog_ | Step            |
 
 {{% /tab %}}
 {{% tab "AWS CodePipeline" %}}
 
-| Datadog | AWS CodePipeline |
-|---|---|
-| Pipeline | Pipeline |
-| Stage | Stage |
-| Job | Action |
-| Step |  |
+| Datadog  | AWS CodePipeline |
+|----------|------------------|
+| Pipeline | Pipeline         |
+| Stage    | Stage            |
+| Job      | Action           |
 
 {{% /tab %}}
 
 {{% tab "Other CI Providers" %}}
 
-| Datadog | Other CI Providers |
-|---|---|
-| Pipeline | Pipeline |
-| Stage | Stage |
-| Job | Job |
-| Step | Step |
+| Datadog  | Other CI Providers |
+|----------|--------------------|
+| Pipeline | Pipeline           |
+| Stage    | Stage              |
+| Job      | Job                |
+| Step     | Step               |
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We have several reports from customers finding this table confusing.
This PR does three things:
- fixing the CircleCI terminology: the pipeline level on Datadog maps to workflows in CircleCI, the job level maps to job in CircleCI, and we don't support steps in Datadog for this provider.
- Deleting useless rows: some providers don't have stages. I don't think that this is useful to show that we support stages in Datadog (we have a level for that) though this concept does not exist in the provider. We were showing "Stage" in the Datadog column and empty in the provider column.
- Replaces _\A pipeline's step granularity is not available in Datadog._ by a row in the corresponding step level for the provider, indicating that this is not available in Datadog.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->