### PR TITLE
Add warning about unified tagging not working for logs for otel apps

### DIFF
--- a/content/en/getting_started/opentelemetry/_index.md
+++ b/content/en/getting_started/opentelemetry/_index.md
@@ -242,7 +242,7 @@ environment:
   - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
 {{< /code-block >}}
 
-<div class="alert alert-warning">For OpenTelemetry applications, unified service tagging is supported only for metrics and traces, not logs.</div>
+<div class="alert alert-warning">For OpenTelemetry applications, unified service tagging is supported for only metrics and traces, not logs.</div>
 
 ## Running the application
 

--- a/content/en/getting_started/opentelemetry/_index.md
+++ b/content/en/getting_started/opentelemetry/_index.md
@@ -242,6 +242,8 @@ environment:
   - OTEL_RESOURCE_ATTRIBUTES=deployment.environment=docker,host.name=otelcol-docker
 {{< /code-block >}}
 
+<div class="alert alert-warning">For OpenTelemetry applications, unified service tagging is supported only for metrics and traces, not logs.</div>
+
 ## Running the application
 
 To start generating and forwarding observability data to Datadog, you need to run the Calendar application with the OpenTelemetry SDK:

--- a/content/en/opentelemetry/schema_semantics/semantic_mapping.md
+++ b/content/en/opentelemetry/schema_semantics/semantic_mapping.md
@@ -19,7 +19,7 @@ OpenTelemetry makes use of a number of [semantic conventions][1] that specify na
 
 ### Unified Service Tagging
 
-<div class="alert alert-warning">For OpenTelemetry applications, unified service tagging is supported only for metrics and traces, not logs.</div>
+<div class="alert alert-warning">For OpenTelemetry applications, unified service tagging is supported for only metrics and traces, not logs.</div>
 
 | OpenTelemetry convention | Datadog convention |
 | --- | --- |

--- a/content/en/opentelemetry/schema_semantics/semantic_mapping.md
+++ b/content/en/opentelemetry/schema_semantics/semantic_mapping.md
@@ -19,6 +19,8 @@ OpenTelemetry makes use of a number of [semantic conventions][1] that specify na
 
 ### Unified Service Tagging
 
+<div class="alert alert-warning">Unified service tagging for logs is not currently supported for OpenTelemetry applications.</div>
+
 | OpenTelemetry convention | Datadog convention |
 | --- | --- |
 | `deployment.environment` | `env` |

--- a/content/en/opentelemetry/schema_semantics/semantic_mapping.md
+++ b/content/en/opentelemetry/schema_semantics/semantic_mapping.md
@@ -19,7 +19,7 @@ OpenTelemetry makes use of a number of [semantic conventions][1] that specify na
 
 ### Unified Service Tagging
 
-<div class="alert alert-warning">Unified service tagging for logs is not currently supported for OpenTelemetry applications.</div>
+<div class="alert alert-warning">For OpenTelemetry applications, unified service tagging is supported only for metrics and traces, not logs.</div>
 
 | OpenTelemetry convention | Datadog convention |
 | --- | --- |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Related to https://datadoghq.atlassian.net/browse/DOCS-7357
For OTel apps, unified service tagging currently works only for metrics and traces, not logs. This is something being worked on this quarter by the dev team. I'll make a note to myself to circle back next quarter to remove these warnings once logs are supported. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->