### PR TITLE
[Error Tracking] Remove beta tag from Dynamic Sampling documentation

### DIFF
--- a/content/en/error_tracking/dynamic_sampling.md
+++ b/content/en/error_tracking/dynamic_sampling.md
@@ -1,7 +1,7 @@
 ---
 title: Error Tracking Dynamic Sampling
 kind: documentation
-is_beta: true
+is_beta: false
 private: true
 description: Learn about how Dynamic Sampling in Error Tracking can make sure that your volume isn't consumed all at once.
 further_reading:
@@ -12,10 +12,6 @@ further_reading:
   tag: 'Documentation'
   text: 'Learn about Error Tracking for Logs'
 ---
-
-<div class="alert alert-info">
-Dynamic Sampling for Error Tracking is in private beta.
-</div>
 
 ## Overview
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Removes the beta banners for Error Tracking Dynamic Sampling documentation.
This feature will start to be rolled out (silently) to some customers next week. We link to this documentation page from Datadog, so non-beta users can start encountering it.

Keeping the `private: true` because the feature is not announced yet and won't be rolled out to all customers at once.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->
<s>Please **don't** merge after reviewing. Will merge as soon as we start rolling out.</s>
Can be merged now!

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->