### PR TITLE
DOCS-7643: Remove non-public link

### DIFF
--- a/content/en/tracing/metrics/runtime_metrics/java.md
+++ b/content/en/tracing/metrics/runtime_metrics/java.md
@@ -34,7 +34,7 @@ If you are running the Agent as a container, ensure that `DD_DOGSTATSD_NON_LOCAL
 - **Kubernetes**: You _must_ [bind the DogstatsD port to a host port][4].
 - **ECS**: [Set the appropriate flags in your task definition][5].
 
-Alternatively, the Agent can ingest metrics with a Unix Domain Socket (UDS) as an alternative to UDP transport. For more information, read [DogStatsD over Unix Domain Socket][10].
+Alternatively, the Agent can ingest metrics with a Unix Domain Socket (UDS) as an alternative to UDP transport. For more information, read [DogStatsD over Unix Domain Socket][9].
 
 **Notes**:
 
@@ -50,7 +50,7 @@ The following metrics are collected by default per JVM process after enabling JV
 
 Along with displaying these metrics in your APM Service Page, Datadog provides a [default JVM Runtime Dashboard][7].
 
-Additional JMX metrics can be added using configuration files that are passed on using `dd.jmxfetch.config.dir` and `dd.jmxfetch.config`. You can also enable existing Datadog JMX integrations individually with the `dd.jmxfetch.<INTEGRATION_NAME>.enabled=true` parameter. This auto-embeds configuration from Datadog's [existing JMX configuration files][8]. See the [JMX Integration][9] for further details on configuration.
+Additional JMX metrics can be added using configuration files that are passed on using `dd.jmxfetch.config.dir` and `dd.jmxfetch.config`. You can also enable existing Datadog JMX integrations individually with the `dd.jmxfetch.<INTEGRATION_NAME>.enabled=true` parameter. This auto-embeds configuration from Datadog's existing JMX configuration files. See the [JMX Integration][8] for further details on configuration.
 
 ## Further Reading
 
@@ -63,6 +63,5 @@ Additional JMX metrics can be added using configuration files that are passed on
 [5]: /agent/amazon_ecs/#create-an-ecs-task
 [6]: https://github.com/DataDog/dd-trace-java/releases/tag/v0.24.0
 [7]: https://app.datadoghq.com/dash/integration/256/jvm-runtime-metrics
-[8]: https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics
-[9]: /integrations/java/#configuration
-[10]: /developers/dogstatsd/unix_socket/
+[8]: /integrations/java/#configuration
+[9]: /developers/dogstatsd/unix_socket/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This had a link to `https://github.com/DataDog/integrations-core/search?q=jmx_metrics&unscoped_q=jmx_metrics`, and although `integrations-core` is a public repo, search is restricted. Removing this link as it won't work for anyone external.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->