### PR TITLE
Update FIPS proxy version to 1.1.2

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -237,7 +237,7 @@ To send data to Datadog's GOVCLOUD datacenter, add the `fips-proxy` sidecar cont
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:1.1.1",
+            "image": "datadog/fips-proxy:1.1.2",
             "portMappings": [
                 {
                     "containerPort": 9803,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Bump latest FIPS Proxy version in the ECS documenation

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

https://docs-staging.datadoghq.com/nicolas.guerguadj/ecs-fips-1.1.2/containers/amazon_ecs/?tab=awscli&site=gov#fips-proxy-for-govcloud-environments

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->