### PR TITLE
Update search_syntax.md

### DIFF
--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -99,7 +99,7 @@ For instance, if your attribute name is **url** and you want to filter on the **
 
 1. It is **not** required to define a facet to search on attributes and tags.
 
-2. Attributes searches are case sensitive. Use free text search to get case insensitive results, see [Wildcards](#wildcards) for more information on free text search. Another option is to use the `lowercase` filter with your Grok parser while parsing to get case insensitive results during search.
+2. Attributes searches are case sensitive. Use full text search to get case insensitive results, see [Full-text search across all log attributes](#full-text-search) for more information. Another option is to use the `lowercase` filter with your Grok parser while parsing to get case insensitive results during search.
 
 3. Searching for an attribute value that contains special characters requires escaping or double quotes.
     - For example, for an attribute `my_attribute` with the value `hello:world`, search using: `@my_attribute:hello\:world` or `@my_attribute:"hello:world"`.
@@ -129,7 +129,7 @@ The `CIDR()` function supports both IPv4 and IPv6 CIDR notations and works in Lo
 
 ## Wildcards
 
-You can use wildcards with free text search. However, it only searches for terms in the log message, the text in the `content` column in Log Explorer. See [Full-text search across all log attributes](#full-text-search-across-all-log-attributes) if you want to search for a value in a log attribute.
+You can use wildcards with free text search. However, it only searches for terms in the log message, the text in the `content` column in Log Explorer. See [Full-text search across all log attributes](#full-text-search) if you want to search for a value in a log attribute.
 
 ### Multi-character wildcard
 


### PR DESCRIPTION
There's a misnomer. Free text search looks only through the log message. Since the sentence is referring to case insensitive *attributes* search, it should refer to full text search here instead.

Also, fixed a broken link to the full-text-search section

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->