### PR TITLE
[RN-v2.4.0] useAccessibilityLabel config parameter

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
@@ -211,6 +211,12 @@ Enables tracking of RUM event when no RUM View is active. By default, background
 **Type**: ProxyConfiguration<br/>
 Optional [proxy configuration][13].
 
+`useAccessibilityLabel`
+: Optional<br/>
+**Type**: Boolean<br/>
+**Default**: `true`<br/>
+Determines whether the accessibility labels can be used to name RUM actions (default is true).
+
 ## Manual instrumentation
 
 If automatic instrumentation doesn't suit your needs, you can manually create RUM Events and Logs:

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/reactnative.md
@@ -215,7 +215,7 @@ Optional [proxy configuration][13].
 : Optional<br/>
 **Type**: Boolean<br/>
 **Default**: `true`<br/>
-Determines whether the accessibility labels can be used to name RUM actions (default is true).
+Determines whether the accessibility labels are used to name RUM actions (default is true).
 
 ## Manual instrumentation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds documentation for new `useAccessibilityLabel` introduced for the first time in RN SDK v2.4.0.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Wait for React Native Datadog SDK v2.4.0 to be released

### Additional notes

The parameter has been introduced for privacy reasons. By default the SDK will try to resolve the action names by using the elements accessibility label, if available. This could lead to PIIs leaking, as it happened in previous instances such as [incident-28493](https://dd.enterprise.slack.com/archives/C07AJ9VEL1Y).

Setting `useAccessibilityLabel` to false will disable this default behaviour.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->