### PR TITLE
[SDTEST-188] Changes after ruby test visibility library major release

### DIFF
--- a/content/en/intelligent_test_runner/setup/ruby.md
+++ b/content/en/intelligent_test_runner/setup/ruby.md
@@ -19,12 +19,12 @@ further_reading:
 
 Intelligent Test Runner is only supported in the following versions and testing frameworks:
 
-* `datadog-ci >= 1.0.0.beta3`
+* `datadog-ci >= 1.0`
 * `Ruby >= 2.7`
   * JRuby is not supported.
 * `rspec >= 3.0.0`
 * `minitest >= 5.0.0`
-  * [Rails parallel testing][2] is not supported as of library version `1.0.0.beta6`.
+  * [Rails parallel testing][2] is not supported.
 * `cucumber >= 3.0.0`
 
 ## Setup
@@ -34,28 +34,6 @@ Intelligent Test Runner is only supported in the following versions and testing 
 Prior to setting up Intelligent Test Runner, set up [Test Visibility for Ruby][1]. If you are reporting data through the Agent, use v6.40 and later or v7.40 and later.
 
 {{% ci-itr-activation-instructions %}}
-
-### Use the latest version of a Test Visibility library
-
-Intelligent Test Runner for Ruby is available in `datadog-ci` gem version `1.0.0.beta3` and later.
-
-Add to your Gemfile:
-
-```ruby
-group :test do
-  gem 'datadog-ci', '~> 1.0.0.beta6'
-end
-```
-
-If you use other datadog products, upgrade to `2.0.0.rc1` version of gem `datadog`:
-
-```ruby
-gem 'datadog', '~> 2.0.0.rc1'
-
-group :test do
-  gem 'datadog-ci', '~> 1.0.0.beta6'
-end
-```
 
 ## Run tests with the Intelligent Test Runner enabled
 

--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -50,12 +50,10 @@ Supported test runners:
 
 ## Configuring reporting method
 
-To report test results to Datadog, you need to configure the `ddtrace` gem:
+To report test results to Datadog, you need to configure the `datadog-ci` gem:
 
 {{< tabs >}}
 {{% tab "Cloud CI provider (Agentless)" %}}
-
-<div class="alert alert-info">Agentless mode is available in `ddtrace` gem versions >= 1.15.0</div>
 
 {{% ci-agentless %}}
 
@@ -67,20 +65,18 @@ To report test results to Datadog, you need to configure the `ddtrace` gem:
 {{% /tab %}}
 {{< /tabs >}}
 
-## Installing the Ruby tracer
+## Installing the Ruby test visibility library
 
-To install the Ruby tracer:
+To install the Ruby test visibility library:
 
-1. Add the `ddtrace` gem to your `Gemfile`:
+1. Add the `datadog-ci` gem to your `Gemfile`:
 
 {{< code-block lang="ruby" filename="Gemfile" >}}
 source '<https://rubygems.org>'
-gem 'ddtrace', "~> 1.0"
+gem 'datadog-ci', "~> 1.0", group: :test
 {{< /code-block >}}
 
 2. Install the gem by running `bundle install`
-
-See the [Ruby tracer installation docs][1] for more details.
 
 ## Instrumenting your tests
 
@@ -98,7 +94,7 @@ require 'datadog/ci'
 # Only activates test instrumentation on CI
 if ENV["DD_ENV"] == "ci"
   Datadog.configure do |c|
-    # Configures the tracer to ensure results delivery
+    # enables test visibility
     c.ci.enabled = true
 
     # The name of the service or library under test
@@ -138,7 +134,7 @@ require 'datadog/ci'
 # Only activates test instrumentation on CI
 if ENV["DD_ENV"] == "ci"
   Datadog.configure do |c|
-    # Configures the tracer to ensure results delivery
+    # enables test visibility
     c.ci.enabled = true
 
     # The name of the service or library under test
