### PR TITLE
IDE Integrations/Open in IDE: Do not list specific IDEs/languages

### DIFF
--- a/content/en/developers/ide_plugins/idea/_index.md
+++ b/content/en/developers/ide_plugins/idea/_index.md
@@ -180,7 +180,7 @@ Clicking the link opens the **Test Runs** tab showing the recent history for one
 
 ## View in IDE
 
-The **View in IntelliJ/GoLand/PyCharm** feature provides a link from the Datadog platform directly to your Java, Go, and Python source files. Look for the button next to frames in stack traces displayed on the platform (for example, in [Error Tracking][6]):
+The **View in IDE** feature provides a link from the Datadog platform directly to the source files in your IDE. Look for the button next to frames in stack traces displayed on the platform (for example, in [Error Tracking][6]):
 
 {{< img src="/developers/ide_plugins/idea/view-in-idea.png" alt="A stack trace on the Datadog platform showing the View in IntelliJ button." style="width:100%;" >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
We are adding "Open in IDE" support for PhpStorm, with RubyMine and other IDEs coming in the future. By making the wording here generic we don't have to update it every time we add support for a new IDE in this specific feature (generally, if an IDE is supported, you can use "Open in IDE" with it).

### Merge instructions
- [ ] Please merge after reviewing

