### PR TITLE
Update Instructions for Adding Java Tracer to JVM for Windows + Tomcat

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/java.md
@@ -136,7 +136,7 @@ To enable tracing when running Tomcat with an environment setup script:
    ```
 If the previous step doesn't work, try adding the following instead:
 ```text
-set JAVA_OPTS=%JAVA_OPTS% -javaagent:\"c:\path\to\dd-java-agent.jar"
+set JAVA_OPTS=%JAVA_OPTS% -javaagent:"c:\path\to\dd-java-agent.jar"
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
* We've had a few customers run into trouble following the existing instructions that rely on `setenv.bat`.
* Added a new section for running Tomcat as a Windows service.
* Added alternate approach for `setenv.bat` as well.

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
https://datadoghq.atlassian.net/browse/DOCS-8153

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->