### PR TITLE
Remove Search Tags for Static Analysis Rules Results

### DIFF
--- a/content/en/code_analysis/static_analysis_rules/_index.md
+++ b/content/en/code_analysis/static_analysis_rules/_index.md
@@ -217,8 +217,6 @@ cascade:
       name: Datadog Code Analysis
       url: https://www.datadoghq.com/code-analysis/
 
-  algolia:
-    tags: ['static analysis', 'static analysis rules', 'static analysis scans', 'static application security testing', 'SAST']
 further_reading:
   - link: "/code_analysis/"
     tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

When you search "Static Analysis" in the Docs Site, the individual Static Analysis Rules pages clog up the search results. We instead would like the documentation for Static Analysis (like the Setup pages) to show up first, so removing the search tags from the Static Analysis Rules section.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->