### PR TITLE
Add Shared Responsibility graf for RUM and Sites Getting Started

### DIFF
--- a/content/en/data_security/real_user_monitoring.md
+++ b/content/en/data_security/real_user_monitoring.md
@@ -22,6 +22,20 @@ further_reading:
 
 ## Overview
 Real User Monitoring (RUM) provides controls for implementing privacy requirements and ensuring organizations of any scale do not expose sensitive or personal information. Data is stored on Datadog-managed cloud instances and encrypted at rest. The default behaviors and configurable options described on this page are designed to protect end user privacy and prevent sensitive organizational information from being collected. Learn more about [Privacy at Datadog][13].
+
+## Shared responsibility
+
+The responsibility of keeping user data secure is shared between Datadog and developers who leverage the RUM SDKs.
+
+Datadog is responsible for:
+
+- Providing a reliable product that handles data securely when it is transmitted to and stored on the Datadog platform.
+- Ensuring that security issues are identified in accordance with internal policies.
+
+Developers are responsible for:
+- Leveraging configuration values and data privacy options as provided by Datadog.
+- Ensuring the integrity of code within their environments.
+
 ## Compliance frameworks
 RUM can be configured for compliance with many standards and regulatory frameworks, including, but not limited to:
 

--- a/content/en/getting_started/site/_index.md
+++ b/content/en/getting_started/site/_index.md
@@ -16,6 +16,18 @@ algolia:
 
 Datadog offers different sites throughout the world. Each site is completely independent, and you cannot share data across sites. Each site gives you benefits (for example, government security regulations) or allows you to store your data in specific locations around the world.
 
+## Shared responsibility
+
+The responsibility of keeping user data secure is shared between Datadog and developers who leverage Datadog products.
+
+Datadog is responsible for:
+- Providing a reliable product that handles data securely when it is transmitted to and stored on the Datadog platform.
+- Ensuring that security issues are identified in accordance with internal policies.
+
+Developers are responsible for:
+- Leveraging configuration values and data privacy options as provided by Datadog.
+- Ensuring the integrity of code within their environments.
+
 ## Access the Datadog site
 
 You can identify which site you are on by matching your Datadog website URL to the site URL in the table below.

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -16,26 +16,26 @@ further_reading:
 
 Datadog Real User Monitoring (RUM) enables you to visualize and analyze the real-time performance and user journeys of your application's individual users. To collect events, add the RUM Browser SDK to your browser application and configure what data is collected using initialization parameters.
 
-The responsibility of keeping user data secure is shared between Datadog and developers who leverage the RUM SDKs. Learn more about [Shared responsibility][28].
+The responsibility of keeping user data secure is shared between Datadog and developers who leverage the RUM SDKs. Learn more about [Shared responsibility][1].
 
 ## Setup
 
-The RUM Browser SDK supports all modern desktop and mobile browsers including IE11. For more information, see the [Browser Support][8] table.
+The RUM Browser SDK supports all modern desktop and mobile browsers including IE11. For more information, see the [Browser Support][2] table.
 
 To set up RUM Browser Monitoring, create a RUM application:
 
