### PR TITLE
Fix iOS error reporting links

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -30,25 +30,25 @@ Enable iOS Crash Reporting and Error Tracking to get comprehensive crash reports
 
 In order to symbolicate your stack traces, find and upload your .dSYM files to Datadog. Then, verify your configuration by running a test crash and restarting your application. 
 
-Your crash reports appear in [**Error Tracking**][8].
+Your crash reports appear in [**Error Tracking**][1].
 
 ## Setup
 
-If you have not set up the iOS SDK yet, follow the [in-app setup instructions][1] or see the [iOS RUM setup documentation][2].
+If you have not set up the iOS SDK yet, follow the [in-app setup instructions][2] or see the [iOS RUM setup documentation][3].
 
 ### Add Crash Reporting 
 
-To enable Crash Reporting, make sure to also enable [RUM][2] and, or [Logs][9]. Then, add the package according to your dependency manager and update your initialize snippet.  
+To enable Crash Reporting, make sure to also enable [RUM][3] and, or [Logs][4]. Then, add the package according to your dependency manager and update your initialize snippet.  
 
 {{< tabs >}}
 {{% tab "CocoaPods" %}}
 
-You can use [CocoaPods][4] to install `dd-sdk-ios`:
+You can use [CocoaPods][1] to install `dd-sdk-ios`:
 ```
 pod 'DatadogCrashReporting'
 ```
 
-[4]: https://cocoapods.org/
+[1]: https://cocoapods.org/
 
 {{% /tab %}}
 {{% tab "Swift Package Manager (SPM)" %}}
@@ -66,7 +66,7 @@ DatadogCrashReporting
 {{% /tab %}}
 {{% tab "Carthage" %}}
 
-You can use [Carthage][5] to install `dd-sdk-ios`:
+You can use [Carthage][1] to install `dd-sdk-ios`:
 ```
 github "DataDog/dd-sdk-ios"
 ```
@@ -77,7 +77,7 @@ DatadogCrashReporting.xcframework
 CrashReporter.xcframework
 ```
 
-[5]: https://github.com/Carthage/Carthage
+[1]: https://github.com/Carthage/Carthage
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -114,7 +114,7 @@ Depending on your setup, you may need to download `.dSYM` files from App Store C
 
 | Bitcode Enabled | Description |
 |---|---|
-| Yes | `.dSYM` files are available after [App Store Connect][6] completes processing your application's build. |
+| Yes | `.dSYM` files are available after [App Store Connect][5] completes processing your application's build. |
 | No | Xcode exports `.dSYM` files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with dSYM File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** for the Release project configuration. |
 
 ### Upload your .dSYM file
@@ -127,7 +127,7 @@ Once your application crashes and you restart the application, the iOS SDK uploa
 
 ### Use Datadog CI to upload your .dSYM file
 
-You can use the command line tool [@datadog/datadog-ci][5] to upload your `.dSYM` file:
+You can use the command line tool [@datadog/datadog-ci][6] to upload your `.dSYM` file:
 
 ```sh
 export DATADOG_API_KEY="<API KEY>"
@@ -147,7 +147,7 @@ Alternatively, if you use Fastlane or GitHub Actions in your workflows, you can 
 
 The Fastlane plugin helps you upload `.dSYM` files to Datadog from your Fastlane configuration.
 
-1. Add [`fastlane-plugin-datadog`][3] to your project.
+1. Add [`fastlane-plugin-datadog`][7] to your project.
 
    ```sh
    fastlane add_plugin datadog
@@ -163,11 +163,11 @@ The Fastlane plugin helps you upload `.dSYM` files to Datadog from your Fastlane
    end
    ```
 
-For more information, see [`fastlane-plugin-datadog`][3].
+For more information, see [`fastlane-plugin-datadog`][7].
 
 ### Use GitHub Actions to upload your .dSYM file
 
-The [Datadog Upload dSYMs GitHub Action][4] allows you to upload your symbols in your GitHub Action jobs:
+The [Datadog Upload dSYMs GitHub Action][8] allows you to upload your symbols in your GitHub Action jobs:
 
 ```yml
 name: Upload dSYM Files
@@ -193,7 +193,7 @@ jobs:
             path/to/zip/dsyms.zip
 ```
 
-For more information, see [dSYMs commands][7].
+For more information, see [dSYMs commands][9].
 
 ## Limitations
 
@@ -217,7 +217,7 @@ To verify your iOS Crash Reporting and Error Tracking configuration, issue a cra
    }
    ```
 
-3. After the crash happens, restart your application and wait for the iOS SDK to upload the crash report in [**Error Tracking**][8].
+3. After the crash happens, restart your application and wait for the iOS SDK to upload the crash report in [**Error Tracking**][1].
 
 **Note:** RUM supports symbolication of system symbol files for iOS v14+ arm64 and arm64e architecture.
 
@@ -225,12 +225,12 @@ To verify your iOS Crash Reporting and Error Tracking configuration, issue a cra
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/rum/application/create
-[2]: https://docs.datadoghq.com/real_user_monitoring/ios
-[3]: https://github.com/DataDog/datadog-fastlane-plugin
-[4]: https://github.com/marketplace/actions/datadog-upload-dsyms
-[5]: https://www.npmjs.com/package/@datadog/datadog-ci
-[6]: https://appstoreconnect.apple.com/
-[7]: https://github.com/DataDog/datadog-ci/blob/master/src/commands/dsyms/README.md
-[8]: https://app.datadoghq.com/rum/error-tracking
-[9]: https://docs.datadoghq.com/logs/log_collection/ios
+[1]: https://app.datadoghq.com/rum/error-tracking
+[2]: https://app.datadoghq.com/rum/application/create
+[3]: /real_user_monitoring/ios
+[4]: /logs/log_collection/ios
+[5]: https://appstoreconnect.apple.com/
+[6]: https://www.npmjs.com/package/@datadog/datadog-ci
+[7]: https://github.com/DataDog/datadog-fastlane-plugin
+[8]: https://github.com/marketplace/actions/datadog-upload-dsyms
+[9]: https://github.com/DataDog/datadog-ci/blob/master/src/commands/dsyms/README.md

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/supported_versions/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/supported_versions/ios.md
@@ -3,9 +3,6 @@ title: RUM iOS and tvOS Monitoring Supported Versions
 kind: documentation
 beta: true
 description: "List of supported operating systems and platforms for the RUM iOS SDK."
-aliases:
-  - /real_user_monitoring/ios
-  - /real_user_monitoring/ios/getting_started
 code_lang: ios
 type: multi-code-lang
 code_lang_weight: 20


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fixed links manually because link checker failed me.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->