### PR TITLE
Node.js updates for ESM support

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -108,7 +108,7 @@ Node.js < v20.6
 node --loader dd-trace/loader-hook.mjs entrypoint.js
 ```
 
-Node.js >= v20.6
+**Node.js >= v20.6**
 ```shell
 node --import dd-trace/register.js entrypoint.js
 ```

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -104,7 +104,7 @@ node --require dd-trace/init app.js
 EcmaScript Modules (ESM) applications require an additional command line argument. Run this command regardless of how the tracer is imported and initialized.
 
 Node.js < v20.6
-```sh
+```shell
 node --loader dd-trace/loader-hook.mjs entrypoint.js
 ```
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -52,7 +52,7 @@ If you are upgrading from a previous major version of the library (0.x, 1.x, or 
 
 ### Import and initialize the tracer
 
-Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
+Import and initialize the tracer either in code or with command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
 
 Once you have completed setup, if you are not receiving complete traces, including missing URL routes for web requests, or disconnected or missing spans, **confirm the tracer has been imported and initialized correctly**. The tracing library being initialized first is necessary for the tracer to properly patch all of the required libraries for automatic instrumentation.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -34,45 +34,42 @@ The latest Node.js Tracer supports versions `>=14`. For a full list of Datadog's
 
 ## Getting started
 
-Before you begin, make sure you've already [installed and configured the Agent][13].
+Before you begin, make sure you've already [installed and configured the Agent][13]. Then, complete the following steps to add the Datadog tracing library to your Node.js application to instrument it. Read more about [compatibility information][1].
 
-### Instrument your application
+### Install the Datadog Tracing library
 
-After you install and configure your Datadog Agent, the next step is to add the tracing library directly in the application to instrument it. Read more about [compatibility information][1].
+To install the Datadog Tracing library using npm for Node.js 14+, run:
 
-After the Agent is installed, follow these steps to add the Datadog tracing library to your Node.js applications:
+  ```sh
+  npm install dd-trace --save
+  ```
+If you need to trace end-of-life Node.js version 12, install version 2.x of `dd-trace` by running:
+  ```
+  npm install dd-trace@latest-node12
+  ```
+For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
+If you are upgrading from a previous major version of the library (0.x, 1.x, or 2.x) to another major version (2.x or 3.x), read the [Migration Guide][5] to assess any breaking changes.
 
-1. Install the Datadog Tracing library using npm for Node.js 14+:
+### Import and initialize the tracer
 
-    ```sh
-    npm install dd-trace --save
-    ```
-    If you need to trace end-of-life Node.js version 12, install version 2.x of `dd-trace` by running:
-    ```
-    npm install dd-trace@latest-node12
-    ```
-    For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
-    If you are upgrading from a previous major version of the library (0.x, 1.x, or 2.x) to another major version (2.x or 3.x), read the [Migration Guide][5] to assess any breaking changes.
+Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
 
-2. Import and initialize the tracer either in code or via command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
+Once you have completed setup, if you are not receiving complete traces, including missing URL routes for web requests, or disconnected or missing spans, **confirm the tracer has been imported and initialized correctly**. The tracing library being initialized first is necessary for the tracer to properly patch all of the required libraries for automatic instrumentation.
 
-   Once you have completed setup, if you are not receiving complete traces, including missing URL routes for web requests, or disconnected or missing spans, **confirm step 2 has been correctly done**. The tracing library being initialized first is necessary for the tracer to properly patch all of the required libraries for automatic instrumentation.
+When using a transpiler such as TypeScript, Webpack, Babel, or others, import and initialize the tracer library in an external file and then import that file as a whole when building your application.
 
-   When using a transpiler such as TypeScript, Webpack, Babel, or others, import and initialize the tracer library in an external file and then import that file as a whole when building your application.
+#### Adding the tracer in code
 
-### Adding the tracer in code
-
-#### JavaScript
+##### JavaScript
 
 ```javascript
 // This line must come before importing any instrumented module.
 const tracer = require('dd-trace').init();
 ```
 
-#### TypeScript and bundlers
+##### TypeScript and bundlers
 
-For TypeScript and bundlers that support EcmaScript Module syntax, initialize the tracer in a separate file in order to maintain correct load
-order.
+For TypeScript and bundlers that support EcmaScript Module syntax, initialize the tracer in a separate file to maintain correct load order.
 
 ```typescript
 // server.ts
@@ -92,17 +89,29 @@ initializes in one step.
 import 'dd-trace/init';
 ```
 
-### Adding the tracer via command line arguments
+#### Adding the tracer via command line arguments
 
-Use the `--require` option to Node.js to load and initialize the tracer in one
-step.
+Use the `--require` option to Node.js to load and initialize the tracer in one step.
 
 ```sh
 node --require dd-trace/init app.js
 ```
 
-**Note:** This approach requires using environment variables for all
-configuration of the tracer.
+**Note:** This approach requires using environment variables for all configuration of the tracer.
+
+#### Additional configuration for ESM
+
+ESM support requires an additional command line argument. Running this line is required regardless of how the tracer was imported and initialized. Use the following to enable experimental ESM support with your application:
+
+Node.js < v20.6
+```sh
+node --loader dd-trace/loader-hook.mjs entrypoint.js
+```
+
+Node.js >= v20.6
+```sh
+node --import dd-trace/register.js entrypoint.js
+```
 
 ### Bundling
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -101,7 +101,7 @@ node --require dd-trace/init app.js
 
 #### ESM applications only: import the loader
 
-EcmaScript Modules (ESM) applications require an additional command line argument. Run this line regardless of how the tracer was imported and initialized.
+EcmaScript Modules (ESM) applications require an additional command line argument. Run this command regardless of how the tracer is imported and initialized.
 
 Node.js < v20.6
 ```sh

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -40,7 +40,7 @@ Before you begin, make sure you've already [installed and configured the Agent][
 
 To install the Datadog tracing library using npm for Node.js 14+, run:
 
-  ```sh
+  ```shell
   npm install dd-trace --save
   ```
 To install the Datadog tracing library (version 2.x of `dd-trace`) for end-of-life Node.js version 12, run:

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -44,7 +44,7 @@ To install the Datadog tracing library using npm for Node.js 14+, run:
   npm install dd-trace --save
   ```
 To install the Datadog tracing library (version 2.x of `dd-trace`) for end-of-life Node.js version 12, run:
-  ```
+  ```shell
   npm install dd-trace@latest-node12
   ```
 For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -47,7 +47,7 @@ To install the Datadog tracing library (version 2.x of `dd-trace`) for end-of-li
   ```shell
   npm install dd-trace@latest-node12
   ```
-For more information on our distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
+For more information on Datadog's distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
 If you are upgrading from a previous major version of the library (0.x, 1.x, or 2.x) to another major version (2.x or 3.x), read the [Migration Guide][5] to assess any breaking changes.
 
 ### Import and initialize the tracer

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -109,7 +109,7 @@ node --loader dd-trace/loader-hook.mjs entrypoint.js
 ```
 
 Node.js >= v20.6
-```sh
+```shell
 node --import dd-trace/register.js entrypoint.js
 ```
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -99,7 +99,7 @@ node --require dd-trace/init app.js
 
 **Note:** This approach requires using environment variables for all configuration of the tracer.
 
-#### ESM applications only: import the loader
+#### ESM applications only: Import the loader
 
 EcmaScript Modules (ESM) applications require an additional command line argument. Run this command regardless of how the tracer is imported and initialized.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -34,16 +34,16 @@ The latest Node.js Tracer supports versions `>=14`. For a full list of Datadog's
 
 ## Getting started
 
-Before you begin, make sure you've already [installed and configured the Agent][13]. Then, complete the following steps to add the Datadog tracing library to your Node.js application to instrument it. Read more about [compatibility information][1].
+Before you begin, make sure you've already [installed and configured the Agent][13]. Then, complete the following steps to add the Datadog tracing library to your Node.js application to instrument it. 
 
-### Install the Datadog Tracing library
+### Install the Datadog tracing library
 
-To install the Datadog Tracing library using npm for Node.js 14+, run:
+To install the Datadog tracing library using npm for Node.js 14+, run:
 
   ```sh
   npm install dd-trace --save
   ```
-If you need to trace end-of-life Node.js version 12, install version 2.x of `dd-trace` by running:
+To install the Datadog tracing library (version 2.x of `dd-trace`) for end-of-life Node.js version 12, run:
   ```
   npm install dd-trace@latest-node12
   ```
@@ -58,7 +58,7 @@ Once you have completed setup, if you are not receiving complete traces, includi
 
 When using a transpiler such as TypeScript, Webpack, Babel, or others, import and initialize the tracer library in an external file and then import that file as a whole when building your application.
 
-#### Adding the tracer in code
+#### Option 1: Add the tracer in code
 
 ##### JavaScript
 
@@ -89,7 +89,7 @@ initializes in one step.
 import 'dd-trace/init';
 ```
 
-#### Adding the tracer via command line arguments
+#### Option 2: Add the tracer via command line arguments
 
 Use the `--require` option to Node.js to load and initialize the tracer in one step.
 
@@ -99,9 +99,9 @@ node --require dd-trace/init app.js
 
 **Note:** This approach requires using environment variables for all configuration of the tracer.
 
-#### Additional configuration for ESM
+#### ESM applications only: import the loader
 
-ESM support requires an additional command line argument. Running this line is required regardless of how the tracer was imported and initialized. Use the following to enable experimental ESM support with your application:
+EcmaScript Modules (ESM) applications require an additional command line argument. Run this line regardless of how the tracer was imported and initialized.
 
 Node.js < v20.6
 ```sh

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -103,7 +103,7 @@ node --require dd-trace/init app.js
 
 EcmaScript Modules (ESM) applications require an additional command line argument. Run this command regardless of how the tracer is imported and initialized.
 
-Node.js < v20.6
+**Node.js < v20.6**
 ```shell
 node --loader dd-trace/loader-hook.mjs entrypoint.js
 ```

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -89,7 +89,7 @@ initializes in one step.
 import 'dd-trace/init';
 ```
 
-#### Option 2: Add the tracer via command line arguments
+#### Option 2: Add the tracer with command line arguments
 
 Use the `--require` option to Node.js to load and initialize the tracer in one step.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -54,7 +54,7 @@ If you are upgrading from a previous major version of the library (0.x, 1.x, or 
 
 Import and initialize the tracer either in code or with command line arguments. The Node.js tracing library needs to be imported and initialized **before** any other module.
 
-Once you have completed setup, if you are not receiving complete traces, including missing URL routes for web requests, or disconnected or missing spans, **confirm the tracer has been imported and initialized correctly**. The tracing library being initialized first is necessary for the tracer to properly patch all of the required libraries for automatic instrumentation.
+After you have completed setup, if you are not receiving complete traces, including missing URL routes for web requests, or disconnected or missing spans, **confirm the tracer has been imported and initialized correctly**. The tracing library being initialized first is necessary for the tracer to properly patch all of the required libraries for automatic instrumentation.
 
 When using a transpiler such as TypeScript, Webpack, Babel, or others, import and initialize the tracer library in an external file and then import that file as a whole when building your application.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/DOCS-7897

Struggled to figure out the right flow/formatting. Main goal of this PR is to clarify requirements for importing and initializing the tracer. 

For non-ESM applications, the steps are to either (a) add tracer in code, or (b) add tracer via command line arguments. 

For ESM applications, the steps are the same -- to either (a) add tracer in code, or (b) add tracer via command line arguments -- BUT with the additional step that regardless of whether (a) or (b) was used, an additional command line argument must be used (`--loader` or `--import` depending on Node.js version). 

I would've like to figure out a way to specify the full command line for ESM applications -- in other words, to merge the "Option 2: Add the tracer via command line arguments" and "ESM applications only: import the loader" sections, and include a single code line sample with everything there. But in order to do this, I would've had to include a call-out under the "Option 1: Add the tracer in code" section to note that ESM apps need to run an additional command line. 

I don't know if this makes sense, but basically I don't love the structure I have here but it seemed like the best approach. If you have thoughts/suggestions, I'd love to hear them!

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->