### PR TITLE
Update according to GitLab deprecation

### DIFF
--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -190,7 +190,7 @@ These filters can also be applied through the facet panel on the left hand side 
 
 If you are using self-hosted GitLab runners, you can correlate jobs with the infrastructure that is running them.
 For this feature to work, the GitLab runner must have a tag of the form `host:<hostname>`. Tags can be added while
-[registering a new runner][6]. For existing runners
+[registering a new runner][6]. For existing runners:
 
 {{< tabs >}}
 {{% tab "GitLab &gt;&equals; 15.8" %}}

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -190,8 +190,18 @@ These filters can also be applied through the facet panel on the left hand side 
 
 If you are using self-hosted GitLab runners, you can correlate jobs with the infrastructure that is running them.
 For this feature to work, the GitLab runner must have a tag of the form `host:<hostname>`. Tags can be added while
-[registering a new runner][6]. For existing runners, add tags by updating the runner's `config.toml`. Or add tags
+[registering a new runner][6]. For existing runners
+
+{{< tabs >}}
+{{% tab "GitLab &gt;&equals; 15.8" %}}
+Add tags through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
+{{% /tab %}}
+
+{{% tab "GitLab &lt; 15.8" %}}
+Add tags by updating the runner's `config.toml`. Or add tags
 through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
+{{% /tab %}}
+{{< /tabs >}}
 
 After these steps, CI Visibility adds the hostname to each job. To see the metrics, click on a job span in the trace
 view. In the drawer, a new tab named **Infrastructure** appears which contains the host metrics.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

GitLab deprecated the `runner.tags` `config.toml` section in the 15.8 release, changes the documentation to reflect this.

- Changelog: https://docs.gitlab.com/ee/update/deprecations.html#registration-tokens-and-server-side-runner-arguments-in-gitlab-runner-register-command
- Design specification: https://gitlab.com/gitlab-org/gitlab/-/issues/380872

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->