### PR TITLE
update data jobs monitoring setup guide wrt databricks integration permissions

### DIFF
--- a/content/en/data_jobs/databricks.md
+++ b/content/en/data_jobs/databricks.md
@@ -25,7 +25,7 @@ Follow these steps to enable Data Jobs Monitoring for Databricks.
 1. In your Databricks workspace, go to **Settings** > **Developer**. Next to **Access tokens**, click **Manage**.
 1. Click **Generate new token**, enter a comment, leave the Lifetime as empty and click **Generate**. Take note of your token.
 1. As an alternative, follow [the guide][10] to generate access token for a [service principal][11].
-1. Ensure the account generating the token has [CAN VIEW][9] access for Databricks Jobs you want to monitor and the token is configured to never expire.
+1. Ensure the account generating the token has [CAN VIEW access][9] for the Databricks jobs you want to monitor, and that the token is configured to never expire.
 1. In Datadog, open the Databricks integration tile.
 1. On the **Configure** tab, click **Add New**.
 1. Enter a workspace name, your Databricks workspace URL, and the Databricks token you generated.

--- a/content/en/data_jobs/databricks.md
+++ b/content/en/data_jobs/databricks.md
@@ -23,7 +23,7 @@ Follow these steps to enable Data Jobs Monitoring for Databricks.
 ### Configure the Datadog-Databricks integration
 
 1. In your Databricks workspace, go to **Settings** > **Developer**. Next to **Access tokens**, click **Manage**.
-1. Click **Generate new token**, enter a comment, leave the Lifetime as empty and click **Generate**. Take note of your token.
+1. Click **Generate new token**, enter "Datadog Integration" in the **Comment** field, remove the default value in **Lifetime (days)**, and click **Generate**. Take note of your token. **Important:** Make sure you delete the default value in **Lifetime (days)** so that the token doesn't expire and the integration doesn't break.
 1. As an alternative, follow the [official Databricks documentation][10] to generate access token for a [service principal][11].
 1. Ensure the account generating the token has [CAN VIEW access][9] for the Databricks jobs you want to monitor, and that the token is configured to never expire.
 1. In Datadog, open the Databricks integration tile.

--- a/content/en/data_jobs/databricks.md
+++ b/content/en/data_jobs/databricks.md
@@ -23,9 +23,14 @@ Follow these steps to enable Data Jobs Monitoring for Databricks.
 ### Configure the Datadog-Databricks integration
 
 1. In your Databricks workspace, click on your profile in the top right corner and go to **Settings**. Select **Developer** in the left side bar. Next to **Access tokens**, click **Manage**.
-1. Click **Generate new token**, enter "Datadog Integration" in the **Comment** field, remove the default value in **Lifetime (days)**, and click **Generate**. Take note of your token. **Important:** Make sure you delete the default value in **Lifetime (days)** so that the token doesn't expire and the integration doesn't break.
-1. As an alternative, follow the [official Databricks documentation][10] to generate access token for a [service principal][11].
-1. Ensure the account generating the token has [CAN VIEW access][9] for the Databricks jobs and clusters you want to monitor, and that the token is configured to never expire.
+1. Click **Generate new token**, enter "Datadog Integration" in the **Comment** field, remove the default value in **Lifetime (days)**, and click **Generate**. Take note of your token. 
+
+   **Important:** 
+   * Make sure you delete the default value in **Lifetime (days)** so that the token doesn't expire and the integration doesn't break.
+   * Ensure the account generating the token has [CAN VIEW access][9] for the Databricks jobs and clusters you want to monitor.
+
+   As an alternative, follow the [official Databricks documentation][10] to generate access token for a [service principal][11].
+
 1. In Datadog, open the Databricks integration tile.
 1. On the **Configure** tab, click **Add New**.
 1. Enter a workspace name, your Databricks workspace URL, and the Databricks token you generated.

--- a/content/en/data_jobs/databricks.md
+++ b/content/en/data_jobs/databricks.md
@@ -24,7 +24,7 @@ Follow these steps to enable Data Jobs Monitoring for Databricks.
 
 1. In your Databricks workspace, go to **Settings** > **Developer**. Next to **Access tokens**, click **Manage**.
 1. Click **Generate new token**, enter a comment, leave the Lifetime as empty and click **Generate**. Take note of your token.
