### PR TITLE
change beta banner (and add it where it was missing)

### DIFF
--- a/content/en/service_management/app_builder/_index.md
+++ b/content/en/service_management/app_builder/_index.md
@@ -15,8 +15,8 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-{{< callout url="https://www.datadoghq.com/dg/datadog-app-builder/" btn_hidden="false" header="Join the Beta!">}}
-Datadog App Builder is in private beta. Complete the form to request access.
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
 {{< /callout >}}
 
 Datadog App Builder is a low-code application building platform. It streamlines the development of your internal tools with a user-friendly drag-and-drop interface and built-in support for JavaScript. App Builder integrates with popular services such as AWS and GitHub, allowing you to leverage data and seamlessly connect with external APIs and data stores. By integrating with Datadog's existing capabilities, App Builder provides a centralized context that enables you to take preventive actions or respond to ongoing incidents, all from within the same view that you use for troubleshooting.

--- a/content/en/service_management/app_builder/auth.md
+++ b/content/en/service_management/app_builder/auth.md
@@ -8,8 +8,8 @@ description: Access and authentication for App builder
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-{{< callout url="https://www.datadoghq.com/dg/datadog-app-builder/" btn_hidden="false" header="Join the Beta!">}}
-Datadog App Builder is in private beta. Complete the form to request access.
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
 {{< /callout >}}
 
 A few tools control access and authentication for apps and their components.

--- a/content/en/service_management/app_builder/build.md
+++ b/content/en/service_management/app_builder/build.md
@@ -14,8 +14,8 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-{{< callout url="https://www.datadoghq.com/dg/datadog-app-builder/" btn_hidden="false" header="Join the Beta!">}}
-Datadog App Builder is in private beta. Complete the form to request access.
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
 {{< /callout >}}
 
 You can create an app or edit existing apps from the [App Builder][1] page. The page lists information about existing apps, including the following:

--- a/content/en/service_management/app_builder/components/_index.md
+++ b/content/en/service_management/app_builder/components/_index.md
@@ -19,8 +19,8 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-{{< callout url="https://www.datadoghq.com/dg/datadog-app-builder/" btn_hidden="false" header="Join the Beta!">}}
-Datadog App Builder is in private beta. Complete the form to request access.
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
 {{< /callout >}}
 
 This page provides a list of UI components that you can use when creating apps in App Builder.

--- a/content/en/service_management/app_builder/components/tables.md
+++ b/content/en/service_management/app_builder/components/tables.md
@@ -13,6 +13,14 @@ further_reading:
   text: "Build Apps"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
+{{< /callout >}}
+
 This page describes advanced features you can use to manipulate table components in your App Builder apps.
 
 ## Client-side filtering

--- a/content/en/service_management/app_builder/connections/_index.md
+++ b/content/en/service_management/app_builder/connections/_index.md
@@ -13,6 +13,10 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
+{{< /callout >}}
+
 Because app actions connect with external software systems, you may need to authenticate your Datadog account to the corresponding integration. An app can run successfully only if every app action that requires authentication can verify the identity of your Datadog account. When granting permissions to Datadog, ensure that you're following security best practice and only granting the permissions necessary for an app to run.
 
 App actions can be authenticated in two ways:

--- a/content/en/service_management/app_builder/connections/http_request.md
+++ b/content/en/service_management/app_builder/connections/http_request.md
@@ -14,6 +14,10 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
+{{< /callout >}}
+
 Use the **Make request** action to make a custom request to an HTTP endpoint. You can control the request method and its contents, how it is authenticated and processed, and how it should respond to scenarios like expired certificates or redirects. If you need to add Datadog IP address ranges to your allowlist so that the HTTP action works as expected, use the IPs listed in the `webhooks` object. See the [IP Ranges API][1] for details.
 
 To add an HTTP request:

--- a/content/en/service_management/app_builder/embedded_apps.md
+++ b/content/en/service_management/app_builder/embedded_apps.md
@@ -12,8 +12,8 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-{{< callout url="https://www.datadoghq.com/dg/datadog-app-builder/" btn_hidden="false" header="Join the Beta!">}}
-Datadog App Builder is in private beta. Complete the form to request access.
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
 {{< /callout >}}
 
 When you have Datadog App Builder apps embedded in your dashboards, you can take direct actions on your resources, and all of the relevant data and context is immediately available. Link your app with the dashboard's time frame and template variables to dynamically set the scope of the app's actions, which allows you to carry out actions in your environment at any needed scope.

--- a/content/en/service_management/app_builder/expressions.md
+++ b/content/en/service_management/app_builder/expressions.md
@@ -10,6 +10,14 @@ further_reading:
   text: "Components"
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+{{< callout url="" btn_hidden="true" header="Try the Beta!">}}
+App Builder is in beta. Access it from the <a href="https://app.datadoghq.com/app-builder/">App Builder</a> page in Datadog.
+{{< /callout >}}
+
 You can use JavaScript (JS) expressions anywhere in App Builder to create custom interactions between the different parts of your app. As you type an expression, App Builder offers autocomplete suggestions based on the existing queries and components in your app. Click on an autocomplete suggestion to use it in your expression, or use the arrow keys on your keyboard and make a selection with the Enter key.
 
 Some fields, like [post-query transformation][1], display a code editor by default and accept plain JS. In all other fields, enclose your JS expressions in `${}`. For example, to interpolate the values of two text input components named `textInput0` and `textInput1` into the **Content** property of a text component (and add an exclamation mark), use the expression `${textInput0.value} ${textInput1.value}!`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Edits the beta banner because App Builder is now in public beta. Also adds it to some pages where it was missing, and adds the govcloud disclaimer to some places where it was missing.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->