### PR TITLE
Add noParent argument for Java trace annotations

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/java/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/java/dd-api.md
@@ -200,20 +200,24 @@ Add `@Trace` to methods to have them be traced when running with `dd-java-agent.
 
 Datadog's Trace annotation is provided by the [dd-trace-api dependency][6].
 
-`@Trace` annotations have the default operation name `trace.annotation` and resource name of the traced method. These can be set as arguments of the `@Trace` annotation to better reflect what is being instrumented. These are the only possible arguments that can be set for the `@Trace` annotation.
+The available arguments for the `@Trace` annotation are:
+
+- `operationName`: Set the operation name for the trace (default: The method's name).
+- `resourceName`: Set the resource name for the trace (default: The same value as `operationName`).
+- `noParent`: Set to `true` to always start a new trace at that method. Supported from v1.22.0+ of `dd-trace-java` (default: `false`).
 
 ```java
 import datadog.trace.api.Trace;
 
 public class SessionManager {
 
-    @Trace(operationName = "database.persist", resourceName = "SessionManager.saveSession")
+    @Trace(operationName = "database.persist", resourceName = "SessionManager.saveSession", noParent = true)
     public static void saveSession() {
         // your method implementation here
     }
 }
 ```
-Note that through the `dd.trace.annotations` system property, other tracing method annotations can be recognized by Datadog as `@Trace`. You can find a list [here][7] if you have previously decorated your code.
+**Note**: Through the `dd.trace.annotations` system property, other tracing method annotations can be recognized by Datadog as `@Trace`. You can find a list in [TraceAnnotationsInstrumentation.java][7] if you have previously decorated your code.
 
 ### Manually creating a new span
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/java/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/java/dd-api.md
@@ -211,7 +211,7 @@ import datadog.trace.api.Trace;
 
 public class SessionManager {
 
-    @Trace(operationName = "database.persist", resourceName = "SessionManager.saveSession", noParent = true)
+    @Trace(operationName = "database.persist", resourceName = "SessionManager.saveSession")
     public static void saveSession() {
         // your method implementation here
     }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
https://github.com/DataDog/documentation/issues/22774

- Document `noParent` argument for Java trace annotations.
- Clean up section to better adhere to our style.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->