### PR TITLE
WEB-4759 | Add external_redirects to redirects.txt

### DIFF
--- a/layouts/_default/list.redirects.txt
+++ b/layouts/_default/list.redirects.txt
@@ -5,4 +5,14 @@
         {{- $target := strings.TrimSuffix "/" $p.RelPermalink -}}
         {{- printf "%s/ %s\n" $alias $p.RelPermalink -}}
     {{- end -}}
+    {{- with $p.Params.external_redirect -}}
+        {{- $redirect_link := . -}}
+        {{- $temp := strings.TrimPrefix "/" $p.RelPermalink -}}
+        {{- $target := strings.TrimSuffix "/" $temp -}}
+        {{- if not (strings.HasPrefix $redirect_link "https://") -}}
+            {{- printf "%s/ %s\n" $target $redirect_link -}}
+        {{- else -}}
+            {{- printf "%s/ %s %s\n" $target $redirect_link "external" -}}
+        {{- end -}}
+    {{- end -}}
 {{- end -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Adds any file with `external_redirect` frontmatter to the `redirects.txt` file that is generated at build time to leverage our post deploy redirect meta job in S3. This will prevent the momentary content flash that currently happens when `external_redirect` is used in `_index.md` files.

https://datadoghq.atlassian.net/browse/WEB-4759

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
https://docs.datadoghq.com/api/ - current `external_redirect` (there is usually a flash of content before the page redirects correctly)
https://docs-staging.datadoghq.com/devin.ford/WEB-4759/api - shouldn't see a page flash on the redirect here

Another good example is the `/meta` route
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->