-1. In Datadog, navigate to the [**Digital Experience** > **Add an Application** page][1] and select the JavaScript (JS) application type.
-   - By default, automatic user data collection is enabled. To disable automatic user data collection for either client IP or geolocation data, uncheck the boxes for those settings. For more information, see [RUM Browser Data Collected][2].
+1. In Datadog, navigate to the [**Digital Experience** > **Add an Application** page][3] and select the JavaScript (JS) application type.
+   - By default, automatic user data collection is enabled. To disable automatic user data collection for either client IP or geolocation data, uncheck the boxes for those settings. For more information, see [RUM Browser Data Collected][4].
    - Enter a name for your application and click **Generate Client Token**. This generates a `clientToken` and an `applicationId` for your application.
    - Choose the installation type for the RUM Browser SDK: [npm](#npm), or a hosted version ([CDN async](#cdn-async) or [CDN sync](#cdn-sync)).
-   - Define the environment name and service name for your application to use unified service tagging for [RUM & Session Replay][19]. Set a version number for your deployed application in the initialization snippet. For more information, see [Tagging](#tagging).
-   - Set the sampling rate of total user sessions collected and use the slider to set the percentage of total [Browser RUM & Session Replay][11] sessions collected. Browser RUM & Session Replay sessions include resources, long tasks, and replay recordings. For more information about configuring the percentage of Browser RUM & Session Replay sessions collected from the total amount of user sessions, see [Configure Your Setup For Browser and Browser RUM & Session Replay Sampling][21].
-   - Click the **Session Replay Enabled** toggle to access replay recordings in [Session Replay][17].
-   - Select a [privacy setting][18] for Session Replay in the dropdown menu.
+   - Define the environment name and service name for your application to use unified service tagging for [RUM & Session Replay][5]. Set a version number for your deployed application in the initialization snippet. For more information, see [Tagging](#tagging).
+   - Set the sampling rate of total user sessions collected and use the slider to set the percentage of total [Browser RUM & Session Replay][6] sessions collected. Browser RUM & Session Replay sessions include resources, long tasks, and replay recordings. For more information about configuring the percentage of Browser RUM & Session Replay sessions collected from the total amount of user sessions, see [Configure Your Setup For Browser and Browser RUM & Session Replay Sampling][7].
+   - Click the **Session Replay Enabled** toggle to access replay recordings in [Session Replay][8].
+   - Select a [privacy setting][9] for Session Replay in the dropdown menu.
 2. Deploy the changes to your application. Once your deployment is live, Datadog collects events from your users' browsers.
-3. Visualize the [data collected][2] in [dashboards][3] or create a search query in the [RUM Explorer][16].
+3. Visualize the [data collected][4] in [dashboards][10] or create a search query in the [RUM Explorer][11].
 4. (Optional) Initialize the RUM SDK with the `allowedTracingUrls` parameter to [Connect RUM and Traces][12] if you want to start linking requests from your web and mobile applications to their corresponding backend traces. See the full list of [initialization parameters](#initialization-parameters).
-5. If you're using the Datadog Content Security Policy (CSP) integration on your site, see [the RUM section of the CSP documentation][22] for additional setup steps.
+5. If you're using the Datadog Content Security Policy (CSP) integration on your site, see [the RUM section of the CSP documentation][13] for additional setup steps.
 
 Until Datadog starts receiving data, your application appears as `pending` on the **RUM Applications** page.
 
@@ -52,7 +52,7 @@ CDN sync
 
 ### npm
 
-Add [`@datadog/browser-rum`][4] to your `package.json` file, then initialize it with:
+Add [`@datadog/browser-rum`][14] to your `package.json` file, then initialize it with:
 
 <details open>
   <summary>Latest version</summary>
@@ -1840,46 +1840,46 @@ The RUM application ID.
 `clientToken`
 : Required<br/>
 **Type**: String<br/>
-A [Datadog client token][5].
+A [Datadog client token][15].
 
 `site`
 : Required<br/>
 **Type**: String<br/>
 **Default**: `datadoghq.com`<br/>
-[The Datadog site parameter of your organization][14].
+[The Datadog site parameter of your organization][16].
 
 `service`
 : Optional<br/>
 **Type**: String<br/>
-The service name for your application. Follows the [tag syntax requirements][15].
+The service name for your application. Follows the [tag syntax requirements][17].
 
 `env`
 : Optional<br/>
 **Type**: String<br/>
-The application's environment, for example: prod, pre-prod, and staging. Follows the [tag syntax requirements][15].
+The application's environment, for example: prod, pre-prod, and staging. Follows the [tag syntax requirements][17].
 
 `version`
 : Optional<br/>
 **Type**: String<br/>
-The application's version, for example: 1.2.3, 6c44da20, and 2020.02.13. Follows the [tag syntax requirements][15].
+The application's version, for example: 1.2.3, 6c44da20, and 2020.02.13. Follows the [tag syntax requirements][17].
 
 `trackingConsent`
 : Optional<br/>
 **Type**: `"granted"` or `"not-granted"`<br/>
 **Default**: `"granted"`<br/>
-Set the initial user tracking consent state. See [User Tracking Consent][27].
+Set the initial user tracking consent state. See [User Tracking Consent][18].
 
 `trackViewsManually`
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**: `false` <br/>
-Allows you to control RUM views creation. See [override default RUM view names][10].
+Allows you to control RUM views creation. See [override default RUM view names][19].
 
 `trackUserInteractions`
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**: `false` <br/>
-Enables [automatic collection of users actions][6].
+Enables [automatic collection of users actions][20].
 
 `trackResources`
 : Optional<br/>
@@ -1897,30 +1897,30 @@ Enables collection of long task events.
 : Optional<br/>
 **Type**: String<br/>
 **Default**: `mask` <br/>
-See [Session Replay Privacy Options][13].
+See [Session Replay Privacy Options][21].
 
 `actionNameAttribute`
 : Optional<br/>
 **Type**: String<br/>
-Specify your own attribute to be used to [name actions][9].
+Specify your own attribute to be used to [name actions][22].
 
 `sessionSampleRate`
 : Optional<br/>
 **Type**: Number<br/>
 **Default**: `100`<br/>
-The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send RUM events. For more details about `sessionSampleRate`, see the [sampling configuration][21].
+The percentage of sessions to track: `100` for all, `0` for none. Only tracked sessions send RUM events. For more details about `sessionSampleRate`, see the [sampling configuration][7].
 
 `sessionReplaySampleRate`
 : Optional<br/>
 **Type**: Number<br/>
 **Default**: `0`<br/>
-The percentage of tracked sessions with [Browser RUM & Session Replay pricing][11] features: `100` for all, `0` for none. For more details about `sessionReplaySampleRate`, see the [sampling configuration][21].
+The percentage of tracked sessions with [Browser RUM & Session Replay pricing][6] features: `100` for all, `0` for none. For more details about `sessionReplaySampleRate`, see the [sampling configuration][7].
 
 `startSessionReplayRecordingManually`
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**: `false`<br/>
-If the session is sampled for Session Replay, only start the recording when `startSessionReplayRecording()` is called, instead of at the beginning of the session. See [Session Replay Usage][26] for details.
+If the session is sampled for Session Replay, only start the recording when `startSessionReplayRecording()` is called, instead of at the beginning of the session. See [Session Replay Usage][23] for details.
 
 `silentMultipleInit`
 : Optional<br/>
@@ -1931,7 +1931,7 @@ Initialization fails silently if the RUM Browser SDK is already initialized on t
 `proxy`
 : Optional<br/>
 **Type**: String<br/>
-Optional proxy URL, for example: https://www.proxy.com/path. For more information, see the full [proxy setup guide][7].
+Optional proxy URL, for example: https://www.proxy.com/path. For more information, see the full [proxy setup guide][24].
 
 `allowedTracingUrls`
 : Optional<br/>
@@ -1953,30 +1953,30 @@ Telemetry data (such as errors and debug logs) about SDK execution is sent to Da
 `excludedActivityUrls`
 : Optional<br/>
 **Type**: List<br/>
-A list of request origins ignored when computing the page activity. See [How page activity is calculated][16].
+A list of request origins ignored when computing the page activity. See [How page activity is calculated][11].
 
 `workerUrl`
 : Optional<br/>
 **Type**: String<br/>
-URL pointing to the Datadog Browser SDK Worker JavaScript file. The URL can be relative or absolute, but is required to have the same origin as the web application. See [Content Security Policy guidelines][22] for more information.
+URL pointing to the Datadog Browser SDK Worker JavaScript file. The URL can be relative or absolute, but is required to have the same origin as the web application. See [Content Security Policy guidelines][13] for more information.
 
 `compressIntakeRequests`
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**: `false`<br/>
-Compress requests sent to the Datadog intake to reduce bandwidth usage when sending large amounts of data. The compression is done in a Worker thread. See [Content Security Policy guidelines][22] for more information.
+Compress requests sent to the Datadog intake to reduce bandwidth usage when sending large amounts of data. The compression is done in a Worker thread. See [Content Security Policy guidelines][13] for more information.
 
 `storeContextsAcrossPages`
 : Optional<br/>
 **Type**: String<br/>
 **Default**: `false`<br/>
-Store global context and user context in `localStorage` to preserve them along the user navigation. See [Contexts life cycle][24] for more details and specific limitations.
+Store global context and user context in `localStorage` to preserve them along the user navigation. See [Contexts life cycle][25] for more details and specific limitations.
 
 `allowUntrustedEvents`
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**: `false`<br/>
-Allow capture of [untrusted events][25], for example in automated UI tests.
+Allow capture of [untrusted events][26], for example in automated UI tests.
 
 Options that must have matching configuration when you are using the Logs Browser SDK:
 
@@ -2008,7 +2008,7 @@ See `usePartitionedCrossSiteSessionCookie`.
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**: `false`<br/>
-Allows the use of `localStorage` when cookies cannot be set. This enables the RUM Browser SDK to run in environments that do not provide cookie support. See [Monitor Electron Applications Using the Browser SDK][23] for a typical use-case.
+Allows the use of `localStorage` when cookies cannot be set. This enables the RUM Browser SDK to run in environments that do not provide cookie support. See [Monitor Electron Applications Using the Browser SDK][27] for a typical use-case.
 
 ### Tagging
 
@@ -2030,7 +2030,7 @@ You can explore the following attributes:
 | user_action    | Object containing action ID (or undefined if no action is found). |
 | view           | Object containing details about the current view event.           |
 
-For more information, see [RUM Browser Data Collected][2].
+For more information, see [RUM Browser Data Collected][4].
 
 #### Example
 
@@ -2086,31 +2086,30 @@ window.DD_RUM && window.DD_RUM.getInternalContext() // { session_id: "xxxx", app
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/rum/list
-[2]: /real_user_monitoring/data_collected/
-[3]: /real_user_monitoring/platform/dashboards/
-[4]: https://www.npmjs.com/package/@datadog/browser-rum
-[5]: /account_management/api-app-keys/#client-tokens
-[6]: /real_user_monitoring/browser/tracking_user_actions
-[7]: /real_user_monitoring/guide/proxy-rum-data/
-[8]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum/BROWSER_SUPPORT.md
-[9]: /real_user_monitoring/browser/tracking_user_actions/#declare-a-name-for-click-actions
-[10]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#override-default-rum-view-names
-[11]: https://www.datadoghq.com/pricing/?product=real-user-monitoring--session-replay#real-user-monitoring--session-replay
+[1]: /data_security/real_user_monitoring/#shared-responsibility
+[2]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum/BROWSER_SUPPORT.md
+[3]: https://app.datadoghq.com/rum/list
+[4]: /real_user_monitoring/data_collected/
+[5]: /getting_started/tagging/using_tags
+[6]: https://www.datadoghq.com/pricing/?product=real-user-monitoring--session-replay#real-user-monitoring--session-replay
+[7]: /real_user_monitoring/guide/sampling-browser-plans/
+[8]: /real_user_monitoring/session_replay/browser/
+[9]: /real_user_monitoring/session_replay/browser/privacy_options
+[10]: /real_user_monitoring/platform/dashboards/
+[11]: /real_user_monitoring/browser/monitoring_page_performance/#how-page-activity-is-calculated
 [12]: /real_user_monitoring/platform/connect_rum_and_traces?tab=browserrum
-[13]: /real_user_monitoring/session_replay/privacy_options?tab=maskuserinput
-[14]: /getting_started/site/
-[15]: /getting_started/tagging/#define-tags
-[16]: /real_user_monitoring/browser/monitoring_page_performance/#how-page-activity-is-calculated
-[17]: /real_user_monitoring/session_replay/browser/
-[18]: /real_user_monitoring/session_replay/browser/privacy_options
-[19]: /getting_started/tagging/using_tags
-[20]: /real_user_monitoring/browser/frustration_signals/
-[21]: /real_user_monitoring/guide/sampling-browser-plans/
-[22]: /integrations/content_security_policy_logs/#use-csp-with-real-user-monitoring-and-session-replay
-[23]: /real_user_monitoring/guide/monitor-electron-applications-using-browser-sdk
-[24]: https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration#contexts-life-cycle
-[25]: https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted
-[26]: /real_user_monitoring/session_replay/browser/#usage
-[27]: /real_user_monitoring/browser/advanced_configuration/#user-tracking-consent
-[28]: /data_security/real_user_monitoring/#shared-responsibility
+[13]: /integrations/content_security_policy_logs/#use-csp-with-real-user-monitoring-and-session-replay
+[14]: https://www.npmjs.com/package/@datadog/browser-rum
+[15]: /account_management/api-app-keys/#client-tokens
+[16]: /getting_started/site/
+[17]: /getting_started/tagging/#define-tags
+[18]: /real_user_monitoring/browser/advanced_configuration/#user-tracking-consent
+[19]: /real_user_monitoring/browser/advanced_configuration/?tab=npm#override-default-rum-view-names
+[20]: /real_user_monitoring/browser/tracking_user_actions
+[21]: /real_user_monitoring/session_replay/privacy_options?tab=maskuserinput
+[22]: /real_user_monitoring/browser/tracking_user_actions/#declare-a-name-for-click-actions
+[23]: /real_user_monitoring/session_replay/browser/#usage
+[24]: /real_user_monitoring/guide/proxy-rum-data/
+[25]: https://docs.datadoghq.com/real_user_monitoring/browser/advanced_configuration#contexts-life-cycle
+[26]: https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted
+[27]: /real_user_monitoring/guide/monitor-electron-applications-using-browser-sdk

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -63,7 +63,9 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
+  // `site` refers to the Datadog site parameter of your organization
+  // see https://docs.datadoghq.com/getting_started/site/
+  site: '<DATADOG_SITE>',
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -86,7 +88,9 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
+  // `site` refers to the Datadog site parameter of your organization
+  // see https://docs.datadoghq.com/getting_started/site/
+  site: '<DATADOG_SITE>',
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -110,7 +114,9 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
+  // `site` refers to the Datadog site parameter of your organization
+  // see https://docs.datadoghq.com/getting_started/site/
+  site: '<DATADOG_SITE>',
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -134,7 +140,9 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
+  // `site` refers to the Datadog site parameter of your organization
+  // see https://docs.datadoghq.com/getting_started/site/
+  site: '<DATADOG_SITE>',
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -156,7 +164,9 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
+  // `site` refers to the Datadog site parameter of your organization
+  // see https://docs.datadoghq.com/getting_started/site/
+  site: '<DATADOG_SITE>',
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -190,7 +200,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -216,7 +228,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -242,7 +256,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -268,7 +284,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -294,7 +312,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -320,7 +340,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -352,7 +374,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -379,7 +403,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -406,7 +432,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -433,7 +461,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -460,7 +490,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -487,7 +519,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -520,7 +554,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -547,7 +583,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -574,7 +612,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -601,7 +641,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -628,7 +670,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -655,7 +699,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -688,7 +734,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -713,7 +761,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -738,7 +788,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -763,7 +815,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -788,7 +842,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -813,7 +869,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -844,7 +902,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -869,7 +929,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -894,7 +956,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -919,7 +983,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -944,7 +1010,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -969,7 +1037,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
+      site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -1004,6 +1074,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1025,6 +1097,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1046,6 +1120,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1067,6 +1143,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1088,6 +1166,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1109,6 +1189,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1136,6 +1218,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1159,6 +1243,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1182,6 +1268,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1205,6 +1293,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1228,6 +1318,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1251,6 +1343,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1280,6 +1374,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1303,6 +1399,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1326,6 +1424,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1349,6 +1449,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1372,6 +1474,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1395,6 +1499,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1424,6 +1530,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1445,6 +1553,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1466,6 +1576,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1487,6 +1599,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1508,6 +1622,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1529,6 +1645,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1556,6 +1674,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1577,6 +1697,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ap1.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1598,6 +1720,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'datadoghq.eu',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1619,6 +1743,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us3.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1640,6 +1766,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'us5.datadoghq.com',
       //  service: 'my-web-application',
       //  env: 'production',
@@ -1661,6 +1789,8 @@ Add the generated code snippet to the head tag (in front of any other script tag
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
+      // `site` refers to the Datadog site parameter of your organization
+      // see https://docs.datadoghq.com/getting_started/site/
       site: 'ddog-gov.com',
       //  service: 'my-web-application',
       //  env: 'production',

--- a/content/en/real_user_monitoring/browser/_index.md
+++ b/content/en/real_user_monitoring/browser/_index.md
@@ -16,6 +16,8 @@ further_reading:
 
 Datadog Real User Monitoring (RUM) enables you to visualize and analyze the real-time performance and user journeys of your application's individual users. To collect events, add the RUM Browser SDK to your browser application and configure what data is collected using initialization parameters.
 
+The responsibility of keeping user data secure is shared between Datadog and developers who leverage the RUM SDKs. Learn more about [Shared responsibility][28].
+
 ## Setup
 
 The RUM Browser SDK supports all modern desktop and mobile browsers including IE11. For more information, see the [Browser Support][8] table.
@@ -61,7 +63,7 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>',
+  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -84,7 +86,7 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>',
+  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -108,7 +110,7 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>',
+  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -132,7 +134,7 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>',
+  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -154,7 +156,7 @@ import { datadogRum } from '@datadog/browser-rum'
 datadogRum.init({
   applicationId: '<DATADOG_APPLICATION_ID>',
   clientToken: '<DATADOG_CLIENT_TOKEN>',
-  site: '<DATADOG_SITE>',
+  site: '<DATADOG_SITE>', // see https://docs.datadoghq.com/getting_started/site/
   //  service: 'my-web-application',
   //  env: 'production',
   //  version: '1.0.0',
@@ -188,7 +190,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com',
+      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -214,7 +216,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com',
+      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -240,7 +242,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu',
+      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -266,7 +268,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com',
+      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -292,7 +294,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com',
+      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -318,7 +320,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com',
+      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -350,7 +352,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com',
+      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -377,7 +379,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com',
+      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -404,7 +406,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu',
+      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -431,7 +433,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com',
+      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -458,7 +460,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com',
+      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -485,7 +487,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com',
+      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -518,7 +520,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com',
+      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -545,7 +547,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com',
+      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -572,7 +574,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu',
+      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -599,7 +601,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com',
+      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -626,7 +628,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com',
+      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -653,7 +655,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com',
+      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -686,7 +688,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com',
+      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -711,7 +713,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com',
+      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -736,7 +738,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu',
+      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -761,7 +763,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com',
+      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -786,7 +788,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com',
+      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -811,7 +813,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com',
+      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -842,7 +844,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.com',
+      site: 'datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -867,7 +869,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ap1.datadoghq.com',
+      site: 'ap1.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -892,7 +894,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'datadoghq.eu',
+      site: 'datadoghq.eu', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -917,7 +919,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us3.datadoghq.com',
+      site: 'us3.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -942,7 +944,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'us5.datadoghq.com',
+      site: 'us5.datadoghq.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -967,7 +969,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
       applicationId: '<APPLICATION_ID>',
-      site: 'ddog-gov.com',
+      site: 'ddog-gov.com', // see https://docs.datadoghq.com/getting_started/site/
       //  service: 'my-web-application',
       //  env: 'production',
       //  version: '1.0.0',
@@ -1981,3 +1983,4 @@ window.DD_RUM && window.DD_RUM.getInternalContext() // { session_id: "xxxx", app
 [25]: https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted
 [26]: /real_user_monitoring/session_replay/browser/#usage
 [27]: /real_user_monitoring/browser/advanced_configuration/#user-tracking-consent
+[28]: /data_security/real_user_monitoring/#shared-responsibility


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds a graf about shared responsibility between Datadog and developers as a response to the incident described in [RUM-4002](https://datadoghq.atlassian.net/browse/RUM-4002) to the RUM Data Security page
- References this graf in each snippet in the Browser setup page
- Adds a similar graf to the Getting Started: Sites page

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
The legal team needs to review this before it gets merged.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[RUM-4002]: https://datadoghq.atlassian.net/browse/RUM-4002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