### PR TITLE
On billing page, correct host status from ??? to INACTIVE

### DIFF
--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -77,7 +77,7 @@ There are two choices for payment method:
 
 ### Credit card
 
-If you pay by credit card, receipts are available to [Administrators][10] for previous months under [Billing History][11]. For copies of your invoice, email [Datadog billing][11].
+If you pay by credit card, receipts are available to [Administrators][10] for previous months under [Billing History][11]. For copies of your invoice, email [Datadog billing][13].
 
 See [Credit Card Billing][12] for more details.
 

--- a/content/en/account_management/billing/_index.md
+++ b/content/en/account_management/billing/_index.md
@@ -13,7 +13,7 @@ Datadog meters the count of hosts and custom metrics hourly. The billable count 
 
 A host is any physical or virtual OS instance that you monitor with Datadog. It could be a server, VM, node (in the case of Kubernetes), App Service Plan instance (in the case of Azure App Service), or Heroku dyno (in the case of the Heroku platform). Hosts can be instances with the Datadog Agent installed plus any Amazon EC2s, Google Cloud, Azure, or vSphere VMs monitored with Datadog integrations. Any EC2s or VMs with the Agent installed count as a single instance (no double-billing).
 
-Non-reporting hosts (status `???` in your [Infrastructure list][2]) do not count towards billing. It could take up to 2 hours for these hosts to drop out of the [Infrastructure List][2]. Datadog retains the historical data for these hosts (paid accounts). Metrics can be graphed on a dashboard by knowing the specific host name or tags.
+Non-reporting hosts (status `INACTIVE` in your [Infrastructure list][2]) do not count towards billing. It could take up to 2 hours for these hosts to drop out of the [Infrastructure List][2]. Datadog retains the historical data for these hosts (paid accounts). Metrics can be graphed on a dashboard by knowing the specific host name or tags.
 
 ### Containers
 
@@ -79,11 +79,11 @@ There are two choices for payment method:
 
 If you pay by credit card, receipts are available to [Administrators][10] for previous months under [Billing History][11]. For copies of your invoice, email [Datadog billing][11].
 
-See [Credit Card Billing][13] for more details.
+See [Credit Card Billing][12] for more details.
 
 ### Invoicing
 
-If you pay by check, ACH, or wire, invoices are emailed to the billing email addresses near the 10th business day of each month. To request an additional copy, email [Datadog billing][12]. Details on where to remit payment can be found on the invoice.
+If you pay by check, ACH, or wire, invoices are emailed to the billing email addresses near the 10th business day of each month. To request an additional copy, email [Datadog billing][13]. Details on where to remit payment can be found on the invoice.
 
 ## Contact
 
@@ -116,6 +116,7 @@ If you pay by check, ACH, or wire, invoices are emailed to the billing email add
 {{< /whatsnext >}}
 
 
+
 [1]: https://app.datadoghq.com/account/usage/hourly
 [2]: /infrastructure/
 [3]: /agent/
@@ -127,6 +128,5 @@ If you pay by check, ACH, or wire, invoices are emailed to the billing email add
 [9]: https://app.datadoghq.com/billing/plan
 [10]: /account_management/rbac/#datadog-default-roles
 [11]: https://app.datadoghq.com/account/billing_history
-[12]: mailto:billing@datadoghq.com
-[13]: /account_management/billing/credit_card/
-
+[12]: /account_management/billing/credit_card/
+[13]: mailto:billing@datadoghq.com


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Changes the text of a status from "???" to "INACTIVE." As verified in the UI, the possible states for a host in the infrastructure list are "ACTIVE" and "INACTIVE." Noticed and pointed out by Alla Igityan, a sales engineer.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->