### PR TITLE
dan.chiniara/add troubleshooting for missing notifications from email

### DIFF
--- a/layouts/shortcodes/notifications-email.md
+++ b/layouts/shortcodes/notifications-email.md
@@ -1,4 +1,4 @@
 * Notify an active Datadog user by email with `@<DD_USER_EMAIL_ADDRESS>`. 
 
-    **Note**: An email address associated with a pending Datadog user invitation or a disabled user is considered inactive and does not receive notifications. Blocklists, ip or domain filtering, spam filtering, or email security tools may also be the reason notificiations are missing. 
+    **Note**: An email address associated with a pending Datadog user invitation or a disabled user is considered inactive and does not receive notifications. Blocklists, ip or domain filtering, spam filtering, or email security tools may also be the reason notifications are missing. 
 * Notify any non-Datadog user by email with `@<EMAIL>`.

--- a/layouts/shortcodes/notifications-email.md
+++ b/layouts/shortcodes/notifications-email.md
@@ -1,6 +1,4 @@
 * Notify an active Datadog user by email with `@<DD_USER_EMAIL_ADDRESS>`. 
 
-    **Note**: An email address associated with a pending Datadog user invitation or a disabled user is considered inactive and does not receive notifications.
+    **Note**: An email address associated with a pending Datadog user invitation or a disabled user is considered inactive and does not receive notifications. Blocklists, ip or domain filtering, spam filtering, or email security tools may also be the reason notificiations are missing. 
 * Notify any non-Datadog user by email with `@<EMAIL>`.
-
-    **Note**: If emails are missing, blocklist, ip or domain filtering, spam filtering, or email security tools may be the issue. 

--- a/layouts/shortcodes/notifications-email.md
+++ b/layouts/shortcodes/notifications-email.md
@@ -2,3 +2,5 @@
 
     **Note**: An email address associated with a pending Datadog user invitation or a disabled user is considered inactive and does not receive notifications.
 * Notify any non-Datadog user by email with `@<EMAIL>`.
+
+    **Note**: If emails are missing, blocklist, ip or domain filtering, spam filtering, or email security tools may be the issue. 

--- a/layouts/shortcodes/notifications-email.md
+++ b/layouts/shortcodes/notifications-email.md
@@ -1,4 +1,4 @@
 * Notify an active Datadog user by email with `@<DD_USER_EMAIL_ADDRESS>`. 
 
-    **Note**: An email address associated with a pending Datadog user invitation or a disabled user is considered inactive and does not receive notifications. Blocklists, ip or domain filtering, spam filtering, or email security tools may also be the reason notifications are missing. 
+    **Note**: An email address associated with a pending Datadog user invitation or a disabled user is considered inactive and does not receive notifications. Blocklists, IP or domain filtering, spam filtering, or email security tools may also cause missing notifications. 
 * Notify any non-Datadog user by email with `@<EMAIL>`.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds recommended next steps for email issues when it comes to notifications 

### Merge instructions

I'm checking with the Monitors Product Team about the wording. Changes can be seen on [this preview page](https://docs-staging.datadoghq.com/dan.chiniara/add-troubleshooting-for-missing-notifications-from-email/monitors/notify/).

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->