### PR TITLE
Rename OSS to SCA

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/dotnet.md
+++ b/content/en/security/application_security/enabling/compatibility/dotnet.md
@@ -25,14 +25,14 @@ The minimum tracer version to get all supported ASM capabilities for .NET is 2.4
 **Note**: Threat Protection requires enabling [Remote Configuration][3], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
-|Type   | Threat Detection support |  Vulnerability Management for OSS support |
-| ---   |   ---             |           ----        |
-| Docker | {{< X >}}  | {{< X >}} |
-| Kubernetes | {{< X >}}  | {{< X >}} |
-| Amazon ECS | {{< X >}}  | {{< X >}} |
-| AWS Fargate | {{< X >}}  | {{< X >}} |
-| AWS Lambda | {{< X >}} | |
-| Azure App Service | {{< X >}}  | {{< X >}} |
+| Type              | Threat Detection support | Software Composition Analysis            |
+|-------------------|--------------------------|------------------------------------------|
+| Docker            | {{< X >}}                | {{< X >}}                                |
+| Kubernetes        | {{< X >}}                | {{< X >}}                                |
+| Amazon ECS        | {{< X >}}                | {{< X >}}                                |
+| AWS Fargate       | {{< X >}}                | {{< X >}}                                |
+| AWS Lambda        | {{< X >}}                |                                          |
+| Azure App Service | {{< X >}}                | {{< X >}}                                |
 
 **Note**: Azure App Service is supported for **web applications only**. ASM doesn't support Azure Functions.
 

--- a/content/en/security/application_security/enabling/compatibility/go.md
+++ b/content/en/security/application_security/enabling/compatibility/go.md
@@ -25,13 +25,13 @@ The minimum tracer version to get all supported ASM capabilities for Go is 1.59.
 **Note**: Threat Protection requires enabling [Remote Configuration][1], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
-|Type | Threat Detection support | Vulnerability Management for OSS support |
-| ---           |   ---             |           ----            |
-| Docker        | {{< X >}}         | {{< X >}}                 |
-| Kubernetes    | {{< X >}}         | {{< X >}}                 |
-| Amazon ECS    | {{< X >}}         | {{< X >}}                 |
-| AWS Fargate   | {{< X >}}         | {{< X >}}                 |
-| AWS Lambda    | {{< X >}}         |                           |
+| Type        | Threat Detection support | Software Composition Analysis |
+|-------------|--------------------------|-------------------------------|
+| Docker      | {{< X >}}                | {{< X >}}                     |
+| Kubernetes  | {{< X >}}                | {{< X >}}                     |
+| Amazon ECS  | {{< X >}}                | {{< X >}}                     |
+| AWS Fargate | {{< X >}}                | {{< X >}}                     |
+| AWS Lambda  | {{< X >}}                |                               |
 
 ## Language and framework compatibility
 

--- a/content/en/security/application_security/enabling/compatibility/java.md
+++ b/content/en/security/application_security/enabling/compatibility/java.md
@@ -25,14 +25,14 @@ The minimum tracer version to get all supported ASM capabilities for Java is 1.3
 **Note**: Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
-|Type           | Threat Detection support |  Vulnerability Management for OSS support |
-| ---           |   ---             |           ----            |
-| Docker        | {{< X >}}         | {{< X >}}                 |
-| Kubernetes    | {{< X >}}         | {{< X >}}                 |
-| Amazon ECS    | {{< X >}}         | {{< X >}}                 |
-| AWS Fargate   | {{< X >}}         | {{< X >}}                 |
-| AWS Lambda    | {{< X >}}         |                           |
-| Azure App Service | {{< X >}}     | {{< X >}}                 |
+| Type              | Threat Detection support | Software Composition Analysis |
+|-------------------|--------------------------|-------------------------------|
+| Docker            | {{< X >}}                | {{< X >}}                     |
+| Kubernetes        | {{< X >}}                | {{< X >}}                     |
+| Amazon ECS        | {{< X >}}                | {{< X >}}                     |
+| AWS Fargate       | {{< X >}}                | {{< X >}}                     |
+| AWS Lambda        | {{< X >}}                |                               |
+| Azure App Service | {{< X >}}                | {{< X >}}                     |
 
 **Note**: Azure App Service is supported for **web applications only**. ASM doesn't support Azure Functions.
 

--- a/content/en/security/application_security/enabling/compatibility/nodejs.md
+++ b/content/en/security/application_security/enabling/compatibility/nodejs.md
@@ -27,13 +27,13 @@ The minimum tracer version to get all supported ASM capabilities for Node.js is 
 - Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
