### PR TITLE
Add enablePrivacyForActionName in RUM browser setup parameter list

### DIFF
--- a/content/en/real_user_monitoring/browser/setup.md
+++ b/content/en/real_user_monitoring/browser/setup.md
@@ -1921,7 +1921,7 @@ See [Mask Action Names][29].
 
 `actionNameAttribute`
 : Optional<br/>
-**Type**: String<br/>
+**Type**: Boolean<br/>
 Specify your own attribute to be used to [name actions][22].
 
 `sessionSampleRate`

--- a/content/en/real_user_monitoring/browser/setup.md
+++ b/content/en/real_user_monitoring/browser/setup.md
@@ -1914,6 +1914,11 @@ Enables collection of long task events.
 **Default**: `mask` <br/>
 See [Session Replay Privacy Options][21].
 
+`enablePrivacyForActionName`
+: Optional<br/>
+**Type**: String<br/>
+See [Mask Action Names][29].
+
 `actionNameAttribute`
 : Optional<br/>
 **Type**: String<br/>
@@ -2129,3 +2134,4 @@ window.DD_RUM && window.DD_RUM.getInternalContext() // { session_id: "xxxx", app
 [26]: https://developer.mozilla.org/en-US/docs/Web/API/Event/isTrusted
 [27]: /real_user_monitoring/guide/monitor-electron-applications-using-browser-sdk
 [28]: https://www.datadoghq.com/private-beta/rum-sdk-auto-injection/
+[29]: /real_user_monitoring/session_replay/browser/privacy_options/#mask-action-names

--- a/content/en/real_user_monitoring/browser/setup.md
+++ b/content/en/real_user_monitoring/browser/setup.md
@@ -1917,6 +1917,7 @@ See [Session Replay Privacy Options][21].
 `enablePrivacyForActionName`
 : Optional<br/>
 **Type**: Boolean<br/>
+**Default**: `false` <br/>
 See [Mask Action Names][29].
 
 `actionNameAttribute`

--- a/content/en/real_user_monitoring/browser/setup.md
+++ b/content/en/real_user_monitoring/browser/setup.md
@@ -1916,12 +1916,12 @@ See [Session Replay Privacy Options][21].
 
 `enablePrivacyForActionName`
 : Optional<br/>
-**Type**: String<br/>
+**Type**: Boolean<br/>
 See [Mask Action Names][29].
 
 `actionNameAttribute`
 : Optional<br/>
-**Type**: Boolean<br/>
+**Type**: String<br/>
 Specify your own attribute to be used to [name actions][22].
 
 `sessionSampleRate`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Introduce `enablePrivacyForActionName` in RUM sdk setup configuration.
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->