### PR TITLE
Update supported_frameworks.md

### DIFF
--- a/content/en/security/cloud_security_management/misconfigurations/frameworks_and_benchmarks/supported_frameworks.md
+++ b/content/en/security/cloud_security_management/misconfigurations/frameworks_and_benchmarks/supported_frameworks.md
@@ -28,8 +28,8 @@ CSM Misconfigurations comes with more than 1,000 out-of-the-box compliance rules
 | [CIS GCP Foundations Benchmark v1.3.0][22]  | `cis-gcp`         | Cloud                    |
 | [CIS Docker Benchmark v1.2.0][4]            | `cis-docker `     | Infrastructure           |
 | [CIS Kubernetes Benchmark v1.7.0**][5]      | `cis-kubernetes`  | Infrastructure           |
-| [CIS Kubernetes Benchmark v1.4.0**][5]      | `cis-aks`         | Cloud and Infrastructure |
-| [CIS Kubernetes Benchmark v1.3.0 **][5]     | `cis-eks`         | Cloud and Infrastructure |
+| [CIS Kubernetes (AKS) Benchmark v1.4.0**][5]      | `cis-aks`         | Cloud and Infrastructure |
+| [CIS Kubernetes (EKS) Benchmark v1.3.0 **][5]     | `cis-eks`         | Cloud and Infrastructure |
 | [CIS Ubuntu 20.04 v1.0.0][23]               | `cis-ubuntu2004`  | Infrastructure           |
 | [CIS Ubuntu 22.04 v1.0.0][23]               | `cis-ubuntu2204 ` | Infrastructure           |
 | [CIS Red Hat Linux 7 v3.1.1][24]            | `cis-rhel7`       | Infrastructure           |


### PR DESCRIPTION
added EKS / AKS referecnes in framework names

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->