### PR TITLE
Fix Code Block Highlight

### DIFF
--- a/assets/styles/vendor/_chroma-styles.scss
+++ b/assets/styles/vendor/_chroma-styles.scss
@@ -2,7 +2,15 @@
 /* Error */ .chroma .err { color: #000000 }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
-/* LineHighlight */ .chroma .hl { display: block; width: 100%; box-shadow: inset 4px 0 0 #632ca6; background-color: #c987ff1d; }
+/* LineHighlight */ .chroma .hl {
+  display: block;
+  width: 100%;
+  box-shadow: inset 4px 0 0 #632ca6;
+  background-color: #c987ff1d;
+  position: relative;
+  margin-left: -8px;
+  padding-left: 8px;
+}
 /* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* Keyword */ .chroma .k { color: #a90d91 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Unindented lines are getting overlapped by the line highlight style.
- Tweak the margins and position to fix this.

Example from @cswatt :
![image](https://github.com/DataDog/documentation/assets/84536271/3f970262-a0ab-49dc-932c-6b0e7b03140b)

Link to example that's broken now: https://docs.datadoghq.com/containers/kubernetes/installation/?tab=helm#container-registries.

^ Verify this looks ok now in the preview build. Here's what it looks like locally for me:
![image](https://github.com/DataDog/documentation/assets/84536271/3b1f66bc-434d-4ab2-952f-bcfb784351b7)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->