### PR TITLE
Devin.ford/bump action versions

### DIFF
--- a/.github/workflows/bump_versions.yml
+++ b/.github/workflows/bump_versions.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - id: set-versions
         name: Load latest SDK versions
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
@@ -36,7 +36,7 @@ jobs:
             }))
             console.log(versions)
             return JSON.stringify(versions)
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Write version
         run: |-
           echo '${{steps.set-versions.outputs.result}}' | jq > ./data/sdk_versions.json
@@ -46,7 +46,7 @@ jobs:
           git add .
           git commit -m "Bump SDK"
           git push -f origin HEAD:refs/heads/sdk/versions
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         name: Propose change with latest versions
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check_cache_values.yml
+++ b/.github/workflows/check_cache_values.yml
@@ -27,7 +27,7 @@ jobs:
         separator: ','
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.1.0
       with:
         python-version: '3.10'
     - run: pip install pyyaml requests

--- a/.github/workflows/gif_check.yml
+++ b/.github/workflows/gif_check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
           fetch-depth: 0
 

--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5.1.0
       with:
         python-version: '3.10'
     - run: pip install Mako docutils
@@ -42,12 +42,12 @@ jobs:
 
     - name: Render template
       id: template
-      uses: chuhlomin/render-template@v1.6
+      uses: chuhlomin/render-template@v1.9
       with:
         template: .github/preview-links-template.md
 
     - name: Find existing comment
-      uses: peter-evans/find-comment@v2.1.0
+      uses: peter-evans/find-comment@v3.1.0
       id: find_comment
       with:
         issue-number: ${{ github.event.pull_request.number }}
@@ -55,7 +55,7 @@ jobs:
         body-includes: "Preview links ("
 
     - name: Post comment
-      uses: peter-evans/create-or-update-comment@v2.1.0
+      uses: peter-evans/create-or-update-comment@v4.0.0
       with:
         issue-number: ${{ github.event.pull_request.number }}
         comment-id: ${{ steps.find_comment.outputs.comment-id }}

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -39,7 +39,7 @@ jobs:
               echo "Currently returning ${status}"
               sleep 30
             fi
-            if [[ $i -eq 15 && ! (" ${SUCCESS_CODES[@]} " =~ " ${status} ") ]]; then
+            if [[ $i -eq 30 && ! (" ${SUCCESS_CODES[@]} " =~ " ${status} ") ]]; then
               echo "Preview site returned ${status} for 15 minutes, there may be an issue with the preview site build"
               exit 1
             fi

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.ref }}
           path: repo
@@ -46,7 +46,7 @@ jobs:
           done
 
       - name: Run Datadog Synthetic tests
-        uses: DataDog/synthetics-ci-github-action@v0.11.0
+        uses: DataDog/synthetics-ci-github-action@v1.3.0
         env:
           CI_COMMIT_REF_NAME: ${{steps.extract_branch.outputs.branch}}
         with:

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           URL="https://docs-staging.datadoghq.com/${{steps.extract_branch.outputs.branch}}"
           SUCCESS_CODES=("200" "302" "304")
-          for i in {1..15}
+          for i in {1..30}
           do
             status=$(curl -o /dev/null -s -w "%{http_code}\n" $URL)
             if [[ " ${SUCCESS_CODES[@]} " =~ " ${status} " ]]; then
@@ -37,7 +37,7 @@ jobs:
             else
               echo "Waiting for preview site to return 200 || 302 || 304..."
               echo "Currently returning ${status}"
-              sleep 60
+              sleep 30
             fi
             if [[ $i -eq 15 && ! (" ${SUCCESS_CODES[@]} " =~ " ${status} ") ]]; then
               echo "Preview site returned ${status} for 15 minutes, there may be an issue with the preview site build"

--- a/.github/workflows/vale_linter.yml
+++ b/.github/workflows/vale_linter.yml
@@ -13,12 +13,12 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Clone Datadog Vale
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: DataDog/datadog-vale
         path: datadog-vale
     
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5.1.0
       with:
         python-version: '3.11'
     - run: pip install vale


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Updates several actions versions due to node 16 deprecation by github
  - `bump_versions`
  - `check_cache_values`
  - `gif_check`
  - `preview_link`
  - `synthetics`
  - `vale_linter`
- Changes timing for the preview site check in synthetics, this will still run for 15 mins due to builds sometimes lagging if runners aren't available, but will ping the URL every 30 seconds now vs every minute.
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
I left the `approved_status` and `labeler` job as is since they appear to be maintained by outside teams, and are also using internal github actions. 

Reason for the upgrade: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Vetting of bumps for jobs that were not directly testable: 

A few of the jobs aren't the easiest to test adhoc, for these jobs I verified these were relatively safe and low risk changes using a few different methods:
- `actions/checkout@v4`:
  - This is run in a few existing jobs here and other areas of websites maintained repos and I'm confident this bump will not have any negative effect. I also went through the change logs and nothing `breaking` was presented
- `peter-evans/*`:
  - I vetted this particular set of actions that are used via the changelogs for each action that is being used. 
  - https://github.com/peter-evans/create-or-update-comment/releases
  - https://github.com/peter-evans/find-comment/releases
- `chuhlomin/render-template`
  - https://github.com/chuhlomin/render-template/releases

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->