### PR TITLE
Remove beta tag from supported deployments table

### DIFF
--- a/content/en/security/cloud_security_management/setup/supported_deployment_types.md
+++ b/content/en/security/cloud_security_management/setup/supported_deployment_types.md
@@ -6,10 +6,10 @@ The following table summarizes the CSM features available relative to each deplo
 
 | Deployment type     | Agent Required (7.46+) | CSM Misconfigurations | CSM Threats | CSM Vulnerabilities | CSM Identity Risks | CSM Agentless Scanning |
 |---------------------|------------------------|-----------------------|-------------|---------------------|--------------------|------------------------|
-| AWS Account         |                        | {{< X >}}             |             |                     | {{< X >}}          | beta                   |
+| AWS Account         |                        | {{< X >}}             |             |                     | {{< X >}}          | {{< X >}}              |
 | Azure Account       |                        | {{< X >}}             |             |                     | {{< X >}}          |                        |
 | GCP Account         |                        | {{< X >}}             |             |                     |                    |                        |
-| Terraform           |                        |                       |             |                     |                    | beta                   |
+| Terraform           |                        |                       |             |                     |                    | {{< X >}}              |
 | Docker              | {{< X >}}              | {{< X >}}             | {{< X >}}   |                     |                    |                        |
 | Kubernetes          | {{< X >}}              | {{< X >}}             | {{< X >}}   | {{< X >}}           |                    |                        |
 | Linux               | {{< X >}}              | {{< X >}}             | {{< X >}}   | {{< X >}}           |                    |                        |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes the beta tag for Agentless Scanning in the supported deployment types table.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->