### PR TITLE
Code blocks fix Java profiler

### DIFF
--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -105,7 +105,7 @@ To begin profiling applications:
 
    **Note**: Profiler is available in the `dd-java-agent.jar` library in versions 0.55+.
 
-4. Enable the profiler by setting `-Ddd.profiling.enabled` flag or `DD_PROFILING_ENABLED` environment variable to `true`. Specify `dd.service`, `dd.env`, and `dd.version` so you can filter and group your profiles across these dimensions:
+3. Enable the profiler by setting `-Ddd.profiling.enabled` flag or `DD_PROFILING_ENABLED` environment variable to `true`. Specify `dd.service`, `dd.env`, and `dd.version` so you can filter and group your profiles across these dimensions:
    {{< tabs >}}
 {{% tab "Command arguments" %}}
 

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -81,25 +81,31 @@ To begin profiling applications:
 
    {{< tabs >}}
    {{% tab "Wget" %}}
+   
       ```shell
       wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
       ```
+      
    {{% /tab %}}
    {{% tab "cURL" %}}
+   
       ```shell
       curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
       ```
+      
    {{% /tab %}}
    {{% tab "Dockerfile" %}}
+   
       ```dockerfile
       ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
       ```
+      
    {{% /tab %}}
    {{< /tabs >}}
 
    **Note**: Profiler is available in the `dd-java-agent.jar` library in versions 0.55+.
 
-3. Enable the profiler by setting `-Ddd.profiling.enabled` flag or `DD_PROFILING_ENABLED` environment variable to `true`. Specify `dd.service`, `dd.env`, and `dd.version` so you can filter and group your profiles across these dimensions:
+4. Enable the profiler by setting `-Ddd.profiling.enabled` flag or `DD_PROFILING_ENABLED` environment variable to `true`. Specify `dd.service`, `dd.env`, and `dd.version` so you can filter and group your profiles across these dimensions:
    {{< tabs >}}
 {{% tab "Command arguments" %}}
 

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -81,25 +81,19 @@ To begin profiling applications:
 
    {{< tabs >}}
    {{% tab "Wget" %}}
-   
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
-   ```
-      
+   ``` 
    {{% /tab %}}
    {{% tab "cURL" %}}
-   
    ```shell
    curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    ```
-      
    {{% /tab %}}
    {{% tab "Dockerfile" %}}
-   
    ```dockerfile
    ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
-   ```
-      
+   ``` 
    {{% /tab %}}
    {{< /tabs >}}
 

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -82,23 +82,23 @@ To begin profiling applications:
    {{< tabs >}}
    {{% tab "Wget" %}}
    
-      ```shell
-      wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
-      ```
+   ```shell
+   wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+   ```
       
    {{% /tab %}}
    {{% tab "cURL" %}}
    
-      ```shell
-      curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
-      ```
+   ```shell
+   curl -Lo dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
+   ```
       
    {{% /tab %}}
    {{% tab "Dockerfile" %}}
    
-      ```dockerfile
-      ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
-      ```
+   ```dockerfile
+   ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
+   ```
       
    {{% /tab %}}
    {{< /tabs >}}

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -83,7 +83,7 @@ To begin profiling applications:
    {{% tab "Wget" %}}
    ```shell
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
-   ``` 
+   ```
    {{% /tab %}}
    {{% tab "cURL" %}}
    ```shell
@@ -93,7 +93,7 @@ To begin profiling applications:
    {{% tab "Dockerfile" %}}
    ```dockerfile
    ADD 'https://dtdg.co/latest-java-tracer' dd-java-agent.jar
-   ``` 
+   ```
    {{% /tab %}}
    {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR fixes a couple of code blocks on the Java profiler documentation page.

Before:
<img width="557" alt="image" src="https://github.com/DataDog/documentation/assets/82873975/f8590866-8f78-4112-927e-f65e06e5abe0">

After:
<img width="600" alt="image" src="https://github.com/DataDog/documentation/assets/82873975/a2a6f060-6c95-4969-9b35-0ef22e4ea2db">
<img width="564" alt="image" src="https://github.com/DataDog/documentation/assets/82873975/624b76fe-c056-4029-9b91-debe80907358">


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->