### PR TITLE
adds a console output example for Java

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -78,7 +78,9 @@ For Log4j, log in JSON format by using the SLF4J module [log4j-over-slf4j][1] co
       <version>6.6</version>
     </dependency>
     ```
-2. Configure a file appender using the JSON layout in `logback.xml`:
+2. Configure an appender using the JSON layout in `logback.xml`:
+
+    For file:
 
     ```xml
     <configuration>
@@ -93,13 +95,31 @@ For Log4j, log in JSON format by using the SLF4J module [log4j-over-slf4j][1] co
     </configuration>
     ```
 
+    For console:
+
+    ```xml
+    <configuration>
+      <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+          <encoder class="ch.qos.logback.classic.encoder.JsonEncoder"/>
+      </appender>
+
+      <root>
+        <level value="DEBUG"/>
+          <appender-ref ref="CONSOLE"/>
+        </root>
+    </configuration>
+    ```
+
 [1]: http://www.slf4j.org/legacy.html#log4j-over-slf4j
 {{% /tab %}}
 {{% tab "Log4j 2" %}}
 
 Log4j 2 includes a JSON layout.
 
-1. Configure a file appender using the JSON layout in `log4j2.xml`:
+1. Configure a an appender using the JSON layout in `log4j2.xml`:
+
+    For a file appender:
+
     ```xml
     <?xml version="1.0" encoding="UTF-8"?>
     <Configuration>
@@ -116,6 +136,28 @@ Log4j 2 includes a JSON layout.
       </Loggers>
     </Configuration>
     ```
+
+    For a console appender:
+
+    ```xml
+    <?xml version="1.0" encoding="UTF-8"?>
+    <Configuration>
+
+        <Appenders>
+            <Console name="console" target="SYSTEM_OUT">
+                <JSONLayout compact="true" eventEol="true" properties="true" stacktraceAsString="true" />
+            </Console>
+        </Appenders>
+
+        <Loggers>
+            <Root level="INFO">
+                <AppenderRef ref="console"/>
+            </Root>
+
+        </Loggers>
+    </Configuration>
+    ```
+
 2. Add the JSON layout dependencies to your `pom.xml`:
     ```xml
     <dependency>
@@ -179,7 +221,7 @@ Use the [logstash-logback-encoder][1] for JSON formatted logs in Logback.
 {{% /tab %}}
 {{% tab "Tinylog" %}}
 
-Create a JSON writer configuration outputting to a file based on the [official Tinylog documentation][1].
+Create a JSON writer configuration based on the [official Tinylog documentation][1].
 
 
 Use the following format in a `tinylog.properties` file:

--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -116,7 +116,7 @@ For Log4j, log in JSON format by using the SLF4J module [log4j-over-slf4j][1] co
 
 Log4j 2 includes a JSON layout.
 
-1. Configure a an appender using the JSON layout in `log4j2.xml`:
+1. Configure an appender using the JSON layout in `log4j2.xml`:
 
     For a file appender:
 


### PR DESCRIPTION
* Currently only have a file example
* K8s/containers more likely to use console output

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Currently there's no specific example of how to do console/stdout output for Java logs in the docs, only file. In a K8s and container world, we're more likely to use console output and it was a bit of trial and error for me to figure it out, it'd be nice to have that directly in the docs. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
I didnt do an example for Tinylog because it doesn't seem to have a non-file based json formatter
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->