### PR TITLE
[DOCS-7986] Update collect-heroku-logs.md

### DIFF
--- a/content/en/logs/guide/collect-heroku-logs.md
+++ b/content/en/logs/guide/collect-heroku-logs.md
@@ -19,7 +19,7 @@ To send all these logs to Datadog:
 * Set up the HTTPS drain with the following command:
 
 ```text
-heroku drains:add "https://http-intake.logs.{{< region-param key="dd_site" >}}/api/v2/logs?dd-api-key=<DD_API_KEY>&ddsource=heroku&env=<ENV>&service=<SERVICE>&host=<HOST>" -a <APPLICATION_NAME>
+heroku drains:add "https://http-intake.logs.{{< region-param key="dd_site" >}}/api/v2/logs?dd-api-key=<DD_API_KEY>&ddsource=heroku&ddtags=env:<ENV>&service=<SERVICE>&host=<HOST>" -a <APPLICATION_NAME>
 ```
 
 * Replace `<DD_API_KEY>` with your [Datadog API Key][2].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
[DOCS-7986](https://datadoghq.atlassian.net/browse/DOCS-7986)
Hotjar feedback.

Reviewing the logs API endpoint documentation it does appear to want the `ddtags`  instead of explicitly passing env

https://docs.datadoghq.com/api/latest/logs/#send-logs

Updated the API to be: `drains:add '<https://http-intake.logs.datadoghq.com/api/v2/logs/?dd-api-key=<DD_API_KEY>>&ddsource=heroku&ddtags=env:<ENV>&service=<SERVICE>&host=<HOST>' -a <APPLICATION_NAME>` 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-7986]: https://datadoghq.atlassian.net/browse/DOCS-7986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