### PR TITLE
[rum mobile] Update deobfuscation docs for mobile error tracking

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/android.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/android.md
@@ -66,6 +66,13 @@ For any Android version, you can override the default setting for reporting non-
 
 ## Get deobfuscated stack traces
 
+Mapping files are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding mapping files. This ensures that regardless of when the mapping file was uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
+
+Depending on the [Android Gradle plugin][1] version, the matching of stack traces and mapping files relies on different fields:
+
+- Version 1.13.0 uses the `build_id` field
+- Older versions use a combination of the `service`, `version`, and `variant` fields
+
 ### Upload your mapping file
 
 **Note**: Re-uploading a source map does not override the existing one if the version has not changed.

--- a/content/en/real_user_monitoring/error_tracking/mobile/flutter.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/flutter.md
@@ -73,6 +73,10 @@ If your application suffers a fatal crash, the Datadog Flutter SDK uploads a cra
 
 ## Get deobfuscated stack traces
 
+Mapping files are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding mapping files. This ensures that regardless of when the mapping file was uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
+
+For Flutter applications, the matching of stack traces and source maps relies on their `service`, `version`, `variant`, and `architecture` fields.
+
 ### Upload symbol files to Datadog
 
 Native iOS crash reports are collected in a raw format and mostly contain memory addresses. To map these addresses into legible symbol information, Datadog requires that you upload .dSYM files, which are generated in your application's build process.

--- a/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -153,6 +153,10 @@ To disable app hang monitoring, update the initialization snippet and set the `a
 
 ## Get deobfuscated stack traces
 
+Mapping files are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding mapping files. This ensures that regardless of when the mapping file was uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
+
+For iOS applications, the matching of stack traces and symbol files relies on their `uuid` field.
+
 ### Symbolicate crash reports
 
 Crash reports are collected in a raw format and mostly contain memory addresses. To map these addresses into legible symbol information, Datadog requires .`dSYM` files, which are generated in your application's build or distribution process.

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -54,6 +54,10 @@ config.nativeCrashReportEnabled = true; // enable native crash reporting
 
 ## Get deobfuscated stack traces
 
+Mapping files are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding mapping files. This ensures that regardless of when the mapping file was uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
+
+For React Native applications, the matching of stack traces and sourcemaps relies on a combination of the `service`, `version`, `bundle_name`, and `platform` fields. Out of all sourcemaps that match with these fields, Datadog uses the one with the highest `build_number` value.
+
 In order to make your application's size smaller, its code is minified when it is built for release. To link errors to your actual code, you need to upload the following symbolication files:
 
 -   JavaScript source map for your iOS JavaScript bundle


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
As per [DOCS-8090](https://datadoghq.atlassian.net/browse/DOCS-8090), adds deobfuscation and mapping details to the following mobile error tracking pages:
- Android
- Flutter
- iOS 
- React Native

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8090]: https://datadoghq.atlassian.net/browse/DOCS-8090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