### PR TITLE
[WEB-4933] updates `notranslate` job to run bulk updates in batches

### DIFF
--- a/local/bin/py/add_notranslate_tag.py
+++ b/local/bin/py/add_notranslate_tag.py
@@ -47,14 +47,12 @@ def process_tags():
         slug = collection_id.split(':')[-1]
         res = project.fetch('resources').get(slug=slug)
 
-        # remove notranslate tags
         print(f"Removing tags for {slug}")
         resource_strings = list(transifex_api.ResourceString.filter(resource=res).all())
 
         for index in range(0, len(resource_strings), transifex_bulk_operation_limit):
             remove_tags(resource_strings[index:index+transifex_bulk_operation_limit])
 
-        # add resource strings again
         print(f"Adding notranslate tags for {slug}")
         resource_strings = list(transifex_api.ResourceString.filter(resource=res).all())
 

--- a/local/bin/py/add_notranslate_tag.py
+++ b/local/bin/py/add_notranslate_tag.py
@@ -3,6 +3,15 @@
 from transifex.api import transifex_api
 import os
 
+transifex_bulk_operation_limit = 150
+fields_to_translate = [
+    'name',
+    'title',
+    'text',
+    'desc',
+    'description',
+    'link_text'
+]
 string_collection_ids = [
     'o:datadog:p:documentation_loc:r:config__default_menus_main_en_yaml',
     'o:datadog:p:documentation_loc:r:config__default_menus_api_en_yaml',
@@ -12,8 +21,24 @@ string_collection_ids = [
     'o:datadog:p:documentation_loc:r:data_partials_requests_yaml'
 ]
 
+def remove_tags(resource_strings):
+    for resource_string in resource_strings:
+        tags = resource_string.attributes.get('tags', [])
+        if 'notranslate' in tags:
+            resource_string.attributes['tags'] = []
+    transifex_api.ResourceString.bulk_update(resource_strings, ['tags'])
 
-def add_tag():
+
+def add_tags(resource_strings):
+    for resource_string in resource_strings:
+        key_parts = resource_string.attributes.get('key', '').split('.')
+        key_val = key_parts[-1]
+        if key_val not in fields_to_translate:
+            resource_string.attributes['tags'] = ['notranslate']
+    transifex_api.ResourceString.bulk_update(resource_strings, ['tags'])
+
+
+def process_tags():
     transifex_api.setup(auth=os.environ.get('transifex_api_key'))
     organization = transifex_api.Organization.get(slug="datadog")
     project = organization.fetch('projects').get(slug="documentation_loc")
@@ -24,25 +49,20 @@ def add_tag():
 
         # remove notranslate tags
         print(f"Removing tags for {slug}")
-        res_strings = transifex_api.ResourceString.filter(resource=res)
-        for res_str in res_strings.data:
-            tags = res_str.attributes.get('tags', [])
-            if 'notranslate' in tags:
-                res_str.attributes['tags'] = []
-        transifex_api.ResourceString.bulk_update(res_strings, ['tags'])
+        resource_strings = list(transifex_api.ResourceString.filter(resource=res).all())
 
-        # add notranslate tags again
+        for index in range(0, len(resource_strings), transifex_bulk_operation_limit):
+            remove_tags(resource_strings[index:index+transifex_bulk_operation_limit])
+
+        # add resource strings again
         print(f"Adding notranslate tags for {slug}")
-        res_strings = transifex_api.ResourceString.filter(resource=res)
-        for res_str in res_strings.data:
-            key_parts = res_str.attributes.get('key', '').split('.')
-            key_val = key_parts[-1]
-            if key_val not in ('name', 'title', 'text', 'desc', 'description', 'link_text'):
-                res_str.attributes['tags'] = ['notranslate']
-        transifex_api.ResourceString.bulk_update(res_strings, ['tags'])
+        resource_strings = list(transifex_api.ResourceString.filter(resource=res).all())
+
+        for index in range(0, len(resource_strings), transifex_bulk_operation_limit):
+            add_tags(resource_strings[index:index+transifex_bulk_operation_limit])
 
     print('Job complete')
 
 
 if __name__ == '__main__':
-    add_tag()
+    process_tags()


### PR DESCRIPTION
### What does this PR do? What is the motivation?
updates the `notranslate` nightly job to perform bulk updates in batches of 150 (transifex limit on bulk operations at once).   this was needed as the job wasn't working beyond the first 150 previously.

### Merge instructions
- [x] Please merge after websites reviews

### Additional notes
strings tagged as notranslate here have the source string translated and reviewed: https://app.transifex.com/datadog/documentation_loc/translate/#fr_FR/config__default_menus_main_en_yaml/490726492

this ran under 2min on my local, so i don't expect a huge impact on runtime in gitlab