### PR TITLE
API Integration Guide should refer to API integrations, not agent-based integrations.

### DIFF
--- a/content/en/developers/integrations/api_integration.md
+++ b/content/en/developers/integrations/api_integration.md
@@ -32,7 +32,7 @@ API integrations can send the following types of data to Datadog:
 - [Traces][6]
 - [Incidents][7]
 
-You can include out-of-the-box assets such as [monitors][25], [dashboards][26], and [log pipelines][27] with your Agent-based integration. When a user clicks **Install** on your integration tile, they are prompted to follow the setup instructions, and all out-of-the-box dashboards will appear in their account. Other assets, such as log pipelines, will appear for users after proper installation and configuration of the integration.
+You can include out-of-the-box assets such as [monitors][25], [dashboards][26], and [log pipelines][27] with your API integration. When a user clicks **Install** on your integration tile, they are prompted to follow the setup instructions, and all out-of-the-box dashboards will appear in their account. Other assets, such as log pipelines, will appear for users after proper installation and configuration of the integration.
 
 To display your offering on the **Integrations** or **Marketplace page**, you need to create a tile (pictured below). This tile will include instructions on how to set up your offering, as well as general information on what the integration does and how to use it. 
 


### PR DESCRIPTION

# Problem

The API Integration Guide refers to "agent-based integrations". 

# Solution

It should refer to API Integrations

# Result

Text is accurate.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

#### Problem

The API Integration Guide refers to "agent-based integrations". 

#### Solution

It should refer to API Integrations
### Merge instructions


- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->