@@ -198,7 +194,7 @@ require 'datadog/ci'
 # Only activates test instrumentation on CI
 if ENV["DD_ENV"] == "ci"
   Datadog.configure do |c|
-    # Configures the tracer to ensure results delivery
+    # enables test visibility
     c.ci.enabled = true
 
     # The name of the service or library under test
@@ -227,8 +223,6 @@ DD_ENV=ci bundle exec rake cucumber
 
 ### Adding custom tags to tests
 
-<div class="alert alert-info"><code>Datadog::CI</code> public API is available in <code>ddtrace</code> gem versions >= 1.17.0</div>
-
 You can add custom tags to your tests by using the current active test:
 
 ```ruby
@@ -243,8 +237,6 @@ Datadog::CI.active_test&.set_tag('test_owner', 'my_team')
 To create filters or `group by` fields for these tags, you must first create facets. For more information about adding tags, see the [Adding Tags][2] section of the Ruby custom instrumentation documentation.
 
 ### Adding custom measures to tests
-
-<div class="alert alert-info">The <code>Datadog::CI</code> public API is available in <code>ddtrace</code> gem versions >= 1.17.0</div>
 
 Like tags, you can add custom measures to your tests by using the current active test:
 
@@ -261,7 +253,7 @@ For more information on custom measures, see the [Add Custom Measures Guide][3].
 
 ## Configuration settings
 
-The following is a list of the most important configuration settings that can be used with the tracer, either in code by using a `Datadog.configure` block, or using environment variables:
+The following is a list of the most important configuration settings that can be used with the test visibility library, either in code by using a `Datadog.configure` block, or using environment variables:
 
 `service`
 : Name of the service or library under test.<br/>
@@ -299,7 +291,7 @@ if ENV["DD_ENV"] == "ci"
     #  ... ci configs and instrumentation here ...
     c.tracing.instrument :redis
     c.tracing.instrument :pg
-    # ... any other instrumentations supported by ddtrace gem ...
+    # ... any other instrumentations supported by datadog gem ...
   end
 end
 ```
@@ -307,12 +299,12 @@ end
 Alternatively, you can enable automatic instrumentation in `test_helper/spec_helper`:
 
 ```ruby
-require "ddtrace/auto_instrument" if ENV["DD_ENV"] == "ci"
+require "datadog/auto_instrument" if ENV["DD_ENV"] == "ci"
 ```
 
 **Note**: In CI mode, these traces are submitted to CI Visibility, and they do **not** show up in Datadog APM.
 
-For the full list of available instrumentation methods, see the [`ddtrace` documentation][6]
+For the full list of available instrumentation methods, see the [tracing documentation][6]
 
 ## Webmock/VCR
 
@@ -401,7 +393,7 @@ Usually it corresponds to a method that contains testing logic.
 
 Create tests in a suite by calling `Datadog::CI#start_test` or `Datadog::CI.trace_test` and passing the name of the test and name of the test suite. Test suite name must be the same as name of the test suite started in previous step.
 
-Call `datadog.trace.api.civisibility.DDTest#end` when a test has finished execution.
+Call `Datadog::CI::Test#finish` when a test has finished execution.
 
 ### Code example
 
@@ -453,7 +445,6 @@ Datadog::CI.active_test_session&.finish
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/trace_collection/dd_libraries/ruby/#installation
 [2]: /tracing/trace_collection/custom_instrumentation/ruby?tab=locally#adding-tags
 [3]: /tests/guides/add_custom_measures/?tab=ruby
 [4]: /getting_started/tagging/unified_service_tagging

--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -73,7 +73,7 @@ To install the Ruby test visibility library:
 
 {{< code-block lang="ruby" filename="Gemfile" >}}
 source '<https://rubygems.org>'
-gem 'datadog-ci', "~> 1.0", group: :test
+gem "datadog-ci", "~> 1.0", group: :test
 {{< /code-block >}}
 
 2. Install the gem by running `bundle install`

