### PR TITLE
Add (SAST) and (SCA) to Code Analysis SKU names

### DIFF
--- a/content/en/code_analysis/software_composition_analysis/_index.md
+++ b/content/en/code_analysis/software_composition_analysis/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Software Composition Analysis
+title: Software Composition Analysis (SCA)
 description: Learn about Datadog Software Composition Analysis to scan your imported open-source libraries for known security vulnerabilities before you ship to production.
 is_beta: true
 further_reading:

--- a/content/en/code_analysis/static_analysis/_index.md
+++ b/content/en/code_analysis/static_analysis/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Static Analysis
+title: Static Analysis (SAST)
 description: Learn about Datadog Static Analysis to scan code for quality issues and security vulnerabilities before your code reaches production.
 aliases:
 - /continuous_integration/static_analysis

--- a/content/en/code_analysis/static_analysis/_index.md
+++ b/content/en/code_analysis/static_analysis/_index.md
@@ -26,7 +26,7 @@ Code Analysis is in public beta.
 
 ## Overview
 
-Static Analysis is a clear-box software testing technique that analyzes a program's pre-production code without the need to execute the program, meaning that the program is static because it isn't running. 
+Static Analysis (SAST) is a clear-box software testing technique that analyzes a program's pre-production code without the need to execute the program, meaning that the program is static because it isn't running. 
 
 Static Analysis helps you identify maintainability issues and security vulnerabilities early in the software development life cycle (SDLC) to ensure only the highest quality, most secure code makes it to production. Static Analysis tools that scan for security vulnerabilities are also commonly referred to as Static Application Security Testing (SAST) tools.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR updates the Code Analysis docs lefthand menu to specify product names:
- Static Analysis (SAST)
- Software Composition Analysis (SCA)

Motivation:
- Searchability and discoverability: SAST and SCA are widely recognizable industry terms
- Align with billable SKUs being created this week

### Merge instructions
- [ x ] Please merge after reviewing

### Additional notes

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->