### PR TITLE
Increase notranslate job timeout

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -568,7 +568,7 @@ run_notranslate_tag:schedule:
   stage: post-deploy
   dependencies:
     - build_live
-  timeout: 2h
+  timeout: 4h
   script:
     - export transifex_api_key="$(get_secret 'transifex_api_key')"
     - python3 ./local/bin/py/add_notranslate_tag.py


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Bump job timeout to 4 hours:

Timed out at 2 hours
https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/507843844

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->