### PR TITLE
Rephrases Learning Center callout

### DIFF
--- a/content/en/getting_started/application/_index.md
+++ b/content/en/getting_started/application/_index.md
@@ -20,7 +20,7 @@ further_reading:
 ---
 
 {{< learning-center-callout header="Try Foundation in the Learning Center" btn_title="Enroll Now" btn_url="https://learn.datadoghq.com/courses/datadog-foundation">}}
-  The Datadog Learning Center is full of hands-on courses to help you learn about this topic. Enroll today to learn more about Datadog Foundation.
+  Learn for free on real cloud compute and a Datadog trial account. Start these hands-on labs to get up to speed with services, logs, metrics, integrations, and dashboards.
 {{< /learning-center-callout >}}
 
 ## Overview

--- a/content/en/getting_started/application/_index.md
+++ b/content/en/getting_started/application/_index.md
@@ -19,8 +19,8 @@ further_reading:
     text: 'DRUIDS, the design system that powers Datadog'
 ---
 
-{{< learning-center-callout header="Try Foundations in the Learning Center" btn_title="Enroll Now" btn_url="https://learn.datadoghq.com/courses/datadog-foundation">}}
-  The Datadog Learning Center is full of hands-on courses to help you learn about this topic. Enroll today to learn more about Datadog Foundations.
+{{< learning-center-callout header="Try Foundation in the Learning Center" btn_title="Enroll Now" btn_url="https://learn.datadoghq.com/courses/datadog-foundation">}}
+  The Datadog Learning Center is full of hands-on courses to help you learn about this topic. Enroll today to learn more about Datadog Foundation.
 {{< /learning-center-callout >}}
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The title of the linked course in the Learning Center was spelled incorrectly ("foundations"). This corrects the spelling ("foundation"). It also rephrases the description to include details about the course instead of repeating the words in the title.

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->