### PR TITLE
[DOCS-7981] Add Datadog Agent source to log volume control

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -3910,21 +3910,26 @@ menu:
       parent: observability_pipelines
       identifier: observability_pipelines_log_volume_control
       weight: 2
+    - name: Datadog Agent
+      url: observability_pipelines/log_volume_control/datadog_agent/
+      parent: observability_pipelines_log_volume_control
+      identifier: observability_pipelines_log_volume_control_datadog_agent
+      weight: 2001
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/log_volume_control/splunk_hec/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_splunk_hec
-      weight: 2001
+      weight: 2002
     - name: Splunk Forwarders (TCP)
       url: observability_pipelines/log_volume_control/splunk_tcp/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_splunk_tcp
-      weight: 2002
+      weight: 2003
     - name: Sumo Logic Hosted Collector
       url: observability_pipelines/log_volume_control/sumo_logic_hosted_collector/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_sumo_logic_hosted_collector
-      weight: 2003
+      weight: 2004
     - name: Dual Ship Logs
       url: observability_pipelines/dual_ship_logs/
       parent: observability_pipelines

--- a/content/en/observability_pipelines/log_volume_control/_index.md
+++ b/content/en/observability_pipelines/log_volume_control/_index.md
@@ -18,6 +18,7 @@ As your infrastructure and applications grow, so does your log volume and the co
 
 Select a log source to get started:
 
+- [Datadog Agent][4]
 - [Splunk HTTP Event Collector (HEC)][1]
 - [Splunk Heavy and Universal Forwarders (TCP)][2]
 - [Sumo Logic Hosted Collector][3]
@@ -25,3 +26,4 @@ Select a log source to get started:
 [1]: /observability_pipelines/log_volume_control/splunk_hec
 [2]: /observability_pipelines/log_volume_control/splunk_tcp
 [3]: /observability_pipelines/log_volume_control/sumo_logic_hosted_collector
+[4]: /observability_pipelines/log_volume_control/datadog_agent

--- a/content/en/observability_pipelines/log_volume_control/_index.md
+++ b/content/en/observability_pipelines/log_volume_control/_index.md
@@ -14,8 +14,6 @@ As your infrastructure and applications grow, so does your log volume and the co
 - **Dedupe**: Drop duplicate copies of your logs, for example, due to retries because of network issues.
 - **Remap**: Add, drop, or rename a field in your logs.
 
