### PR TITLE
Call out the supported Amazon EMR release versions for DJM

### DIFF
--- a/content/en/data_jobs/emr.md
+++ b/content/en/data_jobs/emr.md
@@ -11,7 +11,7 @@ further_reading:
 
 ## Setup
 
-Follow these steps to enable Data Jobs Monitoring for Amazon EMR.
+Follow these steps to enable Data Jobs Monitoring for Amazon EMR. We support [Amazon EMR Release 6.6.0][10] and above.
 
 1. [Store your Datadog API key](#store-your-datadog-api-key-in-aws-secrets-manager) in AWS Secrets Manager.
 1. [Create and configure your EMR cluster](#create-and-configure-your-emr-cluster).
@@ -122,3 +122,4 @@ In Datadog, view the [Data Jobs Monitoring][8] page to see a list of all your da
 [7]: /getting_started/site/
 [8]: https://app.datadoghq.com/data-jobs/
 [9]: /data_jobs
+[10]: https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-660-release.html

--- a/content/en/data_jobs/emr.md
+++ b/content/en/data_jobs/emr.md
@@ -9,6 +9,10 @@ further_reading:
 
 [Data Jobs Monitoring][9] gives visibility into the performance and reliability of Apache Spark applications on Amazon EMR.
 
+## Requirements
+
+[Amazon EMR Release 6.6.0][10] or later is required.
+
 ## Setup
 
 Follow these steps to enable Data Jobs Monitoring for Amazon EMR. [Amazon EMR Release 6.6.0][10] and above are supported.

--- a/content/en/data_jobs/emr.md
+++ b/content/en/data_jobs/emr.md
@@ -11,7 +11,7 @@ further_reading:
 
 ## Setup
 
-Follow these steps to enable Data Jobs Monitoring for Amazon EMR. We support [Amazon EMR Release 6.6.0][10] and above.
+Follow these steps to enable Data Jobs Monitoring for Amazon EMR. [Amazon EMR Release 6.6.0][10] and above are supported.
 
 1. [Store your Datadog API key](#store-your-datadog-api-key-in-aws-secrets-manager) in AWS Secrets Manager.
 1. [Create and configure your EMR cluster](#create-and-configure-your-emr-cluster).

--- a/content/en/data_jobs/emr.md
+++ b/content/en/data_jobs/emr.md
@@ -15,7 +15,7 @@ further_reading:
 
 ## Setup
 
-Follow these steps to enable Data Jobs Monitoring for Amazon EMR. [Amazon EMR Release 6.6.0][10] and above are supported.
+Follow these steps to enable Data Jobs Monitoring for Amazon EMR.
 
 1. [Store your Datadog API key](#store-your-datadog-api-key-in-aws-secrets-manager) in AWS Secrets Manager.
 1. [Create and configure your EMR cluster](#create-and-configure-your-emr-cluster).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
It's not clear to customer what Amazon EMR release version the Data Jobs Monitoring support at the moment, this is causing confusion and unsuccessful setup for customers. This PR is to call out the supported versions: Amazon EMR 6.6.0 and above.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->