### PR TITLE
bump sources version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/DataDog/websites-modules v1.4.141 // indirect
-	github.com/DataDog/websites-sources v0.0.0-20240429180210-49917b24a0b7 // indirect
+	github.com/DataDog/websites-sources v0.0.0-20240509212537-66852c208f36 // indirect
 )
 
 // replace github.com/DataDog/websites-modules => /Users/colin.cole/webops/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/DataDog/websites-modules v1.4.141 h1:uAGjWfXK3UHU+OTo73z69sFC6IKxkgkDPhw2IB85fEI=
 github.com/DataDog/websites-modules v1.4.141/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
-github.com/DataDog/websites-sources v0.0.0-20240429180210-49917b24a0b7 h1:iMvON2TmEfgmSTrXUYIDjHqd3qTz5Hvxs5cbxn1XyHw=
-github.com/DataDog/websites-sources v0.0.0-20240429180210-49917b24a0b7/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=
+github.com/DataDog/websites-sources v0.0.0-20240509212537-66852c208f36 h1:LqUTc+R9UXNqpNPzwjvziOg9FU+tTZ4kY+kflP0WPv0=
+github.com/DataDog/websites-sources v0.0.0-20240509212537-66852c208f36/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=


### PR DESCRIPTION
### What does this PR do? What is the motivation?
`redis-enterprise` tile not surfacing on /integrations

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/websites-source-mod-bump/integrations

locally:
![Screenshot 2024-05-09 at 5 36 42 PM](https://github.com/DataDog/documentation/assets/12885780/753fb0d3-0530-43d3-8857-efbff5ea2a3f)
