### PR TITLE
Fix agent supported platforms page for Windows versions

### DIFF
--- a/content/en/agent/supported_platforms.md
+++ b/content/en/agent/supported_platforms.md
@@ -233,8 +233,8 @@ A check mark ({{< X >}}) indicates support for all minor and patch versions.
   <tr>
     <td>2012/R2</td>
     <td></td>
-    <td><= 6.46.0</td>
-    <td><= 7.46.0</td>
+    <td><= 6.49.1</td>
+    <td><= 7.49.1</td>
     <td></td>
   </tr>
   <tr>
@@ -248,15 +248,15 @@ A check mark ({{< X >}}) indicates support for all minor and patch versions.
     <td rowspan=3>Windows</td>
     <td>7</td>
     <td><i class='icon-check-bold'></td>
-    <td></td>
-    <td></td>
+    <td><= 6.45.1</td>
+    <td><= 7.45.1</td>
     <td></td>
   </tr>
   <tr>
     <td>8.1</td>
     <td></td>
-    <td><= 6.46.0</td>
-    <td><= 7.46.0</td>
+    <td><= 6.49.1</td>
+    <td><= 7.49.1</td>
     <td></td>
   </tr>
   <tr>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Update the list of supported platforms per agent version.
This is incorrect and was reported by a customer.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Deprecation notices:
- Windows Server 2008 and Windows 7: https://github.com/DataDog/datadog-agent/releases/tag/7.46.0
- Windows Server 2012 and Windows 8.1: https://github.com/DataDog/datadog-agent/releases/tag/7.50.0

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->