### PR TITLE
Ruby v2 Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ content/en/tracing/trace_collection/dd_libraries/ruby.md
 content/en/tracing/trace_collection/compatibility/ruby.md
 content/en/tracing/trace_collection/dd_libraries/ruby_v1.md
 content/en/tracing/trace_collection/compatibility/ruby_v1.md
+content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/ruby_v1.md
 
 # Log collection
 content/en/logs/guide/forwarder.md


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

I missed including one of the single sourced files in our .gitignore, so it shows up as a changed file whenever someone pulls from master. This PR should fix that.

File to ignore: `content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/ruby_v1.md` 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->