### PR TITLE
[PROF-9825] Add source code integration step to profiling setup docs

### DIFF
--- a/content/en/profiler/enabling/go.md
+++ b/content/en/profiler/enabling/go.md
@@ -77,7 +77,7 @@ To begin profiling applications:
 
 4. Optional: Enable the [timeline feature][7] (beta), see [prerequisites][8].
 
-5. Optional: Set up [Source Code Integration][9].
+5. Optional: Set up [Source Code Integration][9] to connect your profiling data with your Git repositories.
 
 6. After a minute or two, visualize your profiles in the [Datadog APM > Profiler page][10].
 

--- a/content/en/profiler/enabling/go.md
+++ b/content/en/profiler/enabling/go.md
@@ -22,7 +22,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][17].
+For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][18].
 
 The Datadog Profiler requires Go 1.19+.
 
@@ -34,7 +34,7 @@ Continuous Profiler is not supported on serverless platforms, such as AWS Lambda
 
 To begin profiling applications:
 
-1. Ensure Datadog Agent v6+ is installed and running. Datadog recommends using [Datadog Agent v7+][18].
+1. Ensure Datadog Agent v6+ is installed and running. Datadog recommends using [Datadog Agent v7+][19].
 
 2. Get `dd-trace-go` using the command:
 
@@ -77,9 +77,11 @@ To begin profiling applications:
 
 4. Optional: Enable the [timeline feature][7] (beta), see [prerequisites][8].
 
-5. After a minute or two, visualize your profiles in the [Datadog APM > Profiler page][9].
+5. Optional: Set up [Source Code Integration][9].
 
-**Note**: By default, only the CPU and Heap profiles are enabled. Use [profiler.WithProfileTypes][10] to enable additional [profile types][11].
+6. After a minute or two, visualize your profiles in the [Datadog APM > Profiler page][10].
+
+**Note**: By default, only the CPU and Heap profiles are enabled. Use [profiler.WithProfileTypes][11] to enable additional [profile types][12].
 
 ## Configuration
 
@@ -87,8 +89,8 @@ You can set profiler parameters in code with these functions:
 
 | Function | Type          | Description                                                                                                  |
 | ---------------- | ------------- | ------------------------------------------------------------------------------------------------------------ |
-|  WithService     | String        | The Datadog [service][12] name, for example, `my-web-app`.             |
-|  WithEnv         | String        | The Datadog [environment][13] name, for example, `production`.         |
+|  WithService     | String        | The Datadog [service][13] name, for example, `my-web-app`.             |
+|  WithEnv         | String        | The Datadog [environment][14] name, for example, `production`.         |
 |  WithVersion     | String        | The version of your application.                                                                             |
 |  WithTags        | List of strings        | A list of tags to apply to an uploaded profile. Tags must be of the format `<KEY>:<VALUE>`. |
 
@@ -96,16 +98,16 @@ Alternatively you can set profiler configuration using environment variables:
 
 | Environment variable                             | Type          | Description                                                                                      |
 | ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
-| `DD_ENV`                                         | String        | The [environment][12] name, for example, `production`. |
-| `DD_SERVICE`                                     | String        | The [service][12] name, for example, `web-backend`. |
-| `DD_VERSION`                                     | String        | The [version][12] of your service. |
+| `DD_ENV`                                         | String        | The [environment][13] name, for example, `production`. |
+| `DD_SERVICE`                                     | String        | The [service][13] name, for example, `web-backend`. |
+| `DD_VERSION`                                     | String        | The [version][13] of your service. |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
 
 ### Showing C function calls in CPU profiles
 
 By default, Go's CPU profiler only shows detailed information for Go code. If your program calls C code, the time spent running C code is reflected in the profile, but the call stacks only show Go function calls.
 
-To add detailed C function call information to CPU profiles, you may opt to use library such as [ianlancetaylor/cgosymbolizer][13]. To use this library:
+To add detailed C function call information to CPU profiles, you may opt to use library such as [ianlancetaylor/cgosymbolizer][14]. To use this library:
 
 1. Download the package:
 
@@ -123,13 +125,13 @@ To add detailed C function call information to CPU profiles, you may opt to use 
 
 ## Save up to 14% CPU in production with PGO
 
-Starting [Go 1.21][14], the Go compiler supports Profile-Guided Optimization (PGO). PGO enables additional optimizations on code identified as hot by CPU profiles of production workloads. This is compatible with Datadog Go Continuous Profiler and can be used for production builds.
+Starting [Go 1.21][15], the Go compiler supports Profile-Guided Optimization (PGO). PGO enables additional optimizations on code identified as hot by CPU profiles of production workloads. This is compatible with Datadog Go Continuous Profiler and can be used for production builds.
 
