### PR TITLE
Small update to root cert mounting instructions for PL

### DIFF
--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -236,7 +236,7 @@ This command starts a Docker container and makes your private location ready to 
 
 You can upload custom root certificates to your private locations to have your API and browser tests perform the SSL handshake using your own `.pem` files.
 
-When spinning up your private location containers, mount the relevant certificate `.pem` files to `/etc/datadog/certs` in the same way you mount your private location configuration file. These certificates are considered trusted CA and are used at test runtime.
+When spinning up your private location containers, mount the relevant certificate `.pem` files to `/etc/datadog/certs/<filename>.pem` in the same way you mount your private location configuration file. These certificates are considered trusted CA and are used at test runtime.
 
 For more information about private locations parameters for admins, see [Configuration][2].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Specifies that `.pem` files mounted to private locations should be mounted to a `.pem` file and not directly to the `/certs` directory to clear up some confusion

### Merge instructions


- [ x] Please merge after reviewing

