### PR TITLE
[error-tracking] Add default grouping documentation

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1771,31 +1771,36 @@ menu:
       parent: error_tracking
       identifier: error_tracking_explorer
       weight: 1
+    - name: Default Grouping
+      url: error_tracking/grouping
+      parent: error_tracking
+      identifier: error_tracking_default_grouping
+      weight: 2
     - name: Custom Grouping
       url: error_tracking/custom_grouping
       parent: error_tracking
       identifier: error_tracking_custom_grouping
-      weight: 2
+      weight: 3
     - name: Identify Suspect Commits
       url: error_tracking/suspect_commits
       parent: error_tracking
       identifier: error_tracking_suspect_commits
-      weight: 3
+      weight: 4
     - name: APM
       url: error_tracking/apm
       parent: error_tracking
       identifier: error_tracking_apm
-      weight: 4
+      weight: 5
     - name: Logs
       url: error_tracking/logs
       parent: error_tracking
       identifier: error_tracking_logs
-      weight: 5
+      weight: 6
     - name: Real User Monitoring
       url: error_tracking/rum
       parent: error_tracking
       identifier: error_tracking_rum
-      weight: 6
+      weight: 7
     - name: Service Level Objectives
       url: service_management/service_level_objectives/
       pre: slos

--- a/content/en/error_tracking/grouping.md
+++ b/content/en/error_tracking/grouping.md
@@ -1,0 +1,38 @@
+---
+title: Default Grouping
+kind: documentation
+description: Understand how errors are grouped into issues.
+---
+
+## Overview
+
+Error Tracking intelligently groups similar errors into issues based on their fingerprint. 
+
+Each time an error is sent to Datadog, a fingerprint is calculated using information available on the error.
+
+Four attributes are extracted to compute the fingerprint:
+* service
+* error type (think "exception class")
+* error message
+* stack frame (think "file and line number")
+
+Variable parts such as usernames or ids are removed from attributes in order to group errors into issues.
+
+The fingerprint is highly dependent on how the error is captured and the programming language. We constantly iterate on it to deliver the best user experience.
+
+**Note**: Different attributes will lead to different issues - there is currently no way to group issues across several services or error types.
+
+
+
+## Setup
+ 
+### Mobile and frontend applications
+
+Uploading your source maps will allow us to get the right stack frame and deliver a better grouping.
+
+- Web: [Sourcemaps upload][1]
+- Mobile [Crash reporting][2] 
+
+[1]: /real_user_monitoring/guide/upload-javascript-source-maps
+[2]: /real_user_monitoring/mobile_and_tv_monitoring/setup
+[3]: /tracing/error_tracking/#use-span-tags-to-track-error-spans


### PR DESCRIPTION

### What does this PR do? What is the motivation?
Adds a page to explain the default error tracking grouping. We currently only mention the custom fingerprinting and we're regularly getting customer questions on the topic.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->