### PR TITLE
Fix JavaScript equality symbol

### DIFF
--- a/content/en/synthetics/guide/custom-javascript-assertion.md
+++ b/content/en/synthetics/guide/custom-javascript-assertion.md
@@ -47,7 +47,7 @@ Your browser test results contain `console.error` logs.
 
 ## Assert that a radio button is checked
 
-To verify that a radio button is checked, use `return document.querySelector("<SELECTORS>").checked = true;` in the body assertion.
+To verify that a radio button is checked, use `return document.querySelector("<SELECTORS>").checked === true;` in the body assertion.
 
 ## Set the value of a specified local storage item
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?
Changes `=` to `===` in `return document.querySelector("<SELECTORS>").checked = true;`

Motivation: Strict equality comparison in JavaScript is done using `===`. Single `=` is used to assign, which is not what this code snippet is meant to do.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
No

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->