### PR TITLE
Use consisten datadog-operator name in kubernetes installation instru…

### DIFF
--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -19,7 +19,7 @@ further_reading:
 
 ## Overview
 
-This page provides instructions on installing the Datadog Agent in a Kubernetes environment. 
+This page provides instructions on installing the Datadog Agent in a Kubernetes environment.
 
 For dedicated documentation and examples for major Kubernetes distributions including AWS Elastic Kubernetes Service (EKS), Azure Kubernetes Service (AKS), Google Kubernetes Engine (GKE), Red Hat OpenShift, Rancher, and Oracle Container Engine for Kubernetes (OKE), see [Kubernetes distributions][1].
 
@@ -264,7 +264,7 @@ For more information, see [Changing your container registry][17].
 {{% tab "Datadog Operator" %}}
 ```shell
 kubectl delete datadogagent datadog
-helm delete my-datadog-operator
+helm delete datadog-operator
 ```
 
 This command deletes all Kubernetes resources created by installing Datadog Operator and deploying the Datadog Agent.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The current kubernetes installation instructions are inconsistent with regard to the `datadog-operator` name. It is referred to as `datadog-operator` during [containers/kubernetes#installation](https://docs.datadoghq.com/containers/kubernetes/installation/?tab=datadogoperator#installation) and `my-datadog-operator` during [containers/kubernetes#uninstall](https://docs.datadoghq.com/containers/kubernetes/installation/?tab=datadogoperator#uninstall).

_NOTE_: This is inconsistent across pages with the operator instructions under [containers/datadog_operator](https://docs.datadoghq.com/getting_started/containers/datadog_operator/) where it is always called `my-datadog-operator`. If full consistency is desired, I can rename the installation instructions to `my-datadog-operator`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->