### PR TITLE
Update params.en.yaml

### DIFF
--- a/config/_default/params.en.yaml
+++ b/config/_default/params.en.yaml
@@ -3,8 +3,8 @@ meta_title: Getting Started with Datadog
 meta_description: Datadog, the leading service for cloud-scale monitoring.
 disclaimer: "This page is not yet available in English, we are working on its translation. <br> May you have any questions or feedback about our current translation project, <a href=\"https://docs.datadoghq.com/fr/help/\">feel free to reach out to us!</a>"
 announcement_banner:
-  desktop_message: "Register for the State of DevSecOps Livestream on June 4th"
-  mobile_message: "Join the State of DevSecOps Livestream"
-  external_link: "https://www.datadoghq.com/event/state-of-devsecops-livestream/?utm_source=inbound&utm_medium=corpsite-display&utm_campaign=dg-security-na-docs-announcement-livewebinar-202406DevSecOpsLivestream"
+  desktop_message: "Read the 2024 State of DevSecOps Study!"
+  mobile_message: "Read the State of DevSecOps Study!"
+  external_link: "https://www.datadoghq.com/state-of-devsecops/?utm_source=inbound&utm_medium=corpsite-display&utm_campaign=dg-security-ww-docs-announcement-report-devsecops2024"
 exclude: []
 translate_status_banner: "This translation isn't up-to-date. For the latest English version, click here"


### PR DESCRIPTION
Removes livestream registration CTA

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Removes CTA for June 4th DevSecOps Livestream

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

Preview link here: https://docs-staging.datadoghq.com/leo.schramm/devsecopsCTAremoval/

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->