### PR TITLE
[rum] DOCS-7945 Retrieve Session ID at runtime for Android/iOS/Flutter

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
@@ -533,6 +533,7 @@ To access the RUM session ID:
       }
    ```
 {{% /tab %}}
+{{< /tabs >}}
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
@@ -484,56 +484,17 @@ To modify some attributes in your RUM events, or to drop some of the events enti
    
    **Note**: If you return null from the `EventMapper<T>` implementation, the event is dropped.
 
-## Retrieving the RUM session ID
+## Retrieve the RUM session ID
 
 Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
 
-You can access the RUM session ID at runtime without waiting for the `sessionStarted` event.
+You can access the RUM session ID at runtime without waiting for the `sessionStarted` event:
 
-To access the RUM session ID:
-
-{{< tabs >}}
-{{% tab "Kotlin" %}}
-   ```kotlin
-      fun `M send correct sessionId W getCurrentSessionId { session started, sampled in }`(
-          @StringForgery(type = StringForgeryType.ASCII) key: String,
-          @StringForgery name: String
-      ) {
-          // Given
-          testedMonitor = DatadogRumMonitor(
-              fakeApplicationId,
-              mockSdkCore,
-              100.0f,
-              fakeBackgroundTrackingEnabled,
-              fakeTrackFrustrations,
-              mockWriter,
-              mockHandler,
-              mockTelemetryEventHandler,
-              mockResolver,
-              mockCpuVitalMonitor,
-              mockMemoryVitalMonitor,
-              mockFrameRateVitalMonitor,
-              mockSessionListener
-          )
-          val completableFuture = CompletableFuture<String>()
-          testedMonitor.startView(key, name, fakeAttributes)
-          Thread.sleep(PROCESSING_DELAY)
-
-          // When
-          testedMonitor.getCurrentSessionId { completableFuture.complete(it) }
-
-          // Then
-          completableFuture.thenAccept {
-              argumentCaptor<String> {
-                  verify(mockSessionListener).onSessionStarted(capture(), any())
-
-                  assertThat(it).isEqualTo(firstValue)
-              }
-          }.orTimeout(PROCESSING_DELAY, TimeUnit.MILLISECONDS)
-      }
-   ```
-{{% /tab %}}
-{{< /tabs >}}
+```kotlin
+GlobalRumMonitor.get().getCurrentSessionId { sessionId ->
+  currentSessionId = sessionId
+}
+```
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
@@ -484,6 +484,56 @@ To modify some attributes in your RUM events, or to drop some of the events enti
    
    **Note**: If you return null from the `EventMapper<T>` implementation, the event is dropped.
 
+## Retrieving the RUM session ID
+
+Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
+
+You can access the RUM session ID at runtime without waiting for the `sessionStarted` event.
+
+To access the RUM session ID:
+
+{{< tabs >}}
+{{% tab "Kotlin" %}}
+   ```kotlin
+      fun `M send correct sessionId W getCurrentSessionId { session started, sampled in }`(
+          @StringForgery(type = StringForgeryType.ASCII) key: String,
+          @StringForgery name: String
+      ) {
+          // Given
+          testedMonitor = DatadogRumMonitor(
+              fakeApplicationId,
+              mockSdkCore,
+              100.0f,
+              fakeBackgroundTrackingEnabled,
+              fakeTrackFrustrations,
+              mockWriter,
+              mockHandler,
+              mockTelemetryEventHandler,
+              mockResolver,
+              mockCpuVitalMonitor,
+              mockMemoryVitalMonitor,
+              mockFrameRateVitalMonitor,
+              mockSessionListener
+          )
+          val completableFuture = CompletableFuture<String>()
+          testedMonitor.startView(key, name, fakeAttributes)
+          Thread.sleep(PROCESSING_DELAY)
+
+          // When
+          testedMonitor.getCurrentSessionId { completableFuture.complete(it) }
+
+          // Then
+          completableFuture.thenAccept {
+              argumentCaptor<String> {
+                  verify(mockSessionListener).onSessionStarted(capture(), any())
+
+                  assertThat(it).isEqualTo(firstValue)
+              }
+          }.orTimeout(PROCESSING_DELAY, TimeUnit.MILLISECONDS)
+      }
+   ```
+{{% /tab %}}
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/flutter.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/flutter.md
@@ -262,6 +262,16 @@ For example:
 DatadogSdk.instance.setUserInfo("1234", "John Doe", "john@doe.com");
 ```
 
