### PR TITLE
[LLM Observability] Add tagging information to API

### DIFF
--- a/content/en/tracing/llm_observability/api.md
+++ b/content/en/tracing/llm_observability/api.md
@@ -326,6 +326,7 @@ Evaluations require a `span_id` and `trace_id`.
 | Field   | Type         | Description                                         |
 |---------|--------------|-----------------------------------------------------|
 | metrics [*required*] | [[EvalMetric](#evalmetric)] | A list of evaluations each associated with a span. |
+| tags        | [[Tag](#tag)] | A list of tags to apply to the list of evaluation metrics.       |
 
 #### EvalMetric
 
@@ -339,8 +340,7 @@ Evaluations require a `span_id` and `trace_id`.
 | label [*required*]      | string | The unique name or label for the provided evaluation . |
 | categorical_value [*required if the metric_type is "score"*]    | string | A string representing the category that the evaluation belongs to. |
 | score_value [*required if the metric_type is "score"*]    | number | A score value of the evaluation. |
-| flagged                | boolean| Flag content as inappropriate or incorrect. |
-| annotation             | string | A generic string note about the provided evaluation. |
+| tags        | [[Tag](#tag)] | A list of tags to apply to this particular evaluation metric.       |
 
 #### EvalMetricsRequestData
 

--- a/content/en/tracing/llm_observability/api.md
+++ b/content/en/tracing/llm_observability/api.md
@@ -326,7 +326,7 @@ Evaluations require a `span_id` and `trace_id`.
 | Field   | Type         | Description                                         |
 |---------|--------------|-----------------------------------------------------|
 | metrics [*required*] | [[EvalMetric](#evalmetric)] | A list of evaluations each associated with a span. |
-| tags        | [[Tag](#tag)] | A list of tags to apply to the list of evaluation metrics.       |
+| tags        | [[Tag](#tag)] | A list of tags to apply to all the evaluations in the payload.       |
 
 #### EvalMetric
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Document tags field for evaluation metircs API

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->