### PR TITLE
CCM Update CCM AWS setup instructions to match new AWS UI

### DIFF
--- a/content/en/cloud_cost_management/aws.md
+++ b/content/en/cloud_cost_management/aws.md
@@ -30,10 +30,11 @@ To set up Cloud Cost Management in Datadog, you should:
 
 ### Prerequisite: generate a Cost and Usage Report
 
-[Create a Cost and Usage Report][1] in AWS under the **Legacy Pages** section. At this time, there is no support for creating Cost and Usage Report data exports.
+[Create a Cost and Usage Report][1] in AWS under **Data Exports**.
 
 Select the following content options:
 
+* Export type **Legacy CUR export** (At this time, there is no support for "Standard data export".)
 * **Include resource IDs**
 * **Split cost allocation data** (Enables ECS Cost Allocation. You must also opt in to [AWS Split Cost Allocation][10] in Cost Explorer preferences).
 * **"Refresh automatically"**

--- a/content/en/cloud_cost_management/aws.md
+++ b/content/en/cloud_cost_management/aws.md
@@ -34,7 +34,7 @@ To set up Cloud Cost Management in Datadog, you should:
 
 Select the following content options:
 
-* Export type **Legacy CUR export** (At this time, there is no support for "Standard data export".)
+* Export type: **Legacy CUR export**
 * **Include resource IDs**
 * **Split cost allocation data** (Enables ECS Cost Allocation. You must also opt in to [AWS Split Cost Allocation][10] in Cost Explorer preferences).
 * **"Refresh automatically"**


### PR DESCRIPTION
![Screenshot 2024-05-17 at 9 16 04 AM](https://github.com/DataDog/documentation/assets/12730880/454eeebc-b558-4442-a737-44ae7d4cad80)

### What does this PR do? What is the motivation?
Updates the language in the setup doc to match the new configuration process before AWS deprecates the old page.

### Merge instructions

- [x] Please merge after reviewing

