### PR TITLE
[Container Images] Split instructions for Container Image and SBOM collection

### DIFF
--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -38,12 +38,12 @@ To enable live container collection, see the [containers][3] documentation. It p
 
 Datadog collects container image metadata to provide enhanced debugging context for related containers and [Cloud Security Management][8] (CSM) vulnerabilities.
 
-#### Enable Container Image collection
+#### Enable Container Image Collection
 
 {{< tabs >}}
 {{% tab "Kubernetes (Operator)" %}}
 
-Image collection is enabled by default with Datadog Operator version `>= 1.3.0`. If you are using a previous version, Datadog recommends you to update it to 1.3.0 or a newer one. </br>
+Image collection is enabled by default with Datadog Operator version `>= 1.3.0`. If you are using an older version, Datadog recommends you to update it to `1.3.0` or a newer one. </br>
 
 
 {{% /tab %}}
@@ -122,6 +122,8 @@ spec:
     # ...
     sbom:
       enabled: true
+      containerImage:
+        enabled: true
 ```
 
 {{% /tab %}}

--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -38,7 +38,7 @@ To enable live container collection, see the [containers][3] documentation. It p
 
 Datadog collects container image metadata to provide enhanced debugging context for related containers and [Cloud Security Management][8] (CSM) vulnerabilities.
 
-#### Enable Container Image Collection
+#### Enable Container Image collection
 
 {{< tabs >}}
 {{% tab "Kubernetes (Operator)" %}}

--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -38,12 +38,7 @@ To enable live container collection, see the [containers][3] documentation. It p
 
 Datadog collects container image metadata to provide enhanced debugging context for related containers and [Cloud Security Management][8] (CSM) vulnerabilities.
 
-#### Configure the Agent
-
-The following instructions enable the container image metadata collection and [Software Bill of Materials][5] (SBOM) collection in the Datadog Agent for CSM Vulnerabilities. This allows you to scan the libraries in container images to detect vulnerabilities. Vulnerabilities are evaluated and scanned against your containers every hour.
-
-**Note**: The CSM Vulnerabilities feature is not available for AWS Fargate or Windows environments.
-
+#### Enable Container Image collection
 
 {{< tabs >}}
 {{% tab "Kubernetes (Operator)" %}}
@@ -60,7 +55,6 @@ spec:
   features:
     # ...
     sbom:
-      enabled: true
       containerImage:
         enabled: true
 ```
@@ -76,6 +70,81 @@ Or, add the following to your `values.yaml` Helm configuration file:
 datadog:
   containerImageCollection:
     enabled: true
+```
+[1]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml#L651
+{{% /tab %}}
+
+{{% tab "ECS EC2" %}}
+
+To enable container image collection on your [ECS EC2 instances][1], add the following environment variables to your `datadog-agent` container definition:
+
+```yaml
+{
+    "containerDefinitions": [
+        {
+            "name": "datadog-agent",
+             ...
+            "environment": [
+              ...
+              {
+                "name": "DD_CONTAINER_IMAGE_ENABLED",
+                "value": "true"
+              }
+            ]
+        }
+    ]
+  ...
+}
+```
+
+[1]: https://docs.datadoghq.com/containers/amazon_ecs/?tab=awscli#setup
+
+{{% /tab %}}
+
+{{% tab "Hosts" %}}
+
+Add the following to your `datadog.yaml` configuration file:
+
+```yaml
+container_image:
+  enabled: true
+```
+
+[1]: /containers/amazon_ecs/?tab=awscli#setup
+{{% /tab %}}
+{{< /tabs >}}
+
+#### Enable SBOM collection
+
+The following instructions enable the [Software Bill of Materials][5] (SBOM) collection in the Datadog Agent for CSM Vulnerabilities. This allows you to scan the libraries in container images to detect vulnerabilities. Vulnerabilities are evaluated and scanned against your containers every hour. Vulnerability management for container images is included in [CSM Pro and Enterprise plans][10].
+
+**Note**: The CSM Vulnerabilities feature is not available for AWS Fargate or Windows environments.
+
+{{< tabs >}}
+{{% tab "Kubernetes (Operator)" %}}
+
+Add the following to the spec section of your `values.yaml` file:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  features:
+    # ...
+    sbom:
+      enabled: true
+```
+
+{{% /tab %}}
+
+{{% tab "Kubernetes (Helm)" %}}
+
+Add the following to your `values.yaml` Helm configuration file:
+
+```yaml
+datadog:
   sbom:
     containerImage:
       enabled: true
@@ -95,10 +164,6 @@ To enable container image vulnerability scanning on your [ECS EC2 instances][1],
              ...
             "environment": [
               ...
-              {
-                "name": "DD_CONTAINER_IMAGE_ENABLED",
-                "value": "true"
-              },
               {
                 "name": "DD_SBOM_ENABLED",
                 "value": "true"
@@ -141,8 +206,6 @@ sbom:
   enabled: true
   container_image:
     enabled: true
-container_image:
-  enabled: true
 ```
 
 [1]: /containers/amazon_ecs/?tab=awscli#setup
