### PR TITLE
Update Lambda Extension Installation Instructions for Datadog Lambda Terraform Module (.NET and Java)

### DIFF
--- a/content/en/serverless/aws_lambda/installation/java.md
+++ b/content/en/serverless/aws_lambda/installation/java.md
@@ -263,129 +263,60 @@ The [Datadog CDK construct][1] automatically installs Datadog on your functions 
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 {{% /tab %}}
 {{% tab "Terraform" %}}
-Use this format for your [Terraform resource][1]:
-```sh
-resource "aws_lambda_function" "lambda" {
-  "function_name" = ...
-  ...
 
-  # Remember sure to choose the right layers based on your Lambda architecture and AWS regions
+The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] resource and automatically configures your Lambda function for Datadog Serverless Monitoring by:
 
-  layers = [
-    <DATADOG_TRACER_ARN>,
-    <DATADOG_EXTENSION_ARN>
-  ]
+- Adding the Datadog Lambda layers
+- Redirecting the Lambda handler
+- Enabling the collection and sending of metrics, traces, and logs to Datadog
 
-  environment {
-    variables = {
-      DD_SITE                     = <DATADOG_SITE>
-      DD_API_KEY_SECRET_ARN       = <API_KEY>
-      AWS_LAMBDA_EXEC_WRAPPER     = "/opt/datadog_wrapper"
-    }
+```tf
+module "lambda-datadog" {
+  source  = "DataDog/lambda-datadog/aws"
+  version = "1.2.0"
+
+  environment_variables = {
+    "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
+    "DD_ENV" : "<ENVIRONMENT>"
+    "DD_SERVICE" : "<SERVICE_NAME>"
+    "DD_SITE": "<DATADOG_SITE>"
+    "DD_VERSION" : "<VERSION>"
   }
+
+  datadog_extension_layer_version = 58
+  datadog_java_layer_version = 15
+
+  # aws_lambda_function arguments
 }
 ```
 
-Fill in variables accordingly:
+1. Replace the `aws_lambda_function` resource with the `lambda-datadog` Terraform module. Then, specify the `source` and `version` of the module.
 
-1. Replace `<DATADOG_TRACER_ARN>` with the ARN of the appropriate Datadog tracer depending on your type of region:
+2. Set the `aws_lambda_function` arguments:
 
-    <table>
-        <tr>
-            <th>AWS REGIONS</th>
-            <th>LAYERS</th>
-        </tr>
-        <tr>
-            <td>Commercial</td>
-            <td>
-                <code>
-                arn:aws:lambda:&lt;AWS_REGION&gt;:464622532012:layer:dd-trace-java:{{< latest-lambda-layer-version layer="dd-trace-java" >}}
-                </code>
-            </td>
-        </tr>
-        <tr>
-            <td>GovCloud</td>
-            <td>
-                <code>
-                arn:aws-us-gov:lambda:&lt;AWS_REGION&gt;:002406178527:layer:dd-trace-java:{{< latest-lambda-layer-version layer="dd-trace-java" >}}
-                </code>
-                </td>
-        </tr>
-    </table>
+   All of the arguments available in the `aws_lambda_function` resource are available in this Terraform module. Arguments defined as blocks in the `aws_lambda_function` resource are redefined as variables with their nested arguments.
 
-   In each ARN, replace `<AWS_REGION>` with a valid AWS region, such as `us-east-1`.
+   For example, in `aws_lambda_function`, `environment` is defined as a block with a `variables` argument. In the `lambda-datadog` Terraform module, the value for the `environment_variables` is passed to the `environment.variables` argument in `aws_lambda_function`. See [inputs][3] for a complete list of variables in this module.
 
-2. Replace `<DATADOG_EXTENSION_ARN>` with the ARN of the appropriate Datadog Lambda Extension for your region and architecture:
+3. Fill in the environment variable placeholders:
 
-    <table>
-        <tr>
-            <th>AWS REGIONS</th>
-            <th>ARCHITECTURE</th>
-            <th>LAYERS</th>
-        </tr>
-        <tr>
-            <td rowspan=2>Commercial</td>
-            <td>x86_64</td>
-            <td>
-                <code>
-                arn:aws:lambda:&lt;AWS_REGION&gt;:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}
-                </code>
-            </td>
-        <tr>
-            <td>arm64</td>
-            <td>
-                <code>
-                arn:aws:lambda:&lt;AWS_REGION&gt;:464622532012:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}
-                </code>
-                </td>
-        </tr>
-        <tr>
-            <td rowspan=2>GovCloud</td>
-            <td>x86_64</td>
-            <td>
-                <code>
-                arn:aws-us-gov:lambda:&lt;AWS_REGION&gt;:002406178527:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}
-                </code>
-                </td>
-        <tr>
-            <td>arm64</td>
-            <td>
-                <code>
-                arn:aws-us-gov:lambda:&lt;AWS_REGION&gt;:002406178527:layer:Datadog-Extension-ARM:{{< latest-lambda-layer-version layer="extension" >}}
-                </code>
-            </td>
-        </tr>
-    </table>
+   - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+   - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+   - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+   - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][4] is selected on this page).
+   - Replace `<VERSION>` with the version number of the Lambda function
 
-3. Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}} (ensure the correct SITE is selected on the right).
+4. Select the versions of the Datadog Extension Lambda layer and Datadog Java Lambda layer to use. If left blank the latest layer versions will be used.
 
-4. Replace `<API_KEY>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, use `DD_API_KEY` instead of `DD_API_KEY_SECRET_ARN` and set the value to your Datadog API key in plaintext.
-
-#### Full example
-
-```sh
-resource "aws_lambda_function" "lambda" {
-  "function_name" = ...
-  ...
-
-  # Remember sure to choose the right layers based on your Lambda architecture and AWS regions
-
-  layers = [
-    "arn:aws:lambda:us-east-1:464622532012:layer:dd-trace-java:{{< latest-lambda-layer-version layer="dd-trace-java" >}}",
-    "arn:aws:lambda:us-east-1:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}"
-  ]
-
-  environment {
-    variables = {
-      DD_SITE                     = datadoghq.com
-      DD_API_KEY_SECRET_ARN       = "arn:aws..."
-      AWS_LAMBDA_EXEC_WRAPPER     = "/opt/datadog_wrapper"
-    }
-  }
-}
+```
+  datadog_extension_layer_version = 58
+  datadog_java_layer_version = 15
 ```
 
-[1]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function.html#lambda-layers
+[1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest
+[2]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function
+[3]: https://github.com/DataDog/terraform-aws-lambda-datadog?tab=readme-ov-file#inputs
+[4]: /getting_started/site/
 {{% /tab %}}
 {{% tab "Custom" %}}
 

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -266,7 +266,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.1.0"
+  version = "1.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -257,7 +257,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.1.0"
+  version = "1.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -268,7 +268,7 @@ module "lambda-datadog" {
   }
 
   datadog_extension_layer_version = 58
-  datadog_python_layer_version = 95
+  datadog_python_layer_version = 96
 
   # aws_lambda_function arguments
 }
@@ -294,7 +294,7 @@ module "lambda-datadog" {
 
 ```
   datadog_extension_layer_version = 58
-  datadog_python_layer_version = 95
+  datadog_python_layer_version = 96
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

* Updates the Lambda Extension Installation Instructions for .NET and Java to reference the [lambda-datadog](https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest) Terraform module instead of the old approach.
* Updates Python and Node documentation to reference latest version (`1.2.0`) of the Datadog Lambda Terraform Module.
* Updates Python documentation to reference latest supported layer version (`96`).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

Follows https://github.com/DataDog/documentation/pull/23263

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->