### PR TITLE
Make LastPass nav entry consistent with page title

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6050,7 +6050,7 @@ menu:
       identifier: account_management_saml_google
       parent: account_management_saml
       weight: 405
-    - name: NoPassword
+    - name: LastPass
       url: account_management/saml/lastpass/
       identifier: account_management_saml_lastpass
       parent: account_management_saml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Makes the LastPass navigation entry match the page title. It previously said NoPassword, which is an outdated legacy name. Noticed by a couple of product managers.

The [actual documentation page](https://docs.datadoghq.com/account_management/saml/lastpass/) mentions NoPassword, but is titled LastPass.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->