### PR TITLE
[CLOUDCRAFT-389] Activate your AWS Marketplace Cloudcraft subscription

### DIFF
--- a/content/en/cloudcraft/getting-started/_index.md
+++ b/content/en/cloudcraft/getting-started/_index.md
@@ -12,6 +12,7 @@ kind: guide
     {{< nextlink href="cloudcraft/getting-started/create-your-first-cloudcraft-diagram">}}Create your first live AWS diagram{{< /nextlink >}}
     {{< nextlink href="cloudcraft/getting-started/use-filters-to-create-better-diagrams">}}How to use filters to create better diagrams{{< /nextlink >}}
     {{< nextlink href="cloudcraft/getting-started/embedding-cloudcraft-diagrams-confluence">}}Embedding Cloudcraft diagrams with the Confluence app{{< /nextlink >}}
+    {{< nextlink href="cloudcraft/getting-started/activate-aws-marketplace-cloudcraft-subscription">}}Activate your AWS Marketplace Cloudcraft subscription{{< /nextlink >}}
     {{< nextlink href="cloudcraft/getting-started/generate-api-key">}}Generate an API key{{< /nextlink >}}
     {{< nextlink href="cloudcraft/getting-started/system-requirements">}}System requirements{{< /nextlink >}}
     {{< nextlink href="cloudcraft/getting-started/using-bits-menu">}}Using the bits menu{{< /nextlink >}}

--- a/content/en/cloudcraft/getting-started/activate-aws-marketplace-cloudcraft-subscription.md
+++ b/content/en/cloudcraft/getting-started/activate-aws-marketplace-cloudcraft-subscription.md
@@ -10,7 +10,7 @@ kind: documentation
 ## Activate your subscription
 
 1. In the **AWS Console**, navigate to [the **AWS Marketplace** page][2].
-2. Click the **Managed subscriptions** button in the **Get started** section.
+2. Click the **Manage subscriptions** button in the **Get started** section.
 3. Select the **Cloudcraft** subscription you want to activate.
 4. Click the **Set up your account** button.
 

--- a/content/en/cloudcraft/getting-started/activate-aws-marketplace-cloudcraft-subscription.md
+++ b/content/en/cloudcraft/getting-started/activate-aws-marketplace-cloudcraft-subscription.md
@@ -1,0 +1,20 @@
+---
+title: Activate your AWS Marketplace Cloudcraft subscription
+kind: documentation
+---
+
+## Overview
+
+[A Cloudcraft subscription can be bought through the AWS Marketplace][1]. This guide will show you how to activate your Cloudcraft subscription after you have purchased it.
+
+## Activate your subscription
+
+1. In the **AWS Console**, navigate to [the **AWS Marketplace** page][2].
+2. Click the **Managed subscriptions** button in the **Get started** section.
+3. Select the **Cloudcraft** subscription you want to activate.
+4. Click the **Set up your account** button.
+
+The **Set up your account** button contains a unique link that will set up the purchase for you in Cloudcraft, either with a new or existing Cloudcraft user account.
+
+[1]: https://aws.amazon.com/marketplace/pp/prodview-ksgtxmsy56f5e
+[2]: https://us-east-1.console.aws.amazon.com/marketplace/

--- a/content/en/cloudcraft/getting-started/activate-aws-marketplace-cloudcraft-subscription.md
+++ b/content/en/cloudcraft/getting-started/activate-aws-marketplace-cloudcraft-subscription.md
@@ -5,16 +5,16 @@ kind: documentation
 
 ## Overview
 
-[A Cloudcraft subscription can be bought through the AWS Marketplace][1]. This guide will show you how to activate your Cloudcraft subscription after you have purchased it.
+A Cloudcraft subscription can be bought through the [AWS Marketplace][1]. This guide shows you how to activate your Cloudcraft subscription after you have purchased it.
 
 ## Activate your subscription
 
-1. In the **AWS Console**, navigate to [the **AWS Marketplace** page][2].
-2. Click the **Manage subscriptions** button in the **Get started** section.
+1. In the **AWS Console**, navigate to the [**AWS Marketplace** page][2].
+2. Click **Manage subscriptions** in the **Get started** section.
 3. Select the **Cloudcraft** subscription you want to activate.
-4. Click the **Set up your account** button.
+4. Click **Set up your account**.
 
-The **Set up your account** button contains a unique link that will set up the purchase for you in Cloudcraft, either with a new or existing Cloudcraft user account.
+The **Set up your account** button contains a unique link that sets up the purchase for you in Cloudcraft, either with a new or existing Cloudcraft user account.
 
 [1]: https://aws.amazon.com/marketplace/pp/prodview-ksgtxmsy56f5e
 [2]: https://us-east-1.console.aws.amazon.com/marketplace/


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Add a new article to the Cloudcraft documentation describing how a customer can activate their Cloudcraft subscription bought through the AWS Marketplace.

### Merge instructions
Please wait until the Cloudcraft team has reviewed the content before going ahead with the review and merging of the article.

- [x] Please merge after reviewing