### PR TITLE
Add diff-aware scanning information to generic CI

### DIFF
--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -90,7 +90,7 @@ datadog-ci sarif upload /tmp/report.sarif --service <service> --env <env>
 
 Diff-aware scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
 
-1. Make sure your `DD_APP_KEY`, `DD_SITE` and `DD_API_KEY` variables are set in your CI pipeline
+1. Make sure your `DD_APP_KEY`, `DD_SITE` and `DD_API_KEY` variables are set in your CI pipeline.
 2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.
 3. Ensure that the datadog-static-analyzer is invoked with the flag `--diff-aware`
 

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -88,7 +88,7 @@ datadog-ci sarif upload /tmp/report.sarif --service <service> --env <env>
 
 ## Diff-aware scanning
 
-Diff-Aware Scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
+Diff-aware scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
 
 1. Make sure your `DD_APP_KEY`, `DD_SITE` and `DD_API_KEY` variables are set in your CI pipeline
 2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -91,7 +91,7 @@ datadog-ci sarif upload /tmp/report.sarif --service <service> --env <env>
 Diff-aware scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
 
 1. Make sure your `DD_APP_KEY`, `DD_SITE` and `DD_API_KEY` variables are set in your CI pipeline.
-2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.
+2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that Git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.
 3. Ensure that the datadog-static-analyzer is invoked with the flag `--diff-aware`.
 
 Example of commands sequence:

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -92,7 +92,7 @@ Diff-aware scanning is a feature that enables Datadog Static Analysis to only sc
 
 1. Make sure your `DD_APP_KEY`, `DD_SITE` and `DD_API_KEY` variables are set in your CI pipeline.
 2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.
-3. Ensure that the datadog-static-analyzer is invoked with the flag `--diff-aware`
+3. Ensure that the datadog-static-analyzer is invoked with the flag `--diff-aware`.
 
 Example of commands sequence:
 ```bash

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -90,7 +90,7 @@ datadog-ci sarif upload /tmp/report.sarif --service <service> --env <env>
 
 Diff-Aware Scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
 
-1. Make sure your DD_APP_KEY, DD_SITE and DD_API_KEY variables are set in your CI pipeline
+1. Make sure your `DD_APP_KEY`, `DD_SITE` and `DD_API_KEY` variables are set in your CI pipeline
 2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.
 3. Ensure that the datadog-static-analyzer is invoked with the flag `--diff-aware`
 

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -101,7 +101,7 @@ datadog-ci git-metadata upload
 datadog-static-analyzer -i /path/to/directory -g -o sarif.json -f sarif –diff-aware <...other-options...>
 ```
 
-**Note:** these commands must be invoked in your Git repository.
+**Note:** These commands must be invoked in your Git repository.
 
 ## Further Reading
 

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -86,7 +86,7 @@ mv /tmp/datadog-static-analyzer /usr/local/datadog-static-analyzer
 datadog-ci sarif upload /tmp/report.sarif --service <service> --env <env>
 ```
 
-## Diff-Aware Scanning
+## Diff-aware scanning
 
 Diff-Aware Scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
 

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -86,6 +86,23 @@ mv /tmp/datadog-static-analyzer /usr/local/datadog-static-analyzer
 datadog-ci sarif upload /tmp/report.sarif --service <service> --env <env>
 ```
 
+## Diff-Aware Scanning
+
+Diff-Aware Scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
+
+1. Make sure your DD_APP_KEY, DD_SITE and DD_API_KEY variables are set in your CI pipeline
+2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.
+3. Ensure that the datadog-static-analyzer is invoked with the flag `--diff-aware`
+
+Example of commands sequence:
+```bash
+datadog-ci git-metadata upload
+
+datadog-static-analyzer -i /path/to/directory -g -o sarif.json -f sarif –diff-aware <...other-options...>
+```
+
+**Note:** these commands must be invoked in your Git repository.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds information about diff-aware scanning setup for Generic CI Providers for Datadog Static Analysis

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->