+## Retrieve the RUM session ID
+
+Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
+
+You can access the RUM session ID at runtime without waiting for the `sessionStarted` event:
+
+```dart
+final sessionId = await DatadogSdk.instance.rum?.getCurrentSessionId()
+```
+
 ## Modify or drop RUM events
 
 **Note**: This feature is not yet available for Flutter web applications.

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/flutter.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/flutter.md
@@ -262,16 +262,6 @@ For example:
 DatadogSdk.instance.setUserInfo("1234", "John Doe", "john@doe.com");
 ```
 
-## Retrieve the RUM session ID
-
-Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
-
-You can access the RUM session ID at runtime without waiting for the `sessionStarted` event:
-
-```dart
-final sessionId = await DatadogSdk.instance.rum?.getCurrentSessionId()
-```
-
 ## Modify or drop RUM events
 
 **Note**: This feature is not yet available for Flutter web applications.
@@ -323,6 +313,16 @@ Depending on the event's type, only some specific properties can be modified:
 | RumResourceEvent | `resourceEvent.resource.url`      | URL of the resource.                          |
 |                  | `resourceEvent.view.referrer`     | Referrer of the view linked to this action.   |
 |                  | `resourceEvent.view.url`          | URL of the view linked to this resource.      |
+
+## Retrieve the RUM session ID
+
+Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
+
+You can access the RUM session ID at runtime without waiting for the `sessionStarted` event:
+
+```dart
+final sessionId = await DatadogSdk.instance.rum?.getCurrentSessionId()
+```
 
 ## Set tracking consent (GDPR & CCPA compliance)
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
@@ -265,6 +265,18 @@ Datadog.setUserInfo(id: "1234", name: "John Doe", email: "john@doe.com")
 {{% /tab %}}
 {{< /tabs >}}
 
+## Retrieve the RUM session ID
+
+Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
+
+You can access the RUM session ID at runtime without waiting for the `sessionStarted` event:
+
+```swift
+RumMonitor.shared().currentSessionID(completion: { sessionId in
+  currentSessionId = sessionId
+})
+```
+
 ## Initialization Parameters
 
 You can use the following properties in `Datadog.Configuration` when creating the Datadog configuration to initialize the library:

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
@@ -265,18 +265,6 @@ Datadog.setUserInfo(id: "1234", name: "John Doe", email: "john@doe.com")
 {{% /tab %}}
 {{< /tabs >}}
 
-## Retrieve the RUM session ID
-
-Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
-
-You can access the RUM session ID at runtime without waiting for the `sessionStarted` event:
-
-```swift
-RumMonitor.shared().currentSessionID(completion: { sessionId in
-  currentSessionId = sessionId
-})
-```
-
 ## Initialization Parameters
 
 You can use the following properties in `Datadog.Configuration` when creating the Datadog configuration to initialize the library:
@@ -706,6 +694,18 @@ Depending on the event's type, only some specific properties can be modified:
 |                  | `RUMErrorEvent.view.url`             | URL of the view linked to this error.    |
 | RUMResourceEvent | `RUMResourceEvent.resource.url`      | URL of the resource.                     |
 |                  | `RUMResourceEvent.view.url`          | URL of the view linked to this resource. |
+
+## Retrieve the RUM session ID
+
+Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
+
+You can access the RUM session ID at runtime without waiting for the `sessionStarted` event:
+
+```swift
+RumMonitor.shared().currentSessionID(completion: { sessionId in
+  currentSessionId = sessionId
+})
+```
 
 ## Set tracking consent (GDPR compliance)
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
@@ -333,6 +333,20 @@ Events include additional context:
 |               | `resourceEvent.additionalInformation.userInfo`   | Contains the global user info set by `DdSdkReactNative.setUser`.        |
 |               | `resourceEvent.additionalInformation.attributes` | Contains the global attributes set by `DdSdkReactNative.setAttributes`. |
 
+## Retrieve the RUM session ID
+
+Retrieving the RUM session ID can be helpful for troubleshooting. For example, you can attach the session ID to support requests, emails, or bug reports so that your support team can later find the user session in Datadog.
+
+You can access the RUM session ID at runtime without waiting for the `sessionStarted` event:
+
+```kotlin
+   fun getCurrentSessionId(promise: Promise) {
+       datadog.getRumMonitor().getCurrentSessionId {
+           promise.resolve(it)
+        }
+    }
+```
+
 ## Resource timings
 
 Resource tracking provides the following timings:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds details on how to retrieve session IDs for Android, iOS, Flutter, and React Native, as per https://datadoghq.atlassian.net/browse/DOCS-7945.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->