### PR TITLE
DOCS-7919 - Rename CoTerm

### DIFF
--- a/content/en/coscreen/_index.md
+++ b/content/en/coscreen/_index.md
@@ -83,27 +83,21 @@ Screen sharing is deactivated by default when you join a CoScreen.
 
 You can see the mouse pointers of remote participants whenever they move their pointers over a shared window. When viewing a remote window, two tabs appear: **Control**, which enables you to interact with the window, click on buttons, and type into text fields; and **Draw**, which enables you to draw on the window.
 
-### Collaborate in CoTerm, a shared terminal
+### Collaborate in a shared terminal
 
-CoTerm is a collaborative terminal built into CoScreen that enables users to run commands and to write and debug code together.
+CoScreen includes a shared, collaborative terminal that enables users to run commands and to write and debug code together.
 
-To start shared terminal, click on the **Share terminal** button in the meeting menu:
+To start a shared terminal, click on the **Share terminal** button in the meeting menu:
 
 {{< img src="coscreen/share_terminal.png" alt="A panel of buttons from the CoScreen desktop UI. The 'Share terminal' button is highlighted." style="width:70%;">}}
 
-Then, confirm the onboarding dialog:
-
-{{< img src="coscreen/coterm_dialog.png" alt="The CoTerm onboarding dialog, with an option to allow remote control selected." style="width:50%;">}}
-
 The shared terminal appears for you and all other participants in the CoScreen session. If you enable remote control in CoScreen, other users can type and click into your terminal.
 
-{{< img src="coscreen/coterm.png" alt="A CoTerm window." style="width:60%;">}}
+{{< img src="coscreen/coterm.png" alt="A shared CoScreen terminal window." style="width:60%;">}}
 
 To stop sharing, click the **Unshare** tab on the terminal window, or on the button in the meeting menu. 
 
-For privacy, CoTerm uses [Sensitive Data Scanner][8] and entropy filters to detect and obfuscate sensitive data.
-
-**Note**: Unsharing closes the terminal.
+For privacy, CoScreen uses [Sensitive Data Scanner][8] and entropy filters to detect and obfuscate sensitive data.
 
 ### Integrations
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
CoScreen's shared terminal is no longer called CoTerm. Changing docs to give it a generic name, "shared terminal" or "collaborative terminal". Removing screenshot of onboarding dialog that no longer appears. Also removing the note that the terminal closes when unshared, which is also no longer true.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->