### PR TITLE
update ios syntax to use correct event names

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
@@ -603,20 +603,20 @@ To modify attributes of a RUM event before it is sent to Datadog or to drop an e
 ```swift
 let configuration = RUM.Configuration(
     applicationID: "<rum application id>",
-    viewEventMapper: { viewEvent in
-        return viewEvent
+    viewEventMapper: { RUMViewEvent in
+        return RUMViewEvent
     }
-    resourceEventMapper: { resourceEvent in
-        return resourceEvent
+    resourceEventMapper: { RUMResourceEvent in
+        return RUMResourceEvent
     }
-    actionEventMapper: { actionEvent in
-        return actionEvent
+    actionEventMapper: { RUMActionEvent in
+        return RUMActionEvent
     }
-    errorEventMapper: { errorEvent in
-        return errorEvent
+    errorEventMapper: { RUMErrorEvent in
+        return RUMErrorEvent
     }
-    longTaskEventMapper: { longTaskEvent in
-        return longTaskEvent
+    longTaskEventMapper: { RUMLongTaskEvent in
+        return RUMLongTaskEvent
     }
 )
 ```
@@ -625,24 +625,24 @@ let configuration = RUM.Configuration(
 ```objective-c
 DDRUMConfiguration *configuration = [[DDRUMConfiguration alloc] initWithApplicationID:@"<rum application id>"];
 
-[configuration setViewEventMapper:^DDRUMViewEvent * _Nonnull(DDRUMViewEvent * _Nonnull viewEvent) {
-    return viewEvent;
+[configuration setViewEventMapper:^DDRUMViewEvent * _Nonnull(DDRUMViewEvent * _Nonnull RUMViewEvent) {
+    return RUMViewEvent;
 }];
 
-[configuration setErrorEventMapper:^DDRUMErrorEvent * _Nullable(DDRUMErrorEvent * _Nonnull errorEvent) {
-    return errorEvent;
+[configuration setErrorEventMapper:^DDRUMErrorEvent * _Nullable(DDRUMErrorEvent * _Nonnull RUMErrorEvent) {
+    return RUMErrorEvent;
 }];
 
-[configuration setResourceEventMapper:^DDRUMResourceEvent * _Nullable(DDRUMResourceEvent * _Nonnull resourceEvent) {
-    return resourceEvent;
+[configuration setResourceEventMapper:^DDRUMResourceEvent * _Nullable(DDRUMResourceEvent * _Nonnull RUMResourceEvent) {
+    return RUMResourceEvent;
 }];
 
-[configuration setActionEventMapper:^DDRUMActionEvent * _Nullable(DDRUMActionEvent * _Nonnull actionEvent) {
-    return actionEvent;
+[configuration setActionEventMapper:^DDRUMActionEvent * _Nullable(DDRUMActionEvent * _Nonnull RUMActionEvent) {
+    return RUMActionEvent;
 }];
 
-[configuration setLongTaskEventMapper:^DDRUMLongTaskEvent * _Nullable(DDRUMLongTaskEvent * _Nonnull longTaskEvent) {
-    return longTaskEvent;
+[configuration setLongTaskEventMapper:^DDRUMLongTaskEvent * _Nullable(DDRUMLongTaskEvent * _Nonnull RUMLongTaskEvent) {
+    return RUMLongTaskEvent;
 }];
 ```
 {{% /tab %}}
@@ -657,10 +657,10 @@ For example, to redact sensitive information in a RUM Resource's `url`, implemen
 ```swift
 let configuration = RUM.Configuration(
     applicationID: "<rum application id>",
-    resourceEventMapper: { resourceEvent in
-        var resourceEvent = resourceEvent
-        resourceEvent.resource.url = redacted(resourceEvent.resource.url)
-        return resourceEvent
+    resourceEventMapper: { RUMResourceEvent in
+        var RUMResourceEvent = RUMResourceEvent
+        RUMResourceEvent.resource.url = redacted(RUMResourceEvent.resource.url)
+        return RUMResourceEvent
     }
 )
 ```
@@ -669,8 +669,8 @@ let configuration = RUM.Configuration(
 ```objective-c
 DDRUMConfiguration *configuration = [[DDRUMConfiguration alloc] initWithApplicationID:@"<rum application id>"];
 
-[configuration setResourceEventMapper:^DDRUMResourceEvent * _Nullable(DDRUMResourceEvent * _Nonnull resourceEvent) {
-    return resourceEvent;
+[configuration setResourceEventMapper:^DDRUMResourceEvent * _Nullable(DDRUMResourceEvent * _Nonnull RUMResourceEvent) {
+    return RUMResourceEvent;
 }];
 ```
 {{% /tab %}}
@@ -682,16 +682,16 @@ Depending on the event's type, only some specific properties can be modified:
 
 | Event Type       | Attribute key                     | Description                             |
 |------------------|-----------------------------------|-----------------------------------------|
-| RUMViewEvent     | `viewEvent.view.name`             | Name of the view.                        |
-|                  | `viewEvent.view.url`              | URL of the view.                         |
-| RUMActionEvent   | `actionEvent.action.target?.name` | Name of the action.                      |
-|                  | `actionEvent.view.url`            | URL of the view linked to this action.   |
-| RUMErrorEvent    | `errorEvent.error.message`        | Error message.                           |
-|                  | `errorEvent.error.stack`          | Stacktrace of the error.                 |
-|                  | `errorEvent.error.resource?.url`  | URL of the resource the error refers to. |
-|                  | `errorEvent.view.url`             | URL of the view linked to this error.    |
-| RUMResourceEvent | `resourceEvent.resource.url`      | URL of the resource.                     |
-|                  | `resourceEvent.view.url`          | URL of the view linked to this resource. |
+| RUMViewEvent     | `RUMViewEvent.view.name`             | Name of the view.                        |
+|                  | `RUMViewEvent.view.url`              | URL of the view.                         |
+| RUMActionEvent   | `RUMActionEvent.action.target?.name` | Name of the action.                      |
+|                  | `RUMActionEvent.view.url`            | URL of the view linked to this action.   |
+| RUMErrorEvent    | `RUMErrorEvent.error.message`        | Error message.                           |
+|                  | `RUMErrorEvent.error.stack`          | Stacktrace of the error.                 |
+|                  | `RUMErrorEvent.error.resource?.url`  | URL of the resource the error refers to. |
+|                  | `RUMErrorEvent.view.url`             | URL of the view linked to this error.    |
+| RUMResourceEvent | `RUMResourceEvent.resource.url`      | URL of the resource.                     |
+|                  | `RUMResourceEvent.view.url`          | URL of the view linked to this resource. |
 
 ## Set tracking consent (GDPR compliance)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Syntax for event names is incorrect for iOS. See screenshot from XCode below for the correct names: 
<img width="436" alt="image" src="https://github.com/DataDog/documentation/assets/28220221/26939c2c-2c0d-48b4-b334-0ff406ac13a7">


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->