@@ -179,3 +242,4 @@ Tag and enrich your container images with arbitrary tags by using [extract label
 [6]: /containers/docker/tag/?tab=containerizedagent#extract-labels-as-tags
 [8]: /security/cloud_security_management/vulnerabilities
 [9]: https://app.datadoghq.com/container-images/image-trends
+[10]: https://www.datadoghq.com/pricing/?product=cloud-security-management#products

--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -43,21 +43,8 @@ Datadog collects container image metadata to provide enhanced debugging context 
 {{< tabs >}}
 {{% tab "Kubernetes (Operator)" %}}
 
-Image collection is enabled by default with Datadog Operator version `>= 1.3.0`.</br>
-Or, add the following to the spec section of your `values.yaml` file:
+Image collection is enabled by default with Datadog Operator version `>= 1.3.0`. If you are using a previous version, Datadog recommends you to update it to 1.3.0 or a newer one. </br>
 
-```yaml
-apiVersion: datadoghq.com/v2alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  features:
-    # ...
-    sbom:
-      containerImage:
-        enabled: true
-```
 
 {{% /tab %}}
 

--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -38,20 +38,19 @@ To enable live container collection, see the [containers][3] documentation. It p
 
 Datadog collects container image metadata to provide enhanced debugging context for related containers and [Cloud Security Management][8] (CSM) vulnerabilities.
 
-#### Enable Container Image collection
+#### Enable container image collection
 
 {{< tabs >}}
 {{% tab "Kubernetes (Operator)" %}}
 
-Image collection is enabled by default with Datadog Operator version `>= 1.3.0`. If you are using an older version, Datadog recommends you to update it to `1.3.0` or a newer one. </br>
+In Datadog Operator v1.3.0+, image collection is enabled by default. If you are using an older version of the Datadog Operator, Datadog recommends that you update it to v1.3.0+.
 
 
 {{% /tab %}}
 
 {{% tab "Kubernetes (Helm)" %}}
 
-If you are using Helm version `>= 3.46.0`, image collection is [enabled by default][1].</br>
-Or, add the following to your `values.yaml` Helm configuration file:
+In the Datadog Helm chart v3.46.0+, image collection is [enabled by default][1]. To verify this, or if you are using an earlier Helm chart version, ensure that `datadog.containerImageCollection.enabled` is set to `true` in `datadog-values.yaml`.
 
 ```yaml
 datadog:
@@ -103,14 +102,14 @@ container_image:
 
 #### Enable SBOM collection
 
-The following instructions enable the [Software Bill of Materials][5] (SBOM) collection in the Datadog Agent for CSM Vulnerabilities. SBOM collection enables automatic detection of container image vulnerabilities. Vulnerabilities are evaluated and scanned against your containers every hour. Vulnerability management for container images is included in [CSM Pro and Enterprise plans][10].
+The following instructions turn on [Software Bill of Materials][5] (SBOM) collection for CSM Vulnerabilities. SBOM collection enables automatic detection of container image vulnerabilities. Vulnerabilities are evaluated and scanned against your containers every hour. Vulnerability management for container images is included in [CSM Pro and Enterprise plans][10].
 
 **Note**: The CSM Vulnerabilities feature is not available for AWS Fargate or Windows environments.
 
 {{< tabs >}}
 {{% tab "Kubernetes (Operator)" %}}
 
-Add the following to the spec section of your `values.yaml` file:
+Add the following to the spec section of your `datadog-agent.yaml` file:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -130,7 +129,7 @@ spec:
 
 {{% tab "Kubernetes (Helm)" %}}
 
-Add the following to your `values.yaml` Helm configuration file:
+Add the following to your `datadog-values.yaml` Helm configuration file:
 
 ```yaml
 datadog:

--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -116,7 +116,7 @@ container_image:
 
 #### Enable SBOM collection
 
-The following instructions enable the [Software Bill of Materials][5] (SBOM) collection in the Datadog Agent for CSM Vulnerabilities. This allows you to scan the libraries in container images to detect vulnerabilities. Vulnerabilities are evaluated and scanned against your containers every hour. Vulnerability management for container images is included in [CSM Pro and Enterprise plans][10].
+The following instructions enable the [Software Bill of Materials][5] (SBOM) collection in the Datadog Agent for CSM Vulnerabilities. SBOM collection enables automatic detection of container image vulnerabilities. Vulnerabilities are evaluated and scanned against your containers every hour. Vulnerability management for container images is included in [CSM Pro and Enterprise plans][10].
 
 **Note**: The CSM Vulnerabilities feature is not available for AWS Fargate or Windows environments.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The Datadog Agent has 2 types of Container Image Collection:
- Image Metadata collection, enabled by default
- SBOM collection, not enabled by default and part of the CSM Pro and Enterprise plan

In order to prevent users to accidentally enable the SBOM collection, this PR splits the enablement instructions for each one of them.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->