### PR TITLE
Remove references to deprecated `logs_config.use_tcp` option

### DIFF
--- a/content/en/agent/configuration/proxy.md
+++ b/content/en/agent/configuration/proxy.md
@@ -355,7 +355,7 @@ frontend logs_http_frontend
     option tcplog
     default_backend datadog-logs-http
 
-# If sending logs with use_tcp: true
+# If sending logs with force_use_tcp: true
 # frontend logs_frontend
 #    bind *:10514
 #    mode tcp
@@ -621,7 +621,7 @@ frontend logs_http_frontend
     option tcplog
     default_backend datadog-logs-http
 
-# If sending logs with use_tcp: true
+# If sending logs with force_use_tcp: true
 # frontend logs_frontend
 #    bind *:10514 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
 #    mode tcp

--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -34,7 +34,7 @@ To check which transport is used by the Agent, run the [Agent status command][1]
 
 **Notes**:
 
-* For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+. 
+* For older Agent versions, TCP transport is used by default. Datadog strongly recommends you to enforce HTTPS transport if you are running v6.14+/v7.14+ and HTTPS compression if you are running v6.16+/v7.16+.
 * Always enforce a specific transport (either TCP or HTTPS) when using a proxy to forwards logs to Datadog
 
 ## Enforce a specific transport
@@ -115,12 +115,12 @@ To enforce TCP transport, update the Agent's [main configuration file][1] (`data
 ```yaml
 logs_enabled: true
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
 ```
 To send logs with environment variables, configure the following:
 
 * `DD_LOGS_ENABLED=true`
-* `DD_LOGS_CONFIG_USE_TCP=true`
+* `DD_LOGS_CONFIG_FORCE_USE_TCP=true`
 
 By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication (on port `10516` for Datadog US site and port `443`for Datadog EU site).
 

--- a/content/en/agent/logs/proxy.md
+++ b/content/en/agent/logs/proxy.md
@@ -83,7 +83,7 @@ Edit the `datadog.yaml` Agent configuration file and set `logs_no_ssl` to `true`
 
 ```
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: "<PROXY_SERVER_DOMAIN>:10514"
   logs_no_ssl: true
 ```
@@ -150,7 +150,7 @@ backend datadog-logs
 
 * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
 * `yum install ca-certificates` (CentOS, Redhat)
-        
+
 If successful, the file will be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 
 Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (for example, `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.com` fails over to another IP.
@@ -209,11 +209,11 @@ backend datadog-logs
     server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-bundle.crt check port 443
 ```
 
-Download the certificate with the following command: 
+Download the certificate with the following command:
 
 * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
-* `yum install ca-certificates` (CentOS, Redhat) 
- 
+* `yum install ca-certificates` (CentOS, Redhat)
+
 If successful, the file will be located at `/etc/ssl/certs/ca-bundle.crt` for CentOS, Redhat.
 
 Once the HAProxy configuration is in place, you can reload it or restart HAProxy. **It is recommended to have a `cron` job that reloads HAProxy every 10 minutes** (for example, `service haproxy reload`) to force a refresh of HAProxy's DNS cache, in case `app.datadoghq.eu` fails over to another IP.
@@ -231,7 +231,7 @@ Edit the `datadog.yaml` Agent configuration file and set `logs_config.logs_dd_ur
 
 ```yaml
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: myProxyServer.myDomain:10514
 ```
 

--- a/content/es/agent/configuration/proxy.md
+++ b/content/es/agent/configuration/proxy.md
@@ -356,7 +356,7 @@ frontend logs_http_frontend
     option tcplog
     default_backend datadog-logs-http
 
-# If sending logs with use_tcp: true
+# If sending logs with force_use_tcp: true
 # frontend logs_frontend
 #    bind *:10514
 #    mode tcp
@@ -622,7 +622,7 @@ frontend logs_http_frontend
     option tcplog
     default_backend datadog-logs-http
 
-# If sending logs with use_tcp: true
+# If sending logs with force_use_tcp: true
 # frontend logs_frontend
 #    bind *:10514 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
 #    mode tcp

--- a/content/es/agent/logs/log_transport.md
+++ b/content/es/agent/logs/log_transport.md
@@ -35,7 +35,7 @@ Para comprobar qué transporte utiliza el Agent, ejecuta el [comando de estado d
 **Notas**:
 
 * En las versiones anteriores del Agent, se utiliza el transporte TCP de forma predeterminada. Datadog recomienda encarecidamente aplicar el protocolo de transporte HTTPS si se ejecutan las versiones 6.14/7.14 y posteriores, y el HTTPS comprimido si se ejecutan las versiones 6.16/7.16 y posteriores.
-* Cuando utilices un proxy, aplica siempre un canal de transporte específico (ya sea TCP o HTTPS) para reenviar los logs a Datadog. 
+* Cuando utilices un proxy, aplica siempre un canal de transporte específico (ya sea TCP o HTTPS) para reenviar los logs a Datadog.
 
 ## Aplica un transporte específico
 
@@ -115,12 +115,12 @@ Para aplicar el transporte TCP, actualiza el [archivo de configuración principa
 ```yaml
 logs_enabled: true
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
 ```
 Para enviar logs con variables de entorno, configura lo siguiente:
 
 * `DD_LOGS_ENABLED=true`
-* `DD_LOGS_CONFIG_USE_TCP=true`
+* `DD_LOGS_CONFIG_FORCE_USE_TCP=true`
 
 De forma predeterminada, el Datadog Agent envía sus logs a Datadog mediante el protocolo TCP con cifrado TLS. Esto requiere comunicación de salida (en el puerto `10516` para el sitio de Datadog de EE. UU. y en el puerto `443` para el sitio de Datadog de la UE).
 

--- a/content/es/agent/logs/proxy.md
+++ b/content/es/agent/logs/proxy.md
@@ -83,7 +83,7 @@ Edita el archivo de configuración del Agent `datadog.yaml` y define `logs_no_ss
 
 ```
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: "<PROXY_SERVER_DOMAIN>:10514"
   logs_no_ssl: true
 ```
@@ -209,10 +209,10 @@ backend datadog-logs
     server datadog agent-intake.logs.datadoghq.eu:443 ssl verify required ca-file /etc/ssl/certs/ca-bundle.crt check port 443
 ```
 
-Descarga el certificado con el siguiente comando: 
+Descarga el certificado con el siguiente comando:
 
 * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
-* `yum install ca-certificates` (CentOS, RedHat) 
+* `yum install ca-certificates` (CentOS, RedHat)
 
 Si funciona correctamente, la localización del archivo será `/etc/ssl/certs/ca-bundle.crt` en el caso de CentOS y RedHat.
 
@@ -231,7 +231,7 @@ Edita el archivo de configuración `datadog.yaml` del Agent y define `logs_confi
 
 ```yaml
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: myProxyServer.myDomain:10514
 ```
 

--- a/content/fr/agent/configuration/proxy.md
+++ b/content/fr/agent/configuration/proxy.md
@@ -125,7 +125,7 @@ Sur les hosts Unix, un proxy peut être appliqué à l'ensemble du système via 
 
 L'Agent utilise les valeurs suivantes par ordre de priorité :
 
-1. Les variables d'environnement `DD_PROXY_HTTPS`, `DD_PROXY_HTTP` et `DD_PROXY_NO_PROXY` 
+1. Les variables d'environnement `DD_PROXY_HTTPS`, `DD_PROXY_HTTP` et `DD_PROXY_NO_PROXY`
 2. Les variables d'environnement `HTTPS_PROXY`, `HTTP_PROXY` et `NO_PROXY`
 3. Les valeurs spécifiées dans `datadog.yaml`
 
@@ -356,7 +356,7 @@ frontend logs_http_frontend
     option tcplog
     default_backend datadog-logs-http
 
-# Si les logs sont envoyés avec use_tcp: true
+# Si les logs sont envoyés avec force_use_tcp: true
 # frontend logs_frontend
 #    bind *:10514
 #    mode tcp
@@ -622,7 +622,7 @@ frontend logs_http_frontend
     option tcplog
     default_backend datadog-logs-http
 
-# Si les logs sont envoyés avec use_tcp: true
+# Si les logs sont envoyés avec force_use_tcp: true
 # frontend logs_frontend
 #    bind *:10514 ssl crt <CHEMIN_VERS_PEM_CERTIFICATS_PROXY>
 #    mode tcp

--- a/content/fr/agent/logs/log_transport.md
+++ b/content/fr/agent/logs/log_transport.md
@@ -115,12 +115,12 @@ Pour imposer le transport TCP, mettez à jour le [fichier de configuration princ
 ```yaml
 logs_enabled: true
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
 ```
 Pour envoyer des logs avec des variables d'environnement, configurez ce qui suit :
 
 * `DD_LOGS_ENABLED=true`
-* `DD_LOGS_CONFIG_USE_TCP=true`
+* `DD_LOGS_CONFIG_FORCE_USE_TCP=true`
 
 Par défaut, l'Agent Datadog envoie ses logs à Datadog via le protocole TCP chiffré par TLS. Cela nécessite une communication sortante (sur le port `10516` pour le site américain de Datadog ou `443` pour le site européen).
 

--- a/content/fr/agent/logs/proxy.md
+++ b/content/fr/agent/logs/proxy.md
@@ -83,7 +83,7 @@ Modifiez le fichier de configuration de l'Agent `datadog.yaml` et définissez `l
 
 ```
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: "<DOMAINE_SERVEUR_PROXY>:10514"
   logs_no_ssl: true
 ```
@@ -212,7 +212,7 @@ backend datadog-logs
 Téléchargez le certificat avec la commande suivante :
 
 * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
-* `yum install ca-certificates` (CentOS, Redhat) 
+* `yum install ca-certificates` (CentOS, Redhat)
 
 Si le téléchargement fonctionne, le fichier est stocké à l'emplacement suivant pour CentOS et Redhat : `/etc/ssl/certs/ca-bundle.crt`.
 
@@ -231,7 +231,7 @@ Modifiez le fichier de configuration de l'Agent `datadog.yaml` et définissez `l
 
 ```yaml
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: monServeurProxy.monDomaine:10514
 ```
 

--- a/content/ja/agent/logs/log_transport.md
+++ b/content/ja/agent/logs/log_transport.md
@@ -115,12 +115,12 @@ TCP 転送を実行するには、Agent の[メインコンフィギュレーシ
 ```yaml
 logs_enabled: true
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
 ```
 環境変数を伴った形でログを送信するには、以下の構成を行ってください。
 
 * `DD_LOGS_ENABLED=true`
-* `DD_LOGS_CONFIG_USE_TCP=true`
+* `DD_LOGS_CONFIG_FORCE_USE_TCP=true`
 
 デフォルトでは、Datadog Agent は TLS で暗号化された TCP を介して、ログを Datadog に送信します。これを実施するには、外部へ送信できる通信 (Datadog US サイトではポート `10516`、Datadog EU サイトではポート `443`) が必要です 。
 

--- a/content/ja/agent/logs/proxy.md
+++ b/content/ja/agent/logs/proxy.md
@@ -83,7 +83,7 @@ logs_config:
 
 ```
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: "<プロキシサーバードメイン>:10514"
   logs_no_ssl: true
 ```
@@ -212,7 +212,7 @@ backend datadog-logs
 次のコマンドで証明書をダウンロードしてください:
 
 * `sudo apt-get install ca-certificates` (Debian、Ubuntu)
-* `yum install ca-certificates` (CentOS、Redhat) 
+* `yum install ca-certificates` (CentOS、Redhat)
 
 成功した場合、CentOS、Redhat の場合、ファイルは `/etc/ssl/certs/ca-bundle.crt` にあります。
 
@@ -231,7 +231,7 @@ HAProxy コンフィギュレーションが完成したら、リロードする
 
 ```yaml
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: myProxyServer.myDomain:10514
 ```
 

--- a/content/ko/agent/configuration/proxy.md
+++ b/content/ko/agent/configuration/proxy.md
@@ -52,7 +52,7 @@ Squid와 관련한 자세한 정보는 이 페이지에서 [Squid](#Squid) 섹�
 TCP 전송을 사용하는 경우 <a href="/agent/logs/proxy">로그용 TCP 프록시</a>를 참고하세요.
 </div>
 
-`https` 요청 모두에 HTTP 프록시 설정: 
+`https` 요청 모두에 HTTP 프록시 설정:
 
 ```yaml
 proxy:
@@ -273,7 +273,7 @@ Datadog에 연결되어 있는 호스트에 HAProxy를 설치해야 합니다. �
 
 ```conf
 # 기본 설정
-글로벌 
+글로벌
     log 127.0.0.1 local0
     maxconn 4096
     stats socket /tmp/haproxy
@@ -555,7 +555,7 @@ backend datadog-remote-configuration
     timeout connect 5s
 
 # 포트 3833에서 HAP Proxy 통계 보기를 선언
-# 이 페이지를 보는 데 자격 증명이 필요하지 않고 
+# 이 페이지를 보는 데 자격 증명이 필요하지 않고
 # 구성이 끝나면 전원을 끌 수 있습니다.
 listen stats
     bind *:3833
@@ -622,7 +622,7 @@ frontend logs_http_frontend
     option tcplog
     default_backend datadog-logs-http
 
-# use_tcp: true와 함께 로그를 보내는 경우
+# force_use_tcp: true와 함께 로그를 보내는 경우
 # frontend logs_frontend
 #    bind *:10514 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
 #    mode tcp

--- a/content/ko/agent/logs/log_transport.md
+++ b/content/ko/agent/logs/log_transport.md
@@ -115,12 +115,12 @@ TCP 트랜스포트를 강제 사용하려면 Agent [주요 설정 파일][1](`d
 ```yaml
 logs_enabled: true
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
 ```
 환경 변수와 로그를 보내려면 다음과 같이 설정하세요.
 
 * `DD_LOGS_ENABLED=true`
-* `DD_LOGS_CONFIG_USE_TCP=true`
+* `DD_LOGS_CONFIG_FORCE_USE_TCP=true`
 
 기본적으로 Datadog Agent에서 로그를 Datadog로 전송할 때는 TLS-암호화 TCP를 사용합니다. 이를 위해 아웃바운드 커뮤니케이션(Datadog 미국 사이트의 경우 포트 `10516`로, Datadog 유럽 사이트의 경우 포트 `443`로)이 필요합니다.
 

--- a/content/ko/agent/logs/proxy.md
+++ b/content/ko/agent/logs/proxy.md
@@ -83,7 +83,7 @@ Agent와 HAProxy 사이에는 암호화가 비활성화되어 있으며, 데이�
 
 ```
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: "<PROXY_SERVER_DOMAIN>:10514"
   logs_no_ssl: true
 ```
@@ -129,15 +129,15 @@ resolvers my-dns
     accepted_payload_size 8192
     hold valid 10s
     hold obsolete 60s
-# Agents가 로그 전송을 위해 연결되는 
+# Agents가 로그 전송을 위해 연결되는
 # 엔드포인트를 선언합니다. (예: "logs.config.logs_dd_url"의 값)
 frontend logs_frontend
     bind *:10514
     mode tcp
     option tcplog
     default_backend datadog-logs
-# Datadog 서버입니다. 실제로 위에 정의된 포워더 프런트엔드로 들어오는 
-# 모든 TCP 요청은 
+# Datadog 서버입니다. 실제로 위에 정의된 포워더 프런트엔드로 들어오는
+# 모든 TCP 요청은
 # Datadog의 퍼블릭 엔드포인트로 프록시됩니다.
 backend datadog-logs
     balance roundrobin
@@ -193,13 +193,13 @@ resolvers my-dns
     accepted_payload_size 8192
     hold valid 10s
     hold obsolete 60s
-# 로그 전송을 위해 Agents가 연결되는 
+# 로그 전송을 위해 Agents가 연결되는
 # 엔드포인트를 선언합니다. (예: "logs.config.logs_dd_url"의 값)
 frontend logs_frontend
     bind *:10514
     mode tcp
     default_backend datadog-logs
-# Datadog server입니다. 위에 정의된 포워더 프론트엔드로 
+# Datadog server입니다. 위에 정의된 포워더 프론트엔드로
 # 들어오는 모든 TCP 요청은
 # Datadog의 퍼블릭 엔드포인트로 프록시됩니다.
 backend datadog-logs
@@ -212,7 +212,7 @@ backend datadog-logs
 다음 명령을 사용하여 인증서를 다운로드합니다:
 
 * `sudo apt-get install ca-certificates` (Debian, Ubuntu)
-* `yum install ca-certificates` (CentOS, Redhat) 
+* `yum install ca-certificates` (CentOS, Redhat)
 
 성공적으로 다운로드되었다면, CentOS, Redhat용 `/etc/ssl/certs/ca-bundle.crt`에서 확인할 수 있습니다.
 
@@ -231,7 +231,7 @@ HAProxy 설정이 완료되면 다시 로드하거나 HAProxy를 다시 시작�
 
 ```yaml
 logs_config:
-  use_tcp: true
+  force_use_tcp: true
   logs_dd_url: myProxyServer.myDomain:10514
 ```
 
@@ -272,10 +272,10 @@ pid /run/nginx.pid;
 events {
     worker_connections 1024;
 }
-# Datadog Agent에 대한 TCP Proxy 
+# Datadog Agent에 대한 TCP Proxy
 stream {
     server {
-        listen 10514; #로그에 대한 수신 
+        listen 10514; #로그에 대한 수신
         proxy_ssl on;
         proxy_pass agent-intake.logs.datadoghq.eu:443;
     }


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The `logs_config.use_tcp` option is deprecated. Replace with `logs_config.force_use_tcp`.

The rest of the changes are just whitespace changes from editor formatting (removing trailing whitespace and newlines).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->