### PR TITLE
Add note about PHP ZTS support

### DIFF
--- a/content/en/profiler/enabling/php.md
+++ b/content/en/profiler/enabling/php.md
@@ -24,9 +24,7 @@ For a summary of the minimum and recommended runtime and tracer versions across 
 
 The Datadog Profiler requires at least PHP 7.1, on 64-bit Linux.
 
-The following are **not** supported:
-- PHP ZTS builds
-- PHP debug builds
+PHP ZTS builds are supported since `dd-trace-php` version 0.99+, while PHP debug builds are **not** supported.
 
 {{< tabs >}}
 {{% tab "GNU C Linux" %}}
@@ -77,14 +75,14 @@ To begin profiling applications:
     ```
     # `datadog.profiling_enabled` is not required for v0.82.0+.
     php datadog-setup.php config set -d datadog.profiling.    enabled=1
-    
+
     php datadog-setup.php config set -d datadog.service=app-name     \
       -d datadog.env=prod \
       -d datadog.version=1.3.2
-    
+
     php hello.php
     ```
-    
+
     Apache, PHP-FPM and other servers require a restart after changing the INI
 settings.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The PHP Profiler in version `0.99.0+` supports PHP ZTS builds

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->