### PR TITLE
[CIVIS] Fixing missing link

### DIFF
--- a/content/en/tests/troubleshooting/_index.md
+++ b/content/en/tests/troubleshooting/_index.md
@@ -86,7 +86,7 @@ If you can see test results data in the **Test Runs** tab, but not the **Tests**
 4. If no CI provider environment variables are found, tests results are sent with no Git metadata.
 
 ### The total test time is empty
-If you cannot see the total test time, it is likely that test suite level visibility is not enabled. To confirm, check if your language supports test suite level visibility in [Supported features][15]. If test suite level visibility is supported, update your tracer to the latest version.
+If you cannot see the total test time, it is likely that test suite level visibility is not enabled. To confirm, check if your language supports test suite level visibility in [Supported features][14]. If test suite level visibility is supported, update your tracer to the latest version.
 
 If you still don't see the total time after updating the tracer version, contact [Datadog support][2] for help.
 
@@ -170,3 +170,4 @@ The best way to fix this is to make sure that the test parameters are the same b
 [11]: https://app.datadoghq.com/ci/settings/repository
 [12]: /continuous_integration/intelligent_test_runner/
 [13]: /tests/#parameterized-test-configurations
+[14]: /tests/#supported-features


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
There was a missing link in the docs. This PR fixes it.
<img width="758" alt="image" src="https://github.com/DataDog/documentation/assets/36534744/518c420a-df6d-40f2-ba54-41c8dd70e1e3">

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->