### PR TITLE
[DOCS-7980] Remove buffer in OP docs

### DIFF
--- a/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
+++ b/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
@@ -32,7 +32,7 @@ Use compute optimized instances with at least 8 vCPUs and 16 GiB of memory. Thes
 | AWS           | c6i.2xlarge (recommended) or c6g.2xlarge          	|
 | Azure         | f8                                                	|
 | Google Cloud  | c2 (8 vCPUs, 16 GiB memory)                       	|
-| Private       | 8 vCPUs, 16 GiB of memory, local disk is not required	|
+| Private       | 8 vCPUs, 16 GiB of memory                         	|
 
 ### CPU sizing
 

--- a/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
+++ b/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
@@ -55,15 +55,7 @@ Due to Observability Pipelines Worker's affine type system, memory is rarely con
 
 ### Disk sizing
 
-Provision at least 30 GiB per vCPU of disk space. The recommended sizes are calculated at Observability Pipelines Worker's 10 MiB/s/vCPU throughput for one hour. For example, an 8 vCPU machine would require 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
-
-| Cloud Provider| Recommendation*                                               |
-| ------------- | --------------------------------------------------------------|
-| AWS           | EBS gp3, 30 GiB per vCPU, no additional IOPS or throughput    |
-| Azure         | Ultra-disk or standard SSD, 30 GiB per vCPU                   |
-| Google Cloud  | Balanced or SSD persistent disks, 30 GiB per vCPU             |
-| Private       | Network-based block storage equivalent, 30 GiB per vCPU       |
-
+You need 500MB of disk space to install the Observability Pipelines Worker.
 
 ## Capacity planning and scaling
 

--- a/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
+++ b/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
@@ -51,7 +51,7 @@ Observability Pipelines Worker runs on modern CPU architectures. X86_64 architec
 
 ### Memory sizing
 
-Due to Observability Pipelines Worker's affine type system, memory is rarely constrained for Observability Pipelines Worker workloads. Therefore, Datadog recommends ≥2 GiB of memory per vCPU minimum. Memory usage increases with the number of sinks due to the in-memory buffering and batching. If you have a lot of sinks, consider increasing the memory.
+Due to Observability Pipelines Worker's affine type system, memory is rarely constrained for Observability Pipelines Worker workloads. Therefore, Datadog recommends ≥2 GiB of memory per vCPU minimum. Memory usage increases with the number of destinations due to the in-memory buffering and batching. If you have a lot of destinations, consider increasing the memory.
 
 ### Disk sizing
 

--- a/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
+++ b/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
@@ -51,7 +51,7 @@ Observability Pipelines Worker runs on modern CPU architectures. X86_64 architec
 
 ### Memory sizing
 
-Due to Observability Pipelines Worker's affine type system, memory is rarely constrained for Observability Pipelines Worker workloads. Therefore, Datadog recommends ≥2 GiB of memory per vCPU minimum. Memory usage increases with the number of sinks due to the in-memory buffering and batching. If you have a lot of sinks, consider increasing the memory or switching to disk buffers.
+Due to Observability Pipelines Worker's affine type system, memory is rarely constrained for Observability Pipelines Worker workloads. Therefore, Datadog recommends ≥2 GiB of memory per vCPU minimum. Memory usage increases with the number of sinks due to the in-memory buffering and batching. If you have a lot of sinks, consider increasing the memory.
 
 ### Disk sizing
 

--- a/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
+++ b/content/en/observability_pipelines/best_practices_for_scaling_observability_pipelines.md
@@ -55,14 +55,14 @@ Due to Observability Pipelines Worker's affine type system, memory is rarely con
 
 ### Disk sizing
 
-If you're using Observability Pipelines Worker's disk buffers for high durability (recommended), provision at least 36 GiB per vCPU of disk space. The recommended sizes are calculated at Observability Pipelines Worker's 10 MiB/s/vCPU throughput for one hour. For example, an 8 vCPU machine would require 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
+Provision at least 30 GiB per vCPU of disk space. The recommended sizes are calculated at Observability Pipelines Worker's 10 MiB/s/vCPU throughput for one hour. For example, an 8 vCPU machine would require 288 GiB of disk space (10 MiB * 60 seconds * 60 minutes * 8 vCPUs).
 
 | Cloud Provider| Recommendation*                                               |
 | ------------- | --------------------------------------------------------------|
-| AWS           | EBS gp3, 36 GiB per vCPU, no additional IOPS or throughput    |
-| Azure         | Ultra-disk or standard SSD, 36 GiB per vCPU                   |
-| Google Cloud  | Balanced or SSD persistent disks, 36 GiB per vCPU             |
-| Private       | Network-based block storage equivalent, 36 GiB per vCPU       |
+| AWS           | EBS gp3, 30 GiB per vCPU, no additional IOPS or throughput    |
+| Azure         | Ultra-disk or standard SSD, 30 GiB per vCPU                   |
+| Google Cloud  | Balanced or SSD persistent disks, 30 GiB per vCPU             |
+| Private       | Network-based block storage equivalent, 30 GiB per vCPU       |
 
 
 ## Capacity planning and scaling

--- a/content/en/observability_pipelines/legacy/production_deployment_overview.md
+++ b/content/en/observability_pipelines/legacy/production_deployment_overview.md
@@ -24,6 +24,7 @@ This guide walks you through what to consider when designing your Observability 
 - [Networking](#networking)
 - [Collecting data](#collecting-data)
 - [Processing data](#processing-data)
+- [Buffering data](#buffering-data)
 - [Routing data](#routing-data)
 
 ## Networking
@@ -87,6 +88,29 @@ For remote processing, the Observability Pipelines Worker can be deployed on sep
 Data processing is shifted off your nodes and onto remote aggregator nodes. Remote processing is recommended for environments that require high durability and high availability (most environments). In addition, this is easier to set up since it does not require the infrastructure restructuring necessary when adding an agent.
 
 See [Aggregator Architecture][5] for more details.
+
+## Buffering data
+
+Where and how you buffer your data can also affect the efficiency of your pipeline. 
+
+### Choosing where to buffer data
+
+Buffering should happen close to your destinations, and each destination should have its own isolated buffer, which offers the following benefits:
+
+1. Each destination can configure its buffer to meet the sink's requirements. See [Choosing how to buffer data](#choosing-how-to-buffer-data) for more details.
+2. Isolating buffers for each destination prevents one misbehaving destination from halting the entire pipeline until the buffer reaches the configured capacity.
+
+For these reasons, the Observability Pipelines Worker couples buffers with its sinks.
+
+{{< img src="observability_pipelines/production_deployment_overview/where_to_buffer.png" alt="A diagram showing the agent in a node sending data to an Observability Pipelines Worker with a buffer in a different node" style="width:50%;" >}}
+
+### Choosing how to buffer data
+
+Observability Pipelines Worker's built-in buffers simplify operation and eliminate the need for complex external buffers.
+
+When choosing an Observability Pipelines Worker buffer type, select the type that is optimal for the destination's purpose. For example, your system of record should use disk buffers for high durability, and your system of analysis should use memory buffers for low latency. Additionally, both buffers can overflow to another buffer to prevent back pressure from propagating to your clients.
+
+{{< img src="observability_pipelines/production_deployment_overview/how_to_buffer.png" alt="A diagram showing an Observability Pipelines Worker's sources sending data to the disk buffer and memory buffer that are located close to the sinks" style="width:100%;" >}}
 
 ## Routing data
 

--- a/content/en/observability_pipelines/legacy/production_deployment_overview.md
+++ b/content/en/observability_pipelines/legacy/production_deployment_overview.md
@@ -24,7 +24,6 @@ This guide walks you through what to consider when designing your Observability 
 - [Networking](#networking)
 - [Collecting data](#collecting-data)
 - [Processing data](#processing-data)
-- [Buffering data](#buffering-data)
 - [Routing data](#routing-data)
 
 ## Networking
@@ -88,29 +87,6 @@ For remote processing, the Observability Pipelines Worker can be deployed on sep
 Data processing is shifted off your nodes and onto remote aggregator nodes. Remote processing is recommended for environments that require high durability and high availability (most environments). In addition, this is easier to set up since it does not require the infrastructure restructuring necessary when adding an agent.
 
 See [Aggregator Architecture][5] for more details.
-
-## Buffering data
-
-Where and how you buffer your data can also affect the efficiency of your pipeline. 
-
-### Choosing where to buffer data
-
-Buffering should happen close to your destinations, and each destination should have its own isolated buffer, which offers the following benefits:
-
-1. Each destination can configure its buffer to meet the sink's requirements. See [Choosing how to buffer data](#choosing-how-to-buffer-data) for more details.
-2. Isolating buffers for each destination prevents one misbehaving destination from halting the entire pipeline until the buffer reaches the configured capacity.
-
-For these reasons, the Observability Pipelines Worker couples buffers with its sinks.
-
-{{< img src="observability_pipelines/production_deployment_overview/where_to_buffer.png" alt="A diagram showing the agent in a node sending data to an Observability Pipelines Worker with a buffer in a different node" style="width:50%;" >}}
-
-### Choosing how to buffer data
-
-Observability Pipelines Worker's built-in buffers simplify operation and eliminate the need for complex external buffers.
-
-When choosing an Observability Pipelines Worker buffer type, select the type that is optimal for the destination's purpose. For example, your system of record should use disk buffers for high durability, and your system of analysis should use memory buffers for low latency. Additionally, both buffers can overflow to another buffer to prevent back pressure from propagating to your clients.
-
-{{< img src="observability_pipelines/production_deployment_overview/how_to_buffer.png" alt="A diagram showing an Observability Pipelines Worker's sources sending data to the disk buffer and memory buffer that are located close to the sinks" style="width:100%;" >}}
 
 ## Routing data
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

There isn't a buffer option for OP 2.0 so removing it from the docs.

[DOCS-7980](https://datadoghq.atlassian.net/browse/DOCS-7980)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7980]: https://datadoghq.atlassian.net/browse/DOCS-7980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