### PR TITLE
Remove duplicate swift markdown syntax

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
@@ -529,7 +529,6 @@ If you don't want to track requests, you can disable URLSessionInstrumentation f
 {{< tabs >}}
 {{% tab "Swift" %}}
 ```swift
-```swift
 URLSessionInstrumentation.disable(delegateClass: SessionDelegate.self)
 ```
 {{% /tab %}}


### PR DESCRIPTION
There's an extra "```swift" at the top of this docs page that needs to be removed. 

<img width="760" alt="image" src="https://github.com/DataDog/documentation/assets/28220221/453ef914-7ad7-4ef2-aea0-24de68c0570e">


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->