### PR TITLE
[rum] Break down React Native manual instrumentation options

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
@@ -216,34 +216,20 @@ Optional [proxy configuration][13].
 
 If automatic instrumentation doesn't suit your needs, you can manually create RUM Events and Logs:
 
+### Send logs
+When you instrument your code to send logs, it can include debug, info, warn, or error details:
+
 ```javascript
-import {
-    DdSdkReactNative,
-    DdSdkReactNativeConfiguration,
-    DdLogs,
-    ErrorSource,
-    RumActionType,
-    DdRum
-} from '@datadog/mobile-react-native';
-
-// Initialize the SDK
-const config = new DdSdkReactNativeConfiguration(
-    '<CLIENT_TOKEN>',
-    '<ENVIRONMENT_NAME>',
-    '<RUM_APPLICATION_ID>',
-    true, // track user interactions (such as a tap on buttons)
-    true, // track XHR resources
-    true // track errors
-);
-DdSdkReactNative.initialize(config);
-
-// Send logs (use the debug, info, warn, or error methods)
 DdLogs.debug('Lorem ipsum dolor sit amet…', {});
 DdLogs.info('Lorem ipsum dolor sit amet…', {});
 DdLogs.warn('Lorem ipsum dolor sit amet…', {});
 DdLogs.error('Lorem ipsum dolor sit amet…', {});
+```
 
-// Track RUM Views manually
+### Manually track RUM Views
+To manually track RUM Views, provide a `view key`, `view name`, and `action name` at initialization. Depending on your needs, you can choose one of the following strategies:
+
+```javascript
 DdRum.startView('<view-key>', 'View Name', {}, Date.now());
 //…
 DdRum.stopView('<view-key>', { custom: 42 }, Date.now());
@@ -254,19 +240,35 @@ DdRum.addAction(RumActionType.TAP, 'action name', {}, Date.now());
 DdRum.startAction(RumActionType.TAP, 'action name', {}, Date.now());
 // To stop action above
 DdRum.stopAction({}, Date.now());
+```
 
-// Add custom timings
-DdRum.addTiming('<timing-name>');
+### Manually track RUM Errors
+You can manually track RUM errors:
 
-// Track RUM Errors manually
+```javascript
 DdRum.addError('<message>', ErrorSource.SOURCE, '<stacktrace>', {}, Date.now());
+```
 
-// Track RUM Resource manually
+### Manually track RUM Resources
+You can manually track RUM resources:
+
+```javascript
 DdRum.startResource('<res-key>', 'GET', 'http://www.example.com/api/v1/test', {}, Date.now());
 //…
 DdRum.stopResource('<res-key>', 200, 'xhr', (size = 1337), {}, Date.now());
+```
 
-// Send spans manually
+### Add custom timings
+You can add custom timings:
+
+```javascript
+DdRum.addTiming('<timing-name>');
+```
+
+### Manually send spans
+You can send spans manually:
+
+```javascript
 const spanId = await DdTrace.startSpan('foo', { custom: 42 }, Date.now());
 //...
 DdTrace.finishSpan(spanId, { custom: 21 }, Date.now());


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Breaks down the many options available for manual instrumentation of the React Native SDK into separate paragraphs instead of them being in one long snippet, as per https://datadoghq.atlassian.net/browse/DOCS-8151

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Not sure if there is enough detail for some of these options, so definitely open to feedback and suggestions.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->