### PR TITLE
[DOCS-8428] Rename setup doc and add referencing files in k8s

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4194,215 +4194,215 @@ menu:
       identifier: observability_pipelines
       parent: log_management_heading
       weight: 10000
-    - name: Setup
-      url: observability_pipelines/setup_opw/
-      parent: observability_pipelines
-      identifier: observability_pipelines_setup_opw
-      weight: 1
     - name: Log Volume Control
       url: observability_pipelines/log_volume_control/
       parent: observability_pipelines
       identifier: observability_pipelines_log_volume_control
-      weight: 2
+      weight: 1
     - name: Datadog Agent
       url: observability_pipelines/log_volume_control/datadog_agent/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_datadog_agent
-      weight: 2001
+      weight: 101
     - name: Fluent
       url: observability_pipelines/log_volume_control/fluent/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_fluent
-      weight: 2002
+      weight: 102
     - name: HTTP Client
       url: observability_pipelines/log_volume_control/http_client/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_http_client
-      weight: 2003
+      weight: 103
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/log_volume_control/splunk_hec/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_splunk_hec
-      weight: 2004
+      weight: 104
     - name: Splunk Forwarders (TCP)
       url: observability_pipelines/log_volume_control/splunk_tcp/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_splunk_tcp
-      weight: 2005
+      weight: 105
     - name: Sumo Logic Hosted Collector
       url: observability_pipelines/log_volume_control/sumo_logic_hosted_collector/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_sumo_logic_hosted_collector
-      weight: 2006
+      weight: 106
     - name: Syslog
       url: observability_pipelines/log_volume_control/syslog/
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_syslog
-      weight: 2007
+      weight: 107
     - name: Dual Ship Logs
       url: observability_pipelines/dual_ship_logs/
       parent: observability_pipelines
       identifier: observability_pipelines_dual_ship_logs
-      weight: 3
+      weight: 2
     - name: Datadog Agent
       url: observability_pipelines/dual_ship_logs/datadog_agent/
       parent: observability_pipelines_dual_ship_logs
       identifier: observability_pipelines_dual_ship_logs_datadog_agent
-      weight: 3001
+      weight: 201
     - name: Fluent
       url: observability_pipelines/dual_ship_logs/fluent/
       parent: observability_pipelines_dual_ship_logs
       identifier: observability_pipelines_dual_ship_logs_fluent
-      weight: 3002
+      weight: 202
     - name: HTTP Client
       url: observability_pipelines/dual_ship_logs/http_client/
       parent: observability_pipelines_dual_ship_logs
       identifier: observability_pipelines_dual_ship_logs_http_client
-      weight: 3003
+      weight: 203
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/dual_ship_logs/splunk_hec/
       parent: observability_pipelines_dual_ship_logs
       identifier: observability_pipelines_dual_ship_logs_splunk_hec
-      weight: 3004
+      weight: 204
     - name: Splunk Forwarders (TCP)
       url: observability_pipelines/dual_ship_logs/splunk_tcp/
       parent: observability_pipelines_dual_ship_logs
       identifier: observability_pipelines_dual_ship_logs_splunk_tcp
-      weight: 3005
+      weight: 205
     - name: Sumo Logic Hosted Collector
       url: observability_pipelines/dual_ship_logs/sumo_logic_hosted_collector/
       parent: observability_pipelines_dual_ship_logs
       identifier: observability_pipelines_dual_ship_logs_sumo_logic_hosted_collector
-      weight: 3006
+      weight: 206
     - name: Syslog
       url: observability_pipelines/dual_ship_logs/syslog/
       parent: observability_pipelines_dual_ship_logs
       identifier: observability_pipelines_dual_ship_logs_syslog
-      weight: 3007
+      weight: 207
     - name: Archive Logs
       url: observability_pipelines/archive_logs/
       parent: observability_pipelines
       identifier: observability_pipelines_archive_logs
-      weight: 4
+      weight: 3
     - name: Datadog Agent
       url: observability_pipelines/archive_logs/datadog_agent/
       parent: observability_pipelines_archive_logs
       identifier: observability_pipelines_archive_logs_datadog_agent
-      weight: 4001
+      weight: 301
     - name: Fluent
       url: observability_pipelines/archive_logs/fluent/
       parent: observability_pipelines_archive_logs
       identifier: observability_pipelines_archive_logs_fluent
