### PR TITLE
reset bootstrap hover color variable to fix link hover color issues

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -5,6 +5,10 @@ $lightGreyGrey: #d6d6d6;
 $darkGreyGrey: #a1a1a1;
 $dimGreyGrey: #707070;
 
+:root {
+    --bs-link-hover-color: #{$ddpurple};
+}
+
 html {
     font-size: 18px;
     opacity: 1 !important;


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Some links were displaying a default blue hover color instead of the datadog purple. This was caused by the default bootstrap link color CSS variable.

Resetting this variable to the correct link hover color solved the problem.

https://datadoghq.atlassian.net/browse/WEB-4977

### Merge instructions

- [x] Please merge after reviewing

### Additional notes

https://docs-staging.datadoghq.com/fitzage/anchor-fix/account_management/rbac/permissions/#log-management [scroll down to table with logs_live_tail linked in the first column to see the fixed example]
https://docs-staging.datadoghq.com/fitzage/anchor-fix/service_management/workflows/actions_catalog/
