### PR TITLE
fargate-cws: use `public.ecr.aws` ecr instead of dockerhub

### DIFF
--- a/content/en/security/guide/aws_fargate_config_guide.md
+++ b/content/en/security/guide/aws_fargate_config_guide.md
@@ -79,8 +79,8 @@ Datadog Security provides multiple layers of visibility for AWS Fargate. Use the
 
 ### Images
 
-* `cws-instrumentation-init`: `datadog/cws-instrumentation:latest`
-* `datadog-agent`: `datadog/agent:latest`
+* `cws-instrumentation-init`: `public.ecr.aws/datadog/cws-instrumentation:latest`
+* `datadog-agent`: `public.ecr.aws/datadog/agent:latest`
 
 ### Installation
 
@@ -111,7 +111,7 @@ Datadog Security provides multiple layers of visibility for AWS Fargate. Use the
     "containerDefinitions": [
         {
             "name": "cws-instrumentation-init",
-            "image": "datadog/cws-instrumentation:latest",
+            "image": "public.ecr.aws/datadog/cws-instrumentation:latest",
             "essential": false,
             "user": "0",
             "command": [
@@ -130,7 +130,7 @@ Datadog Security provides multiple layers of visibility for AWS Fargate. Use the
         },
         {
             "name": "datadog-agent",
-            "image": "datadog/agent:latest",
+            "image": "public.ecr.aws/datadog/agent:latest",
             "essential": true,
             "environment": [
                 {
@@ -276,7 +276,7 @@ spec:
    spec:
      initContainers:
      - name: cws-instrumentation-init
-       image: datadog/cws-instrumentation:latest
+       image: public.ecr.aws/datadog/cws-instrumentation:latest
        command:
          - "/cws-instrumentation"
          - "setup"
@@ -300,7 +300,7 @@ spec:
            mountPath: "/cws-instrumentation-volume"
            readOnly: true
      - name: datadog-agent
-       image: datadog/agent:latest 
+       image: public.ecr.aws/datadog/agent:latest
        env:
          - name: DD_API_KEY
            value: "<DD_API_KEY>"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR updates the fargate CWS setup documentation to use the public.ecr.aws images instead of the dockerhub ones since ECS/EKS run on AWS it makes sense to use AWS registries by default.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->