### PR TITLE
Remove dd-trace-js v3.x references from ASM documentation pages

### DIFF
--- a/content/en/security/application_security/enabling/compatibility/nodejs.md
+++ b/content/en/security/application_security/enabling/compatibility/nodejs.md
@@ -10,15 +10,15 @@ code_lang_weight: 50
 
 The following ASM capabilities are supported in the Node.js library, for the specified tracer version:
 
-| ASM capability                         | Minimum NodeJS tracer version                                               |
-|----------------------------------------|-----------------------------------------------------------------------------|
-| Threat Detection                       | 3.13.1                                                                      |
-| Threat Protection                      | 3.19.0                                                                      |
-| Customize response to blocked requests | 3.22.0 for Node.js 14+, 4.1.0 for Node.js 16+                               |
-| Software Composition Analysis (SCA)    | 3.10.0 for Node.js 14+                                                      |
-| Code Security (beta)                   | 3.39.0 for Node.js 14+, 4.18.0 for Node.js 16+, or 5.0.0 for Node.js 18+    |
-| Automatic user activity event tracking | 3.25.0 for Node.js 14+, or 4.4.0 for Node.js 16+                            |
-| API Security                           | 3.51.0 for Node.js 14+, or 4.30.0 for Node.js 16+, or 5.6.0 for Node.js 18+ |
+| ASM capability                         | Minimum NodeJS tracer version                      |
+|----------------------------------------|----------------------------------------------------|
+| Threat Detection                       | 4.0.0                                              |
+| Threat Protection                      | 4.0.0                                              |
+| Customize response to blocked requests | 4.1.0                                              |
+| Software Composition Analysis (SCA)    | 4.0.0                                              |
+| Code Security (beta)                   | 4.18.0 for Node.js 16+, or 5.0.0 for Node.js 18+   |
+| Automatic user activity event tracking | 4.4.0 for Node.js 16+                              |
+| API Security                           | 4.30.0 for Node.js 16+, or 5.6.0 for Node.js 18+   |
 
 The minimum tracer version to get all supported ASM capabilities for Node.js is 3.51.0.
 

--- a/content/en/security/application_security/enabling/compatibility/nodejs.md
+++ b/content/en/security/application_security/enabling/compatibility/nodejs.md
@@ -20,7 +20,7 @@ The following ASM capabilities are supported in the Node.js library, for the spe
 | Automatic user activity event tracking | 4.4.0 for Node.js 16+                              |
 | API Security                           | 4.30.0 for Node.js 16+, or 5.6.0 for Node.js 18+   |
 
-The minimum tracer version to get all supported ASM capabilities for Node.js is 3.51.0.
+The minimum tracer version to get all supported ASM capabilities for Node.js is 4.30.0.
 
 
 **Note**:

--- a/layouts/shortcodes/asm-libraries-capabilities.md
+++ b/layouts/shortcodes/asm-libraries-capabilities.md
@@ -1,14 +1,14 @@
 
 The following ASM capabilities are supported relative to each language's tracing library:
 
-| ASM capability                         | Java    | .NET     | Node.js                                                                  | Python        | Go              | Ruby          | PHP           |
-|----------------------------------------|---------|----------|--------------------------------------------------------------------------|---------------|-----------------|---------------|---------------|
-| Threat Detection                       | 1.8.0   | 2.23.0   | 3.13.1                                                                   | 1.9.0         | 1.47.0          | 1.9.0         | 0.84.0        |
-| API Security                           | 1.31.0  | 2.42.0   | 3.51.0 for Node.js 14+, 4.30.0 for Node.js 16+, or 5.6.0 for Node.js 18+ | not supported | 1.59.0          | 1.15.0        | 0.98.0        |
-| Threat Protection                      | 1.9.0   | 2.26.0   | 3.19.0                                                                   | 1.10.0        | v1.50.0         | 1.11.0        | 0.86.0        |
-| Customize response to blocked requests | 1.11.0  | 2.27.0   | 3.22.0 for Node.js 14+, or 4.1.0 for Node.js 16+                         | 1.19.0        | v1.53.0         | 1.15.0        | 0.86.0        |
-| Software Composition Analysis (SCA)    | 1.1.4   | 2.16.0   | 3.10.0 for Node.js 14+                                                   | 1.5.0         | 1.49.0          | 1.11.0        | 0.90.0        |
-| Code Security (beta)                   | 1.15.0  | 2.42.0   | 3.39.0 for Node.js 14+, 4.18.0 for Node.js 16+, or 5.0.0 for Node.js 18+ | private beta  | not supported   | not supported | not supported |
-| Automatic user activity event tracking | 1.20.0  | 2.32.0   | 3.25.0 for Node.js 14+, or 4.4.0 for Node.js 16+                         | 1.17.0        | not supported   | 1.14.0        | 0.89.0        |
+| ASM capability                         | Java    | .NET     | Node.js                                          | Python        | Go              | Ruby          | PHP           |
+|----------------------------------------|---------|----------|--------------------------------------------------|---------------|-----------------|---------------|---------------|
+| Threat Detection                       | 1.8.0   | 2.23.0   | 4.0.0                                            | 1.9.0         | 1.47.0          | 1.9.0         | 0.84.0        |
+| API Security                           | 1.31.0  | 2.42.0   | 4.30.0 for Node.js 16+, or 5.6.0 for Node.js 18+ | not supported | 1.59.0          | 1.15.0        | 0.98.0        |
+| Threat Protection                      | 1.9.0   | 2.26.0   | 4.0.0                                            | 1.10.0        | v1.50.0         | 1.11.0        | 0.86.0        |
+| Customize response to blocked requests | 1.11.0  | 2.27.0   | 4.1.0                                            | 1.19.0        | v1.53.0         | 1.15.0        | 0.86.0        |
+| Software Composition Analysis (SCA)    | 1.1.4   | 2.16.0   | 4.0.0                                            | 1.5.0         | 1.49.0          | 1.11.0        | 0.90.0        |
+| Code Security (beta)                   | 1.15.0  | 2.42.0   | 4.18.0                                           | private beta  | not supported   | not supported | not supported |
+| Automatic user activity event tracking | 1.20.0  | 2.32.0   | 4.4.0                                            | 1.17.0        | not supported   | 1.14.0        | 0.89.0        |
 
 Select your application language for details about framework compatibility and feature support.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Remove dd-trace-js v3.x references from ASM documentation pages because it is in end-of-life and not supported anymore.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->