### PR TITLE
Update minimum agent version for Aurora auto-discovery feature

### DIFF
--- a/content/en/database_monitoring/guide/aurora_autodiscovery.md
+++ b/content/en/database_monitoring/guide/aurora_autodiscovery.md
@@ -15,9 +15,7 @@ Supported databases
 : Postgres, MySQL
 
 Supported Agent versions
-: 7.53.0+ (beta)
-
-To use this feature, you must install the beta version of the Agent. See the [Install Datadog Agent 7.53.0+](#install-datadog-agent-7530) section on this page.
+: 7.53.0+
 
 ## Overview
 
@@ -27,26 +25,10 @@ With Autodiscovery and Database Monitoring, you can define configuration templat
 
 ## Enabling Autodiscovery for Aurora clusters
 
-1. [Install Datadog Agent 7.53.0+](#install-datadog-agent-7530)
-2. [Grant AWS permissions](#grant-aws-permissions)
-3. [Configure Aurora tags](#configure-aurora-tags)
-4. [Configure the Datadog Agent](#configure-the-datadog-agent)
-5. [Create a configuration template](#create-a-configuration-template)
-
-### Install Datadog Agent 7.53.0+
-
-To use this feature, you need to install a [beta version][9] of the Agent.
-
-You can use the Agent installation script to install the correct version by running the following command:
-
-```bash
-DD_API_KEY=<API_KEY> DD_SITE="{{< region-param key="dd_site" code="true" >}}" \
-DD_AGENT_DIST_CHANNEL=beta DD_AGENT_MAJOR_VERSION=7 \
-DD_AGENT_MINOR_VERSION=52.0~dbm~aurora~autodiscovery~beta~0.3-1 \
-bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
-```
-
-For more information on installing the Datadog Agent, see [Basic Agent Usage for Amazon Linux][10].
+1. [Grant AWS permissions](#grant-aws-permissions)
+2. [Configure Aurora tags](#configure-aurora-tags)
+3. [Configure the Datadog Agent](#configure-the-datadog-agent)
+4. [Create a configuration template](#create-a-configuration-template)
 
 ### Grant AWS permissions
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The 7.53 version of the agent has been released, so customers no longer need to install a beta version

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->