### PR TITLE
Added RN docs for DATADOG_RELEASE_VERSION env var

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -85,6 +85,12 @@ project.ext.datadog = [
 
 Options for the `datadog-ci react-native xcode` command are available on the [command documentation page][12].
 
+#### Custom Release Version
+
+Use the `DATADOG_RELEASE_VERSION` environment variable to specify a different release version for your sourcemaps, starting from `@datadog/mobile-react-native@2.3.5` and `@datadog/datadog-ci@v2.37.0`.
+
+When the SDK is initialized with a version suffix, you must manually override the release version in order for the sourcemap and build versions to match.
+
 ## Limitations
 
 {{< site-region region="us,us3,us5,eu,gov" >}}

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -85,7 +85,7 @@ project.ext.datadog = [
 
 Options for the `datadog-ci react-native xcode` command are available on the [command documentation page][12].
 
-#### Custom Release Version
+#### Specifying a custom release version
 
 Use the `DATADOG_RELEASE_VERSION` environment variable to specify a different release version for your sourcemaps, starting from `@datadog/mobile-react-native@2.3.5` and `@datadog/datadog-ci@v2.37.0`.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds documentation for new environment variable that can be used to override the release version of the uploaded sourcemaps on Android and iOS.

### Merge instructions

- [x] Waiting for Datadog React Native v2.3.5 to be released (https://github.com/DataDog/dd-sdk-reactnative/pull/668)