### PR TITLE
Add the required permissions to run the Datadog Integration Stack

### DIFF
--- a/content/en/getting_started/integrations/aws.md
+++ b/content/en/getting_started/integrations/aws.md
@@ -69,6 +69,7 @@ Before getting started, ensure you have the following prerequisites:
     * iam:GetRolePolicy
     * iam:PassRole
     * iam:PutRolePolicy
+    * iam:TagRole
     * iam:UpdateAssumeRolePolicy
     * kms:Decrypt
     * lambda:AddPermission
@@ -97,6 +98,7 @@ Before getting started, ensure you have the following prerequisites:
     * s3:PutBucketPolicy
     * s3:PutBucketPublicAccessBlock
     * s3:PutEncryptionConfiguration
+    * s3:PutLifecycleConfiguration
     * secretsmanager:CreateSecret
     * secretsmanager:DeleteSecret
     * secretsmanager:GetSecretValue


### PR DESCRIPTION
What does this PR do? What is the motivation?
Add the required permissions to run the Datadog Integration Stack.
https://datadoghq.atlassian.net/browse/CLOUDS-4831

Merge instructions
I'm checking with the Monitors Product Team about the wording. Changes can be seen on [this preview page](https://docs-staging.datadoghq.com/dan.chiniara/add-troubleshooting-for-missing-notifications-from-email/monitors/notify/).

 Please merge after reviewing