### PR TITLE
[Kubernetes integrations] Clarify conf.d directory and fix mountPath

### DIFF
--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -104,7 +104,7 @@ If you define pods indirectly (with deployments, ReplicaSets, or ReplicationCont
 {{% /tab %}}
 {{% tab "Local file" %}}
 
-You can store Autodiscovery templates as local files inside the mounted `/conf.d` directory. You must restart your Agent containers each time you change, add, or remove templates.
+You can store Autodiscovery templates as local files inside the mounted `conf.d` directory (`/etc/datadog-agent/conf.d`). You must restart your Agent containers each time you change, add, or remove templates.
 
 1. Create a `conf.d/<INTEGRATION_NAME>.d/conf.yaml` file on your host:
    ```yaml
@@ -503,7 +503,7 @@ Then, in your manifest, define the `volumeMounts` and `volumes`:
         volumeMounts:
         # [...]
           - name: postgresql-config-map
-            mountPath: /conf.d/postgresql.d
+            mountPath: /etc/datadog-agent/conf.d/postgresql.d
         # [...]
       volumes:
       # [...]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
* Clarifies the Agent conf.d directory being `/etc/datadog-agent/conf.d`
* Fixes the `mountPath` in the example ConfigMap so it's the proper path

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->