-1. As an alternative, follow [the guide][10] to generate access token for a [service principal][11].
+1. As an alternative, follow the [official Databricks documentation][10] to generate access token for a [service principal][11].
 1. Ensure the account generating the token has [CAN VIEW access][9] for the Databricks jobs you want to monitor, and that the token is configured to never expire.
 1. In Datadog, open the Databricks integration tile.
 1. On the **Configure** tab, click **Add New**.

--- a/content/en/data_jobs/databricks.md
+++ b/content/en/data_jobs/databricks.md
@@ -22,7 +22,7 @@ Follow these steps to enable Data Jobs Monitoring for Databricks.
 
 ### Configure the Datadog-Databricks integration
 
-1. In your Databricks workspace, go to **Settings** > **Developer**. Next to **Access tokens**, click **Manage**.
+1. In your Databricks workspace, click on your profile in the top right corner and go to **Settings**. Select **Developer** in the left side bar. Next to **Access tokens**, click **Manage**.
 1. Click **Generate new token**, enter "Datadog Integration" in the **Comment** field, remove the default value in **Lifetime (days)**, and click **Generate**. Take note of your token. **Important:** Make sure you delete the default value in **Lifetime (days)** so that the token doesn't expire and the integration doesn't break.
 1. As an alternative, follow the [official Databricks documentation][10] to generate access token for a [service principal][11].
 1. Ensure the account generating the token has [CAN VIEW access][9] for the Databricks jobs you want to monitor, and that the token is configured to never expire.

--- a/content/en/data_jobs/databricks.md
+++ b/content/en/data_jobs/databricks.md
@@ -25,7 +25,7 @@ Follow these steps to enable Data Jobs Monitoring for Databricks.
 1. In your Databricks workspace, click on your profile in the top right corner and go to **Settings**. Select **Developer** in the left side bar. Next to **Access tokens**, click **Manage**.
 1. Click **Generate new token**, enter "Datadog Integration" in the **Comment** field, remove the default value in **Lifetime (days)**, and click **Generate**. Take note of your token. **Important:** Make sure you delete the default value in **Lifetime (days)** so that the token doesn't expire and the integration doesn't break.
 1. As an alternative, follow the [official Databricks documentation][10] to generate access token for a [service principal][11].
-1. Ensure the account generating the token has [CAN VIEW access][9] for the Databricks jobs you want to monitor, and that the token is configured to never expire.
+1. Ensure the account generating the token has [CAN VIEW access][9] for the Databricks jobs and clusters you want to monitor, and that the token is configured to never expire.
 1. In Datadog, open the Databricks integration tile.
 1. On the **Configure** tab, click **Add New**.
 1. Enter a workspace name, your Databricks workspace URL, and the Databricks token you generated.

--- a/content/en/data_jobs/databricks.md
+++ b/content/en/data_jobs/databricks.md
@@ -23,7 +23,9 @@ Follow these steps to enable Data Jobs Monitoring for Databricks.
 ### Configure the Datadog-Databricks integration
 
 1. In your Databricks workspace, go to **Settings** > **Developer**. Next to **Access tokens**, click **Manage**.
-1. Click **Generate new token**, enter a comment, and click **Generate**. Take note of your token.
+1. Click **Generate new token**, enter a comment, leave the Lifetime as empty and click **Generate**. Take note of your token.
+1. As an alternative, follow [the guide][10] to generate access token for a [service principal][11].
+1. Ensure the account generating the token has [CAN VIEW][9] access for Databricks Jobs you want to monitor and the token is configured to never expire.
 1. In Datadog, open the Databricks integration tile.
 1. On the **Configure** tab, click **Add New**.
 1. Enter a workspace name, your Databricks workspace URL, and the Databricks token you generated.
@@ -191,3 +193,6 @@ In Datadog, view the [Data Jobs Monitoring][6] page to see a list of all your Da
 [6]: https://app.datadoghq.com/data-jobs/
 [7]: /data_jobs
 [8]: https://docs.databricks.com/api/workspace/jobs/submit
+[9]: https://docs.databricks.com/en/security/auth-authz/access-control/index.html#job-acls
+[10]: https://docs.databricks.com/en/admin/users-groups/service-principals.html#manage-personal-access-tokens-for-a-service-principal
+[11]: https://docs.databricks.com/en/admin/users-groups/service-principals.html#what-is-a-service-principal


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This update is to call out some important steps in data jobs monitoring setup wrt the access token permission during Databricks Integration setup:
* the token needs to never expire.
* the token needs to have Can View ACL permissions to Databricks Jobs.
* call out an alternative way of generating access token (as service principal is recommended way of managing identity in Databricks for automated tools)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->