### PR TITLE
Fix operator yaml indentation

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -213,10 +213,10 @@ To enable Single Step Instrumentation with the Datadog Operator:
          apiSecret:
            secretName: datadog-secret
            keyName: api-key
-   features:
-     apm:
-       instrumentation:
-         enabled: true  
+     features:
+       apm:
+         instrumentation:
+           enabled: true  
    ```
    Replace `<DATADOG_SITE>` with your [Datadog site][6] and `<AGENT_ENV>` with the environment your Agent is installed on (for example, `env:staging`).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Corrects operator YAML indentation of `features`, I stumbled on this during local setup. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing