### PR TITLE
CCM add info on lookback range of new GCP usage and cost exports

### DIFF
--- a/content/en/cloud_cost_management/google_cloud.md
+++ b/content/en/cloud_cost_management/google_cloud.md
@@ -48,7 +48,7 @@ The <a href="https://cloud.google.com/billing/docs/how-to/export-data-bigquery-t
 
 {{< img src="cloud_cost/billing_export.png" alt="Google Cloud project and dataset info highlighted" >}}
 
-_Newly created BigQuery datasets will only contain the most recent two months of data._
+_Newly created BigQuery billing export datasets only contain the most recent two months of data. It can take a day or two for this data to backfill in BigQuery._
 
 #### Enable Google Service APIs
 The following permissions allow Datadog to access and transfer the billing export into the storage bucket using a scheduled BigQuery query.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Clarifies the default expected backfill for a newly created GCP Usage and Cost bigquery export

### Merge instructions
- [x] Please merge after reviewing after code freeze

### Additional notes
I'll get a CCM reviewer and review the snapshot build