### PR TITLE
better document infra metrics correlation for GitLab

### DIFF
--- a/content/en/continuous_integration/guides/infrastructure_metrics_with_gitlab.md
+++ b/content/en/continuous_integration/guides/infrastructure_metrics_with_gitlab.md
@@ -10,13 +10,15 @@ further_reading:
     text: "Learn how to search and manage your pipeline executions"
 ---
 
+<div class="alert alert-info"><strong>Note</strong>: This method only applies to runners using the "Instance" or "Docker Autoscaler" executors.</div>
+
 ## Overview
 
-When you click on a GitLab job in the [CI Visibility Explorer][9], you can access an **Infrastructure** tab with information about the host displaying information about the host, system, host tags, host metrics, and more. 
+When you click on a GitLab job in the [CI Visibility Explorer][9], you can access an **Infrastructure** tab with information about the host displaying information about the host, system, host tags, host metrics, and more.
 
 {{< img src="continuous_integration/infrastructure_tab.png" alt="The Infrastructure tab displaying information about a host and its system, along with host metrics such as CPU usage and load averages." style="width:100%;">}}
 
-This guide explains how to correlate infrastructure metrics with your GitLab jobs if you are using GitLab “Instance” or “Docker Autoscaler” executors and [CI Visibility][1]. 
+This guide explains how to correlate infrastructure metrics with your GitLab jobs if you are using GitLab “Instance” or “Docker Autoscaler” executors and [CI Visibility][1].
 
 ## Prerequisites
 
@@ -24,23 +26,23 @@ The Datadog Agent must be installed in the virtual machines (VM) where the GitLa
 
 ## Ensure that the Datadog Agent is installed in your instances
 
-If you are using an [AWS Autoscaling Group][4], you should make sure that the machine image that is configured in the template launches with the [Datadog Agent][5]. 
+If you are using an [AWS Autoscaling Group][4], you should make sure that the machine image that is configured in the template launches with the [Datadog Agent][5].
 
 To test that you have performed this step successfully, you can try executing a job and you should see the host appear on the [Infrastructure List page][6].
 
-If you are using AWS, make sure that the host name is in the format `“i-xxxxx”`. If this is not the case, you should check that your instance is compatible with IMDSv1. For more information, see the [official AWS documentation][7]. 
+If you are using AWS, make sure that the host name is in the format `“i-xxxxx”`. If this is not the case, you should check that your instance is compatible with IMDSv1. For more information, see the [official AWS documentation][7].
 
 You can set this up inside the template of your AWS Autoscaling Group. The Datadog Agent uses the metadata service endpoint to resolve the host name.
 
 ## Set up CI Visibility and log collection for your GitLab jobs
 
-For instructions on setting up CI Visibility for your GitLab jobs, see [Set up Pipeline Visibility on a GitLab Pipeline][1]. 
+For instructions on setting up CI Visibility for your GitLab jobs, see [Set up Pipeline Visibility on a GitLab Pipeline][1].
 
 To test that you have performed the setup successfully, you can try running a GitLab pipeline and checking if it appears on the [**Executions** page][8].
 
 You are required to enable the collection of job logs. You can check if Datadog is receiving the logs correctly by clicking on the Logs tab of your pipeline execution.
 
-After you have completed these steps, your GitLab jobs should be correlated with infrastructure metrics. The correlation is per job and not pipeline, as different jobs may run on different hosts. The **Infrastructure** tab appears after the job is finished and Datadog receives the logs for that job. 
+After you have completed these steps, your GitLab jobs should be correlated with infrastructure metrics. The correlation is per job and not pipeline, as different jobs may run on different hosts. The **Infrastructure** tab appears after the job is finished and Datadog receives the logs for that job.
 
 ## Further reading
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -188,9 +188,15 @@ These filters can also be applied through the facet panel on the left hand side 
 
 ### Correlate infrastructure metrics to jobs
 
-If you are using self-hosted GitLab runners, you can correlate jobs with the infrastructure that is running them.
-For this feature to work, the GitLab runner must have a tag of the form `host:<hostname>`. Tags can be added while
-[registering a new runner][6]. For existing runners:
+If you are using self-hosted GitLab runners, you can correlate jobs with the infrastructure that is running them. Datadog infrastructure correlation is possible using different methods:
+
+#### Tagging runners with hostname
+
+The GitLab runner must have a tag of the form `host:<hostname>`. Tags can be added while
+[registering a new runner][6]. As a result, this method is is only available when the runner is directly running the job, excluding executors that are autoscaling the infrastructure in order to run the job
+(such as the Kubernetes, Docker Autoscaler or Instance executors) as it is not possible to add tags dynamically for those runners.
+
+For existing runners:
 
 {{< tabs >}}
 {{% tab "GitLab &gt;&equals; 15.8" %}}
@@ -206,8 +212,12 @@ through the UI by going to **Settings > CI/CD > Runners** and editing the approp
 After these steps, CI Visibility adds the hostname to each job. To see the metrics, click on a job span in the trace
 view. In the drawer, a new tab named **Infrastructure** appears which contains the host metrics.
 
+#### Instance and Docker Autoscaler executors
 CI Visibility also supports Infrastructure metrics for "Instance" and "Docker Autoscaler" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][18].
 
+#### Other executors
+
+CI Visibility does not support Infrastructure metrics for other executors such as the Kubernetes executor.
 
 ### View error messages for pipeline failures
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We are receiving a lot of questions related to the infrastructure correlation for GitLab with CI Visibility. The documentation was not very explicit about this, so I am making the limitations more prominent. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->