### PR TITLE
Update metrics libraries for Rust.

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -229,6 +229,17 @@ Classic:
       official: true
       dogstatsd: true
       authors: Datadog
+  - Rust:
+    - name: cadence
+      link: https://docs.rs/cadence/latest/cadence/
+      official: false
+      dogstatsd: true
+      authors: Nick Pillitteri
+    - name: metrics-exporter-statsd
+      link: https://docs.rs/metrics-exporter-statsd/latest/metrics_exporter_statsd/
+      official: false
+      dogstatsd: true
+      authors: GitHub
   - Scala:
     - name: datadog-scala
       link: https://github.com/gphat/datadog-scala


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a new subcategory for Rust under [API and DogStatsD client libraries](https://docs.datadoghq.com/developers/community/libraries/#api-and-dogstatsd-client-libraries), with two initial entries for `cadence` and `metrics-exporter-statsd`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes

N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->