### PR TITLE
Fix link copy-paste error

### DIFF
--- a/content/en/service_management/app_builder/components.md
+++ b/content/en/service_management/app_builder/components.md
@@ -3,7 +3,7 @@ title: Components
 kind: documentation
 disable_toc: true
 further_reading:
-- link: "/service_management/workflows/build/"
+- link: "/service_management/app_builder/build/"
   tag: "Documentation"
   text: "Build Apps"
 ---


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes a link that is currently pointing to Workflows, when it should be pointing to App Builder.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->