### PR TITLE
DOCS-8116 Add Cloud Cost Monitors to Docs Navigation

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -2708,6 +2708,11 @@ menu:
       parent: cloud_cost
       identifier: cloud_cost_recommendations
       weight: 8
+    - name: Cost Monitors
+      url: /monitors/types/cloud_cost/
+      parent: cloud_cost
+      identifier: cloud_cost_monitors
+      weight: 9
     - name: APM
       url: tracing/
       pre: apm


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Add link to Cloud Cost Monitors in the CCM navigation.

Requested by Kayla on Jira.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->