### PR TITLE
DOCS-7988 - Feature parity for Operator and Helm

### DIFF
--- a/content/en/agent/guide/agent-v6-python-3.md
+++ b/content/en/agent/guide/agent-v6-python-3.md
@@ -54,7 +54,7 @@ To switch from Python 2 to Python 3, update the image tag used to deploy the Age
 {{% tab "Helm" %}}
 By default, the [Datadog Helm chart][1] uses the Agent 7 image that embeds the Python 3 runtime.
 
-To keep the Datadog Agent updated, edit your `values.yaml` to remove any information under the `agent.image` and the `clusterChecksRunner.image` sections.
+To keep the Datadog Agent updated, edit your `datadog-values.yaml` to remove any information under the `agent.image` and the `clusterChecksRunner.image` sections.
 
 To use a specific container registry, set it with `agent.image.repository` and `clusterChecksRunner.image.repository`. Ensure that `agents.image.tag` and  `clusterChecksRunner.image.tag` are undefined.
 
@@ -191,7 +191,7 @@ spec:
 
 [1]: https://github.com/DataDog/datadog-operator
 {{% /tab %}}
-{{% tab "DaemonSet" %}}
+{{% tab "Manual (DaemonSet)" %}}
 
 In your DaemonSet manifest, update the image tag in each container definition:
 

--- a/content/en/agent/logs/advanced_log_collection.md
+++ b/content/en/agent/logs/advanced_log_collection.md
@@ -664,14 +664,33 @@ DD_LOGS_CONFIG_PROCESSING_RULES='[{"type": "mask_sequences", "name": "mask_user_
 ```
 
 {{% /tab %}}
-{{% tab "Helm" %}}
+{{% tab "Datadog Operator" %}}
 
-Use the `env` parameter in the helm chart to set the `DD_LOGS_CONFIG_PROCESSING_RULES` environment variable to configure global processing rules. For example:
+Use the `spec.override.[key].env` parameter in your Datadog Operator manifest to set the `DD_LOGS_CONFIG_PROCESSING_RULES` environment variable to configure global processing rules, where `[key]` is `nodeAgent`, `clusterAgent`, or `clusterChecksRunner`. For example:
 
 ```yaml
-env:
-  - name: DD_LOGS_CONFIG_PROCESSING_RULES
-    value: '[{"type": "mask_sequences", "name": "mask_user_email", "replace_placeholder": "MASKED_EMAIL", "pattern" : "\\w+@datadoghq.com"}]'
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    nodeAgent:
+      env:
+        - name: DD_LOGS_CONFIG_PROCESSING_RULES
+          value: '[{"type": "mask_sequences", "name": "mask_user_email", "replace_placeholder": "MASKED_EMAIL", "pattern" : "\\w+@datadoghq.com"}]'
+```
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+Use the `datadog.env` parameter in the Helm chart to set the `DD_LOGS_CONFIG_PROCESSING_RULES` environment variable to configure global processing rules. For example:
+
+```yaml
+datadog:
+  env:
+    - name: DD_LOGS_CONFIG_PROCESSING_RULES
+      value: '[{"type": "mask_sequences", "name": "mask_user_email", "replace_placeholder": "MASKED_EMAIL", "pattern" : "\\w+@datadoghq.com"}]'
 ```
 
 {{% /tab %}}

--- a/content/en/agent/troubleshooting/hostname_containers.md
+++ b/content/en/agent/troubleshooting/hostname_containers.md
@@ -53,18 +53,7 @@ This prevents the Agent from connecting to the Kubelet API through HTTPS, becaus
 You can disable TLS verification by using dedicated parameters or by setting the `DD_KUBELET_TLS_VERIFY` variable for **all containers** in the Agent manifest:
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  kubelet:
-    tlsVerify: false
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 `DatadogAgent` Kubernetes Resource:
 
@@ -79,9 +68,21 @@ spec:
 ```
 
 {{% /tab %}}
-{{% tab "Manifest" %}}
+{{% tab "Helm" %}}
 
-`DaemonSet` manifest:
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  kubelet:
+    tlsVerify: false
+```
+
+{{% /tab %}}
+
+{{% tab "Manual (DaemonSet)" %}}
+
+DaemonSet manifest:
 
 ```yaml
 apiVersion: apps/v1
@@ -116,21 +117,7 @@ Use this solution only in the unlikely event that you **explicitly** don't want 
 In this case you can use the downward API to set `DD_HOSTNAME`:
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  env:
-    - name: DD_HOSTNAME
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 `DatadogAgent` Kubernetes Resource:
 
@@ -149,9 +136,24 @@ spec:
 ```
 
 {{% /tab %}}
-{{% tab "Manifest" %}}
+{{% tab "Helm" %}}
 
-`DaemonSet` manifest
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  env:
+    - name: DD_HOSTNAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+```
+
+{{% /tab %}}
+
+{{% tab "Manual (DaemonSet)" %}}
+
+DaemonSet manifest:
 
 ```yaml
 apiVersion: apps/v1

--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -29,11 +29,11 @@ Datadog's Admission Controller is `MutatingAdmissionWebhook` type. For more deta
 
 ## Configuration
 {{< tabs >}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 To enable the Admission Controller for the Datadog Operator, set the parameter `features.admissionController.enabled` to `true` in your `DatadogAgent` configuration:
 
-{{< code-block lang="yaml" disable_copy="false" >}}
+{{< code-block lang="yaml" filename="datadog-agent.yaml" disable_copy="false" >}}
 apiVersion: datadoghq.com/v2alpha1
 kind: DatadogAgent
 metadata:
@@ -51,7 +51,7 @@ Starting from Helm chart v2.35.0, Datadog Admission controller is activated by d
 
 To enable the Admission Controller for Helm chart v2.34.6 and earlier, set the parameter `clusterAgent.admissionController.enabled` to `true`:
 
-{{< code-block lang="yaml" filename="values.yaml" disable_copy="false" >}}
+{{< code-block lang="yaml" filename="datadog-values.yaml" disable_copy="false" >}}
 #(...)
 clusterAgent:
   #(...)

--- a/content/en/containers/cluster_agent/clusterchecks.md
+++ b/content/en/containers/cluster_agent/clusterchecks.md
@@ -36,21 +36,7 @@ Using cluster checks is recommended if your infrastructure is configured for hig
 The setup process involves enabling the dispatching ability in the Cluster Agent, as well as ensuring the Agents are prepared to receive configurations from the `clusterchecks` provider. Once this is done, configurations are passed to the Cluster Agent through mounted configuration files or through Kubernetes service annotations.
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-Cluster check dispatching is enabled by default in the Helm deployment of the Cluster Agent through the `datadog.clusterChecks.enabled` configuration key:
-```yaml
-datadog:
-  clusterChecks:
-    enabled: true
-  # (...)
-clusterAgent:
-  enabled: true
-  # (...)
-```
-
-This enables the cluster check setup in the Cluster Agent and allows it to process configurations from the Kubernetes service annotations (`kube_services`).
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 Cluster check dispatching is enabled in the Operator deployment of the Cluster Agent by using the `spec.features.clusterChecks.enabled` configuration key:
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -66,7 +52,22 @@ spec:
 This enables the cluster check setup in the Cluster Agent and allows it to process configurations from the Kubernetes service annotations (`kube_services`).
 
 {{% /tab %}}
-{{% tab "DaemonSet" %}}
+{{% tab "Helm" %}}
+Cluster check dispatching is enabled by default in the Helm deployment of the Cluster Agent through the `datadog.clusterChecks.enabled` configuration key:
+```yaml
+datadog:
+  clusterChecks:
+    enabled: true
+  # (...)
+clusterAgent:
+  enabled: true
+  # (...)
+```
+
+This enables the cluster check setup in the Cluster Agent and allows it to process configurations from the Kubernetes service annotations (`kube_services`).
+{{% /tab %}}
+
+{{% tab "Manual (DaemonSet)" %}}
 ### Cluster Agent
 
 Once your [Cluster Agent][1] is running, make the following changes to the Cluster Agent deployment:
@@ -109,7 +110,7 @@ The [Datadog Helm Chart][3] and the [Datadog Operator][4] additionally offer the
 
 The Cluster Agent can use an advanced dispatching logic for cluster checks, which takes into account the execution time and metric samples from check instances. This logic enables the Cluster Agent to optimize dispatching and distribution between cluster check runners.
 
-To configure advanced dispatching logic, set the `DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED` environment variable to `true` for the Cluster Agent.
+To configure advanced dispatching logic, set the `DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED` environment variable to `true` for the Cluster Agent. See [Cluster Agent environment variables][15] for how to set environment variables in your Datadog Operator manifest or Helm chart.
 
 The following environment variables are required to configure the node Agents (or cluster check runners) to expose their check stats. The stats are consumed by the Cluster Agent and are used to optimize the cluster checks' dispatching logic.
 
@@ -138,25 +139,7 @@ When the URL or IP of a given resource is constant (for example, an external ser
 In Cluster Agent v1.18.0+, you can use `advanced_ad_identifiers` and [Autodiscovery template variables][7] in your check configuration to target Kubernetes services ([see example][8]).
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-With Helm, these configuration files can be created within the `clusterAgent.confd` section.
-
-```yaml
-#(...)
-clusterAgent:
-  confd:
-    <INTEGRATION_NAME>.yaml: |-
-      cluster_check: true
-      init_config:
-        - <INIT_CONFIG>
-      instances:
-        - <INSTANCES_CONFIG>
-```
-
-**Note**: This is separate from the `datadog.confd` section, where the files are created in the node-based Agents. The `<INTEGRATION_NAME>` must exactly match the desired integration check you want to run.
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 With the Datadog Operator, these configuration files can be created within the `spec.override.clusterAgent.extraConfd.configDataMap` section:
 
 ```yaml
