### PR TITLE
Java live-heap alpha mention addition

### DIFF
--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -276,7 +276,7 @@ The allocation profiler engine does not depend on the `/proc/sys/kernel/perf_eve
 
 _Since: v1.17.0. Requires JDK 11+._
 
-<div class="alert alert-warning">This is an alpha feature, we do not recommand enabling it in production.</a></div>
+<div class="alert alert-warning">This is an alpha feature, it is not recommended to enable this feature in production environments.</a></div>
 
 The live-heap profiler engine is useful for investigating the overall memory usage of your service and identifying potential memory leaks.
 The engine samples allocations and keeps track of whether those samples survived the most recent garbage collection cycle. The number of surviving samples is used to estimate the number of live objects in the heap.

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -272,9 +272,11 @@ The allocation profiler engine does not depend on the `/proc/sys/kernel/perf_eve
 
 {{< /tabs >}}
 
-### Live-heap profiler engine
+### Live-heap profiler engine (alpha)
 
 _Since: v1.17.0. Requires JDK 11+._
+
+<div class="alert alert-warning">This is an alpha feature, we do not recommand enabling it in production.</a></div>
 
 The live-heap profiler engine is useful for investigating the overall memory usage of your service and identifying potential memory leaks.
 The engine samples allocations and keeps track of whether those samples survived the most recent garbage collection cycle. The number of surviving samples is used to estimate the number of live objects in the heap.


### PR DESCRIPTION
Adding a mention that the live-heap is in alpha and should not be enabled in production

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->