### PR TITLE
DOCS-7683 Adds CI Test Visibility Terminology to the Docs Glossary

### DIFF
--- a/content/en/glossary/terms/absolute_change.md
+++ b/content/en/glossary/terms/absolute_change.md
@@ -1,0 +1,10 @@
+---
+title: absolute change
+core_product:
+  - ci-cd
+related_terms:
+  - baseline mean
+  - test duration
+  - relative change
+---
+In Datadog CI Test Visibility, an absolute change is the absolute difference between the test duration and the baseline mean. For more information, <a href="/continuous_integration/explorer/?tab=testruns">see the documentation</a>.

--- a/content/en/glossary/terms/baseline_mean.md
+++ b/content/en/glossary/terms/baseline_mean.md
@@ -1,0 +1,8 @@
+---
+title: baseline mean
+core_product:
+  - ci-cd
+related_terms:
+  - test run
+---
+In Datadog CI Test Visibility, a baseline mean is the mean duration of the same test in the default branch, calculated over the last week of test runs. For more information, <a href="/continuous_integration/explorer/?tab=testruns">see the documentation</a>.

--- a/content/en/glossary/terms/baseline_standard_deviation.md
+++ b/content/en/glossary/terms/baseline_standard_deviation.md
@@ -1,0 +1,8 @@
+---
+title: baseline standard deviation
+core_product:
+  - ci-cd
+related_terms:
+  - test run
+---
+In Datadog CI Test Visibility, a baseline standard deviation is the standard deviation of the same test in the default branch, calculated over the last week of test runs. For more information, <a href="/continuous_integration/explorer/?tab=testruns">see the documentation</a>.

--- a/content/en/glossary/terms/performance_regression_(Test Visibility).md
+++ b/content/en/glossary/terms/performance_regression_(Test Visibility).md
@@ -1,0 +1,9 @@
+---
+title: performance regression
+core_product:
+  - ci-cd
+related_terms:
+  - test regression
+  - test service
+---
+In Datadog CI Test Visibility, a performance regression is a measurable decline in performance metrics for a test service. For more information, <a href="/monitors/types/ci/?tab=pipelines#trigger-alerts-for-performance-regressions">see the documentation</a>.

--- a/content/en/glossary/terms/relative_change.md
+++ b/content/en/glossary/terms/relative_change.md
@@ -1,0 +1,10 @@
+---
+title: relative change
+core_product:
+  - ci-cd
+related_terms:
+  - baseline mean
+  - test duration
+  - absolute change
+---
+In Datadog CI Test Visibility, a relative change is the relative difference between the test duration and the baseline mean. For more information, <a href="/continuous_integration/explorer/?tab=testruns">see the documentation</a>.

--- a/content/en/glossary/terms/standard_deviation_change.md
+++ b/content/en/glossary/terms/standard_deviation_change.md
@@ -1,0 +1,8 @@
+---
+title: standard deviation change
+core_product:
+  - ci-cd
+related_terms:
+  - baseline mean
+---
+In Datadog CI Test Visibility, a standard deviation change is the number of standard deviation above the baseline mean. For more information, <a href="/continuous_integration/explorer/?tab=testruns">see the documentation</a>.

--- a/content/en/glossary/terms/test_duration.md
+++ b/content/en/glossary/terms/test_duration.md
@@ -1,0 +1,9 @@
+---
+title: test duration
+core_product:
+  - ci-cd
+related_terms:
+  - absolute change
+  - relative change
+---
+In Datadog CI Test Visibility, a test duration is the length of time for a CI test to complete. For more information, <a href="/continuous_integration/explorer/?tab=testruns">see the documentation</a>.

--- a/content/en/glossary/terms/test_regression.md
+++ b/content/en/glossary/terms/test_regression.md
@@ -1,11 +1,11 @@
 ---
 # Glossary Term
 title: test regression
-
 core_product:
   - ci-cd
-  
+related_terms:
+  - performance regression
 ---
-A test run is marked as a regression when its duration is both five times the mean and greater than the max duration for the same test in the default branch. A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. 
+In Datadog CI Test Visibility, a test run is marked as a regression when its duration is both five times the mean and greater than the max duration for the same test in the default branch. A benchmark test run is marked as a regression when its duration is five times the standard deviation above the mean for the same test in the default branch. 
 
 A benchmark test has `@test.type:benchmark`. The mean and the max of the default branch is calculated over the last week of test runs. For more information, <a href="/tests/search/#test-regressions">see the documentation</a>.

--- a/content/en/glossary/terms/test_run.md
+++ b/content/en/glossary/terms/test_run.md
@@ -3,5 +3,6 @@
 title: test run
 core_product:
   - synthetic monitoring
+  - ci-cd
 ---
-In Datadog Synthetic Monitoring, a test run is an executed set of tests on software to ensure its functionality. A browser test run is a simulation of a web transaction, up to 25 steps. For more information, <a href="/continuous_testing/explorer/search_runs/">see the documentation</a>.
+In Datadog Synthetic Monitoring and CI Test Visibility, a test run is an executed set of tests on software to ensure its functionality. A browser test run is a simulation of a web transaction, up to 25 steps. For more information, <a href="/continuous_testing/explorer/search_runs/">see the documentation</a>.

--- a/content/en/glossary/terms/test_service.md
+++ b/content/en/glossary/terms/test_service.md
@@ -7,4 +7,4 @@ core_product:
 related_terms:
   - test suite
 ---
-In Datadog Synthetic Monitoring and CI Visibility, a test service is generally a group of tests associated with, for example, a project or repo. It contains all the individual tests for your code, optionally organized into test suites, which are like folders for your tests. For more information, <a href="/tests/search/#test-suite-performance">see the documentation</a>.
+In Datadog Synthetic Monitoring and CI Test Visibility, a test service is generally a group of tests associated with, for example, a project or repo. It contains all the individual tests for your code, optionally organized into test suites, which are like folders for your tests. For more information, <a href="/tests/search/#test-suite-performance">see the documentation</a>.

--- a/content/en/glossary/terms/test_suite.md
+++ b/content/en/glossary/terms/test_suite.md
@@ -7,4 +7,4 @@ core_product:
 related_terms:
   - test service
 ---
-In Datadog Synthetic Monitoring and CI Visibility, a test suite is generally a group of tests exercising the same unit of code depending on your language and testing framework. You can access an <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/junit/__tests__/upload.test.ts">example of a test suite</a> which corresponds to a test file in the `datadog-ci` repository. For more information, <a href="/tests/#supported-features">see the documentation</a>.
+In Datadog Synthetic Monitoring and CI Test Visibility, a test suite is generally a group of tests exercising the same unit of code depending on your language and testing framework. You can access an <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/junit/__tests__/upload.test.ts">example of a test suite</a> which corresponds to a test file in the `datadog-ci` repository. For more information, <a href="/tests/#supported-features">see the documentation</a>.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Updates some existing Test Visibility terms to clarify they are for Test Visibility and adds seven new terms from the CI Tests dashboard performance regression section.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->