### PR TITLE
Updates docs for multi-index apm dashboard queries

### DIFF
--- a/content/en/glossary/terms/intelligent_retention_filter.md
+++ b/content/en/glossary/terms/intelligent_retention_filter.md
@@ -3,4 +3,4 @@ title: Intelligent Retention Filter
 core_product:
   - apm
 ---
-A Datadog default retention filter that is always active, keeping a representative proportion of traces, true high latency, and diverse error traces to help you monitor the health of your applications. It is not random, and so traces only retained by Intelligent Retention are not included in trace metrics.
+A Datadog default retention filter that is always active, keeping a representative proportion of traces, true high latency, and diverse error traces to help you monitor the health of your applications. It ensures that you always see individual sample traces in any service and resource page.

--- a/content/en/tracing/guide/trace_queries_dataset.md
+++ b/content/en/tracing/guide/trace_queries_dataset.md
@@ -46,7 +46,7 @@ To find spans that are sampled by the 1% flat sampling or the diversity sampling
 
 {{< img src="tracing/trace_queries/intelligent_retention_filter_change.png" style="width:90%; background:none; border:none; box-shadow:none;" alt="Event Overlay Intelligent Retention Filter" >}}
 
-Spans indexed by the Intelligent retention filter are excluded from APM queries [Trace Analytics monitor][5] evaluations. Therefore, monitors are **not impacted** by this change.
+Spans indexed by the Intelligent retention filter are excluded from APM queries in [Trace Analytics monitor][5] evaluations. Therefore, monitors are **not impacted** by this change.
 
 ## Further reading
 

--- a/content/en/tracing/guide/trace_queries_dataset.md
+++ b/content/en/tracing/guide/trace_queries_dataset.md
@@ -46,13 +46,7 @@ To find spans that are sampled by the 1% flat sampling or the diversity sampling
 
 {{< img src="tracing/trace_queries/intelligent_retention_filter_change.png" style="width:90%; background:none; border:none; box-shadow:none;" alt="Event Overlay Intelligent Retention Filter" >}}
 
-Spans indexed by the Intelligent retention filter are excluded from APM queries in:
-
-- Dashboards
-- Notebooks
-- [Trace Analytics monitor][5] evaluations
-
-Therefore, they are **not impacted** by this change.
+Spans indexed by the Intelligent retention filter are excluded from APM queries [Trace Analytics monitor][5] evaluations. Therefore, monitors are **not impacted** by this change.
 
 ## Further reading
 

--- a/content/en/tracing/trace_explorer/_index.md
+++ b/content/en/tracing/trace_explorer/_index.md
@@ -130,7 +130,7 @@ All spans indexed by custom retention filters or the intelligent retention filte
 
 From the timeseries view, export your query to a [dashboard][1], [monitor][2], or [notebook][3] to investigate further or to alert automatically when an aggregate number of spans crosses a specific threshold. 
 
-**Note**: Spans indexed by the intelligent retention filter are excluded from APM queries that appear in dashboards, notebooks, and from trace analytics monitor evaluations. For more information, see [Trace Retention][4].
+**Note**: Spans indexed by the intelligent retention filter are excluded from APM trace analytics monitor evaluations. For more information, see [Trace Retention][4].
 
 [1]: /dashboards/widgets/timeseries/
 [2]: /monitors/types/apm/?tab=analytics

--- a/content/en/tracing/trace_pipeline/trace_retention.md
+++ b/content/en/tracing/trace_pipeline/trace_retention.md
@@ -118,9 +118,9 @@ For example, you can create filters to keep all traces for:
 
 ## Trace search and analytics on indexed spans
 
-### In the Trace Explorer
+### In the Trace Explorer, dashboards and notebooks.
 
-By default, spans indexed by custom retention filters **and** the intelligent retention filter are included in the Trace Explorer [aggregated views][6] (timeseries, toplist, table).
+By default, spans indexed by custom retention filters **and** the intelligent retention filter are included in the Trace Explorer [aggregated views][6] (timeseries, toplist, table), as well as in dashboards and notebook queries.
 
 However, because the diversity-sampled set of data is **not uniformly sampled** (that is, not proportionally representative of the full traffic) and is biased towards errors and high latency traces, you can choose to exclude these spans from these views by adding `-retained_by:diversity_sampling` query parameter to the query.
 
@@ -131,9 +131,9 @@ The `retained_by` attribute is present on all retained spans. Its value is:
 
 {{< img src="tracing/trace_indexing_and_ingestion/retention_filters/trace_analytics.png" style="width:100%;" alt="Retained By facet" >}}
 
-### In dashboards, notebooks, and monitors
+### In trace analytics monitors
 
-For the reasons explained above, spans indexed by the intelligent retention filter are **excluded** from APM queries that appear in dashboards and notebooks, and also **excluded** from trace analytics monitor evaluation.
+For the reasons explained above, spans indexed by the intelligent retention filter are **excluded** from APM trace analytics monitor evaluation.
 
 ## Further Reading
 

--- a/content/en/tracing/trace_pipeline/trace_retention.md
+++ b/content/en/tracing/trace_pipeline/trace_retention.md
@@ -118,7 +118,7 @@ For example, you can create filters to keep all traces for:
 
 ## Trace search and analytics on indexed spans
 
-### In the Trace Explorer, dashboards and notebooks.
+### In the Trace Explorer, dashboards, and notebooks
 
 By default, spans indexed by custom retention filters **and** the intelligent retention filter are included in the Trace Explorer [aggregated views][6] (timeseries, toplist, table), as well as in dashboards and notebook queries.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
We recently made a change to include spans indexed by the intelligent retention filter in dashboards and notebooks: see more [here](https://docs.google.com/document/d/1orsLsMowaf_p6qmY-RAChiT0YvH8uBZw081rOCRa9aY/edit?usp=drive_open&ouid=104493353650582068529).
Updating the documentation accordingly

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->