-      weight: 4002
+      weight: 302
     - name: HTTP Client
       url: observability_pipelines/archive_logs/http_client/
       parent: observability_pipelines_archive_logs
       identifier: observability_pipelines_archive_logs_http_client
-      weight: 4003
+      weight: 303
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/archive_logs/splunk_hec/
       parent: observability_pipelines_archive_logs
       identifier: observability_pipelines_archive_logs_splunk_hec
-      weight: 4004
+      weight: 304
     - name: Splunk Forwarders (TCP)
       url: observability_pipelines/archive_logs/splunk_tcp/
       parent: observability_pipelines_archive_logs
       identifier: observability_pipelines_archive_logs_splunk_tcp
-      weight: 4005
+      weight: 305
     - name: Sumo Logic Hosted Collector
       url: observability_pipelines/archive_logs/sumo_logic_hosted_collector/
       parent: observability_pipelines_archive_logs
       identifier: observability_pipelines_archive_logs_sumo_logic_hosted_collector
-      weight: 4006
+      weight: 306
     - name: Syslog
       url: observability_pipelines/archive_logs/syslog/
       parent: observability_pipelines_archive_logs
       identifier: observability_pipelines_archive_logs_syslog
-      weight: 4007
+      weight: 307
     - name: Split Logs
       url: observability_pipelines/split_logs/
       parent: observability_pipelines
       identifier: observability_pipelines_split_logs
-      weight: 5
+      weight: 4
     - name: Datadog Agent
       url: observability_pipelines/split_logs/datadog_agent/
       parent: observability_pipelines_split_logs
       identifier: observability_pipelines_split_logs_datadog_agent
-      weight: 5001
+      weight: 401
     - name: Fluent
       url: observability_pipelines/split_logs/fluent/
       parent: observability_pipelines_split_logs
       identifier: observability_pipelines_split_logs_fluent
-      weight: 5002
+      weight: 402
     - name: HTTP Client
       url: observability_pipelines/split_logs/http_client/
       parent: observability_pipelines_split_logs
       identifier: observability_pipelines_split_logs_http_client
-      weight: 5003
+      weight: 403
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/split_logs/splunk_hec/
       parent: observability_pipelines_split_logs
       identifier: observability_pipelines_split_logs_splunk_hec
-      weight: 5004
+      weight: 404
     - name: Splunk Forwarders (TCP)
       url: observability_pipelines/split_logs/splunk_tcp/
       parent: observability_pipelines_split_logs
       identifier: observability_pipelines_split_logs_splunk_tcp
-      weight: 5005
+      weight: 405
     - name: Sumo Logic Hosted Collector
       url: observability_pipelines/split_logs/sumo_logic_hosted_collector/
       parent: observability_pipelines_split_logs
       identifier: observability_pipelines_split_logs_sumo_logic_hosted_collector
-      weight: 5006
+      weight: 406
     - name: Syslog
       url: observability_pipelines/split_logs/syslog/
       parent: observability_pipelines_split_logs
       identifier: observability_pipelines_split_logs_syslog
-      weight: 5007
+      weight: 407
     - name: Sensitive Data Redaction
       url: observability_pipelines/sensitive_data_redaction/
       parent: observability_pipelines
       identifier: observability_pipelines_sensitive_data_redaction
-      weight: 6
+      weight: 5
     - name: Datadog Agent
       url: observability_pipelines/sensitive_data_redaction/datadog_agent/
       parent: observability_pipelines_sensitive_data_redaction
       identifier: observability_pipelines_sensitive_data_redaction_datadog_agent
-      weight: 6001
+      weight: 501
     - name: Fluent
       url: observability_pipelines/sensitive_data_redaction/fluent/
       parent: observability_pipelines_sensitive_data_redaction
       identifier: observability_pipelines_sensitive_data_redaction_fluent
-      weight: 6002
+      weight: 502
     - name: HTTP Client
       url: observability_pipelines/sensitive_data_redaction/http_client/
       parent: observability_pipelines_sensitive_data_redaction
       identifier: observability_pipelines_sensitive_data_redaction_http_client
-      weight: 6003
+      weight: 503
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/sensitive_data_redaction/splunk_hec/
       parent: observability_pipelines_sensitive_data_redaction
       identifier: observability_pipelines_sensitive_data_redaction_splunk_hec
