### PR TITLE
updating code security supported languages and duplicate callout

### DIFF
--- a/content/en/security/application_security/enabling/single_step/code_security.md
+++ b/content/en/security/application_security/enabling/single_step/code_security.md
@@ -9,7 +9,7 @@ kind: documentation
 ## Requirements
 
 - **Minimum Agent version 7.53.0**
-- **Languages and architectures**: Single step ASM instrumentation for code security only supports tracing Java, Node.js, python (private beta), and .NET Core services on `x86_64` and `arm64` architectures.
+- **Languages and architectures**: Single step ASM instrumentation for code security only supports tracing Java, Node.js, Python (private beta), and .NET Core services on `x86_64` and `arm64` architectures.
 - **Operating systems**: Linux VMs (Debian, Ubuntu, Amazon Linux, CentOS/Red Hat, Fedora), Docker, Kubernetes clusters with Linux containers.
 
 ## Enabling in one step

--- a/content/en/security/application_security/enabling/single_step/code_security.md
+++ b/content/en/security/application_security/enabling/single_step/code_security.md
@@ -9,7 +9,7 @@ kind: documentation
 ## Requirements
 
 - **Minimum Agent version 7.53.0**
-- **Languages and architectures**: Single step ASM instrumentation only supports tracing Java, Python, Ruby, Node.js, and .NET Core services on `x86_64` and `arm64` architectures.
+- **Languages and architectures**: Single step ASM instrumentation for code security only supports tracing Java, Node.js, python (private beta), and .NET Core services on `x86_64` and `arm64` architectures.
 - **Operating systems**: Linux VMs (Debian, Ubuntu, Amazon Linux, CentOS/Red Hat, Fedora), Docker, Kubernetes clusters with Linux containers.
 
 ## Enabling in one step
@@ -54,7 +54,7 @@ For an Ubuntu host:
 
 ### Specifying tracing library versions {#lib-linux}
 
-By default, enabling APM on your server installs support for Java, Python, Ruby, Node.js, and .NET Core services. If you only have services implemented in some of these languages, set `DD_APM_INSTRUMENTATION_LIBRARIES` in your one-line installation command:
+By default, enabling APM on your server installs support for Java, Python, Node.js, and .NET Core services. If you only have services implemented in some of these languages, set `DD_APM_INSTRUMENTATION_LIBRARIES` in your one-line installation command:
 
 ```shell
 DD_APM_INSTRUMENTATION_LIBRARIES="java:1.25.0,python" DD_API_KEY=<YOUR_DD_API_KEY> DD_SITE="<YOUR_DD_SITE>" DD_APM_INSTRUMENTATION_ENABLED=host DD_IAST_ENABLED=true  DD_ENV=staging bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
@@ -68,7 +68,6 @@ Supported languages include:
 - Python (`python`)
 - Java (`java`)
 - Node.js (`js`)
-- Ruby (`ruby`)
 
 **Note**: For the Node.js tracing library, different versions of Node.js are compatible with different versions of the Node.js tracing library. See [DataDog/dd-trace-js: JavaScript APM Tracer][6] for more information.
 
@@ -125,7 +124,7 @@ For a Docker Linux container:
 
 ### Specifying tracing library versions {#lib-docker}
 
-By default, enabling APM on your server installs support for Java, Python, Ruby, Node.js, and .NET services. If you only have services implemented in some of these languages, set `DD_APM_INSTRUMENTATION_LIBRARIES` when running the installation script.
+By default, enabling APM on your server installs support for Java, Python, Node.js, and .NET services. If you only have services implemented in some of these languages, set `DD_APM_INSTRUMENTATION_LIBRARIES` when running the installation script.
 
 For example, to install support for only v1.25.0 of the Java tracing library and the latest Python tracing library, add the following to the installation command:
 
@@ -141,7 +140,6 @@ Supported languages include:
 - Python (`python`)
 - Java (`java`)
 - Node.js (`js`)
-- Ruby (`ruby`)
 
 **Note**: For the Node.js tracing library, different versions of Node.js are compatible with different versions of the Node.js tracing library. See [DataDog/dd-trace-js: JavaScript APM Tracer][7] for more information.
 

--- a/content/en/security/application_security/enabling/tracing_libraries/code_security/dotnet.md
+++ b/content/en/security/application_security/enabling/tracing_libraries/code_security/dotnet.md
@@ -26,8 +26,6 @@ You can monitor application security for .NET apps running in Docker, Kubernetes
 
 {{% appsec-getstarted %}}
 
-{{% appsec-getstarted-with-rc %}}
-
 
 ## Enabling code security vulnerability detection
 

--- a/content/en/security/application_security/enabling/tracing_libraries/code_security/java.md
+++ b/content/en/security/application_security/enabling/tracing_libraries/code_security/java.md
@@ -27,8 +27,6 @@ You can monitor application security for Java apps running in Docker, Kubernetes
 
 {{% appsec-getstarted %}}
 
-{{% appsec-getstarted-with-rc %}}
-
 ## Enabling code security vulnerability detection
 
 If your service runs a [tracing library version that supports code security vulnerability detection][3], enable the capability by setting the `DD_IAST_ENABLED=true` environment variable and restarting your service.

--- a/content/en/security/application_security/enabling/tracing_libraries/code_security/nodejs.md
+++ b/content/en/security/application_security/enabling/tracing_libraries/code_security/nodejs.md
@@ -26,8 +26,6 @@ You can monitor application security for Node.js apps running in Docker, Kuberne
 
 {{% appsec-getstarted %}}
 
-{{% appsec-getstarted-with-rc %}}
-
 ## Enabling code security vulnerability detection
 If your service runs a [tracing library version that supports code security vulnerability detection][3], enable the capability by setting the `DD_IAST_ENABLED=true` environment variable and restarting your service.
 


### PR DESCRIPTION


### What does this PR do? What is the motivation?

This PR removes duplicated 1 click enablement callouts on the Code Security pages for ASM and additionally updates the supported languages for code security for single step instrumentation

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->