### PR TITLE
[APM > .NET Tracer] Docs updates

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -270,7 +270,7 @@ For more information on adding spans and tags for custom instrumentation, see th
 To attach automatic instrumentation to your service, set the required environment variables before starting the application. See [Enable the tracer for your service](#enable-the-tracer-for-your-service) section to identify which environment variables to set based on your .NET Tracer installation method and follow the examples below to correctly set the environment variables based on the environment of your instrumented service.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> The .NET runtime tries to load the tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>It is not recommended to set these environment variables globally on a host as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
+  <strong>Note:</strong> The .NET runtime tries to load the tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. It is not recommended to set these environment variables globally on a host as this causes <em>all</em> .NET processes on the host to load the tracing library.
 </div>
 
 ### Windows

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing .NET Core Applications
+title: Tracing .NET Core and .NET 5+ Applications
 kind: documentation
 aliases:
   - /tracing/dotnet-core
@@ -29,9 +29,9 @@ further_reading:
   - link: "https://www.datadoghq.com/blog/net-monitoring-apm/"
     tag: "Blog"
     text: ".NET monitoring with Datadog APM and distributed tracing"
-  - link: 'https://www.datadoghq.com/blog/asp-dotnet-core-monitoring/'
-    tag: 'Blog'
-    text: 'Monitor containerized ASP.NET Core applications'
+  - link: "https://www.datadoghq.com/blog/asp-dotnet-core-monitoring/"
+    tag: "Blog"
+    text: "Monitor containerized ASP.NET Core applications"
   - link: "https://www.datadoghq.com/blog/deploy-dotnet-core-azure-app-service/"
     tag: "Blog"
     text: "Deploy ASP.NET Core applications to Azure App Service"
@@ -48,16 +48,18 @@ further_reading:
 
 ## Compatibility requirements
 
-### Supported .NET Core runtimes
+### Supported .NET Core and .NET runtimes
 
 The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
 
-For a full list of Datadog's .NET Core library and processor architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+For .NET Framework, see [Tracing .NET Framework Applications][7].
+
+For a full list of Datadog's .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 
 ## Installation and getting started
 
 <div class="alert alert-info">
-    To set up Datadog APM in AWS Lambda, see <strong><a href="/tracing/serverless_functions/">Tracing Serverless Functions</a></strong>, in Azure App Service, see <strong><a href="/serverless/azure_app_services/">Tracing Azure App Service</a></strong>.
+  To set up Datadog APM in AWS Lambda, see <strong>[Tracing Serverless Functions][8]</strong>. To set up in Azure App Service, see <strong>[Tracing Azure App Services][9]</strong>.
 </div>
 
 <div class="alert alert-warning">
@@ -442,5 +444,8 @@ When using `systemctl` to run .NET applications as a service, you can also set e
 [4]: /tracing/trace_collection/library_config/dotnet-core/
 [5]: /tracing/trace_collection/custom_instrumentation/dotnet/
 [6]: https://www.freedesktop.org/software/systemd/man/systemctl.html#set-environment%20VARIABLE=VALUE%E2%80%A6
+[7]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework/
+[8]: /tracing/serverless_functions/
+[9]: /serverless/azure_app_services/
 [11]: /tracing/trace_collection/library_injection_local/
 [12]: /tracing/trace_collection/automatic_instrumentation/?tab=datadoglibraries#install-and-configure-the-agent

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -50,11 +50,7 @@ further_reading:
 
 ### Supported .NET and .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5 to .NET 8.
-
-For applications built on .NET Framework, see [Tracing .NET Framework Applications][7].
-
-For a full list of Datadog's .NET runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5 to .NET 8. For applications built on .NET Framework, see [Tracing .NET Framework Applications][7]. For a full list of Datadog's .NET and .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 
 ## Installation and getting started
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -48,18 +48,22 @@ further_reading:
 
 ## Compatibility requirements
 
-### Supported .NET Core and .NET runtimes
+### Supported .NET runtimes
 
 The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
 
-For .NET Framework, see [Tracing .NET Framework Applications][7].
+For application built on .NET Framework, see [Tracing .NET Framework Applications][7].
 
 For a full list of Datadog's .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+
+<div class="alert alert-info">
+  .NET Core was rebranded as simply ".NET" starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
+</div>
 
 ## Installation and getting started
 
 <div class="alert alert-info">
-  To set up Datadog APM in AWS Lambda, see <strong>[Tracing Serverless Functions][8]</strong>. To set up in Azure App Service, see <strong>[Tracing Azure App Services][9]</strong>.
+  To set up Datadog APM in AWS Lambda, see [Tracing Serverless Functions][8]. To set up Datadog APM in Azure App Service, see [Tracing Azure App Services][9].
 </div>
 
 <div class="alert alert-warning">

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -1,5 +1,5 @@
 ---
-title: Tracing .NET Core and .NET 5+ Applications
+title: Tracing .NET and .NET Core Applications
 kind: documentation
 aliases:
   - /tracing/dotnet-core

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -50,7 +50,9 @@ further_reading:
 
 ### Supported .NET and .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, and .NET 5 to .NET 8. For applications built on .NET Framework, see [Tracing .NET Framework Applications][7]. For a full list of Datadog's .NET and .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, and .NET 5 to .NET 8.
+
+For a full list of Datadog's .NET and .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1]. For applications built on .NET Framework, see [Tracing .NET Framework Applications][7].
 
 ## Installation and getting started
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -50,21 +50,13 @@ further_reading:
 
 ### Supported .NET and .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5 to .NET 8. For applications built on .NET Framework, see [Tracing .NET Framework Applications][7]. For a full list of Datadog's .NET and .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, and .NET 5 to .NET 8. For applications built on .NET Framework, see [Tracing .NET Framework Applications][7]. For a full list of Datadog's .NET and .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 
 ## Installation and getting started
 
-<div class="alert alert-info">
-  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. This page may refer to <strong>.NET Core</strong> or <strong>.NET</strong> interchangeably unless referring to a specific version.
-</div>
+To set up Datadog APM in AWS Lambda, see [Distributed Tracing with AWS Lambda Serverless Applications][8]. To set up Datadog APM in Azure App Service, see [Monitoring Azure App Service][9].
 
-<div class="alert alert-info">
-  To set up Datadog APM in AWS Lambda, see [Tracing Serverless Functions][8]. To set up Datadog APM in Azure App Service, see [Tracing Azure App Services][9].
-</div>
-
-<div class="alert alert-info">
-  To instrument trimmed apps, reference the <a href="https://www.nuget.org/packages/Datadog.Trace.Trimming/">Datadog.Trace.Trimming</a> NuGet package in your project. Support for trimmed apps is in beta.
-</div>
+To instrument [trimmed apps][13], reference the [`Datadog.Trace.Trimming`][10] NuGet package in your project. Support for trimmed apps is a beta feature.
 
 <div class="alert alert-warning">
   <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog APM). To ensure maximum visibility, run only one APM solution in your application environment. 
@@ -240,8 +232,8 @@ To use custom instrumentation in your .NET application:
 1. Add the `Datadog.Trace` [NuGet package][1] to your application.
 2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-
 [1]: https://www.nuget.org/packages/Datadog.Trace
+
 {{% /tab %}}
 
 {{% tab "Linux" %}}
@@ -251,11 +243,12 @@ To use custom instrumentation in your .NET application:
 </div>
 
 To use custom instrumentation in your .NET application:
+
 1. Add the `Datadog.Trace` [NuGet package][1] to your application.
 2. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
-
 [1]: https://www.nuget.org/packages/Datadog.Trace
+
 {{% /tab %}}
 
 {{% tab "NuGet" %}}
@@ -441,7 +434,9 @@ When using `systemctl` to run .NET applications as a service, you can also set e
 [5]: /tracing/trace_collection/custom_instrumentation/dotnet/
 [6]: https://www.freedesktop.org/software/systemd/man/systemctl.html#set-environment%20VARIABLE=VALUE%E2%80%A6
 [7]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework/
-[8]: /tracing/serverless_functions/
+[8]: /serverless/aws_lambda/distributed_tracing/
 [9]: /serverless/azure_app_services/
+[10]: https://www.nuget.org/packages/Datadog.Trace.Trimming/
 [11]: /tracing/trace_collection/library_injection_local/
 [12]: /tracing/trace_collection/automatic_instrumentation/?tab=datadoglibraries#install-and-configure-the-agent
+[13]: https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -50,7 +50,7 @@ further_reading:
 
 ### Supported .NET and .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
