### PR TITLE
CI test visibility and ITR: remove max pytest version

### DIFF
--- a/content/en/intelligent_test_runner/setup/python.md
+++ b/content/en/intelligent_test_runner/setup/python.md
@@ -20,7 +20,7 @@ further_reading:
 
 Intelligent Test Runner is only supported in the following versions and testing frameworks:
 
-* `pytest>=6.8.0` up to `<=7.0.0`
+* `pytest>=6.8.0`
   * From `ddtrace>=2.1.0`.
   * From `Python>=3.7`.
   * Requires `coverage>=5.5`.

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -41,7 +41,7 @@ Supported test frameworks:
 
 | Test Framework | Version |
 |---|---|
-| `pytest` | >= 3.0.0 <= 7.0.0 |
+| `pytest` | >= 3.0.0 |
 | `pytest-benchmark` | >= 3.1.0 |
 | `unittest` | >= 3.7 |
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes the max supported `pytest` versions for Test Visibility and the Intelligent Test Runner because incompatibilities with `8.x` have been resolved.

### Merge instructions

- [x] Please merge after reviewing