### PR TITLE
ITR tracked files: add info that tracked files are always relative to repo's root

### DIFF
--- a/content/en/intelligent_test_runner/_index.md
+++ b/content/en/intelligent_test_runner/_index.md
@@ -84,7 +84,7 @@ Tracked files are non-code files that can potentially impact your tests. Changes
 
 When you specify a set of tracked files, Intelligent Test Runner runs all tests if any of these files change.
 
-You may use the `*` and `**` wildcard characters to match multiple files or directories. For instance, `**/*.mdx` matches any `.mdx` file in the repository.
+All file paths are considered to be relative to the root of the repository. You may use the `*` and `**` wildcard characters to match multiple files or directories. For instance, `**/*.mdx` matches any `.mdx` file in the repository.
 
 {{< img src="continuous_integration/itr_configuration2.png" alt="Select branches to exclude and tracked files" style="width:80%;">}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds a sentence to the tracked files documentation in ITR about tracked files being always relative to the repository's root

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing
