### PR TITLE
Fix default value for the DD_AGENTLESS_LOG_SUBMISSION_ENABLED env var

### DIFF
--- a/content/en/tests/correlate_logs_and_tests/_index.md
+++ b/content/en/tests/correlate_logs_and_tests/_index.md
@@ -34,7 +34,7 @@ Use the following environment variables to enable and configure agentless log su
 
 | Name | Description | Default value |
 |---|---|---|
-| `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` (required) | Enables/disables log submission | `true` 
+| `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` (required) | Enables/disables log submission | `false` 
 | `DD_AGENTLESS_LOG_SUBMISSION_LEVEL` (optional) | Sets log level for agentless submission | `INFO`
 | `DD_AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE` (optional) | Sets the maximum size of pending logs queue | `1024`
 | `DD_AGENTLESS_LOG_SUBMISSION_URL` (optional) | Sets custom URL for submitting logs | -


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Fixes the default value of `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` environment variable: logs submission is disabled by default.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->