### PR TITLE
[SDCI] Clarify running pipelines limitations

### DIFF
--- a/content/en/continuous_integration/pipelines/awscodepipeline.md
+++ b/content/en/continuous_integration/pipelines/awscodepipeline.md
@@ -29,7 +29,7 @@ Set up tracing on AWS CodePipeline to collect data about pipeline executions, an
 | Pipeline Visibility | Platform | Definition |
 |---|---|---|
 | [Partial retries][14] | Partial pipelines | View partially retried pipeline executions. |
-| *[Running pipelines][15] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines will show with status "Running" on Datadog. |
+| *[Running pipelines][15] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines show with status "Running" on Datadog. |
 | **Logs correlation | Logs correlation	| Correlate pipeline and job spans to logs and enable [job log correlation](#enable-log-correlation). |
 | [Approval wait time][17] | Approval wait time  | View the amount of time jobs and pipelines wait for manual approvals. |
 

--- a/content/en/continuous_integration/pipelines/awscodepipeline.md
+++ b/content/en/continuous_integration/pipelines/awscodepipeline.md
@@ -29,7 +29,7 @@ Set up tracing on AWS CodePipeline to collect data about pipeline executions, an
 | Pipeline Visibility | Platform | Definition |
 |---|---|---|
 | [Partial retries][14] | Partial pipelines | View partially retried pipeline executions. |
-| *[Running pipelines][15] | Running pipelines | View pipeline executions that are running. |
+| *[Running pipelines][15] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines will show with status "Running" on Datadog. |
 | **Logs correlation | Logs correlation	| Correlate pipeline and job spans to logs and enable [job log correlation](#enable-log-correlation). |
 | [Approval wait time][17] | Approval wait time  | View the amount of time jobs and pipelines wait for manual approvals. |
 

--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -31,7 +31,7 @@ Set up tracing in GitHub Actions to track the execution of your workflows, ident
 
 | Pipeline Visibility | Platform | Definition |
 |---|---|---|
-| [Running pipelines][12] | Running pipelines | View pipeline executions that are running. |
+| [Running pipelines][12] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines will show with status "Running" on Datadog. |
 | [Partial retries][13] | Partial pipelines | View partially retried pipeline executions. |
 | Logs correlation | Logs correlation | Correlate pipeline and job spans to logs and enable [job log collection][10]. |
 | Infrastructure metric correlation | Infrastructure metric correlation | Correlate jobs to [infrastructure host metrics][11] for GitHub jobs. |

--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -31,7 +31,7 @@ Set up tracing in GitHub Actions to track the execution of your workflows, ident
 
 | Pipeline Visibility | Platform | Definition |
 |---|---|---|
-| [Running pipelines][12] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines will show with status "Running" on Datadog. |
+| [Running pipelines][12] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines show with status "Running" on Datadog. |
 | [Partial retries][13] | Partial pipelines | View partially retried pipeline executions. |
 | Logs correlation | Logs correlation | Correlate pipeline and job spans to logs and enable [job log collection][10]. |
 | Infrastructure metric correlation | Infrastructure metric correlation | Correlate jobs to [infrastructure host metrics][11] for GitHub jobs. |

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -28,7 +28,7 @@ Set up tracing in GitLab to collect data on your pipeline executions, analyze pe
 
 | Pipeline Visibility | Platform | Definition |
 |---|---|---|
-| [Running pipelines][25] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines will show with status "Running" on Datadog. |
+| [Running pipelines][25] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines show with status "Running" on Datadog. |
 | [Partial retries][20] | Partial pipelines | View partially retried pipeline executions. |
 | [Manual steps][21] | Manual steps | View manually triggered pipelines. |
 | [Queue time][22] | Queue time | View the amount of time pipeline jobs sit in the queue before processing. |

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -28,6 +28,7 @@ Set up tracing in GitLab to collect data on your pipeline executions, analyze pe
 
 | Pipeline Visibility | Platform | Definition |
 |---|---|---|
+| [Running pipelines][25] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines will show with status "Running" on Datadog. |
 | [Partial retries][20] | Partial pipelines | View partially retried pipeline executions. |
 | [Manual steps][21] | Manual steps | View manually triggered pipelines. |
 | [Queue time][22] | Queue time | View the amount of time pipeline jobs sit in the queue before processing. |
@@ -330,3 +331,4 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 [22]: /glossary/#queue-time
 [23]: /glossary/#approval-wait-time
 [24]: /glossary/#pipeline-execution-time
+[25]: /glossary/#running-pipeline


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Pipelines with status `running` also encapsulate queued and waiting pipelines. We do not have statuses for those yet so this PR marks this as a known limitation.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->