-      weight: 6004
+      weight: 504
     - name: Splunk Forwarders (TCP)
       url: observability_pipelines/sensitive_data_redaction/splunk_tcp/
       parent: observability_pipelines_sensitive_data_redaction
       identifier: observability_pipelines_sensitive_data_redaction_splunk_tcp
-      weight: 6005
+      weight: 505
     - name: Sumo Logic Hosted Collector
       url: observability_pipelines/sensitive_data_redaction/sumo_logic_hosted_collector/
       parent: observability_pipelines_sensitive_data_redaction
       identifier: observability_pipelines_sensitive_data_redaction_sumo_logic_hosted_collector
-      weight: 6006
+      weight: 506
     - name: Syslog
       url: observability_pipelines/sensitive_data_redaction/syslog/
       parent: observability_pipelines_sensitive_data_redaction
       identifier: observability_pipelines_sensitive_data_redaction_syslog
-      weight: 6007
+      weight: 507
     - name: Update Existing Pipelines
       url: observability_pipelines/update_existing_pipelines/
       parent: observability_pipelines
       identifier: observability_pipelines_update_existing_pipelines
+      weight: 6
+    - name: Advanced Configurations
+      url: observability_pipelines/advanced_configurations/
+      parent: observability_pipelines
+      identifier: observability_pipelines_advanced_configurations
       weight: 7
     - name: Best Practices for Scaling Observability Pipelines
       url: observability_pipelines/best_practices_for_scaling_observability_pipelines/

--- a/content/en/observability_pipelines/_index.md
+++ b/content/en/observability_pipelines/_index.md
@@ -57,24 +57,25 @@ The Datadog UI provides a control plane to manage your Observability Pipelines W
 
 ## Get started
 
-1. [Set up bootstrap options for the Observability Pipelines Worker][1].
-1. Navigate to [Observability Pipelines][2].
+1. Navigate to [Observability Pipelines][1].
 1. Select a use case:
-    - [Log volume control][3]
-    - [Dual ship logs][4]
-    - [Split logs][5]
-    - [Archive logs to Datadog Archives][6]
-    - [Sensitive data redaction][7]
+    - [Log volume control][2]
+    - [Dual ship logs][3]
+    - [Split logs][4]
+    - [Archive logs to Datadog Archives][5]
+    - [Sensitive data redaction][6]
 1. Enable monitors.
+
+See [Advanced Configurations][7] for bootstrapping options and for details on setting up the Worker with Kubernetes.
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /observability_pipelines/setup_opw/
-[2]: https://app.datadoghq.com/observability-pipelines
-[3]: /observability_pipelines/log_volume_control/
-[4]: /observability_pipelines/dual_ship_logs/
-[5]: /observability_pipelines/split_logs/
-[6]: /observability_pipelines/archive_logs/
-[7]: /observability_pipelines/sensitive_data_redaction/
+[1]: https://app.datadoghq.com/observability-pipelines
+[2]: /observability_pipelines/log_volume_control/
+[3]: /observability_pipelines/dual_ship_logs/
+[4]: /observability_pipelines/split_logs/
+[5]: /observability_pipelines/archive_logs/
+[6]: /observability_pipelines/sensitive_data_redaction/
+[7]: /observability_pipelines/setup_opw/

--- a/content/en/observability_pipelines/advanced_configurations.md
+++ b/content/en/observability_pipelines/advanced_configurations.md
@@ -84,9 +84,9 @@ To set bootstrap options, do one of the following:
 
 ## Referencing files in Kubernetes
 
-If you are referencing files (for example, `credentials.json` for Google Cloud Storage or TLS certificates for sources) in Kubernetes, you need to use `volumeMounts[*].subPath` to mount files from `configMap` or `secret`.
+If you are referencing files in Kubernetes for Google Cloud Storage authentication, TLS certificates for certain sources, or an enrichment table processor, you need to use `volumeMounts[*].subPath` to mount files from `configMap` or `secret`.
 
-For example, if you are have a `secret` defined as:
+For example, if you have a `secret` defined as:
 
 ```
 apiVersion: v1
@@ -118,7 +118,7 @@ extraVolumeMounts:
     subPath: credentials2.json
 ```
 
-**Note**: If you override  the`datadog.dataDir` parameter, you need to override the `mountPath` as well.
+**Note**: If you override the`datadog.dataDir` parameter, you need to override the `mountPath` as well.
 
 ## Further reading
 

