### PR TITLE
Separate Regression Detection in Error Tracking

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1920,41 +1920,46 @@ menu:
       parent: error_tracking
       identifier: error_tracking_states
       weight: 2
+    - name: Regression Detection
+      url: error_tracking/regression_detection
+      parent: error_tracking
+      identifier: error_tracking_regression_detection
+      weight: 3
     - name: Default Grouping
       url: error_tracking/default_grouping
       parent: error_tracking
       identifier: error_tracking_default_grouping
-      weight: 3
+      weight: 4
     - name: Custom Grouping
       url: error_tracking/custom_grouping
       parent: error_tracking
       identifier: error_tracking_custom_grouping
-      weight: 4
+      weight: 5
     - name: Identify Suspect Commits
       url: error_tracking/suspect_commits
       parent: error_tracking
       identifier: error_tracking_suspect_commits
-      weight: 5
+      weight: 6
     - name: APM
       url: error_tracking/apm
       parent: error_tracking
       identifier: error_tracking_apm
-      weight: 6
+      weight: 7
     - name: Logs
       url: error_tracking/logs
       parent: error_tracking
       identifier: error_tracking_logs
-      weight: 7
+      weight: 8
     - name: Real User Monitoring
       url: error_tracking/rum
       parent: error_tracking
       identifier: error_tracking_rum
-      weight: 8
+      weight: 9
     - name: Troubleshooting
       url: error_tracking/troubleshooting
       parent: error_tracking
       identifier: error_tracking_troubleshooting
-      weight: 9
+      weight: 10
     - name: Service Level Objectives
       url: service_management/service_level_objectives/
       pre: slos

