### PR TITLE
remove backticks from title

### DIFF
--- a/content/en/integrations/guide/add-event-log-files-to-the-win32-ntlogevent-wmi-class.md
+++ b/content/en/integrations/guide/add-event-log-files-to-the-win32-ntlogevent-wmi-class.md
@@ -1,5 +1,5 @@
 ---
-title: Add event log files to the `Win32_NTLogEvent` WMI class
+title: Add event log files to the Win32_NTLogEvent WMI class
 kind: guide
 aliases:
   - /integrations/faq/how-to-add-event-log-files-to-the-win32-ntlogevent-wmi-class


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes backticks from a title, because

- it doesn't render properly (it renders as backticks; it does not render a `<code>` style)
- in some languages, `Win32_NTLogEvent` is how you start the sentence, and a backtick character at the beginning of a line appears to cause issues.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->