### PR TITLE
[SCI] Add Azure Devops Services to the list of supported providers

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -355,6 +355,7 @@ The source code integration supports the following Git providers:
 | GitLab SaaS (gitlab.com) | Yes | Yes |
 | GitLab self-managed | Yes | No |
 | Bitbucket | Yes | No |
+| Azure DevOps Services | Yes | No |
 | Azure DevOps Server | Yes | No |
 
 {{< tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Azure Devops Services is the managed, SaaS version of Azure Devops Server (see https://learn.microsoft.com/en-us/azure/devops/user-guide/about-azure-devops-services-tfs?view=azure-devops)
It is supported by Source Code Integration. This PR clarifies that we support both in the provider support table.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->