### PR TITLE
Clarify default scheduled for alert graph widget

### DIFF
--- a/content/en/dashboards/widgets/alert_graph.md
+++ b/content/en/dashboards/widgets/alert_graph.md
@@ -15,7 +15,7 @@ Alert graphs are timeseries graphs showing the current status of most monitors d
 
 {{< img src="dashboards/widgets/alert_graph/alert_graph.png" alt="Alert Graph" >}}
 
-This widget is supported in query alert monitors such as metric, anomaly, outlier, forecast, APM, and integration.
+This widget is supported in default scheduled query alert monitors such as metric, anomaly, outlier, forecast, APM, and integration.
 
 ## Setup
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/MNTS-90650

Clarifies that the alert graph widget does not support custom scheduling monitors at the moment.

### Merge instructions
Doc update. Look at this [line](https://docs-staging.datadoghq.com/dan.chiniara/update-alert-graph-widget-doc/dashboards/widgets/alert_graph/). 
<img width="566" alt="2024-05-21_15-38-44" src="https://github.com/DataDog/documentation/assets/6266179/0b2c12ce-ccf7-43bf-b27c-5586e80f0092">


### Additional notes

We refer to non-custom scheduled monitors as default in the [custom scheduled doc](https://docs.datadoghq.com/monitors/guide/custom_schedules/?tab=day#alerting-behavior-of-monitors-with-custom-schedules). 