### PR TITLE
Clarify conf.d directory and fix mountPath

### DIFF
--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -104,7 +104,7 @@ If you define pods indirectly (with deployments, ReplicaSets, or ReplicationCont
 {{% /tab %}}
 {{% tab "Local file" %}}
 
-You can store Autodiscovery templates as local files inside the mounted `/conf.d` directory. You must restart your Agent containers each time you change, add, or remove templates.
+You can store Autodiscovery templates as local files inside the mounted `conf.d` directory (`/etc/datadog-agent/conf.d`). You must restart your Agent containers each time you change, add, or remove templates.
 
 1. Create a `conf.d/<INTEGRATION_NAME>.d/conf.yaml` file on your host:
    ```yaml
@@ -503,7 +503,7 @@ Then, in your manifest, define the `volumeMounts` and `volumes`:
         volumeMounts:
         # [...]
           - name: postgresql-config-map
-            mountPath: /conf.d/postgresql.d
+            mountPath: /etc/datadog-agent/conf.d/postgresql.d
         # [...]
       volumes:
       # [...]


### PR DESCRIPTION
### What does this PR do? What is the motivation?
* Clarifies the Agent conf.d directory being `/etc/datadog-agent/conf.d`
* Fixes the mountPath in the example ConfigMap so it's the proper path

### Merge instructions

- [x] Please merge after reviewing