-Follow [this guide][15] to set it up.
+Follow [this guide][16] to set it up.
 
 ## Not sure what to do next?
 
-The [Getting Started with Profiler][16] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
+The [Getting Started with Profiler][17] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Further Reading
 
@@ -143,13 +145,14 @@ The [Getting Started with Profiler][16] guide takes a sample service with a perf
 [6]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#pkg-constants
 [7]: /profiler/connect_traces_and_profiles/#span-execution-timeline-view
 [8]: /profiler/connect_traces_and_profiles/#prerequisites
-[9]: https://app.datadoghq.com/profiling
-[10]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithProfileTypes
-[11]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#ProfileType
-[12]: /getting_started/tagging/unified_service_tagging
-[13]: https://pkg.go.dev/github.com/ianlancetaylor/cgosymbolizer#pkg-overview
-[14]: https://tip.golang.org/doc/go1.21
-[15]: /profiler/guide/save-cpu-in-production-with-go-pgo
-[16]: /getting_started/profiler/
-[17]: /profiler/enabling/supported_versions/
-[18]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
+[9]: /integrations/guide/source-code-integration/?tab=go
+[10]: https://app.datadoghq.com/profiling
+[11]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#WithProfileTypes
+[12]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/profiler#ProfileType
+[13]: /getting_started/tagging/unified_service_tagging
+[14]: https://pkg.go.dev/github.com/ianlancetaylor/cgosymbolizer#pkg-overview
+[15]: https://tip.golang.org/doc/go1.21
+[16]: /profiler/guide/save-cpu-in-production-with-go-pgo
+[17]: /getting_started/profiler/
+[18]: /profiler/enabling/supported_versions/
+[19]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -147,7 +147,7 @@ When the service binary is built, you can use environment variables to enable an
 
    **Note**: The `-javaagent` argument needs to be before `-jar`. This adds it as a JVM option rather than an application argument. For example, `java -javaagent:dd-java-agent.jar ... -jar my-service.jar -more-flags`. For more information, see the [Oracle documentation][6].
 
-4. Optional: Set up [Source Code Integration][7].
+4. Optional: Set up [Source Code Integration][7] to connect your profiling data with your Git repositories.
 
 5. After a minute or two, you can visualize your profiles on the [Datadog APM > Profiling page][8].
 

--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -22,7 +22,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][12].
+For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][13].
 
 As of dd-trace-java 1.0.0, you have two options for the engine that generates profile data for Java applications: [Java Flight Recorder (JFR)][2] or the Datadog Profiler. As of dd-trace-java 1.7.0, Datadog Profiler is the default. Each profiler engine has different side effects, requirements, available configurations, and limitations, and this page describes each. You can enable either one or both engines. Enabling both captures both profile types at the same time.
 
@@ -57,12 +57,12 @@ Minimum JDK versions:
 
 Because non-LTS JDK versions may not contain stability and performance fixes related to the Datadog Profiler library, use versions 8, 11, and 17 of the Long Term Support JDK.
 
-Additional requirements for profiling [Code Hotspots][11]:
+Additional requirements for profiling [Code Hotspots][12]:
  - OpenJDK 11+ and `dd-trace-java` version 0.65.0+
  - OpenJDK 8 8u282+ and `dd-trace-java` version 0.77.0+
 
 [3]: /profiler/profiler_troubleshooting/java/#java-8-support
-[11]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
+[12]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -134,7 +134,7 @@ java \
 
 {{% collapse-content title="(Optional) Build and run native-image" level="h4" %}}
 
-Follow the [Tracer Setup Instructions][13] to build your native image with the Datadog Java Profiler.
+Follow the [Tracer Setup Instructions][14] to build your native image with the Datadog Java Profiler.
 
 When the service binary is built, you can use environment variables to enable and configure the Datadog Java Profiler:
 
@@ -147,7 +147,9 @@ When the service binary is built, you can use environment variables to enable an
 
    **Note**: The `-javaagent` argument needs to be before `-jar`. This adds it as a JVM option rather than an application argument. For example, `java -javaagent:dd-java-agent.jar ... -jar my-service.jar -more-flags`. For more information, see the [Oracle documentation][6].
 
-4. After a minute or two, you can visualize your profiles on the [Datadog APM > Profiling page][7].
+4. Optional: Set up [Source Code Integration][7].
+
+5. After a minute or two, you can visualize your profiles on the [Datadog APM > Profiling page][8].
 
 ### Enabling CPU profiler engine options
 
