### PR TITLE
Add documentation for masking action name options

### DIFF
--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -32,7 +32,7 @@ You can accomplish the following objectives:
 
 The `trackUserInteractions` initialization parameter enables the collection of user clicks in your application, which means sensitive and private data contained in your pages may be included to identify elements that a user interacted with.
 
-To control which information is sent to Datadog, [manually set an action name](#declare-a-name-for-click-actions), or [implement a global scrubbing rule in the Datadog Browser SDK for RUM][1].
+To control which information is sent to Datadog, you can [mask action names with privacy options][6], [manually set an action name](#declare-a-name-for-click-actions), or [implement a global scrubbing rule in the Datadog Browser SDK for RUM][1].
 
 ## Track user interactions
 
@@ -124,3 +124,4 @@ For more information, see [Send Custom Actions][5].
 [3]: /real_user_monitoring/browser/data_collected/#default-attributes
 [4]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v2160
 [5]: /real_user_monitoring/guide/send-rum-custom-actions
+[6]: /real_user_monitoring/session_replay/privacy_options#mask-action-names

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -125,7 +125,7 @@ For example, override the following name with `<div data-dd-action-name="Address
 Additional use cases to override the default action name include masking sensitive data in the RUM Explorer and streamlining your analytics and search with custom naming conventions.
 
 ### Mask action names
-By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation will automatically substitute all non-overridden action names with the placeholder `Masked Element`.
+By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`.
 
 <div class="alert alert-info">
 

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -125,7 +125,7 @@ For example, override the following name with `<div data-dd-action-name="Address
 Additional use cases to override the default action name include masking sensitive data in the RUM Explorer and streamlining your analytics and search with custom naming conventions.
 
 ### Mask action names
-By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`. This setting is also designed to be compatible with existing [HTML override attributes](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/privacy_options/#override-an-html-element).
+By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`. This setting is also designed to be compatible with existing [HTML override attributes](/real_user_monitoring/session_replay/browser/privacy_options/#override-an-html-element).
 
 <div class="alert alert-info">
 

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -123,6 +123,8 @@ You can rename the default action name by overriding the name of a specific HTML
 For example, override the following name with `<div data-dd-action-name="Address" > → Action: "Click on Address"`.
 
 Additional use cases to override the default action name include masking sensitive data in the RUM Explorer and streamlining your analytics and search with custom naming conventions.
+### Mask Action Names
+By default, if you wish to mask all action names, you can utilize the `enablePrivacyForActionName` function in conjunction with the `mask` privacy setting. This operation will automatically substitute all non-overridden action names with a placeholder termed `Masked Element`.
 
 <div class="alert alert-info">
 

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -138,4 +138,3 @@ Datadog is working to add more privacy features to RUM & Session Replay. Have so
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes
-[2]: /real_user_monitoring/session_replay/browser/privacy_options/#override-an-html-element

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -125,7 +125,7 @@ For example, override the following name with `<div data-dd-action-name="Address
 Additional use cases to override the default action name include masking sensitive data in the RUM Explorer and streamlining your analytics and search with custom naming conventions.
 
 ### Mask action names
-By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`.
+By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`. This setting is also designed to be compatible with existing [HTML override attributes](https://docs-staging.datadoghq.com/congyao/RUM-4868-action-name-privacy-doc/real_user_monitoring/session_replay/browser/privacy_options/#override-an-html-element).
 
 <div class="alert alert-info">
 

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -138,3 +138,4 @@ Datadog is working to add more privacy features to RUM & Session Replay. Have so
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes
+[2]: /real_user_monitoring/session_replay/browser/privacy_options/#override-an-html-element

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -124,7 +124,7 @@ For example, override the following name with `<div data-dd-action-name="Address
 
 Additional use cases to override the default action name include masking sensitive data in the RUM Explorer and streamlining your analytics and search with custom naming conventions.
 ### Mask Action Names
-By default, if you wish to mask all action names, you can utilize the `enablePrivacyForActionName` function in conjunction with the `mask` privacy setting. This operation will automatically substitute all non-overridden action names with a placeholder termed `Masked Element`.
+By default, if you wish to mask all action names, you can utilize the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation will automatically substitute all non-overridden action names with a placeholder termed `Masked Element`.
 
 <div class="alert alert-info">
 

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -125,7 +125,7 @@ For example, override the following name with `<div data-dd-action-name="Address
 Additional use cases to override the default action name include masking sensitive data in the RUM Explorer and streamlining your analytics and search with custom naming conventions.
 
 ### Mask action names
-By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`. This setting is also designed to be compatible with existing [HTML override attributes](/real_user_monitoring/session_replay/browser/privacy_options/#override-an-html-element).
+By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`. This setting is also designed to be compatible with existing [HTML override attributes](#override-an-html-element).
 
 <div class="alert alert-info">
 

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -123,8 +123,9 @@ You can rename the default action name by overriding the name of a specific HTML
 For example, override the following name with `<div data-dd-action-name="Address" > → Action: "Click on Address"`.
 
 Additional use cases to override the default action name include masking sensitive data in the RUM Explorer and streamlining your analytics and search with custom naming conventions.
-### Mask Action Names
-By default, if you wish to mask all action names, you can utilize the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation will automatically substitute all non-overridden action names with a placeholder termed `Masked Element`.
+
+### Mask action names
+By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation will automatically substitute all non-overridden action names with the placeholder `Masked Element`.
 
 <div class="alert alert-info">
 

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -125,7 +125,7 @@ For example, override the following name with `<div data-dd-action-name="Address
 Additional use cases to override the default action name include masking sensitive data in the RUM Explorer and streamlining your analytics and search with custom naming conventions.
 
 ### Mask action names
-By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`. This setting is also designed to be compatible with existing [HTML override attributes](https://docs-staging.datadoghq.com/congyao/RUM-4868-action-name-privacy-doc/real_user_monitoring/session_replay/browser/privacy_options/#override-an-html-element).
+By default, if you wish to mask all action names, you can use the `enablePrivacyForActionName` option in conjunction with the `mask` privacy setting. This operation automatically substitutes all non-overridden action names with the placeholder `Masked Element`. This setting is also designed to be compatible with existing [HTML override attributes](https://docs.datadoghq.com/real_user_monitoring/session_replay/browser/privacy_options/#override-an-html-element).
 
 <div class="alert alert-info">
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR adds documentations on a new privacy configuration concerning action names in RUM Browser SDK. 
When the user opt-in for enablePrivacyForActionName, we mask action names when no action name attributes given or no html override.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->