--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -72,7 +72,7 @@ To install the Ruby test visibility library:
 1. Add the `datadog-ci` gem to your `Gemfile`:
 
 {{< code-block lang="ruby" filename="Gemfile" >}}
-source '<https://rubygems.org>'
+source "<https://rubygems.org>"
 gem "datadog-ci", "~> 1.0", group: :test
 {{< /code-block >}}
 
@@ -88,8 +88,8 @@ The RSpec integration traces all executions of example groups and examples when 
 To activate your integration, add this to the `spec_helper.rb` file:
 
 ```ruby
-require 'rspec'
-require 'datadog/ci'
+require "rspec"
+require "datadog/ci"
 
 # Only activates test instrumentation on CI
 if ENV["DD_ENV"] == "ci"
@@ -98,7 +98,7 @@ if ENV["DD_ENV"] == "ci"
     c.ci.enabled = true
 
     # The name of the service or library under test
-    c.service = 'my-ruby-app'
+    c.service = "my-ruby-app"
 
     # Enables the RSpec instrumentation
     c.ci.instrument :rspec
@@ -128,8 +128,8 @@ The Minitest integration traces all executions of tests when using the `minitest
 To activate your integration, add this to the `test_helper.rb` file:
 
 ```ruby
-require 'minitest'
-require 'datadog/ci'
+require "minitest"
+require "datadog/ci"
 
 # Only activates test instrumentation on CI
 if ENV["DD_ENV"] == "ci"
@@ -138,7 +138,7 @@ if ENV["DD_ENV"] == "ci"
     c.ci.enabled = true
 
     # The name of the service or library under test
-    c.service = 'my-ruby-app'
+    c.service = "my-ruby-app"
 
     c.ci.instrument :minitest
   end
@@ -165,14 +165,14 @@ DD_ENV=ci bundle exec rake test
 Example configuration with `minitest/autorun`:
 
 ```ruby
-require 'datadog/ci'
-require 'minitest/autorun'
+require "datadog/ci"
+require "minitest/autorun"
 
 if ENV["DD_ENV"] == "ci"
   Datadog.configure do |c|
     c.ci.enabled = true
 
-    c.service = 'my-ruby-app'
+    c.service = "my-ruby-app"
 
     c.ci.instrument :minitest
   end
@@ -188,8 +188,8 @@ The Cucumber integration traces executions of scenarios and steps when using the
 To activate your integration, add the following code to your application:
 
 ```ruby
-require 'cucumber'
-require 'datadog/ci'
+require "cucumber"
+require "datadog/ci"
 
 # Only activates test instrumentation on CI
 if ENV["DD_ENV"] == "ci"
@@ -198,7 +198,7 @@ if ENV["DD_ENV"] == "ci"
     c.ci.enabled = true
 
     # The name of the service or library under test
-    c.service = 'my-ruby-app'
+    c.service = "my-ruby-app"
 
     # Enables the Cucumber instrumentation
     c.ci.instrument :cucumber
@@ -226,10 +226,10 @@ DD_ENV=ci bundle exec rake cucumber
 You can add custom tags to your tests by using the current active test:
 
 ```ruby
-require 'datadog/ci'
+require "datadog/ci"
 
 # inside your test
-Datadog::CI.active_test&.set_tag('test_owner', 'my_team')
+Datadog::CI.active_test&.set_tag("test_owner", "my_team")
 # test continues normally
 # ...
 ```
@@ -241,10 +241,10 @@ To create filters or `group by` fields for these tags, you must first create fac
 Like tags, you can add custom measures to your tests by using the current active test:
 
 ```ruby
-require 'datadog/ci'
+require "datadog/ci"
 
 # inside your test
-Datadog::CI.active_test&.set_metric('memory_allocations', 16)
+Datadog::CI.active_test&.set_metric("memory_allocations", 16)
 # test continues normally
 # ...
 ```


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Test visibility has been fully migrated to datadog-ci gem v1.0 - I change the documentation to reflect that

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->