### PR TITLE
asm: add mention of the datadog.no_waf build tag

### DIFF
--- a/content/en/security/application_security/enabling/tracing_libraries/threat_detection/go.md
+++ b/content/en/security/application_security/enabling/tracing_libraries/threat_detection/go.md
@@ -49,6 +49,7 @@ You can monitor application security for Go apps running in Docker, Kubernetes, 
    - The Go build tag `appsec` is not necessary if CGO is enabled with `CGO_ENABLED=1`.
    - Datadog WAF needs the following shared libraries on Linux: `libc.so.6` and `libpthread.so.0`.
    - When using the build tag `appsec` and CGO is disabled, the produced binary is still linked dynamically to these libraries.
+   - The Go build tag `datadog.no_waf` can be used in any situation where the requirements above are a hinderance to disable ASM at build time.
 
 4. **Redeploy your Go service and enable ASM** by setting the `DD_APPSEC_ENABLED` environment variable to `true`:
    ```console


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The docs are missing a mention to this emergency button build tag

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->