### PR TITLE
[SEC-13439] Update Signal Notification Template Variables documentation

### DIFF
--- a/content/en/security/notifications/variables.md
+++ b/content/en/security/notifications/variables.md
@@ -102,6 +102,8 @@ Use attribute variables to customize signal notifications with specific informat
 
 To see a signal's list of event attributes, click **JSON** at the bottom of the **Overview** tab in the signal's side panel. Use the following syntax to add these event attributes in your rule notifications: `{{@attribute}}`. To access inner keys of the event attributes, use JSON dot notation, for example, `{{@attribute.inner_key}})`.
 
+If the signal JSON does not contain an attribute which is present in the related log JSON, use the previously outlined syntax with the attribute name from the log JSON. This attribute will then be included in both the signal JSON and the signal notifications.
+
 The following is an example JSON object with event attributes that may be associated with a security signal:
 
 {{< tabs >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

With the automatic projection of template variables, customers do not need anymore to create log facets to project log attributes in signal JSON.
If a log attribute is used in the rule message, it will be automatically added to the Signal JSON.

This PR updates the documentation to inform customers about this new behaviour.

### Merge instructions

- [ ] Please merge after reviewing