### PR TITLE
remove newlines to fix go.sum issues

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,2 @@
 github.com/DataDog/websites-modules v1.4.128 h1:lbsPBA7xFJOCxC5m+z83TgY6F/h9wVy+LZZL3wttoQI=
 github.com/DataDog/websites-modules v1.4.128/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
-


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Too many new lines at the end of go.sum is causing some strange hugo errors. This PR fixes this.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->