### PR TITLE
[rum] Move custom global attributes for React Native

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
@@ -272,6 +272,41 @@ const spanId = await DdTrace.startSpan('foo', { custom: 42 }, Date.now());
 DdTrace.finishSpan(spanId, { custom: 21 }, Date.now());
 ```
 
+## Track custom global attributes
+
+You can attach user information to all RUM events to get more detailed information from your RUM sessions.
+
+### User information
+
+For user-specific information, use the following code wherever you want in your app (after the SDK has been initialized). The `id`, `name`, and `email` attributes are built into Datadog, and you can add other attributes that makes sense for your app.
+
+```js
+DdSdkReactNative.setUser({
+    id: '1337',
+    name: 'John Smith',
+    email: 'john@example.com',
+    type: 'premium'
+});
+```
+
+If you want to clear the user information (for example, when the user signs out), you can do so by passing an empty object, as follows:
+
+```js
+DdSdkReactNative.setUser({});
+```
+
+### Global attributes
+
+You can also keep global attributes to track information about a specific session, such as A/B testing configuration, ad campaign origin, or cart status.
+
+```js
+DdSdkReactNative.setAttributes({
+    profile_mode: 'wall',
+    chat_enabled: true,
+    campaign_origin: 'example_ad_network'
+});
+```
+
 ## Modify or drop RUM events
 
 To modify attributes of a RUM event before it is sent to Datadog, or to drop an event entirely, use the Event Mappers API when configuring the RUM React Native SDK:

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
@@ -358,42 +358,7 @@ Use one of Datadog's integrations to automatically track views for the following
 -   If you use the [`react-native-navigation`][5] library, then add the `@datadog/mobile-react-native-navigation` package and follow the [setup instructions][6].
 -   If you use the [`react-navigation`][7] library, then add the `@datadog/mobile-react-navigation` package and follow the [setup instructions][8].
 
-If you experience any issues setting up View tracking with `@datadog/mobile-react-navigation` you can see our [example application][16] as a reference.
-
-## Track custom attributes
-
-You can attach user information to all RUM events to get more detailed information from your RUM sessions.
-
-### User information
-
-For user-specific information, use the following code wherever you want in your app (after the SDK has been initialized). The `id`, `name`, and `email` attributes are built into Datadog, and you can add other attributes that makes sense for your app.
-
-```js
-DdSdkReactNative.setUser({
-    id: '1337',
-    name: 'John Smith',
-    email: 'john@example.com',
-    type: 'premium'
-});
-```
-
-If you want to clear the user information (for example, when the user signs out), you can do so by passing an empty object, as follows:
-
-```js
-DdSdkReactNative.setUser({});
-```
-
-### Global attributes
-
-You can also keep global attributes to track information about a specific session, such as A/B testing configuration, ad campaign origin, or cart status.
-
-```js
-DdSdkReactNative.setAttributes({
-    profile_mode: 'wall',
-    chat_enabled: true,
-    campaign_origin: 'example_ad_network'
-});
-```
+If you experience any issues setting up View tracking with `@datadog/mobile-react-navigation` you can see this Datadog [example application][16] as a reference.
 
 ## Track background events
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
As per https://datadoghq.atlassian.net/browse/DOCS-8150:
- Moves the custom attributes section for React Native from the setup page to advanced configuration page
- Renames the section title from "Track custom attributes" to "Track custom global attributes" to be consistent with naming for other platforms

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->