### PR TITLE
(DOCS-8008) Hide UI extension references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ temp
 
 # Developers/ui_extensions
 content/en/developers/ui_extensions.md
+content/en/developers/faq/ui_extensions.md
 
 # Agent section
 content/en/agent/basic_agent_usage/ansible.md

--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -876,11 +876,6 @@ menu:
       url: developers/integrations/python/
       parent: dev_tools_integrations
       weight: 411
-    - name: UI Extensions
-      url: developers/ui_extensions
-      parent: dev_tools
-      identifier: dev_tools_ui_extensions
-      weight: 5
     - name: Service Checks
       url: developers/service_checks/
       parent: dev_tools

--- a/content/en/account_management/org_settings/oauth_apps.md
+++ b/content/en/account_management/org_settings/oauth_apps.md
@@ -21,7 +21,7 @@ Only users with the Datadog Admin role or the `org_authorized_apps_write` permis
 
 ### Enable
 
-Enabled OAuth applications allow users with necessary permissions to authorize access on their behalf. OAuth applications include the Datadog Mobile App and your custom [UI Extensions][4] that have [OAuth API Access][5]. 
+Enabled OAuth applications allow users with necessary permissions to authorize access on their behalf. OAuth applications include the Datadog Mobile App<!-- and your custom [UI Extensions][4] that have [OAuth API Access][5]-->. 
 
 ### Disable
 

--- a/content/en/developers/authorization/_index.md
+++ b/content/en/developers/authorization/_index.md
@@ -25,7 +25,8 @@ Datadog uses the [OAuth 2.0 (OAuth2) Authorization Framework][1] to allow users 
 An OAuth2 client is the component of an application that enables users to authorize the application access to Datadog resources on the user's behalf. OAuth2 defines two types of clients: public and [confidential][3]. 
 
 Public Clients
-: Typically used for browser-based applications and are not capable of storing confidential information. Examples of public clients include OAuth clients for [UI Extensions][4]. 
+: Typically used for browser-based applications and are not capable of storing confidential information.
+<!--Examples of public clients include OAuth clients for [UI Extensions][4]. -->
 
 Confidential Clients
 : Capable of storing sensitive data and requires an additional `client_secret` to make authorization requests. OAuth clients for integrations are confidential clients. 

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -532,11 +532,12 @@
           globs:
             - "docs/en/getting-started.md"
           options:
-            dest_path: "/developers/"
+            dest_path: "/developers/faq/"
             file_name: "ui_extensions.md"
             front_matters:
               dependencies: ["https://github.com/DataDog/apps/blob/master/docs/en/getting-started.md"]
-              aliases: ["/developers/datadog_apps/"]
+              aliases: ["/developers/datadog_apps/", "/developers/ui_extensions"]
+              private: true
 
       - repo_name: datadog-agent
         contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci
@@ -533,11 +533,12 @@
           globs:
             - "docs/en/getting-started.md"
           options:
-            dest_path: "/developers/"
+            dest_path: "/developers/faq/"
             file_name: "ui_extensions.md"
             front_matters:
               dependencies: ["https://github.com/DataDog/apps/blob/master/docs/en/getting-started.md"]
-              aliases: ["/developers/datadog_apps/"]
+              aliases: ["/developers/datadog_apps/", "/developers/ui_extensions"]
+              private: true
 
       - repo_name: datadog-agent
         contents:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Hides references to UI Extensions. The main page is moved to /developers/faq/ui_extensions/ so it will not be discoverable unless someone is given the URL or has the old URL bookmarked.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->