### PR TITLE
[CIVIS-9922] Improve logs correlation docs for CI providers

### DIFF
--- a/content/en/continuous_integration/pipelines/awscodepipeline.md
+++ b/content/en/continuous_integration/pipelines/awscodepipeline.md
@@ -120,7 +120,7 @@ The AWS CodePipeline integration supports correlating **CodeBuild** actions with
 
 <div class="alert alert-warning"><strong>Note</strong>: Log correlation for CodeBuild actions requires the CodeBuild project to have the default CloudWatch log group and log stream names.</div>
 
-<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for AWS CodeBuild can be identified by the `source:codebuild` and `sourcecategory:aws` tags.</div>
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for AWS CodeBuild can be identified by the <code>source:codebuild</code> and <code>sourcecategory:aws</code> tags.</div>
 
 ## Visualize pipeline data in Datadog
 

--- a/content/en/continuous_integration/pipelines/awscodepipeline.md
+++ b/content/en/continuous_integration/pipelines/awscodepipeline.md
@@ -120,6 +120,8 @@ The AWS CodePipeline integration supports correlating **CodeBuild** actions with
 
 <div class="alert alert-warning"><strong>Note</strong>: Log correlation for CodeBuild actions requires the CodeBuild project to have the default CloudWatch log group and log stream names.</div>
 
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for AWS CodeBuild can be identified by the `source:codebuild` and `sourcecategory:aws` tags.</div>
+
 ## Visualize pipeline data in Datadog
 
 View your data on the [**CI Pipeline List**][11] and [**Executions**][12] pages after the pipelines finish.

--- a/content/en/continuous_integration/pipelines/azure.md
+++ b/content/en/continuous_integration/pipelines/azure.md
@@ -109,7 +109,7 @@ Datadog supports log collection for your Azure DevOps pipelines. To enable it:
 
 2. Add the Datadog app registration to your Azure DevOps organization and to every project for which you want to enable Log Collection. You can do this by going to "Organization settings" in your DevOps console. You may select "Add to all projects" to configure all projects in bulk.
 
-<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for Azure jobs can be identified by the `datadog.product:cipipeline` and `source:azurepipelines` tags.</div>
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for Azure jobs can be identified by the <code>datadog.product:cipipeline</code> and <code>source:azurepipelines</code> tags.</div>
 
 ## Visualize pipeline data in Datadog
 

--- a/content/en/continuous_integration/pipelines/azure.md
+++ b/content/en/continuous_integration/pipelines/azure.md
@@ -109,6 +109,7 @@ Datadog supports log collection for your Azure DevOps pipelines. To enable it:
 
 2. Add the Datadog app registration to your Azure DevOps organization and to every project for which you want to enable Log Collection. You can do this by going to "Organization settings" in your DevOps console. You may select "Add to all projects" to configure all projects in bulk.
 
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for Azure jobs can be identified by the `datadog.product:cipipeline` and `source:azurepipelines` tags.</div>
 
 ## Visualize pipeline data in Datadog
 

--- a/content/en/continuous_integration/pipelines/circleci.md
+++ b/content/en/continuous_integration/pipelines/circleci.md
@@ -92,7 +92,7 @@ The Datadog CircleCI integration collects logs from your finished CircleCI jobs 
 
 To install and configure this integration, follow the [CircleCI setup guide][11].
 
-<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for CircleCI jobs can be identified by the `datadog.product:cipipeline` and `source:circleci` tags.</div>
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for CircleCI jobs can be identified by the <code>datadog.product:cipipeline</code> and <code>source:circleci</code> tags.</div>
 
 ## Visualize pipeline data in Datadog
 

--- a/content/en/continuous_integration/pipelines/circleci.md
+++ b/content/en/continuous_integration/pipelines/circleci.md
@@ -92,6 +92,7 @@ The Datadog CircleCI integration collects logs from your finished CircleCI jobs 
 
 To install and configure this integration, follow the [CircleCI setup guide][11].
 
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for CircleCI jobs can be identified by the `datadog.product:cipipeline` and `source:circleci` tags.</div>
 
 ## Visualize pipeline data in Datadog
 

