### PR TITLE
DOCS-8116 Use Full Page Reuse for Cloud Cost Monitors Documentation

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -2709,7 +2709,7 @@ menu:
       identifier: cloud_cost_recommendations
       weight: 8
     - name: Cost Monitors
-      url: /monitors/types/cloud_cost/
+      url: /cloud_cost_management/monitors
       parent: cloud_cost
       identifier: cloud_cost_monitors
       weight: 9

--- a/content/en/cloud_cost_management/monitors/_index.md
+++ b/content/en/cloud_cost_management/monitors/_index.md
@@ -1,0 +1,26 @@
+---
+title: Cloud Cost Monitor
+kind: documentation
+description: Learn how to create a monitor with Cloud Cost data.
+further_reading:
+- link: "https://www.datadoghq.com/blog/ccm-cost-monitors/"
+  tag: "Blog"
+  text: "React quickly to cost overruns with Cost Monitors for Datadog Cloud Cost Management"
+- link: "https://www.datadoghq.com/blog/google-cloud-cost-management/"
+  tag: "Blog"
+  text: "Empower engineers to take ownership of Google Cloud costs with Datadog"
+- link: "https://docs.datadoghq.com/cloud_cost_management/?tab=aws#overview"
+  tag: "Documentation"
+  text: "Learn about Cloud Cost Management"
+- link: "/monitors/notify/"
+  tag: "Documentation"
+  text: "Configure your monitor notifications"
+- link: "/monitors/downtimes/"
+  tag: "Documentation"
+  text: "Schedule a downtime to mute a monitor"
+- link: "/monitors/manage/status/"
+  tag: "Documentation"
+  text: "Consult your monitor status"
+---
+
+{{< include-markdown "content/en/monitors/types/cloud_cost.md" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Use a full page reuse partial so the page breadcrumbs are **DOCS > CLOUD COST MANAGEMENT > MONITORS**.

Requested by Kayla on Jira.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->