### PR TITLE
[DOCS-8248] Fix link in Tracing Android Applications

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/android.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/android.md
@@ -270,7 +270,7 @@ dependencies {
    * `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
    * `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
 
-**Note**: In the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM error stack traces. For more information see the [guide to uploading Android source mapping files][8].
+**Note**: In the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM error stack traces. For more information see the [guide to uploading Android source mapping files][12].
 
    Use the utility method `isInitialized` to check if the SDK is properly initialized:
 
@@ -947,3 +947,4 @@ The following methods in `AndroidTracer.Builder` can be used when initializing t
 [9]: https://github.com/square/retrofit/tree/master/retrofit-adapters/rxjava3
 [10]: /tracing/trace_collection/custom_instrumentation/android/otel
 [11]: https://opentracing.io
+[12]: /real_user_monitoring/error_tracking/mobile/android/?tab=us#upload-your-mapping-file


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- "For more information see the **guide to uploading Android source mapping files**" linked to the wrong place.
- A link reference already existed for [8], and a new one wasn't created when the content was created: https://github.com/DataDog/dd-sdk-android/commit/c1774144cab5671462ddc650e51afe98fabe672a.
- Replaced the link reference to point to the correct place: [Upload your mapping file](https://docs.datadoghq.com/real_user_monitoring/error_tracking/mobile/android/?tab=us#upload-your-mapping-file).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->