### PR TITLE
fix number font in search bar

### DIFF
--- a/assets/styles/instantsearch/searchbar-with-dropdown.scss
+++ b/assets/styles/instantsearch/searchbar-with-dropdown.scss
@@ -41,6 +41,7 @@
     }
 
     .ais-SearchBox-input {
+        font-feature-settings: "lnum" 1;
         padding-left: 9px;
         margin-right: 8px;
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
fix font for numbers in search input

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-5002
preview: type into the search bars. the numbers should be linear.
   - home: https://docs-staging.datadoghq.com/stefon.simmons/fix-font-feature-search/monitors/
   - search page: https://docs-staging.datadoghq.com/stefon.simmons/fix-font-feature-search/search/
   - left nav and on mobile: https://docs-staging.datadoghq.com/stefon.simmons/fix-font-feature-search/opentelemetry/

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->