### PR TITLE
Document GraphQL Yoga Support for Node.js

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -76,6 +76,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [express][7]           | `>=4`    | Fully supported | Supports Sails, Loopback, and [more][8]     |
 | [fastify][9]           | `>=1`    | Fully supported |                                             |
 | [graphql][10]           | `>=0.10` | Fully supported | Supports Apollo Server and express-graphql |
+| [graphql-yoga][65]      | `>=3`    | Fully supported | Supports graphql-yoga v3 executor          |
 | [gRPC][11]              | `>=1.13` | Fully supported |                                            |
 | [hapi][12]              | `>=2`    | Fully supported | Supports [@hapi/hapi] versions `>=17.9`    |
 | [koa][13]               | `>=2`    | Fully supported |                                            |
@@ -256,3 +257,4 @@ For additional information or to discuss [leave a comment on this github issue][
 [62]: https://github.com/DataDog/dd-trace-js/issues/1229
 [63]: https://github.com/mariadb-corporation/mariadb-connector-nodejs
 [64]: https://github.com/openai/openai-node
+[65]: https://github.com/dotansimha/graphql-yoga

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -76,7 +76,7 @@ For details about how to how to toggle and configure plugins, check out the [API
 | [express][7]           | `>=4`    | Fully supported | Supports Sails, Loopback, and [more][8]     |
 | [fastify][9]           | `>=1`    | Fully supported |                                             |
 | [graphql][10]           | `>=0.10` | Fully supported | Supports Apollo Server and express-graphql |
-| [graphql-yoga][65]      | `>=3`    | Fully supported | Supports graphql-yoga v3 executor          |
+| [graphql-yoga][65]      | `>=3.6.0`| Fully supported | Supports graphql-yoga v3 executor          |
 | [gRPC][11]              | `>=1.13` | Fully supported |                                            |
 | [hapi][12]              | `>=2`    | Fully supported | Supports [@hapi/hapi] versions `>=17.9`    |
 | [koa][13]               | `>=2`    | Fully supported |                                            |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- dd-trace-js supports GraphQL Yoga as of https://github.com/DataDog/dd-trace-js/pull/3610.
- Note this on the Node.js compatibility page.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->