### PR TITLE
add a note about Mobile Application Testing not supporting Flutter SDK for now

### DIFF
--- a/content/en/synthetics/mobile_app_testing/settings/_index.md
+++ b/content/en/synthetics/mobile_app_testing/settings/_index.md
@@ -61,6 +61,8 @@ To add a mobile application, navigate to the [**Mobile Applications List** tab][
 
 To edit or delete a mobile application, hover over a mobile application in the **Mobile Applications List** and click on the respective icon.
 
+**Note**: Mobile Application Testing does not support applications built with Flutter SDK.
+
 ## Manage application versions
 
 Clicking on a mobile application in the **Mobile Applications List** displays existing versions of the application. Hover over a version and click the **+** icon to [create a mobile app test][6] with the selected mobile application's version.

--- a/content/en/synthetics/mobile_app_testing/settings/_index.md
+++ b/content/en/synthetics/mobile_app_testing/settings/_index.md
@@ -61,7 +61,7 @@ To add a mobile application, navigate to the [**Mobile Applications List** tab][
 
 To edit or delete a mobile application, hover over a mobile application in the **Mobile Applications List** and click on the respective icon.
 
-**Note**: Mobile Application Testing does not provide full support for applications developed with Flutter SDK.
+**Note**: Mobile Application Testing does not provide full support for Flutter applications.
 
 ## Manage application versions
 

--- a/content/en/synthetics/mobile_app_testing/settings/_index.md
+++ b/content/en/synthetics/mobile_app_testing/settings/_index.md
@@ -61,7 +61,7 @@ To add a mobile application, navigate to the [**Mobile Applications List** tab][
 
 To edit or delete a mobile application, hover over a mobile application in the **Mobile Applications List** and click on the respective icon.
 
-**Note**: Mobile Application Testing does not support applications built with Flutter SDK.
+**Note**: Mobile Application Testing does not provide full support for applications developed with Flutter SDK.
 
 ## Manage application versions
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Our automation tooling does not support apps built with Flutter SDK: it would help stating it clearly in our documentation