### PR TITLE
Fix Cloudcraft's article index

### DIFF
--- a/content/en/cloudcraft/advanced/_index.md
+++ b/content/en/cloudcraft/advanced/_index.md
@@ -5,7 +5,7 @@ kind: guide
 
 {{< whatsnext desc="General:" >}}
     {{< nextlink href="cloudcraft/advanced/minimal-iam-policy">}}Create a custom IAM policy to use with Cloudcraft{{< /nextlink >}}
-    {{< nextlink href="cloudcraft/advanced/find-id-using-api.md">}}Find Cloud Account or Team ID using our API{{< /nextlink >}}
+    {{< nextlink href="cloudcraft/advanced/find-id-using-api">}}Find Cloud Account or Team ID using our API{{< /nextlink >}}
     {{< nextlink href="cloudcraft/advanced/auto-layout-via-api">}}Automate Snapshots of Cloud Accounts via the Cloudcraft API{{< /nextlink >}}
     {{< nextlink href="cloudcraft/advanced/add-aws-account-via-api">}}Add AWS accounts via the Cloudcraft API{{< /nextlink >}}
     {{< nextlink href="cloudcraft/advanced/add-azure-account-via-api">}}Add Azure accounts via the Cloudcraft API{{< /nextlink >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Fix article index on Cloudcraft's "Advanced" category by removing a file extension from the URL.

### Merge instructions
- [x] Please merge after reviewing