### PR TITLE
Update profiling.md table

### DIFF
--- a/content/en/serverless/aws_lambda/profiling.md
+++ b/content/en/serverless/aws_lambda/profiling.md
@@ -36,8 +36,8 @@ Depending on your runtime, this feature requires the following tracer and layer 
 
 | Runtime | Minimum tracer version | Minimum layer version |
 | ------- | ---------------------- | --------------------- |
-| Python | 4.62.0 | 62 |
-| Node.js | 6.87.0 | 87 |
+| Python | 1.4.0 | 62 |
+| Node.js | 2.22.1, 3.9.0 | 87 |
 
 ## Further Reading
 


### PR DESCRIPTION
Update the table since it is misleading. The column for ‘minimum tracer version’ is referring to the runtime library layer. It should refer versions of the tracing library.

