### PR TITLE
Intelligent Test Runner: add installing coverage package to Python setup instructions

### DIFF
--- a/content/en/intelligent_test_runner/setup/python.md
+++ b/content/en/intelligent_test_runner/setup/python.md
@@ -39,6 +39,17 @@ Prior to setting up Intelligent Test Runner, set up [Test Visibility for Python]
 
 {{% ci-itr-activation-instructions %}}
 
+### Required dependencies
+
+The Intelligent Test Runner requires the [`coverage` package][2].
+
+Install it in your environment by specifying it in your `requirements.txt` (for example), or using `pip`:
+{{< code-block lang="shell" >}}
+pip install coverage
+{{< /code-block >}}
+
+See [known limitations](#known-limitations) if you are already using the `coverage` package or a plugin like `pytest-cov`.
+
 ## Running tests with the Intelligent Test Runner enabled
 
 The Intelligent Test Runner is enabled when you run tests with the Datadog integration active. Run your tests with the following command:

--- a/content/en/intelligent_test_runner/setup/python.md
+++ b/content/en/intelligent_test_runner/setup/python.md
@@ -43,7 +43,8 @@ Prior to setting up Intelligent Test Runner, set up [Test Visibility for Python]
 
 The Intelligent Test Runner requires the [`coverage` package][2].
 
-Install the package in your environment by specifying it in your `requirements.txt` for example, or using `pip`:
+Install the package in your CI test environment by specifying it in the relevant requirements file, for example, or using `pip`:
+
 {{< code-block lang="shell" >}}
 pip install coverage
 {{< /code-block >}}

--- a/content/en/intelligent_test_runner/setup/python.md
+++ b/content/en/intelligent_test_runner/setup/python.md
@@ -43,7 +43,7 @@ Prior to setting up Intelligent Test Runner, set up [Test Visibility for Python]
 
 The Intelligent Test Runner requires the [`coverage` package][2].
 
-Install it in your environment by specifying it in your `requirements.txt` (for example), or using `pip`:
+Install the package in your environment by specifying it in your `requirements.txt` for example, or using `pip`:
 {{< code-block lang="shell" >}}
 pip install coverage
 {{< /code-block >}}

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -122,28 +122,8 @@ def test_simple_case(ddspan):
 ```
 Read more about custom measures in the [Add Custom Measures Guide][2].
 
-### Known limitations
-
-Plugins for `pytest` that alter test execution may cause unexpected behavior.
-
-#### Parallelization
-
-Plugins that introduce parallelization to `pytest` (such as [`pytest-xdist`][3] or [`pytest-forked`][4]) create one session event for each parallelized instance. Multiple module or suite events may be created if tests from the same package or module execute in different processes.
-
-The overall count of test events (and their correctness) remain unaffected. Individual session, module, or suite events may have inconsistent results with other events in the same `pytest` run.
-
-#### Test ordering
-
-Plugins that change the ordering of test execution (such as [`pytest-randomly`][5]) can create multiple module or suite events. The duration and results of module or suite events may also be inconsistent with the results reported by `pytest`.
-
-The overall count of test events (and their correctness) remain unaffected.
-
-
 [1]: /tracing/trace_collection/custom_instrumentation/python?tab=locally#adding-tags
 [2]: /tests/guides/add_custom_measures/?tab=python
-[3]: https://pypi.org/project/pytest-xdist/
-[4]: https://pypi.org/project/pytest-forked/
-[5]: https://pypi.org/project/pytest-randomly/
 {{% /tab %}}
 
 {{% tab "pytest-benchmark" %}}
@@ -185,12 +165,6 @@ def test_will_pass(self):
 assert True
 {{< /code-block >}}
 
-#### Known limitations
-
-In some cases, if your `unittest` test execution is run in a parallel manner, this may break the instrumentation and affect test visibility.
-
-Datadog recommends you use up to one process at a time to prevent affecting test visibility.
-
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -224,6 +198,45 @@ All other [Datadog Tracer configuration][3] options can also be used.
 ## Collecting Git metadata
 
 {{% ci-git-metadata %}}
+
+## Known limitations
+
+{{< tabs >}}
+
+{{% tab "pytest" %}}
+
+Plugins for `pytest` that alter test execution may cause unexpected behavior.
+
+#### Parallelization
+
+Plugins that introduce parallelization to `pytest` (such as [`pytest-xdist`][1] or [`pytest-forked`][2]) create one session event for each parallelized instance. Multiple module or suite events may be created if tests from the same package or module execute in different processes.
+
+The overall count of test events (and their correctness) remain unaffected. Individual session, module, or suite events may have inconsistent results with other events in the same `pytest` run.
+
+#### Test ordering
+
+Plugins that change the ordering of test execution (such as [`pytest-randomly`][3]) can create multiple module or suite events. The duration and results of module or suite events may also be inconsistent with the results reported by `pytest`.
+
+The overall count of test events (and their correctness) remain unaffected.
+
+
+[1]: https://pypi.org/project/pytest-xdist/
+[2]: https://pypi.org/project/pytest-forked/
+[3]: https://pypi.org/project/pytest-randomly/
+
+{{% /tab %}}
+
+{{% tab "unittest" %}}
+
+
+In some cases, if your `unittest` test execution is run in a parallel manner, this may break the instrumentation and affect test visibility.
+
+Datadog recommends you use up to one process at a time to prevent affecting test visibility.
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
 
 ## Further reading
 

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -207,13 +207,13 @@ All other [Datadog Tracer configuration][3] options can also be used.
 
 Plugins for `pytest` that alter test execution may cause unexpected behavior.
 
-#### Parallelization
+### Parallelization
 
 Plugins that introduce parallelization to `pytest` (such as [`pytest-xdist`][1] or [`pytest-forked`][2]) create one session event for each parallelized instance. Multiple module or suite events may be created if tests from the same package or module execute in different processes.
 
 The overall count of test events (and their correctness) remain unaffected. Individual session, module, or suite events may have inconsistent results with other events in the same `pytest` run.
 
-#### Test ordering
+### Test ordering
 
 Plugins that change the ordering of test execution (such as [`pytest-randomly`][3]) can create multiple module or suite events. The duration and results of module or suite events may also be inconsistent with the results reported by `pytest`.
 
@@ -227,7 +227,6 @@ The overall count of test events (and their correctness) remain unaffected.
 {{% /tab %}}
 
 {{% tab "unittest" %}}
-
 
 In some cases, if your `unittest` test execution is run in a parallel manner, this may break the instrumentation and affect test visibility.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds instructions to install the `coverage` package when setting up the Intelligent Test Runner for Python.

This also moves the "known limitations" in the test visibility setup page for Python to their own level-2 header for better visibility. Prior to this, the known limitations seemed easy to miss in the documentation (since they didn't appear in the "On this page" section).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing