### PR TITLE
Add clarifications for squash commits & switching data sources 

### DIFF
--- a/content/en/dora_metrics/deployments/_index.md
+++ b/content/en/dora_metrics/deployments/_index.md
@@ -139,6 +139,9 @@ DORA Metrics for the service `shopist` only consider the Git commits that includ
 
 - Change lead time stage breakdown metrics are only available for GitHub.
 - Change lead time is not available for the first deployment of a service that includes Git information.
+- Change lead time handles squash commit workflows in the following ways:
+  - If commits on a feature branch are squashed into a single commit prior to reaching the default branch (i.e, commits are squashed when a pull request is merged into the default branch), commit history for that pull request is not included in the change lead time calculation. The first commit included in the calculation is the newly created single commit. 
+  - If commits on a feature branch are not squashed, and an additional merge commit is created on the default branch after commits are made on a feature branch, that merge commit will be included in change lead time calculation as the final commit.
 
 ## Calculating change failure rate
 

--- a/content/en/dora_metrics/setup/_index.md
+++ b/content/en/dora_metrics/setup/_index.md
@@ -41,8 +41,9 @@ Each event type supports different data sources.
 {{< /whatsnext >}}
 
 ## Limitations
-
-Deployments or incidents of the same service cannot occur at the same second.
+- The first time you select a data source option (e.g. APM Deployment Tracking or PagerDuty), data is populated in DORA Metrics from that point in time.
+If you switch from source A to source B, then back to source A, historical data from source A will populate from the time when the source was first selected. 
+- Deployments or incidents of the same service cannot occur at the same second.
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Add clarifications for squash commits & switching data sources
Motivation - DORA Metrics recently moved to public beta and we anticipate questions about both from customers.

### Merge instructions
- [ x ] Please merge after reviewing