### PR TITLE
Clarify containers pod exclusion annotation

### DIFF
--- a/content/en/containers/guide/autodiscovery-management.md
+++ b/content/en/containers/guide/autodiscovery-management.md
@@ -21,7 +21,7 @@ You can adjust the discovery rules for the Agent to restrict metric and log coll
 
 These restrictions can be set by either:
 - Providing environment variables to the Datadog Agent container as an allowlist/blocklist of containers.
-- Adding annotations to your Kubernetes pods to allow/block individual containers.
+- Adding annotations to your Kubernetes pods to block individual pods or containers.
 
 The first option works well as a list of container names, images, or Kubernetes namespaces to exclude for the entire cluster. The second option works well for more fine tuned exclusions in Kubernetes.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Small clarification as the annotation you can put on the pod like `ad.datadoghq.com/exclude: true` is only for excluding/blocking - it is not for allowing. As all pods/containers are monitored by default. 

There is no `ad.datadoghq.com/include: true` type of annotation. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->