### PR TITLE
Broken Links on Data Volume Guidelines Page

### DIFF
--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -165,7 +165,7 @@ kubectl exec -it <agent-pod-name> -c trace-agent -- agent flare <case-id> --loca
 [5]: /tracing/troubleshooting/tracer_debug_logs/
 [6]: /tracing/glossary/#services
 [7]: /tracing/glossary/#resources
-[8]: /tracing/glossary/#span-tags
+[8]: /glossary/#span-tag
 [9]: /tracing/troubleshooting/agent_rate_limits
 [10]: /tracing/troubleshooting/agent_apm_resource_usage/
 [11]: /tracing/custom_instrumentation/agent_customization


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Links to span tags are broken. Span tags are not defined in the APM glossary, just the main glossary.
- Change link.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->