### PR TITLE
update custom eval metric and ml_app naming guidelines

### DIFF
--- a/content/en/tracing/llm_observability/api.md
+++ b/content/en/tracing/llm_observability/api.md
@@ -207,7 +207,7 @@ For more information about tags, see [Getting Started with Tags][3].
 
 #### Application naming guidelines
 
-Your application name (the value of `ml_app`) must start with a letter. It may contain the characters listed below:
+Your application name (the value of `DD_LLMOBS_ML_APP`) must be a lowercase unicode string. It may contain the characters listed below:
 
 - Alphanumerics
 - Underscores
@@ -216,7 +216,7 @@ Your application name (the value of `ml_app`) must start with a letter. It may c
 - Periods
 - Slashes
 
-The name can be up to 200 characters long and contain Unicode letters (which includes most character sets, including languages such as Japanese).
+The name can be up to 193 characters long and may not contain contiguous or trailing underscores.
 
 ## Evaluations API
 

--- a/content/en/tracing/llm_observability/api.md
+++ b/content/en/tracing/llm_observability/api.md
@@ -207,7 +207,7 @@ For more information about tags, see [Getting Started with Tags][3].
 
 #### Application naming guidelines
 
-Your application name (the value of `DD_LLMOBS_ML_APP`) must be a lowercase unicode string. It may contain the characters listed below:
+Your application name (the value of `DD_LLMOBS_ML_APP`) must be a lowercase Unicode string. It may contain the characters listed below:
 
 - Alphanumerics
 - Underscores

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -106,7 +106,7 @@ LLMObs.enable(
 
 #### Application naming guidelines
 
-Your application name (the value of `DD_LLMOBS_ML_APP`) must start with a letter. It may contain the characters listed below:
+Your application name (the value of `DD_LLMOBS_ML_APP`) must be a lowercase unicode string. It may contain the characters listed below:
 
 - Alphanumerics
 - Underscores
@@ -115,7 +115,7 @@ Your application name (the value of `DD_LLMOBS_ML_APP`) must start with a letter
 - Periods
 - Slashes
 
-The name can be up to 200 characters long and contain Unicode letters (which includes most character sets, including languages such as Japanese).
+The name can be up to 193 characters long and may not contain contiguous or trailing underscores.
 
 ## Tracing spans
 

--- a/content/en/tracing/llm_observability/sdk.md
+++ b/content/en/tracing/llm_observability/sdk.md
@@ -106,7 +106,7 @@ LLMObs.enable(
 
 #### Application naming guidelines
 
-Your application name (the value of `DD_LLMOBS_ML_APP`) must be a lowercase unicode string. It may contain the characters listed below:
+Your application name (the value of `DD_LLMOBS_ML_APP`) must be a lowercase Unicode string. It may contain the characters listed below:
 
 - Alphanumerics
 - Underscores

--- a/content/en/tracing/llm_observability/submit_evaluations.md
+++ b/content/en/tracing/llm_observability/submit_evaluations.md
@@ -13,14 +13,14 @@ LLM Observability is not available in the US1-FED site.
 ## Overview
 
 In the context of LLM applications, it's important to track user feedback and evaluate the quality of your LLM application's responses.
-While LLM Observability provides a few out-of-the-box evaluations for your traces, you can submit your own evaluations to LLM Observability in two ways: with Datadog's [Python SDK](#submitting-evaluations-with-the-sdk), or with the [LLM Observability API](#submitting-evaluations-with-the-api).
+While LLM Observability provides a few out-of-the-box evaluations for your traces, you can submit your own evaluations to LLM Observability in two ways: with Datadog's [Python SDK](#submitting-evaluations-with-the-sdk), or with the [LLM Observability API](#submitting-evaluations-with-the-api). See [Naming custom metrics][1] for guidelines on how to choose an appropriate label for your evaluations.
 
 ## Submitting evaluations with the SDK
 
 To submit evaluations from your traced LLM application to Datadog, you'll need to associate it with a span using the below steps:
 
-1. Extract the span context from the given span by using `LLMObs.export_span(span)`. If `span` is not provided (as when using function decorators), the SDK exports the current active span. See [Exporting a span][1] for more details.
-2. Use `LLMObs.submit_evaluation()` with the extracted span context and evaluation information. See [Submitting evaluations][2] in the SDK documentation for details.
+1. Extract the span context from the given span by using `LLMObs.export_span(span)`. If `span` is not provided (as when using function decorators), the SDK exports the current active span. See [Exporting a span][2] for more details.
+2. Use `LLMObs.submit_evaluation()` with the extracted span context and evaluation information. See [Submitting evaluations][3] in the SDK documentation for details.
 
 ### Example
 
@@ -44,7 +44,7 @@ def llm_call():
 
 ## Submitting evaluations with the API
 
-You can use the evaluations API provided by LLM Observability to send evaluations associated with spans to Datadog. See the [Evaluations API][3] for more details on the API specifications.
+You can use the evaluations API provided by LLM Observability to send evaluations associated with spans to Datadog. See the [Evaluations API][4] for more details on the API specifications.
 
 ### Example
 
@@ -75,6 +75,7 @@ You can use the evaluations API provided by LLM Observability to send evaluation
 }
 {{< /code-block >}}
 
-[1]: /tracing/llm_observability/sdk/#exporting-a-span
-[2]: /tracing/llm_observability/sdk/#submit-evaluations
-[3]: /tracing/llm_observability/api/?tab=model#evaluations-api
+[1]: /metrics/custom_metrics/#naming-custom-metrics
+[2]: /tracing/llm_observability/sdk/#exporting-a-span
+[3]: /tracing/llm_observability/sdk/#submit-evaluations
+[4]: /tracing/llm_observability/api/?tab=model#evaluations-api


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates the `ml_app` naming guidelines and adds a reference to Datadog's naming custom metrics documentation to inform users on acceptable custom evaluation labels. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->