### PR TITLE
[ci-visibility] Clarify git upload and other small improvements

### DIFF
--- a/content/en/tests/_index.md
+++ b/content/en/tests/_index.md
@@ -52,7 +52,7 @@ cascade:
     {{< nextlink href="tests/containers" >}}Tests running in containers{{< /nextlink >}}
 {{< /whatsnext >}}
 
-In addition to tests, Test Visibility provides visibility over the whole testing phase of your project (except for Ruby).
+In addition to tests, Test Visibility provides visibility over the whole testing phase of your project.
 
 ### Supported features
 
@@ -153,13 +153,9 @@ In order to filter using these configurations tags, [you must create facets for 
 {{< nextlink href="/tests/swift_tests" >}}Instrument Swift Tests with Browser RUM{{< /nextlink >}}
 {{< /whatsnext >}}
 
-If [Intelligent Test Runner][12] is enabled for .NET, Java, JavaScript, or Swift, per test code coverage information, including file names and line numbers covered by each test, are collected from your projects.
-
-When creating a [dashboard][8] or a [notebook][9], you can use test execution data in your search query, which updates the visualization widget options.
-
 ## Alert on test data
 
-When you evaluate failed or flaky tests, or the performance of a CI test on the [**Test Runs** page][10], click **Create Monitor** to create a [CI Test monitor][11].
+When you evaluate failed or flaky tests, or the performance of a CI test on the [**Test Runs** page][3], click **Create Monitor** to create a [CI Test monitor][4].
 
 ## Further reading
 
@@ -167,8 +163,5 @@ When you evaluate failed or flaky tests, or the performance of a CI test on the 
 
 [1]: https://app.datadoghq.com/ci/test-services
 [2]: /continuous_integration/explorer/facets/
-[8]: https://app.datadoghq.com/dashboard/lists
-[9]: https://app.datadoghq.com/notebook/list
-[10]: https://app.datadoghq.com/ci/test-runs
-[11]: /monitors/types/ci/
-[12]: /tests/code_coverage/
+[3]: https://app.datadoghq.com/ci/test-runs
+[4]: /monitors/types/ci/

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -585,11 +585,6 @@ For more information about `service` and `env` reserved tags, see [Unified Servi
 
 {{% ci-git-metadata %}}
 
-## Git metadata upload
-
-From `dd-trace>=3.15.0` and `dd-trace>=2.28.0`, CI Visibility automatically uploads git metadata information (commit history). This metadata contains file names but no file contents. If you want to opt out of this behavior, you can do so by setting `DD_CIVISIBILITY_GIT_UPLOAD_ENABLED` to `false`. However, this is not recommended, as features like Intelligent Test Runner and others do not work without it.
-
-
 ## Manual testing API
 
 <div class="alert alert-warning">


### PR DESCRIPTION
### What does this PR do? What is the motivation?

* Remove "Git metadata upload" section, as it's not there for languages other than JS and it adds confusion. 
* Remove unnecessary Intelligent Test Runner reference.
* Remove `(except for Ruby)`, since that's no longer the case.


### Merge instructions
- [x] Please merge after reviewing

### Additional notes
