### PR TITLE
DOCS-7811

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4556,7 +4556,7 @@ menu:
       identifier: threats_threat_intelligence
       weight: 709
     - name: Attack Summary
-      url: security/application_security/threats/threat-overview/
+      url: security/application_security/threats/attack-summary/
       parent: appsec_threats
       identifier: attack_summary_overview
       weight: 710

--- a/content/en/security/application_security/threats/attack-summary.md
+++ b/content/en/security/application_security/threats/attack-summary.md
@@ -1,7 +1,8 @@
 ---
 title: Attack Summary
 kind: documentation
-aliases:  
+aliases:
+  - /security/application_security/threats/threat-overview
 ---
 
 {{< img src="security/application_security/threats/appsec-threat-overview-page-top.png" alt="Screenshot of the ASM Attack Summary page"  >}}


### PR DESCRIPTION
change URL for Attacks Summary page

### Merge instructions
- [x] Please merge after reviewing

### Additional notes

The feature name changed and so I updated the related topic, but the URL still has the old feature name in it.

Old (threat-overview):

https://docs.datadoghq.com/security/application_security/threats/threat-overview/ 

Should be:

https://docs.datadoghq.com/security/application_security/threats/attack-summary/

