### PR TITLE
Document ddagentuser is now part of the Performance Log Users group

### DIFF
--- a/content/en/agent/guide/windows-agent-ddagent-user.md
+++ b/content/en/agent/guide/windows-agent-ddagent-user.md
@@ -13,6 +13,7 @@ By default, the Windows Agent uses the `ddagentuser` account created at install 
   * Necessary to access WMI information
   * Necessary to access Windows performance counter data
 * It becomes a member of the "Event Log Readers" group
+* It becomes a member of the "Performance Log Users" group (since 7.51)
 
 **Note**: The installer doesn't add the account it creates to the `Users` groups by default. In rare cases, you may encounter permission issues. If so, manually add the created user to the `Users` group.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR updates the documentation for the `ddagentuser` to include that, starting with 7.51, it is also a member of the "Performance Log Users" group.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->