### PR TITLE
[docker] Update process collection environment variable

### DIFF
--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -169,11 +169,11 @@ For more information about proxy settings, see the [Agent v6 Proxy documentation
 
 Optional collection Agents are disabled by default for security or performance reasons. Use these environment variables to enable them:
 
-| Env Variable               | Description                                                                                                                                                                                                                                                      |
-|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_APM_NON_LOCAL_TRAFFIC` | Allow non-local traffic when [tracing from other containers][16].       |
-| `DD_LOGS_ENABLED`          | Enable [log collection][17] with the Logs Agent.                                                                                                                                                                                                                 |
-| `DD_PROCESS_AGENT_ENABLED` | Enable [live process collection][18] with the Process Agent. The [live container view][19] is already enabled by default if the Docker socket is available. If set to `false`, the [live process collection][18] and the [live container view][19] are disabled. |
+| Env Variable                                  | Description                                                                                                                                                   |
+|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_APM_NON_LOCAL_TRAFFIC`                    | Allow non-local traffic when [tracing from other containers][16].                                                                                             |
+| `DD_LOGS_ENABLED`                             | Enable [log collection][17] with the Logs Agent.                                                                                                              |
+| `DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED` | Enable [live process collection][18] with the Process Agent. The [live container view][19] is already enabled by default if the Docker socket is available. |
 
 ### DogStatsD (custom metrics)
 

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -169,11 +169,11 @@ For more information about proxy settings, see the [Agent v6 Proxy documentation
 
 Optional collection Agents are disabled by default for security or performance reasons. Use these environment variables to enable them:
 
-| Env Variable                                  | Description                                                                                                                                                   |
-|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DD_APM_NON_LOCAL_TRAFFIC`                    | Allow non-local traffic when [tracing from other containers][16].                                                                                             |
-| `DD_LOGS_ENABLED`                             | Enable [log collection][17] with the Logs Agent.                                                                                                              |
-| `DD_PROCESS_AGENT_PROCESS_COLLECTION_ENABLED` | Enable [live process collection][18] with the Process Agent. The [live container view][19] is already enabled by default if the Docker socket is available. |
+| Env Variable                                   | Description                                                                                                                                                   |
+|------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DD_APM_NON_LOCAL_TRAFFIC`                     | Allow non-local traffic when [tracing from other containers][16].                                                                                             |
+| `DD_LOGS_ENABLED`                              | Enable [log collection][17] with the Logs Agent.                                                                                                              |
+| `DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED` | Enable [live process collection][18] with the Process Agent. The [live container view][19] is already enabled by default if the Docker socket is available. |
 
 ### DogStatsD (custom metrics)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Update the process collection environment variable from `DD_PROCESS_AGENT_ENABLED` to `DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED`. This was added in agent version 7.35.0 (https://github.com/DataDog/datadog-agent/pull/10555) and is also consistent with the current [Processes public docs](https://docs.datadoghq.com/infrastructure/process/?tab=docker#installation)

<img width="769" alt="image" src="https://github.com/DataDog/documentation/assets/1155971/9a62bfbf-092e-488e-a40d-217d397d3f92">


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->