### PR TITLE
Add sample RUM session info for all frameworks

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
@@ -484,18 +484,6 @@ To modify some attributes in your RUM events, or to drop some of the events enti
    
    **Note**: If you return null from the `EventMapper<T>` implementation, the event is dropped.
 
-## Sample RUM sessions
-
-To control the data your application sends to Datadog RUM, you can specify a sample rate for RUM sessions while [initializing the RUM feature][2] as a percentage between 0 and 100.
-
-```kotlin
-val rumConfig = RumConfiguration.Builder(applicationId)
-        // Here 75% of the RUM sessions are sent to Datadog
-        .setSessionSampleRate(75.0f)
-        .build()
-Rum.enable(rumConfig)
-```
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
@@ -705,29 +705,6 @@ For example, if the current tracking consent is `.pending`:
 - If you change the value to `.granted`, the RUM iOS SDK sends all current and future data to Datadog;
 - If you change the value to `.notGranted`, the RUM iOS SDK wipes all current data and does not collect future data.
 
-## Sample RUM sessions
-
-To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM iOS SDK][1] as a percentage between 0 and 100.
-
-For example, to only keep 50% of sessions use:
-
-{{< tabs >}}
-{{% tab "Swift" %}}
-```swift
-let configuration = RUM.Configuration(
-    applicationID: "<rum application id>",
-    sessionSampleRate: 50
-)
-```
-{{% /tab %}}
-{{% tab "Objective-C" %}}
-```objective-c
-DDRUMConfiguration *configuration = [[DDRUMConfiguration alloc] initWithApplicationID:@"<rum application id>"];
-configuration.sessionSampleRate = 50;
-```
-{{% /tab %}}
-{{< /tabs >}}
-
 ## Sending data when device is offline
 
 RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the RUM iOS SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
@@ -297,6 +297,18 @@ The initialization credentials require your application's variant name and uses 
 
 The Gradle plugin automatically uploads the appropriate ProGuard `mapping.txt` file at build time so you can view deobfuscated RUM error stack traces. For more information, see the [Track Android Errors][8].
 
+### Sample RUM sessions
+
+To control the data your application sends to Datadog RUM, you can specify a sample rate for RUM sessions while [initializing the RUM feature][2] as a percentage between 0 and 100.
+
+```kotlin
+val rumConfig = RumConfiguration.Builder(applicationId)
+        // Here 75% of the RUM sessions are sent to Datadog
+        .setSessionSampleRate(75.0f)
+        .build()
+Rum.enable(rumConfig)
+```
+
 ### Enable RUM feature to start sending data
 
 {{< tabs >}}
@@ -361,7 +373,7 @@ This records each request processed by the `OkHttpClient` as a resource in RUM, 
 
 You can also add an `EventListener` for the `OkHttpClient` to [automatically track resource timing][11] for third-party providers and network requests.
 
-### Track background events
+## Track background events
 
 You can track events such as crashes and network requests when your application is in the background (for example, no active view is available). 
 
@@ -382,9 +394,9 @@ Add the following snippet during RUM configuration:
 <div class="alert alert-info"><p>Tracking background events may lead to additional sessions, which can impact billing. For questions, <a href="https://docs.datadoghq.com/help/">contact Datadog support.</a></p>
 </div>
 
-### Kotlin Extensions
+## Kotlin Extensions
 
-#### `Closeable` extension
+### `Closeable` extension
 
 You can monitor `Closeable` instance usage by using `useMonitored` method, it will report any error happened to Datadog and close the resource afterwards.
 
@@ -396,7 +408,7 @@ closeable.useMonitored {
 
 ```
 
-#### Track local assets as RUM resources
+### Track local assets as RUM resources
 
 You can track access to the assets by using `getAssetAsRumResource` extension method:
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
@@ -83,7 +83,7 @@ await DdSdkReactNative.initialize(config);
 
 #### Sample RUM sessions
 
-To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while initializing the Expo RUM SDK as a percentage between 0 and 100. To set this rate, use the `config.sessionSamplingRate` parameter.
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM Expo SDK][9] as a percentage between 0 and 100. To set this rate, use the `config.sessionSamplingRate` parameter. 
 
 ### Upload source maps on EAS builds
 
@@ -200,10 +200,6 @@ import { DdSdkReactNative } from 'expo-datadog';
 const config = new DdSdkReactNativeConfiguration(/* your config */);
 DdSdkReactNative.initialize(config);
 ```
-
-## Sample RUM sessions
-
-To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM Expo SDK][9] as a percentage between 0 and 100.
 
 ## Troubleshooting
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
@@ -81,6 +81,10 @@ await DdSdkReactNative.initialize(config);
 // Once the Datadog SDK is initialized, you need to setup view tracking in order to see data in the RUM dashboard.
 ```
 
+#### Sample RUM sessions
+
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while initializing the Expo RUM SDK as a percentage between 0 and 100. To set this rate, use the `config.sessionSamplingRate` parameter.
+
 ### Upload source maps on EAS builds
 
 <div class="alert alert-info"><p>If you have not enabled Crash Reporting, you can skip this step.<p></div>
@@ -197,11 +201,15 @@ const config = new DdSdkReactNativeConfiguration(/* your config */);
 DdSdkReactNative.initialize(config);
 ```
 
