### PR TITLE
Migrate Standard integrations section

### DIFF
--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -7,7 +7,7 @@ algolia:
   tags: ['custom metrics billing']
 ---
 
-If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a [custom metric][2]<sup>[(1)][14]</sup>.
+If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a [custom metric][2]. Certain standard integrations can also potentially emit customer metrics. For more information, see [Custom metrics and standard integrations][14].
 
 **A custom metric is uniquely identified by a combination of a metric name and tag values (including the host tag)**. In general, any metric you send using [DogStatsD][3] or through a [custom Agent Check][4] is a custom metric.
 

--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -300,20 +300,9 @@ These allocations are counted across your entire infrastructure. For example, if
 
 The billable number of indexed custom metrics is based on the average number of custom metrics (from all paid hosts) per hour over a given month. The billable number of ingested custom metrics only grows if you've used Metrics without Limits™ to configure your metric. Contact [Sales][11] or your [Customer Success][12] Manager to discuss custom metrics for your account or to purchase an additional custom metrics package.
 
-## Standard integrations
-
-The following standard integrations can potentially emit custom metrics.
-
-| Type of integrations                           | Integrations                                                                       |
-|------------------------------------------------|------------------------------------------------------------------------------------|
-| Limited to 350 custom metrics by default.      | [ActiveMQ XML][13] / [Go-Expvar][14] / [Java-JMX][15]                              |
-| No default limit on custom metrics collection. | [Nagios][16] /[PDH Check][17] /[OpenMetrics][18] /[Windows performance counters][19] /[WMI][20] /[Prometheus][21] |
-| Can be configured to collect custom metrics.   | [MySQL][22] /[Oracle][23] /[Postgres][24] /[SQL Server][25]                        |
-| Custom metrics sent from cloud integrations    | [AWS][26]                                                                          |
-
 ## Troubleshooting
 
-For technical questions, contact [Datadog support][27].
+For technical questions, contact [Datadog support][17].
 
 For billing questions, contact your [Customer Success][12] Manager.
 
@@ -329,18 +318,5 @@ For billing questions, contact your [Customer Success][12] Manager.
 [10]: https://app.datadoghq.com/metric/summary
 [11]: mailto:sales@datadoghq.com
 [12]: mailto:success@datadoghq.com
-[13]: /integrations/activemq/#activemq-xml-integration
-[14]: /integrations/go_expvar/
-[15]: /integrations/java/
 [16]: /integrations/nagios/
-[17]: /integrations/pdh_check/
-[18]: /integrations/openmetrics/
-[19]: /integrations/windows_performance_counters/
-[20]: /integrations/wmi_check/
-[21]: /integrations/prometheus
-[22]: /integrations/mysql/
-[23]: /integrations/oracle/
-[24]: /integrations/postgres/
-[25]: /integrations/sqlserver/
-[26]: /integrations/amazon_web_services/
-[27]: /help/
+[17]: /help/

--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -7,7 +7,7 @@ algolia:
   tags: ['custom metrics billing']
 ---
 
-If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a [custom metric][2]. Certain standard integrations can also potentially emit customer metrics. For more information, see [Custom metrics and standard integrations][14].
+If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a [custom metric][2]. Certain standard integrations can also potentially emit custom metrics. For more information, see [Custom metrics and standard integrations][14].
 
 **A custom metric is uniquely identified by a combination of a metric name and tag values (including the host tag)**. In general, any metric you send using [DogStatsD][3] or through a [custom Agent Check][4] is a custom metric.
 

--- a/content/en/account_management/billing/custom_metrics.md
+++ b/content/en/account_management/billing/custom_metrics.md
@@ -7,7 +7,7 @@ algolia:
   tags: ['custom metrics billing']
 ---
 
