### PR TITLE
use csharp icon for `C#` language filter

### DIFF
--- a/layouts/static-analysis/list.html
+++ b/layouts/static-analysis/list.html
@@ -42,8 +42,8 @@
         showEmptyResultsMsg: false,
         filteredRulesets: new Set(),
         lang_aliases: {
-            // map to appropriate integration logo name
-            csharp: 'net'
+            // if logo name different than language_alias,
+            // map to appropriate integration logo name (e.g. csharp: 'net')
         },
         resetFilteredRulesets () {
             // Empty filtered rulesets


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
uses the default C# (`csharp`) icon for the **Languages** filter on page load instead of the `NET` icon.

preview: 
- loading this page should add the `C#` filter selection to the `Languages` filter toggler. The icon to the left of `C#` should match the `C#` results displayed under the `Search` bar.
   - https://docs-staging.datadoghq.com/stefon.simmons/fix-csharp-icon-static-analysis/code_analysis/static_analysis_rules/?languages=CSharp
- loading this page should not add any selections. Select `C#` from the `Languages` filter. Refresh the page. the icon should match the  results for `C#`.
   - https://docs-staging.datadoghq.com/stefon.simmons/fix-csharp-icon-static-analysis/code_analysis/static_analysis_rules/

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->