### PR TITLE
fix(linux key rotation): Use a more direct command that works on every system

### DIFF
--- a/content/en/agent/guide/linux-key-rotation-2024.md
+++ b/content/en/agent/guide/linux-key-rotation-2024.md
@@ -103,7 +103,7 @@ $ curl https://keys.datadoghq.com/DATADOG_APT_KEY_C0962C7D.public | sudo apt-key
 Run the following command on the host:
 
 ```
-$ curl https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public | sudo rpm --import -
+$ sudo rpm --import https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public
 ```
 
 {{% /tab %}}
@@ -190,7 +190,7 @@ Agent v5 users on DEB-based systems (Debian/Ubuntu) are also required to trust t
 **Note**: Agent v5 uses Python 2 which reached end-of-life on January 1, 2020. Datadog recommends [upgrading to Agent v7][13].
 
 [1]: https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
-[2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public 
+[2]: https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public
 [3]: https://keys.datadoghq.com/DATADOG_APT_KEY_F14F620E.public
 [4]: https://keys.datadoghq.com/DATADOG_APT_KEY_C0962C7D.public
 [5]: https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Change the suggested command for red had-like systems. The current one was not ok on `amazonlinux2`, see [customer request](https://datadog.zendesk.com/agent/tickets/1631027)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
Tested on RHEL, CentOS, SUSE, fedora, rockylinux and amazonlinux
Thanks to @mirzanurkic-dd 
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->