+## Sample RUM sessions
+
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM Expo SDK][9] as a percentage between 0 and 100.
+
 ## Troubleshooting
 
 ### App produces a lot of /logs RUM Resources
 
-When Resource tracking is enabled and SDK verbosity is set to `DEBUG`, each RUM Resource will trigger a `/logs` call to the Expo dev server to print the log, which will itself create a new RUM resource, creating an infinite loop.
+When Resource tracking is enabled and SDK verbosity is set to `DEBUG`, each RUM Resource triggers a `/logs` call to the Expo dev server to print the log, which will itself create a new RUM resource, creating an infinite loop.
 The most common patterns of Expo dev server host URL are filtered by the SDK, therefore, you may not encounter this error in most situations.
 If this error occurs, add the following RUM Resource mapper to filter out the calls:
 
@@ -233,3 +241,4 @@ config.resourceEventMapper = event => {
 [6]: /real_user_monitoring/error_tracking/expo/
 [7]: https://expo.github.io/router/docs/
 [8]: https://github.com/DataDog/dd-sdk-reactnative-examples/tree/main/rum-expo-react-navigation
+[9]: /real_user_monitoring/mobile_and_tv_monitoring/setup/expo#initialize-the-library-with-application-context

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
@@ -364,6 +364,30 @@ NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConf
 ```
 {{% /tab %}}
 {{< /tabs >}}
+
+## Sample RUM sessions
+
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM iOS SDK][1] as a percentage between 0 and 100.
+
+For example, to only keep 50% of sessions use:
+
+{{< tabs >}}
+{{% tab "Swift" %}}
+```swift
+let configuration = RUM.Configuration(
+    applicationID: "<rum application id>",
+    sessionSampleRate: 50
+)
+```
+{{% /tab %}}
+{{% tab "Objective-C" %}}
+```objective-c
+DDRUMConfiguration *configuration = [[DDRUMConfiguration alloc] initWithApplicationID:@"<rum application id>"];
+configuration.sessionSampleRate = 50;
+```
+{{% /tab %}}
+{{< /tabs >}}
+
 ## Track background events
 
 <div class="alert alert-info"><p>Tracking background events may lead to additional sessions, which can impact billing. For questions, <a href="https://docs.datadoghq.com/help/">contact Datadog support.</a></p>

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
@@ -104,7 +104,7 @@ const config = new DatadogProviderConfiguration(
 config.site = 'US1';
 // Optional: Enable or disable native crash reports
 config.nativeCrashReportEnabled = true;
-// Optional: Sample RUM sessions (in this example, 80% of session are sent to Datadog. Default is 100%)
+// Optional: Sample RUM sessions (in this example, 80% of session are sent to Datadog. Default is 100%).
 config.sessionSamplingRate = 80;
 // Optional: Sample tracing integrations for network calls between your app and your backend (in this example, 80% of calls to your instrumented backend are linked from the RUM view to the APM view. Default is 20%)
 // You need to specify the hosts of your backends to enable tracing with these backends
@@ -290,6 +290,10 @@ export default function App() {
 ```
 
 {{< /site-region >}}
+
+### Sample RUM sessions
+
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM React Native SDK][18] as a percentage between 0 and 100. You can specify the rate with the `config.sampleRate` parameter.
 
 ### Override the reported version
 
@@ -488,3 +492,4 @@ end
 [15]: /getting_started/tagging/#define-tags
 [16]: https://github.com/DataDog/dd-sdk-reactnative-examples/tree/main/rum-react-navigation
 [17]: https://reactnative.dev/docs/the-new-architecture/landing-page
+[18]: /real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative/#initialize-the-library-with-application-context

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/roku.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/roku.md
@@ -176,6 +176,10 @@ end sub
 ```
 {{< /site-region >}}
 
+### Sample RUM sessions
+
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM Roku SDK][9] as a percentage between 0 and 100. You can specify the rate with the `sessionSampleRate` parameter.
+
 ### Instrument the channel
 
 See [**Track RUM Resources**][8] to enable automatic tracking of all your resources, and [**Enrich user sessions**][9] to add custom global or user information to your events.
@@ -228,3 +232,4 @@ Whenever you perform an operation that might throw an exception, you can forward
 [7]: /getting_started/tagging/using_tags/#rum--session-replay
 [8]: /real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/roku#track-rum-resources
 [9]: /real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/roku#enrich-user-sessions
+[10]: 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/unity.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/unity.md
@@ -50,6 +50,10 @@ Datadog does not support Desktop (Windows, Mac, or Linux), console, or web deplo
 
 To ensure the safety of your data, you must use a client token. For more information about setting up a client token, see the [Client Token documentation][2].
 
+#### Sample RUM sessions
+
+You can control the data your application sends to Datadog RUM during instrumentation of the RUM Unity SDK. Specify the **Session Sample Rate** as a percentage between 0 and 100 in the Project Settings window in Unity.
+
 ### Installing
 
 1. Install [External Dependency Manager for Unity (EDM4U)][3]. This can be done using [Open UPM][4].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Setting the sampling rate for RUM sessions is very important to customers and should not be hidden within advanced configuration instructions. The instructions have been moved or added to all setup pages as per [DOCS-7658](https://datadoghq.atlassian.net/browse/DOCS-7658).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Should be reviewed by @MaelNamNam or at least one person on the rum-mobile team before merging.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7658]: https://datadoghq.atlassian.net/browse/DOCS-7658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