### PR TITLE
Add SSI Uninstall Steps to Agent Pages

### DIFF
--- a/content/en/agent/basic_agent_usage/amazonlinux.md
+++ b/content/en/agent/basic_agent_usage/amazonlinux.md
@@ -166,6 +166,8 @@ sudo userdel dd-agent \
 {{% /tab %}}
 {{< /tabs >}}
 
+{{% apm-ssi-uninstall-linux %}}
+
 ## Troubleshooting
 
 See the [Agent Troubleshooting documentation][2].

--- a/content/en/agent/basic_agent_usage/centos.md
+++ b/content/en/agent/basic_agent_usage/centos.md
@@ -167,6 +167,8 @@ sudo userdel dd-agent \
 {{% /tab %}}
 {{< /tabs >}}
 
+{{% apm-ssi-uninstall-linux %}}
+
 ## Troubleshooting
 
 See the [Agent Troubleshooting documentation][2].

--- a/content/en/agent/basic_agent_usage/deb.md
+++ b/content/en/agent/basic_agent_usage/deb.md
@@ -148,6 +148,8 @@ sudo apt-get --purge remove datadog-agent -y
 {{% /tab %}}
 {{< /tabs >}}
 
+{{% apm-ssi-uninstall-linux %}}
+
 ## Troubleshooting
 
 See the [Agent Troubleshooting documentation][3].

--- a/content/en/agent/basic_agent_usage/fedora.md
+++ b/content/en/agent/basic_agent_usage/fedora.md
@@ -151,6 +151,8 @@ sudo userdel dd-agent \
 {{% /tab %}}
 {{< /tabs >}}
 
+{{% apm-ssi-uninstall-linux %}}
+
 ## Troubleshooting
 
 See the [Agent Troubleshooting documentation][2].

--- a/content/en/agent/basic_agent_usage/redhat.md
+++ b/content/en/agent/basic_agent_usage/redhat.md
@@ -174,6 +174,8 @@ sudo userdel dd-agent \
 {{% /tab %}}
 {{< /tabs >}}
 
+{{% apm-ssi-uninstall-linux %}}
+
 ## Troubleshooting
 
 See the [Agent Troubleshooting documentation][2].

--- a/content/en/agent/basic_agent_usage/ubuntu.md
+++ b/content/en/agent/basic_agent_usage/ubuntu.md
@@ -143,6 +143,7 @@ sudo apt-get --purge remove datadog-agent -y
 {{% /tab %}}
 {{< /tabs >}}
 
+{{% apm-ssi-uninstall-linux %}}
 
 ## Troubleshooting
 

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -283,7 +283,7 @@ Returns `CRITICAL` if an Agent check is unable to send metrics to Datadog, other
 
 ## Uninstall Single Step APM Instrumentation
 
-If you would like to uninstall the Datadog Docker Agent and originally installed it with Single Step APM Instrumentation, you need to [run additional commands to uninstall Single Step Instrumentation][33].
+If you installed the Datadog Docker Agent using Single Step APM Instrumentation and now want to uninstall the Agent, you need to [run additional commands][33].
 
 ## Further Reading
 

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -281,6 +281,10 @@ Returns `CRITICAL` if the Agent is unable to connect to Datadog, otherwise retur
 **datadog.agent.check_status**: <br>
 Returns `CRITICAL` if an Agent check is unable to send metrics to Datadog, otherwise returns `OK`.
 
+## Uninstall Single Step APM Instrumentation
+
+If you would like to uninstall the Datadog Docker Agent and originally installed it with Single Step APM Instrumentation, you need to [run additional commands to uninstall Single Step Instrumentation][33].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -317,3 +321,4 @@ Returns `CRITICAL` if an Agent check is unable to send metrics to Datadog, other
 [30]: /agent/docker/data_collected/#metrics
 [31]: /integrations/network/#metrics
 [32]: /integrations/ntp/#metrics
+[33]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=docker#removing-apm-for-all-services-on-the-infrastructure

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -283,7 +283,7 @@ Returns `CRITICAL` if an Agent check is unable to send metrics to Datadog, other
 
 ## Uninstall Single Step APM Instrumentation
 
-If you used Single Step APM Instrumentation to install the Datadog Docker Agent, and you want to uninstall the Agent, you need to [run additional commands][33] to uninstall Single Step Instrumentation.
+If you installed the Datadog Docker Agent with Single Step APM Instrumentation, and you want to uninstall the Agent, you need to [run additional commands][33] to uninstall APM Instrumentation.
 
 ## Further Reading
 

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -283,7 +283,7 @@ Returns `CRITICAL` if an Agent check is unable to send metrics to Datadog, other
 
 ## Uninstall Single Step APM Instrumentation
 
-If you installed the Datadog Docker Agent using Single Step APM Instrumentation and now want to uninstall the Agent, you need to [run additional commands][33].
+If you used Single Step APM Instrumentation to install the Datadog Docker Agent, and you want to uninstall the Agent, you need to [run additional commands][33] to uninstall Single Step Instrumentation.
 
 ## Further Reading
 

--- a/layouts/shortcodes/apm-ssi-uninstall-linux.md
+++ b/layouts/shortcodes/apm-ssi-uninstall-linux.md
@@ -1,4 +1,4 @@
-## Uninstall Single Step APM Instrumentation
+### Uninstall Single Step APM Instrumentation
 
 If you installed the Agent with Single Step APM Instrumentation, you need to [run additional commands][1] to uninstall Single Step Instrumentation.
 

--- a/layouts/shortcodes/apm-ssi-uninstall-linux.md
+++ b/layouts/shortcodes/apm-ssi-uninstall-linux.md
@@ -1,0 +1,5 @@
+## Uninstall Single Step APM Instrumentation
+
+If you installed the Agent with Single Step APM Instrumentation, you need to [run additional commands][1].
+
+[1]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=linuxhostorvm#removing-apm-for-all-services-on-the-infrastructure

--- a/layouts/shortcodes/apm-ssi-uninstall-linux.md
+++ b/layouts/shortcodes/apm-ssi-uninstall-linux.md
@@ -1,5 +1,5 @@
 ## Uninstall Single Step APM Instrumentation
 
-If you installed the Agent with Single Step APM Instrumentation, you need to [run additional commands][1].
+If you installed the Agent with Single Step APM Instrumentation, you need to [run additional commands][1] to uninstall Single Step Instrumentation.
 
 [1]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=linuxhostorvm#removing-apm-for-all-services-on-the-infrastructure


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/DOCS-7937
Per this JIRA ticket ^^, adding instructions for uninstalling Single Step Instrumentation (if user installed Agent via SSI and then uninstalls the Agent, they need to perform additional steps to uninstall SSI as well). Using shortcode for Linux pages since there are a handful of them. Added section to Docker page. Cecelia mentioned she would create a ticket to add an "Uninstall Agent" section to this page. For now, just added the "Uninstall SSI" section. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->