### PR TITLE
DOCS-7421: Add product identifier tags to Security Overview docs

### DIFF
--- a/content/en/security/audit_trail.md
+++ b/content/en/security/audit_trail.md
@@ -9,7 +9,19 @@ further_reading:
 - link: "/account_management/audit_trail/events/"
   tag: "Documentation"
   text: "Learn about Audit Trail events"
+products:
+- name: Cloud SIEM
+  url: /security/cloud_siem/
+  icon: siem
+- name: Cloud Security Management
+  url: /security/cloud_security_management/
+  icon: cloud-security-management
+- name: Application Security Management
+  url: /security/application_security/
+  icon: app-sec
 ---
+
+{{< product-availability >}}
 
 As an administrator or security team member, you can use [Audit Trail][1] to see what actions your team is taking in Datadog Security. As an individual, you can see a stream of your own actions. For security admins or InfoSec teams, audit trail events help with compliance checks and maintaining audit trails of who did what, and when, for your Datadog resources.
 

--- a/content/en/security/detection_rules/_index.md
+++ b/content/en/security/detection_rules/_index.md
@@ -19,7 +19,19 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/impossible-travel-detection-rules/"
   tag: "Blog"
   text: "Detect suspicious login activity with impossible travel detection rules"
+products:
+- name: Cloud SIEM
+  url: /security/cloud_siem/
+  icon: siem
+- name: Cloud Security Management
+  url: /security/cloud_security_management/
+  icon: cloud-security-management
+- name: Application Security Management
+  url: /security/application_security/
+  icon: app-sec
 ---
+
+{{< product-availability >}}
 
 Detection rules define conditional logic that is applied to all ingested logs and cloud configurations. When at least one case defined in a rule is matched over a given period of time, a security signal is generated. You can view these signals in the [Signals Explorer][16].
 

--- a/content/en/security/notifications/_index.md
+++ b/content/en/security/notifications/_index.md
@@ -13,7 +13,19 @@ further_reading:
 - link: "/security/detection_rules/"
   tag: "Documentation"
   text: "Explore security detection rules"
+products:
+- name: Cloud SIEM
+  url: /security/cloud_siem/
+  icon: siem
+- name: Cloud Security Management
+  url: /security/cloud_security_management/
+  icon: cloud-security-management
+- name: Application Security Management
+  url: /security/application_security/
+  icon: app-sec
 ---
+
+{{< product-availability >}}
 
 ## Overview
 

--- a/content/en/security/notifications/rules.md
+++ b/content/en/security/notifications/rules.md
@@ -12,7 +12,19 @@ further_reading:
 - link: "/security/detection_rules/"
   tag: "Documentation"
   text: "Explore security detection rules"
+products:
+- name: Cloud SIEM
+  url: /security/cloud_siem/
+  icon: siem
+- name: Cloud Security Management
+  url: /security/cloud_security_management/
+  icon: cloud-security-management
+- name: Application Security Management
+  url: /security/application_security/
+  icon: app-sec
 ---
+
+{{< product-availability >}}
 
 ## Overview
 

--- a/content/en/security/notifications/variables.md
+++ b/content/en/security/notifications/variables.md
@@ -10,7 +10,19 @@ further_reading:
 - link: "/security/notifications/"
   tag: "Documentation"
   text: "Learn more about Security notifications"
+products:
+- name: Cloud SIEM
+  url: /security/cloud_siem/
+  icon: siem
+- name: Cloud Security Management
+  url: /security/cloud_security_management/
+  icon: cloud-security-management
+- name: Application Security Management
+  url: /security/application_security/
+  icon: app-sec
 ---
+
+{{< product-availability >}}
 
 ## Overview
 

--- a/content/en/security/security_inbox.md
+++ b/content/en/security/security_inbox.md
@@ -14,7 +14,16 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/security-inbox/"
   tag: "Blog"
   text: "Easily identify and prioritize your top security risks with Datadog Security Inbox"
+products:
+- name: Cloud Security Management
+  url: /security/cloud_security_management/
+  icon: cloud-security-management
+- name: Application Security Management
+  url: /security/application_security/
+  icon: app-sec
 ---
+
+{{< product-availability >}}
 
 Security Inbox provides a consolidated, actionable list of your most important security findings. It automatically contextualizes and correlates insights from Datadog security products across vulnerabilities, signals, misconfigurations, and identity risks into a unified, prioritized view of actions to take to strengthen your environment.
 

--- a/content/en/security/threat_intelligence.md
+++ b/content/en/security/threat_intelligence.md
@@ -8,7 +8,19 @@ further_reading:
   - link: "/security/application_security/threats/threat-intelligence/"
     tag: "documentation"
     text: "ASM Threat Intelligence"
+products:
+- name: Cloud SIEM
+  url: /security/cloud_siem/
+  icon: siem
+- name: CSM Threats
+  url: /security/threats/
+  icon: cloud-security-management
+- name: Application Security Management
+  url: /security/application_security/
+  icon: app-sec
 ---
+
+{{< product-availability >}}
 
 ## Overview
 Threat Intelligence is reputation information that helps responders make informed decisions on attacks and compromises. 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

DOCS-7421. Adds product identifier tags to Security Overview docs.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->