### PR TITLE
[DOCS-8066] update prereq shortcode and update docs

### DIFF
--- a/content/en/observability_pipelines/log_volume_control/datadog_agent.md
+++ b/content/en/observability_pipelines/log_volume_control/datadog_agent.md
@@ -17,19 +17,6 @@ This document walks you through the following steps:
 
 {{% observability_pipelines/prerequisites/datadog_agent %}}
 
-{{< tabs >}}
-{{% tab "Splunk HEC" %}}
-
-{{% observability_pipelines/prerequisites/splunk_hec %}}
-
-{{% /tab %}}
-{{% tab "Sumo Logic" %}}
-
-{{% observability_pipelines/prerequisites/sumo_logic %}}
-
-{{% /tab %}}
-{{< /tabs >}}
-
 ## Set up Observability Pipelines
 
 1. Navigate to [Observability Pipelines][1].

--- a/content/en/observability_pipelines/split_logs/datadog_agent.md
+++ b/content/en/observability_pipelines/split_logs/datadog_agent.md
@@ -22,12 +22,12 @@ This document walks you through the following steps:
 {{< tabs >}}
 {{% tab "Splunk HEC" %}}
 
-{{% observability_pipelines/prerequisites/splunk_hec %}}
+{{% observability_pipelines/prerequisites/splunk_hec_destination_only %}}
 
 {{% /tab %}}
 {{% tab "Sumo Logic" %}}
 
-{{% observability_pipelines/prerequisites/sumo_logic %}}
+{{% observability_pipelines/prerequisites/sumo_logic_destination_only %}}
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/layouts/shortcodes/observability_pipelines/prerequisites/splunk_hec_destination_only.md
+++ b/layouts/shortcodes/observability_pipelines/prerequisites/splunk_hec_destination_only.md
@@ -1,0 +1,13 @@
+To use Observability Pipelines's Splunk HEC destination, you have a Splunk Enterprise or Cloud instance configured with an HTTP Event Collector (HEC) input. You also have the following information available:
+
+- The Splunk HEC token.
+- The bind address that your Observability Pipelines Worker will listen on to receive logs from your applications. For example, `0.0.0.0:8080`. Later on, you [configure your applications](#send-logs-to-the-observability-pipelines-worker-over-splunk-hec) to send logs to this address.
+- The base URL of the Splunk instance that the Worker will send processed logs to. This URL should include the port that is globally configured for Splunk HTTP Event Collectors on your Splunk instance. For example, for Splunk Cloud: `https://prd-p-0mupp.splunkcloud.com:8088`.
+- If your HECs are globally configured to enable SSL, then you also need the appropriate [TLS certificates][3001] and password you used to create your private key file.
+
+See [Configure HTTP Event Collector on Splunk Web][3002] for more information about setting up Splunk HEC.
+
+**Note**: Observability Pipelines does not support HEC Indexer Acknowledgement.
+
+[3001]: https://docs.splunk.com/Documentation/Splunk/9.2.0/Security/StepstosecuringSplunkwithTLS#2._Obtain_the_certificates_that_you_need_to_secure_your_Splunk_platform_deployment
+[3002]: https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector

--- a/layouts/shortcodes/observability_pipelines/prerequisites/sumo_logic_destination_only.md
+++ b/layouts/shortcodes/observability_pipelines/prerequisites/sumo_logic_destination_only.md
@@ -1,0 +1,7 @@
+To use Observability Pipelines's Sumo Logic destination, you have a Hosted Sumo Logic Collector with a HTTP Logs source, and the following information available:
+- The bind address that your Observability Pipelines Worker will listen on to receive logs. For example, `0.0.0.0:80`.
+- The URL of the Sumo Logic HTTP Logs Source that the Worker will send processed logs to. This URL is provided by Sumo Logic once you configure your hosted collector and set up an HTTP Logs and Metrics source.
+
+See [Configure HTTP Logs Source on Sumo Logic][101] for more information.
+
+[101]: https://help.sumologic.com/docs/send-data/hosted-collectors/http-source/logs-metrics/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR has no new content, but does the following:
- Splits up prereqs shortcodes for Splunk HEC and Sumo Logic so that there are destination-only shortcodes for the Split Logs use case docs.
- Removes Splunk HEC and Sumo Logic tabs from Datadog Agent source prereqs for Log Volume Control. There are no tabs on the other sources.

[DOCS-8066](https://datadoghq.atlassian.net/browse/DOCS-8066)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8066]: https://datadoghq.atlassian.net/browse/DOCS-8066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