### PR TITLE
Remove CSM Windows FIM beta banner

### DIFF
--- a/layouts/shortcodes/csm-windows-setup.md
+++ b/layouts/shortcodes/csm-windows-setup.md
@@ -69,8 +69,6 @@ To get alerts whenever a Windows signal is created, create a [Notification Rule]
 
 ### Enable FIM and Registry Monitoring
 
-<div class="alert alert-warning">File Integrity Monitoring (FIM) and Registry Monitoring is in beta and should not be enabled on production workloads.</div>
-
 1. Ensure you have access to `C:\ProgramData`, which is a hidden folder.
     - In **File Explorer**, click the **View** tab, and clear the **Hidden items** checkbox. The **ProgramData** folder should now be visible when navigating to the `C:` drive. The transparent icon indicates it is a hidden folder.
 1. In `C:\ProgramData\Datadog\system-probe.yaml`, set the `fim_enabled` flag:<br><br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes beta banner for CSM Windows File Integrity Monitoring.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->