### PR TITLE
fixes anchor links in chrome on pages with tabs

### DIFF
--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -86,7 +86,7 @@ const initCodeTabs = () => {
             const selectedLanguageTab = document.querySelector(`a[data-lang="${tabQueryParameter}"]`);
 
             if (selectedLanguageTab) {
-                selectedLanguageTab.click()
+                activateCodeTab(selectedLanguageTab)
             }else{
                 activateCodeTab(firstTab)
             }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/WEB-4932

Fixes weird table of contents behavior reported in the above ticket.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

1. Visit a page with tabs and a table of contents, like this one: https://docs-staging.datadoghq.com/fitzage/anchor-fix/real_user_monitoring/browser/advanced_configuration/?tab=npm
2. Click on one of the table of contents links.
3. Click the same table of contents link again. It should work correctly instead of jumping to the top of the page.
