### PR TITLE
Update span tag length limitation

### DIFF
--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -54,7 +54,7 @@ Datadog truncates the following strings if they exceed the indicated number of c
 | type         |  100       |
 | [resource][7]   |  5000      |
 | [tag key][8]    |  200       |
-| [tag value][8]  |  5000      |
+| [tag value][8]  |  25000     |
 
 Additionally, the number of [span tags][8] present on any span cannot exceed 1024.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates allowed span tag value length to 25K, since this is what we actually enforce.

See escalation for motivation and testing:
https://datadoghq.atlassian.net/browse/APMS-12177


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->