### PR TITLE
DOCS-7655 Adds Code Analysis Troubleshooting Doc Page

### DIFF
--- a/config/_default/menus/menus.en.yaml
+++ b/config/_default/menus/menus.en.yaml
@@ -3580,6 +3580,11 @@ main:
     parent: code_analysis
     identifier: code_analysis_github_prs
     weight: 4
+  - name: Troubleshooting
+    url: code_analysis/troubleshooting
+    parent: code_analysis
+    identifier: code_analysis_troubleshooting
+    weight: 5
   - name: Quality Gates
     url: quality_gates/
     pre: ci

--- a/content/en/code_analysis/troubleshooting/_index.md
+++ b/content/en/code_analysis/troubleshooting/_index.md
@@ -1,0 +1,53 @@
+---
+title: Code Analysis Troubleshooting
+kind: documentation
+description: Learn how to troubleshoot common Code Analysis issues and how to engage with Support.
+further_reading:
+- link: "/code_analysis/"
+  tag: "Documentation"
+  text: "Learn about Code Analysis"
+- link: "/code_analysis/static_analysis/"
+  tag: "Documentation"
+  text: "Learn about Static Analysis"
+- link: "/code_analysis/software_composition_analysis/"
+  tag: "Documentation"
+  text: "Learn about Software Composition Analysis"
+---
+
+## Overview
+
+If you experience issues setting up or configuring Datadog Code Analysis, use this page to start troubleshooting. If you continue to have trouble, [contact Datadog Support][1].
+
+## Static Analysis
+
+For issues with the Datadog Static Analyzer, include the following information in a bug report to Support as well as your customer success manager.
+
+- Your `static-analysis.datadog.yml` file
+- The output of your static analysis tool (such as a CLI) that is run locally or in a CI/CD pipeline
+- The SARIF file produced (if there are any and are available)
+- The URL of your repository (public or private)
+- The exact command line used to run the Datadog Static Analyzer
+
+### Performance issues
+
+If you are experiencing performance issues, you can enable the `--performance-statistics` flag when running the static analysis tool from the command line.
+
+For performance issues, include the following information:
+
+- Your `static-analysis.datadog.yml` file
+- The output of your static analysis tool (such as a CLI) that is run locally or in a CI/CD pipeline
+- The URL of your repository (public or private)
+
+**Note:** If you are using [Static Analysis and GitHub Actions][2], set the [`enable_performance_statistics`][3] parameter to true.
+
+### Blocking issues
+
+If you are experiencing issues unrelated to performance or if the Datadog Static Analyzer fails to exit, run the Datadog Static Analyzer with the `--debug true --performance-statistics` flag.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /help/
+[2]: /code_analysis/static_analysis/github_actions
+[3]: /code_analysis/static_analysis/github_actions#inputs

--- a/content/en/code_analysis/troubleshooting/_index.md
+++ b/content/en/code_analysis/troubleshooting/_index.md
@@ -26,6 +26,7 @@ For issues with the Datadog Static Analyzer, include the following information i
 - The output of your static analysis tool (such as a CLI) that is run locally or in a CI/CD pipeline
 - The SARIF file produced (if there are any and are available)
 - The URL of your repository (public or private)
+- The name of the branch you ran the analysis on
 - The exact command line used to run the Datadog Static Analyzer
 
 ### Performance issues
@@ -43,6 +44,16 @@ For performance issues, include the following information:
 ### Blocking issues
 
 If you are experiencing issues unrelated to performance or if the Datadog Static Analyzer fails to exit, run the Datadog Static Analyzer with the `--debug true --performance-statistics` flag.
+
+## Software Composition Analysis
+
+For issues with Datadog Software Composition Analysis, include the following information in a bug report to Support as well as your customer success manager.
+
+- The output of your SCA tool (such as CLI) that is run locally or in a CI/CD pipeline
+- The SBOM file produced (if there are any available)
+- The URL of your repository (public or private)
+- The name of the branch you ran the analysis on
+- The list of dependency files in your repository (e.g. package-lock.json, requirements.txt, pom.xml)
 
 ## Further reading
 

--- a/content/en/code_analysis/troubleshooting/_index.md
+++ b/content/en/code_analysis/troubleshooting/_index.md
@@ -20,11 +20,11 @@ If you experience issues setting up or configuring Datadog Code Analysis, use th
 
 ## Static Analysis
 
-For issues with the Datadog Static Analyzer, include the following information in a bug report to Support as well as your customer success manager.
+For issues with the Datadog Static Analyzer, include the following information in a bug report to Support as well as your Customer Success Manager.
 
 - Your `static-analysis.datadog.yml` file
 - The output of your static analysis tool (such as a CLI) that is run locally or in a CI/CD pipeline
-- The SARIF file produced (if there are any and are available)
+- The SARIF file produced (if there are any available)
 - The URL of your repository (public or private)
 - The name of the branch you ran the analysis on
 - The exact command line used to run the Datadog Static Analyzer
@@ -47,13 +47,13 @@ If you are experiencing issues unrelated to performance or if the Datadog Static
 
 ## Software Composition Analysis
 
-For issues with Datadog Software Composition Analysis, include the following information in a bug report to Support as well as your customer success manager.
+For issues with Datadog Software Composition Analysis, include the following information in a bug report to Support as well as your Customer Success Manager.
 
 - The output of your SCA tool (such as CLI) that is run locally or in a CI/CD pipeline
 - The SBOM file produced (if there are any available)
 - The URL of your repository (public or private)
 - The name of the branch you ran the analysis on
-- The list of dependency files in your repository (e.g. package-lock.json, requirements.txt, pom.xml)
+- The list of dependency files in your repository (such as `package-lock.json`, `requirements.txt`, or `pom.xml`)
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds a Troubleshooting page to the Code Analysis section.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->