--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -26,7 +26,7 @@ further_reading:
 
 [GitHub Actions][1] is an automation tool that allows you to build, test, and deploy your code in GitHub. Create workflows that automate every step of your development process, streamlining software updates and enhancing code quality with CI/CD features integrated into your repositories.
 
-Set up tracing in GitHub Actions to track the execution of your workflows, identify performance bottlenecks,  troubleshoot operational issues, and optimize your deployment processes. 
+Set up tracing in GitHub Actions to track the execution of your workflows, identify performance bottlenecks,  troubleshoot operational issues, and optimize your deployment processes.
 
 ### Compatibility
 
@@ -82,9 +82,9 @@ To enable logs, follow these steps:
 3. Click **Enable Job Logs Collection** to enable logs for the whole account.
 4. Alternatively, you can enable individual repositories by scrolling through the repository list and clicking the **Enable Job Logs Collection** toggle.
 
-Immediately after toggling logs collection, workflow job logs are forwarded to Datadog Logs. Note that logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings.
+Immediately after toggling logs collection, workflow job logs are forwarded to Datadog Logs. Log files larger than 1GiB are truncated.
 
-Log files larger than 1GiB are truncated.
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for GitHub jobs can be identified by the `datadog.product:cipipeline` and `source:github` tags.</div>
 
 ### Correlate infrastructure metrics to jobs
 

--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -26,7 +26,7 @@ further_reading:
 
 [GitHub Actions][1] is an automation tool that allows you to build, test, and deploy your code in GitHub. Create workflows that automate every step of your development process, streamlining software updates and enhancing code quality with CI/CD features integrated into your repositories.
 
-Set up tracing in GitHub Actions to track the execution of your workflows, identify performance bottlenecks,  troubleshoot operational issues, and optimize your deployment processes.
+Set up tracing in GitHub Actions to track the execution of your workflows, identify performance bottlenecks, troubleshoot operational issues, and optimize your deployment processes.
 
 ### Compatibility
 
@@ -84,7 +84,7 @@ To enable logs, follow these steps:
 
 Immediately after toggling logs collection, workflow job logs are forwarded to Datadog Logs. Log files larger than 1GiB are truncated.
 
-<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for GitHub jobs can be identified by the `datadog.product:cipipeline` and `source:github` tags.</div>
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for GitHub jobs can be identified by the <code>datadog.product:cipipeline</code> and <code>source:github</code> tags.</div>
 
 ### Correlate infrastructure metrics to jobs
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -299,7 +299,7 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 {{% /tab %}}
 {{< /tabs >}}
 
-<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for GitLab jobs can be identified by the `datadog.product:cipipeline` and `source:gitlab` tags.</div>
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for GitLab jobs can be identified by the <code>datadog.product:cipipeline</code> and <code>source:gitlab</code> tags.</div>
 
 ## Further reading
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -299,6 +299,7 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 {{% /tab %}}
 {{< /tabs >}}
 
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for GitLab jobs can be identified by the `datadog.product:cipipeline` and `source:gitlab` tags.</div>
 
 ## Further reading
 

--- a/content/en/continuous_integration/pipelines/jenkins.md
+++ b/content/en/continuous_integration/pipelines/jenkins.md
@@ -720,6 +720,8 @@ To enable [collecting logs from your jobs](#enable-job-log-collection), configur
 
 With this configuration, the Agent listens for logs on port `10518`.
 
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for Jenkins jobs can be identified by the `source:jenkins` tag.</div>
+
 ### Correlate infrastructure metrics
 
 If you are using Jenkins workers, you can correlate pipelines with the infrastructure that is running them. For this feature to work:

--- a/content/en/continuous_integration/pipelines/jenkins.md
+++ b/content/en/continuous_integration/pipelines/jenkins.md
@@ -720,7 +720,7 @@ To enable [collecting logs from your jobs](#enable-job-log-collection), configur
 
 With this configuration, the Agent listens for logs on port `10518`.
 
-<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for Jenkins jobs can be identified by the `source:jenkins` tag.</div>
+<div class="alert alert-info"><strong>Note</strong>: Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in Logs Settings. Logs for Jenkins jobs can be identified by the <code>source:jenkins</code> tag.</div>
 
 ### Correlate infrastructure metrics
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This patch adds some extra information to the docs of all of CI Visibility's supported providers that mention how the collected logs for the respective provider can be identified and indexed.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->