### PR TITLE
(maint) Fix incorrect link on JA homepage

### DIFF
--- a/data/partials/home.ja.yaml
+++ b/data/partials/home.ja.yaml
@@ -121,7 +121,7 @@ nav_sections:
       title: RDS
     - desc: 脅威、脆弱性、誤構成の検出
       icon: security-platform
-      link: synthetics/api_tests/udp_tests
+      link: security/
       title: セキュリティ
     - desc: メトリクスの探索、検索、および分布の作成
       icon: メトリクス


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->