@@ -329,14 +331,14 @@ You can configure the profiler using the following environment variables:
 | ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------ |
 | `DD_PROFILING_ENABLED`                           | Boolean       | Alternate for `-Ddd.profiling.enabled` argument. Set to `true` to enable profiler.               |
 | `DD_PROFILING_ALLOCATION_ENABLED`                | Boolean       | Alternate for `-Ddd.profiling.allocation.enabled` argument. Set to `true` to enable the allocation profiler. It requires the profiler to be enabled already. |
-| `DD_ENV`                                         | String        | The [environment][9] name, for example: `production`. |
-| `DD_SERVICE`                                     | String        | The [service][9] name, for example, `web-backend`. |
-| `DD_VERSION`                                     | String        | The [version][9] of your service. |
+| `DD_ENV`                                         | String        | The [environment][10] name, for example: `production`. |
+| `DD_SERVICE`                                     | String        | The [service][10] name, for example, `web-backend`. |
+| `DD_VERSION`                                     | String        | The [version][10] of your service. |
 | `DD_TAGS`                                        | String        | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.  |
 
 ## Not sure what to do next?
 
-The [Getting Started with Profiler][10] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
+The [Getting Started with Profiler][11] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Further Reading
 
@@ -348,10 +350,11 @@ The [Getting Started with Profiler][10] guide takes a sample service with a perf
 [4]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
 [5]: https://app.datadoghq.com/account/settings/agent/6?platform=overview
 [6]: https://docs.oracle.com/javase/7/docs/technotes/tools/solaris/java.html
-[7]: https://app.datadoghq.com/profiling
-[8]: /profiler/profiler_troubleshooting/#enabling-the-allocation-profiler
-[9]: /getting_started/tagging/unified_service_tagging
-[10]: /getting_started/profiler/
-[11]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
-[12]: /profiler/enabling/supported_versions/
-[13]: /tracing/trace_collection/compatibility/java/?tab=graalvm#setup
+[7]: /integrations/guide/source-code-integration/?tab=java
+[8]: https://app.datadoghq.com/profiling
+[9]: /profiler/profiler_troubleshooting/#enabling-the-allocation-profiler
+[10]: /getting_started/tagging/unified_service_tagging
+[11]: /getting_started/profiler/
+[12]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
+[13]: /profiler/enabling/supported_versions/
+[14]: /tracing/trace_collection/compatibility/java/?tab=graalvm#setup

--- a/content/en/profiler/enabling/nodejs.md
+++ b/content/en/profiler/enabling/nodejs.md
@@ -22,7 +22,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 ## Requirements
 
-For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][6].
+For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][7].
 
 The Datadog Profiler requires at least Node.js 14, but Node.js 16 or higher is recommended. If you use a version of Node.js earlier than 16, some applications see tail latency spikes every minute when starting the next profile.
 
@@ -75,11 +75,13 @@ const tracer = require('dd-trace/init')
 {{% /tab %}}
 {{< /tabs >}}
 
-4. A minute or two after starting your Node.js application, your profiles will show up on the [APM > Profiler page][4].
+4. Optional: Set up [Source Code Integration][4].
+
+5. A minute or two after starting your Node.js application, your profiles will show up on the [APM > Profiler page][5].
 
 ## Not sure what to do next?
 
-The [Getting Started with Profiler][5] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
+The [Getting Started with Profiler][6] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Experiencing high overhead?
 
