### PR TITLE
 Remove "beta" callouts from Feature Flag Tracking

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -397,9 +397,6 @@ The RUM Browser SDK ignores:
 - Modifications made to a RUM view event context
 
 ### Enrich RUM events with feature flags
-{{< callout btn_hidden="true" header="Join the Feature Flag Tracking Beta!">}}
-<a href="/real_user_monitoring/guide/setup-feature-flag-data-collection/">Set up your data collection</a> to join the Feature Flag Tracking beta.
-{{< /callout >}}
 
 You can [enrich your RUM event data with feature flags][6] to get additional context and visibility into performance monitoring. This lets you determine which users are shown a specific user experience and if it is negatively affecting the user's performance.
 

--- a/content/en/real_user_monitoring/browser/data_collected.md
+++ b/content/en/real_user_monitoring/browser/data_collected.md
@@ -128,9 +128,6 @@ In addition to default attributes, you can add user-related data to all RUM even
 
 ### Feature flag attributes
 
-{{< callout btn_hidden="true" header="Join the Feature Flag Tracking Beta!">}}
-<a href="/real_user_monitoring/guide/setup-feature-flag-data-collection/">Set up your data collection</a> to join the Feature Flag Tracking beta.
-{{< /callout >}}
 
 You can [enrich your RUM event data with feature flags][6] to get additional context and visibility into performance monitoring. This lets you determine which users are shown a specific user experience and if it is negatively affecting the user's performance.
 

--- a/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
+++ b/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
@@ -14,11 +14,6 @@ further_reading:
   text: 'Visualize your RUM data in the RUM Explorer'
 ---
 
-<div class="alert alert-warning">
-    Feature Flag Tracking is in beta.
-</div>
-
-
 ## Overview
 Feature flag data gives you greater visibility into your user experience and performance monitoring by allowing you to determine which users are being shown a specific feature and if any change you introduce is impacting your user experience or negatively affecting performance.
 
@@ -652,12 +647,12 @@ Initialize Statsig's SDK with `statsig.initialize`.
    ```javascript
     await statsig.initialize('client-<STATSIG CLIENT KEY>',
     {userID: '<USER ID>'},
-    {     
+    {
         gateEvaluationCallback: (key, value) => {
             datadogRum.addFeatureFlagEvaluation(key, value);
         }
     }
-    ); 
+    );
    ```
 
 [1]: https://docs.statsig.com/client/jsClientSDK


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This commit removes the beta status of Feature Flag Tracking including the callouts.