### PR TITLE
Stop hardcoding collapse-content text size

### DIFF
--- a/assets/styles/components/_collapsible-section.scss
+++ b/assets/styles/components/_collapsible-section.scss
@@ -29,7 +29,6 @@
 }
 
 .header-text-inner {
-    font-size: 1.5rem;
     margin: 0;
     line-height: 1.5;
     font-weight: bold;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Stop hardcoding text size for collapse-content. It will now use the normal size of our headings. Style for this shortcode is based on the `level` param. For example, `level=h4`.

![image](https://github.com/DataDog/documentation/assets/84536271/03685905-7382-4872-90c7-52b3279a77a1)

This change is an add on to: https://github.com/DataDog/documentation/pull/23603.

### Preview link

https://docs-staging.datadoghq.com/brett0000FF/fix-collapse-text-size/

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->