### PR TITLE
Update Layer Version for Step Fn

### DIFF
--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -11,7 +11,7 @@ further_reading:
 
 ### Requirements
 * The full Step Function execution length must be less than 90 minutes for full traces.
-* Linked Lambda traces are supported for Node.js (layer v94+) and Python (layer v75+) runtimes.
+* Linked Lambda traces are supported for Node.js (layer v112+) and Python (layer v95+) runtimes.
 
 ### How it works
 Datadog AWS Step Functions Monitoring collects logs and integration metrics from the AWS integration and uses ingested logs from AWS Step Functions to generate enhanced metrics and traces for your Step Function executions.


### PR DESCRIPTION
Updating the version because it was missed with the last release

> Lambda traces will be disjoint from Step Function traces to support 128 bit trace IDs. Please upgrade your Lambda Node Layer version to v9.112.0 and Datadog Lambda Python Layer version to v6.95.0 on your Lambda functions to resolve this issue. Please reach out to Datadog support if you have any questions.