### PR TITLE
Add direct link to auto discovery docs in mysql/postgres aurora setup

### DIFF
--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -186,7 +186,7 @@ instances:
     port: 3306
     username: datadog
     password: '<YOUR_CHOSEN_PASSWORD>' # from the CREATE USER step earlier
-        
+
     # After adding your project and instance, configure the Datadog AWS integration to pull additional cloud data such as CPU and Memory.
     aws:
       instance_endpoint: '<AWS_INSTANCE_ENDPOINT>'
@@ -197,6 +197,8 @@ instances:
 **Note**: Wrap your password in single quotes in case a special character is present.
 
 [Restart the Agent][3] to start sending MySQL metrics to Datadog.
+
+**The Datadog Agent supports auto-discovering all aurora endpoints in a cluster.** In order to do this, please [follow this guide.][10]
 
 
 [1]: /agent/configuration/agent-configuration-files/#agent-configuration-directory
@@ -370,3 +372,4 @@ If you have installed and configured the integrations and Agent as described and
 [7]: https://app.datadoghq.com/databases
 [8]: /integrations/amazon_rds
 [9]: /database_monitoring/troubleshooting/?tab=mysql
+[10]: /database_monitoring/guide/aurora_autodiscovery/?tab=mysql

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -198,7 +198,7 @@ instances:
 
 [Restart the Agent][3] to start sending MySQL metrics to Datadog.
 
-**The Datadog Agent supports auto-discovering all aurora endpoints in a cluster.** In order to do this, please [follow this guide.][10]
+**The Datadog Agent supports [Autodiscovery][10] of all Aurora endpoints in a cluster.** 
 
 
 [1]: /agent/configuration/agent-configuration-files/#agent-configuration-directory

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -204,6 +204,7 @@ instances:
 [1]: /agent/configuration/agent-configuration-files/#agent-configuration-directory
 [2]: https://github.com/DataDog/integrations-core/blob/master/mysql/datadog_checks/mysql/data/conf.yaml.example
 [3]: /agent/configuration/agent-commands/#start-stop-and-restart-the-agent
+[10]: /database_monitoring/guide/aurora_autodiscovery/?tab=mysql
 {{% /tab %}}
 {{% tab "Docker" %}}
 
@@ -372,4 +373,4 @@ If you have installed and configured the integrations and Agent as described and
 [7]: https://app.datadoghq.com/databases
 [8]: /integrations/amazon_rds
 [9]: /database_monitoring/troubleshooting/?tab=mysql
-[10]: /database_monitoring/guide/aurora_autodiscovery/?tab=mysql
+

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -225,6 +225,7 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example
 [2]: /agent/configuration/agent-commands/#start-stop-and-restart-the-agent
+[14]: /database_monitoring/guide/aurora_autodiscovery/?tab=postgres
 {{% /tab %}}
 {{% tab "Docker" %}}
 
@@ -428,4 +429,4 @@ If you have installed and configured the integrations and Agent as described and
 [11]: /integrations/amazon_rds
 [12]: /database_monitoring/troubleshooting/?tab=postgres
 [13]: /database_monitoring/guide/managed_authentication
-[14]: /database_monitoring/guide/aurora_autodiscovery/?tab=postgres
+

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -220,6 +220,8 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
 
 2. [Restart the Agent][2].
 
+**The Datadog Agent supports auto-discovering all aurora endpoints in a cluster.** In order to do this, please [follow this guide.][14]
+
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example
 [2]: /agent/configuration/agent-commands/#start-stop-and-restart-the-agent
@@ -426,3 +428,4 @@ If you have installed and configured the integrations and Agent as described and
 [11]: /integrations/amazon_rds
 [12]: /database_monitoring/troubleshooting/?tab=postgres
 [13]: /database_monitoring/guide/managed_authentication
+[14]: /database_monitoring/guide/aurora_autodiscovery/?tab=postgres

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -220,7 +220,7 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
 
 2. [Restart the Agent][2].
 
-**The Datadog Agent supports auto-discovering all aurora endpoints in a cluster.** In order to do this, please [follow this guide.][14]
+**The Datadog Agent supports [Autodiscovery][14] of all Aurora endpoints in a cluster.** 
 
 
 [1]: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds direct note in setup docs on how to use the new auto discovery feature in the agent

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->