### PR TITLE
Ask to update service name in documentation

### DIFF
--- a/content/en/data_streams/java.md
+++ b/content/en/data_streams/java.md
@@ -24,18 +24,20 @@ To start with Data Streams Monitoring, you need recent versions of the Datadog A
 
 ### Installation
 
-Java uses auto-instrumentation to inject and extract additional metadata required by Data Streams Monitoring for measuring end-to-end latencies and the relationship between queues and services. To enable Data Streams Monitoring, set the `DD_DATA_STREAMS_ENABLED` environment variable to `true` on services sending messages to (or consuming messages from) Kafka or RabbitMQ.
+Java uses auto-instrumentation to inject and extract additional metadata required by Data Streams Monitoring for measuring end-to-end latencies and the relationship between queues and services. To enable Data Streams Monitoring, set the `DD_DATA_STREAMS_ENABLED` environment variable to `true` on services sending messages to (or consuming messages from) Kafka, SQS or RabbitMQ.
+Also, to make the DSM to APM link work, set `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED` to true. `DD_SERVICE` will be used as the service name in traces.
 
 For example:
 ```yaml
 environment:
   - DD_DATA_STREAMS_ENABLED: "true"
+  - DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED: "true"
 ```
 
 As an alternative, you can set the `-Ddd.data.streams.enabled=true` system property by running the following when you start your Java application:
 
 ```bash
-java -javaagent:/path/to/dd-java-agent.jar -Ddd.data.streams.enabled=true -jar path/to/your/app.jar
+java -javaagent:/path/to/dd-java-agent.jar -Ddd.data.streams.enabled=true -Ddd.trace.remove.integration.service.names.enabled=true -jar path/to/your/app.jar
 ```
 
 ### One-Click Installation

--- a/content/en/data_streams/java.md
+++ b/content/en/data_streams/java.md
@@ -25,7 +25,8 @@ To start with Data Streams Monitoring, you need recent versions of the Datadog A
 ### Installation
 
 Java uses auto-instrumentation to inject and extract additional metadata required by Data Streams Monitoring for measuring end-to-end latencies and the relationship between queues and services. To enable Data Streams Monitoring, set the `DD_DATA_STREAMS_ENABLED` environment variable to `true` on services sending messages to (or consuming messages from) Kafka, SQS or RabbitMQ.
-Also, to make the DSM to APM link work, set `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED` to true. `DD_SERVICE` will be used as the service name in traces.
+
+Also, set the `DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED` variable to `true` so that `DD_SERVICE` is used as the service name in traces.
 
 For example:
 ```yaml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Today, customers setting up DSM have services named `kafka` in APM. Which is not useful.
Recommending them to override that service name by default to `DD_SERVICE`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->