### PR TITLE
probabilistic sampler requires 128 bit trace ids

### DIFF
--- a/content/en/opentelemetry/ingestion_sampling_with_opentelemetry.md
+++ b/content/en/opentelemetry/ingestion_sampling_with_opentelemetry.md
@@ -116,6 +116,7 @@ To configure probabilistic sampling, do one of the following:
 
 - The probabilistic sampler will ignore the sampling priority of spans that are set at the tracing library level. As a result, probabilistic sampling is **incompatible with [head-based sampling][16]**. This means that head-based sampled traces might still be dropped by probabilistic sampling.
 - Spans not captured by the probabilistic sampler may still be captured by the Datadog Agent's [error and rare samplers][12].
+- For consistent sampling all tracers must support [128-bit trace IDs][17].
 
 ## Monitoring ingested volumes in Datadog
 
@@ -143,3 +144,4 @@ If the ingestion volume is higher than expected, consider adjusting your samplin
 [14]: /opentelemetry/guide/migration/
 [15]: /opentelemetry/interoperability/otlp_ingest_in_the_agent/?tab=host
 [16]: /tracing/trace_pipeline/ingestion_mechanisms#head-based-sampling
+[17]: /opentelemetry/interoperability/otel_api_tracing_interoperability/#128-bit-trace-ids


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Makes it clear that the new probabilistic sampler requires 128 bit trace IDs. We recently ran into a support case where a customer was using an older version of a tracer without this support and had disconnected traces when trying to use the probabilistic sampler.
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->