### PR TITLE
Add sentence concerning renotification timeout of 30 hours

### DIFF
--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -56,7 +56,7 @@ Enable monitor renotification (optional) to remind your team that a problem is n
 
 Configure the renotify interval, the monitor states from which the monitor renotifies (within `alert`, `no data`, and `warn`) and optionally set a limit to the number of renotification messages sent.
 
-For example, configure the monitor to `stop renotifying after 1 occurrence` to receive a single escalation message after the main alert. By default, the renotifications will stop 30 hours after the first alert.
+For example, configure the monitor to `stop renotifying after 1 occurrence` to receive a single escalation message after the main alert. By default, the renotifications stop 30 hours after the first alert.
 **Note:** [Attribute and tag variables][7] in the renotification are populated with the data available to the monitor during the time period of the renotification.
 
 If renotification is enabled, you are given the option to include an escalation message that is sent if the monitor remains in one of the chosen states for the specified time period.

--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -56,7 +56,7 @@ Enable monitor renotification (optional) to remind your team that a problem is n
 
 Configure the renotify interval, the monitor states from which the monitor renotifies (within `alert`, `no data`, and `warn`) and optionally set a limit to the number of renotification messages sent.
 
-For example, configure the monitor to `stop renotifying after 1 occurrence` to receive a single escalation message after the main alert.
+For example, configure the monitor to `stop renotifying after 1 occurrence` to receive a single escalation message after the main alert. By default, the renotifications will stop 30 hours after the first alert.
 **Note:** [Attribute and tag variables][7] in the renotification are populated with the data available to the monitor during the time period of the renotification.
 
 If renotification is enabled, you are given the option to include an escalation message that is sent if the monitor remains in one of the chosen states for the specified time period.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Several customers have reached out wondering why their monitor stopped renotifying after 30 hours. Adding a sentence to the docs will help have a record of this default behavior.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->