### PR TITLE
unstick glossary filters - [WEB-4792]

### DIFF
--- a/assets/styles/pages/_glossary.scss
+++ b/assets/styles/pages/_glossary.scss
@@ -22,6 +22,7 @@
         @include media-breakpoint-up(md) {
             margin-top: 3px;
             padding-top: 11px;
+            padding-bottom: 6px;
             background: white;
             width: 100%;
             top: 89px;
@@ -63,7 +64,7 @@
             flex-direction: column;
 
             @include media-breakpoint-up(md) {
-                padding-left: 15px;
+                padding-left: 0px;
                 flex-direction: row;
             }
 
@@ -77,10 +78,10 @@
                 }
             }
         }
-        .filters-glossary{
-            padding-left: 15px;
-            margin-top: 16px;
-            font-size: 16px;
-        }
+    }
+    .filters-glossary{
+        padding-left: 15px;
+        margin-top: 16px;
+        font-size: 16px;
     }
 }

--- a/layouts/glossary/list.html
+++ b/layouts/glossary/list.html
@@ -133,6 +133,7 @@
             class="d-none d-md-block" 
             x-init="setGlossaryNavHeight($el)" 
             @resize.window.throttle="setGlossaryNavHeight($el)" >
+                <!-- Go to letter section -->
                 <ul class="nav js-glossary-nav col-2 col-md-12 d-flex align-items-end">
                     {{ range $letters }}
                         <li class="nav-item" x-cloak x-show="shouldShowGlossaryLetter('{{ . | lower }}')">
@@ -141,26 +142,26 @@
                     {{ end }}
                 </ul>
 
-                <!-- Filtering section -->
-                <!-- pushState adds the product query param to url without loading/refreshing the url/page  -->
-                <div class="filters-glossary">
-                    {{ if  $products }}
-                        <button 
-                        @click="resetFilteredLetters($el.dataset.filter); filterValue = ''; pushState('all')"
-                        :class="(filterValue === 'all' || !filterValue) && 'active'"
-                        class="filter-btn mb-1 me-1 btn btn-sm-tag btn-outline-secondary"
-                        data-filter="{{ .Params.filter_all | lower }}">{{.Params.filter_all }}</button> 
-                    {{ end }}
-                    {{ range $products | sort }}
-                        {{ $product := . | anchorize}}
-                        <button 
-                        @click="resetFilteredLetters('{{ $product }}'); filterValue = '{{ $product }}'; pushState('{{ $product }}')"
-                        :class="$el.dataset.filter === filterValue && 'active'"
-                        class="filter-btn mb-1 me-1 btn btn-sm-tag btn-outline-secondary"
-                        data-filter="{{ $product }}">{{ . | upper }}</button>
-                    {{ end }}
-                </div>
             </nav>
+            <!-- Filtering section -->
+            <!-- pushState adds the product query param to url without loading/refreshing the url/page  -->
+            <div class="filters-glossary">
+                {{ if  $products }}
+                    <button 
+                    @click="resetFilteredLetters($el.dataset.filter); filterValue = ''; pushState('all')"
+                    :class="(filterValue === 'all' || !filterValue) && 'active'"
+                    class="filter-btn mb-1 me-1 btn btn-sm-tag btn-outline-secondary"
+                    data-filter="{{ .Params.filter_all | lower }}">{{.Params.filter_all }}</button> 
+                {{ end }}
+                {{ range $products | sort }}
+                    {{ $product := . | anchorize}}
+                    <button 
+                    @click="resetFilteredLetters('{{ $product }}'); filterValue = '{{ $product }}'; pushState('{{ $product }}')"
+                    :class="$el.dataset.filter === filterValue && 'active'"
+                    class="filter-btn mb-1 me-1 btn btn-sm-tag btn-outline-secondary"
+                    data-filter="{{ $product }}">{{ . | upper }}</button>
+                {{ end }}
+            </div>
         </div>
     </div>
 {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

unstick the glossary filter buttons section on scroll

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-4792
preview: https://docs-staging.datadoghq.com/stefon.simmons/adjust-glossary-filter-section/glossary/

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->