### PR TITLE
fixed broken link on events page

### DIFF
--- a/content/en/service_management/events/_index.md
+++ b/content/en/service_management/events/_index.md
@@ -37,7 +37,7 @@ More than 100 Datadog integrations support events collection, including [Kuberne
 
 {{< whatsnext desc="Event Management features:">}}
     {{< nextlink href="/service_management/events/ingest/" >}}<u>Ingest events</u> - Learn how to send events to Datadog{{< /nextlink >}}
-     {{< nextlink href="/service_management/events/pipelines_and_processors/overview/">}}<u>Pipelines and Processors</u> - Enrich and Normalize your events{{< /nextlink >}}
+     {{< nextlink href="/service_management/events/pipelines_and_processors/">}}<u>Pipelines and Processors</u> - Enrich and Normalize your events{{< /nextlink >}}
     {{< nextlink href="/service_management/events/explorer/" >}}<u>Events Explorer</u> - View, search and send notifications from events coming into Datadog{{< /nextlink >}}
     {{< nextlink href="/service_management/events/guides/usage/" >}}<u>Using events</u> - Analyze, investigate, and monitor events {{< /nextlink >}}
     {{< nextlink href="/service_management/events/correlation/" >}}<u>Correlation</u> - reduce alert fatigure and the number of tickets/notifictions you recieve {{< /nextlink >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Pipeline was throwing errors for a broken link that was linking to `/service_management/events/pipelines_and_processors/overview/` instead of `/service_management/events/pipelines_and_processors/`

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

https://docs-staging.datadoghq.com/fitzage/fix-link/service_management/events/
