### PR TITLE
[rum] Add batch frequency to browser RUM Datadog intake

### DIFF
--- a/content/en/real_user_monitoring/browser/troubleshooting.md
+++ b/content/en/real_user_monitoring/browser/troubleshooting.md
@@ -41,7 +41,16 @@ You can also check your browser developer tools console or network tab if you no
 
 ### Data to the Datadog intake
 
-The RUM Browser SDK sends batches of data periodically to the Datadog intake. If data is being sent, you should see network requests targeting `/v1/input` (the URL origin part may differ due to RUM configuration) in the Network section of your browser developer tools:
+The RUM Browser SDK sends batches of data periodically to the Datadog intake.
+
+The RUM SDK sends batches of event data to Datadog's intake every time one of these conditions have been met:
+
+- Every 30 seconds
+- When 50 events have been reached
+- When the payload is >16 kB
+- On `visibility:hidden` or `beforeUnload`
+
+If data is being sent, you should see network requests targeting `/v1/input` (the URL origin part may differ due to RUM configuration) in the Network section of your browser developer tools:
 
 {{< img src="real_user_monitoring/browser/troubleshooting/network_intake.png" alt="RUM requests to Datadog intake">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds details on batch frequency for browser RUM, as per [DOCS-7961](https://datadoghq.atlassian.net/browse/DOCS-7961)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->