### PR TITLE
Update the Java profiler docs for setting the maximum stack depth

### DIFF
--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -110,7 +110,6 @@ java \
     -Ddd.env=<YOUR_ENVIRONMENT> \
     -Ddd.version=<YOUR_VERSION> \
     -Ddd.profiling.enabled=true \
-    -XX:FlightRecorderOptions=stackdepth=256 \
     -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
 ```
 
@@ -124,7 +123,6 @@ export DD_VERSION=<YOUR_VERSION>
 export DD_PROFILING_ENABLED=true
 java \
     -javaagent:dd-java-agent.jar \
-    -XX:FlightRecorderOptions=stackdepth=256 \
     -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
 ```
 
@@ -252,7 +250,7 @@ or:
 {{% tab "Datadog Profiler" %}}
 
 The Datadog allocation profiling engine contextualizes allocation profiles, which supports allocation profiles filtered by endpoint.
-In dd-java-agent earlier than v1.28.0 it is **disabled** by default. The allocation profiler relies on JVMTI APIs which could crash before OpenJDK 21.0.3 and is disabled on older JDK versions. Enable it 
+In dd-java-agent earlier than v1.28.0 it is **disabled** by default. The allocation profiler relies on JVMTI APIs which could crash before OpenJDK 21.0.3 and is disabled on older JDK versions. Enable it
 with:
 
 ```

--- a/content/en/profiler/profiler_troubleshooting/java.md
+++ b/content/en/profiler/profiler_troubleshooting/java.md
@@ -26,9 +26,25 @@ If the default setup overhead is not acceptable, you can use the profiler with m
 
 To use the minimal configuration ensure you have `dd-java-agent` version `0.70.0` then change your service invocation to the following:
 
-```
+```shell
 java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.jfr-template-override-file=minimal -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
 ```
+
+## Modify the maximum stack depth for collected stack traces
+
+If the default maximum stack depth of 512 is not sufficient for your use case, or it is causing performance issues,
+you can increase it by setting the `dd.profiling.stackdepth` system property.
+
+For example, to decrease the maximum stack depth to 256, start your service with the following JVM setting:
+
+```shell
+java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.stackdepth=256 -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
+```
+
+The same limit will be used for data collected by JFR and the Datadog profiler.
+
+**Note**: If the `-XX:FlightRecorderOptions=stackdepth=<stack-depth>` JVM argument is provided, the maximum stack depth set via the
+`dd.profiling.stackdepth` system property will be ignored in the data collected by JFR, for technical reasons.
 
 ## Increase profiler information granularity
 
@@ -39,7 +55,7 @@ If you want more granularity in your profiling data, you can specify the `compre
 
 To use the comprehensive configuration ensure you have `dd-trace-java` version `0.70.0` then change your service invocation to the following:
 
-```
+```shell
 java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.jfr-template-override-file=comprehensive -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
 ```
 
@@ -130,7 +146,7 @@ If your vendor is not on the list, [open a support ticket][2], as other vendors 
 Override templates let you specify profiling properties to override. However, the default settings are balanced for a good tradeoff between overhead and data density that cover most use cases. To use an override file, perform the following steps:
 
 1. Create an override file in a directory accessible by `dd-java-agent` at service invocation:
-    ```
+    ```shell
     touch dd-profiler-overrides.jfp
     ```
 
@@ -144,7 +160,7 @@ Override templates let you specify profiling properties to override. However, th
 
 3. When running your application with `dd-java-agent`, your service invocation must point to the override file with `-Ddd.profiling.jfr-template-override-file=</path/to/override.jfp>`, for example:
 
-    ```
+    ```shell
     java -javaagent:/path/to/dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true -Ddd.profiling.jfr-template-override-file=</path/to/override.jfp> -jar path/to/your/app.jar
     ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
It updates the Java profiler related documentation to the new ability to set the maximum stack depth for the collected data via the standard configuration options (system property and env variable).

See [PROF-8797]

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[PROF-8797]: https://datadoghq.atlassian.net/browse/PROF-8797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