### PR TITLE
Update connector configuration

### DIFF
--- a/content/en/opentelemetry/guide/otel_demo_to_datadog.md
+++ b/content/en/opentelemetry/guide/otel_demo_to_datadog.md
@@ -108,7 +108,9 @@ Complete the following steps to configure these three components.
             action: upsert
 
     connectors:
-        datadog/connector:
+      datadog/connector:
+        traces:
+          span_name_as_resource_name: true
 
     service:
       pipelines:
@@ -180,7 +182,9 @@ Complete the following steps to configure these three components.
                 action: upsert
 
         connectors:
-            datadog/connector:
+          datadog/connector:
+            traces:
+              span_name_as_resource_name: true
 
         service:
           pipelines:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

This PR adds a the setting `span_name_as_resource_name` to the connector config, as this is required to have Traces and Metrics stats aligned.
 
```yaml
      traces:
        span_name_as_resource_name: true
```

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->