### PR TITLE
WEB-5022 | update ubuntu and python

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -119,7 +119,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: registry.ddbuild.io/ci/websites/webops-site-build:v37994898-b2c3e3ba
+  image: registry.ddbuild.io/ci/websites/webops-site-build:v38140093-597ff66c
   tags:
     - "arch:amd64"
   rules:


### PR DESCRIPTION
## What does this PR do?

Points the CI to our new build image with an updated version of ubuntu and python.

## [Link to Jira card ](https://datadoghq.atlassian.net/browse/WEB-5022)

## [Link to preview site](https://corpsite-preview.datadoghq.com/jackie.robson/update-build-image/) and any special testing guidelines

https://docs-staging.datadoghq.com/jackie.robson/update-build-image/