-{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for the split logs use case" width="100%" >}}
-
 Select a log source to get started:
 
 - [Datadog Agent][4]

--- a/content/en/observability_pipelines/log_volume_control/datadog_agent.md
+++ b/content/en/observability_pipelines/log_volume_control/datadog_agent.md
@@ -8,8 +8,6 @@ disable_toc: false
 
 Set up the Observability Pipelines Worker with the Datadog Agent source so that you route only useful logs to your destinations.
 
-{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for this use case" width="100%" >}}
-
 This document walks you through the following steps:
 1. The [prerequisites](#prerequisites) needed to set up Observability Pipelines
 1. [Setting up Observability Pipelines](#set-up-observability-pipelines)

--- a/content/en/observability_pipelines/log_volume_control/datadog_agent.md
+++ b/content/en/observability_pipelines/log_volume_control/datadog_agent.md
@@ -1,34 +1,57 @@
 ---
-title: Log Volume Control for the Sumo Logic Hosted Collector HTTP Logs Source
+title: Log Volume Control for the Datadog Agent
 kind: document
 disable_toc: false
 ---
 
 ## Overview
 
-This document walks you through the following steps to set up the Observability Pipelines Worker with the Sumo Logic Hosted Collector HTTP Logs source so that you only route useful logs to your destinations:
-
-1. The [prerequisites](#prerequisites) needed to set up Observability Pipelines
-1. [Setting up Observability Pipelines](#set-up-observability-pipelines)
-1. [Sending logs to the Observability Pipelines Worker over Sumo Logic HTTP Source](#send-logs-to-the-observability-pipelines-worker-over-sumo-logic-http-source)
+Set up the Observability Pipelines Worker with the Datadog Agent source so that you route only useful logs to your destinations.
 
 {{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for this use case" width="100%" >}}
 
+This document walks you through the following steps:
+1. The [prerequisites](#prerequisites) needed to set up Observability Pipelines
+1. [Setting up Observability Pipelines](#set-up-observability-pipelines)
+1. [Connecting the Datadog Agent to the Observability Pipelines Worker](#connect-the-datadog-agent-to-the-observability-pipelines-worker)
+
 ## Prerequisites
 
+{{% observability_pipelines/prerequisites/datadog_agent %}}
+
+{{< tabs >}}
+{{% tab "Splunk HEC" %}}
+
+{{% observability_pipelines/prerequisites/splunk_hec %}}
+
+{{% /tab %}}
+{{% tab "Sumo Logic" %}}
+
 {{% observability_pipelines/prerequisites/sumo_logic %}}
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Set up Observability Pipelines
 
 1. Navigate to [Observability Pipelines][1].
 1. Select the **Log Volume Control** template to create a new pipeline.
-1. Select **Sumo Logic** as the source.
+1. Select **Datadog Agent** as the source.
 
-### Set up the destination
+### Set up the source
+
+{{% observability_pipelines/source_settings/datadog_agent %}}
+
+### Set up the destinations
 
 Enter the following information based on your selected logs destination.
 
 {{< tabs >}}
+{{% tab "Datadog" %}}
+
+{{% observability_pipelines/destination_settings/datadog %}}
+
+{{% /tab %}}
 {{% tab "Splunk HEC" %}}
 
 {{% observability_pipelines/destination_settings/splunk_hec %}}
@@ -79,9 +102,14 @@ Enter the following information based on your selected logs destination.
 
 ### Install the Observability Pipelines Worker
 1. Select your platform in the **Choose your installation platform** dropdown menu.
-1. Enter the Sumo Logic address. This is the address and port where your applications are sending their logging data. The Observability Pipelines Worker listens to this address for incoming logs.
-1. Provide the environment variables for each of your selected destinations. See [prerequisites](#prerequisites) for more information.
+1. Enter the Datadog Agent address. This is the address and port where your Datadog Agent is sending its logging data. The Observability Pipelines Worker listens to this address for incoming logs.
+1. Provide the environment variables for each of your selected destinations.
 {{< tabs >}}
+{{% tab "Datadog" %}}
+
+{{% observability_pipelines/destination_env_vars/datadog %}}
+
+{{% /tab %}}
 {{% tab "Splunk HEC" %}}
 
 {{% observability_pipelines/destination_env_vars/splunk_hec %}}
@@ -132,6 +160,6 @@ Enter the following information based on your selected logs destination.
 {{% /tab %}}
 {{< /tabs >}}
 
-{{% observability_pipelines/log_source_configuration/sumo_logic %}}
+{{% observability_pipelines/log_source_configuration/datadog_agent %}}
 
 [1]: https://app.datadoghq.com/observability-pipelines

--- a/content/en/observability_pipelines/log_volume_control/splunk_hec.md
+++ b/content/en/observability_pipelines/log_volume_control/splunk_hec.md
@@ -13,7 +13,7 @@ This document walks you through the following steps:
 1. [Setting up Observability Pipelines](#set-up-observability-pipelines)
 1. [Sending logs to the Worker over Splunk HEC](#send-logs-to-the-observability-pipelines-worker-over-splunk-hec)
 
-{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for the split logs use case" width="100%" >}}
+{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for this use case" width="100%" >}}
 
 ## Prerequisites
 

--- a/content/en/observability_pipelines/log_volume_control/splunk_hec.md
+++ b/content/en/observability_pipelines/log_volume_control/splunk_hec.md
@@ -13,8 +13,6 @@ This document walks you through the following steps:
 1. [Setting up Observability Pipelines](#set-up-observability-pipelines)
 1. [Sending logs to the Worker over Splunk HEC](#send-logs-to-the-observability-pipelines-worker-over-splunk-hec)
 
-{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for this use case" width="100%" >}}
-
 ## Prerequisites
 
 {{% observability_pipelines/prerequisites/splunk_hec %}}

--- a/content/en/observability_pipelines/log_volume_control/splunk_tcp.md
+++ b/content/en/observability_pipelines/log_volume_control/splunk_tcp.md
@@ -12,7 +12,7 @@ This document walks you through the following steps to set up the Observability 
 1. [Setting up Observability Pipelines](#set-up-observability-pipelines)
 1. [Connecting Splunk Forwarder to the Observability Pipelines Worker](#connect-splunk-forwarder-to-the-observability-pipelines-worker)
 
-{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for the split logs use case" width="100%" >}}
+{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for this use case" width="100%" >}}
 
 ## Prerequisites
 

--- a/content/en/observability_pipelines/log_volume_control/splunk_tcp.md
+++ b/content/en/observability_pipelines/log_volume_control/splunk_tcp.md
@@ -12,8 +12,6 @@ This document walks you through the following steps to set up the Observability 
 1. [Setting up Observability Pipelines](#set-up-observability-pipelines)
 1. [Connecting Splunk Forwarder to the Observability Pipelines Worker](#connect-splunk-forwarder-to-the-observability-pipelines-worker)
 
-{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for this use case" width="100%" >}}
-
 ## Prerequisites
 
 {{% observability_pipelines/prerequisites/splunk_tcp %}}

--- a/content/en/observability_pipelines/log_volume_control/sumo_logic_hosted_collector.md
+++ b/content/en/observability_pipelines/log_volume_control/sumo_logic_hosted_collector.md
@@ -12,8 +12,6 @@ This document walks you through the following steps to set up the Observability 
 1. [Setting up Observability Pipelines](#set-up-observability-pipelines)
 1. [Sending logs to the Observability Pipelines Worker over Sumo Logic HTTP Source](#send-logs-to-the-observability-pipelines-worker-over-sumo-logic-http-source)
 
-{{< img src="observability_pipelines/use_cases/log_volume_control.png" alt="The log sources, processors, and destinations available for this use case" width="100%" >}}
-
 ## Prerequisites
 
 {{% observability_pipelines/prerequisites/sumo_logic %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds the Datadog Agent source page for the Log Volume Control use case. The doc uses mostly existing general reuse shortcodes so there isn't a lot of new content to review.

[DOCS-7981](https://datadoghq.atlassian.net/browse/DOCS-7981)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7981]: https://datadoghq.atlassian.net/browse/DOCS-7981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