### PR TITLE
bump browser -rum and -logs v5.20 - [WEB-4984]

### DIFF
--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -65,12 +65,12 @@ if (window.DD_LOGS) {
     });
 
     // global context
-    window.DD_LOGS.addLoggerGlobalContext('host', window.location.host);
-    window.DD_LOGS.addLoggerGlobalContext('referrer', document.referrer);
-    window.DD_LOGS.addLoggerGlobalContext('lang', lang);
+    window.DD_LOGS.setGlobalContextProperty('host', window.location.host);
+    window.DD_LOGS.setGlobalContextProperty('referrer', document.referrer);
+    window.DD_LOGS.setGlobalContextProperty('lang', lang);
 
     if (branch) {
-        window.DD_LOGS.addLoggerGlobalContext('branch', branch);
+        window.DD_LOGS.setGlobalContextProperty('branch', branch);
     }
 
     // Locally log to console

--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -31,20 +31,19 @@ if (window.DD_RUM) {
             env,
             service: 'docs',
             version: CI_COMMIT_SHORT_SHA,
-            trackInteractions: true,
             trackUserInteractions: true,
             trackFrustrations: true,
             enableExperimentalFeatures: ["clickmap"],
             sessionSampleRate: 100,
             sessionReplaySampleRate: 50,
-            allowedTracingOrigins: [window.location.origin],
+            allowedTracingUrls: [window.location.origin],
             internalAnalyticsSubdomain: IA_SUBDOMAIN
         });
 
         window.DD_RUM.startSessionReplayRecording();
 
         if (branch) {
-            window.DD_RUM.addRumGlobalContext('branch', branch);
+            window.DD_RUM.setGlobalContextProperty('branch', branch);
         }
 
         if (env === 'live') {

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
         "@babel/polyfill": "^7.12.1",
-        "@datadog/browser-logs": "^4.50.1",
-        "@datadog/browser-rum": "^4.50.1",
+        "@datadog/browser-logs": "^5.20.0",
+        "@datadog/browser-rum": "^5.20.0",
         "@popperjs/core": "^2.11.8",
         "algoliasearch": "4.22.1",
         "alpinejs": "^3.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2714,48 +2714,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@datadog/browser-core@npm:4.50.1":
-  version: 4.50.1
-  resolution: "@datadog/browser-core@npm:4.50.1"
-  checksum: d3581d68b6164e9cd07f7514d79708782209dad9a5746eccdfce3d8f9249c4f496d0ad342f7b96168a89dfdf83551ff80acd6132719832a1decdaf64b4fa0005
+"@datadog/browser-core@npm:5.20.0":
+  version: 5.20.0
+  resolution: "@datadog/browser-core@npm:5.20.0"
+  checksum: 82fb37ee0d02bda6f958549fd7b0c7f075613172bcb27133d2fa2fb91b22f6b4b1002042c0e96960993ebf0cde1d14aa55cdfaa2bc99bc358a793e491563d5c2
   languageName: node
   linkType: hard
 
-"@datadog/browser-logs@npm:^4.50.1":
-  version: 4.50.1
-  resolution: "@datadog/browser-logs@npm:4.50.1"
+"@datadog/browser-logs@npm:^5.20.0":
+  version: 5.20.0
+  resolution: "@datadog/browser-logs@npm:5.20.0"
   dependencies:
-    "@datadog/browser-core": 4.50.1
+    "@datadog/browser-core": 5.20.0
   peerDependencies:
-    "@datadog/browser-rum": 4.50.1
+    "@datadog/browser-rum": 5.20.0
   peerDependenciesMeta:
     "@datadog/browser-rum":
       optional: true
-  checksum: f43f67f328a9063b63836f38a2f5e30bc11d22316c363c23ad794693f99ecee8d9a22f91c863fabe8f28150a7398f1429d1f39586d2042e1a2b8297503bcf114
+  checksum: d3ead69bb892e7d4015c58bdf180a318e0e2efcb572e503334852a458c31014b26b9948b1aec759b6b5a2fc743045b071be6a58685b191249b3bc4235b407fca
   languageName: node
   linkType: hard
 
-"@datadog/browser-rum-core@npm:4.50.1":
-  version: 4.50.1
-  resolution: "@datadog/browser-rum-core@npm:4.50.1"
+"@datadog/browser-rum-core@npm:5.20.0":
+  version: 5.20.0
+  resolution: "@datadog/browser-rum-core@npm:5.20.0"
   dependencies:
-    "@datadog/browser-core": 4.50.1
-  checksum: 3f73524686c030cfcd5ff40bb5e5b4cbcd158239755f6e56713a3e89a3a1e4f7d9315f796f30ea98468c6509231720b0278385a06dc601b9d3bb2e2c9a14b896
+    "@datadog/browser-core": 5.20.0
+  checksum: cec616fe07c37877abef7a02f5ef67efc54b4bd790372628049350d94d4c3fa852c9c4d9d3a9998d30c8c0927b426ceddbc52a4211e3521dbe477aa37def2b1a
   languageName: node
   linkType: hard
 
-"@datadog/browser-rum@npm:^4.50.1":
-  version: 4.50.1
-  resolution: "@datadog/browser-rum@npm:4.50.1"
+"@datadog/browser-rum@npm:^5.20.0":
+  version: 5.20.0
+  resolution: "@datadog/browser-rum@npm:5.20.0"
   dependencies:
-    "@datadog/browser-core": 4.50.1
-    "@datadog/browser-rum-core": 4.50.1
+    "@datadog/browser-core": 5.20.0
+    "@datadog/browser-rum-core": 5.20.0
   peerDependencies:
-    "@datadog/browser-logs": 4.50.1
+    "@datadog/browser-logs": 5.20.0
   peerDependenciesMeta:
     "@datadog/browser-logs":
       optional: true
-  checksum: 202867d39d1e8bfaa64a9a9679d1806052af181951f9091520356e5a22d7c237708d0781adf439e721eff56c3b208480a252cb0e6fbd7bfa820bfa5812a9f880
+  checksum: 22da9ed6f07642db87540ce9c085a16a86a9cbf0f9b41d0eb6605c66631ed1769a66a14fa3ff70e8b36d27f9e8780b806cb4569a97aa87ab1202383a57068bcb
   languageName: node
   linkType: hard
 
@@ -6371,8 +6371,8 @@ __metadata:
     "@babel/plugin-proposal-object-rest-spread": ^7.20.7
     "@babel/polyfill": ^7.12.1
     "@babel/preset-env": ^7.24.0
-    "@datadog/browser-logs": ^4.50.1
-    "@datadog/browser-rum": ^4.50.1
+    "@datadog/browser-logs": ^5.20.0
+    "@datadog/browser-rum": ^5.20.0
     "@datadog/datadog-ci": ^2.36.0
     "@popperjs/core": ^2.11.8
     acorn: ^7.4.1


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
bump `browser-rum` and `browser-logs` `v5.20.0`
  - also updated `addLoggerGlobalContext` to `setGlobalContextProperty` due to error after bumping browser-logs to 5.20.0 [here](https://dd-corpsite.datadoghq.com/rum/sessions?query=%40type%3Aview%20env%3Apreview%20%40view.name%3A%22%2Fstefon.simmons%2F%3F%2Fwatchdog%22%20%40view.error.count%3A1&agg_m=count&agg_m_source=base&agg_q=%40application.name%2Csdk_version&agg_q_source=base%2Cbase&agg_t=count&cols=&config_rum_raw_event_tab=true&event=AgAAAY_k4V7A9492hwAAAAAAAAAYAAAAAEFZX2s0VjdBQUFBaW00cEVBamFOc2FXQwAAACQAAAAAMDE4ZmU1MDktNWRlMy00NDNjLWE1ZmYtYzdkYWUzM2UwNmNk&fromUser=false&funnel=%5B%5D&p_tab=issues&p_tab_h_event=AgAAAY_k3w2-G9vqzgAAAAAAAAAYAAAAAEFZX2szeFFzQUFBd0ZFMk5lSGV6TndBQQAAACQAAAAAMDE4ZmU0ZGYtM2U0OS00ZTBkLTljODItNzNiNjI0YjY1Njhm&saved-view-id=2733208&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&step=auto&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1717448677944&to_ts=1717535077944&live=true)

motivation: https://datadoghq.atlassian.net/browse/WEB-4984
preview (no change): https://docs-staging.datadoghq.com/stefon.simmons/bump-browser-rum-v5/
 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->