@@ -204,7 +187,25 @@ data:
 ```
 
 {{% /tab %}}
-{{% tab "DaemonSet" %}}
+{{% tab "Helm" %}}
+With Helm, these configuration files can be created within the `clusterAgent.confd` section.
+
+```yaml
+#(...)
+clusterAgent:
+  confd:
+    <INTEGRATION_NAME>.yaml: |-
+      cluster_check: true
+      init_config:
+        - <INIT_CONFIG>
+      instances:
+        - <INSTANCES_CONFIG>
+```
+
+**Note**: This is separate from the `datadog.confd` section, where the files are created in the node-based Agents. The `<INTEGRATION_NAME>` must exactly match the desired integration check you want to run.
+
+{{% /tab %}}
+{{% tab "Manual (DaemonSet)" %}}
 With the manual approach you must create a ConfigMap to store the desired static configuration files, and then mount this ConfigMap into the corresponding `/conf.d` file of the Cluster Agent container. This follows the same approach for [mounting ConfigMaps into the Agent container][1]. For example:
 
 ```yaml
@@ -274,27 +275,7 @@ instances:
 If there is a Kubernetes service you would like the to perform an [HTTP check][10] against once per cluster:
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-Use the `clusterAgent.confd` field to define your check configuration:
-
-```yaml
-#(...)
-clusterAgent:
-  confd:
-    http_check.yaml: |-
-      advanced_ad_identifiers:
-        - kube_service:
-            name: "<SERVICE_NAME>"
-            namespace: "<SERVICE_NAMESPACE>"
-      cluster_check: true
-      init_config:
-      instances:
-        - url: "http://%%host%%"
-          name: "<EXAMPLE_NAME>"
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 Use the `spec.override.clusterAgent.extraConfd.configDataMap` field to define your check configuration:
 
 ```yaml
@@ -316,7 +297,27 @@ spec:
                 name: "<EXAMPLE_NAME>"
 ```
 {{% /tab %}}
-{{% tab "DaemonSet" %}}
+{{% tab "Helm" %}}
+Use the `clusterAgent.confd` field to define your check configuration:
+
+```yaml
+#(...)
+clusterAgent:
+  confd:
+    http_check.yaml: |-
+      advanced_ad_identifiers:
+        - kube_service:
+            name: "<SERVICE_NAME>"
+            namespace: "<SERVICE_NAMESPACE>"
+      cluster_check: true
+      init_config:
+      instances:
+        - url: "http://%%host%%"
+          name: "<EXAMPLE_NAME>"
+```
+
+{{% /tab %}}
+{{% tab "Manual (DaemonSet)" %}}
 Mount a `/conf.d/http_check.yaml` file in the Cluster Agent container with the following content:
 
 ```yaml
