### PR TITLE
Remove beta label from Azure container costs in CCM

### DIFF
--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -57,8 +57,6 @@ The following table presents the list of collected features and the minimal Agen
 {{% /tab %}}
 {{% tab "Azure" %}}
 
-<div class="alert alert-warning">Container Cost Allocation for Azure is in beta.</div>
-
 CCM allocates costs of all Kubernetes clusters, including those managed through Azure Kubernetes Service (AKS).
 
 The following table presents the list of collected features and the minimal Agent and Cluster Agent versions for each.
@@ -138,8 +136,6 @@ ECS tasks that run on Fargate are already fully allocated [in the CUR][103]. CCM
 
 {{% /tab %}}
 {{% tab "Azure" %}}
-
-<div class="alert alert-warning">Container Cost Allocation for Azure is in beta.</div>
 
 ### Compute
 
@@ -225,8 +221,6 @@ The cost of an AWS EBS volume has three components: IOPS, throughput, and storag
 {{% /tab %}}
 {{% tab "Azure" %}}
 
-<div class="alert alert-warning">Container Cost Allocation for Azure is in beta.</div>
-
 ### Compute
 
 The cost of a host instance is split into two components: 60% for the CPU and 40% for the memory. Each component is allocated to individual workloads based on their resource reservations and usage.
@@ -289,8 +283,6 @@ When the prerequisites are met, the following cost metrics automatically appear.
 
 {{% /tab %}}
 {{% tab "Azure" %}}
-
-<div class="alert alert-warning">Container Cost Allocation for Azure is in beta.</div>
 
 | Cost Metric                    | Description    |
 | ---                                | ----------- |
@@ -359,8 +351,6 @@ In addition to ECS task tags, the following out-of-the-box tags are applied to c
 
 {{% /tab %}}
 {{% tab "Azure" %}}
-
-<div class="alert alert-warning">Container Cost Allocation for Azure is in beta.</div>
 
 ### Kubernetes
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Azure container costs are now GA, we dont need to show the beta label anymore

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->