-If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a [custom metric][2]<sup>[(1)](#standard-integrations)</sup>.
+If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a [custom metric][2]<sup>[(1)][14]</sup>.
 
 **A custom metric is uniquely identified by a combination of a metric name and tag values (including the host tag)**. In general, any metric you send using [DogStatsD][3] or through a [custom Agent Check][4] is a custom metric.
 
@@ -302,7 +302,7 @@ The billable number of indexed custom metrics is based on the average number of 
 
 ## Troubleshooting
 
-For technical questions, contact [Datadog support][17].
+For technical questions, contact [Datadog support][13].
 
 For billing questions, contact your [Customer Success][12] Manager.
 
@@ -318,5 +318,5 @@ For billing questions, contact your [Customer Success][12] Manager.
 [10]: https://app.datadoghq.com/metric/summary
 [11]: mailto:sales@datadoghq.com
 [12]: mailto:success@datadoghq.com
-[16]: /integrations/nagios/
-[17]: /help/
+[13]: /help/
+[14]: /metrics/custom_metrics/#standard-integrations

--- a/content/en/metrics/custom_metrics.md
+++ b/content/en/metrics/custom_metrics.md
@@ -32,7 +32,7 @@ algolia:
 
 ## Overview
 
-If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a custom metric<sup>[(1)][2]</sup>. Custom metrics help you track your application KPIs: number of visitors, average customer basket size, request latency, or performance distribution for a custom algorithm.
+If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a custom metric<sup>[(1)](#standard-integrations)</sup>. Custom metrics help you track your application KPIs: number of visitors, average customer basket size, request latency, or performance distribution for a custom algorithm.
 
 A custom metric is identified by **a unique combination of a metric's name and tag values (including the host tag)**. In general, any metric you send using [DogStatsD][3] or through a [custom Agent Check][4] is a custom metric.
 
@@ -85,11 +85,20 @@ You can also use one of the [Datadog official and community contributed API and 
 
 **Note**: There are no enforced fixed rate limits on custom metric submission. If your default allotment is exceeded, you are billed according to [Datadog's billing policy for custom metrics][6].
 
+## Standard integrations
+
+The following standard integrations can potentially emit custom metrics.
+
+| Type of integrations                           | Integrations                                                                       |
+|------------------------------------------------|------------------------------------------------------------------------------------|
+| Limited to 350 custom metrics by default.      | [ActiveMQ XML][16] / [Go-Expvar][17] / [Java-JMX][18]                              |
+| No default limit on custom metrics collection. | [Nagios][19] /[PDH Check][20] /[OpenMetrics][21] /[Windows performance counters][22] /[WMI][23] /[Prometheus][21] |
+| Can be configured to collect custom metrics.   | [MySQL][24] /[Oracle][25] /[Postgres][26] /[SQL Server][27]                        |
+| Custom metrics sent from cloud integrations    | [AWS][28]                                                                          |
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-
-<br><sup>(1)</sup> *[Some integrations do emit custom metrics][2]*
 
 [1]: /integrations/
 [2]: /account_management/billing/custom_metrics/#standard-integrations
@@ -106,3 +115,16 @@ You can also use one of the [Datadog official and community contributed API and 
 [13]: /dashboards/guide/unit-override/
 [14]: /metrics/units/
 [15]: /developers/community/libraries/
+[16]: /integrations/activemq/#activemq-xml-integration
+[17]: /integrations/go_expvar/
+[18]: /integrations/java/
+[19]: /integrations/nagios
+[20]: /integrations/pdh_check/
+[21]: /integrations/openmetrics/
+[22]: /integrations/windows_performance_counters/
+[23]: /integrations/wmi_check/
+[24]: /integrations/mysql/
+[25]: /integrations/oracle/
+[26]: /integrations/postgres/
+[27]: /integrations/sqlserver/
+[28]: /integrations/amazon_web_services/

--- a/content/en/metrics/custom_metrics.md
+++ b/content/en/metrics/custom_metrics.md
@@ -32,7 +32,7 @@ algolia:
 
 ## Overview
 
-If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a custom metric<sup>[(1)](#standard-integrations)</sup>. Custom metrics help you track your application KPIs: number of visitors, average customer basket size, request latency, or performance distribution for a custom algorithm.
+If a metric is not submitted from one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1] it's considered a custom metric. Custom metrics help you track your application KPIs: number of visitors, average customer basket size, request latency, or performance distribution for a custom algorithm. Certain [standard integrations](#standard-integrations) can also potentially emit customer metrics. 
 
 A custom metric is identified by **a unique combination of a metric's name and tag values (including the host tag)**. In general, any metric you send using [DogStatsD][3] or through a [custom Agent Check][4] is a custom metric.
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?
The standard integrations list is in the billing doc which doesn't make sense it should be in the main doc that lists all the other metric submission methods.