### PR TITLE
Fix OP Google Chronicle destination setting links

### DIFF
--- a/layouts/shortcodes/observability_pipelines/destination_settings/chronicle.md
+++ b/layouts/shortcodes/observability_pipelines/destination_settings/chronicle.md
@@ -12,6 +12,6 @@ To set up the Worker's Google Chronicle destination:
 
 **Note**: Logs sent to the Google Chronicle destination must have ingestion labels. For example, if the logs are from a A10 load balancer, it must have the ingestion label `A10_LOAD_BALANCER`. See Google Cloud's [Support log types with a default parser][10003] for a list of available log types and their respective ingestion labels.
 
-[10001]: /logs/log_configuration/archives/?tab=awss3#advanced-settings
-[10002]: /logs/log_configuration/archives
+[10001]: https://console.cloud.google.com/storage
+[10002]: https://cloud.google.com/docs/authentication#service-accounts
 [10003]: https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers#with-default-parser


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Fix links.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->