### PR TITLE
Remove log_throttling config from Serverless documentation

### DIFF
--- a/content/en/serverless/guide/agent_configuration.md
+++ b/content/en/serverless/guide/agent_configuration.md
@@ -53,7 +53,6 @@ The Agent's [main configuration file][1] is `datadog.yaml`. For the serverless A
 | `DD_APM_DD_URL`           | Define the endpoint and port to hit when using a proxy for APM. String in the format `<ENDPOINT>:<PORT>`. Because traces are forwarded in TCP, the proxy must be able to handle TCP connections.                                                        |
 | `DD_APM_REPLACE_TAGS`     | Defines a set of rules to replace or remove certain tags that contain [potentially sensitive information][3].                                                                                                                |
 | `DD_APM_IGNORE_RESOURCES` | An exclusion list of regular expressions. Any trace with a resource name that matches one of these expressions is ignored. Use a comma-separated list and surround each entry with double quotes. For example: `"^foo$", "bar$"`                                              |
-| `DD_APM_LOG_THROTTLING`   | Set to `true` to limit the total number of warnings and errors to 10 for every 10 second interval. Defaults to `true`.                                                                                                                                                    |
 
 ### Advanced networking configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Remove the `apm_config.log_throttling` config from the serverless documentation.
This config has been deprecated since 7.54.0 (released more than a month ago) by https://github.com/DataDog/datadog-agent/pull/24353.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->