### PR TITLE
Remove mention of a future release related to query param deobfuscation

### DIFF
--- a/content/en/database_monitoring/troubleshooting.md
+++ b/content/en/database_monitoring/troubleshooting.md
@@ -17,7 +17,7 @@ For specific database setup troubleshooting, use the corresponding troubleshooti
 ## Diagnosing common problems
 ### Query bind parameters cannot be viewed
 
-At this time, the raw query bind parameters are obfuscated for Query Samples and Explain Plans, and are replaced with a `?` character. In a future release, settings to expose the un-obfuscated query bind parameters are planned.
+At this time, the raw query bind parameters are obfuscated for Query Samples and Explain Plans, and are replaced with a `?` character.
 
 
 ### DBM host limit


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
In our DBM Troubleshooting docs [here](https://docs.datadoghq.com/database_monitoring/troubleshooting/#query-bind-parameters-cannot-be-viewed), we had the following line:
_In a future release, settings to expose the un-obfuscated query bind parameters are planned._

As a best practice, we should never mention or commit to future releases in our public-facing docs, so this PR removes this line.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->