### PR TITLE
[web-4831] ignoring all faq paths from translation pipeline

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -9,7 +9,7 @@ sync_dry_run_enabled: false
 
 # These files will be ignored or deleted when syncing with Transifex.
 ignores:
-  - "content/en/**/faq/!(agent_v6_changes|certificate_verify_failed-error).md"
+  - "content/en/**/faq/*.md"
   - "content/en/security/default_rules/*.md"
   - "content/en/security/cspm/custom_rules/*.md"
   - "content/en/infrastructure/resource_catalog/*.md"


### PR DESCRIPTION
### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/WEB-4831

@hestonhoffman confirming the two exceptions under `content/en/**/faq` can be safely removed: https://dd.slack.com/archives/C0DESMBQU/p1714497363983109

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
no UI changes