### PR TITLE
fix yaml formatting issue in Data Jobs Monitoring

### DIFF
--- a/content/en/data_jobs/kubernetes.md
+++ b/content/en/data_jobs/kubernetes.md
@@ -55,7 +55,7 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
    spec:
      features:
        apm:
-       enabled: true
+         enabled: true
        hostPortConfig:
          enabled: true
          hostPort: 8126


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fix incorrect yaml indention where `spec.apm.enabled` is incorrectly formatted.
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->