### PR TITLE
fix library links on Intelligent Test Runner docs page

### DIFF
--- a/content/en/intelligent_test_runner/_index.md
+++ b/content/en/intelligent_test_runner/_index.md
@@ -48,12 +48,12 @@ There are several configuration mechanisms that you can use in these scenarios t
 Before setting up Intelligent Test Runner, you must configure [Test Visibility][4] for your particular language. If you are reporting data through the Agent, use v6.40 or 7.40 and later.
 
 {{< whatsnext desc="Choose a language to set up Intelligent Test Runner in Datadog:" >}}
-    {{< nextlink href="continuous_integration/intelligent_test_runner/setup/dotnet" >}}.NET{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/intelligent_test_runner/setup/java" >}}Java{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/intelligent_test_runner/setup/javascript" >}}JavaScript{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/intelligent_test_runner/setup/swift" >}}Swift{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/intelligent_test_runner/setup/python" >}}Python{{< /nextlink >}}
-    {{< nextlink href="continuous_integration/intelligent_test_runner/setup/ruby" >}}Ruby{{< /nextlink >}}
+    {{< nextlink href="intelligent_test_runner/setup/dotnet" >}}.NET{{< /nextlink >}}
+    {{< nextlink href="intelligent_test_runner/setup/java" >}}Java{{< /nextlink >}}
+    {{< nextlink href="intelligent_test_runner/setup/javascript" >}}JavaScript{{< /nextlink >}}
+    {{< nextlink href="intelligent_test_runner/setup/swift" >}}Swift{{< /nextlink >}}
+    {{< nextlink href="intelligent_test_runner/setup/python" >}}Python{{< /nextlink >}}
+    {{< nextlink href="intelligent_test_runner/setup/ruby" >}}Ruby{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Configuration


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Fixes library setup links on Intelligent Test Runner page to match new format. Fixes broken link for Ruby on this page.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

