### PR TITLE
Remove notranslate manual job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -564,6 +564,7 @@ set_redirect_metadata_live:
 
 run_notranslate_tag:schedule:
   <<: *base_template
+  <<: *live_schedule_rules
   stage: post-deploy
   dependencies:
     - build_live
@@ -571,27 +572,21 @@ run_notranslate_tag:schedule:
   script:
     - export transifex_api_key="$(get_secret 'transifex_api_key')"
     - python3 ./local/bin/py/add_notranslate_tag.py
-  rules:
-    - if: $CI_COMMIT_BRANCH == "master" && $CI_PIPELINE_SOURCE == "schedule"
-      when: always
-    - if: $CI_COMMIT_TAG != null || $CI_COMMIT_BRANCH =~ "/pull/\/.*/"
-      when: never
 
-run_notranslate_tag:manual:
-  <<: *base_template
-  stage: post-deploy
-  dependencies:
-    - build_preview
-  timeout: 2h
-  script:
-    - export transifex_api_key="$(get_secret 'transifex_api_key')"
-    - python3 ./local/bin/py/add_notranslate_tag.py
-  rules:
-    - if: $CI_COMMIT_TAG != null || $CI_COMMIT_BRANCH =~ "/pull/\/.*/"
-      when: never
-    - if: $CI_COMMIT_TAG == null
-      when: manual
-
+# run_notranslate_tag:manual:
+#   <<: *base_template
+#   <<: *live_schedule_rules
+#   allow_failure: true
+#   stage: post-deploy
+#   timeout: 2h
+#   script:
+#     - export transifex_api_key="$(get_secret 'transifex_api_key')"
+#     - python3 ./local/bin/py/add_notranslate_tag.py
+#   rules:
+#     - if: $CI_COMMIT_TAG != null || $CI_COMMIT_BRANCH =~ "/pull/\/.*/"
+#       when: never
+#     - if: $CI_COMMIT_TAG == null
+#       when: manual
 
 ####################################
 #                                  #


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
There was a misconfiguration with the `notranslate` manual Gitlab job which is preventing pipelines from moving past `post-deploy` stage. This should unblock.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->