### PR TITLE
[web-4864] fixing android keyboard issue on search

### DIFF
--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -180,6 +180,15 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
             const aisSearchBoxSubmit = document.querySelector('.ais-SearchBox-submit');
             const searchPathname = `${basePathName}search`;
 
+            // dirty fix for android devices - keyboard disappearing after search input focused
+            aisSearchBoxInput.addEventListener('focus', () => {
+                window.removeEventListener('resize');
+
+                setTimeout(() => {
+                    window.addEventListener('resize')
+                }, 500)
+            })
+
             const handleSearchbarKeydown = (e) => {
                 if (e.code === 'Enter') {
                     e.preventDefault();

--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -275,9 +275,10 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
 
             const handleResizeDebounced = debounce(handleResize, 500, false);
 
-            window.addEventListener('resize', handleResizeDebounced);
-
             handleResizeDebounced();
+            if (!navigator.userAgent.toLowerCase().match(/android/i)) {
+                window.addEventListener('resize', handleResizeDebounced);
+            } 
         }
     }
 }

--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -147,7 +147,7 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
             searchBox({
                 container: searchBoxContainer,
                 placeholder: 'Search documentation...',
-                autofocus: true,
+                autofocus: false,
                 showReset: false,
                 showSubmit: true,
                 templates: {
@@ -179,15 +179,6 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
             const aisSearchBoxInput = document.querySelector('.ais-SearchBox-input');
             const aisSearchBoxSubmit = document.querySelector('.ais-SearchBox-submit');
             const searchPathname = `${basePathName}search`;
-
-            // dirty fix for android devices - keyboard disappearing after search input focused
-            aisSearchBoxInput.addEventListener('focus', () => {
-                window.removeEventListener('resize');
-
-                setTimeout(() => {
-                    window.addEventListener('resize')
-                }, 500)
-            })
 
             const handleSearchbarKeydown = (e) => {
                 if (e.code === 'Enter') {
@@ -276,6 +267,8 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
             const handleResizeDebounced = debounce(handleResize, 500, false);
 
             handleResizeDebounced();
+            
+            // Bugfix for disappearing android keyboard on search input focus/autoresizing
             if (!navigator.userAgent.toLowerCase().match(/android/i)) {
                 window.addEventListener('resize', handleResizeDebounced);
             } 

--- a/assets/scripts/components/algolia.js
+++ b/assets/scripts/components/algolia.js
@@ -147,7 +147,7 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
             searchBox({
                 container: searchBoxContainer,
                 placeholder: 'Search documentation...',
-                autofocus: false,
+                autofocus: true,
                 showReset: false,
                 showSubmit: true,
                 templates: {


### PR DESCRIPTION
### What does this PR do? What is the motivation?
fixes a bug only reproducible on android devices, where the keyboard immediately appears and disappears when the search input is in focus.

https://datadoghq.atlassian.net/browse/WEB-4864

### Merge instructions
- [x] Please merge after websites reviewing

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/WEB-4864-android-search-issue/

no UI regressions/console errors stem from these changes.   check the instant search functionality across homepage and side nav at various screen sizes.