### PR TITLE
Add enablePrivacyForActionName in default configuration docs

### DIFF
--- a/content/en/real_user_monitoring/browser/setup.md
+++ b/content/en/real_user_monitoring/browser/setup.md
@@ -76,6 +76,7 @@ datadogRum.init({
   trackResources: true,
   trackLongTasks: true,
   trackUserInteractions: true,
+  enablePrivacyForActionName: true,
 });
 ```
 
@@ -213,6 +214,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
   })
 </script>
@@ -241,6 +243,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
   })
 </script>
@@ -269,6 +272,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
   })
 </script>
@@ -297,6 +301,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
   })
 </script>
@@ -325,6 +330,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
   })
 </script>
@@ -353,6 +359,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
   })
 </script>
@@ -1087,6 +1094,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
 </script>
 ```
@@ -1110,6 +1118,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
 </script>
 ```
@@ -1133,6 +1142,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
 </script>
 ```
@@ -1156,6 +1166,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
 </script>
 ```
@@ -1179,6 +1190,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
 </script>
 ```
@@ -1202,6 +1214,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,
+      enablePrivacyForActionName: true,
     });
 </script>
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
We want to recommend masking action names in the default config
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->
Make `enablePrivacyForActionName: true` as default setting.

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->