### PR TITLE
Add info about how to disable session replay for older sdks

### DIFF
--- a/content/en/real_user_monitoring/session_replay/browser/_index.md
+++ b/content/en/real_user_monitoring/session_replay/browser/_index.md
@@ -78,6 +78,8 @@ To stop the Session Replay recording, call `stopSessionReplayRecording()`.
 
 To stop session recordings, set `sessionReplaySampleRate` to `0`. This stops collecting data for the [Browser RUM & Session Replay plan][6].
 
+<div class="alert alert-warning">When using a version of the RUM Browser SDK older than v5.0.0, set `replaySampleRate` to `0`.</div>
+
 ## Retention
 
 By default, Session Replay data is retained for 30 days.

--- a/content/en/real_user_monitoring/session_replay/browser/_index.md
+++ b/content/en/real_user_monitoring/session_replay/browser/_index.md
@@ -78,7 +78,7 @@ To stop the Session Replay recording, call `stopSessionReplayRecording()`.
 
 To stop session recordings, set `sessionReplaySampleRate` to `0`. This stops collecting data for the [Browser RUM & Session Replay plan][6].
 
-<div class="alert alert-warning">If you're using a version of the RUM Browser SDK previous to v5.0.0, set `replaySampleRate` to `0`.</div>
+<div class="alert alert-warning">If you're using a version of the RUM Browser SDK previous to v5.0.0, set <code>replaySampleRate</code> to <code>0</code>.</div>
 
 ## Retention
 

--- a/content/en/real_user_monitoring/session_replay/browser/_index.md
+++ b/content/en/real_user_monitoring/session_replay/browser/_index.md
@@ -78,7 +78,7 @@ To stop the Session Replay recording, call `stopSessionReplayRecording()`.
 
 To stop session recordings, set `sessionReplaySampleRate` to `0`. This stops collecting data for the [Browser RUM & Session Replay plan][6].
 
-<div class="alert alert-warning">When using a version of the RUM Browser SDK older than v5.0.0, set `replaySampleRate` to `0`.</div>
+<div class="alert alert-warning">If you're using a version of the RUM Browser SDK previous to v5.0.0, set `replaySampleRate` to `0`.</div>
 
 ## Retention
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Added info about how to disable session replay for sdks older than v5. A customer just wasn't able to find this info on our docs.
Got info from:
https://docs.datadoghq.com/real_user_monitoring/guide/browser-sdk-upgrade/#sdk-initialization-parameters

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->