### PR TITLE
Fix reference links for PGO docs

### DIFF
--- a/content/en/profiler/guide/save-cpu-in-production-with-go-pgo.md
+++ b/content/en/profiler/guide/save-cpu-in-production-with-go-pgo.md
@@ -57,6 +57,7 @@ The `pgo` tag was implemented in dd-trace-go 1.61.0, so any profiles prior to th
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
+
 [1]: https://tip.golang.org/doc/go1.21
 [2]: /profiler/enabling/go
 [3]: https://github.com/golang/go/issues/65532


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Fix links that were broken in https://github.com/DataDog/documentation/pull/23671.

Add space between Further reading and reference links.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->