### PR TITLE
Fix Installation Steps for the VMWare Tanzu Application Monitoring Tile

### DIFF
--- a/content/en/integrations/guide/application-monitoring-vmware-tanzu.md
+++ b/content/en/integrations/guide/application-monitoring-vmware-tanzu.md
@@ -51,9 +51,8 @@ Datadog Application Monitoring for VMware Tanzu has the following requirements:
 2. Go to the Tanzu Ops Manager Installation Dashboard and click **Import a Product** to upload the product file.
 3. Select the product file downloaded in step **1**. This adds the tile to your staging area.
 4. Click the newly added **Datadog Application Monitoring for VMware Tanzu** tile.
-5. Enter your [Datadog API key][3] in the **Datadog Config** section.
-6. Click **Save**.
-7. Return to the Tanzu Ops Manager Installation Dashboard, and click **Apply changes** to install the Datadog Application Monitoring for the VMware Tanzu tile.
+5. Click **Save**.
+6. Return to the Tanzu Ops Manager Installation Dashboard, and click **Apply changes** to install the Datadog Application Monitoring for the VMware Tanzu tile.
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Removes Step number 5 from the installation steps of the Application Monitoring Tile.
This step is only valid for the cluster monitoring tile, for the application monitoring tile the Datadog API Key is injected for each application independently either via their application manifest, env variable, etc..

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->