### PR TITLE
CMTY-47 Remove ITR Icon for Test Visibility Documentation

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -3476,7 +3476,7 @@ menu:
       weight: 303
     - name: Test Visibility
       url: tests/
-      pre: intelligent-test-runner
+      pre: ci
       parent: software_delivery_heading
       identifier: tests
       weight: 30000

--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -121,7 +121,7 @@ nav_sections:
         desc: Monitor the health and performance of your CI pipelines
       - title: Test Visibility
         link: tests/
-        icon: intelligent-test-runner
+        icon: ci
         desc: Detect flaky tests and identify commits introducing flaky tests
       - title: Security
         link: security/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Ideally we would like to use the `Flaky Test` icon in Druids for the Test Visibility docs, but that is not available in `websites-modules` yet. While we wait for a custom icon for Test Visibility, replacing it with the CI Visibility icon (as ITR should have one standalone icon).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->