### PR TITLE
Update browser test recorder docs

### DIFF
--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -161,7 +161,7 @@ For more information, see [Using Synthetic Test Monitors][7].
 
 ## Record your steps
 
-Tests can be only recorded from [Google Chrome][8]. To record your test, download the [Datadog Record Test extension for Google Chrome][9].
+Tests can be recorded from [Google Chrome][8] and [Microsoft Edge][18]. To record your test, download the [Datadog Record Test extension][9].
 
 You can switch tabs in a browser test recording in order to perform an action on your application (such as clicking on a link that opens another tab) and add another test step. Your browser test must interact with the page first (through a click) before it can perform an [assertion][10]. By recording all of the test steps, the browser test can switch tabs automatically at test execution.
 
@@ -212,3 +212,4 @@ You can restrict access to a browser test based on the roles in your organizatio
 [15]: /continuous_testing/environments/proxy_firewall_vpn
 [16]: /synthetics/guide/browser-tests-passkeys
 [17]: /monitors/notify/variables/?tab=is_alert#conditional-variables
+[18]: https://www.microsoft.com/edge/download


### PR DESCRIPTION
adding references to microsoft edge and the recorder

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
We had a customer reach out as they were confused if we supported microsoft edge with the browser recorder, which we do -> the goal of the PR is to make that information more explicit

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->