### PR TITLE
Enhance styling for p level with collapse-content shortcode

### DIFF
--- a/assets/styles/components/_collapsible-section.scss
+++ b/assets/styles/components/_collapsible-section.scss
@@ -29,6 +29,7 @@
 }
 
 .header-text-inner {
+    font-size: 1.5rem;
     margin: 0;
     line-height: 1.5;
     font-weight: bold;

--- a/assets/styles/components/_collapsible-section.scss
+++ b/assets/styles/components/_collapsible-section.scss
@@ -29,7 +29,6 @@
 }
 
 .header-text-inner {
-    font-size: 1.5rem;
     margin: 0;
     line-height: 1.5;
     font-weight: bold;

--- a/assets/styles/components/_collapsible-section.scss
+++ b/assets/styles/components/_collapsible-section.scss
@@ -62,12 +62,6 @@
     align-items: center;
 }
 
-.header-text-inner {
-    font-size: 1.5rem;
-    margin: 0;
-    line-height: 1.5;
-}
-
 .collapsible-content {
     padding: 16px;
 }

--- a/assets/styles/components/_collapsible-section.scss
+++ b/assets/styles/components/_collapsible-section.scss
@@ -24,6 +24,17 @@
     color: white;
 }
 
+.collapsible-section[open] .header-text-inner {
+    color: white;
+}
+
+.header-text-inner {
+    font-size: 1.5rem;
+    margin: 0;
+    line-height: 1.5;
+    font-weight: bold;
+}
+
 .header-content {
     display: flex;
     align-items: center;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
New style when level = p:

![image](https://github.com/DataDog/documentation/assets/84536271/904ae654-57f9-4e55-8c77-365e103e41c9)

![image](https://github.com/DataDog/documentation/assets/84536271/1f4db6cd-d9ed-4190-a33a-ccc3a995d584)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->