-| Type        | Threat Detection support | Vulnerability Management for OSS support |
-|-------------|--------------------------|------------------------------------------|
-| Docker      | {{< X >}}                | {{< X >}}                                |
-| Kubernetes  | {{< X >}}                | {{< X >}}                                |
-| Amazon ECS  | {{< X >}}                | {{< X >}}                                |
-| AWS Fargate | {{< X >}}                | {{< X >}}                                |
-| AWS Lambda  | {{< X >}}                | beta                                     |
+| Type        | Threat Detection support | Software Composition Analysis |
+|-------------|--------------------------|-------------------------------|
+| Docker      | {{< X >}}                | {{< X >}}                     |
+| Kubernetes  | {{< X >}}                | {{< X >}}                     |
+| Amazon ECS  | {{< X >}}                | {{< X >}}                     |
+| AWS Fargate | {{< X >}}                | {{< X >}}                     |
+| AWS Lambda  | {{< X >}}                | beta                          |
 
 ## Language and framework compatibility
 

--- a/content/en/security/application_security/enabling/compatibility/php.md
+++ b/content/en/security/application_security/enabling/compatibility/php.md
@@ -26,13 +26,13 @@ The minimum tracer version to get all supported ASM capabilities for PHP is 0.98
 <div class="alert alert-info">If you would like to see support added for any of the unsupported capabilities, let us know! Fill out <a href="https://forms.gle/gHrxGQMEnAobukfn7">this short form to send details</a>.</div>
 
 ### Supported deployment types
-|Type | Threat Detection support | Vulnerability Management for OSS support |
-| ---           |   ---             |           ----            |
-| Docker        | {{< X >}}         |  {{< X >}}                |
-| Kubernetes    | {{< X >}}         |  {{< X >}}                |
-| Amazon ECS    | {{< X >}}         |  {{< X >}}                |
-| AWS Fargate   |                   |                           |
-| AWS Lambda    |                   |                           |
+| Type        | Threat Detection support | Software Composition Analysis |
+|-------------|--------------------------|-------------------------------|
+| Docker      | {{< X >}}                | {{< X >}}                     |
+| Kubernetes  | {{< X >}}                | {{< X >}}                     |
+| Amazon ECS  | {{< X >}}                | {{< X >}}                     |
+| AWS Fargate |                          |                               |
+| AWS Lambda  |                          |                               |
 
 ## Language and framework compatibility
 

--- a/content/en/security/application_security/enabling/compatibility/python.md
+++ b/content/en/security/application_security/enabling/compatibility/python.md
@@ -21,13 +21,13 @@ The following ASM capabilities are supported in the Python library, for the spec
 **Note**: Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version.
 
 ### Supported deployment types
-|Type | Threat Detection support | Vulnerability Management for OSS support |
-| ---           |   ---             |           ----            |
-| Docker        | {{< X >}}         | {{< X >}}                 |
-| Kubernetes    | {{< X >}}         | {{< X >}}                 |
-| Amazon ECS    | {{< X >}}         | {{< X >}}                 |
-| AWS Fargate   | {{< X >}}         | {{< X >}}                 |
-| AWS Lambda    | {{< X >}}         |                           |
+| Type        | Threat Detection support | Software Composition Analysis |
+|-------------|--------------------------|-------------------------------|
+| Docker      | {{< X >}}                | {{< X >}}                     |
+| Kubernetes  | {{< X >}}                | {{< X >}}                     |
+| Amazon ECS  | {{< X >}}                | {{< X >}}                     |
+| AWS Fargate | {{< X >}}                | {{< X >}}                     |
+| AWS Lambda  | {{< X >}}                |                               |
 
 
 ## Language and framework compatibility

--- a/content/en/security/application_security/enabling/compatibility/ruby.md
+++ b/content/en/security/application_security/enabling/compatibility/ruby.md
@@ -25,13 +25,13 @@ The minimum tracer version to get all supported ASM capabilities for Ruby is 1.1
 <div class="alert alert-info">If you would like to see support added for any of the unsupported capabilities, or for your Ruby framework, let us know! Fill out <a href="https://forms.gle/gHrxGQMEnAobukfn7">this short form to send details</a>.</div>
 
 ### Supported deployment types
-|Type | Threat Detection support | Vulnerability Management for OSS support |
-| ---   |   ---             |           ----        |
-| Docker | {{< X >}}  |  |
-| Kubernetes | {{< X >}}  | |
-| Amazon ECS | {{< X >}}  | |
-| AWS Fargate | {{< X >}}  | |
-| AWS Lambda |  | |
+| Type        | Threat Detection support | Software Composition Analysis |
+|-------------|--------------------------|-------------------------------|
+| Docker      | {{< X >}}                |                               |
+| Kubernetes  | {{< X >}}                |                               |
+| Amazon ECS  | {{< X >}}                |                               |
+| AWS Fargate | {{< X >}}                |                               |
+| AWS Lambda  |                          |                               |
 
 ## Language and framework compatibility
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Renames Vulnerability Management for OSS support to Software Composition Analysis.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->