### PR TITLE
RUM-3834 Fix iOS snippets in `connect_rum_and_traces.md`

### DIFF
--- a/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
+++ b/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
@@ -162,7 +162,7 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
 
 1. Set up [RUM iOS Monitoring][1].
 
-2. Enable `RUM` with `urlSessionTracking` option and `firstPartyHostsTracing` parameter:
+2. Enable `RUM` with the `urlSessionTracking` option and `firstPartyHostsTracing` parameter:
     ```swift
     RUM.enable(
         with: RUM.Configuration(

--- a/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
+++ b/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
@@ -407,7 +407,7 @@ RUM supports several propagator types to connect resources with backends that ar
 
 1. Set up RUM to connect with APM as described above.
 
-2. Use `.traceWithHeaders(hostsWithHeaders:sampleRate:)` instead of `.trace(hostsWithHeaders:sampleRate:)` as follows:
+2. Use `.traceWithHeaders(hostsWithHeaders:sampleRate:)` instead of `.trace(hosts:sampleRate:)` as follows:
     ```swift
       RUM.enable(
           with: RUM.Configuration(

--- a/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
+++ b/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
@@ -162,10 +162,11 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
 
 1. Set up [RUM iOS Monitoring][1].
 
-2. Enable `Trace`:
+2. Enable `RUM` with `urlSessionTracking` option and `firstPartyHostsTracing` parameter:
     ```swift
-    Trace.enable(
-        with: .init(
+    RUM.enable(
+        with: RUM.Configuration(
+            applicationID: "<rum application id>",
             urlSessionTracking: .init(
                 firstPartyHostsTracing: .trace(
                     hosts: [
@@ -204,8 +205,9 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
 
      To keep 100% of backend traces:
     ```swift
-    Trace.enable(
-        with: .init(
+    RUM.enable(
+        with: RUM.Configuration(
+            applicationID: "<rum application id>",
             urlSessionTracking: .init(
                 firstPartyHostsTracing: .trace(
                     hosts: [
@@ -407,8 +409,9 @@ RUM supports several propagator types to connect resources with backends that ar
 
 2. Use `.traceWithHeaders(hostsWithHeaders:sampleRate:)` instead of `.trace(hostsWithHeaders:sampleRate:)` as follows:
     ```swift
-      Trace.enable(
-          with: .init(
+      RUM.enable(
+          with: RUM.Configuration(
+              applicationID: "<rum application id>",
               urlSessionTracking: .init(
                   firstPartyHostsTracing: .traceWithHeaders(
                       hostsWithHeaders: [


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixing the wrong iOS code snippets in [Connect RUM and Traces](https://docs.datadoghq.com/real_user_monitoring/platform/connect_rum_and_traces/?tab=iosrum). They referenced `Trace` module, instead of `RUM`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->