### PR TITLE
Fix typo in "Enabling CSM Enterprise on Linux"

### DIFF
--- a/content/en/security/cloud_security_management/setup/csm_enterprise/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/csm_enterprise/agent/linux.md
@@ -48,7 +48,7 @@ compliance_config:
   host_benchmarks:
     enabled: true
 
-# Vulnerabilities are evaluated and and scanned against your containers and hosts every hour.
+# Vulnerabilities are evaluated and scanned against your containers and hosts every hour.
 sbom:
   enabled: true
   container_image:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Found a minor typo on one of our public docs: [Enabling CSM Enterprise on Linux](https://docs.datadoghq.com/security/cloud_security_management/setup/csm_enterprise/agent/linux). This PR removes the second `and`
![Screenshot 2024-04-09 at 18 08 37](https://github.com/DataDog/documentation/assets/1433183/63c2c45b-e4e1-420e-97d7-bdbdb86ca440)


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->