@@ -92,6 +94,7 @@ Node.js 16 or higher is recommended. On earlier versions, some applications see 
 [1]: /tracing/trace_collection/
 [2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
 [3]: https://app.datadoghq.com/account/settings/agent/6?platform=overview
-[4]: https://app.datadoghq.com/profiling
-[5]: /getting_started/profiler/
-[6]: /profiler/enabling/supported_versions/
+[4]: /integrations/guide/source-code-integration/?tab=nodejs
+[5]: https://app.datadoghq.com/profiling
+[6]: /getting_started/profiler/
+[7]: /profiler/enabling/supported_versions/

--- a/content/en/profiler/enabling/python.md
+++ b/content/en/profiler/enabling/python.md
@@ -26,7 +26,7 @@ For a summary of the minimum and recommended runtime and tracer versions across 
 
 The Datadog Profiler requires Python 2.7+.
 
-The following profiling features are available depending on your Python version. For more details, read [Profile Types][7]:
+The following profiling features are available depending on your Python version. For more details, read [Profile Types][8]:
 
 |      Feature         | Supported Python versions          |
 |----------------------|------------------------------------|
@@ -76,7 +76,9 @@ To automatically profile your code, set the `DD_PROFILING_ENABLED` environment v
 
 See [Configuration](#configuration) for more advanced usage.
 
-After a couple of minutes, visualize your profiles on the [Datadog APM > Profiler page][4].
+Optionally set up [Source Code Integration][4].
+
+After a couple of minutes, visualize your profiles on the [Datadog APM > Profiler page][5].
 
 If you want to manually control the lifecycle of the profiler, use the `ddtrace.profiling.Profiler` object:
 
@@ -111,7 +113,7 @@ prof.start()  # Should be as early as possible, eg before other imports, to ensu
 
 ## Configuration
 
-You can configure the profiler using the [environment variables][5].
+You can configure the profiler using the [environment variables][6].
 
 ### Code provenance
 
@@ -122,7 +124,7 @@ disabled by default, you can turn it on by setting
 
 ## Not sure what to do next?
 
-The [Getting Started with Profiler][6] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
+The [Getting Started with Profiler][7] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Further Reading
 
@@ -131,10 +133,11 @@ The [Getting Started with Profiler][6] guide takes a sample service with a perfo
 [1]: /tracing/trace_collection/
 [2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
 [3]: https://app.datadoghq.com/account/settings/agent/6?platform=overview
-[4]: https://app.datadoghq.com/profiling
-[5]: https://ddtrace.readthedocs.io/en/stable/configuration.html#configuration
-[6]: /getting_started/profiler/
-[7]: /profiler/profile_types/?code-lang=python
+[4]: /integrations/guide/source-code-integration/?tab=python
+[5]: https://app.datadoghq.com/profiling
+[6]: https://ddtrace.readthedocs.io/en/stable/configuration.html#configuration
+[7]: /getting_started/profiler/
+[8]: /profiler/profile_types/?code-lang=python
 [12]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
 [13]: /profiler/connect_traces_and_profiles/#break-down-code-performance-by-api-endpoints
 [14]: /profiler/enabling/supported_versions/

--- a/content/en/profiler/enabling/python.md
+++ b/content/en/profiler/enabling/python.md
@@ -76,7 +76,7 @@ To automatically profile your code, set the `DD_PROFILING_ENABLED` environment v
 
 See [Configuration](#configuration) for more advanced usage.
 
-Optionally set up [Source Code Integration][4].
+Optionally, set up [Source Code Integration][4] to connect your profiling data with your Git repositories.
 
 After a couple of minutes, visualize your profiles on the [Datadog APM > Profiler page][5].
 

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -59,9 +59,9 @@ To begin profiling applications:
 
     If you're running a version of `ddtrace` older than 1.15.0, add the `google-protobuf` gem (version ~> 3.0) as a dependency.
 
-2. Install the gems with `bundle install`.
+3. Install the gems with `bundle install`.
 
-3. Enable the profiler:
+4. Enable the profiler:
 
    {{< tabs >}}
 {{% tab "Environment variables" %}}
@@ -90,7 +90,7 @@ end
 {{% /tab %}}
 {{< /tabs >}}
 
-4. Add the `ddprofrb exec` command to your Ruby application start command:
+5. Add the `ddprofrb exec` command to your Ruby application start command:
 
     ```shell
     bundle exec ddprofrb exec ruby myapp.rb
@@ -112,12 +112,13 @@ end
     require 'datadog/profiling/preload'
     ```
 
+6. Optional: Set up [Source Code Integration][4].
 
-4. A minute or two after starting your Ruby application, your profiles will show up on the [Datadog APM > Profiler page][4].
+7. A minute or two after starting your Ruby application, your profiles will show up on the [Datadog APM > Profiler page][5].
 
 ## Not sure what to do next?
 
-The [Getting Started with Profiler][5] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
+The [Getting Started with Profiler][6] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
 
 ## Further Reading
 
@@ -126,8 +127,9 @@ The [Getting Started with Profiler][5] guide takes a sample service with a perfo
 [1]: /tracing/trace_collection/
 [2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
 [3]: https://app.datadoghq.com/account/settings/agent/6?platform=overview
-[4]: https://app.datadoghq.com/profiling
-[5]: /getting_started/profiler/
+[4]: /integrations/guide/source-code-integration/?tab=ruby
+[5]: https://app.datadoghq.com/profiling
+[6]: /getting_started/profiler/
 [12]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
 [13]: /profiler/connect_traces_and_profiles/#break-down-code-performance-by-api-endpoints
 [14]: /profiler/enabling/supported_versions/

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -112,7 +112,7 @@ end
     require 'datadog/profiling/preload'
     ```
 
-6. Optional: Set up [Source Code Integration][4].
+6. Optional: Set up [Source Code Integration][4] to connect your profiling data with your Git repositories.
 
 7. A minute or two after starting your Ruby application, your profiles will show up on the [Datadog APM > Profiler page][5].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Source code integration is an important feature that makes profiling flame graphs more intuitive and easier to explore. Encouraging users to set it up at the same time as they're configuring the profiler is desirable. Profiling currently supports the integration for Java, Python, Node.js, Go and Ruby.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->