### PR TITLE
Fix minimum pytest version supported by ITR

### DIFF
--- a/content/en/intelligent_test_runner/setup/python.md
+++ b/content/en/intelligent_test_runner/setup/python.md
@@ -20,7 +20,7 @@ further_reading:
 
 Intelligent Test Runner is only supported in the following versions and testing frameworks:
 
-* `pytest>=6.8.0`
+* `pytest>=7.2.0`
   * From `ddtrace>=2.1.0`.
   * From `Python>=3.7`.
   * Requires `coverage>=5.5`.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the minimum pytest version supported by the Intelligent Test Runner to `7.2.0`. There was previously a typo specifying `6.8.0` which was never a valid version.

### Merge instructions

- [x] Please merge after reviewing
