### PR TITLE
support blocklist to not render integration version

### DIFF
--- a/layouts/partials/integration-labels/integration-labels.html
+++ b/layouts/partials/integration-labels/integration-labels.html
@@ -1,4 +1,5 @@
 {{ $dot := . }}
+{{ $integration_version_blocklist := slice "oracle" }}
 
 {{ if .Params.is_beta }}
     <div class="row">
@@ -69,12 +70,11 @@
     {{ partial "badge.html" (dict "context" . "text" "marketplace") }}
 {{ end }}
 
-{{ with .Params.integration_version }}
+{{ if and (.Params.integration_version) (not (in $integration_version_blocklist .Params.app_id)) }}
 <div class="row integration-labels">
     <div class="integration-version col-12">
-        <span>{{ i18n "integration_version" }}</span><span>{{ . }}</span>
+        <span>{{ i18n "integration_version" }}</span><span>{{ .Params.integration_version }}</span>
     </div>
-
 </div>
 {{ end }}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
adds support to avoid rendering `integration_version` in specific integrations

jira: https://datadoghq.atlassian.net/browse/WEB-4787

### Merge instructions
- [ ] Please merge after webops reviewing

### Additional notes
`integration_version` label is not rendered in the `oracle` integration page: https://docs-staging.datadoghq.com/brian.deutsch/web-4787-remove-oracle-int-version-label/integrations/oracle/?tab=linux

label still appears on other pages for example: https://docs-staging.datadoghq.com/brian.deutsch/web-4787-remove-oracle-int-version-label/integrations/active_directory/