### PR TITLE
DOCS-7786: Add OS compatibility matrix for CSM Vulnerabilities

### DIFF
--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -110,10 +110,27 @@ CSM Threats supports the following Linux distributions:
 | [Helm Chart][103]            | v3.49.6 or later (Kubernetes only)      |
 | [containerd][104]              | v1.5.6 or later (Kubernetes and hosts only)|
 
-**Note**: CSM Vulnerabilities is **not** available for the following container runtimes:
+**Note**: CSM Vulnerabilities is **not** available for CRI-O runtime and podman runtime.
 
-  - CRI-O runtime
-  - podman runtime
+Vulnerability scanning is supported for hosts and containers running the following OS versions:
+
+| OS                       | Supported Versions                                  | Package Managers |
+|--------------------------|-----------------------------------------------------|------------------|
+| Alpine Linux             | 2.2 - 2.7, 3.0 - 3.19 (edge is not supported)       | apk              |
+| Wolfi Linux              | N/A                                                 | apk              |
+| Chainguard               | N/A                                                 | apk              |
+| Red Hat Enterprise Linux | 6, 7, 8                                             | dnf/yum/rpm      |
+| CentOS                   | 6, 7, 8                                             | dnf/yum/rpm      |
+| AlmaLinux                | 8, 9                                                | dnf/yum/rpm      |
+| Rocky Linux              | 8, 9                                                | dnf/yum/rpm      |
+| Oracle Linux             | 5, 6, 7, 8                                          | dnf/yum/rpm      |
+| CBL-Mariner              | 1.0, 2.0                                            | dnf/yum/rpm      |
+| Amazon Linux             | 1, 2, 2023                                          | dnf/yum/rpm      |
+| openSUSE Leap            | 42, 15                                              | dnf/yum/rpm      |
+| SUSE Enterprise Linux    | 11, 12, 15                                          | zypper/rpm       |
+| Photon OS                | 1.0, 2.0, 3.0, 4.0                                  | tndf/yum/rpm     |
+| Debian GNU/Linux         | 7, 8, 9, 10, 11, 12 (unstable/sid is not supported) | apt/dpkg         |
+| Ubuntu                   | All versions supported by Canonical                 | apt/dpkg         |
 
 ### CSM Identity Risks 
 

--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -116,7 +116,7 @@ Vulnerability scanning is supported for hosts and containers running the followi
 
 | OS                       | Supported Versions                                  | Package Managers |
 |--------------------------|-----------------------------------------------------|------------------|
-| Alpine Linux             | 2.2 - 2.7, 3.0 - 3.19 (edge is not supported)       | apk              |
+| Alpine Linux             | 2.2-2.7, 3.0-3.19 (edge is not supported)           | apk              |
 | Wolfi Linux              | N/A                                                 | apk              |
 | Chainguard               | N/A                                                 | apk              |
 | Red Hat Enterprise Linux | 6, 7, 8                                             | dnf/yum/rpm      |
@@ -126,7 +126,7 @@ Vulnerability scanning is supported for hosts and containers running the followi
 | Oracle Linux             | 5, 6, 7, 8                                          | dnf/yum/rpm      |
 | CBL-Mariner              | 1.0, 2.0                                            | dnf/yum/rpm      |
 | Amazon Linux             | 1, 2, 2023                                          | dnf/yum/rpm      |
-| openSUSE Leap            | 42, 15                                              | dnf/yum/rpm      |
+| openSUSE Leap            | 42, 15                                              | zypper/rpm       |
 | SUSE Enterprise Linux    | 11, 12, 15                                          | zypper/rpm       |
 | Photon OS                | 1.0, 2.0, 3.0, 4.0                                  | tndf/yum/rpm     |
 | Debian GNU/Linux         | 7, 8, 9, 10, 11, 12 (unstable/sid is not supported) | apt/dpkg         |

--- a/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
+++ b/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
@@ -19,26 +19,6 @@ further_reading:
 
 If you experience issues with Cloud Security Management (CSM) Vulnerabilities, use the following troubleshooting guidelines. If you need further assistance, contact [Datadog support][1].
 
-## Confirm CSM Vulnerabilities is enabled
-
-Review the documentation for [configuring the Agent for vulnerability scanning][2] to ensure your hosts and containers are configured for Software Bill of Materials (SBOM) collection. Additionally, review the in-app [Cloud Security Management][3] instructions to confirm that all steps for the initial setup are complete.
-
-## Prerequisites
-
-Ensure all the prerequisites are met for CSM Vulnerabilities:
-
-| Component                | Version/Requirement                     |
-| ------------------------ | ----------------------------------------|
-| [Helm Chart][6]            | v3.49.6 or later (Kubernetes only)      |
-| [containerd][7]              | v1.5.6 or later (Kubernetes and hosts only)|</br>
-
-CSM Vulnerabilities is **not** available for the following environments:
-
-  - Windows
-  - AWS Fargate 
-  - CRI-O runtime
-  - podman runtime
-
 ## Error messages
 
 ### Disk space requirements
@@ -84,5 +64,3 @@ The workaround for this issue is to set the configuration option `discard_unpack
 [2]: /security/cloud_security_management/setup/csm_enterprise?tab=aws#configure-the-agent-for-vulnerabilities
 [3]: https://app.datadoghq.com/security/configuration/csm/setup
 [4]: https://app.datadoghq.com/metric/summary
-[6]: /security/cloud_security_management/troubleshooting
-[7]: /containers/kubernetes/installation/?tab=helm


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds OS compatibility matrix. See DOCS-7786 for more details.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->