### PR TITLE
Specify Browsers compatible for the Browser test recorder

### DIFF
--- a/content/en/synthetics/browser_tests/actions.md
+++ b/content/en/synthetics/browser_tests/actions.md
@@ -19,7 +19,7 @@ The default timeout for each step is 60 seconds. You can override this default t
 
 ## Automatically recorded steps
 
-Once you click **Start Recording**, the [Datadog browser test recorder extension][3] automatically detects and records steps on your website.
+Once you click **Start Recording**, the [Datadog browser test recorder extension][3], available for Chrome and Edge browsers, automatically detects and records steps on your website.
 
 ### Click
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adding the name of browsers that support the DD Test recorder extension

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->