### PR TITLE
LLMObs SDK documentation edits

### DIFF
--- a/content/en/tracing/llm_observability/_index.md
+++ b/content/en/tracing/llm_observability/_index.md
@@ -46,7 +46,7 @@ Monitor the throughput, latency, and token usage trends for all your LLM applica
 
 ### Evaluate the quality and effectiveness of your LLM applications
 
-Identify problematic topics and monitor the quality of responses over time with topical clustering with checks like sentiment analysis.
+Identify problematic clusters and monitor the quality of responses over time with topical clustering and checks like sentiment, failure-to-answer etc.
 
 {{< img src="tracing/llm_observability/clusters-page.png" alt="The clusters page in LLM Observability" style="width:100%;" >}}
 

--- a/content/en/tracing/llm_observability/_index.md
+++ b/content/en/tracing/llm_observability/_index.md
@@ -46,7 +46,7 @@ Monitor the throughput, latency, and token usage trends for all your LLM applica
 
 ### Evaluate the quality and effectiveness of your LLM applications
 
-Identify problematic clusters and monitor the quality of responses over time with topical clustering and checks like sentiment, failure-to-answer etc.
+Identify problematic clusters and monitor the quality of responses over time with topical clustering and checks like sentiment, failure to answer, and so on.
 
 {{< img src="tracing/llm_observability/clusters-page.png" alt="The clusters page in LLM Observability" style="width:100%;" >}}
 

--- a/content/en/tracing/llm_observability/api.md
+++ b/content/en/tracing/llm_observability/api.md
@@ -225,7 +225,7 @@ Endpoint
 Method
 : `POST`
 
-Evaluation metrics require a `span_id` and `trace_id`.
+Evaluation metrics require a `span_id` and `trace_id`. 
 - If you are not using the LLM Observability SDK, send the `span_id` and `trace_id` that you used to create your target span.
 - If you are using the LLM Observability SDK, obtain the `span_id` and `trace_id` by finding your target span, and accessing the `root_span.span_id` and the `root_span.trace_id` attributes.
 
@@ -342,10 +342,10 @@ Evaluation metrics require a `span_id` and `trace_id`.
 
 #### EvalMetricsRequestData
 
-| Field      | Type            | Description  |
+| Field      | Type            | Description  | 
 |------------|-----------------|--------------|
 | type [*required*]      | string | Identifier for the request. Set to `evaluation_metric`. |
-| attributes [*required*] | [[EvalMetric](#evalmetric)] | The body of the request. |
+| attributes [*required*] | [[EvalMetric](#evalmetric)] | The body of the request. | 
 
 [1]: /tracing/llm_observability/sdk/
 [2]: /tracing/llm_observability/span_kinds/

--- a/content/en/tracing/llm_observability/api.md
+++ b/content/en/tracing/llm_observability/api.md
@@ -216,7 +216,7 @@ Your application name (the value of `ml_app`) must start with a letter. It may c
 
 The name can be up to 200 characters long and contain Unicode letters (which includes most character sets, including languages such as Japanese).
 
-## Eval metrics API
+## Evaluation metrics API
 Use this endpoint to send evaluation metrics for a span to Datadog.
 
 Endpoint
@@ -225,7 +225,7 @@ Endpoint
 Method
 : `POST`
 
-Evaluation metrics require a `span_id` and `trace_id`. 
+Evaluation metrics require a `span_id` and `trace_id`.
 - If you are not using the LLM Observability SDK, send the `span_id` and `trace_id` that you used to create your target span.
 - If you are using the LLM Observability SDK, obtain the `span_id` and `trace_id` by finding your target span, and accessing the `root_span.span_id` and the `root_span.trace_id` attributes.
 
@@ -342,10 +342,10 @@ Evaluation metrics require a `span_id` and `trace_id`.
 
 #### EvalMetricsRequestData
 
-| Field      | Type            | Description  | 
+| Field      | Type            | Description  |
 |------------|-----------------|--------------|
 | type [*required*]      | string | Identifier for the request. Set to `evaluation_metric`. |
-| attributes [*required*] | [[EvalMetric](#evalmetric)] | The body of the request. | 
+| attributes [*required*] | [[EvalMetric](#evalmetric)] | The body of the request. |
 
 [1]: /tracing/llm_observability/sdk/
 [2]: /tracing/llm_observability/span_kinds/

--- a/content/en/tracing/llm_observability/quickstart.md
+++ b/content/en/tracing/llm_observability/quickstart.md
@@ -65,7 +65,10 @@ A trace of your LLM call should appear in [the Traces tab][3] of LLM Observabili
 
 {{< img src="tracing/llm_observability/quickstart-trace.png" alt="An LLM Observability trace displaying a single LLM request" style="width:100%;" >}}
 
-The trace you see is composed of a single LLM span. The `ddtrace-run` command automatically traces your LLM calls from Datadog's list of supported integrations.
+The trace you see is composed of a single LLM span. The `ddtrace-run` command automatically traces your LLM calls from [Datadog's list of supported integrations][10].
+
+If your application consists of more elaborate prompting or complex chains or workflows involving LLMs, you can instrument accordingly using the [instructions here][11] and the [SDK documentation][1].
+
 
 [1]: /tracing/llm_observability/sdk/
 [3]: https://app.datadoghq.com/llm/traces
@@ -75,3 +78,5 @@ The trace you see is composed of a single LLM span. The `ddtrace-run` command au
 [7]: /account_management/api-app-keys/#add-an-api-key-or-client-token
 [8]: /tracing/llm_observability/api
 [9]: /tracing/llm_observability/sdk/#command-line-setup
+[10]: /tracing/llm_observability/sdk/#llm-integrations
+[11]: /tracing/llm_observability/trace_an_llm_application

--- a/content/en/tracing/llm_observability/quickstart.md
+++ b/content/en/tracing/llm_observability/quickstart.md
@@ -67,7 +67,7 @@ A trace of your LLM call should appear in [the Traces tab][3] of LLM Observabili
 
 The trace you see is composed of a single LLM span. The `ddtrace-run` command automatically traces your LLM calls from [Datadog's list of supported integrations][10].
 
-If your application consists of more elaborate prompting or complex chains or workflows involving LLMs, you can instrument accordingly using the [instructions here][11] and the [SDK documentation][1].
+If your application consists of more elaborate prompting or complex chains or workflows involving LLMs, you can trace it using the [instrumentation guide][11] and the [SDK documentation][1].
 
 
 [1]: /tracing/llm_observability/sdk/

--- a/content/en/tracing/llm_observability/quickstart.md
+++ b/content/en/tracing/llm_observability/quickstart.md
@@ -22,10 +22,11 @@ Use the steps below to run a simple Python script that generates an LLM Observab
 
 ## 1. Install the SDK
 
-Install the following `ddtrace` package hash:
+Install the following `ddtrace` package hash and `openai` package:
 
 {{< code-block lang="shell" >}}
 pip install git+https://github.com/DataDog/dd-trace-py.git@main
+pip install openai
 {{< /code-block >}}
 
 ## 2. Create the script
@@ -54,7 +55,7 @@ Run the Python script with the following shell command, sending a trace of the O
 {{< code-block lang="shell" >}}
 DD_LLMOBS_ENABLED=1 DD_LLMOBS_APP_NAME=onboarding-quickstart \ 
 DD_API_KEY=<YOUR_DATADOG_API_KEY> DD_SITE=<YOUR_DATADOG_SITE> \ 
-DD_LLMOBS_NO_APM=1 ddtrace-run python quickstart.py
+DD_LLMOBS_AGENTLESS_ENABLED=1 ddtrace-run python quickstart.py
 {{< /code-block >}}
 
 For details on the required environment variables, see [the SDK documentation][9].

--- a/content/en/tracing/llm_observability/quickstart.md
+++ b/content/en/tracing/llm_observability/quickstart.md
@@ -9,20 +9,18 @@ LLM Observability is not available in the US1-FED site.
 
 <div class="alert alert-info">LLM Observability is in public beta.</a></div>
 
-Our quickstart docs make use of our Python SDK. For detailed usage, see [the SDK documentation][1]. If your application is written in another language, you can create traces by calling the [API][8] instead.
-
-## Command line quickstart
+Our quickstart docs make use of the LLM Observability SDK for Python. For detailed usage, see [the SDK documentation][1]. If your application is written in another language, you can create traces by calling the [API][8] instead.
 
 Use the steps below to run a simple Python script that generates an LLM Observability trace.
 
-### Prerequisites
+## Prerequisites
 
 - LLM Observability requires a Datadog API key (see [the instructions for creating an API key][7]).
 - The example script below uses OpenAI, but you can modify it to use a different provider. To run the script as written, you need:
     - An OpenAI API key stored in your environment as `OPENAI_API_KEY`. To create one, see [Account Setup][4] and [Set up your API key][6] in the OpenAI documentation.
     - The OpenAI Python library installed. See [Setting up Python][5] in the OpenAI documentation for instructions.
 
-### 1. Install the SDK
+## 1. Install the SDK
 
 Install the following `ddtrace` package hash:
 
@@ -30,7 +28,7 @@ Install the following `ddtrace` package hash:
 pip install git+https://github.com/DataDog/dd-trace-py.git@main
 {{< /code-block >}}
 
-### 2. Create the script
+## 2. Create the script
 
 The Python script below makes a single OpenAI call. Save it as `quickstart.py`.
 
@@ -49,17 +47,19 @@ completion = oai_client.chat.completions.create(
 )
 {{< /code-block >}}
 
-### 3. Run the script
+## 3. Run the script
 
-Run the Python script with the following shell command, and a trace of the OpenAI call will be sent to Datadog:
+Run the Python script with the following shell command, sending a trace of the OpenAI call to Datadog:
 
 {{< code-block lang="shell" >}}
 DD_LLMOBS_ENABLED=1 DD_LLMOBS_APP_NAME=onboarding-quickstart \ 
-DD_API_KEY=<YOUR_DATADOG_API_KEY> DD_SITE={{< region-param key="dd_site" code="true" >}} \ 
+DD_API_KEY=<YOUR_DATADOG_API_KEY> DD_SITE=<YOUR_DATADOG_SITE> \ 
 DD_LLMOBS_NO_APM=1 ddtrace-run python quickstart.py
 {{< /code-block >}}
 
-### 4. View the trace
+For details on the required environment variables, see [the SDK documentation][9].
+
+## 4. View the trace
 
 A trace of your LLM call should appear in [the Traces tab][3] of LLM Observability in Datadog.
 
@@ -74,3 +74,4 @@ The trace you see is composed of a single LLM span. The `ddtrace-run` command au
 [6]: https://platform.openai.com/docs/quickstart/step-2-set-up-your-api-key
 [7]: /account_management/api-app-keys/#add-an-api-key-or-client-token
 [8]: /tracing/llm_observability/api
+[9]: /tracing/llm_observability/sdk/#command-line-setup

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -28,36 +28,14 @@ pip install git+https://github.com/DataDog/dd-trace-py.git@main
 
 2. LLM Observability requires a Datadog API key (see [the instructions for creating an API key][7]).
 
-#### In-code setup
-
-Enable LLM Observability through the `LLMOBs.enable()` function, as shown in the example below.
-
-- Use the `integrations` argument to turn on automatic tracing for supported LLM Observability integrations (OpenAI, Bedrock, and LangChain).
-
-- If you do not have Datadog APM set up, set `dd_llmobs_no_apm` to `True`. This configures the `ddtrace` library to not send any data that requires Datadog APM.
-
-- When choosing a value for `ml_app`, see [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints.
-
-{{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
-
-LLMObs.enable(
-    ml_app="<YOUR_ML_APP_NAME>",
-    dd_api_key="<YOUR_DATADOG_API_KEY>",
-    dd_site="{{< region-param key="dd_site" code="true" >}}",
-    dd_llmobs_no_apm=True,
-    integrations=[LLMObs.openai, LLMObs.botocore, LLMObs.langchain],
-)
-{{< /code-block >}}
-
 #### Command-line setup
 
-You can also enable LLM Observability by running your application using the `ddtrace-run` command and specifying the required environment variables.
+Enable LLM Observability by running your application using the `ddtrace-run` command and specifying the required environment variables.
 
 **Note**: `ddtrace-run` automatically turns on all LLM Observability integrations.
 
 {{< code-block lang="shell">}}
-DD_SITE={{< region-param key="dd_site" code="true" >}} DD_API_KEY=<YOUR_API_KEY> DD_LLMOBS_ENABLED=1 \
+DD_SITE=<YOUR_DATADOG_SITE> DD_API_KEY=<YOUR_API_KEY> DD_LLMOBS_ENABLED=1 \
 DD_LLMOBS_APP_NAME=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 {{< /code-block >}}
 
@@ -83,7 +61,7 @@ DD_LLMOBS_APP_NAME=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 
 #### Application naming guidelines
 
-Your application name (the value of `ml_app` or `DD_LLMOBS_APP_NAME`) must start with a letter. It may contain the characters listed below:
+Your application name (the value of `DD_LLMOBS_APP_NAME`) must start with a letter. It may contain the characters listed below:
 
 - Alphanumerics
 - Underscores

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -59,6 +59,49 @@ DD_LLMOBS_APP_NAME=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not a Datadog APM customer, in which case this should be set to `1` or `true`.
 
+#### In-code setup
+
+Enable LLM Observability programatically through the `LLMOBs.enable()` function instead of running with the `ddtrace-run` command. **Note**: This setup method will not work if used with `ddtrace-run`.
+
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
+LLMObs.enable(
+  ml_app="<YOUR_ML_APP_NAME>",
+  dd_api_key="<YOUR_DATADOG_API_KEY>",
+  dd_site=“<YOUR_DATADOG_SITE>”,
+  dd_llmobs_no_apm=True,
+  integrations=["langchain", "openai"],
+)
+{{< /code-block >}}
+
+`ml_app`
+: optional - _string_
+<br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given trace, see [Tracing multiple applications](#tracing-multiple-applications). If not provided, this will default to the value of `DD_LLMOBS_ML_APP`.
+
+`integrations`
+: optional - _list_ 
+<br />A list of integration names to enable automatically tracing LLM calls for (e.g. `["openai", "langchain"]`). See [LLM integrations](#llm-integrations) for more information about Datadog's supported LLM integrations. **Note**: if not provided, all supported LLM integrations will be enabled by default. To disable all integrations, pass in an empty list `[]`.
+
+`dd_llmobs_no_apm`
+: optional - _boolean_ 
+<br />Only required if you are not a Datadog APM customer, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires Datadog APM. If not provided, this will default to the value of `DD_LLMOBS_NO_APM`.
+
+`dd_site`
+: optional - _string_ 
+<br />The Datadog site to submit your LLM data. Your site is {{< region-param key="dd_site" code="true" >}}. If not provided, this will default to the value of `DD_SITE`.
+
+`dd_api_key`
+: optional - _string_ 
+<br />Your Datadog API key. If not provided, this will default to the value of `DD_API_KEY`.
+
+`dd_env`
+: optional - _string_
+<br />The name of your application's environment (e.g. `prod`, `pre-prod`, `staging`). If not provided, this will default to the value of `DD_ENV`.
+
+`dd_service`
+: optional - _string_
+<br />The name of the service used for your application. If not provided, this will default to the value of `DD_SERVICE`.
+
 #### Application naming guidelines
 
 Your application name (the value of `DD_LLMOBS_APP_NAME`) must start with a letter. It may contain the characters listed below:
@@ -436,9 +479,9 @@ The `LLMObs.submit_evaluation()` method accepts the following arguments:
 
 The Python SDK includes out-of-the-box integrations to automatically trace and annotate the LLM calls for:
 
-- OpenAI (using the [OpenAI Python SDK][1]): supports all versions
-- AWS Bedrock Runtime (using [Boto3][2]/[Botocore][3]): supports all versions
-- LangChain LLM/Chat Models/Chains (using [LangChain][4]): supports all versions
+- `openai` - OpenAI (using the [OpenAI Python SDK][1]): supports all versions
+- `bedrock` - AWS Bedrock Runtime (using [Boto3][2]/[Botocore][3]): supports all versions
+- `langchain` - LangChain LLM/Chat Models/Chains (using [LangChain][4]): supports all versions
 
 This means that you do not need to manually instrument your LLM calls with `LLMObs.llm()` as the SDK will capture them automatically.
 

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -14,7 +14,7 @@ LLM Observability is not available in the US1-FED site.
 
 The LLM Observability SDK for Python enhances the observability of your Python-based LLM applications. The SDK supports Python versions 3.7 and newer. For information about LLM Observability's integration support, see [LLM integrations](#llm-integrations).
 
-You can install and configure tracing of various operations such as workflows, tasks, and API calls with simple context managers or function decorators. You can also annotate these traces with metadata for deeper insights into the performance and behavior of your applications, supporting multiple LLM services or models from the same environment.
+You can install and configure tracing of various operations such as workflows, tasks, and API calls with simple function decorators or context managers. You can also annotate these traces with metadata for deeper insights into the performance and behavior of your applications, supporting multiple LLM services or models from the same environment.
 
 ## Setup
 
@@ -117,17 +117,17 @@ The name can be up to 200 characters long and contain Unicode letters (which inc
 
 ## Tracing spans
 
-To trace a span, use `LLMObs.<SPAN_KIND>()` as a context manager (for example, `LLMObs.task()` for a task span). For a list of available span kinds, see the [Span Kinds documentation][8].
+To trace a span, use `ddtrace.llmobs.decorators.<SPAN_KIND>()` as a function decorator (for example, `llmobs.decorators.task()` for a task span) for the function you'd like to trace. For a list of available span kinds, see the [Span Kinds documentation][8]. For more granular tracing of operations within functions, see [Tracing spans using inline methods](#tracing-spans-using-inline-methods).
 
 ### Agent span
 
-To trace an agent span, use `LLMObs.agent()` as a context manager.
+To trace an agent span, use the function decorator `ddtrace.llmobs.decorators.agent()`.
 
 #### Arguments
 
 `name`
-: optional - _string_ - **default**: `"agent"`
-<br/>The name of the operation.
+: optional - _string_
+<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -140,23 +140,23 @@ To trace an agent span, use `LLMObs.agent()` as a context manager.
 #### Example
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import agent
 
+@agent(name="react_agent")
 def run_agent():
-    with LLMObs.agent(name="react_agent") as agent_span:
-        ... # user application logic
+    ... # user application logic
     return 
 {{< /code-block >}}
 
 ### Workflow span
 
-To trace a workflow span, use `LLMObs.workflow()` as a context manager.
+To trace a workflow span, use the function decorator `ddtrace.llmobs.decorators.workflow()`.
 
 #### Arguments
 
 `name`
-: optional - _string_ - **default**: `"workflow"`
-<br/>The name of the operation.
+: optional - _string_
+<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -169,11 +169,11 @@ To trace a workflow span, use `LLMObs.workflow()` as a context manager.
 #### Example
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import workflow
 
+@workflow(name="process_message")
 def process_message():
-    with LLMObs.workflow(name="process_message") as workflow_span:
-        ... # user application logic
+    ... # user application logic
     return 
 {{< /code-block >}}
 
@@ -187,7 +187,7 @@ def process_message():
 
 For more information about Datadog's LLM integrations, see [LLM integrations](#llm-integrations).
 
-To trace an LLM span, use `LLMObs.llm()` as a context manager.
+To trace an LLM span, use the function decorator `ddtrace.llmobs.decorators.llm()`.
 
 #### Arguments
 
@@ -196,8 +196,8 @@ To trace an LLM span, use `LLMObs.llm()` as a context manager.
 <br/>The name of the invoked LLM.
 
 `name`
-: optional - _string_ - **default**: `"llm"`
-<br/>The name of the operation.
+: optional - _string_
+<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
 
 `model_provider`
 : optional - _string_ - **default**: `"custom"`
@@ -213,23 +213,23 @@ To trace an LLM span, use `LLMObs.llm()` as a context manager.
 #### Example
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import llm
 
+@llm(model_name="claude", name="invoke_llm", model_provider="anthropic")
 def llm_call():
-    with LLMObs.llm(name="invoke_llm", model_name="claude", model_provider="anthropic") as llm_span:
-        completion = ... # user application logic to invoke LLM
+    completion = ... # user application logic to invoke LLM
     return completion
 {{< /code-block >}}
 
 ### Tool span
 
-To trace a tool span, use `LLMObs.tool()` as a context manager.
+To trace a tool span, use the function decorator `ddtrace.llmobs.decorators.tool()`.
 
 #### Arguments
 
 `name`
-: optional - _string_ - **default**: `"tool"`
-<br/>The name of the operation.
+: optional - _string_
+<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -242,17 +242,17 @@ To trace a tool span, use `LLMObs.tool()` as a context manager.
 #### Example
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import tool
 
+@tool(name="get_current_weather")
 def call_weather_api():
-    with LLMObs.tool(name="get_current_weather") as tool_span:
-        ... # user application logic
+    ... # user application logic
     return 
 {{< /code-block >}}
 
 ### Embedding span
 
-To trace an embedding span, use `LLMObs.embedding()` as a context manager.
+To trace an embedding span, use the function decorator `LLMObs.embedding()`.
 
 **Note**: Annotating an embedding span's input requires different formatting than other span types. See [Annotating a span](#annotating-a-span) for more details on how to specify embedding inputs.
 
@@ -263,8 +263,8 @@ To trace an embedding span, use `LLMObs.embedding()` as a context manager.
 <br/>The name of the invoked LLM.
 
 `name`
-: optional - _string_ - **default**: `"embedding"`
-<br/>The name of the operation.
+: optional - _string_
+<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
 
 `model_provider`
 : optional - _string_ - **default**: `"custom"`
@@ -280,25 +280,25 @@ To trace an embedding span, use `LLMObs.embedding()` as a context manager.
 #### Example
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import embedding
 
+@embedding(model_name="text-embedding-3", name="openai_embedding")
 def perform_embedding():
-    with LLMObs.embedding(model_name="text-embedding-3", name="openai_embedding") as embedding_span:
-        ... # user application logic
+    ... # user application logic
     return 
 {{< /code-block >}}
 
 ### Retrieval span
 
-To trace a retrieval span, use `LLMObs.retrieval()` as a context manager.
+To trace a retrieval span, use the function decorator `ddtrace.llmobs.decorators.retrieval()`.
 
 **Note**: Annotating a retrieval span's output requires different formatting than other span types. See [Annotating a span](#annotating-a-span) for more details on how to specify retrieval outputs.
 
 #### Arguments
 
 `name`
-: optional - _string_ - **default**: `"retrieval"`
-<br/>The name of the operation.
+: optional - _string_
+<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -311,23 +311,23 @@ To trace a retrieval span, use `LLMObs.retrieval()` as a context manager.
 #### Example
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import retrieval
 
+@retrieval(name="get_relevant_docs")
 def similarity_search():
-    with LLMObs.retrieval(name="get_relevant_docs") as retrieval_span:
-        ... # user application logic
+    ... # user application logic
     return 
 {{< /code-block >}}
 
 ### Task span
 
-To trace a task span, use `LLMObs.task()` as a context manager.
+To trace a task span, use the function decorator `LLMObs.task()`.
 
 #### Arguments
 
 `name`
-: optional - _string_ - **default**: `"task"`
-<br/>The name of the operation.
+: optional - _string_
+<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -340,11 +340,11 @@ To trace a task span, use `LLMObs.task()` as a context manager.
 #### Example
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import task
 
+@task(name="sanitize_input")
 def sanitize_input():
-    with LLMObs.task(name="sanitize_input") as task_span:
-        ... # user application logic
+    ... # user application logic
     return 
 {{< /code-block >}}
 
@@ -353,11 +353,11 @@ def sanitize_input():
 Session tracking allows you to associate multiple interactions with a given user. When starting a root span for a new trace or span in a new process, specify the `session_id` argument with the string ID of the underlying user session:
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import workflow
 
+@workflow(name="process_message", session_id="<SESSION_ID>")
 def process_message():
-    with LLMObs.workflow(name="process_message", session_id="<SESSION_ID>") as workflow_span:
-        ... # user application logic
+    ... # user application logic
     return 
 {{< /code-block >}}
 
@@ -397,19 +397,19 @@ The `LLMObs.annotate()` method accepts the following arguments:
 
 {{< code-block lang="python" >}}
 from ddtrace.llmobs import LLMObs
-from ddtrace.llmobs.decorators import workflow
+from ddtrace.llmobs.decorators import embedding, llm, retrieval, workflow
 
+@llm(name="llm_call", model="model_name", model_provider="model_provider")
 def llm_call(prompt):
-    with LLMObs.llm(name="llm_call", model="model_name", model_provider="model_provider") as llm_span:
-        resp = ... # llm call here
-        LLMObs.annotate(
-            span=llm_span,
-            input_data=[{"role": "user", "content": "Hello world!"}],
-            output_data=[{"role": "assistant", "content": "How can I help?"}],
-            metadata={"temperature": 0, "max_tokens": 200},
-            metrics={"input_tokens": 4, "output_tokens": 6, "total_tokens": 10},
-            tags={"host": "host_name"},
-        )
+    resp = ... # llm call here
+    LLMObs.annotate(
+        span=None,
+        input_data=[{"role": "user", "content": "Hello world!"}],
+        output_data=[{"role": "assistant", "content": "How can I help?"}],
+        metadata={"temperature": 0, "max_tokens": 200},
+        metrics={"input_tokens": 4, "output_tokens": 6, "total_tokens": 10},
+        tags={"host": "host_name"},
+    )
     return resp
 
 @workflow(name="process_message")
@@ -423,27 +423,27 @@ def process_message(prompt):
     )
     return resp
 
+@embedding(model_name="text-embedding-3", name="openai_embedding")
 def perform_embedding():
-    with LLMObs.embedding(model_name="text-embedding-3", name="openai_embedding") as embedding_span:
-        ... # user application logic
-        LLMObs.annotate(
-            span=embedding_span,
-            input_data={"text": "Hello world!"},
-            output_data=[0.0023064255, -0.009327292, ...],
-            metrics={"input_tokens": 4},
-            tags={"host": "host_name"},
-        )
+    ... # user application logic
+    LLMObs.annotate(
+        span=None,
+        input_data={"text": "Hello world!"},
+        output_data=[0.0023064255, -0.009327292, ...],
+        metrics={"input_tokens": 4},
+        tags={"host": "host_name"},
+    )
     return
 
+@retrieval(name="get_relevant_docs")
 def similarity_search():
-    with LLMObs.retrieval(name="get_relevant_docs") as retrieval_span:
-        ... # user application logic
-        LLMObs.annotate(
-            span=retrieval_span,
-            input_data="Hello world!",
-            output_data=[{"text": "Hello world is ...", "name": "Hello, World! program", "id": "document_id", "score": 0.9893}],
-            tags={"host": "host_name"},
-        )
+    ... # user application logic
+    LLMObs.annotate(
+        span=None,
+        input_data="Hello world!",
+        output_data=[{"text": "Hello world is ...", "name": "Hello, World! program", "id": "document_id", "score": 0.9893}],
+        tags={"host": "host_name"},
+    )
     return
 
 {{< /code-block >}}
@@ -475,6 +475,25 @@ The `LLMObs.submit_evaluation()` method accepts the following arguments:
 : required - _string or numeric type_
 <br />The value of the evaluation metric. Must be a string (for categorical `metric_type`) or integer/float (for numerical/score `metric_type`).
 
+### Example
+
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import llm
+
+@llm(model_name="claude", name="invoke_llm", model_provider="anthropic")
+def llm_call():
+    completion = ... # user application logic to invoke LLM
+    span_context = LLMObs.export_span(span=None)
+    LLMObs.submit_evaluation(
+        span_context,
+        label="sentiment",
+        metric_type="score",
+        value=10,
+    )
+    return completion
+{{< /code-block >}}
+
 ## LLM integrations
 
 The Python SDK includes out-of-the-box integrations to automatically trace and annotate the LLM calls for:
@@ -487,18 +506,18 @@ This means that you do not need to manually instrument your LLM calls with `LLMO
 
 ## Advanced tracing
 
-### Tracing spans using function decorators
+### Tracing spans using inline methods
 
-For each span kind, the `ddtrace.llmobs.decorators` module provides a corresponding function decorator to automatically trace the operation a given function entails. These function decorators have the same argument signature as their inline counterparts, with the addition that `name` will default to the name of the given function.
+For each span kind, the `ddtrace.llmobs.LLMObs` class provides a corresponding inline method to automatically trace the operation a given code block entails. These methods have the same argument signature as their function decorator counterparts, with the addition that `name` will default to the span kind (e.g. `llm`, `workflow` and so on) if not provided. These methods can be used as context managers to automatically finish the span once the enclosed code block is completed.
 
 #### Example
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs.decorators import workflow
+from ddtrace.llmobs import LLMObs
 
-@workflow(name="process_message", session_id="<SESSION_ID>", ml_app="<ML_APP>")
 def process_message():
-    ... # user application logic
+    with LLMObs.workflow(name="process_message", session_id="<SESSION_ID>", ml_app="<ML_APP>") as workflow_span:
+        ... # user application logic
     return
 {{< /code-block >}}
 
@@ -506,9 +525,9 @@ def process_message():
 
 To manually start and stop a span across different contexts or scopes:
 
-1. Start a span manually using the same methods (for example, the `LLMObs.workflow` method for a workflow span), but inline rather than as a context manager.
+1. Start a span manually using the same methods (for example, the `LLMObs.workflow` method for a workflow span), but as a plain function call rather than as a context manager.
 2. Pass the span object as an argument to other functions.
-3. Stop the span manually with the `span.finish()` method.
+3. Stop the span manually with the `span.finish()` method. **Note**: the span must be manually finished, otherwise it will not be submitted.
 
 #### Example
 
@@ -540,11 +559,11 @@ You can configure an environment variable `DD_LLMOBS_APP_NAME` to the name of yo
 To override this configuration and use a different LLM application name for a given root span, pass the `ml_app` argument with the string name of the underlying LLM application when starting a root span for a new trace or a span in a new process.
 
 {{< code-block lang="python">}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import workflow
 
+@workflow(name="process_message", ml_app="<NON_DEFAULT_LLM_APP_NAME>")
 def process_message():
-    with LLMObs.workflow(name="process_message", ml_app="<NON_DEFAULT_LLM_APP_NAME>") as workflow_span:
-        ... # user application logic
+    ... # user application logic
     return
 {{< /code-block >}}
 

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -44,15 +44,15 @@ DD_LLMOBS_APP_NAME=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 <br />Your Datadog API key.
 
 `DD_SITE`
-: required - _string_ 
+: required - _string_
 <br />The Datadog site to submit your LLM data. Your site is {{< region-param key="dd_site" code="true" >}}.
 
 `DD_LLMOBS_ENABLED`
-: required - _integer or string_ 
+: required - _integer or string_
 <br />Toggle to enable submitting data to LLM Observability. Should be set to `1` or `true`.
 
 `DD_LLMOBS_APP_NAME`
-: required - _string_ 
+: required - _string_
 <br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given root span, see [Tracing multiple applications](#tracing-multiple-applications).
 
 `DD_LLMOBS_NO_APM`
@@ -86,6 +86,14 @@ To trace an agent span, use `LLMObs.agent()` as a context manager.
 : optional - _string_ - **default**: `"agent"`
 <br/>The name of the operation.
 
+`session_id`
+: optional - _string_
+<br/>The ID of the underlying user session. See [Tracking user sessions](#tracking-user-sessions) for more information.
+
+`ml_app`
+: optional - _string_
+<br/>The name of the ML application that the operation belongs to. See [Tracing multiple applications](#tracing-multiple-applications) for more information.
+
 #### Example
 
 {{< code-block lang="python" >}}
@@ -94,7 +102,7 @@ from ddtrace.llmobs import LLMObs
 def run_agent():
     with LLMObs.agent(name="react_agent") as agent_span:
         ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Workflow span
@@ -107,6 +115,14 @@ To trace a workflow span, use `LLMObs.workflow()` as a context manager.
 : optional - _string_ - **default**: `"workflow"`
 <br/>The name of the operation.
 
+`session_id`
+: optional - _string_
+<br/>The ID of the underlying user session. See [Tracking user sessions](#tracking-user-sessions) for more information.
+
+`ml_app`
+: optional - _string_
+<br/>The name of the ML application that the operation belongs to. See [Tracing multiple applications](#tracing-multiple-applications) for more information.
+
 #### Example
 
 {{< code-block lang="python" >}}
@@ -115,7 +131,7 @@ from ddtrace.llmobs import LLMObs
 def process_message():
     with LLMObs.workflow(name="process_message") as workflow_span:
         ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### LLM span
@@ -141,6 +157,14 @@ To trace an LLM span, use `LLMObs.llm()` as a context manager.
 `model_provider`
 : optional - _string_ - **default**: `"custom"`
 
+`session_id`
+: optional - _string_
+<br/>The ID of the underlying user session. See [Tracking user sessions](#tracking-user-sessions) for more information.
+
+`ml_app`
+: optional - _string_
+<br/>The name of the ML application that the operation belongs to. See [Tracing multiple applications](#tracing-multiple-applications) for more information.
+
 #### Example
 
 {{< code-block lang="python" >}}
@@ -162,6 +186,14 @@ To trace a tool span, use `LLMObs.tool()` as a context manager.
 : optional - _string_ - **default**: `"tool"`
 <br/>The name of the operation.
 
+`session_id`
+: optional - _string_
+<br/>The ID of the underlying user session. See [Tracking user sessions](#tracking-user-sessions) for more information.
+
+`ml_app`
+: optional - _string_
+<br/>The name of the ML application that the operation belongs to. See [Tracing multiple applications](#tracing-multiple-applications) for more information.
+
 #### Example
 
 {{< code-block lang="python" >}}
@@ -170,7 +202,7 @@ from ddtrace.llmobs import LLMObs
 def call_weather_api():
     with LLMObs.tool(name="get_current_weather") as tool_span:
         ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Embedding span
@@ -179,9 +211,24 @@ To trace an embedding span, use `LLMObs.embedding()` as a context manager.
 
 #### Arguments
 
+`model_name`
+: required - _string_
+<br/>The name of the invoked LLM.
+
 `name`
-: optional - _string_ - **default**: `"embedding"`
+: optional - _string_ - **default**: `"llm"`
 <br/>The name of the operation.
+
+`model_provider`
+: optional - _string_ - **default**: `"custom"`
+
+`session_id`
+: optional - _string_
+<br/>The ID of the underlying user session. See [Tracking user sessions](#tracking-user-sessions) for more information.
+
+`ml_app`
+: optional - _string_
+<br/>The name of the ML application that the operation belongs to. See [Tracing multiple applications](#tracing-multiple-applications) for more information.
 
 #### Example
 
@@ -191,7 +238,7 @@ from ddtrace.llmobs import LLMObs
 def perform_embedding():
     with LLMObs.embedding(name="openai_embedding") as embedding_span:
         ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Retrieval span
@@ -204,6 +251,14 @@ To trace a retrieval span, use `LLMObs.retrieval()` as a context manager.
 : optional - _string_ - **default**: `"retrieval"`
 <br/>The name of the operation.
 
+`session_id`
+: optional - _string_
+<br/>The ID of the underlying user session. See [Tracking user sessions](#tracking-user-sessions) for more information.
+
+`ml_app`
+: optional - _string_
+<br/>The name of the ML application that the operation belongs to. See [Tracing multiple applications](#tracing-multiple-applications) for more information.
+
 #### Example
 
 {{< code-block lang="python" >}}
@@ -212,7 +267,7 @@ from ddtrace.llmobs import LLMObs
 def similarity_search():
     with LLMObs.retrieval(name="get_relevant_docs") as retrieval_span:
         ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Task span
@@ -225,6 +280,14 @@ To trace a task span, use `LLMObs.task()` as a context manager.
 : optional - _string_ - **default**: `"task"`
 <br/>The name of the operation.
 
+`session_id`
+: optional - _string_
+<br/>The ID of the underlying user session. See [Tracking user sessions](#tracking-user-sessions) for more information.
+
+`ml_app`
+: optional - _string_
+<br/>The name of the ML application that the operation belongs to. See [Tracing multiple applications](#tracing-multiple-applications) for more information.
+
 #### Example
 
 {{< code-block lang="python" >}}
@@ -233,12 +296,12 @@ from ddtrace.llmobs import LLMObs
 def sanitize_input():
     with LLMObs.task(name="sanitize_input") as task_span:
         ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ## Tracing spans using function decorators
 
-For each span kind, the `ddtrace.llmobs.decorators` module provides a corresponding function decorator to automatically trace the operation a given function entails. These function decorators can be used the same way as their inline counterparts.
+For each span kind, the `ddtrace.llmobs.decorators` module provides a corresponding function decorator to automatically trace the operation a given function entails. These function decorators have the same argument signature as their inline counterparts, with the addition that `name` will default to the name of the given function.
 
 ### Example
 
@@ -253,29 +316,29 @@ def process_message():
 
 ## Annotating a span
 
-The SDK provides the method `LLMObs.annotate()` to annotate spans with inputs, outputs, and metadata. 
+The SDK provides the method `LLMObs.annotate()` to annotate spans with inputs, outputs, and metadata.
 
 ### Arguments
 
 The `LLMObs.annotate()` method accepts the following arguments:
 
-`span` 
+`span`
 : optional - _Span_ - **default**: the current active span
 <br />The span to annotate. If `span` is not provided (as when using function decorators), the SDK annotates the current active span.
 
-`input_data` 
-: optional - _JSON serializable type or list of dictionaries_ 
-<br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{"role": "...", "content": "..."}` (for LLM spans).
+`input_data`
+: optional - _JSON serializable type or list of dictionaries_
+<br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{"role": "...", "content": "..."}` (for LLM spans).  **Note**: Embedding spans are a special case and require a string, dictionary, or a list of dictionaries with this format: `{"text": "...", "name": "...", "score": float, "id": "..."}`.
 
-`output_data` 
-: optional - _JSON serializable type or list of dictionaries_ 
-<br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{"role": "...", "content": "..."}` (for LLM spans). **Note**: Retrieval spans are a special case and require a list of dictionaries with this format: `{"text": "...", "name": "...", "score": float, "id": "..."}`.
+`output_data`
+: optional - _JSON serializable type or list of dictionaries_
+<br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{"role": "...", "content": "..."}` (for LLM spans). **Note**: Retrieval spans are a special case and require a string, dictionary, or a list of dictionaries with this format: `{"text": "...", "name": "...", "score": float, "id": "..."}`.
 
-`metadata` 
+`metadata`
 : optional - _dictionary_
 <br />A dictionary of JSON serializable key-value pairs that users can add as metadata information relevant to the input or output operation described by the span (`model_temperature`, `max_tokens`, `top_k`, and so on).
 
-`tags` 
+`tags`
 : optional - _dictionary_
 <br />A dictionary of JSON serializable key-value pairs that users can add as tags regarding the span's context (`session`, `environment`, `system`, `versioning`, and so on).
 
@@ -309,11 +372,38 @@ def process_message(prompt):
     return resp
 {{< /code-block >}}
 
+## Submitting custom evaluation metrics
+
+To submit evaluation metrics for a span to Datadog:
+
+1. Extract the span context from the given span by using `LLMObs.export_span(span)`. If `span` is not provided (as when using function decorators), the SDK will export the current active span.
+2. Use `LLMObs.submit_evaluation()` with the extracted span context and evaluation metric information.
+
+### Arguments
+
+The `LLMObs.submit_evaluation()` method accepts the following arguments:
+
+`span_context`
+: required - _dictionary_
+<br />The span context to correlate the evaluation metric to.
+
+`label`
+: required - _string_
+<br />The name of the evaluation metric.
+
+`metric_type`
+: required - _string_
+<br />The type of the evaluation metric. Must be one of "categorical", "numerical", and "score".
+
+`value`
+: required - _string or numeric type_
+<br />The value of the evaluation metric. Must be a string (for categorical `metric_type`) or integer/float (for numerical/score `metric_type`).
+
 ## Persisting a span across contexts
 
 To manually start and stop a span across different contexts or scopes:
 
-1. Start a span manually using the same methods (for example, the `LLMObs.workflow` method for a workflow span), but inline rather than as a context manager. 
+1. Start a span manually using the same methods (for example, the `LLMObs.workflow` method for a workflow span), but inline rather than as a context manager.
 2. Pass the span object as an argument to other functions.
 3. Stop the span manually with the `span.finish()` method.
 
@@ -323,7 +413,7 @@ To manually start and stop a span across different contexts or scopes:
 from ddtrace.llmobs import LLMObs
 
 def separate_task(workflow_span):
-    ... # user application logic 
+    ... # user application logic
     workflow_span.finish()
     return
 
@@ -344,7 +434,7 @@ from ddtrace.llmobs import LLMObs
 def process_message():
     with LLMObs.workflow(name="process_message", session_id="<SESSION_ID>") as workflow_span:
         ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 
@@ -366,7 +456,7 @@ from ddtrace.llmobs import LLMObs
 def process_message():
     with LLMObs.workflow(name="process_message", ml_app="<NON_DEFAULT_LLM_APP_NAME>") as workflow_span:
         ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 [1]: https://github.com/openai/openai-python

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -44,15 +44,15 @@ DD_LLMOBS_APP_NAME=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 <br />Your Datadog API key.
 
 `DD_SITE`
-: required - _string_
+: required - _string_ 
 <br />The Datadog site to submit your LLM data. Your site is {{< region-param key="dd_site" code="true" >}}.
 
 `DD_LLMOBS_ENABLED`
-: required - _integer or string_
+: required - _integer or string_ 
 <br />Toggle to enable submitting data to LLM Observability. Should be set to `1` or `true`.
 
 `DD_LLMOBS_APP_NAME`
-: required - _string_
+: required - _string_ 
 <br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given root span, see [Tracing multiple applications](#tracing-multiple-applications).
 
 `DD_LLMOBS_NO_APM`
@@ -102,7 +102,7 @@ from ddtrace.llmobs import LLMObs
 def run_agent():
     with LLMObs.agent(name="react_agent") as agent_span:
         ... # user application logic
-    return
+    return 
 {{< /code-block >}}
 
 ### Workflow span
@@ -131,7 +131,7 @@ from ddtrace.llmobs import LLMObs
 def process_message():
     with LLMObs.workflow(name="process_message") as workflow_span:
         ... # user application logic
-    return
+    return 
 {{< /code-block >}}
 
 ### LLM span
@@ -202,7 +202,7 @@ from ddtrace.llmobs import LLMObs
 def call_weather_api():
     with LLMObs.tool(name="get_current_weather") as tool_span:
         ... # user application logic
-    return
+    return 
 {{< /code-block >}}
 
 ### Embedding span
@@ -216,7 +216,7 @@ To trace an embedding span, use `LLMObs.embedding()` as a context manager.
 <br/>The name of the invoked LLM.
 
 `name`
-: optional - _string_ - **default**: `"llm"`
+: optional - _string_ - **default**: `"embedding"`
 <br/>The name of the operation.
 
 `model_provider`
@@ -238,7 +238,7 @@ from ddtrace.llmobs import LLMObs
 def perform_embedding():
     with LLMObs.embedding(name="openai_embedding") as embedding_span:
         ... # user application logic
-    return
+    return 
 {{< /code-block >}}
 
 ### Retrieval span
@@ -267,7 +267,7 @@ from ddtrace.llmobs import LLMObs
 def similarity_search():
     with LLMObs.retrieval(name="get_relevant_docs") as retrieval_span:
         ... # user application logic
-    return
+    return 
 {{< /code-block >}}
 
 ### Task span
@@ -296,7 +296,7 @@ from ddtrace.llmobs import LLMObs
 def sanitize_input():
     with LLMObs.task(name="sanitize_input") as task_span:
         ... # user application logic
-    return
+    return 
 {{< /code-block >}}
 
 ## Tracing spans using function decorators
@@ -316,25 +316,25 @@ def process_message():
 
 ## Annotating a span
 
-The SDK provides the method `LLMObs.annotate()` to annotate spans with inputs, outputs, and metadata.
+The SDK provides the method `LLMObs.annotate()` to annotate spans with inputs, outputs, and metadata. 
 
 ### Arguments
 
 The `LLMObs.annotate()` method accepts the following arguments:
 
-`span`
+`span` 
 : optional - _Span_ - **default**: the current active span
 <br />The span to annotate. If `span` is not provided (as when using function decorators), the SDK annotates the current active span.
 
-`input_data`
-: optional - _JSON serializable type or list of dictionaries_
+`input_data` 
+: optional - _JSON serializable type or list of dictionaries_ 
 <br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{"role": "...", "content": "..."}` (for LLM spans).  **Note**: Embedding spans are a special case and require a string, dictionary, or a list of dictionaries with this format: `{"text": "...", "name": "...", "score": float, "id": "..."}`.
 
-`output_data`
-: optional - _JSON serializable type or list of dictionaries_
+`output_data` 
+: optional - _JSON serializable type or list of dictionaries_ 
 <br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{"role": "...", "content": "..."}` (for LLM spans). **Note**: Retrieval spans are a special case and require a string, dictionary, or a list of dictionaries with this format: `{"text": "...", "name": "...", "score": float, "id": "..."}`.
 
-`metadata`
+`metadata` 
 : optional - _dictionary_
 <br />A dictionary of JSON serializable key-value pairs that users can add as metadata information relevant to the input or output operation described by the span (`model_temperature`, `max_tokens`, `top_k`, and so on).
 
@@ -403,7 +403,7 @@ The `LLMObs.submit_evaluation()` method accepts the following arguments:
 
 To manually start and stop a span across different contexts or scopes:
 
-1. Start a span manually using the same methods (for example, the `LLMObs.workflow` method for a workflow span), but inline rather than as a context manager.
+1. Start a span manually using the same methods (for example, the `LLMObs.workflow` method for a workflow span), but inline rather than as a context manager. 
 2. Pass the span object as an argument to other functions.
 3. Stop the span manually with the `span.finish()` method.
 
@@ -413,7 +413,7 @@ To manually start and stop a span across different contexts or scopes:
 from ddtrace.llmobs import LLMObs
 
 def separate_task(workflow_span):
-    ... # user application logic
+    ... # user application logic 
     workflow_span.finish()
     return
 
@@ -434,7 +434,7 @@ from ddtrace.llmobs import LLMObs
 def process_message():
     with LLMObs.workflow(name="process_message", session_id="<SESSION_ID>") as workflow_span:
         ... # user application logic
-    return
+    return 
 {{< /code-block >}}
 
 
@@ -456,7 +456,7 @@ from ddtrace.llmobs import LLMObs
 def process_message():
     with LLMObs.workflow(name="process_message", ml_app="<NON_DEFAULT_LLM_APP_NAME>") as workflow_span:
         ... # user application logic
-    return
+    return 
 {{< /code-block >}}
 
 [1]: https://github.com/openai/openai-python

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -28,7 +28,7 @@ pip install git+https://github.com/DataDog/dd-trace-py.git@main
 
 2. LLM Observability requires a Datadog API key (see [the instructions for creating an API key][7]).
 
-#### Command-line setup
+### Command-line setup
 
 Enable LLM Observability by running your application using the `ddtrace-run` command and specifying the required environment variables.
 
@@ -59,16 +59,16 @@ DD_LLMOBS_APP_NAME=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not a Datadog APM customer, in which case this should be set to `1` or `true`.
 
-#### In-code setup
+### In-code setup
 
-Enable LLM Observability programatically through the `LLMOBs.enable()` function instead of running with the `ddtrace-run` command. **Note**: This setup method will not work if used with `ddtrace-run`.
+Enable LLM Observability programatically through the `LLMOBs.enable()` function instead of running with the `ddtrace-run` command. **Note**: Do not use this setup method with the `ddtrace-run` command.
 
 {{< code-block lang="python" >}}
 from ddtrace.llmobs import LLMObs
 LLMObs.enable(
   ml_app="<YOUR_ML_APP_NAME>",
   dd_api_key="<YOUR_DATADOG_API_KEY>",
-  dd_site=“<YOUR_DATADOG_SITE>”,
+  dd_site="<YOUR_DATADOG_SITE>",
   dd_llmobs_no_apm=True,
   integrations=["langchain", "openai"],
 )

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -55,9 +55,9 @@ DD_LLMOBS_APP_NAME=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 : required - _string_ 
 <br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given root span, see [Tracing multiple applications](#tracing-multiple-applications).
 
-`DD_LLMOBS_NO_APM`
+`DD_LLMOBS_AGENTLESS_ENABLED`
 : optional - _integer or string_ - **default**: `false`
-<br />Only required if you are not a Datadog APM customer, in which case this should be set to `1` or `true`.
+<br />Only required if you are not using the Datadog agent, in which case this should be set to `1` or `true`.
 
 ### In-code setup
 
@@ -69,22 +69,22 @@ LLMObs.enable(
   ml_app="<YOUR_ML_APP_NAME>",
   api_key="<YOUR_DATADOG_API_KEY>",
   site="<YOUR_DATADOG_SITE>",
-  llmobs_no_apm=True,
+  agentless_enabled=True,
   integrations=["langchain", "openai"],
 )
 {{< /code-block >}}
 
 `ml_app`
 : optional - _string_
-<br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given trace, see [Tracing multiple applications](#tracing-multiple-applications). If not provided, this will default to the value of `DD_LLMOBS_ML_APP`.
+<br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given trace, see [Tracing multiple applications](#tracing-multiple-applications). If not provided, this will default to the value of `DD_LLMOBS_APP_NAME`.
 
 `integrations`
 : optional - _list_ 
 <br />A list of integration names to enable automatically tracing LLM calls for (example: `["openai", "langchain"]`). See [LLM integrations](#llm-integrations) for more information about Datadog's supported LLM integrations. **Note**: if not provided, all supported LLM integrations are enabled by default. To disable all integrations, pass in an empty list `[]`.
 
-`llmobs_no_apm`
+`agentless_enabled`
 : optional - _boolean_ 
-<br />Only required if you are not a Datadog APM customer, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires Datadog APM. If not provided, this defaults to the value of `DD_LLMOBS_NO_APM`.
+<br />Only required if you are not using the Datadog agent, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires the Datadog agent. If not provided, this defaults to the value of `DD_LLMOBS_AGENTLESS_ENABLED`.
 
 `site`
 : optional - _string_ 

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -14,7 +14,7 @@ LLM Observability is not available in the US1-FED site.
 
 The LLM Observability SDK for Python enhances the observability of your Python-based LLM applications. The SDK supports Python versions 3.7 and newer. For information about LLM Observability's integration support, see [LLM integrations](#llm-integrations).
 
-You can install and configure tracing of various operations such as workflows, tasks, and API calls with simple function decorators or context managers. You can also annotate these traces with metadata for deeper insights into the performance and behavior of your applications, supporting multiple LLM services or models from the same environment.
+You can install and configure tracing of various operations such as workflows, tasks, and API calls with function decorators or context managers. You can also annotate these traces with metadata for deeper insights into the performance and behavior of your applications, supporting multiple LLM services or models from the same environment.
 
 ## Setup
 
@@ -452,7 +452,7 @@ def similarity_search():
 
 To submit evaluation metrics for a span to Datadog:
 
-1. Extract the span context from the given span by using `LLMObs.export_span(span)`. If `span` is not provided (as when using function decorators), the SDK will export the current active span.
+1. Extract the span context from the given span by using `LLMObs.export_span(span)`. If `span` is not provided (as when using function decorators), the SDK exports the current active span.
 2. Use `LLMObs.submit_evaluation()` with the extracted span context and evaluation metric information.
 
 ### Arguments
@@ -502,13 +502,13 @@ The Python SDK includes out-of-the-box integrations to automatically trace and a
 - `bedrock` - AWS Bedrock Runtime (using [Boto3][2]/[Botocore][3]): supports all versions
 - `langchain` - LangChain LLM/Chat Models/Chains (using [LangChain][4]): supports all versions
 
-This means that you do not need to manually instrument your LLM calls with `LLMObs.llm()` as the SDK will capture them automatically.
+This means that you do not need to manually instrument your LLM calls with `LLMObs.llm()`, as the SDK captures them automatically.
 
 ## Advanced tracing
 
 ### Tracing spans using inline methods
 
-For each span kind, the `ddtrace.llmobs.LLMObs` class provides a corresponding inline method to automatically trace the operation a given code block entails. These methods have the same argument signature as their function decorator counterparts, with the addition that `name` will default to the span kind (e.g. `llm`, `workflow` and so on) if not provided. These methods can be used as context managers to automatically finish the span once the enclosed code block is completed.
+For each span kind, the `ddtrace.llmobs.LLMObs` class provides a corresponding inline method to automatically trace the operation a given code block entails. These methods have the same argument signature as their function decorator counterparts, with the addition that `name` defaults to the span kind (`llm`, `workflow`, and so on) if not provided. These methods can be used as context managers to automatically finish the span once the enclosed code block is completed.
 
 #### Example
 

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -80,27 +80,27 @@ LLMObs.enable(
 
 `integrations`
 : optional - _list_ 
-<br />A list of integration names to enable automatically tracing LLM calls for (e.g. `["openai", "langchain"]`). See [LLM integrations](#llm-integrations) for more information about Datadog's supported LLM integrations. **Note**: if not provided, all supported LLM integrations will be enabled by default. To disable all integrations, pass in an empty list `[]`.
+<br />A list of integration names to enable automatically tracing LLM calls for (example: `["openai", "langchain"]`). See [LLM integrations](#llm-integrations) for more information about Datadog's supported LLM integrations. **Note**: if not provided, all supported LLM integrations are enabled by default. To disable all integrations, pass in an empty list `[]`.
 
 `llmobs_no_apm`
 : optional - _boolean_ 
-<br />Only required if you are not a Datadog APM customer, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires Datadog APM. If not provided, this will default to the value of `DD_LLMOBS_NO_APM`.
+<br />Only required if you are not a Datadog APM customer, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires Datadog APM. If not provided, this defaults to the value of `DD_LLMOBS_NO_APM`.
 
 `site`
 : optional - _string_ 
-<br />The Datadog site to submit your LLM data. Your site is {{< region-param key="dd_site" code="true" >}}. If not provided, this will default to the value of `DD_SITE`.
+<br />The Datadog site to submit your LLM data. Your site is {{< region-param key="dd_site" code="true" >}}. If not provided, this defaults to the value of `DD_SITE`.
 
 `api_key`
 : optional - _string_ 
-<br />Your Datadog API key. If not provided, this will default to the value of `DD_API_KEY`.
+<br />Your Datadog API key. If not provided, this defaults to the value of `DD_API_KEY`.
 
 `env`
 : optional - _string_
-<br />The name of your application's environment (e.g. `prod`, `pre-prod`, `staging`). If not provided, this will default to the value of `DD_ENV`.
+<br />The name of your application's environment (examples: `prod`, `pre-prod`, `staging`). If not provided, this defaults to the value of `DD_ENV`.
 
 `service`
 : optional - _string_
-<br />The name of the service used for your application. If not provided, this will default to the value of `DD_SERVICE`.
+<br />The name of the service used for your application. If not provided, this defaults to the value of `DD_SERVICE`.
 
 #### Application naming guidelines
 
@@ -127,7 +127,7 @@ To trace an agent span, use the function decorator `ddtrace.llmobs.decorators.ag
 
 `name`
 : optional - _string_
-<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
+<br/>The name of the operation. If not provided, `name` defaults to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -156,7 +156,7 @@ To trace a workflow span, use the function decorator `ddtrace.llmobs.decorators.
 
 `name`
 : optional - _string_
-<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
+<br/>The name of the operation. If not provided, `name` defaults to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -197,7 +197,7 @@ To trace an LLM span, use the function decorator `ddtrace.llmobs.decorators.llm(
 
 `name`
 : optional - _string_
-<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
+<br/>The name of the operation. If not provided, `name` defaults to the name of the traced function.
 
 `model_provider`
 : optional - _string_ - **default**: `"custom"`
@@ -229,7 +229,7 @@ To trace a tool span, use the function decorator `ddtrace.llmobs.decorators.tool
 
 `name`
 : optional - _string_
-<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
+<br/>The name of the operation. If not provided, `name` defaults to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -298,7 +298,7 @@ To trace a retrieval span, use the function decorator `ddtrace.llmobs.decorators
 
 `name`
 : optional - _string_
-<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
+<br/>The name of the operation. If not provided, `name` defaults to the name of the traced function.
 
 `session_id`
 : optional - _string_
@@ -327,7 +327,7 @@ To trace a task span, use the function decorator `LLMObs.task()`.
 
 `name`
 : optional - _string_
-<br/>The name of the operation. If not provided, `name` will be set to the name of the traced function.
+<br/>The name of the operation. If not provided, `name` defaults to the name of the traced function.
 
 `session_id`
 : optional - _string_

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -57,7 +57,7 @@ DD_LLMOBS_APP_NAME=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 
 `DD_LLMOBS_AGENTLESS_ENABLED`
 : optional - _integer or string_ - **default**: `false`
-<br />Only required if you are not using the Datadog agent, in which case this should be set to `1` or `true`.
+<br />Only required if you are not using the Datadog Agent, in which case this should be set to `1` or `true`.
 
 ### In-code setup
 
@@ -84,7 +84,7 @@ LLMObs.enable(
 
 `agentless_enabled`
 : optional - _boolean_ 
-<br />Only required if you are not using the Datadog agent, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires the Datadog agent. If not provided, this defaults to the value of `DD_LLMOBS_AGENTLESS_ENABLED`.
+<br />Only required if you are not using the Datadog Agent, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires the Datadog Agent. If not provided, this defaults to the value of `DD_LLMOBS_AGENTLESS_ENABLED`.
 
 `site`
 : optional - _string_ 

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -171,7 +171,7 @@ To trace a workflow span, use the function decorator `ddtrace.llmobs.decorators.
 {{< code-block lang="python" >}}
 from ddtrace.llmobs.decorators import workflow
 
-@workflow(name="process_message")
+@workflow
 def process_message():
     ... # user application logic
     return 
@@ -282,7 +282,7 @@ To trace an embedding span, use the function decorator `LLMObs.embedding()`.
 {{< code-block lang="python" >}}
 from ddtrace.llmobs.decorators import embedding
 
-@embedding(model_name="text-embedding-3", name="openai_embedding")
+@embedding(model_name="text-embedding-3", model_provider="openai")
 def perform_embedding():
     ... # user application logic
     return 
@@ -342,7 +342,7 @@ To trace a task span, use the function decorator `LLMObs.task()`.
 {{< code-block lang="python" >}}
 from ddtrace.llmobs.decorators import task
 
-@task(name="sanitize_input")
+@task
 def sanitize_input():
     ... # user application logic
     return 
@@ -355,7 +355,7 @@ Session tracking allows you to associate multiple interactions with a given user
 {{< code-block lang="python" >}}
 from ddtrace.llmobs.decorators import workflow
 
-@workflow(name="process_message", session_id="<SESSION_ID>")
+@workflow(session_id="<SESSION_ID>")
 def process_message():
     ... # user application logic
     return 
@@ -399,7 +399,7 @@ The `LLMObs.annotate()` method accepts the following arguments:
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs.decorators import embedding, llm, retrieval, workflow
 
-@llm(name="llm_call", model="model_name", model_provider="model_provider")
+@llm(model="model_name", model_provider="model_provider")
 def llm_call(prompt):
     resp = ... # llm call here
     LLMObs.annotate(
@@ -412,7 +412,7 @@ def llm_call(prompt):
     )
     return resp
 
-@workflow(name="process_message")
+@workflow
 def process_message(prompt):
     resp = llm_call_inline(prompt)
     LLMObs.annotate(
@@ -423,7 +423,7 @@ def process_message(prompt):
     )
     return resp
 
-@embedding(model_name="text-embedding-3", name="openai_embedding")
+@embedding(model_name="text-embedding-3", model_provider="openai")
 def perform_embedding():
     ... # user application logic
     LLMObs.annotate(

--- a/content/en/tracing/llm_observability/trace_an_llm_application.md
+++ b/content/en/tracing/llm_observability/trace_an_llm_application.md
@@ -43,7 +43,7 @@ To trace an LLM application:
 1. In your code, use the SDK to create spans representing your application's tasks.
     - See the span creation example below.
     - For additional examples and detailed usage, see the [Quickstart][10] and the [SDK documentation for tracing spans][11]. 
-1. [Annotate your spans][7] with input data, output data, metadata (such as `max_tokens`), and key-value tags (such as `version:1.0.0`).
+1. [Annotate your spans][7] with input data, output data, metadata (such as `temperature`), metrics (such as `input_tokens`), and key-value tags (such as `version:1.0.0`).
 1. Explore the resulting traces on the [LLM Observability traces page][2], and the resulting metrics on the out-of-the-box [LLM Observability dashboard][14].
 
 Optionally, you can also:
@@ -51,7 +51,7 @@ Optionally, you can also:
 - Associate multiple interactions with one user by specifying a `session_id`. See [Tracking user sessions][6] in the SDK documentation.
 - [Persist a span between contexts or scopes][8] by manually starting and stopping it.
 - [Override the name of the LLM application with a different name][9] when starting a root span, which can be useful for differentiating between services or running an experiment.
-- Submit feedback from the users of your LLM application (thumbs up/thumbs down, rating from 1 to 5, and so on) as custom evaluation metrics via the [API][15]. This allows you to visualize the feedback evaluation metrics in your traces and also in the [cluster map view][16], where you can monitor any patterns in different topics of your LLM applications against these metrics.
+- Submit feedback from the users of your LLM application (thumbs up/thumbs down, rating from 1 to 5, and so on) as custom evaluation metrics via the [SDK][15] or the [API][16]. This allows you to visualize the feedback evaluation metrics in your traces and also in the [cluster map view][17], where you can monitor any patterns in different topics of your LLM applications against these metrics.
 
 ### Span creation example
 
@@ -82,6 +82,6 @@ def process_message():
 [12]: /tracing/llm_observability/sdk
 [13]: /tracing/llm_observability/api
 [14]: https://app.datadoghq.com/dash/integration/llm_analytics
-[15]: /tracing/llm_observability/api/?tab=model#eval-metrics-api
-[16]: https://app.datadoghq.com/llm/clusters
-[17]: /tracing/llm_observability/sdk/#in-code-setup
+[15]: /tracing/llm_observability/sdk/#submitting-evaluation-metrics
+[16]: /tracing/llm_observability/api/?tab=model#eval-metrics-api
+[17]: https://app.datadoghq.com/llm/clusters

--- a/content/en/tracing/llm_observability/trace_an_llm_application.md
+++ b/content/en/tracing/llm_observability/trace_an_llm_application.md
@@ -39,9 +39,7 @@ Different span kinds also have different parent-child relationships. For details
 To trace an LLM application:
 
 1. [Install the LLM Observability SDK][1].
-1. Configure the SDK by doing one of the following:
-    - Add [setup code to your application][17] that provides the name of your application, your Datadog API key, and so on.
-    - [Start your application using `ddtrace-run`][5], providing the required environment variables.
+1. Configure the SDK by providing [the required environment variables][5] in your application startup command.
 1. In your code, use the SDK to create spans representing your application's tasks.
     - See the span creation example below.
     - For additional examples and detailed usage, see the [Quickstart][10] and the [SDK documentation for tracing spans][11]. 

--- a/content/en/tracing/llm_observability/trace_an_llm_application.md
+++ b/content/en/tracing/llm_observability/trace_an_llm_application.md
@@ -55,18 +55,20 @@ Optionally, you can also:
 
 ### Span creation example
 
-To create a span, use the LLM Observability SDK's `LLMObs.<SPAN_KIND>()` as a context manager, replacing `<SPAN_KIND>` with the desired [span kind][4]. 
+To create a span, use the LLM Observability SDK's `llmobs.decorators.<SPAN_KIND>()` as a function decorator, replacing `<SPAN_KIND>` with the desired [span kind][4].
 
 The example below creates a workflow span:
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
+from ddtrace.llmobs.decorators import workflow
 
+@workflow(name="process_message")
 def process_message():
-    with LLMObs.workflow(name="process_message") as workflow_span:
-        ... # user application logic
+    ... # user application logic
     return
 {{< /code-block >}}
+
+For more information on alternative tracing methods and tracing features, see the [SDK documentation][12].
 
 [1]: /tracing/llm_observability/sdk/#installation
 [2]: https://app.datadoghq.com/llm/traces


### PR DESCRIPTION
This PR adds the following details to the SDK documentation:
- Reorganize sections (key features and setup are top level, rest are in `Advanced tracing`)
- Introduce tracing using function decorators instead of context managers, move context/inline methods into `Advanced tracing`
- Instructions for submitting custom eval metrics using SDK
- Embedding documentation adds model_name/model_provider args
- Span starting documentation adds session_id/ml_app args
- Decorator documentation adds detail about name arg
- Annotation documentation adds detail about input_data arg for embedding spans, output_data arg for retrieval spans
- In-code configuration documentation for `LLMObs.enable()`

In addition, this makes a change to some other LLM Observability pages:
- API documentation to rename `Eval metrics API` subsection title to `Evaluation metrics API`.
- Quickstart adds notes/links to datadog integrations and SDK documentation
- Index page makes an edit to a subsection sentence to add more detail. 

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->