### PR TITLE
Add "No Chat Support" message for Memorial Day 2024

### DIFF
--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -7,7 +7,7 @@ further_reading:
   text: "Agent Troubleshooting"
 ---
 
-{{< callout header="false" >}}
+{{< callout header="false" btn_hidden="true" >}}
 Our US offices are closed on Monday, May 27th for Memorial Day. Support will be operating with limited staffing, and so Live Chat will not be available on Memorial Day for Standard Support customers during normal US business hours. Premier Support customers retain access to chat 24x7x365. For urgent issues, contact us through the <a href="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/">Support Portal</a>.
 {{< /callout >}}
 

--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -7,6 +7,9 @@ further_reading:
   text: "Agent Troubleshooting"
 ---
 
+{{< callout header="false" >}}
+Our US offices are closed on Monday, May 27th for Memorial SDay. Support will be operating with limited staffing, and so Live Chat will not be available on Memorial Day for Standard Support customers during normal US business hours. Premier Support customers retain access to chat 24x7x365. For urgent issues, contact us through the <a href="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/">Support Portal</a>.
+
 ## Overview
 
 Datadog provides two primary channels for customers seeking support:

--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -8,7 +8,7 @@ further_reading:
 ---
 
 {{< callout header="false" >}}
-Our US offices are closed on Monday, May 27th for Memorial SDay. Support will be operating with limited staffing, and so Live Chat will not be available on Memorial Day for Standard Support customers during normal US business hours. Premier Support customers retain access to chat 24x7x365. For urgent issues, contact us through the <a href="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/">Support Portal</a>.
+Our US offices are closed on Monday, May 27th for Memorial Day. Support will be operating with limited staffing, and so Live Chat will not be available on Memorial Day for Standard Support customers during normal US business hours. Premier Support customers retain access to chat 24x7x365. For urgent issues, contact us through the <a href="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/">Support Portal</a>.
 
 ## Overview
 

--- a/content/en/getting_started/support/_index.md
+++ b/content/en/getting_started/support/_index.md
@@ -9,6 +9,7 @@ further_reading:
 
 {{< callout header="false" >}}
 Our US offices are closed on Monday, May 27th for Memorial Day. Support will be operating with limited staffing, and so Live Chat will not be available on Memorial Day for Standard Support customers during normal US business hours. Premier Support customers retain access to chat 24x7x365. For urgent issues, contact us through the <a href="https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/">Support Portal</a>.
+{{< /callout >}}
 
 ## Overview
 


### PR DESCRIPTION
Adding a banner to indicate that we will not provide Chat Support message on Memorial Day 2024.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The Support team does not provide Chat Support during US holidays. This banner is intended to inform customers of this change.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
I reached out about this on slack here: https://dd.slack.com/archives/C0DESMBQU/p1716473847069609

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->