### PR TITLE
node: kafka-node has been "coming soon" for 4 years

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -152,7 +152,6 @@ Or, modify the `package.json` file if you typically start an application with np
 | [amqplib][44]              | `>=0.5`  | Fully supported | Supports AMQP 0.9 brokers (such as RabbitMQ, or Apache Qpid) |
 | [generic-pool][45]         | `>=2`    | Fully supported |                                                        |
 | [kafkajs][46]         | `>=1.4`    | Fully supported |                                                        |
-| [kafka-node][47]           |          | Coming Soon     |                                                        |
 | [rhea][48]                 | `>=1`    | Fully supported |                                                        |
 
 ### SDK compatibility
@@ -239,7 +238,6 @@ For additional information or to discuss [leave a comment on this github issue][
 [44]: https://github.com/squaremo/amqp.node
 [45]: https://github.com/coopernurse/node-pool
 [46]: https://github.com/tulios/kafkajs
-[47]: https://github.com/SOHU-Co/kafka-node
 [48]: https://github.com/amqp/rhea
 [49]: https://github.com/aws/aws-sdk-js
 [50]: https://github.com/petkaantonov/bluebird


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- deletes the "coming soon" line for the Node.js `kafka-node` library
- there is no ongoing effort to support this library

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
- a line for this also exists in the Japanese translation; should it be removed in this PR as well?

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->