### PR TITLE
[CIVIS] improve GitLab logs collection warning

### DIFF
--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -278,7 +278,7 @@ To enable collection of job logs:
 {{% /tab %}}
 
 {{% tab "GitLab &gt;&equals; 15.3" %}}
-<div class="alert alert-warning"><strong>Warning</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
+<div class="alert alert-warning">Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
 This means that for Datadog servers to access the storage, the storage must not have network restrictions
 The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.</div>
 
@@ -288,7 +288,7 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 {{% /tab %}}
 
 {{% tab "GitLab &gt;&equals; 14.8" %}}
-<div class="alert alert-warning"><strong>Warning</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
+<div class="alert alert-warning"Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
 This means that for Datadog servers to access the storage, the storage must not have network restrictions
 The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.</div>
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -288,7 +288,7 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 {{% /tab %}}
 
 {{% tab "GitLab &gt;&equals; 14.8" %}}
-<div class="alert alert-warning"Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
+<div class="alert alert-warning">Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
 This means that for Datadog servers to access the storage, the storage must not have network restrictions
 The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.</div>
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -278,8 +278,9 @@ To enable collection of job logs:
 {{% /tab %}}
 
 {{% tab "GitLab &gt;&equals; 15.3" %}}
-<div class="alert alert-info"><strong>Note</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
-The storage must not have network restrictions, such as an IP range allowlist.</div>
+<div class="alert alert-warning"><strong>Warning</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
+This means that the storage must not have network restrictions. Datadog servers will be accessing the storage, and those server IPs are available in the Webhooks section of <a href="https://docs.datadoghq.com/api/latest/ip-ranges/">IP Ranges</a> </div>
+The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.
 
 1. Click **Enable job logs collection** checkbox in the GitLab integration under **Settings > Integrations > Datadog**.
 2. Click **Save changes**.
@@ -287,6 +288,10 @@ The storage must not have network restrictions, such as an IP range allowlist.</
 {{% /tab %}}
 
 {{% tab "GitLab &gt;&equals; 14.8" %}}
+<div class="alert alert-warning"><strong>Warning</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
+This means that the storage must not have network restrictions. Datadog servers will be accessing the storage, and those server IPs are available in the Webhooks section of <a href="https://docs.datadoghq.com/api/latest/ip-ranges/">IP Ranges</a> </div>
+The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.'
+
 1. Enable the `datadog_integration_logs_collection` [feature flag][1] in your GitLab. This allows you to see the **Enable job logs collection** checkbox in the GitLab integration under **Settings > Integrations > Datadog**.
 2. Click **Enable job logs collection**.
 3. Click **Save changes**.

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -279,8 +279,8 @@ To enable collection of job logs:
 
 {{% tab "GitLab &gt;&equals; 15.3" %}}
 <div class="alert alert-warning"><strong>Warning</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
-This means that the storage must not have network restrictions. Datadog servers will be accessing the storage, and those server IPs are available in the Webhooks section of <a href="https://docs.datadoghq.com/api/latest/ip-ranges/">IP Ranges</a> </div>
-The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.
+This means that the storage must not have network restrictions. Datadog servers will be accessing the storage.
+The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.</div>
 
 1. Click **Enable job logs collection** checkbox in the GitLab integration under **Settings > Integrations > Datadog**.
 2. Click **Save changes**.
@@ -289,8 +289,8 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 
 {{% tab "GitLab &gt;&equals; 14.8" %}}
 <div class="alert alert-warning"><strong>Warning</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
-This means that the storage must not have network restrictions. Datadog servers will be accessing the storage, and those server IPs are available in the Webhooks section of <a href="https://docs.datadoghq.com/api/latest/ip-ranges/">IP Ranges</a> </div>
-The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.'
+This means that the storage must not have network restrictions. Datadog servers will be accessing the storage
+The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.</div>
 
 1. Enable the `datadog_integration_logs_collection` [feature flag][1] in your GitLab. This allows you to see the **Enable job logs collection** checkbox in the GitLab integration under **Settings > Integrations > Datadog**.
 2. Click **Enable job logs collection**.

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -289,7 +289,7 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 
 {{% tab "GitLab &gt;&equals; 14.8" %}}
 <div class="alert alert-warning"><strong>Warning</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
-This means that the storage must not have network restrictions. Datadog servers will be accessing the storage
+This means that for Datadog servers to access the storage, the storage must not have network restrictions
 The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.</div>
 
 1. Enable the `datadog_integration_logs_collection` [feature flag][1] in your GitLab. This allows you to see the **Enable job logs collection** checkbox in the GitLab integration under **Settings > Integrations > Datadog**.

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -279,7 +279,7 @@ To enable collection of job logs:
 
 {{% tab "GitLab &gt;&equals; 15.3" %}}
 <div class="alert alert-warning"><strong>Warning</strong>: Datadog downloads log files directly from your GitLab logs <a href="https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage">object storage</a> with temporary pre-signed URLs.
-This means that the storage must not have network restrictions. Datadog servers will be accessing the storage.
+This means that for Datadog servers to access the storage, the storage must not have network restrictions
 The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazon-s3">endpoint</a>, if set, should resolve to a publicly accessible URL.</div>
 
 1. Click **Enable job logs collection** checkbox in the GitLab integration under **Settings > Integrations > Datadog**.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We had several customers reaching out because they cannot see GitLab logs after enabling the feature. This is because:
- either they do not realise that their storage DNS must resolve to an IP
- or that they do not allowed access from outside to their storage.

This PR clarifies that, by:
- changing the "note" to a "warning"
- linking to the GitLab `endpoint` doc so that people are aware this endpoint should resolve
- adding the IP range that Datadog servers will be using so that people can protect their storage behind that list.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->