### PR TITLE
(DOCS-7398)(DEV) Clarify hostname default

### DIFF
--- a/content/en/developers/dogstatsd/datagram_shell.md
+++ b/content/en/developers/dogstatsd/datagram_shell.md
@@ -105,7 +105,7 @@ The value is a Unix timestamp (UTC) and must be prefixed by `T`, for example:
 | `<TITLE_UTF8_LENGTH>`                | Yes      | The length (in bytes) of the UTF-8-encoded `<TITLE>`                                                                              |
 | `<TEXT_UTF8_LENGTH>`                 | Yes      | The length (in bytes) of the UTF-8-encoded `<TEXT>`                                                                               |
 | `d:<TIMESTAMP>`                      | No       | Add a timestamp to the event. The default is the current Unix epoch timestamp.                                         |
-| `h:<HOSTNAME>`                       | No       | Add a hostname to the event. No default.                                                                               |
+| `h:<HOSTNAME>`                       | No       | Add a hostname to the event. Defaults to the Datadog Agent instance.                                                                               |
 | `k:<AGGREGATION_KEY>`                | No       | Add an aggregation key to group the event with others that have the same key. No default.                              |
 | `p:<PRIORITY>`                       | No       | Set to `normal` or `low`. Default `normal`.                                                                            |
 | `s:<SOURCE_TYPE_NAME>`               | No       | Add a source type to the event. No default.                                                                            |


### PR DESCRIPTION
Clarifies hostname default for DogStatsD events

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->