### PR TITLE
[reporting] update docs re: permissions change

### DIFF
--- a/content/en/dashboards/scheduled_reports.md
+++ b/content/en/dashboards/scheduled_reports.md
@@ -67,7 +67,7 @@ From the configuration modal that opens, you can pause an existing report or cre
 ## Permissions
 
 Users need the **Dashboards Report Write** [permission][2] to create and edit report schedules.
-This permission can be granted by another user with the **User Access Manage** permission, and is available by default to users with the **Datadog Admin** [out-of-the-box role][3].
+This permission can be granted by another user with the **User Access Manage** permission and is available by default to users with the **Datadog Standard** [out-of-the-box role][3].
 
 {{< img src="dashboards/scheduled_reports/dashboard_permissions.png" alt="A screenshot of an individual user's permissions from within the organization settings page. The dashboards report write permission is highlighted under the dashboards section" style="width:90%;" >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
See [Reporting access logic](https://datadoghq.atlassian.net/wiki/spaces/DB/pages/3565551852/2024.04.19+Reporting+access+logic) doc in Confluence:
> Currently, users need the Dashboards Report Write [permission](https://github.com/DataDog/dogweb/blob/7467669eb49effb31c5348f9512f567c0b3e16a4/lib/dogweb-model/dogweb_model/permissions/permission_definitions.py#L1230-L1239) to create and edit report schedules. Its description reads:
> 
> Schedule custom reports from a dashboard. These reports will display any viewable data regardless of any granular restrictions (restriction queries, scoped indexes) applied to the report's creator.
> 
> This permission is granted by default to users with the prepackaged Datadog Admin role and may also be assigned to custom roles by users with the User Access Manage [permission](https://github.com/DataDog/dogweb/blob/7467669eb49effb31c5348f9512f567c0b3e16a4/lib/dogweb-model/dogweb_model/permissions/permission_definitions.py#L255-L262). 
> 
> We chose to limit the Dashboards Report Write permission to privileged users because HTML reports did not obey granular data access controls. Now, Reporting v2 generates reports using OBO tokens that ensure the report data reflects the same granular data access controls that apply to the report author. This means that a user who creates a report schedule will only be able to export the same data they would see within the Datadog platform.
> 
> Once Reporting v2 is GA, we can deprecate the Dashboards Report Write permission and grant reporting access to users with the prepackaged Datadog Standard role by default.

- [ ] Please merge after reviewing

### Additional notes
- [ ] https://github.com/DataDog/dogweb/pull/118506 must deploy **BEFORE MERGE**