### PR TITLE
Update tracking-rum-usage-with-usage-attribution-tags.md

### DIFF
--- a/content/en/real_user_monitoring/guide/tracking-rum-usage-with-usage-attribution-tags.md
+++ b/content/en/real_user_monitoring/guide/tracking-rum-usage-with-usage-attribution-tags.md
@@ -23,7 +23,7 @@ As an example, this guide walks through how to track RUM usage by department.
 
 Categories for usage are determined by tags. Before setting up your RUM usage attribution, make sure that the tags you want to use are configured on the Usage Attribution page. Click **Edit tags**, then select the tags that you want to use to view usage and click **Save**. In this example, we've added "department" as a tag.
 
-{{< img src="real_user_monitoring/guide/rum-usage-attribution-tags/rum-use-attribution-tags-4.jpeg" alt="Check your tags on the Usage Attribution page" style="width:100%;">}}
+{{< img src="real_user_monitoring/guide/rum-usage-attribution-tags/rum-use-attribution-tags-1.jpeg" alt="Check your tags on the Usage Attribution page" style="width:100%;">}}
 
 ### Add tags to your RUM sessions
 Once your usage attribution tags have been configured, you can tag your RUM sessions with them. 


### PR DESCRIPTION
Wrong image listed in Check Your Tags section - should be rum-use-attribution-tags-1.jpeg but was rum-use-attribution-tags-4.jpeg

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Wrong image was specified for the first image on the page.  The referenced image didn't appear to be listed in the static images for that page.
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->