### PR TITLE
[FR] add link to `sourcemaps` documentation on Github

### DIFF
--- a/content/fr/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/fr/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -162,6 +162,10 @@ L'exemple suivant représente une stack trace minifiée :
 
 {{< img src="real_user_monitoring/error_tracking/unminified_stacktrace.png" alt="Stack trace non minifiée pour le suivi des erreurs" >}}
 
+## Documentation complète (EN)
+
+Une [documentation complète de la commande sourcemap](https://github.com/DataDog/datadog-ci/tree/457d25821e838db9067dbe376d0f34fb1a197869/src/commands/sourcemaps) en anglais est disponible sur Github.
+
 ## Pour aller plus loin
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The full API documentation of the `sourcemaps` command is hard to find and does not appear in the "What's next" section. Thought it would be a good addition.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->