### PR TITLE
Add Snapshot API unscoped app key requirement

### DIFF
--- a/data/api/v1/translate_actions.json
+++ b/data/api/v1/translate_actions.json
@@ -234,7 +234,7 @@
     "summary": "Revoke embed"
   },
   "GetGraphSnapshot": {
-    "description": "Take graph snapshots.\n**Note**: When a snapshot is created, there is some delay before it is available.",
+    "description": "Take graph snapshots.\n\n**Notes**:\n- When a snapshot is created, there is some delay before it is available.\n- This endpoint requires an unscoped App Key.",
     "summary": "Take graph snapshots"
   },
   "MuteHost": {


### PR DESCRIPTION
### What does this PR do? What is the motivation?
1. Turns inline "Note" into a bulleted list, "Notes" (following pattern established [here](https://docs.datadoghq.com/api/latest/monitors/#create-a-monitor))
2. Adds note: "This endpoint requires an unscoped App Key." (re-using phrasing [here](https://docs.datadoghq.com/api/latest/monitors/#create-a-monitor:~:text=for%20more%20information.-,Log%20monitors%20require%20an%20unscoped%20App%20Key,-.))

#### Motivation
A customer reached out (Zendesk ticket [169490](https://datadog.zendesk.com/agent/tickets/1694390)) because they were getting a 403 from the endpoint. I found that it only works for unscoped app keys.

**Validation**:
App key:
<img width="648" alt="image" src="https://github.com/DataDog/documentation/assets/64992066/fff47a08-09a2-4960-8f74-cf7f5efc0ef5">
Endpoint result:
<img width="862" alt="image" src="https://github.com/DataDog/documentation/assets/64992066/2764cb40-ada9-4acb-bdc1-2ab12b19d593">
Updated App key:
<img width="618" alt="image" src="https://github.com/DataDog/documentation/assets/64992066/4dfdd60a-b483-48d7-bb38-0fefc39c7659">
Endpoint result:
<img width="1150" alt="image" src="https://github.com/DataDog/documentation/assets/64992066/5be22da0-7032-48b5-9cd1-512111a4763d">

### Merge instructions

- [x] Please merge after reviewing
