### PR TITLE
Govcloud limitation for Service Catalog On-Call Integrations

### DIFF
--- a/content/en/service_catalog/integrations.md
+++ b/content/en/service_catalog/integrations.md
@@ -14,7 +14,12 @@ further_reading:
   tag: "Documentation"
   text: "Learn about the PagerDuty integration"
 ---
-
+{{% site-region region="gov" %}}
+<div class="alert alert-warning">
+PagerDuty and OpsGenie integrations for Service Catalog are not supported in the {{< region-param key=dd_datacenter code="true" >}} site.
+</div>
+{{% /site-region %}}
+  
 ## Overview
 
 When you configure a service account for a [Datadog integration][10], you can incorporate metadata from your integrations into service definitions in the [Service Catalog][9]. You can also use autocomplete and validation features when editing a service definition in an [integrated development environment (IDE)](#ide-integrations).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adding alert that service catalog on-call integrations are unsupported in govcloud

### Merge instructions

- [ X] Please merge after reviewing