### PR TITLE
Add http2 monitoring documentation

### DIFF
--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -849,6 +849,46 @@ agents:
 
 {{< /tabs >}}
 
+### HTTP/2 Monitoring
+
+<div class="alert alert-info">
+Universal Service Monitoring is available in <strong>beta</strong> to monitor services behind <a href="https://datatracker.ietf.org/doc/html/rfc7540">HTTP/2</a> and to capture HTTP/2 traffic.
+</div>
+
+Requires Agent version 7.53 or greater.
+
+{{< tabs >}}
+{{% tab "Configuration file" %}}
+
+Add the following configuration to the `system-probe.yaml`:
+
+```yaml
+service_monitoring_config:
+  enable_http2_monitoring: true
+```
+
+{{% /tab %}}
+{{% tab "Environment variable" %}}
+
+```conf
+DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP2_MONITORING=true
+```
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+
+```conf
+agents:
+  containers:
+    systemProbe:
+      env:
+        - name: DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP2_MONITORING
+          value: "true"
+```
+{{% /tab %}}
+
+{{< /tabs >}}
+
 ## Path exclusion and replacement
 
 Use `http_replace_rules` or `DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES` to configure the Agent to drop HTTP endpoints that match a regex, or to convert matching endpoints into a different format.

--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -852,7 +852,7 @@ agents:
 ### HTTP/2 Monitoring
 
 <div class="alert alert-info">
-Universal Service Monitoring is available in <strong>beta</strong> to capture <a href="https://datatracker.ietf.org/doc/html/rfc7540">HTTP/2</a> traffic.
+Universal Service Monitoring is available to capture <a href="https://datatracker.ietf.org/doc/html/rfc7540">HTTP/2</a> traffic.
 </div>
 
 Requires Agent version 7.53 or greater.

--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -851,7 +851,7 @@ agents:
 
 ### HTTP/2 Monitoring
 
-Universal Service Monitoring is available to capture HTTP/2 traffic.
+Universal Service Monitoring is available to capture HTTP/2 and gRPC traffic.
 
 Requires Agent version 7.53 or greater.
 

--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -852,7 +852,7 @@ agents:
 ### HTTP/2 Monitoring
 
 <div class="alert alert-info">
-Universal Service Monitoring is available in <strong>beta</strong> to monitor services behind <a href="https://datatracker.ietf.org/doc/html/rfc7540">HTTP/2</a> and to capture HTTP/2 traffic.
+Universal Service Monitoring is available in <strong>beta</strong> to capture <a href="https://datatracker.ietf.org/doc/html/rfc7540">HTTP/2</a> traffic.
 </div>
 
 Requires Agent version 7.53 or greater.

--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -851,9 +851,7 @@ agents:
 
 ### HTTP/2 Monitoring
 
-<div class="alert alert-info">
-Universal Service Monitoring is available to capture <a href="https://datatracker.ietf.org/doc/html/rfc7540">HTTP/2</a> traffic.
-</div>
+Universal Service Monitoring is available to capture HTTP/2 traffic.
 
 Requires Agent version 7.53 or greater.
 

--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -849,9 +849,9 @@ agents:
 
 {{< /tabs >}}
 
-### HTTP/2 Monitoring
+### HTTP/2 monitoring
 
-Universal Service Monitoring is available to capture HTTP/2 and gRPC traffic.
+Universal Service Monitoring can capture HTTP/2 and gRPC traffic.
 
 Requires Agent version 7.53 or greater.
 
@@ -872,7 +872,6 @@ service_monitoring_config:
 DD_SERVICE_MONITORING_CONFIG_ENABLE_HTTP2_MONITORING=true
 ```
 {{% /tab %}}
-
 {{% tab "Helm" %}}
 
 ```conf


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds documentation to enable USM to capture HTTP/2 and gRPC traffic.

### Merge instructions


- [x] Please merge after reviewing

### Additional notes