### PR TITLE
Add Algolia Tags in Code Analysis Documentation

### DIFF
--- a/content/en/code_analysis/_index.md
+++ b/content/en/code_analysis/_index.md
@@ -19,7 +19,7 @@ further_reading:
   tag: "Documentation"
   text: "Learn about Software Composition Analysis"
 algolia:
-  tags: ["code analysis", "datadog code analysis", "static analysis", "software composition analysis", "SAST", "SCA"]
+  tags: ['code analysis', 'datadog code analysis', 'static analysis', 'software composition analysis', 'SAST', 'SCA']
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/_index.md
+++ b/content/en/code_analysis/_index.md
@@ -18,6 +18,8 @@ further_reading:
 - link: "/security/application_security/software_composition_analysis"
   tag: "Documentation"
   text: "Learn about Software Composition Analysis"
+algolia:
+  tags: ["code analysis", "datadog code analysis", "static analysis", "software composition analysis", "SAST", "SCA"]
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/ide_plugins/_index.md
+++ b/content/en/code_analysis/ide_plugins/_index.md
@@ -6,6 +6,8 @@ further_reading:
 - link: "/developers/ide_plugins"
   tag: "Documentation"
   text: "Learn about Datadog IDE Plugins"
+algolia:
+  tags: ["code analysis", "datadog code analysis", "static analysis", "ide plugins"", "SAST"]
 ---
 
 ## Overview

--- a/content/en/code_analysis/ide_plugins/_index.md
+++ b/content/en/code_analysis/ide_plugins/_index.md
@@ -7,7 +7,7 @@ further_reading:
   tag: "Documentation"
   text: "Learn about Datadog IDE Plugins"
 algolia:
-  tags: ["code analysis", "datadog code analysis", "static analysis", "ide plugins"", "SAST"]
+  tags: ['code analysis', 'datadog code analysis', 'static analysis', 'ide plugins', 'SAST']
 ---
 
 ## Overview

--- a/content/en/code_analysis/software_composition_analysis/_index.md
+++ b/content/en/code_analysis/software_composition_analysis/_index.md
@@ -19,7 +19,7 @@ further_reading:
   tag: "Documentation"
   text: "Learn about the Source Code Integration"
 algolia:
-  tags: ["software composition analysis", "datadog software composition analysis", "library vulnerabilities", "SCA"]
+  tags: ['software composition analysis', 'datadog software composition analysis', 'library vulnerabilities', 'SCA']
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/software_composition_analysis/_index.md
+++ b/content/en/code_analysis/software_composition_analysis/_index.md
@@ -18,6 +18,8 @@ further_reading:
 - link: "/integrations/guide/source-code-integration/"
   tag: "Documentation"
   text: "Learn about the Source Code Integration"
+algolia:
+  tags: ["software composition analysis", "datadog software composition analysis", "library vulnerabilities", "SCA"]
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
@@ -7,7 +7,7 @@ further_reading:
   tag: "Blog"
   text: "Monitor all your CI pipelines with Datadog"
 algolia:
-  tags: ["software composition analysis", "ci pipeline", "SCA"]
+  tags: ['software composition analysis', 'ci pipeline', 'SCA']
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
@@ -1,11 +1,13 @@
 ---
 title: Generic CI Providers
-description: Learn about Datadog Static Analysis to scan code for quality issues and security vulnerabilities before your code reaches production.
+description: Learn how to run the Datadog CLI directly in your CI pipeline to configure environment variables, install dependencies, and scan code for quality and security issues before they reach production.
 is_beta: true
 further_reading:
 - link: "https://www.datadoghq.com/blog/monitor-ci-pipelines/"
   tag: "Blog"
   text: "Monitor all your CI pipelines with Datadog"
+algolia:
+  tags: ["software composition analysis", "ci pipeline", "SCA"]
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/software_composition_analysis/setup.md
+++ b/content/en/code_analysis/software_composition_analysis/setup.md
@@ -18,6 +18,8 @@ further_reading:
 - link: "/code_analysis/static_analysis/"
   tag: "Documentation"
   text: "Learn about Static Analysis"
+algolia:
+  tags: ["static analysis", "static analysis rules", "static application security testing", "SAST"]
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/software_composition_analysis/setup.md
+++ b/content/en/code_analysis/software_composition_analysis/setup.md
@@ -19,7 +19,7 @@ further_reading:
   tag: "Documentation"
   text: "Learn about Static Analysis"
 algolia:
-  tags: ["static analysis", "static analysis rules", "static application security testing", "SAST"]
+  tags: ['software composition analysis', 'software composition analysis rules', 'library vulnerabilities', 'SCA']
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/static_analysis/_index.md
+++ b/content/en/code_analysis/static_analysis/_index.md
@@ -12,6 +12,8 @@ further_reading:
 - link: "/integrations/guide/source-code-integration/"
   tag: "Documentation"
   text: "Learn about the Source Code Integration"
+algolia:
+  tags: ['static analysis', 'datadog static analysis', 'code quality', 'SAST']
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -6,6 +6,8 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/monitor-ci-pipelines/"
   tag: "Blog"
   text: "Monitor all your CI pipelines with Datadog"
+algolia:
+  tags: ['static analysis', 'ci pipeline', 'SAST']
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/static_analysis/setup.md
+++ b/content/en/code_analysis/static_analysis/setup.md
@@ -12,6 +12,8 @@ further_reading:
 - link: "/integrations/guide/source-code-integration/"
   tag: "Documentation"
   text: "Learn about the Source Code Integration"
+algolia:
+  tags: ['static analysis', 'static analysis rules', 'static application security testing', 'SAST']
 ---
 
 {{% site-region region="gov" %}}

--- a/content/en/code_analysis/static_analysis_rules/_index.md
+++ b/content/en/code_analysis/static_analysis_rules/_index.md
@@ -6,8 +6,6 @@ aliases:
 - /static_analysis/rules
 is_beta: true
 type: static-analysis
-algolia:
-  tags: ["static analysis", "static analysis rules", "static analysis scans", "static application security testing", "SAST"]
 rulesets:
   csharp-best-practices:
     title: "Best Practices for C#"

--- a/content/en/code_analysis/static_analysis_rules/_index.md
+++ b/content/en/code_analysis/static_analysis_rules/_index.md
@@ -217,7 +217,8 @@ cascade:
       name: Datadog Code Analysis
       url: https://www.datadoghq.com/code-analysis/
 
-
+  algolia:
+    tags: ['static analysis', 'static analysis rules', 'static analysis scans', 'static application security testing', 'SAST']
 further_reading:
   - link: "/code_analysis/"
     tag: "Documentation"

--- a/content/en/code_analysis/static_analysis_rules/_index.md
+++ b/content/en/code_analysis/static_analysis_rules/_index.md
@@ -6,7 +6,8 @@ aliases:
 - /static_analysis/rules
 is_beta: true
 type: static-analysis
-
+algolia:
+  tags: ["static analysis", "static analysis rules", "static analysis scans", "static application security testing", "SAST"]
 rulesets:
   csharp-best-practices:
     title: "Best Practices for C#"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds acronyms (SCA + SAST) and additional search terms to the Code Analysis doc pages for better search results! i.e. a search for "Static Analysis" directs a user to the Code Analysis section, not the Security > Software Composition Analysis section.

Chat with Kassen on Slack

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

A redo of https://github.com/DataDog/documentation/pull/24053.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->