+The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5 to .NET 8.
 
 For applications built on .NET Framework, see [Tracing .NET Framework Applications][7].
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -278,11 +278,11 @@ For more information on adding spans and tags for custom instrumentation, see th
 
 To attach automatic instrumentation to your service, set the required environment variables before starting the application. See [Enable the tracer for your service](#enable-the-tracer-for-your-service) section to identify which environment variables to set based on your .NET Tracer installation method and follow the examples below to correctly set the environment variables based on the environment of your instrumented service.
 
-### Windows
-
 <div class="alert alert-warning">
-  <strong>Note:</strong> The .NET runtime tries to load a tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
+  <strong>Note:</strong> The .NET runtime tries to load the tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>It is not recommended to set these environment variables globally on a host as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
 </div>
+
+### Windows
 
 #### Windows services
 
@@ -413,10 +413,6 @@ When using `systemctl` to run .NET applications as a service, you can add the re
 3. Restart the .NET service for the environment variable settings to take effect.
 
 #### `systemctl` (all services)
-
-<div class="alert alert-warning">
-  <strong>Note:</strong> The .NET runtime tries to load a tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
-</div>
 
 When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services run by `systemctl`.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -92,7 +92,11 @@ To install the .NET Tracer machine-wide:
 
 2. Run the .NET Tracer MSI installer with administrator privileges.
 
-You can also script the MSI setup by running the following in PowerShell: `Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-apm.msi'`
+You can also script the MSI setup by running the following in PowerShell:
+
+```powershell
+Start-Process -Wait msiexec -ArgumentList '/qn /i <PATH TO MSI INSTALLER>'
+```
 
 [1]: https://github.com/DataDog/dd-trace-dotnet/releases
 {{% /tab %}}
@@ -138,9 +142,7 @@ To install the .NET Tracer per-application:
 
 ### Enable the tracer for your service
 
-To enable the .NET Tracer for your service, set the required environment variables and restart the application.
-
-For information about the different methods for setting environment variables, see [Configuring process environment variables](#configuring-process-environment-variables).
+To enable the .NET Tracer for your service, set the required environment variables and restart the application. For information about the different methods for setting environment variables, see [Configuring process environment variables](#configuring-process-environment-variables).
 
 {{< tabs >}}
 
@@ -148,7 +150,7 @@ For information about the different methods for setting environment variables, s
 
 #### Internet Information Services (IIS)
 
-1. The .NET Tracer MSI installer adds all required environment variables. There are no environment variables you need to configure.
+1. The .NET Tracer MSI installer adds all required environment variables. There are no environment variables you need to configure manually.
 
    <div class="alert alert-warning">
      <strong>Note:</strong> You must set the <strong>.NET CLR version</strong> for the application pool to <strong>No Managed Code</strong> as recommended by <a href='https://learn.microsoft.com/aspnet/core/host-and-deploy/iis/advanced#create-the-iis-site'> Microsoft</a>.
@@ -169,15 +171,13 @@ For information about the different methods for setting environment variables, s
 
 #### Services not in IIS
 
-<div class="alert alert-info">Starting v2.14.0, you don't need to set <code>CORECLR_PROFILER</code> if you installed the tracer using the MSI.</div>
-
-1. Set the following required environment variables for automatic instrumentation to attach to your application:
+1. Set the following required environment variable for automatic instrumentation to attach to your application:
 
    ```
    CORECLR_ENABLE_PROFILING=1
-   CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    ```
-2. For standalone applications and Windows services, manually restart the application.
+
+2. Manually restart the application.
 
 {{% /tab %}}
 
@@ -192,7 +192,7 @@ For information about the different methods for setting environment variables, s
    DD_DOTNET_TRACER_HOME=/opt/datadog
    ```
 
-2. For standalone applications, manually restart the application as you normally would.
+2. Manually restart the application.
 
 {{% /tab %}}
 
@@ -270,13 +270,15 @@ For more information on adding spans and tags for custom instrumentation, see th
 
 ## Configuring process environment variables
 
-To attach automatic instrumentation to your service, you must set the required environment variables before starting the application. See [Enable the tracer for your service](#enable-the-tracer-for-your-service) section to identify which environment variables to set based on your .NET Tracer installation method and follow the examples below to correctly set the environment variables based on the environment of your instrumented service.
+To attach automatic instrumentation to your service, set the required environment variables before starting the application. See [Enable the tracer for your service](#enable-the-tracer-for-your-service) section to identify which environment variables to set based on your .NET Tracer installation method and follow the examples below to correctly set the environment variables based on the environment of your instrumented service.
 
 ### Windows
 
-#### Windows services
+<div class="alert alert-warning">
+  <strong>Note:</strong> The .NET runtime tries to load a tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
+</div>
 
-<div class="alert alert-info">Starting v2.14.0, you don't need to set <code>CORECLR_PROFILER</code> if you installed the tracer using the MSI.</div>
+#### Windows services
 
 {{< tabs >}}
 
@@ -286,7 +288,6 @@ In the Registry Editor, create a multi-string value called `Environment` in the 
 
 ```text
 CORECLR_ENABLE_PROFILING=1
-CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
 {{< img src="tracing/setup/dotnet/RegistryEditorCore.png" alt="Using the Registry Editor to create environment variables for a Windows service" >}}
@@ -296,14 +297,14 @@ CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 {{% tab "PowerShell" %}}
 
 ```powershell
-[string[]] $v = @("CORECLR_ENABLE_PROFILING=1", "CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}")
+[string[]] $v = @("CORECLR_ENABLE_PROFILING=1")
 Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<SERVICE NAME> -Name Environment -Value $v
 ```
 {{% /tab %}}
 
 {{< /tabs >}}
 
-#### IIS
+#### Internet Information Services (IIS)
 
 After installing the MSI, no additional configuration is needed to automatically instrument your IIS sites. To set additional environment variables that are inherited by all IIS sites, perform the following steps:
 
@@ -313,7 +314,7 @@ After installing the MSI, no additional configuration is needed to automatically
    DD_RUNTIME_METRICS_ENABLED=true
    ```
 2. Run the following commands to restart IIS:
-   ```cmd
+   ```bat
    net stop /y was
    net start w3svc
    # Also, start any other services that were stopped when WAS was shut down.
@@ -326,16 +327,14 @@ After installing the MSI, no additional configuration is needed to automatically
 To automatically instrument a console application, set the environment variables from a batch file before starting your application:
 
 ```bat
-rem Set environment variables
+rem Set required environment variable
 SET CORECLR_ENABLE_PROFILING=1
-rem Unless v2.14.0+ and you installed the tracer with the MSI
-SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 
-rem Set additional Datadog environment variables
+rem Example: set additional configuration variables
 SET DD_LOGS_INJECTION=true
 SET DD_RUNTIME_METRICS_ENABLED=true
 
-rem Start application
+rem Start your application
 dotnet.exe example.dll
 ```
 
@@ -346,13 +345,13 @@ dotnet.exe example.dll
 To set the required environment variables from a bash file before starting your application:
 
 ```bash
-# Set environment variables
+# Set required environment variables
 export CORECLR_ENABLE_PROFILING=1
 export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 export CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 export DD_DOTNET_TRACER_HOME=/opt/datadog
 
-# Set additional Datadog environment variables
+# Example: set additional configuration variables
 export DD_LOGS_INJECTION=true
 export DD_RUNTIME_METRICS_ENABLED=true
 
@@ -367,13 +366,13 @@ dotnet example.dll
 To set the required environment variables on a Linux Docker container:
 
   ```docker
-  # Set environment variables
+  # Set required environment variables
   ENV CORECLR_ENABLE_PROFILING=1
   ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
   ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
   ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 
-  # Set additional Datadog environment variables
+  # Example: set additional configuration variables
   ENV DD_LOGS_INJECTION=true
   ENV DD_RUNTIME_METRICS_ENABLED=true
 
@@ -388,12 +387,13 @@ When using `systemctl` to run .NET applications as a service, you can add the re
 1. Create a file called `environment.env` containing:
 
     ```ini
+    # Set required environment variables
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
     CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
     DD_DOTNET_TRACER_HOME=/opt/datadog
 
-    # Set additional Datadog environment variables
+    # Example: set additional configuration variables
     DD_LOGS_INJECTION=true
     DD_RUNTIME_METRICS_ENABLED=true
     ```
@@ -409,7 +409,7 @@ When using `systemctl` to run .NET applications as a service, you can add the re
 #### `systemctl` (all services)
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> The .NET runtime tries to load a profiler into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be traced. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to load the profiler.</strong>
+  <strong>Note:</strong> The .NET runtime tries to load a tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
 </div>
 
 When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services run by `systemctl`.
@@ -417,12 +417,13 @@ When using `systemctl` to run .NET applications as a service, you can also set e
 1. Set the required environment variables by running [`systemctl set-environment`][6]:
 
     ```bash
+    # Set required environment variables
     systemctl set-environment CORECLR_ENABLE_PROFILING=1
     systemctl set-environment CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
     systemctl set-environment CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
     systemctl set-environment DD_DOTNET_TRACER_HOME=/opt/datadog
 
-    # Set additional Datadog environment variables
+    # Example: set additional configuration variables
     systemctl set-environment DD_LOGS_INJECTION=true
     systemctl set-environment DD_RUNTIME_METRICS_ENABLED=true
     ```

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -54,10 +54,10 @@ The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5
 
 For application built on .NET Framework, see [Tracing .NET Framework Applications][7].
 
-For a full list of Datadog's .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+For a full list of Datadog's .NET runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 
 <div class="alert alert-info">
-  .NET Core was rebranded as simply ".NET" starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
+  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
 </div>
 
 ## Installation and getting started

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -50,7 +50,7 @@ further_reading:
 
 ### Supported .NET and .NET Core runtimes
 
-The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, and .NET 5 to .NET 8.
+The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
 
 For a full list of Datadog's .NET and .NET Core runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1]. For applications built on .NET Framework, see [Tracing .NET Framework Applications][7].
 
@@ -61,7 +61,7 @@ To set up APM in AWS Lambda, see [Distributed Tracing with AWS Lambda Serverless
 To instrument [trimmed apps][13], reference the [`Datadog.Trace.Trimming`][10] NuGet package in your project. Support for trimmed apps is a beta feature.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog APM). To ensure maximum visibility, run only one APM solution in your application environment. 
+  <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog APM). To ensure maximum visibility, run only one APM solution in your application environment.
 </div>
 
 ### Installation

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -56,22 +56,22 @@ For applications built on .NET Framework, see [Tracing .NET Framework Applicatio
 
 For a full list of Datadog's .NET runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 
-<div class="alert alert-info">
-  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
-</div>
-
 ## Installation and getting started
+
+<div class="alert alert-info">
+  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. This page may refer to <strong>.NET Core</strong> or <strong>.NET</strong> interchangeably unless referring to a specific version.
+</div>
 
 <div class="alert alert-info">
   To set up Datadog APM in AWS Lambda, see [Tracing Serverless Functions][8]. To set up Datadog APM in Azure App Service, see [Tracing Azure App Services][9].
 </div>
 
-<div class="alert alert-warning">
-  <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog APM). To ensure maximum visibility, run only one APM solution in your application environment. 
-</div>
-
 <div class="alert alert-info">
   To instrument trimmed apps, reference the <a href="https://www.nuget.org/packages/Datadog.Trace.Trimming/">Datadog.Trace.Trimming</a> NuGet package in your project. Support for trimmed apps is in beta.
+</div>
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog APM). To ensure maximum visibility, run only one APM solution in your application environment. 
 </div>
 
 ### Installation

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -48,7 +48,7 @@ further_reading:
 
 ## Compatibility requirements
 
-### Supported .NET runtimes
+### Supported .NET and .NET Core runtimes
 
 The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -56,7 +56,7 @@ For a full list of Datadog's .NET and .NET Core runtime, OS, and architecture su
 
 ## Installation and getting started
 
-To set up Datadog APM in AWS Lambda, see [Distributed Tracing with AWS Lambda Serverless Applications][8]. To set up Datadog APM in Azure App Service, see [Monitoring Azure App Service][9].
+To set up APM in AWS Lambda, see [Distributed Tracing with AWS Lambda Serverless Applications][8]. To set up APM in Azure App Service, see [Monitoring Azure App Service][9].
 
 To instrument [trimmed apps][13], reference the [`Datadog.Trace.Trimming`][10] NuGet package in your project. Support for trimmed apps is a beta feature.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -52,7 +52,7 @@ further_reading:
 
 The .NET Tracer supports instrumentation on .NET Core 2.1, .NET Core 3.1, .NET 5, .NET 6, .NET 7, and .NET 8.
 
-For application built on .NET Framework, see [Tracing .NET Framework Applications][7].
+For applications built on .NET Framework, see [Tracing .NET Framework Applications][7].
 
 For a full list of Datadog's .NET runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -59,9 +59,7 @@ The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above. For 
 
 ## Installation and getting started
 
-<div class="alert alert-info">
-  To set up Datadog APM in AWS Lambda, see [Tracing Serverless Functions][7] . To set up Datadog APM in Azure App Service, see [Tracing Azure App Services][8].
-</div>
+To set up Datadog APM in AWS Lambda, see [Distributed Tracing with AWS Lambda Serverless Applications][7] . To set up Datadog APM in Azure App Service, see [Monitoring Azure App Service][8].
 
 <div class="alert alert-warning">
   <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog APM). To ensure maximum visibility, run only one APM solution in your application environment.
@@ -292,7 +290,7 @@ example.exe
 [4]: /tracing/trace_collection/library_config/dotnet-framework/
 [5]: /tracing/trace_collection/custom_instrumentation/dotnet/
 [6]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core/
-[7]: /tracing/serverless_functions/
+[7]: /serverless/aws_lambda/distributed_tracing/
 [8]: /serverless/azure_app_services/
 [11]: /tracing/trace_collection/library_injection_local/
 [12]: /tracing/trace_collection/automatic_instrumentation/?tab=datadoglibraries#install-and-configure-the-agent

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -218,7 +218,7 @@ For more information on adding spans and tags for custom instrumentation, see th
 To attach automatic instrumentation to your service, set the required environment variables before starting the application. See [Enable the tracer for your service](#enable-the-tracer-for-your-service) section to identify which environment variables to set based on your .NET Tracer installation method and follow the examples below to correctly set the environment variables based on the environment of your instrumented service.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> The .NET runtime tries to load the tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>It is not recommended to set these environment variables globally on a host as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
+  <strong>Note:</strong> The .NET runtime tries to load the tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. It is not recommended to set these environment variables globally on a host as this causes <em>all</em> .NET processes on the host to load the tracing library.
 </div>
 
 #### Windows services

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -55,11 +55,7 @@ further_reading:
 
 ### Supported .NET Framework runtimes
 
-The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above.
-
-For applications built on .NET 5 and above or on .NET Core, see [Tracing .NET and .NET Core Applications][6].
-
-For a full list of Datadog's .NET Framework runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above. For applications built on .NET 5 and above or on .NET Core, see [Tracing .NET and .NET Core Applications][6]. For a full list of Datadog's .NET Framework runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 
 ## Installation and getting started
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -57,14 +57,14 @@ further_reading:
 
 The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above.
 
-For .NET Core and .NET 5 and above, see [Tracing .NET Core and .NET 5+ Applications][6].
+For applications built on .NET Core or .NET 5 and above, see [Tracing .NET Core and .NET 5+ Applications][6].
 
 For a full list of Datadog's .NET Framework runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 
 ## Installation and getting started
 
 <div class="alert alert-info">
-  To set up Datadog APM in AWS Lambda, see <strong>[Tracing Serverless Functions][7]</strong>. To set up in Azure App Service, see <strong>[Tracing Azure App Services][8]</strong>.
+  To set up Datadog APM in AWS Lambda, see [Tracing Serverless Functions][7] . To set up Datadog APM in Azure App Service, see [Tracing Azure App Services][8].
 </div>
 
 <div class="alert alert-warning">

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -57,7 +57,7 @@ further_reading:
 
 The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above.
 
-For applications built on .NET Core or .NET 5 and above, see [Tracing .NET Core and .NET 5+ Applications][6].
+For applications built on .NET 5 and above or on .NET Core, see [Tracing .NET and .NET Core Applications][6].
 
 For a full list of Datadog's .NET Framework runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -61,7 +61,7 @@ For a full list of Datadog's .NET Framework runtime, OS, and architecture suppor
 
 ## Installation and getting started
 
-To set up Datadog APM in AWS Lambda, see [Distributed Tracing with AWS Lambda Serverless Applications][7] . To set up Datadog APM in Azure App Service, see [Monitoring Azure App Service][8].
+To set up APM in AWS Lambda, see [Distributed Tracing with AWS Lambda Serverless Applications][7]. To set up APM in Azure App Service, see [Monitoring Azure App Service][8].
 
 <div class="alert alert-warning">
   <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog APM). To ensure maximum visibility, run only one APM solution in your application environment.

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -55,7 +55,9 @@ further_reading:
 
 ### Supported .NET Framework runtimes
 
-The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above. For applications built on .NET 5 and above or on .NET Core, see [Tracing .NET and .NET Core Applications][6]. For a full list of Datadog's .NET Framework runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above.
+
+For a full list of Datadog's .NET Framework runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1]. For applications built on .NET 5 and above or on .NET Core, see [Tracing .NET and .NET Core Applications][6].
 
 ## Installation and getting started
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -50,18 +50,21 @@ further_reading:
     tag: "GitHub"
     text: "Source code"
 ---
+
 ## Compatibility requirements
 
 ### Supported .NET Framework runtimes
 
-The .NET Tracer supports instrumentation on .NET Framework >= 4.6.1.
+The .NET Tracer supports instrumentation on .NET Framework 4.6.1 and above.
 
-For a full list of Datadog's .NET Framework library and processor architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
+For .NET Core and .NET 5 and above, see [Tracing .NET Core and .NET 5+ Applications][6].
+
+For a full list of Datadog's .NET Framework runtime, OS, and architecture support (including legacy and maintenance versions), see [Compatibility Requirements][1].
 
 ## Installation and getting started
 
 <div class="alert alert-info">
-  To set up Datadog APM in AWS Lambda, see <strong><a href="/tracing/serverless_functions/">Tracing Serverless Functions</a></strong>, in Azure App Service, see <strong><a href="/serverless/azure_app_services/">Tracing Azure App Service</a></strong>.
+  To set up Datadog APM in AWS Lambda, see <strong>[Tracing Serverless Functions][7]</strong>. To set up in Azure App Service, see <strong>[Tracing Azure App Services][8]</strong>.
 </div>
 
 <div class="alert alert-warning">
@@ -292,5 +295,8 @@ example.exe
 [3]: https://app.datadoghq.com/apm/traces
 [4]: /tracing/trace_collection/library_config/dotnet-framework/
 [5]: /tracing/trace_collection/custom_instrumentation/dotnet/
+[6]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core/
+[7]: /tracing/serverless_functions/
+[8]: /serverless/azure_app_services/
 [11]: /tracing/trace_collection/library_injection_local/
 [12]: /tracing/trace_collection/automatic_instrumentation/?tab=datadoglibraries#install-and-configure-the-agent

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -222,7 +222,7 @@ For more information on adding spans and tags for custom instrumentation, see th
 To attach automatic instrumentation to your service, set the required environment variables before starting the application. See [Enable the tracer for your service](#enable-the-tracer-for-your-service) section to identify which environment variables to set based on your .NET Tracer installation method and follow the examples below to correctly set the environment variables based on the environment of your instrumented service.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> The .NET runtime tries to load a tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
+  <strong>Note:</strong> The .NET runtime tries to load the tracing library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>It is not recommended to set these environment variables globally on a host as this causes <em>all</em> .NET processes on the host to load the tracing library.</strong>
 </div>
 
 #### Windows services

--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -43,7 +43,7 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
  Additional information can be found within [Microsoft's .NET and .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions), and in [Runtime support policy for .NET APM](#runtime-support-policy-for-net-apm).
 
 <div class="alert alert-info">
-  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
+  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. This page may refer to <strong>.NET Core</strong> or <strong>.NET</strong> interchangeably unless referring to a specific version.
 </div>
 
 ## Supported processor architectures

--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -24,11 +24,7 @@ The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual B
 
 The .NET Tracer is open source. For more information, see the [.NET Tracer repository][1].
 
-<div class="alert alert-info">
-  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
-</div>
-
-## Supported .NET runtimes
+## Supported .NET and .NET Core runtimes
 
 The .NET Tracer supports automatic and custom instrumentation on the following .NET versions. It also supports [.NET Framework][2].
 
@@ -45,6 +41,10 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 | .NET Core 2.0        | 10/01/2018            | [EOL](#support-eol)  | Not recommended       |
 
  Additional information can be found within [Microsoft's .NET and .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions), and in [Runtime support policy for .NET APM](#runtime-support-policy-for-net-apm).
+
+<div class="alert alert-info">
+  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
+</div>
 
 ## Supported processor architectures
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -20,7 +20,7 @@ further_reading:
       text: 'Monitor containerized ASP.NET Core applications'
 ---
 
-The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic). It has [beta support for trimmed apps][12].
+The .NET Tracer supports all .NET-based languages (for example, C#, F#, and Visual Basic). It has [beta support for trimmed apps][12].
 
 The .NET Tracer is open source. For more information, see the [.NET Tracer repository][1].
 
@@ -41,10 +41,6 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 | .NET Core 2.0        | 10/01/2018            | [EOL](#support-eol)  | Not recommended      |
 
  Additional information can be found within [Microsoft's .NET and .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions), and in [Runtime support policy for .NET APM](#runtime-support-policy-for-net-apm).
-
-<div class="alert alert-info">
-  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. This page may refer to <strong>.NET Core</strong> or <strong>.NET</strong> interchangeably unless referring to a specific version.
-</div>
 
 ## Supported processor architectures
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -36,9 +36,9 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 | .NET 5               | 05/10/2022            | [GA](#support-ga)    | latest (>= 2.0.0)    |
 | .NET Core 3.1        | 12/13/2022            | [GA](#support-ga)    | latest               |
 | .NET Core 2.1        | 08/21/2021            | [GA](#support-ga)    | latest               |
-| .NET Core 3.0        | 03/03/2020            | [EOL](#support-eol)  | Not recommended       |
-| .NET Core 2.2        | 12/23/2019            | [EOL](#support-eol)  | Not recommended       |
-| .NET Core 2.0        | 10/01/2018            | [EOL](#support-eol)  | Not recommended       |
+| .NET Core 3.0        | 03/03/2020            | [EOL](#support-eol)  | Not recommended      |
+| .NET Core 2.2        | 12/23/2019            | [EOL](#support-eol)  | Not recommended      |
+| .NET Core 2.0        | 10/01/2018            | [EOL](#support-eol)  | Not recommended      |
 
  Additional information can be found within [Microsoft's .NET and .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions), and in [Runtime support policy for .NET APM](#runtime-support-policy-for-net-apm).
 
@@ -50,13 +50,13 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 
 The .NET Tracer supports automatic instrumentation on the following architectures:
 
-| Processor architectures                   | Support level         | Package version                        |
-| ------------------------------------------|-----------------------|----------------------------------------|
-| Windows x86 (`win-x86`)                   | [GA](#support-ga)     | latest                                 |
-| Windows x64 (`win-x64`)                   | [GA](#support-ga)     | latest                                 |
-| Linux x64 (`linux-x64`)                   | [GA](#support-ga)     | latest                                 |
-| Alpine Linux x64 (`linux-musl-x64`)       | [GA](#support-ga)     | latest                                 |
-| Linux ARM64 (`linux-arm64`)               | [GA](#support-ga)     | .NET 5+ only, added in version 1.27.0  |
+| Processor architectures             | Support level     | Package version                       |
+| ------------------------------------|-------------------|---------------------------------------|
+| Windows x86 (`win-x86`)             | [GA](#support-ga) | latest                                |
+| Windows x64 (`win-x64`)             | [GA](#support-ga) | latest                                |
+| Linux x64 (`linux-x64`)             | [GA](#support-ga) | latest                                |
+| Alpine Linux x64 (`linux-musl-x64`) | [GA](#support-ga) | latest                                |
+| Linux ARM64 (`linux-arm64`)         | [GA](#support-ga) | .NET 5+ only, added in version 1.27.0 |
 
 ## Integrations
 
@@ -104,9 +104,9 @@ For these libraries, set `DD_TRACE_OTEL_ENABLED=true`, and the .NET tracer autom
 
 The following list of libraries have been tested with this setup:
 
-| Framework or library            | NuGet package                                                                 | Integration Name     | Specific instructions         |
-| ------------------------------- | ----------------------------------------------------------------------------- | -------------------- | ----------------------------- |
-| Azure Service Bus               | `Azure.Messaging.ServiceBus` 7.14.0+                                          | `AzureServiceBus`    | See `Azure SDK` section below |
+| Framework or library | NuGet package                        | Integration Name  | Specific instructions         |
+| -------------------- | ------------------------------------ | ----------------- | ----------------------------- |
+| Azure Service Bus    | `Azure.Messaging.ServiceBus` 7.14.0+ | `AzureServiceBus` | See `Azure SDK` section below |
 
 ### Azure SDK
 
@@ -120,17 +120,17 @@ The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, 3.0, and 3.1, and on .NET 5 an
 |-----------------------------------------------|-------------------------------------------|------------------------------------------------------------------------|-----------------------------------------|
 | JIT Compiler bug on Linux/x64                 | 2.0.x,</br>2.1.0-2.1.11,</br>2.2.0-2.2.5  | Upgrade .NET Core to the latest patch version, or follow steps in the linked issue | [DataDog/dd-trace-dotnet/issues/302][6] |
 | Resource lookup bug with a non `en-US` locale | 2.0.0                                     | Upgrade .NET Core to 2.0.3 or above                                    | [dotnet/runtime/issues/23938][7]        |
-| JIT Compiler bug causing crash on shutdown    | 2.0.0-2.2.x                               | Upgrade .NET Core to 3.1.0 or above | [dotnet/runtime/pull/11885][15]   |
-| JIT Compiler bug                              | 2.x, 3.x, 5.x, 6.x, 7.x, 8.0.0-8.0.5      | Upgrade .NET 8.0.6 or above    | [dotnet/runtime/pull/73760][16]   |
-| JIT Compiler bug                              | All versions of .NET                      | No current workaround    | [dotnet/runtime/issues/85777][17]   |
+| JIT Compiler bug causing crash on shutdown    | 2.0.0-2.2.x                               | Upgrade .NET Core to 3.1.0 or above                                    | [dotnet/runtime/pull/11885][15]         |
+| JIT Compiler bug                              | 2.x, 3.x, 5.x, 6.x, 7.x, 8.0.0-8.0.5      | Upgrade .NET 8.0.6 or above                                            | [dotnet/runtime/pull/73760][16]         |
+| JIT Compiler bug                              | All versions of .NET                      | No current workaround                                                  | [dotnet/runtime/issues/85777][17]       |
 
 ## Supported Datadog Agent versions
 
-| **Datadog Agent version**   | **Package version** |
-|-----------------------------|---------------------|
-| [7.x][8]                    | Latest              |
-| [6.x][8]                    | Latest              |
-| [5.x][9]                    | Latest              |
+| **Datadog Agent version** | **Package version** |
+|---------------------------|---------------------|
+| [7.x][8]                  | Latest              |
+| [6.x][8]                  | Latest              |
+| [5.x][9]                  | Latest              |
 
 ## Runtime support policy for .NET APM
 
@@ -138,13 +138,13 @@ Datadog APM for .NET depends on the host operating system, .NET runtime, certain
 
 ### Levels of support
 
-| **Level**                                              | **Support provided**                                                                                                                                                          |
-|--------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact customer support for special requests.][10]                                                             |
-| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis.                                    |
-| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                                                    |
-| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                                                              |
-| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                                                                  |
+| **Level**                                              | **Support provided**                                                                                                                       |
+|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
+| <span id="support-unsupported">Unsupported</span>      |  No implementation. [Contact customer support for special requests.][10]                                                                   |
+| <span id="support-beta">Beta</span>                    |  Initial implementation. May not yet contain all features. Support for new features, bug & security fixes provided on a best-effort basis. |
+| <span id="support-ga">General Availability (GA)</span> |  Full implementation of all features. Full support for new features, bug & security fixes.                                                 |
+| <span id="support-maintenance">Maintenance</span>      |  Full implementation of existing features. Does not receive new features. Support for bug & security fixes only.                           |
+| <span id="support-eol">End-of-life (EOL)</span>        |  No support.                                                                                                                               |
 
 ### Package versioning
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -132,7 +132,7 @@ The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, 3.0, and 3.1, and on .NET 5 an
 | [6.x][8]                  | Latest              |
 | [5.x][9]                  | Latest              |
 
-## Runtime support policy for .NET APM
+## Runtime support policy
 
 Datadog APM for .NET depends on the host operating system, .NET runtime, certain .NET libraries, and the Datadog Agent/API. These third party software systems support specific versions of .NET. When the external software no longer supports a version of .NET, Datadog APM for .NET also limits its support for that version.
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core and .NET 5+ Compatibility Requirements
+title: .NET and .NET Core Compatibility Requirements
 kind: documentation
 description: 'Compatibility Requirements for the .NET tracer'
 aliases:
@@ -25,7 +25,7 @@ The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual B
 The .NET Tracer is open source. For more information, see the [.NET Tracer repository][1].
 
 <div class="alert alert-info">
-  .NET Core was rebranded as simply ".NET" starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
+  <strong>.NET Core</strong> was rebranded as <strong>.NET</strong> starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
 </div>
 
 ## Supported .NET runtimes
@@ -44,7 +44,7 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 | .NET Core 2.2        | 12/23/2019            | [EOL](#support-eol)  | Not recommended       |
 | .NET Core 2.0        | 10/01/2018            | [EOL](#support-eol)  | Not recommended       |
 
- Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions), and in [Runtime support policy for .NET Core APM](#runtime-support-policy-for-net-core-apm).
+ Additional information can be found within [Microsoft's .NET and .NET Core Lifecycle Policy][3], [End of life APM .NET Core versions](#end-of-life-net-core-versions), and in [Runtime support policy for .NET APM](#runtime-support-policy-for-net-apm).
 
 ## Supported processor architectures
 
@@ -132,9 +132,9 @@ The .NET Tracer works on .NET Core 2.0, 2.1, 2.2, 3.0, and 3.1, and on .NET 5 an
 | [6.x][8]                    | Latest              |
 | [5.x][9]                    | Latest              |
 
-## Runtime support policy for .NET Core APM
+## Runtime support policy for .NET APM
 
-Datadog APM for .NET Core depends on the host operating system, .NET Core runtime, certain .NET Core libraries, and the Datadog Agent/API. These third party software systems support specific versions of .NET Core. When the external software no longer supports a version of .NET Core, Datadog APM for .NET Core also limits its support for that version.
+Datadog APM for .NET depends on the host operating system, .NET runtime, certain .NET libraries, and the Datadog Agent/API. These third party software systems support specific versions of .NET. When the external software no longer supports a version of .NET, Datadog APM for .NET also limits its support for that version.
 
 ### Levels of support
 
@@ -148,11 +148,11 @@ Datadog APM for .NET Core depends on the host operating system, .NET Core runtim
 
 ### Package versioning
 
-Datadog APM for .NET Core practices [semantic versioning][11].
+Datadog APM for .NET practices [semantic versioning][11].
 Version updates imply the following changes to runtime support:
 
   - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[EOL](#support-eol).
-  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower the level of support for one runtime but may add support for one.
+  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower the level of support for one runtime, but may add support for one.
   - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
 
 ## Further reading

--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -1,5 +1,5 @@
 ---
-title: .NET Core Compatibility Requirements
+title: .NET Core and .NET 5+ Compatibility Requirements
 kind: documentation
 description: 'Compatibility Requirements for the .NET tracer'
 aliases:
@@ -20,14 +20,17 @@ further_reading:
       text: 'Monitor containerized ASP.NET Core applications'
 ---
 
-
 The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic). It has [beta support for trimmed apps][12].
 
 The .NET Tracer is open source. For more information, see the [.NET Tracer repository][1].
 
-## Supported .NET Core runtimes
+<div class="alert alert-info">
+  .NET Core was rebranded as simply ".NET" starting with version 5. In this page, may refer to ".NET Core" or ".NET" interchangeably unless referring to a specific version.
+</div>
 
-The .NET Tracer supports automatic instrumentation on the following .NET Core versions. It also supports [.NET Framework][2].
+## Supported .NET runtimes
+
+The .NET Tracer supports automatic and custom instrumentation on the following .NET versions. It also supports [.NET Framework][2].
 
 | Version              | Microsoft End of Life | Support level        | Package version      |
 | -------------------- | --------------------- | -------------------- | -------------------- |
@@ -61,15 +64,15 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 
 | Framework or library            | NuGet package                                                                                        | Integration Name     |
 | ------------------------------- | ---------------------------------------------------------------------------------------------------- | -------------------- |
-| ADO.NET                         | All AdoNet integrations                                                                              | `AdoNet`             |
+| ADO.NET                         | All ADO.NET libraries                                                                                | `AdoNet`             |
 | Aerospike                       | `Aerospike.Client` 4.0.0+                                                                            | `Aerospike`          |
 | ASP.NET Core                    | `Microsoft.AspNetCore`</br>`Microsoft.AspNetCore.App`</br>2.0+ and 3.0+                              | `AspNetCore`         |
 | Azure Functions                 | `Microsoft.Azure.Webjobs` 3.0+                                                                       | `AzureFunctions`     |
 | Amazon DynamoDB                 | `AWSSDK.DynamoDBv2`  3.0+                                                                            | `AwsDynamoDb`        |
-| Amazon Kinesis                     | `AWSSDK.Kinesis`  3.0+                                                                               | `AwsKinesis`         |
-| Amazon SNS                         | `AWSSDK.SNS`  3.0+                                                                                   | `AwsSns`             |
-| Amazon SQS                         | `AWSSDK.SQS`  3.0+                                                                                   | `AwsSqs`             |
-| CosmosDb                        | `Microsoft.Azure.Cosmos` 3.6.0+                                                               | `CosmosDb`           |
+| Amazon Kinesis                  | `AWSSDK.Kinesis`  3.0+                                                                               | `AwsKinesis`         |
+| Amazon SNS                      | `AWSSDK.SNS`  3.0+                                                                                   | `AwsSns`             |
+| Amazon SQS                      | `AWSSDK.SQS`  3.0+                                                                                   | `AwsSqs`             |
+| CosmosDb                        | `Microsoft.Azure.Cosmos` 3.6.0+                                                                      | `CosmosDb`           |
 | Couchbase                       | `CouchbaseNetClient` 2.2.8+                                                                          | `Couchbase`          |
 | Elasticsearch                   | `Elasticsearch.Net` 5.3.0+                                                                           | `ElasticsearchNet`   |
 | GraphQL .NET                    | `GraphQL` 2.3.0+                                                                                     | `GraphQL`            |
@@ -77,7 +80,7 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 | HotChocolate                    | `HotChocolate` 11.0.0+                                                                               | `HotChocolate`       |
 | HttpClient / HttpMessageHandler | `System.Net.Http` 4.0+                                                                               | `HttpMessageHandler` |
 | Kafka                           | `Confluent.Kafka` 1.4+                                                                               | `Kafka`              |
-| IBM MQ                          | `amqmdnetstd` 9.0.0+                                                                      | `IbmMq`              |
+| IBM MQ                          | `amqmdnetstd` 9.0.0+                                                                                 | `IbmMq`              |
 | MongoDB                         | `MongoDB.Driver.Core` 2.1.0+                                                                         | `MongoDb`            |
 | MySql                           | `MySql.Data` 6.7.0+</br>`MySqlConnector` 0.61.0+                                                     | `MySql`              |
 | Oracle                          | `Oracle.ManagedDataAccess` 4.122.0+                                                                  | `Oracle`             |
@@ -91,11 +94,15 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 | SQL Server                      | `System.Data` 4.0.0+</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+        | `SqlClient`          |
 | WebClient / WebRequest          | `System.Net.Requests` 4.0+                                                                           | `WebRequest`         |
 
-Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (for example, [activity based tracing][13]). If not, Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
+Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (for example, [`Activity`-based tracing][13]). If not, Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
 
-## OpenTelemetry based integrations
+## OpenTelemetry integrations
 
-Some libraries provide built in [Activity based tracing][13]. This is the same mechanism the OpenTelemetry project relies on. By setting `DD_TRACE_OTEL_ENABLED` to `true`, the .NET tracer will automatically resurface traces provided by the libraries themselves. This is possible since [version 2.21.0][4]. Here are a list of libraries that are tested with this setup (more libraries provide such tracing though, they aren't yet expliciitly tested).
+Some libraries provide built-in [`Activity`-based tracing][13]. This is the same mechanism that OpenTelemetry is based on.
+
+For these libraries, set `DD_TRACE_OTEL_ENABLED=true`, and the .NET tracer automatically captures their traces. This is supported since [version 2.21.0][4].
+
+The following list of libraries have been tested with this setup:
 
 | Framework or library            | NuGet package                                                                 | Integration Name     | Specific instructions         |
 | ------------------------------- | ----------------------------------------------------------------------------- | -------------------- | ----------------------------- |
@@ -103,8 +110,7 @@ Some libraries provide built in [Activity based tracing][13]. This is the same m
 
 ### Azure SDK
 
-Azure SDK provides built-in OpenTelemetry support. Enable it by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable to `true` or by setting the `Azure.Experimental.EnableActivitySource` context switch to `true` in your application code. See [Azure SDK documentation][14] for more details.
-
+The Azure SDK provides built-in OpenTelemetry support. Enable it by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable to `true` or by setting the `Azure.Experimental.EnableActivitySource` context switch to `true` in your application code. See [Azure SDK documentation][14] for more details.
 
 ## End of life .NET and .NET Core versions
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -18,7 +18,7 @@ further_reading:
 ---
 
 
-The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
+The .NET Tracer supports all .NET-based languages (for example, C#, F#, and Visual Basic).
 
 The .NET Tracer is open source. For more information, see the [.NET Tracer repository][1].
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -24,7 +24,7 @@ The .NET Tracer is open source. For more information, see the [.NET Tracer repos
 
 ## Supported .NET Framework runtimes
 
-The .NET Tracer supports automatic and custom instrumentation on the following .NET Framework versions. It also supports [.NET Core and .NET 5+][2]. The .NET Tracer does not support code running in partial trust environments.
+The .NET Tracer supports automatic and custom instrumentation on the following .NET Framework versions. It also supports [.NET 5+ and .NET Core][2]. The .NET Tracer does not support code running in partial trust environments.
 
 | .NET Framework Version  | Microsoft End of Life | Support level                       | Package version             | Datadog End of Life |
 | ----------------------- | --------------------- | ----------------------------------- | --------------------------- | ------------------- |
@@ -39,7 +39,7 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 | 4.5.1                   | 01/12/2016            | [EOL](#support-eol)                 | < 2.0.0 (e.g. [1.31.2][3]) | 04/26/2022          |
 | 4.5                     | 01/12/2016            | [EOL](#support-eol)                 | < 2.0.0 (e.g. [1.31.2][3]) | 04/26/2022          |
 
-Additional information can be found within [Microsoft's .NET Core Lifecycle Policy][4] and in [Runtime support policy for .NET Framework APM](#runtime-support-policy-for-net-framework-apm).
+Additional information can be found within [Microsoft's .NET and .NET Core Lifecycle Policy][4] and in [Runtime support policy for .NET APM](#runtime-support-policy-for-net-apm).
 
 <div class="alert alert-info">
   <div class="alert-info"><b>Note:</b> When deciding which tracer version to use for an automatic instrumentation, use the .NET Framework version installed on the application server. For example, if you compile your application to target .NET Framework 4.5.1, but the application runs on a server that has .NET Framework 4.8 installed, use the latest version of the tracer. To determine which version of .NET Framework is installed on a machine, follow the <a href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed">guidance provided by Microsoft</a>.
@@ -122,7 +122,7 @@ The Azure SDK provides built-in OpenTelemetry support. Enable it by setting the 
 
 ## Runtime support policy for .NET Framework APM
 
-Datadog APM for .NET Framework depends on the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. These third party software systems support specific versions of .NET Framework. When the external software no longer supports a version of .NET Framework, Datadog APM for .NET Framework also limits its support for that version.
+Datadog APM for .NET depends on the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. These third party software systems support specific versions of .NET Framework. When the external software no longer supports a version of .NET Framework, Datadog APM for .NET also limits its support for that version.
 
 ### Levels of support
 
@@ -136,11 +136,11 @@ Datadog APM for .NET Framework depends on the host operating system, .NET Framew
 
 ### Package versioning
 
-Datadog APM for .NET Framework practices [semantic versioning][10].
+Datadog APM for .NET practices [semantic versioning][10].
 Version updates imply the following changes to runtime support:
 
   - **Major version updates** (for example `1.0.0` to `2.0.0`) may change support for any runtime from [Beta](#support-beta)/[GA](#support-ga) to [Maintenance](#support-maintenance)/[EOL](#support-eol).
-  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower the level of support for one runtime but may add support for one.
+  - **Minor version updates** (for example `1.0.0` to `1.1.0`) won't lower the level of support for one runtime, but may add support for one.
   - **Patch version updates** (for example `1.0.0` to `1.0.1`) will not change support for any runtime.
 
 ## Further reading

--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -119,7 +119,7 @@ The Azure SDK provides built-in OpenTelemetry support. Enable it by setting the 
 | [6.x][7]                  | latest              |
 | [5.x][8]                  | latest              |
 
-## Runtime support policy for .NET Framework APM
+## Runtime support policy
 
 Datadog APM for .NET depends on the host operating system, .NET Framework runtime, certain .NET Framework libraries, and the Datadog Agent/API. These third party software systems support specific versions of .NET Framework. When the external software no longer supports a version of .NET Framework, Datadog APM for .NET also limits its support for that version.
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -49,49 +49,49 @@ Additional information can be found within [Microsoft's .NET and .NET Core Lifec
 
 The .NET Tracer supports automatic instrumentation on the following architectures:
 
-| Processor architectures                                                 | Support level         | Package version                        |
-| ------------------------------------------------------------------------|-----------------------|----------------------------------------|
-| Windows x86 (`win-x86`)                                                 | [GA](#support-ga)     | latest                                 |
-| Windows x64 (`win-x64`)                                                 | [GA](#support-ga)     | latest                                 |
+| Processor architectures | Support level     | Package version |
+| ------------------------|-------------------|-----------------|
+| Windows x86 (`win-x86`) | [GA](#support-ga) | latest          |
+| Windows x64 (`win-x64`) | [GA](#support-ga) | latest          |
 
 ## Integrations
 
 The [latest version of the .NET Tracer][5] can automatically instrument the following libraries:
 
-| Framework or library            | NuGet package                                                                             | Integration Name     |
-| ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
-| .NET Remoting                   | built-in                                                                                  | `Remoting`           |
-| ADO.NET                         | All ADO.NET libraries                                                                     | `AdoNet`             |
-| Aerospike                       | `Aerospike.Client` 4.0.0+                                                                 | `Aerospike`          |
-| ASP.NET (including Web Forms)   | built-in                                                                                  | `AspNet`             |
-| ASP.NET MVC                     | `Microsoft.AspNet.Mvc` 4.0+                                                               | `AspNetMvc`          |
-| ASP.NET Web API 2               | `Microsoft.AspNet.WebApi` 5.1+                                                            | `AspNetWebApi2`      |
-| Amazon DynamoDB                 | `AWSSDK.DynamoDBv2`  3.0+                                                                 | `AwsDynamoDb`        |
-| Amazon Kinesis                  | `AWSSDK.Kinesis`  3.0+                                                                    | `AwsKinesis`         |
-| Amazon SNS                      | `AWSSDK.SNS`  3.0+                                                                        | `AwsSns`             |
-| Amazon SQS                      | `AWSSDK.SQS`  3.0+                                                                        | `AwsSqs`             |
-| CosmosDb                        | `Microsoft.Azure.Cosmos` 3.6.0+                                                           | `CosmosDb`           |
-| Couchbase                       | `CouchbaseNetClient` 2.2.8+                                                               | `Couchbase`          |
-| Elasticsearch                   | `Elasticsearch.Net` 5.3.0+                                                                | `ElasticsearchNet`   |
-| GraphQL .NET                    | `GraphQL` 2.3.0+                                                                          | `GraphQL`            |
-| gRPC                            | `Grpc.Core` 2.3.0+                                                                        | `Grpc`               |
-| HotChocolate                    | `HotChocolate` 11.0.0+                                                                    | `HotChocolate`       |
-| HttpClient / HttpMessageHandler | built-in                                                                                  | `HttpMessageHandler` |
-| IBM MQ                          | `amqmdnetstd` 9.0.0+                                                                      | `IbmMq`              |
-| Kafka                           | `Confluent.Kafka` 1.4+                                                                    | `Kafka`              |
-| MongoDB                         | `MongoDB.Driver.Core` 2.1.0+                                                              | `MongoDb`            |
-| MSMQ                            | built-in                                                                                  | `Msmq`               |
-| MySql                           | `MySql.Data` 6.7.0+</br>`MySqlConnector` 0.61.0+                                          | `MySql`              |
-| Oracle                          | `Oracle.ManagedDataAccess` 4.122.0+                                                       | `Oracle`             |
-| PostgreSQL                      | `Npgsql` 4.0+                                                                             | `Npgsql`             |
-| Process                         | `"System.Diagnostics.Process"` 4.0+                                                       | `Process`            |
-| RabbitMQ                        | `RabbitMQ.Client` 3.6.9+,                                                                 | `RabbitMQ`           |
-| Redis (ServiceStack client)     | `ServiceStack.Redis` 4.0.48+                                                              | `ServiceStackRedis`  |
-| Redis (StackExchange client)    | `StackExchange.Redis` 1.0.187+                                                            | `StackExchangeRedis` |
-| SQLite                          | `System.Data.Sqlite` 2.0.0+ </br>`Microsoft.Data.Sqlite` 1.0.0+                           | `Sqlite`             |
-| SQL Server                      | built-in</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+         | `SqlClient`          |
-| WCF (server)                    | built-in                                                                                  | `Wcf`                |
-| WebClient / WebRequest          | built-in                                                                                  | `WebRequest`         |
+| Framework or library            | NuGet package                                                                     | Integration Name     |
+| ------------------------------- | --------------------------------------------------------------------------------- | -------------------- |
+| .NET Remoting                   | built-in                                                                          | `Remoting`           |
+| ADO.NET                         | All ADO.NET libraries                                                             | `AdoNet`             |
+| Aerospike                       | `Aerospike.Client` 4.0.0+                                                         | `Aerospike`          |
+| ASP.NET (including Web Forms)   | built-in                                                                          | `AspNet`             |
+| ASP.NET MVC                     | `Microsoft.AspNet.Mvc` 4.0+                                                       | `AspNetMvc`          |
+| ASP.NET Web API 2               | `Microsoft.AspNet.WebApi` 5.1+                                                    | `AspNetWebApi2`      |
+| Amazon DynamoDB                 | `AWSSDK.DynamoDBv2`  3.0+                                                         | `AwsDynamoDb`        |
+| Amazon Kinesis                  | `AWSSDK.Kinesis`  3.0+                                                            | `AwsKinesis`         |
+| Amazon SNS                      | `AWSSDK.SNS`  3.0+                                                                | `AwsSns`             |
+| Amazon SQS                      | `AWSSDK.SQS`  3.0+                                                                | `AwsSqs`             |
+| CosmosDb                        | `Microsoft.Azure.Cosmos` 3.6.0+                                                   | `CosmosDb`           |
+| Couchbase                       | `CouchbaseNetClient` 2.2.8+                                                       | `Couchbase`          |
+| Elasticsearch                   | `Elasticsearch.Net` 5.3.0+                                                        | `ElasticsearchNet`   |
+| GraphQL .NET                    | `GraphQL` 2.3.0+                                                                  | `GraphQL`            |
+| gRPC                            | `Grpc.Core` 2.3.0+                                                                | `Grpc`               |
+| HotChocolate                    | `HotChocolate` 11.0.0+                                                            | `HotChocolate`       |
+| HttpClient / HttpMessageHandler | built-in                                                                          | `HttpMessageHandler` |
+| IBM MQ                          | `amqmdnetstd` 9.0.0+                                                              | `IbmMq`              |
+| Kafka                           | `Confluent.Kafka` 1.4+                                                            | `Kafka`              |
+| MongoDB                         | `MongoDB.Driver.Core` 2.1.0+                                                      | `MongoDb`            |
+| MSMQ                            | built-in                                                                          | `Msmq`               |
+| MySql                           | `MySql.Data` 6.7.0+</br>`MySqlConnector` 0.61.0+                                  | `MySql`              |
+| Oracle                          | `Oracle.ManagedDataAccess` 4.122.0+                                               | `Oracle`             |
+| PostgreSQL                      | `Npgsql` 4.0+                                                                     | `Npgsql`             |
+| Process                         | `"System.Diagnostics.Process"` 4.0+                                               | `Process`            |
+| RabbitMQ                        | `RabbitMQ.Client` 3.6.9+,                                                         | `RabbitMQ`           |
+| Redis (ServiceStack client)     | `ServiceStack.Redis` 4.0.48+                                                      | `ServiceStackRedis`  |
+| Redis (StackExchange client)    | `StackExchange.Redis` 1.0.187+                                                    | `StackExchangeRedis` |
+| SQLite                          | `System.Data.Sqlite` 2.0.0+ </br>`Microsoft.Data.Sqlite` 1.0.0+                   | `Sqlite`             |
+| SQL Server                      | built-in</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+ | `SqlClient`          |
+| WCF (server)                    | built-in                                                                          | `Wcf`                |
+| WebClient / WebRequest          | built-in                                                                          | `WebRequest`         |
 
 Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (for example, [`Activity`-based tracing][11]). If not, Datadog is continually adding additional support. [Check with the Datadog team][6] for help.
 
@@ -103,9 +103,9 @@ For these libraries, set `DD_TRACE_OTEL_ENABLED=true`, and the .NET tracer autom
 
 The following list of libraries have been tested with this setup:
 
-| Framework or library            | NuGet package                                                                 | Integration Name     | Specific instructions         |
-| ------------------------------- | ----------------------------------------------------------------------------- | -------------------- | ----------------------------- |
-| Azure Service Bus               | `Azure.Messaging.ServiceBus` 7.14.0+                                          | `AzureServiceBus`    | See `Azure SDK` section below |
+| Framework or library | NuGet package                        | Integration Name     | Specific instructions         |
+| -------------------- | ------------------------------------ | -------------------- | ----------------------------- |
+| Azure Service Bus    | `Azure.Messaging.ServiceBus` 7.14.0+ | `AzureServiceBus`    | See `Azure SDK` section below |
 
 ### Azure SDK
 
@@ -113,11 +113,11 @@ The Azure SDK provides built-in OpenTelemetry support. Enable it by setting the 
 
 ## Supported Datadog Agent versions
 
-| **Datadog Agent version**   | **Package version** |
-|-----------------------------|---------------------|
-| [7.x][7]                   | latest              |
-| [6.x][7]                   | latest              |
-| [5.x][8]                   | latest              |
+| **Datadog Agent version** | **Package version** |
+|---------------------------|---------------------|
+| [7.x][7]                  | latest              |
+| [6.x][7]                  | latest              |
+| [5.x][8]                  | latest              |
 
 ## Runtime support policy for .NET Framework APM
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -42,8 +42,7 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 Additional information can be found within [Microsoft's .NET and .NET Core Lifecycle Policy][4] and in [Runtime support policy for .NET APM](#runtime-support-policy-for-net-apm).
 
 <div class="alert alert-info">
-  <div class="alert-info"><b>Note:</b> When deciding which tracer version to use for an automatic instrumentation, use the .NET Framework version installed on the application server. For example, if you compile your application to target .NET Framework 4.5.1, but the application runs on a server that has .NET Framework 4.8 installed, use the latest version of the tracer. To determine which version of .NET Framework is installed on a machine, follow the <a href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed">guidance provided by Microsoft</a>.
-  </div>
+  <b>Note:</b> When deciding which tracer version to use for an automatic instrumentation, use the .NET Framework version installed on the application server. For example, if you compile your application to target .NET Framework 4.5.1, but the application runs on a server that has .NET Framework 4.8 installed, use the latest version of the tracer. To determine which version of .NET Framework is installed on a machine, follow the [guidance provided by Microsoft][13].
 </div>
 
 ## Supported processor architectures
@@ -159,3 +158,4 @@ Version updates imply the following changes to runtime support:
 [10]: https://semver.org/
 [11]: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing
 [12]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#enabling-experimental-tracing-features
+[13]: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed

--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -42,7 +42,7 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 Additional information can be found within [Microsoft's .NET and .NET Core Lifecycle Policy][4] and in [Runtime support policy for .NET APM](#runtime-support-policy-for-net-apm).
 
 <div class="alert alert-info">
-  <b>Note:</b> When deciding which tracer version to use for an automatic instrumentation, use the .NET Framework version installed on the application server. For example, if you compile your application to target .NET Framework 4.5.1, but the application runs on a server that has .NET Framework 4.8 installed, use the latest version of the tracer. To determine which version of .NET Framework is installed on a machine, follow the [guidance provided by Microsoft][13].
+  <b>Note:</b> When deciding which tracer version to use for an automatic instrumentation, use the .NET Framework version installed on the application server. For example, if you compile your application to target .NET Framework 4.5.1, but the application runs on a server that has .NET Framework 4.8 installed, use the latest version of the tracer. To determine which version of .NET Framework is installed on a machine, follow the <a href="https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed">guidance provided by Microsoft</a>.
 </div>
 
 ## Supported processor architectures
@@ -158,4 +158,3 @@ Version updates imply the following changes to runtime support:
 [10]: https://semver.org/
 [11]: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing
 [12]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#enabling-experimental-tracing-features
-[13]: https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed

--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -18,11 +18,13 @@ further_reading:
 ---
 
 
-The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic). It is open source. For more information, see the [.NET Tracer repository][1].
+The .NET Tracer supports all .NET-based languages (for example, C#, F#, Visual Basic).
+
+The .NET Tracer is open source. For more information, see the [.NET Tracer repository][1].
 
 ## Supported .NET Framework runtimes
 
-The .NET Tracer supports automatic and custom instrumentation on the following .NET Framework versions. It also supports [.NET Core][2]. The .NET Tracer does not support code running in partial trust environments.
+The .NET Tracer supports automatic and custom instrumentation on the following .NET Framework versions. It also supports [.NET Core and .NET 5+][2]. The .NET Tracer does not support code running in partial trust environments.
 
 | .NET Framework Version  | Microsoft End of Life | Support level                       | Package version             | Datadog End of Life |
 | ----------------------- | --------------------- | ----------------------------------- | --------------------------- | ------------------- |
@@ -60,7 +62,7 @@ The [latest version of the .NET Tracer][5] can automatically instrument the foll
 | Framework or library            | NuGet package                                                                             | Integration Name     |
 | ------------------------------- | ----------------------------------------------------------------------------------------- | -------------------- |
 | .NET Remoting                   | built-in                                                                                  | `Remoting`           |
-| ADO.NET                         | All AdoNet integrations                                                                   | `AdoNet`             |
+| ADO.NET                         | All ADO.NET libraries                                                                     | `AdoNet`             |
 | Aerospike                       | `Aerospike.Client` 4.0.0+                                                                 | `Aerospike`          |
 | ASP.NET (including Web Forms)   | built-in                                                                                  | `AspNet`             |
 | ASP.NET MVC                     | `Microsoft.AspNet.Mvc` 4.0+                                                               | `AspNetMvc`          |
@@ -69,7 +71,7 @@ The [latest version of the .NET Tracer][5] can automatically instrument the foll
 | Amazon Kinesis                  | `AWSSDK.Kinesis`  3.0+                                                                    | `AwsKinesis`         |
 | Amazon SNS                      | `AWSSDK.SNS`  3.0+                                                                        | `AwsSns`             |
 | Amazon SQS                      | `AWSSDK.SQS`  3.0+                                                                        | `AwsSqs`             |
-| CosmosDb                        | `Microsoft.Azure.Cosmos` 3.6.0+                                                    | `CosmosDb`           |
+| CosmosDb                        | `Microsoft.Azure.Cosmos` 3.6.0+                                                           | `CosmosDb`           |
 | Couchbase                       | `CouchbaseNetClient` 2.2.8+                                                               | `Couchbase`          |
 | Elasticsearch                   | `Elasticsearch.Net` 5.3.0+                                                                | `ElasticsearchNet`   |
 | GraphQL .NET                    | `GraphQL` 2.3.0+                                                                          | `GraphQL`            |
@@ -88,17 +90,17 @@ The [latest version of the .NET Tracer][5] can automatically instrument the foll
 | Redis (ServiceStack client)     | `ServiceStack.Redis` 4.0.48+                                                              | `ServiceStackRedis`  |
 | Redis (StackExchange client)    | `StackExchange.Redis` 1.0.187+                                                            | `StackExchangeRedis` |
 | SQLite                          | `System.Data.Sqlite` 2.0.0+ </br>`Microsoft.Data.Sqlite` 1.0.0+                           | `Sqlite`             |
-| SQL Server                      | `System.Data` 4.0.0+</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+  | `SqlClient`     |
+| SQL Server                      | built-in</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+         | `SqlClient`          |
 | WCF (server)                    | built-in                                                                                  | `Wcf`                |
 | WebClient / WebRequest          | built-in                                                                                  | `WebRequest`         |
 
-Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (for example, [activity based tracing][11]). If not, Datadog is continually adding additional support. [Check with the Datadog team][6] for help.
+Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (for example, [`Activity`-based tracing][11]). If not, Datadog is continually adding additional support. [Check with the Datadog team][6] for help.
 
-## OpenTelemetry based integrations
+## OpenTelemetry integrations
 
-Some libraries provide built-in [Activity based tracing][11]. This is the same mechanism that OpenTelemetry is based on.
+Some libraries provide built-in [`Activity`-based tracing][11]. This is the same mechanism that OpenTelemetry is based on.
 
-For these libraries, set `DD_TRACE_OTEL_ENABLED` to `true`, and the .NET tracer automatically captures traces their traces. This is supported since [version 2.21.0][4].
+For these libraries, set `DD_TRACE_OTEL_ENABLED=true`, and the .NET tracer automatically captures their traces. This is supported since [version 2.21.0][5].
 
 The following list of libraries have been tested with this setup:
 
@@ -108,7 +110,7 @@ The following list of libraries have been tested with this setup:
 
 ### Azure SDK
 
-Azure SDK provides built-in OpenTelemetry support. Enable it by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable to `true` or by setting the `Azure.Experimental.EnableActivitySource` context switch to `true` in your application code. See [Azure SDK documentation][12] for more details.
+The Azure SDK provides built-in OpenTelemetry support. Enable it by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable to `true` or by setting the `Azure.Experimental.EnableActivitySource` context switch to `true` in your application code. See [Azure SDK documentation][12] for more details.
 
 ## Supported Datadog Agent versions
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fix several small issues in the APM doc pages for .NET tracing library.
- ~Restore warning about running multiple APM products at the same time~ Done in #23024 and #23055.
- Remove `CORECLR_PROFILER=<GUID>` from Windows code snippets (no longer needed), and remove notes about this changing in v2.14 (we are up to v2.51 now)
- Clarify that setting `DD_LOGS_INJECTION` and `DD_RUNTIME_METRICS_ENABLED` are examples of _optional_ configuration
- Update uses of ".NET Core" vs ".NET" (moving towards dropping ".NET Core" since it rebranded in v5)
- Improve notes about AWS Lambda and Azure App Services
- Miscellaneous grammar improvements
- Remove excessive space in markdown tables (not user-visible)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->