### PR TITLE
DOCS-8081: Add Cloud Security Management videos

### DIFF
--- a/content/en/security/cloud_security_management/_index.md
+++ b/content/en/security/cloud_security_management/_index.md
@@ -94,6 +94,14 @@ Use the [Resource Catalog][12] to view specific misconfigurations and threats th
 
 Receive a weekly summary of Cloud Security Management activity over the past week, including important new security issues discovered in the last seven days. Subscriptions to the weekly digest report are managed on a per user basis. To [subscribe to the weekly digest report][11], you must have the `security_monitoring_signals_read` permission.
 
+## Video walkthrough
+
+The following video provides an overview of how to enable and use Cloud Security Management:
+
+{{< youtube id=fVcp2W7zqwg loading=lazy >}}
+
+<br>
+
 ## Next steps
 
 To get started with CSM, navigate to the [**Cloud Security Management Setup**][3] page in Datadog, which has detailed steps on how to set up and configure CSM. For more information, see [Setting Up Cloud Security Management][10].

--- a/content/en/security/cloud_security_management/identity_risks/_index.md
+++ b/content/en/security/cloud_security_management/identity_risks/_index.md
@@ -59,7 +59,9 @@ Datadog CIEM is integrated with [AWS IAM Access Analyzer][5] to further improve 
 
 The following video provides an overview of how to enable and use CSM Identity Risks:
 
-{{< img src="security/csm/how-to-use-csm-identity-risks.mp4" alt="Video that provides an overview of how to install and use CSM Identity Risks" video=true >}}
+{{< youtube id=fho9qYHfMe8 loading=lazy >}}
+
+<br>
 
 ## Further Reading
 

--- a/content/en/security/cloud_security_management/misconfigurations/_index.md
+++ b/content/en/security/cloud_security_management/misconfigurations/_index.md
@@ -48,6 +48,14 @@ Investigate details using the [Misconfigurations Explorer][10]. View detailed in
 
 {{< img src="security/cspm/misconfigurations_explorer.png" alt="CSM Misconfigurations Explorer page" width="100%">}}
 
+## Video walkthrough
+
+The following video provides an overview of how to enable and use CSM Misconfigurations:
+
+{{< youtube id=L2E8D5q1rRY loading=lazy >}}
+
+<br>
+
 ## Get started
 
 {{< learning-center-callout header="Try Detect, Prioritize, and Remediate Cloud Security Risks with Datadog CSM in the Learning Center" btn_title="Enroll Now" btn_url="https://learn.datadoghq.com/courses/csm-misconfigurations">}}

--- a/content/en/security/cloud_security_management/vulnerabilities/_index.md
+++ b/content/en/security/cloud_security_management/vulnerabilities/_index.md
@@ -71,7 +71,13 @@ The [Vulnerabilities Explorer][1] also offers triaging options for detected vuln
 
 The following video provides an overview of how to enable and use CSM Vulnerabilities:
 
-{{< img src="security/csm/how-to-use-csm-vulnerabilities.mp4" alt="Video that provides an overview of how to install and use CSM Vulnerabilities" video=true >}}
+{{< youtube id=9A-WaQFSWo8 loading=lazy >}}
+
+<br>
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/security/csm/vm
 [2]: https://app.datadoghq.com/containers/images
@@ -80,8 +86,3 @@ The following video provides an overview of how to enable and use CSM Vulnerabil
 [5]: /security/application_security/software_composition_analysis/
 [6]: https://www.datadoghq.com/product/infrastructure-monitoring/
 [9]: https://www.cisa.gov/known-exploited-vulnerabilities-catalog
-
-
-## Further reading
-
-{{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/security/threats/_index.md
+++ b/content/en/security/threats/_index.md
@@ -56,6 +56,14 @@ Investigate and triage security signals in the [Signals Explorer][8]. View detai
 Datadog is introducing a new feature called Active Protection to address the crypto threats detected in your environment automatically. Active Protection is in private beta. Fill out the form to request access.
 {{< /callout >}}
 
+## Video walkthrough
+
+The following video provides an overview of how to enable and use CSM Threats:
+
+{{< youtube id=RPILU7A76Pc loading=lazy >}}
+
+<br>
+
 ## Get started
 
 {{< whatsnext >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds Cloud Security Management videos. See DOCS-8081 for details.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->