### PR TITLE
Revert "(DOCS-8102) Add Snowflake redirect"

### DIFF
--- a/content/en/integrations/_index.md
+++ b/content/en/integrations/_index.md
@@ -111,10 +111,6 @@ cascade:
     path: /integrations/amazon_s3.md
   aliases:
     - /integrations/awss3
-- _target:
-    path: /integrations/snowflake_web.md
-  aliases:
-    - /integrations/snowflake/
 ---
 
 More than {{< translate key="integration_count" >}} built-in integrations. See across all your systems, apps, and services.


### PR DESCRIPTION
Reverts DataDog/documentation#23492 -- integration merging logic has not yet been implemented, so users are currently unable to load Snowflake agent-based integration docs