### PR TITLE
fix incorrectly formated yaml file in data_jobs/kubernetes.md

### DIFF
--- a/content/en/data_jobs/kubernetes.md
+++ b/content/en/data_jobs/kubernetes.md
@@ -48,31 +48,31 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
 1. Create a file, `datadog-agent.yaml`, that contains the following configuration:
 
    ```yaml
-   kind: DatadogAgent
-   apiVersion: datadoghq.com/v2alpha1
-   metadata:
-     name: datadog
-   spec:
-    features:
+    kind: DatadogAgent
+    apiVersion: datadoghq.com/v2alpha1
+    metadata:
+      name: datadog
+    spec:
+      features:
         apm:
         enabled: true
         hostPortConfig:
-            enabled: true
-            hostPort: 8126
+          enabled: true
+          hostPort: 8126
         admissionController:
-        enabled: true
-        mutateUnlabelled: false
-     global:
-       tags:
-         - 'data_workload_monitoring_trial:true'
-       site: <DATADOG_SITE>
-       credentials:
-         apiSecret:
-           secretName: datadog-secret
-           keyName: api-key
-         appSecret:
-           secretName: datadog-secret
-           keyName: app-key
+          enabled: true
+          mutateUnlabelled: false
+      global:
+        tags:
+          - "data_workload_monitoring_trial:true"
+        site: <DATADOG_SITE>
+        credentials:
+          apiSecret:
+            secretName: datadog-secret
+            keyName: api-key
+          appSecret:
+            secretName: datadog-secret
+            keyName: app-key
    ```
    Replace `<DATADOG_SITE>` with your [Datadog site][5]. Your site is {{< region-param key="dd_site" code="true" >}}. (Ensure the correct SITE is selected on the right).
 1. Deploy the Datadog Agent with the above configuration file:

--- a/content/en/data_jobs/kubernetes.md
+++ b/content/en/data_jobs/kubernetes.md
@@ -48,31 +48,31 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
 1. Create a file, `datadog-agent.yaml`, that contains the following configuration:
 
    ```yaml
-    kind: DatadogAgent
-    apiVersion: datadoghq.com/v2alpha1
-    metadata:
-      name: datadog
-    spec:
-      features:
-        apm:
-        enabled: true
-        hostPortConfig:
-          enabled: true
-          hostPort: 8126
-        admissionController:
-          enabled: true
-          mutateUnlabelled: false
-      global:
-        tags:
-          - "data_workload_monitoring_trial:true"
-        site: <DATADOG_SITE>
-        credentials:
-          apiSecret:
-            secretName: datadog-secret
-            keyName: api-key
-          appSecret:
-            secretName: datadog-secret
-            keyName: app-key
+   kind: DatadogAgent
+   apiVersion: datadoghq.com/v2alpha1
+   metadata:
+     name: datadog
+   spec:
+     features:
+       apm:
+       enabled: true
+       hostPortConfig:
+         enabled: true
+         hostPort: 8126
+       admissionController:
+         enabled: true
+         mutateUnlabelled: false
+     global:
+       tags:
+         - "data_workload_monitoring_trial:true"
+       site: <DATADOG_SITE>
+       credentials:
+         apiSecret:
+           secretName: datadog-secret
+           keyName: api-key
+         appSecret:
+           secretName: datadog-secret
+           keyName: app-key
    ```
    Replace `<DATADOG_SITE>` with your [Datadog site][5]. Your site is {{< region-param key="dd_site" code="true" >}}. (Ensure the correct SITE is selected on the right).
 1. Deploy the Datadog Agent with the above configuration file:

--- a/content/en/data_jobs/kubernetes.md
+++ b/content/en/data_jobs/kubernetes.md
@@ -64,7 +64,7 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
          mutateUnlabelled: false
      global:
        tags:
-         - "data_workload_monitoring_trial:true"
+         - 'data_workload_monitoring_trial:true'
        site: <DATADOG_SITE>
        credentials:
          apiSecret:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
Fix incorrectly formatted yaml file in data_jobs/kubernetes.md.

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The incorrectly formatted yaml will not correctly set `features.admissionController.enabled` to `true` and `features.admissionController.mutateUnlabelled` to `false` as intended by the documentation.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->