### PR TITLE
[APM > .NET Tracer] Add .NET 4.8.1 to list of supported runtimes

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -26,6 +26,7 @@ The .NET Tracer supports automatic and custom instrumentation on the following .
 
 | .NET Framework Version  | Microsoft End of Life | Support level                       | Package version             | Datadog End of Life |
 | ----------------------- | --------------------- | ----------------------------------- | --------------------------- | ------------------- |
+| 4.8.1                   |                       | [GA](#support-ga)                   | latest                      |                     |
 | 4.8                     |                       | [GA](#support-ga)                   | latest                      |                     |
 | 4.7.2                   |                       | [GA](#support-ga)                   | latest                      |                     |
 | 4.7                     |                       | [GA](#support-ga)                   | latest                      |                     |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add .NET Framework 4.8.1 to the list of supported runtimes.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
[DOCS-7949](https://datadoghq.atlassian.net/browse/DOCS-7949)

[DOCS-7949]: https://datadoghq.atlassian.net/browse/DOCS-7949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