--- a/content/en/observability_pipelines/advanced_configurations.md
+++ b/content/en/observability_pipelines/advanced_configurations.md
@@ -84,7 +84,7 @@ To set bootstrap options, do one of the following:
 
 ## Referencing files in Kubernetes
 
-If you are referencing files in Kubernetes for Google Cloud Storage authentication, TLS certificates for certain sources, or an enrichment table processor, you need to use `volumeMounts[*].subPath` to mount files from `configMap` or `secret`.
+If you are referencing files in Kubernetes for Google Cloud Storage authentication, TLS certificates for certain sources, or an enrichment table processor, you need to use `volumeMounts[*].subPath` to mount files from a `configMap` or `secret`.
 
 For example, if you have a `secret` defined as:
 

--- a/layouts/shortcodes/observability_pipelines/configure_log_archive/google_cloud_storage/instructions.md
+++ b/layouts/shortcodes/observability_pipelines/configure_log_archive/google_cloud_storage/instructions.md
@@ -12,6 +12,8 @@
 1. Create a Google Cloud Storage [service account][9092].
 1. Follow these [instructions][9093] to create a service account key and download the JSON service account key file. This is the credentials JSON file and must be placed under `DD_OP_DATA_DIR/config`.
 
+**Note**: If you are installing the Worker in Kubernetes, see [Referencing files in Kubernetes][9097] for information on how to reference the credentials file.
+
 ### Connect the storage bucket to Datadog Log Archives
 
 1. Navigate to Datadog [Log Forwarding][9094].
@@ -34,3 +36,4 @@ See the [Log Archives documentation][9096] for additional information.
 [9094]: https://app.datadoghq.com/logs/pipelines/log-forwarding
 [9095]: /logs/log_configuration/archives/?tab=awss3#advanced-settings
 [9096]: /logs/log_configuration/archives
+[9097]: /observability_pipelines/advanced_configurations/#referencing-files-in-kubernetes

--- a/layouts/shortcodes/observability_pipelines/destination_settings/chronicle.md
+++ b/layouts/shortcodes/observability_pipelines/destination_settings/chronicle.md
@@ -3,6 +3,9 @@ To authenticate the Worker for Google Chronicle:
 1. Create a Google Cloud Storage [service account][10001].
 1. Follow these [instructions][10002] to create a service account key and download the JSON service account key file. This is the credentials JSON file and must be placed under `DD_OP_DATA_DIR/config`.
 
+**Note**: If you are installing the Worker in Kubernetes, see [Referencing files in Kubernetes][10004] for information on how to reference the credentials file.
+
+
 To set up the Worker's Google Chronicle destination:
 
 1. Enter the customer ID for your Google Chronicle instance.
@@ -15,3 +18,4 @@ To set up the Worker's Google Chronicle destination:
 [10001]: /logs/log_configuration/archives/?tab=awss3#advanced-settings
 [10002]: /logs/log_configuration/archives
 [10003]: https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers#with-default-parser
+[10004]: /observability_pipelines/advanced_configurations/#referencing-files-in-kubernetes

--- a/layouts/shortcodes/observability_pipelines/processors/enrichment_table.md
+++ b/layouts/shortcodes/observability_pipelines/processors/enrichment_table.md
@@ -8,6 +8,7 @@ To set up the enrichment table processor:
    - For the **File** type:
         1. Enter the file path.
         1. Enter the column name. The column name in the enrichment table is used for matching the source attribute value. See the [Enrichment file example](#enrichment-file-example).
+        <br>**Note**: If you are installing the Worker in Kubernetes, see [Referencing files in Kubernetes][10011] for information on how to reference the file.
    - For the **GeoIP** type, enter the GeoIP path.
 
 ##### Enrichment file example
@@ -36,4 +37,4 @@ merchant_info {
     "state":"Colorado"
 }
 ```
-
+[10011]: /observability_pipelines/advanced_configurations/#referencing-files-in-kubernetes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

- Renames Setup to Advanced Configuration.
- Move nav item lower
- Add info on referencing files in Kubernetes

[DOCS-8428](https://datadoghq.atlassian.net/browse/DOCS-8428)

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8428]: https://datadoghq.atlassian.net/browse/DOCS-8428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