--- a/content/en/error_tracking/issue_states copy.md
+++ b/content/en/error_tracking/issue_states copy.md
@@ -1,0 +1,61 @@
+---
+title: Issue States in Error Tracking
+---
+
+## Overview
+
+All issues in Error Tracking have a status to help you triage and prioritize issues or dismiss noise. There are four statuses:
+
+- **FOR REVIEW**: Ongoing and in need of attention because the issue is new or it's a regression.
+- **REVIEWED**: Triaged and needs to be fixed, either now or later. 
+- **IGNORED**: Requiring no additional investigation or action.
+- **RESOLVED**: Fixed and no longer occurring.
+
+All issues start with a FOR REVIEW status. Error Tracking automatically updates the status in the cases described below, or you can [manually update the status](#updating-an-error-status). You can also [view the history](#issue-history) of a given error's state changes.
+
+The diagram below shows how the Error Tracking states are updated automatically and manually:
+{{< img src="error_tracking/issue-states-diagram.png" alt="Error Tracking Issue States" style="width:75%;" >}}
+
+## Automatic review
+
+Error Tracking automatically marks issues as **REVIEWED** if one of the following actions has been taken:
+
+- The issue has been assigned
+- A case has been created from the issue
+
+{{< img src="error_tracking/auto-review-actions.png" alt="Error Tracking automatic review actions" style="width:75%;" >}}
+
+## Automatic resolution
+
+Error Tracking automatically marks issues as **RESOLVED** that appear to be inactive or resolved due to a lack of recent error occurrences:
+
+- If the issue was last reported in a version that is more than 14 days old, and a newer version has been released but does not report the same error, Error Tracking automatically resolves the issue. Configure your services with version tags (see instructions for [APM][1], [RUM][2], and [Logs][3]) to ensure that automatic resolution accounts for versions of your services. 
+- If `version` tags are not set up, Error Tracking automatically resolves an issue if there have been no new errors reported for that issue within the last 14 days.
+
+## Automatic re-opening through regression detection
+
+If a **RESOLVED** error recurs in a newer version of the code, or the error occurs again in code without versions, Error Tracking triggers a regression. The issue moves to the **FOR REVIEW** state, and is tagged with a **Regression** tag:
+
+{{< img src="error_tracking/regression-detection.png" alt="The details of regression in Error Tracking" style="width:90%;" >}}
+
+Regressions take into account the versions of your service where the error is known to occur, and only trigger on new versions after an issue is marked as **RESOLVED**. Configure your services with version tags (see instructions for [APM][1], [RUM][2], and [Logs][3]) to ensure that issues automatically resolve only if the same errors occur on newer versions of your services.
+
+If you don't have version tags set up, issues are tagged with **Regression** when an error occurs on an issue marked as **RESOLVED**.
+
+You can also set up [monitors][4] to alert you when regressions occur.
+
+## Updating the issue status
+
+The issue status appears anywhere the issue can be viewed, such as in the issues list or on the details panel for a given issue. To manually update the status of an issue, click the status and choose a different one in the dropdown menu.
+
+{{< img src="error_tracking/updating-issue-status.png" alt="The Activity Timeline in the Error Tracking Issue" style="width:100%;" >}}
+
+## Issue history
+View a history of your issue activity with the **Activity Timeline**. On the details panel of any Error Tracking issue, view the Activity Timeline by clicking the **Activity** tab. 
+
+{{< img src="error_tracking/issue-status-history.png" alt="The Activity Timeline in the Error Tracking Issue" style="width:80%;" >}}
+
+[1]: /tracing/services/deployment_tracking
+[2]: /real_user_monitoring/guide/setup-rum-deployment-tracking/?tab=npm
+[3]: /getting_started/tagging/unified_service_tagging/
+[4]: /monitors/types/error_tracking/

--- a/content/en/error_tracking/issue_states.md
+++ b/content/en/error_tracking/issue_states.md
@@ -1,5 +1,9 @@
 ---
 title: Issue States in Error Tracking
+further_reading:
+  - link: '/error_tracking/regression_detection/'
+    tag: 'Documentation'
+    text: 'Regression Detection'
 ---
 
 ## Overview
@@ -34,15 +38,7 @@ Error Tracking automatically marks issues as **RESOLVED** that appear to be inac
 
 ## Automatic re-opening through regression detection
 
-If a **RESOLVED** error recurs in a newer version of the code, or the error occurs again in code without versions, Error Tracking triggers a regression. The issue moves to the **FOR REVIEW** state, and is tagged with a **Regression** tag:
-
-{{< img src="error_tracking/regression-detection.png" alt="The details of regression in Error Tracking" style="width:90%;" >}}
-
-Regressions take into account the versions of your service where the error is known to occur, and only trigger on new versions after an issue is marked as **RESOLVED**. Configure your services with version tags (see instructions for [APM][1], [RUM][2], and [Logs][3]) to ensure that issues automatically resolve only if the same errors occur on newer versions of your services.
-
-If you don't have version tags set up, issues are tagged with **Regression** when an error occurs on an issue marked as **RESOLVED**.
-
-You can also set up [monitors][4] to alert you when regressions occur.
+See [Regression Detection][4].
 
 ## Updating the issue status
 
@@ -55,7 +51,11 @@ View a history of your issue activity with the **Activity Timeline**. On the det
 
 {{< img src="error_tracking/issue-status-history.png" alt="The Activity Timeline in the Error Tracking Issue" style="width:80%;" >}}
 
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
 [1]: /tracing/services/deployment_tracking
 [2]: /real_user_monitoring/guide/setup-rum-deployment-tracking/?tab=npm
 [3]: /getting_started/tagging/unified_service_tagging/
-[4]: /monitors/types/error_tracking/
+[4]: /error_tracking/regression_detection/

--- a/content/en/error_tracking/regression_detection.md
+++ b/content/en/error_tracking/regression_detection.md
@@ -1,36 +1,15 @@
 ---
-title: Issue States in Error Tracking
+title: Regression Detection
+description: Learn how a resolved error gets automatically re-opened through regression detection.
+further_reading:
+  - link: '/error_tracking/issue_states/'
+    tag: 'Documentation'
+    text: 'Issue States in Error Tracking'
 ---
 
 ## Overview
 
-All issues in Error Tracking have a status to help you triage and prioritize issues or dismiss noise. There are four statuses:
-
-- **FOR REVIEW**: Ongoing and in need of attention because the issue is new or it's a regression.
-- **REVIEWED**: Triaged and needs to be fixed, either now or later. 
-- **IGNORED**: Requiring no additional investigation or action.
-- **RESOLVED**: Fixed and no longer occurring.
-
-All issues start with a FOR REVIEW status. Error Tracking automatically updates the status in the cases described below, or you can [manually update the status](#updating-an-error-status). You can also [view the history](#issue-history) of a given error's state changes.
-
-The diagram below shows how the Error Tracking states are updated automatically and manually:
-{{< img src="error_tracking/issue-states-diagram.png" alt="Error Tracking Issue States" style="width:75%;" >}}
-
-## Automatic review
-
-Error Tracking automatically marks issues as **REVIEWED** if one of the following actions has been taken:
-
-- The issue has been assigned
-- A case has been created from the issue
-
-{{< img src="error_tracking/auto-review-actions.png" alt="Error Tracking automatic review actions" style="width:75%;" >}}
-
-## Automatic resolution
-
-Error Tracking automatically marks issues as **RESOLVED** that appear to be inactive or resolved due to a lack of recent error occurrences:
-
-- If the issue was last reported in a version that is more than 14 days old, and a newer version has been released but does not report the same error, Error Tracking automatically resolves the issue. Configure your services with version tags (see instructions for [APM][1], [RUM][2], and [Logs][3]) to ensure that automatic resolution accounts for versions of your services. 
-- If `version` tags are not set up, Error Tracking automatically resolves an issue if there have been no new errors reported for that issue within the last 14 days.
+A regression refers to the unintended reappearance of a bug or issue that was previously fixed. In Datadog, resolved issues are automatically re-opened through regression detection so that you can see all the context of the issues without duplicating information.
 
 ## Automatic re-opening through regression detection
 
@@ -54,6 +33,10 @@ The issue status appears anywhere the issue can be viewed, such as in the issues
 View a history of your issue activity with the **Activity Timeline**. On the details panel of any Error Tracking issue, view the Activity Timeline by clicking the **Activity** tab. 
 
 {{< img src="error_tracking/issue-status-history.png" alt="The Activity Timeline in the Error Tracking Issue" style="width:80%;" >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/services/deployment_tracking
 [2]: /real_user_monitoring/guide/setup-rum-deployment-tracking/?tab=npm


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Makes Regression Detection its own section in the nav based on Oli feedback ([DOCS-8398](https://datadoghq.atlassian.net/browse/DOCS-8398)).
- Cross references the landing page and the regression detection page in Further Reading.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8398]: https://datadoghq.atlassian.net/browse/DOCS-8398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