### PR TITLE
Update ruby tracer gem name in libraries.yaml

### DIFF
--- a/data/libraries.yaml
+++ b/data/libraries.yaml
@@ -343,7 +343,7 @@ Tracing:
       link: https://github.com/DataDog/dd-trace-rb
       official: true
       authors: Datadog
-      notes: gem is called 'ddtrace'.
+      notes: gem is called 'datadog'.
     - name: ddtrace-rb-method-wrapper
       link: https://github.com/brandfolder/ddtrace-rb-method-wrapper
       authors: Brandfolder


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Update ruby trace gem name from 'ddtrace' to 'datadog'

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->