### PR TITLE
Update nodejs.md with new version info

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -30,7 +30,7 @@ further_reading:
 ---
 ## Compatibility requirements
 
-The latest Node.js Tracer supports versions `>=14`. For a full list of Datadog's Node.js version and framework support (including legacy and maintenance versions), see the [Compatibility Requirements][1] page.
+The latest Node.js Tracer supports Node.js versions `>=18`. For a full list of Datadog's Node.js version and framework support (including legacy and maintenance versions), see the [Compatibility Requirements][1] page.
 
 ## Getting started
 
@@ -38,17 +38,17 @@ Before you begin, make sure you've already [installed and configured the Agent][
 
 ### Install the Datadog tracing library
 
-To install the Datadog tracing library using npm for Node.js 14+, run:
+To install the Datadog tracing library using npm for Node.js 18+, run:
 
   ```shell
   npm install dd-trace --save
   ```
-To install the Datadog tracing library (version 2.x of `dd-trace`) for end-of-life Node.js version 12, run:
+To install the Datadog tracing library (version 4.x of `dd-trace`) for end-of-life Node.js version 16, run:
   ```shell
-  npm install dd-trace@latest-node12
+  npm install dd-trace@latest-node16
   ```
 For more information on Datadog's distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
-If you are upgrading from a previous major version of the library (0.x, 1.x, or 2.x) to another major version (2.x or 3.x), read the [Migration Guide][5] to assess any breaking changes.
+If you are upgrading from a previous major version of the library (0.x, 1.x, 2.x or 4.x) to another major version, read the [Migration Guide][5] to assess any breaking changes.
 
 ### Import and initialize the tracer
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -48,7 +48,7 @@ To install the Datadog tracing library (version 4.x of `dd-trace`) for end-of-li
   npm install dd-trace@latest-node16
   ```
 For more information on Datadog's distribution tags and Node.js runtime version support, see the [Compatibility Requirements][1] page.
-If you are upgrading from a previous major version of the library (0.x, 1.x, 2.x or 4.x) to another major version, read the [Migration Guide][5] to assess any breaking changes.
+If you are upgrading from a previous major version of the library (0.x, 1.x, 2.x, 3.x or 4.x) to another major version, read the [Migration Guide][5] to assess any breaking changes.
 
 ### Import and initialize the tracer
 


### PR DESCRIPTION
Update the Node.js tracer docs to match the README.md documentation in the dd-trace-js repo, specifically adding information about version 4 and 5 of the tracer.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->