### PR TITLE
Custom Instrumentation Tweaks

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/_index.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/_index.md
@@ -56,7 +56,7 @@ Datadog tracing libraries provide an implementation of the OpenTelemetry API for
 
 {{% /tab %}}
 
-{{% tab "OpenTracing" %}}
+{{% tab "OpenTracing (legacy)" %}}
 
 If [OpenTelemetry][1] or [`ddtrace`][2] custom instrumentation doesn't work for you, each of the supported languages also has support for sending [OpenTracing][3] data to Datadog. OpenTracing is archived and the project is unsupported. 
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/java/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/java/dd-api.md
@@ -23,6 +23,8 @@ further_reading:
 
 This page details common use cases for adding and customizing observability with Datadog APM. If you have not read the setup instructions for automatic instrumentation, start with the [Java Setup Instructions][11].
 
+<div class="alert alert-info">The Datadog Java tracer is built on OpenTracing. Although OpenTracing is deprecated in favor of OpenTelemetry, the following examples correctly import the <code>opentracing</code> library.</div>
+
 ## Adding tags
 
 Add custom [span tags][1] to your [spans][2] to customize your observability within Datadog. The span tags are applied to your incoming traces, allowing you to correlate observed behavior with code-level information such as merchant tier, checkout amount, or user ID.

--- a/layouts/shortcodes/otel-custom-instrumentation-lang.md
+++ b/layouts/shortcodes/otel-custom-instrumentation-lang.md
@@ -1,5 +1,5 @@
 <div class="alert alert-info">
-If you are new to OpenTelemetry, start by reading <a href="/tracing/trace_collection/custom_instrumentation/otel_instrumentation/">Custom Instrumentation with the OpenTelemetry API</a> to understand how OpenTelemetry integrates with Datadog.
+Unsure when to use OpenTelemetry with Datadog? Start with <a href="/tracing/trace_collection/custom_instrumentation/otel_instrumentation/">Custom Instrumentation with the OpenTelemetry API</a> to learn more.
 </div>
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Users were missing the OTel API alert banner that links to more details. They were looking for information about when to use OpenTelemetry with Datadog. Tweaked alert banner message to emphasize that.
- Noted OpenTracing is legacy in the tab name.
- Noted that Datadog Java tracer is built on OpenTracing, so the code examples are correct as-is.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->