### PR TITLE
[ecos 1482] Bump Assetlib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ placeholders: hugpython update_pre_build
 hugpython: local/etc/requirements3.txt
 	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<;\
 	if [[ "$(CI_COMMIT_REF_NAME)" != "" ]]; then \
-		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.34132650-py3-none-any.whl; \
+		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.37052508-py3-none-any.whl; \
 	fi
 
 update_pre_build: hugpython


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
I relaxed the resource_type validation so that new changes to the enum will not be forward breaking. The manifests-validator delancie job will handle validating the enum.

Note: the assetlib schema will no longer validate the manifest.tile.resources.resource_type field, so if you want to specifically add validations around that, you would just need to update your validator to import [TILE_RESOURCE_TYPES](https://github.com/DataDog/dd-source/blob/5e75ee953c5ff1a27a030931d62758d86f1e51bd/domains/assets/shared/libs/python/assetlib/constants.py#L59). However, I don’t think you would need to since the manifets-validator will be doing the validation, and IIRC all validators are dependent on that job
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->