### PR TITLE
Update dotnet-core.md to remove misleading statement in installation …

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -61,7 +61,7 @@ For a full list of Datadog's .NET Core library and processor architecture suppor
 </div>
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog's .NET Tracer with Profiler enabled). To ensure maximum visibility, run only one APM solution in your application environment.
+  <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber, with exception of our Datadog APM and the Continous Profiler. To ensure maximum visibility, run only one APM solution in your application environment. 
 </div>
 
 <div class="alert alert-info">

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -61,7 +61,7 @@ For a full list of Datadog's .NET Core library and processor architecture suppor
 </div>
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber, with exception of our Datadog APM and the Continous Profiler. To ensure maximum visibility, run only one APM solution in your application environment. 
+  <strong>Note:</strong> Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog APM). To ensure maximum visibility, run only one APM solution in your application environment. 
 </div>
 
 <div class="alert alert-info">


### PR DESCRIPTION
…Note

While the Datadog products (APM and Cont. Profiler) use the same API, we (Datadog) have a way to share this internally so they can both work at the same time.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
clarifies the following - While the Datadog products (APM and Cont. Profiler) use the same API, we (Datadog) have a way to share this internally so they can both work at the same time.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->