### PR TITLE
Note Enterprise prerequisite and site-region for SCIM

### DIFF
--- a/content/en/account_management/scim/_index.md
+++ b/content/en/account_management/scim/_index.md
@@ -12,6 +12,10 @@ algolia:
   tags: ["scim", "identity provider", "IdP"]
 ---
 
+<div class="alert alert-info">
+SCIM is only available for the Enterprise plan.
+</div>
+
 ## Overview
 
 The System for Cross-domain Identity Management, or SCIM, is an open standard that allows for the automation of user provisioning. Using SCIM, you can automatically provision and deprovision users in your Datadog organization in sync with your organization's identity provider (IdP).

--- a/content/en/account_management/scim/azure.md
+++ b/content/en/account_management/scim/azure.md
@@ -7,7 +7,17 @@ algolia:
 
 See the following instructions to synchronize your Datadog users with Azure Active Directory using SCIM.
 
-For prerequisites, capabilities, and limitations, see [SCIM][1].
+For capabilities and limitations of this feature, see [SCIM][1].
+
+## Prerequisites
+
+SCIM in Datadog is an advanced feature included in the Enterprise plan.
+
+This documentation assumes your organization manages user identities using an identity provider.
+
+Datadog strongly recommends that you use a service account application key when configuring SCIM to avoid any disruption in access. For further details, see [using a service account with SCIM][2].
+
+When using SAML and SCIM together, Datadog strongly recommends disabling SAML just-in-time (JIT) provisioning to avoid discrepancies in access. Manage user provisioning through SCIM only.
 
 ## Add Datadog to the Azure AD application gallery
 
@@ -26,8 +36,8 @@ For prerequisites, capabilities, and limitations, see [SCIM][1].
 2. In the **Provisioning Mode** menu, select **Automatic**
 3. Open **Admin Credentials**
 4. Complete the **Admin Credentials** section as follows:
-    - **Tenant URL**: `https://app.datadoghq.com/api/v2/scim`
-    - **Secret Token**: Use a valid Datadog application key. You can create an application key on [your organization settings page][2]. To maintain continuous access to your data, use a [service account][3] application key.
+    - **Tenant URL**: `https://{{< region-param key="dd_full_site" >}}/api/v2/scim` **Note:** Use the appropriate subdomain for your site. To find your URL, see [Datadog sites][3].
+    - **Secret Token**: Use a valid Datadog application key. You can create an application key on [your organization settings page][4]. To maintain continuous access to your data, use a [service account][5] application key.
 
 {{< img src="/account_management/scim/admin-credentials.png" alt="Azure AD Admin Credentials configuration screen">}}
 
@@ -61,5 +71,7 @@ For prerequisites, capabilities, and limitations, see [SCIM][1].
 Group mapping is not supported.
 
 [1]: /account_management/scim/
-[2]: https://app.datadoghq.com/organization-settings/application-keys
-[3]: /account_management/org_settings/service_accounts
+[2]: /account_management/scim/#using-a-service-account-with-scim
+[3]: /getting_started/site
+[4]: https://app.datadoghq.com/organization-settings/application-keys
+[5]: /account_management/org_settings/service_accounts

--- a/content/en/account_management/scim/okta.md
+++ b/content/en/account_management/scim/okta.md
@@ -7,7 +7,17 @@ algolia:
 
 See the following instructions to synchronize your Datadog users with Okta using SCIM.
 
-For prerequisites, capabilities, and limitations, see [SCIM][1].
+For the capabilities and limitations of this feature, see [SCIM][1].
+
+## Prerequisites
+
+SCIM in Datadog is an advanced feature included in the Enterprise plan.
+
+This documentation assumes your organization manages user identities using an identity provider.
+
+Datadog strongly recommends that you use a service account application key when configuring SCIM to avoid any disruption in access. For further details, see [using a service account with SCIM][2].
+
+When using SAML and SCIM together, Datadog strongly recommends disabling SAML just-in-time (JIT) provisioning to avoid discrepancies in access. Manage user provisioning through SCIM only.
 
 ## Select the Datadog application in the Okta application gallery
 
@@ -25,8 +35,8 @@ For prerequisites, capabilities, and limitations, see [SCIM][1].
 2. Click **Configuration API integration**.
 3. Select **Enable API integration**.
 3. Complete the **Credentials** section as follows:
-    - **Base URL**: `https://app.datadoghq.com/api/v2/scim` **Note:** Use the appropriate subdomain for your site. To find your URL, see [Datadog sites][2].
-    - **API Token**: Use a valid Datadog application key. You can create an application key on [your organization settings page][3]. To maintain continuous access to your data, use a [service account][4] application key.
+    - **Base URL**: `https://{{< region-param key="dd_full_site" >}}/api/v2/scim` **Note:** Use the appropriate subdomain for your site. To find your URL, see [Datadog sites][3].
+    - **API Token**: Use a valid Datadog application key. You can create an application key on [your organization settings page][4]. To maintain continuous access to your data, use a [service account][5] application key.
 
 {{< img src="/account_management/scim/okta-admin-credentials.png" alt="Okta Admin Credentials configuration screen">}}
 
@@ -43,6 +53,7 @@ For prerequisites, capabilities, and limitations, see [SCIM][1].
 Group mapping is not supported.
 
 [1]: /account_management/scim/
-[2]: /getting_started/site
-[3]: https://app.datadoghq.com/organization-settings/application-keys
-[4]: /account_management/org_settings/service_accounts
+[2]: /account_management/scim/#using-a-service-account-with-scim
+[3]: /getting_started/site
+[4]: https://app.datadoghq.com/organization-settings/application-keys
+[5]: /account_management/org_settings/service_accounts


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
DOCS-8009
Adds and clarifies content in the SCIM documentation as requested by a Technical Support Engineer
- Adds a callout drawing attention the the Enterprise plan prerequisite for SCIM
- Copies the **Prerequisites** section from the main SCIM page to the child pages for setting up SCIM for Okta and Azure.
- Fixes the configuration URLs for Okta and Azure to be region-specific.
- Renumbers the links to maintain their sequential order.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->