### PR TITLE
Add Code Hotspots tab to Trace View

### DIFF
--- a/content/en/tracing/trace_explorer/trace_view.md
+++ b/content/en/tracing/trace_explorer/trace_view.md
@@ -170,9 +170,11 @@ Click **View in ASM** to investigate further using [Datadog Application Security
 {{% /tab %}}
 {{% tab "Code Hotspots" %}}
 
-View [Code Hotspots][5] to identify lines of code related to performance issues. The values on the left side represent the time spent in that method call during the selected span.
+View [Code Hotspots][1] to identify lines of code related to performance issues. The values on the left side represent the time spent in each method call during the selected span.
 
 {{< img src="profiler/code_hotspots_tab.png" alt="Code Hotspots tab showing time spent in each method for a selected span" style="width:90%;">}}
+
+[1]: /profiler/connected_traces_and_profiles/
 
 {{% /tab %}}
 {{% tab "Span Links (Beta)" %}}
@@ -193,7 +195,6 @@ To learn more about span links and how to add them with custom instrumentation, 
 [2]: /tracing/trace_collection/custom_instrumentation/php#adding-span-links-beta
 [3]: /tracing/trace_collection/otel_instrumentation/java#requirements-and-limitations
 [4]: /tracing/trace_collection/span_links/
-[5]: /profiler/connected_traces_and_profiles/
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/tracing/trace_explorer/trace_view.md
+++ b/content/en/tracing/trace_explorer/trace_view.md
@@ -174,7 +174,7 @@ View [Code Hotspots][1] to identify lines of code related to performance issues.
 
 {{< img src="profiler/code_hotspots_tab.png" alt="Code Hotspots tab showing time spent in each method for a selected span" style="width:90%;">}}
 
-[1]: /profiler/connected_traces_and_profiles/
+[1]: /profiler/connect_traces_and_profiles/
 
 {{% /tab %}}
 {{% tab "Span Links (Beta)" %}}

--- a/content/en/tracing/trace_explorer/trace_view.md
+++ b/content/en/tracing/trace_explorer/trace_view.md
@@ -168,6 +168,13 @@ Click **View in ASM** to investigate further using [Datadog Application Security
 
 [1]: /security/application_security/how-appsec-works/
 {{% /tab %}}
+{{% tab "Code Hotspots" %}}
+
+View [Code Hotspots][5] to identify lines of code related to performance issues. The values on the left side represent the time spent in that method call during the selected span.
+
+{{< img src="profiler/code_hotspots_tab.png" alt="Code Hotspots tab showing time spent in each method for a selected span" style="width:90%;">}}
+
+{{% /tab %}}
 {{% tab "Span Links (Beta)" %}}
 
 <div class="alert alert-info">Span link support is in beta.</div>
@@ -186,6 +193,7 @@ To learn more about span links and how to add them with custom instrumentation, 
 [2]: /tracing/trace_collection/custom_instrumentation/php#adding-span-links-beta
 [3]: /tracing/trace_collection/otel_instrumentation/java#requirements-and-limitations
 [4]: /tracing/trace_collection/span_links/
+[5]: /profiler/connected_traces_and_profiles/
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/tracing/trace_explorer/trace_view.md
+++ b/content/en/tracing/trace_explorer/trace_view.md
@@ -174,7 +174,7 @@ View [Code Hotspots][1] to identify lines of code related to performance issues.
 
 {{< img src="profiler/code_hotspots_tab.png" alt="Code Hotspots tab showing time spent in each method for a selected span" style="width:90%;">}}
 
-[1]: /profiler/connect_traces_and_profiles/
+[1]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
 
 {{% /tab %}}
 {{% tab "Span Links (Beta)" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Fix for https://datadoghq.atlassian.net/browse/DOCS-7127. Added Code Hotspots tab to Trace View because that was missing. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->