@@ -515,3 +516,4 @@ Now, run the [node Agent's `status` subcommand][14] and look for the check name 
 [12]: /integrations/nginx/
 [13]: /containers/troubleshooting/cluster-and-endpoint-checks#dispatching-logic-in-the-cluster-agent
 [14]: /containers/cluster_agent/commands/#cluster-agent-commands
+[15]: /containers/cluster_agent/commands/?tab=datadogoperator#cluster-agent-environment-variables

--- a/content/en/containers/cluster_agent/commands.md
+++ b/content/en/containers/cluster_agent/commands.md
@@ -75,7 +75,7 @@ The following environment variables are supported:
 : Enable Cluster Check Autodiscovery. Defaults to `false`.
 
 `DD_CLUSTER_AGENT_AUTH_TOKEN`                 
-: 32 characters long token that needs to be shared between the node Agent and the Datadog Cluster Agent.
+: 32-character token that needs to be shared between the node Agent and the Datadog Cluster Agent.
 
 `DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME`    
 : Name of the Kubernetes service through which Cluster Agents are exposed. Defaults to `datadog-cluster-agent`.
@@ -96,7 +96,7 @@ The following environment variables are supported:
 : Name of the instance tag set with the `DD_CLUSTER_NAME` option. Defaults to `cluster_name`.
 
 `DD_CLUSTER_CHECKS_EXTRA_TAGS`                
-: Adds extra tags to cluster checks metrics.
+: Adds extra tags to cluster check metrics.
 
 `DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED`
 : When true, the leader Cluster Agent collects stats from the cluster-level check runners to optimize check dispatching logic. Default: `false`.

--- a/content/en/containers/cluster_agent/commands.md
+++ b/content/en/containers/cluster_agent/commands.md
@@ -34,21 +34,81 @@ The available commands for the Datadog Cluster Agents are:
 `datadog-cluster-agent flare <CASE_ID>`     
 : Similarly to the node-based Agent, the Cluster Agent can aggregate the logs and the configurations used and forward an archive to the support team, or be deflated and used locally. **Note**: this command runs from within the Cluster Agent pod.
 
-## Cluster Agent options
+## Cluster Agent environment variables
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+Set Cluster Agent environment variables under `override.clusterAgent.env`:
+
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    clusterAgent:
+      env:
+        - name: <ENV_VAR_NAME>
+          value: <ENV_VAR_VALUE>
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+Set Cluster Agent environment variables under `clusterAgent.env`:
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
+clusterAgent:
+  env:
+    - name: <ENV_VAR_NAME>
+      value: <ENV_VAR_VALUE>
+{{< /code-block >}}
+
+{{% /tab %}}
+{{< /tabs >}}
 
 The following environment variables are supported:
 
 `DD_API_KEY`                                  
 : Your [Datadog API key][1].
 
+`DD_CLUSTER_CHECKS_ENABLED`                   
+: Enable Cluster Check Autodiscovery. Defaults to `false`.
+
+`DD_CLUSTER_AGENT_AUTH_TOKEN`                 
+: 32 characters long token that needs to be shared between the node Agent and the Datadog Cluster Agent.
+
+`DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME`    
+: Name of the Kubernetes service through which Cluster Agents are exposed. Defaults to `datadog-cluster-agent`.
+
+`DD_CLUSTER_NAME`                             
+: Cluster name. Added as an instance tag to all cluster check configurations.
+
+`DD_CLUSTER_CHECKS_ENABLED`
+: When true, enables dispatching logic on the leader Cluster Agent. Default: `false`.
+
+`DD_CLUSTER_CHECKS_NODE_EXPIRATION_TIMEOUT`   
+: Time (in seconds) after which node-based Agents are considered down and removed from the pool. Defaults to `30` seconds.
+
+`DD_CLUSTER_CHECKS_WARMUP_DURATION`           
+: Delay (in seconds) between acquiring leadership and starting the Cluster Checks logic, allowing for all node-based Agents to register first. Default is `30` seconds.
+
+`DD_CLUSTER_CHECKS_CLUSTER_TAG_NAME`          
+: Name of the instance tag set with the `DD_CLUSTER_NAME` option. Defaults to `cluster_name`.
+
+`DD_CLUSTER_CHECKS_EXTRA_TAGS`                
+: Adds extra tags to cluster checks metrics.
+
+`DD_CLUSTER_CHECKS_ADVANCED_DISPATCHING_ENABLED`
+: When true, the leader Cluster Agent collects stats from the cluster-level check runners to optimize check dispatching logic. Default: `false`.
+
+`DD_CLUSTER_CHECKS_CLC_RUNNERS_PORT`
+: The port used by the Cluster Agent client to reach cluster-level check runners and collect their stats. Default: `5005`.
+
 `DD_HOSTNAME`                                 
 : Hostname to use for the Datadog Cluster Agent.
 
 `DD_ENV`                                      
 : Sets the `env` tag for data emitted by the Cluster Agent. Recommended only if the Cluster Agent monitors services within a single environment.
-
-`DD_CLUSTER_AGENT_CMD_PORT`                   
-: Port for the Datadog Cluster Agent to serve. Defaults to `5005`.
 
 `DD_USE_METADATA_MAPPER`                      
 : Enables cluster level metadata mapping. Defaults to `true`.
@@ -62,14 +122,8 @@ The following environment variables are supported:
 `DD_LEADER_LEASE_DURATION`                    
 : Used only if leader election is activated. Value in seconds, 60 by default.
 
-`DD_CLUSTER_AGENT_AUTH_TOKEN`                 
-: 32 characters long token that needs to be shared between the node Agent and the Datadog Cluster Agent.
-
 `DD_KUBE_RESOURCES_NAMESPACE`                 
 : Configures the namespace where the Cluster Agent creates the configmaps required for the leader election, event collection (optional), and horizontal pod autoscaling.
-
-`DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME`    
-: Name of the Kubernetes service through which Cluster Agents are exposed. Defaults to `datadog-cluster-agent`.
 
 `DD_KUBERNETES_INFORMERS_RESYNC_PERIOD`       
 : Frequency (in seconds) for querying the API server to resync the local cache. The default is 5 minutes, or `300` seconds.
@@ -95,29 +149,11 @@ The following environment variables are supported:
 `DD_EXTERNAL_METRICS_LOCAL_COPY_REFRESH_RATE` 
 : Rate to resync local cache of processed metrics with the global store. Useful when there are several replicas of the Cluster Agent.
 
-`DD_CLUSTER_CHECKS_ENABLED`                   
-: Enable Cluster Check Autodiscovery. Defaults to `false`.
-
 `DD_EXTRA_CONFIG_PROVIDERS`                   
 : Additional Autodiscovery configuration providers to use.
 
 `DD_EXTRA_LISTENERS`                          
 : Additional Autodiscovery listeners to run.
-
-`DD_CLUSTER_NAME`                             
-: Cluster name. Added as an instance tag to all cluster check configurations.
-
-`DD_CLUSTER_CHECKS_CLUSTER_TAG_NAME`          
-: Name of the instance tag set with the `DD_CLUSTER_NAME` option. Defaults to `cluster_name`.
-
-`DD_CLUSTER_CHECKS_NODE_EXPIRATION_TIMEOUT`   
-: Time (in seconds) after which node-based Agents are considered down and removed from the pool. Defaults to `30` seconds.
-
-`DD_CLUSTER_CHECKS_WARMUP_DURATION`           
-: Delay (in seconds) between acquiring leadership and starting the Cluster Checks logic, allowing for all node-based Agents to register first. Default is `30` seconds.
-
-`DD_CLUSTER_CHECKS_EXTRA_TAGS`                
-: Adds extra tags to cluster checks metrics.
 
 `DD_PROXY_HTTPS`                
 : Sets a proxy server for HTTPS requests.

--- a/content/en/containers/cluster_agent/endpointschecks.md
+++ b/content/en/containers/cluster_agent/endpointschecks.md
@@ -81,7 +81,7 @@ By design, endpoint checks are dispatched to Agents that run on the same node as
 ## Set up endpoint check dispatching
 
 {{< tabs >}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 Endpoint check dispatching is enabled in the Operator deployment of the Cluster Agent by using the `features.clusterChecks.enabled` configuration key:
 ```yaml
@@ -177,6 +177,30 @@ In Cluster Agent v1.18.0+, you can use `advanced_ad_identifiers` and [Autodiscov
 To perform an [HTTP check][9] against the endpoints of a Kubernetes service,
 
 {{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+Use the `spec.override.clusterAgent.extraConfd.configDataMap` section to define your check configuration:
+
+```yaml
+spec:
+#(...)
+  override:
+    clusterAgent:
+      extraConfd:
+        configDataMap:
+          <INTEGRATION_NAME>.yaml: |-
+            advanced_ad_identifiers:
+              - kube_endpoints:
+                  name: "<ENDPOINTS_NAME>"
+                  namespace: "<ENDPOINTS_NAMESPACE>"
+            cluster_check: true
+            init_config:
+            instances:
+              - url: "http://%%host%%"
+                name: "<EXAMPLE_NAME>"
+```
+
+{{% /tab %}}
 {{% tab "Helm" %}}
 Use the `clusterAgent.confd` field to define your check configuration:
 

--- a/content/en/containers/cluster_agent/setup.md
+++ b/content/en/containers/cluster_agent/setup.md
@@ -25,29 +25,7 @@ algolia:
 If you deploy the Datadog Agent using Helm chart v2.7.0+ or Datadog Operator v0.7.0+, the Cluster Agent is enabled by default.
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-The Cluster Agent is enabled by default since Helm chart v2.7.0.
-
-To activate it on older versions, or if you use a custom [datadog-values.yaml][1] that overrides the `clusterAgent` key, update your [datadog-values.yaml][1] file with the following Cluster Agent configuration:
-
-  ```yaml
-  clusterAgent:
-    # clusterAgent.enabled -- Set this to false to disable Datadog Cluster Agent
-    enabled: true
-  ```
-
-Then, upgrade your Datadog Helm chart.
-
-This automatically updates the necessary RBAC files for the Cluster Agent and Datadog Agent. Both Agents use the same API key.
-
-This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token using the `clusterAgent.token` configuration. You can alternatively set this by referencing the name of an existing `Secret` containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration.
-
-When set manually, this token must be 32 alphanumeric characters.
-
-[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 The Cluster Agent is enabled by default since Datadog Operator v1.0.0. The Operator creates the necessary RBACs, deploys the Cluster Agent, and modifies the Agent DaemonSet configuration.
 
@@ -70,6 +48,28 @@ This also automatically generates a random token in a `Secret` shared by both th
 When set manually, this token must be 32 alphanumeric characters.
 
 [1]: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#override
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+The Cluster Agent is enabled by default since Helm chart v2.7.0.
+
+To activate it on older versions, or if you use a custom [datadog-values.yaml][1] that overrides the `clusterAgent` key, update your [datadog-values.yaml][1] file with the following Cluster Agent configuration:
+
+  ```yaml
+  clusterAgent:
+    # clusterAgent.enabled -- Set this to false to disable Datadog Cluster Agent
+    enabled: true
+  ```
+
+Then, upgrade your Datadog Helm chart.
+
+This automatically updates the necessary RBAC files for the Cluster Agent and Datadog Agent. Both Agents use the same API key.
+
+This also automatically generates a random token in a `Secret` shared by both the Cluster Agent and the Datadog Agent to secure communication. You can manually specify this token using the `clusterAgent.token` configuration. You can alternatively set this by referencing the name of an existing `Secret` containing a `token` value through the `clusterAgent.tokenExistingSecret` configuration.
+
+When set manually, this token must be 32 alphanumeric characters.
+
+[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
 {{% /tab %}}
 {{% tab "Manual (DaemonSet)" %}}
 
@@ -254,7 +254,7 @@ The Datadog Cluster Agent can only be deployed on Linux nodes.
 
 To monitor Windows containers, use two installations of the Helm chart in a mixed cluster. The first Helm chart deploys the Datadog Cluster Agent and the Agent DaemonSet for Linux nodes (with `targetSystem: linux`). The second Helm chart (with `targetSystem: windows`) deploys the Agent only on Windows nodes and connects to the existing Cluster Agent deployed as part of the first Helm chart.
 
-Use the following `values.yaml` file to configure communication between Agents deployed on Windows nodes and the Cluster Agent.
+Use the following `datadog-values.yaml` file to configure communication between Agents deployed on Windows nodes and the Cluster Agent.
 
 ```yaml
 targetSystem: windows
@@ -276,9 +276,9 @@ For more information, see [Troubleshooting Windows Container Issues][2].
 
 ## Monitoring AWS managed services
 
-To monitor an AWS managed service like MSK, ElastiCache, or RDS, set `clusterChecksRunner` to create a Pod with an IAM role assigned through the serviceAccountAnnotation in the Helm chart. Then, set the integration configurations under `clusterAgent.confd`.
+To monitor an AWS managed service like MSK, ElastiCache, or RDS, set `clusterChecksRunner` in your Helm chart to create a Pod with an IAM role assigned through `serviceAccountAnnotation`. Then, set the integration configurations under `clusterAgent.confd`.
 
-{{< code-block lang="yaml" >}}
+{{< code-block lang="yaml" filename="datadog-values.yaml">}}
 clusterChecksRunner:
   enabled: true
   rbac:

--- a/content/en/containers/cluster_agent/setup.md
+++ b/content/en/containers/cluster_agent/setup.md
@@ -276,7 +276,7 @@ For more information, see [Troubleshooting Windows Container Issues][2].
 
 ## Monitoring AWS managed services
 
-To monitor an AWS managed service like MSK, ElastiCache, or RDS, set `clusterChecksRunner` in your Helm chart to create a Pod with an IAM role assigned through `serviceAccountAnnotation`. Then, set the integration configurations under `clusterAgent.confd`.
+To monitor an AWS managed service like Amazon Managed Streaming for Apache Kafka (MSK), ElastiCache, or Relational Database Service (RDS), set `clusterChecksRunner` in your Helm chart to create a Pod with an IAM role assigned through `serviceAccountAnnotation`. Then, set the integration configurations under `clusterAgent.confd`.
 
 {{< code-block lang="yaml" filename="datadog-values.yaml">}}
 clusterChecksRunner:

--- a/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -44,32 +44,7 @@ As of v1.0.0, the Custom Metrics Server in the Datadog Cluster Agent implements 
 ### Installation
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-To enable the external metrics server with your Cluster Agent in Helm, update your [values.yaml][1] file with the following configurations. Provide a valid Datadog API Key, Application Key, and set the `clusterAgent.metricsProvider.enabled` to `true`. Then redeploy your Datadog Helm chart:
-
-  ```yaml
-  datadog:
-    apiKey: <DATADOG_API_KEY>
-    appKey: <DATADOG_APP_KEY>
-    #(...)
-
-  clusterAgent:
-    enabled: true
-    # Enable the metricsProvider to be able to scale based on metrics in Datadog
-    metricsProvider:
-      # clusterAgent.metricsProvider.enabled
-      # Set this to true to enable Metrics Provider
-      enabled: true
-  ```
-
-This automatically updates the necessary RBAC configurations and sets up the corresponding `Service` and `APIService` for Kubernetes to use.
-
-The keys can alternatively be set by referencing the names of pre-created `Secrets` containing the data keys `api-key` and `app-key` with the configurations `datadog.apiKeyExistingSecret` and `datadog.appKeyExistingSecret`.
-
-[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 To enable the external metrics server with your Cluster Agent managed by the Datadog Operator, first [set up the Datadog Operator][1]. Then, provide a valid Datadog API Key, Application Key, and set the `features.externalMetricsServer.enabled` to `true` in your `DatadogAgent` custom resource:
 
@@ -114,7 +89,33 @@ The keys can alternatively be set by referencing the names of pre-created `Secre
 
 [1]: /agent/guide/operator-advanced
 {{% /tab %}}
-{{% tab "Daemonset" %}}
+{{% tab "Helm" %}}
+
+To enable the external metrics server with your Cluster Agent in Helm, update your [datadog-values.yaml][1] file with the following configurations. Provide a valid Datadog API Key, Application Key, and set the `clusterAgent.metricsProvider.enabled` to `true`. Then redeploy your Datadog Helm chart:
+
+  ```yaml
+  datadog:
+    apiKey: <DATADOG_API_KEY>
+    appKey: <DATADOG_APP_KEY>
+    #(...)
+
+  clusterAgent:
+    enabled: true
+    # Enable the metricsProvider to be able to scale based on metrics in Datadog
+    metricsProvider:
+      # clusterAgent.metricsProvider.enabled
+      # Set this to true to enable Metrics Provider
+      enabled: true
+  ```
+
+This automatically updates the necessary RBAC configurations and sets up the corresponding `Service` and `APIService` for Kubernetes to use.
+
+The keys can alternatively be set by referencing the names of pre-created `Secrets` containing the data keys `api-key` and `app-key` with the configurations `datadog.apiKeyExistingSecret` and `datadog.appKeyExistingSecret`.
+
+[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
+{{% /tab %}}
+
+{{% tab "Manual (DaemonSet)" %}}
 
 #### Custom metrics server
 
@@ -184,27 +185,7 @@ For autoscaling to work correctly, custom queries must follow these rules:
 The Custom Resource Definition (CRD) for the `DatadogMetric` object can be added to your Kubernetes cluster by using Helm, the Datadog Operator, or Daemonset:
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-To activate usage of the `DatadogMetric` CRD update your [values.yaml][1] Helm configuration to set `clusterAgent.metricsProvider.useDatadogMetrics` to `true`. Then redeploy your Datadog Helm chart:
-
-  ```yaml
-  clusterAgent:
-    enabled: true
-    metricsProvider:
-      enabled: true
-      # clusterAgent.metricsProvider.useDatadogMetrics
-      # Enable usage of DatadogMetric CRD to autoscale on arbitrary Datadog queries
-      useDatadogMetrics: true
-  ```
-
-**Note:** This attempts to install the `DatadogMetric` CRD automatically. If that CRD already exists prior to the initial Helm installation, it may conflict.
-
-This automatically updates the necessary RBAC files and directs the Cluster Agent to manage these HPA queries through these `DatadogMetric` resources.
-
-[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 To activate the usage of the `DatadogMetric` CRD update your `DatadogAgent` custom resource and set `features.externalMetricsServer.useDatadogMetrics` to `true`.
 
@@ -227,7 +208,27 @@ To activate the usage of the `DatadogMetric` CRD update your `DatadogAgent` cust
 The Operator automatically updates the necessary RBAC configurations and directs the Cluster Agent to manage these HPA queries through these `DatadogMetric` resources.
 
 {{% /tab %}}
-{{% tab "DaemonSet" %}}
+{{% tab "Helm" %}}
+
+To activate usage of the `DatadogMetric` CRD update your [values.yaml][1] Helm configuration to set `clusterAgent.metricsProvider.useDatadogMetrics` to `true`. Then redeploy your Datadog Helm chart:
+
+  ```yaml
+  clusterAgent:
+    enabled: true
+    metricsProvider:
+      enabled: true
+      # clusterAgent.metricsProvider.useDatadogMetrics
+      # Enable usage of DatadogMetric CRD to autoscale on arbitrary Datadog queries
+      useDatadogMetrics: true
+  ```
+
+**Note:** This attempts to install the `DatadogMetric` CRD automatically. If that CRD already exists prior to the initial Helm installation, it may conflict.
+
+This automatically updates the necessary RBAC files and directs the Cluster Agent to manage these HPA queries through these `DatadogMetric` resources.
+
+[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/values.yaml
+{{% /tab %}}
+{{% tab "Manual (DaemonSet)" %}}
 To activate usage of the `DatadogMetric` CRD, follow these extra steps:
 
 1. Install the `DatadogMetric` CRD in your cluster.

--- a/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -91,7 +91,7 @@ The keys can alternatively be set by referencing the names of pre-created `Secre
 {{% /tab %}}
 {{% tab "Helm" %}}
 
-To enable the external metrics server with your Cluster Agent in Helm, update your [datadog-values.yaml][1] file with the following configurations. Provide a valid Datadog API Key, Application Key, and set the `clusterAgent.metricsProvider.enabled` to `true`. Then redeploy your Datadog Helm chart:
+To enable the external metrics server with your Cluster Agent in Helm, update your [datadog-values.yaml][1] file with the following configurations. Provide a valid Datadog API Key and Application Key, and set `clusterAgent.metricsProvider.enabled` to `true`. Then redeploy your Datadog Helm chart:
 
   ```yaml
   datadog:

--- a/content/en/containers/guide/clustercheckrunners.md
+++ b/content/en/containers/guide/clustercheckrunners.md
@@ -30,7 +30,7 @@ First, [deploy the Cluster Agent][3].
 Then, deploy the cluster check runner using either [Datadog Operator][4] or [Helm][5]:
 
 {{< tabs >}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 Using the Operator, you can launch and manage all of these resources with a single manifest. For example:
 

--- a/content/en/containers/kubernetes/apm.md
+++ b/content/en/containers/kubernetes/apm.md
@@ -298,7 +298,7 @@ List of environment variables available for configuring APM:
 | `DD_APM_CONNECTION_LIMIT`  | Maximum connection limit for a 30 second time window. <br/>**Default**: 2000 |
 | `DD_APM_ADDITONAL_ENDPOINTS`     | Send data to multiple endpoints and/or with multiple API keys. <br/>See [Dual Shipping][12]. |
 | `DD_APM_DEBUG_PORT`     | Port for the debug endpoints for the Trace Agent. Set to `0` to disable the server. <br/>**Default**: `5012`. |
-| `DD_BIND_HOST`             | Set the StatsD & receiver hostname. |
+| `DD_BIND_HOST`             | Set the StatsD and receiver hostname. |
 | `DD_DOGSTATSD_PORT`        | For tracing over TCP, set the DogStatsD port. |
 | `DD_ENV`                   | Sets the global `env` for all data emitted by the Agent. If `env` is not present in your trace data, this variable is used. |
 | `DD_HOSTNAME`         | Manually set the hostname to use for metrics if autodetection fails, or when running the Datadog Cluster Agent. |

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -255,9 +255,9 @@ datadog:
   kubelet:
     tlsVerify: false
   ignoreAutoConfig:
-  - etcd
-  - kube_scheduler
-  - kube_controller_manager
+    - etcd
+    - kube_scheduler
+    - kube_controller_manager
   confd:
     etcd.yaml: |-
       ad_identifiers:
@@ -765,12 +765,12 @@ agents:
       mountPath: /host/opt/rke/etc/kubernetes/ssl
       readOnly: true
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/controlplane
-    operator: Exists
-  - effect: NoExecute
-    key: node-role.kubernetes.io/etcd
-    operator: Exists
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/controlplane
+      operator: Exists
+    - effect: NoExecute
+      key: node-role.kubernetes.io/etcd
+      operator: Exists
 {{< /code-block >}}
 
 {{% /tab %}}
@@ -881,12 +881,12 @@ agents:
       mountPath: /host/opt/rke/etc/kubernetes/ssl
       readOnly: true
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/controlplane
-    operator: Exists
-  - effect: NoExecute
-    key: node-role.kubernetes.io/etcd
-    operator: Exists
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/controlplane
+      operator: Exists
+    - effect: NoExecute
+      key: node-role.kubernetes.io/etcd
+      operator: Exists
 {{< /code-block >}}
 
 {{% /tab %}}

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -51,49 +51,9 @@ The API server integration is automatically configured. The Datadog Agent discov
 By providing read access to the Etcd certificates located on the host, the Datadog Agent check can communicate with Etcd and start collecting Etcd metrics.
 
 {{< tabs >}}
-{{% tab "Helm" %}}
+{{% tab "Datadog Operator" %}}
 
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  kubelet:
-    tlsVerify: false
-  ignoreAutoConfig:
-  - etcd
-  confd:
-    etcd.yaml: |-
-      ad_identifiers:
-        - etcd
-      instances:
-        - prometheus_url: https://%%host%%:2379/metrics
-          tls_ca_cert: /host/etc/kubernetes/pki/etcd/ca.crt
-          tls_cert: /host/etc/kubernetes/pki/etcd/server.crt
-          tls_private_key: /host/etc/kubernetes/pki/etcd/server.key
-agents:
-  volumes:
-    - hostPath:
-        path: /etc/kubernetes/pki/etcd
-      name: etcd-certs
-  volumeMounts:
-    - name: etcd-certs
-      mountPath: /host/etc/kubernetes/pki/etcd
-      readOnly: true
-  tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Exists
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
-
-DatadogAgent Kubernetes Resource:
-
-```yaml
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
 kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
@@ -149,27 +109,12 @@ data:
         tls_ca_cert: /host/etc/kubernetes/pki/etcd/ca.crt
         tls_cert: /host/etc/kubernetes/pki/etcd/server.crt
         tls_private_key: /host/etc/kubernetes/pki/etcd/server.key
-```
+{{< /code-block >}}
 
 {{% /tab %}}
-{{< /tabs >}}
-
-### Controller Manager and Scheduler
-
-#### Insecure ports
-
-If the insecure ports of your Controller Manager and Scheduler instances are enabled, the Datadog Agent discovers the integrations and starts collecting metrics without any additional configuration. 
-
-#### Secure ports
-
-Secure ports allow authentication and authorization to protect your Control Plane components. The Datadog Agent can collect Controller Manager and Scheduler metrics by targeting their secure ports.
-
-{{< tabs >}}
 {{% tab "Helm" %}}
 
-Custom `values.yaml`:
-
-```yaml
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
 datadog:
   apiKey: <DATADOG_API_KEY>
   appKey: <DATADOG_APP_KEY>
@@ -178,8 +123,6 @@ datadog:
     tlsVerify: false
   ignoreAutoConfig:
   - etcd
-  - kube_scheduler
-  - kube_controller_manager
   confd:
     etcd.yaml: |-
       ad_identifiers:
@@ -189,20 +132,6 @@ datadog:
           tls_ca_cert: /host/etc/kubernetes/pki/etcd/ca.crt
           tls_cert: /host/etc/kubernetes/pki/etcd/server.crt
           tls_private_key: /host/etc/kubernetes/pki/etcd/server.key
-    kube_scheduler.yaml: |-
-      ad_identifiers:
-        - kube-scheduler
-      instances:
-        - prometheus_url: https://%%host%%:10259/metrics
-          ssl_verify: false
-          bearer_token_auth: true
-    kube_controller_manager.yaml: |-
-      ad_identifiers:
-        - kube-controller-manager
-      instances:
-        - prometheus_url: https://%%host%%:10257/metrics
-          ssl_verify: false
-          bearer_token_auth: true
 agents:
   volumes:
     - hostPath:
@@ -216,14 +145,26 @@ agents:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
     operator: Exists
-```
+{{< /code-block >}}
 
 {{% /tab %}}
-{{% tab "Operator" %}}
 
-DatadogAgent Kubernetes Resource:
+{{< /tabs >}}
 
-```yaml
+### Controller Manager and Scheduler
+
+#### Insecure ports
+
+If the insecure ports of your Controller Manager and Scheduler instances are enabled, the Datadog Agent discovers the integrations and starts collecting metrics without any additional configuration. 
+
+#### Secure ports
+
+Secure ports allow authentication and authorization to protect your Control Plane components. The Datadog Agent can collect Controller Manager and Scheduler metrics by targeting their secure ports.
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
 kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
@@ -301,9 +242,62 @@ data:
       - prometheus_url: https://%%host%%:10257/metrics
         ssl_verify: false
         bearer_token_auth: true
-```
+{{< /code-block >}}
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  clusterName: <CLUSTER_NAME>
+  kubelet:
+    tlsVerify: false
+  ignoreAutoConfig:
+  - etcd
+  - kube_scheduler
+  - kube_controller_manager
+  confd:
+    etcd.yaml: |-
+      ad_identifiers:
+        - etcd
+      instances:
+        - prometheus_url: https://%%host%%:2379/metrics
+          tls_ca_cert: /host/etc/kubernetes/pki/etcd/ca.crt
+          tls_cert: /host/etc/kubernetes/pki/etcd/server.crt
+          tls_private_key: /host/etc/kubernetes/pki/etcd/server.key
+    kube_scheduler.yaml: |-
+      ad_identifiers:
+        - kube-scheduler
+      instances:
+        - prometheus_url: https://%%host%%:10259/metrics
+          ssl_verify: false
+          bearer_token_auth: true
+    kube_controller_manager.yaml: |-
+      ad_identifiers:
+        - kube-controller-manager
+      instances:
+        - prometheus_url: https://%%host%%:10257/metrics
+          ssl_verify: false
+          bearer_token_auth: true
+agents:
+  volumes:
+    - hostPath:
+        path: /etc/kubernetes/pki/etcd
+      name: etcd-certs
+  volumeMounts:
+    - name: etcd-certs
+      mountPath: /host/etc/kubernetes/pki/etcd
+      readOnly: true
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+{{< /code-block >}}
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 **Notes:**
@@ -382,29 +376,9 @@ These certificates should be mounted on the Cluster Check Runner pods by adding 
 
 
 {{< tabs >}}
-{{% tab "Helm" %}}
+{{% tab "Datadog Operator" %}}
 
-```yaml
-...
-clusterChecksRunner:
-  volumes:
-    - name: etcd-certs
-      secret:
-        secretName: kube-etcd-client-certs
-    - name: disable-etcd-autoconf
-      emptyDir: {}
-  volumeMounts:
-    - name: etcd-certs
-      mountPath: /host/etc/etcd
-      readOnly: true
-    - name: disable-etcd-autoconf
-      mountPath: /etc/datadog-agent/conf.d/etcd.d
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
-
-```yaml
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
 kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
@@ -426,9 +400,30 @@ spec:
             secretName: kube-etcd-client-certs
         - name: disable-etcd-autoconf
           emptyDir: {}
-```
+{{< /code-block >}}
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
+...
+clusterChecksRunner:
+  volumes:
+    - name: etcd-certs
+      secret:
+        secretName: kube-etcd-client-certs
+    - name: disable-etcd-autoconf
+      emptyDir: {}
+  volumeMounts:
+    - name: etcd-certs
+      mountPath: /host/etc/etcd
+      readOnly: true
+    - name: disable-etcd-autoconf
+      mountPath: /etc/datadog-agent/conf.d/etcd.d
+{{< /code-block >}}
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 
@@ -516,29 +511,9 @@ Certificates are needed to communicate with the Etcd service, which are located 
 **Note**: Mounts are also included to disable the Etcd check autoconfiguration file packaged with the agent.
 
 {{< tabs >}}
-{{% tab "Helm" %}}
+{{% tab "Datadog Operator" %}}
 
-```yaml
-...
-clusterChecksRunner:
-  volumes:
-    - hostPath:
-        path: /etc/etcd
-      name: etcd-certs
-    - name: disable-etcd-autoconf
-      emptyDir: {}
-  volumeMounts:
-    - name: etcd-certs
-      mountPath: /host/etc/etcd
-      readOnly: true
-    - name: disable-etcd-autoconf
-      mountPath: /etc/datadog-agent/conf.d/etcd.d
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
-
-```yaml
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
 kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
@@ -560,7 +535,27 @@ spec:
             path: /etc/etcd
         - name: disable-etcd-autoconf
           emptyDir: {}
-```
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
+...
+clusterChecksRunner:
+  volumes:
+    - hostPath:
+        path: /etc/etcd
+      name: etcd-certs
+    - name: disable-etcd-autoconf
+      emptyDir: {}
+  volumeMounts:
+    - name: etcd-certs
+      mountPath: /host/etc/etcd
+      readOnly: true
+    - name: disable-etcd-autoconf
+      mountPath: /etc/datadog-agent/conf.d/etcd.d
+{{< /code-block >}}
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -631,7 +626,7 @@ annotations:
   ad.datadoghq.com/endpoints.instances: '[{ "prometheus_url": "https://%%host%%:%%port%%/metrics", "bearer_token_auth": "true" }]'
 ```
 
-### Add Kubernetes services to configure auto-discovery checks
+### Add Kubernetes services to configure Autodiscovery checks
 
 By adding headless Kubernetes services to define check configurations, the Datadog Agent is able to target the `pushprox` pods and collect metrics.
 
@@ -711,41 +706,9 @@ spec:
 Deploy the Datadog Agent with manifests based on the following configurations:
 
 {{< tabs >}}
-{{% tab "Helm" %}}
+{{% tab "Datadog Operator" %}}
 
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  kubelet:
-    tlsVerify: false
-agents:
-  volumes:
-    - hostPath:
-        path: /opt/rke/etc/kubernetes/ssl
-      name: etcd-certs
-  volumeMounts:
-    - name: etcd-certs
-      mountPath: /host/opt/rke/etc/kubernetes/ssl
-      readOnly: true
-  tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/controlplane
-    operator: Exists
-  - effect: NoExecute
-    key: node-role.kubernetes.io/etcd
-    operator: Exists
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
-
-DatadogAgent Kubernetes Resource:
-
-```yaml
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
 kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
@@ -780,7 +743,35 @@ spec:
         - key: node-role.kubernetes.io/etcd
           operator: Exists
           effect: NoExecute
-```
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  clusterName: <CLUSTER_NAME>
+  kubelet:
+    tlsVerify: false
+agents:
+  volumes:
+    - hostPath:
+        path: /opt/rke/etc/kubernetes/ssl
+      name: etcd-certs
+  volumeMounts:
+    - name: etcd-certs
+      mountPath: /host/opt/rke/etc/kubernetes/ssl
+      readOnly: true
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/controlplane
+    operator: Exists
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
+    operator: Exists
+{{< /code-block >}}
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -831,41 +822,9 @@ The following are examples of how to configure the Datadog Agent with Helm and t
 
 
 {{< tabs >}}
-{{% tab "Helm" %}}
+{{% tab "Datadog Operator" %}}
 
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  kubelet:
-    tlsVerify: false
-agents:
-  volumes:
-    - hostPath:
-        path: /opt/rke/etc/kubernetes/ssl
-      name: etcd-certs
-  volumeMounts:
-    - name: etcd-certs
-      mountPath: /host/opt/rke/etc/kubernetes/ssl
-      readOnly: true
-  tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/controlplane
-    operator: Exists
-  - effect: NoExecute
-    key: node-role.kubernetes.io/etcd
-    operator: Exists
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
-
-DatadogAgent Kubernetes Resource:
-
-```yaml
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
 kind: DatadogAgent
 apiVersion: datadoghq.com/v2alpha1
 metadata:
@@ -900,7 +859,35 @@ spec:
         - key: node-role.kubernetes.io/etcd
           operator: Exists
           effect: NoExecute
-```
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  clusterName: <CLUSTER_NAME>
+  kubelet:
+    tlsVerify: false
+agents:
+  volumes:
+    - hostPath:
+        path: /opt/rke/etc/kubernetes/ssl
+      name: etcd-certs
+  volumeMounts:
+    - name: etcd-certs
+      mountPath: /host/opt/rke/etc/kubernetes/ssl
+      readOnly: true
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/controlplane
+    operator: Exists
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
+    operator: Exists
+{{< /code-block >}}
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -454,9 +454,9 @@ kube-state-metrics:
 
 ## Rancher {#Rancher}
 
-Rancher installations are close to vanilla Kubernetes, requiring only some minor configuration:
-- Tolerations are required to schedule the Node Agent on `controlplane` and `etcd` nodes
-- Cluster name should be set as it cannot be retrieved automatically from cloud provider
+Rancher installations are similar to vanilla Kubernetes installations, requiring only some minor configuration:
+- Tolerations are required to schedule the Node Agent on `controlplane` and `etcd` nodes.
+- The cluster name should be set as it cannot be retrieved automatically from the cloud provider.
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
@@ -591,8 +591,8 @@ datadog:
 
 {{< /tabs >}}
 
-More `datadog-values.yaml` examples can be found in the [Helm chart repository][3]
-More `datadog-agent.yaml` examples can be found in the [Datadog Operator repository][4]
+More `datadog-values.yaml` examples can be found in the [Helm chart repository][3].
+More `datadog-agent.yaml` examples can be found in the [Datadog Operator repository][4].
 
 ## vSphere Tanzu Kubernetes Grid (TKG) {#TKG}
 

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -47,22 +47,7 @@ No specific configuration is required.
 If you are using AWS Bottlerocket OS on your nodes, add the following to enable container monitoring (`containerd` check):
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  criSocketPath: /run/dockershim.sock
-  env:
-  - name: DD_AUTOCONFIG_INCLUDE_FEATURES
-    value: "containerd"
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 In an EKS cluster, you can install the Operator using [Helm][5] or as an [EKS add-on][6].
 
@@ -92,6 +77,22 @@ spec:
 ```
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  criSocketPath: /run/dockershim.sock
+  env:
+  - name: DD_AUTOCONFIG_INCLUDE_FEATURES
+    value: "containerd"
+```
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ## Azure Kubernetes Service (AKS) {#AKS}
@@ -99,27 +100,7 @@ spec:
 AKS requires a specific configuration for the `Kubelet` integration due to how AKS has setup the SSL Certificates. Additionally, the optional [Admission Controller][1] feature requires a specific configuration to prevent an error when reconciling the webhook.
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  # Required as of Agent 7.35. See Kubelet Certificate note below.
-  kubelet:
-    tlsVerify: false
-
-providers:
-  aks:
-    enabled: true
-```
-
-The `providers.aks.enabled` option sets the necessary environment variable `DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS="true"` for you.
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 DatadogAgent Kubernetes Resource:
 
@@ -148,6 +129,27 @@ spec:
 ```
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  # Required as of Agent 7.35. See Kubelet Certificate note below.
+  kubelet:
+    tlsVerify: false
+
+providers:
+  aks:
+    enabled: true
+```
+
+The `providers.aks.enabled` option sets the necessary environment variable `DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS="true"` for you.
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 The `kubelet.tlsVerify=false` sets the environment variable `DD_KUBELET_TLS_VERIFY=false` for you to deactivate verification of the server certificate.
@@ -159,29 +161,7 @@ There is a known issue with the format of the AKS Kubelet certificate in older n
 If all the nodes within your AKS cluster are using a supported node image version, you can use Kubelet TLS Verification. Your version must be at or above the [versions listed here for the 2022-10-30 release][2]. You must also update your Kubelet configuration to use the node name for the address and map in the custom certificate path.
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  # Requires supported node image version
-  kubelet:
-    host:
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
-    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
-
-providers:
-  aks:
-    enabled: true
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 DatadogAgent Kubernetes Resource:
 
@@ -210,6 +190,28 @@ spec:
           env:
             - name: DD_ADMISSION_CONTROLLER_ADD_AKS_SELECTORS
               value: "true"
+```
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  # Requires supported node image version
+  kubelet:
+    host:
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
+
+providers:
+  aks:
+    enabled: true
 ```
 
 {{% /tab %}}
@@ -242,7 +244,7 @@ Datadog recommends that you specify resource limits for the Agent container. Aut
 {{< tabs >}}
 {{% tab "Helm" %}}
 
-Custom `values.yaml`:
+Custom `datadog-values.yaml`:
 
 ```yaml
 datadog:
@@ -340,42 +342,7 @@ OpenShift comes with hardened security by default (SELinux, SecurityContextConst
 This configuration supports OpenShift 3.11 and OpenShift 4, but works best with OpenShift 4.
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  criSocketPath: /var/run/crio/crio.sock
-  # Depending on your DNS/SSL setup, it might not be possible to verify the Kubelet cert properly
-  # If you have proper CA, you can switch it to true
-  kubelet:
-    tlsVerify: false
-agents:
-  podSecurity:
-    securityContextConstraints:
-      create: true
-  tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Exists
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/infra
-    operator: Exists
-clusterAgent:
-  podSecurity:
-    securityContextConstraints:
-      create: true
-kube-state-metrics:
-  securityContext:
-    enabled: false
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 When using the Datadog Operator in OpenShift, it is recommended that you install it through OperatorHub or RedHat Marketplace.
 The configuration below is meant to work with this setup (due to SCC/ServiceAccount setup), when the
@@ -447,6 +414,42 @@ spec:
 **Note**: The nodeAgent Security Context override is necessary for Log Collection and APM Trace Collection with the `/var/run/datadog/apm/apm.socket` socket. If these features are not enabled, you can omit this override.
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  clusterName: <CLUSTER_NAME>
+  criSocketPath: /var/run/crio/crio.sock
+  # Depending on your DNS/SSL setup, it might not be possible to verify the Kubelet cert properly
+  # If you have proper CA, you can switch it to true
+  kubelet:
+    tlsVerify: false
+agents:
+  podSecurity:
+    securityContextConstraints:
+      create: true
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/infra
+    operator: Exists
+clusterAgent:
+  podSecurity:
+    securityContextConstraints:
+      create: true
+kube-state-metrics:
+  securityContext:
+    enabled: false
+```
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ## Rancher {#Rancher}
@@ -456,29 +459,7 @@ Rancher installations are close to vanilla Kubernetes, requiring only some minor
 - Cluster name should be set as it cannot be retrieved automatically from cloud provider
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  clusterName: <CLUSTER_NAME>
-  kubelet:
-    tlsVerify: false
-agents:
-  tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/controlplane
-    operator: Exists
-  - effect: NoExecute
-    key: node-role.kubernetes.io/etcd
-    operator: Exists
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 DatadogAgent Kubernetes Resource:
 
@@ -532,6 +513,29 @@ spec:
 ```
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  clusterName: <CLUSTER_NAME>
+  kubelet:
+    tlsVerify: false
+agents:
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/controlplane
+    operator: Exists
+  - effect: NoExecute
+    key: node-role.kubernetes.io/etcd
+    operator: Exists
+```
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ## Oracle Container Engine for Kubernetes (OKE) {#OKE}
@@ -541,22 +545,7 @@ No specific configuration is required.
 To enable container monitoring, add the following (`containerd` check):
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  criSocketPath: /run/dockershim.sock
-  env:
-  - name: DD_AUTOCONFIG_INCLUDE_FEATURES
-    value: "containerd"
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 DatadogAgent Kubernetes Resource:
 
@@ -584,10 +573,26 @@ spec:
 ```
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  criSocketPath: /run/dockershim.sock
+  env:
+  - name: DD_AUTOCONFIG_INCLUDE_FEATURES
+    value: "containerd"
+```
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
-More `values.yaml` examples can be found in the [Helm chart repository][3]
-More `DatadogAgent` examples can be found in the [Datadog Operator repository][4]
+More `datadog-values.yaml` examples can be found in the [Helm chart repository][3]
+More `datadog-agent.yaml` examples can be found in the [Datadog Operator repository][4]
 
 ## vSphere Tanzu Kubernetes Grid (TKG) {#TKG}
 
@@ -595,31 +600,7 @@ TKG requires some small configuration changes, shown below. For example, setting
 
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-Custom `values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  kubelet:
-    # Set tlsVerify to false since the Kubelet certificates are self-signed
-    tlsVerify: false
-  # Disable the `kube-state-metrics` dependency chart installation.
-  kubeStateMetricsEnabled: false
-  # Enable the new `kubernetes_state_core` check.
-  kubeStateMetricsCore:
-    enabled: true
-# Add a toleration so that the agent can be scheduled on the control plane nodes.
-agents:
-  tolerations:
-    - key: node-role.kubernetes.io/master
-      effect: NoSchedule
-```
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
 
 DatadogAgent Kubernetes Resource:
 
@@ -652,6 +633,31 @@ spec:
 ```
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+Custom `datadog-values.yaml`:
+
+```yaml
+datadog:
+  apiKey: <DATADOG_API_KEY>
+  appKey: <DATADOG_APP_KEY>
+  kubelet:
+    # Set tlsVerify to false since the Kubelet certificates are self-signed
+    tlsVerify: false
+  # Disable the `kube-state-metrics` dependency chart installation.
+  kubeStateMetricsEnabled: false
+  # Enable the new `kubernetes_state_core` check.
+  kubeStateMetricsCore:
+    enabled: true
+# Add a toleration so that the agent can be scheduled on the control plane nodes.
+agents:
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      effect: NoSchedule
+```
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -49,7 +49,7 @@ If you are using AWS Bottlerocket OS on your nodes, add the following to enable 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
 
-In an EKS cluster, you can install the Operator using [Helm][5] or as an [EKS add-on][6].
+In an EKS cluster, you can install the Operator using [Helm][1] or as an [EKS add-on][2].
 
 The configuration below is meant to work with either setup (Helm or EKS add-on) when the Agent is installed in the same namespace as the Datadog Operator.
 
@@ -76,6 +76,9 @@ spec:
         name: gcr.io/datadoghq/cluster-agent:latest
 ```
 
+[1]:/containers/kubernetes/installation/?tab=datadogoperator
+[2]: /agent/guide/operator-eks-addon
+
 {{% /tab %}}
 {{% tab "Helm" %}}
 
@@ -87,8 +90,8 @@ datadog:
   appKey: <DATADOG_APP_KEY>
   criSocketPath: /run/dockershim.sock
   env:
-  - name: DD_AUTOCONFIG_INCLUDE_FEATURES
-    value: "containerd"
+    - name: DD_AUTOCONFIG_INCLUDE_FEATURES
+      value: "containerd"
 ```
 
 {{% /tab %}}
@@ -433,12 +436,12 @@ agents:
     securityContextConstraints:
       create: true
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-    operator: Exists
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/infra
-    operator: Exists
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/master
+      operator: Exists
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+      operator: Exists
 clusterAgent:
   podSecurity:
     securityContextConstraints:
@@ -526,12 +529,12 @@ datadog:
     tlsVerify: false
 agents:
   tolerations:
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/controlplane
-    operator: Exists
-  - effect: NoExecute
-    key: node-role.kubernetes.io/etcd
-    operator: Exists
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/controlplane
+      operator: Exists
+    - effect: NoExecute
+      key: node-role.kubernetes.io/etcd
+      operator: Exists
 ```
 
 {{% /tab %}}
@@ -583,8 +586,8 @@ datadog:
   appKey: <DATADOG_APP_KEY>
   criSocketPath: /run/dockershim.sock
   env:
-  - name: DD_AUTOCONFIG_INCLUDE_FEATURES
-    value: "containerd"
+    - name: DD_AUTOCONFIG_INCLUDE_FEATURES
+      value: "containerd"
 ```
 
 {{% /tab %}}

--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -229,20 +229,46 @@ Once the Prometheus scrape feature is enabled, the Datadog Agent collects custom
 #### Basic configuration
 
 {{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+Update your Datadog Operator configuration to contain the following:
+
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+
+  features:
+    prometheusScrape:
+      enabled: true
+      enableServiceEndpoints: true
+{{< /code-block >}}
+
+{{% k8s-operator-redeploy %}}
+
+{{% /tab %}}
 {{% tab "Helm" %}}
 
-In your Helm `values.yaml`, add the following:
+Update your Helm configuration to contain the following:
 
-```yaml
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
 datadog:
   # (...)
   prometheusScrape:
     enabled: true
     serviceEndpoints: true
   # (...)
-```
+{{< /code-block >}}
+
+{{% k8s-helm-redeploy %}}
+
 {{% /tab %}}
-{{% tab "DaemonSet" %}}
+{{% tab "Manual (DaemonSet)" %}}
 
 In your DaemonSet manifest for the Agent `daemonset.yaml`, add the following environment variables for the Agent container:
 ```yaml
@@ -274,80 +300,92 @@ This configuration generates a check that collects all metrics exposed using the
 
 #### Advanced configuration
 
-{{< tabs >}}
-{{% tab "Helm" %}}
+You can further configure metric collection (beyond native Prometheus annotations) with the `additionalConfigs` field. 
 
-You can define advanced OpenMetrics check configurations or custom Autodiscovery rules other than native Prometheus annotations with the `additionalConfigs` configuration field in `values.yaml`.
+##### Additional OpenMetrics check configurations
 
-`additionalConfigs` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
+Use `additionalConfigs.configurations` to define additional OpenMetrics check configurations. See the [list of supported OpenMetrics parameters][15] that you can pass in `additionalConfigs`.
 
-Only the parameters [on this page][2] are supported for OpenMetrics v2 with Autodiscovery and can be passed in the configurations list.
+##### Custom Autodiscovery rules
 
-The Autodiscovery configuration can be based on container names, Kubernetes annotations, or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
+Use `additionalConfigs.autodiscovery` to define custom Autodiscovery rules. These rules can be based on container names, Kubernetes annotations, or both. 
 
-- `kubernetes_container_names` is a list of container names to target, in regular expression format.
-- `kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
+`additionalConfigs.autodiscovery.kubernetes_container_names`
+: A list of container names to target, in regular expression format.
 
-**Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
+`additionalConfigs.autodiscovery.kubernetes_annotations` 
+: Two maps (`include` and `exclude`) of annotations to define discovery rules.
 
-```yaml
-kubernetes_annotations:
+  Default:
+  ```yaml
   include:
      prometheus.io/scrape: "true"
   exclude:
      prometheus.io/scrape: "false"
-```
+  ```
 
-**Example:**
+If both `kubernetes_container_names` and `kubernetes_annotations` are defined, **AND** logic is used (both rules must match).
 
-In this example we're defining an advanced configuration targeting a container named `my-app` running in a pod with the annotation `app=my-app`. We're customizing the OpenMetrics check configuration as well, by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
+##### Examples
 
-```yaml
+The following configuration targets a container named `my-app` running in a pod with the annotation `app=my-app`. The OpenMetrics check configuration is customized to enable the `send_distribution_buckets` option and define a custom timeout of 5 seconds.
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+Update your Datadog Operator configuration to contain the following:
+
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    credentials:
+      apiKey: <DATADOG_API_KEY>
+
+  features:
+    prometheusScrape:
+      enabled: true
+      enableServiceEndpoints: true
+      additionalConfigs:
+        - autodiscovery:
+            kubernetes_container_names:
+              - my-app
+            kubernetes_annotations:
+              include:
+                app: my-app
+          configurations:
+            - timeout: 5
+              send_distribution_buckets: true
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
 datadog:
   # (...)
   prometheusScrape:
     enabled: true
     serviceEndpoints: true
     additionalConfigs:
-      -
-        configurations:
-        - timeout: 5
-          send_distribution_buckets: true
-        autodiscovery:
+      - autodiscovery:
           kubernetes_container_names:
             - my-app
           kubernetes_annotations:
             include:
               app: my-app
-```
+        configurations:
+          - timeout: 5
+            send_distribution_buckets: true
 
-
-[1]: https://github.com/DataDog/integrations-core/blob/master/openmetrics/datadog_checks/openmetrics/data/conf.yaml.example
-[2]: https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/common/types/prometheus.go#L99-L123
+{{< /code-block >}}
 {{% /tab %}}
-{{% tab "DaemonSet" %}}
+{{% tab "Manual (DaemonSet)" %}}
 
-You can define advanced OpenMetrics check configurations or custom Autodiscovery rules other than native Prometheus annotations with the `DD_PROMETHEUS_SCRAPE_CHECKS` environment variable in the Agent and Cluster Agent manifests.
-
-`DD_PROMETHEUS_SCRAPE_CHECKS` is a list of structures containing OpenMetrics check configurations and Autodiscovery rules.
-
-Only the parameters [on this page][2] are supported for OpenMetrics v2 with Autodiscovery and can be passed in the configurations list.
-
-The Autodiscovery configuration can be based on container names, Kubernetes annotations, or both. When both `kubernetes_container_names` and `kubernetes_annotations` are defined, it uses AND logic (both rules must match).
-
-- `kubernetes_container_names` is a list of container names to target, in regular expression format.
-- `kubernetes_annotations` contains two maps of annotations to define the discovery rules: `include` and `exclude`.
-
-**Note:** The default value of `kubernetes_annotations` in the Datadog Agent configuration is the following:
-
-```yaml
-- name: DD_PROMETHEUS_SCRAPE_CHECKS
-  value: "[{\"autodiscovery\":{\"kubernetes_annotations\":{\"exclude\":{\"prometheus.io/scrape\":\"false\"},\"include\":{\"prometheus.io/scrape\":\"true\"}}}}]"
-```
-
-**Example:**
-
-This example of advanced configuration targets a container named `my-app` running in a pod with the annotation `app=my-app`. The OpenMetrics check configuration is customized by enabling the `send_distribution_buckets` option and defining a custom timeout of 5 seconds.
+For DaemonSet, advanced configuration is defined in the `DD_PROMETHEUS_SCRAPE_CHECKS` environment variable, not an `additionalConfigs` field.
 
 ```yaml
 - name: DD_PROMETHEUS_SCRAPE_ENABLED
@@ -388,3 +426,4 @@ Official integrations have their own dedicated directories. There's a default in
 [12]: https://app.datadoghq.com/metric/summary
 [13]: /agent/faq/template_variables/
 [14]: https://github.com/DataDog/integrations-core/tree/master/kube_proxy
+[15]: https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/common/types/prometheus.go#L57-L123

--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -16,13 +16,11 @@ further_reading:
   text: "Limit data collection to a subset of containers only"
 ---
 
-The Agent can create and assign tags to all metrics, traces, and logs emitted by a Pod, based on its labels or annotations.
-
-If you are running the Agent as a binary on a host, configure your tag extractions with the [Agent](?tab=agent) tab instructions. If you are running the Agent as a container in your Kubernetes cluster, configure your tag extraction with the [Containerized Agent](?tab=containerizedagent) tab instructions.
+The Datadog Agent can automatically assign tags to metrics, traces, and logs emitted by a pod (or an individual container within a pod) based on labels or annotations.
 
 ## Out-of-the-box tags
 
-The Agent can autodiscover and attach tags to all data emitted by the entire pods or an individual container within this pod. The list of tags attached automatically depends on the agent [cardinality configuration][1].
+The list of automatically-assigned tags depends on the Agent's [cardinality configuration][1].
 
 <div style="overflow-x: auto;">
 
@@ -175,7 +173,7 @@ datadog:
 ```
 {{% /tab %}}
 
-{{% tab "Containerized Agent" %}}
+{{% tab "Manual (DaemonSet)" %}}
 To extract a given node label `<NODE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -268,7 +266,7 @@ datadog:
 ```
 {{% /tab %}}
 
-{{% tab "Containerized Agent" %}}
+{{% tab "Manual (DaemonSet)" %}}
 To extract a given pod label `<POD_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -361,7 +359,7 @@ datadog:
 ```
 {{% /tab %}}
 
-{{% tab "Containerized Agent" %}}
+{{% tab "Manual (DaemonSet)" %}}
 To extract a given pod annotation `<POD_ANNOTATION>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -454,7 +452,7 @@ datadog:
 ```
 {{% /tab %}}
 
-{{% tab "Containerized Agent" %}}
+{{% tab "Manual (DaemonSet)" %}}
 To extract a given namespace label `<NAMESPACE_LABEL>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -535,7 +533,7 @@ datadog:
 ```
 {{% /tab %}}
 
-{{% tab "Containerized Agent" %}}
+{{% tab "Manual (DaemonSet)" %}}
 To extract a given environment variable `<ENV_VAR>` and transform it as a tag key `<TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
 ```bash
@@ -613,7 +611,7 @@ datadog:
 ```
 {{% /tab %}}
 
-{{% tab "Containerized Agent" %}}
+{{% tab "Manual (DaemonSet)" %}}
 To extract a given container label `<CONTAINER_LABEL>` and transform it to a tag key `<TAG_KEY>`, add the following environment variable to the Datadog Agent:
 
 ```bash

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -498,7 +498,7 @@ Set the `DD_APM_REPLACE_TAGS` environment variable:
           ]'
 ```
 
-**Examples**
+#### Examples
 
 Datadog Operator:
 

--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -463,9 +463,12 @@ DD_APM_REPLACE_TAGS=[
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-Put this environment variable in the trace-agent container if you are using the [daemonset configuration][1], or use `agents.containers.traceAgent.env` in the `values.yaml` file if you are using [helm chart][2].
+Set the `DD_APM_REPLACE_TAGS` environment variable:
+- For Datadog Operator, in `override.nodeAgent.env` in your `datadog-agent.yaml`
+- For Helm, in `agents.containers.traceAgent.env` in your `datadog-values.yaml`
+- For manual configuration, in the `trace-agent` container section of your manifest
 
-```datadog-agent.yaml
+```yaml
 - name: DD_APM_REPLACE_TAGS
   value: '[
             {
@@ -493,6 +496,42 @@ Put this environment variable in the trace-agent container if you are using the 
               "repl": "[REDACTED]"
             }
           ]'
+```
+
+**Examples**
+
+Datadog Operator:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    nodeAgent:
+      env:
+        - name: DD_APM_REPLACE_TAGS
+          value: '[
+                   {
+                     "name": "http.url",
+                  # (...)
+                  ]'
+```
+
+Helm:
+
+```yaml
+agents:
+  containers:
+    traceAgent:
+      env:
+        - name: DD_APM_REPLACE_TAGS
+          value: '[
+                   {
+                     "name": "http.url",
+                  # (...)
+                  ]'
 ```
 
 [1]: /containers/kubernetes/installation/?tab=daemonset

--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -59,18 +59,39 @@ apm_config:
 {{< /code-block >}}
 
 {{% /tab %}}
-{{% tab "Kubernetes Helm" %}}
+{{% tab "Kubernetes" %}}
+#### Datadog Operator
 
-In the `traceAgent` section of the `values.yaml` file, add `DD_APM_FILTER_TAGS_REJECT` in the `env` section, then [spin up helm as usual][1]. For multiple tags, separate each key:value with a space.
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  override:
+    nodeAgent:
+      containers:
+        trace-agent:
+          env:
+            - name: DD_APM_FILTER_TAGS_REJECT
+              value: tag_key1:tag_val2 tag_key2:tag_val2
+{{< /code-block >}}
 
-{{< code-block lang="yaml" filename="values.yaml" >}}
-traceAgent:
-  # agents.containers.traceAgent.env -- Additional environment variables for the trace-agent container
-    env:
-      - name: DD_APM_FILTER_TAGS_REJECT
-        value: tag_key1:tag_val2 tag_key2:tag_val2
+{{% k8s-operator-redeploy %}}
+
+#### Helm
+
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
+agents:
+  containers:
+    traceAgent:
+      env:
+        - name: DD_APM_FILTER_TAGS_REJECT
+          value: tag_key1:tag_val2 tag_key2:tag_val2
 
 {{< /code-block >}}
+
+{{% k8s-helm-redeploy %}}
 
 [1]: /agent/kubernetes/?tab=helm#installation
 {{% /tab %}}

--- a/content/en/tracing/guide/setting_up_apm_with_kubernetes_service.md
+++ b/content/en/tracing/guide/setting_up_apm_with_kubernetes_service.md
@@ -26,16 +26,9 @@ If you installed the Datadog Agent by using the Datadog [Helm chart][3] or [Data
 
 ### Agent configuration
 {{< tabs >}}
-{{% tab "Helm" %}}
+{{% tab "Datadog Operator" %}}
 
-```yaml
-datadog:
-  apm:
-    portEnabled: true
-```    
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+Update your `datadog-agent.yaml` to set `features.apm.enabled` to `true`.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -48,6 +41,22 @@ spec:
     apm:
       enabled: true
 ```
+
+{{% k8s-operator-redeploy %}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+Update your `datadog-values.yaml` to set `datadog.apm.portEnabled` to `true`.
+
+```yaml
+datadog:
+  apm:
+    portEnabled: true
+```    
+
+{{% k8s-helm-redeploy %}}
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -58,17 +67,8 @@ You can configure your application to use the Kubernetes service by using the Cl
 The [Cluster Agent's Admission Controller][2] can inject the configuration for APM connectivity into your containers. The options are `hostip`, `socket`, or `service`. Choose the `service` mode to have the Admission Controller add the `DD_AGENT_HOST` environment variable for the DNS name of the service.
 
 {{< tabs >}}
-{{% tab "Helm" %}}
-
-```yaml
-clusterAgent:
-  admissionController:
-    enabled: true
-    configMode: service
-```    
-
-{{% /tab %}}
-{{% tab "Operator" %}}
+{{% tab "Datadog Operator" %}}
+Update your `datadog-agent.yaml` with the following:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -84,6 +84,22 @@ spec:
       enabled: true
       agentCommunicationMode: service
 ```
+
+{{% k8s-operator-redeploy %}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+Update your `datadog-values.yaml` with the following:
+
+```yaml
+clusterAgent:
+  admissionController:
+    enabled: true
+    configMode: service
+```
+
+{{% k8s-helm-redeploy %}}
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/layouts/shortcodes/k8s-helm-redeploy.md
+++ b/layouts/shortcodes/k8s-helm-redeploy.md
@@ -1,7 +1,5 @@
 After making your changes, upgrade your Datadog Helm chart using the following command: 
 
 ```shell
-helm upgrade -f values.yaml <RELEASE NAME> datadog/datadog
+helm upgrade -f datadog-values.yaml <RELEASE NAME> datadog/datadog
 ```
-
-If you did not set your operating system in `values.yaml`, add `--set targetSystem=linux` or `--set targetSystem=windows` to this command.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR:
- Adds Operator support where there is Helm support, and vice versa
- Standardizes "Operator" in tabs to "Datadog Operator"
- Standardizes the helm config file to be called `datadog-values.yaml`
- Puts the operator tab ahead of the helm tab where possible

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->