### PR TITLE
Add datadog static analyzer

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -1,0 +1,21 @@
+on: [push]
+
+name: Datadog Static Analysis
+
+jobs:
+  static-analysis:
+    runs-on: ubuntu-latest
+    name: Datadog Static Analyzer
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Check code meets quality and security standards
+      id: datadog-static-analysis
+      uses: DataDog/datadog-static-analyzer-github-action@v1
+      with:
+        dd_api_key: ${{ secrets.DD_API_KEY }}
+        dd_app_key: ${{ secrets.DD_APP_KEY }}
+        dd_service: documentation
+        dd_env: ci
+        dd_site: datadoghq.com
+        cpu_count: 2

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,0 +1,5 @@
+rulesets:
+  - sit-ci-best-practices:
+    only:
+      - ".github/workflows"
+


### PR DESCRIPTION
## What does this PR do?

This PR adds supports for Datadog static analysis. It only checks rules that validates the GitHub actions are safe and secure.

## Motivation

We want to ensure our GitHub actions are safe and secure.


## Related

[PR](https://github.com/DataDog/datadog-agent/pull/26627) in `datadog-agent`