### PR TITLE
Update description of "span" for EWMA.

### DIFF
--- a/content/en/dashboards/functions/smoothing.md
+++ b/content/en/dashboards/functions/smoothing.md
@@ -28,7 +28,7 @@ The `autosmooth()` function cannot be used in monitors. Being that the span is c
 | :----      | :-------                                                            | :---------                 |
 | `ewma_3()` | Compute the exponentially weighted moving average over a span of 3. | `ewma_3(<METRIC_NAME>{*})` |
 
-Note: The span value is weighted average age of the series. So `ewma_3()` is comparable to a 3-day rolling average.
+Note: The span value is twice the weighted average age of the series. So `ewma_3()` is comparable to a 3-day rolling average.
 
 Example:
 
@@ -42,7 +42,7 @@ If a metric `10 + x%10 {*}` increments itself by 1 starting from 10 until it dro
 | :----      | :-------                                                            | :---------                 |
 | `ewma_5()` | Compute the exponentially weighted moving average over a span of 5. | `ewma_5(<METRIC_NAME>{*})` |
 
-Note: The span value is weighted average age of the series. So `ewma_5()` is comparable to a 5-day rolling average.
+Note: The span value is twice the weighted average age of the series. So `ewma_5()` is comparable to a 5-day rolling average.
 
 Example:
 
@@ -56,7 +56,7 @@ If a metric `10 + x%10 {*}` increments itself by 1 starting from 10 until it dro
 | :----      | :-------                                                            | :---------                 |
 | `ewma_7()` | Compute the exponentially weighted moving average over a span of 7. | `ewma_7(<METRIC_NAME>{*})` |
 
-Note: The span value is weighted average age of the series. So `ewma_7()` is comparable to a 7-day rolling average.
+Note: The span value is twice the weighted average age of the series. So `ewma_7()` is comparable to a 7-day rolling average.
 
 ### Ewma 10
 
@@ -64,7 +64,7 @@ Note: The span value is weighted average age of the series. So `ewma_7()` is com
 | :----       | :-------                                                             | :---------                  |
 | `ewma_10()` | Compute the exponentially weighted moving average over a span of 10. | `ewma_10(<METRIC_NAME>{*})` |
 
-Note: The span value is weighted average age of the series. So `ewma_10()` is comparable to a 10-day rolling average.
+Note: The span value is twice the weighted average age of the series. So `ewma_10()` is comparable to a 10-day rolling average.
 
 Example:
 
@@ -78,7 +78,7 @@ If a metric `10 + x%10 {*}` increments itself by 1 starting from 10 until it dro
 | :----       | :-------                                                             | :---------                  |
 | `ewma_20()` | Compute the exponentially weighted moving average over a span of 20. | `ewma_20(<METRIC_NAME>{*})` |
 
-Note: The span value is weighted average age of the series. So `ewma_20()` is comparable to a 20-day rolling average.
+Note: The span value is twice the weighted average age of the series. So `ewma_20()` is comparable to a 20-day rolling average.
 
 Example:
 

--- a/content/en/dashboards/functions/smoothing.md
+++ b/content/en/dashboards/functions/smoothing.md
@@ -28,7 +28,7 @@ The `autosmooth()` function cannot be used in monitors. Being that the span is c
 | :----      | :-------                                                            | :---------                 |
 | `ewma_3()` | Compute the exponentially weighted moving average over a span of 3. | `ewma_3(<METRIC_NAME>{*})` |
 
-Note: The span value is the number of data points. So `ewma_3()` uses the last 3 data points to calculate the average.
+Note: The span value is weighted average age of the series. So `ewma_3()` is comparable to a 3-day rolling average.
 
 Example:
 
@@ -42,7 +42,7 @@ If a metric `10 + x%10 {*}` increments itself by 1 starting from 10 until it dro
 | :----      | :-------                                                            | :---------                 |
 | `ewma_5()` | Compute the exponentially weighted moving average over a span of 5. | `ewma_5(<METRIC_NAME>{*})` |
 
-Note: The span value is the number of data points. So `ewma_5()` uses the last 5 data points to calculate the average.
+Note: The span value is weighted average age of the series. So `ewma_5()` is comparable to a 5-day rolling average.
 
 Example:
 
@@ -56,7 +56,7 @@ If a metric `10 + x%10 {*}` increments itself by 1 starting from 10 until it dro
 | :----      | :-------                                                            | :---------                 |
 | `ewma_7()` | Compute the exponentially weighted moving average over a span of 7. | `ewma_7(<METRIC_NAME>{*})` |
 
-Note: The span value is the number of data points. So `ewma_7()` uses the last 7 data points to calculate the average.
+Note: The span value is weighted average age of the series. So `ewma_7()` is comparable to a 7-day rolling average.
 
 ### Ewma 10
 
@@ -64,7 +64,7 @@ Note: The span value is the number of data points. So `ewma_7()` uses the last 7
 | :----       | :-------                                                             | :---------                  |
 | `ewma_10()` | Compute the exponentially weighted moving average over a span of 10. | `ewma_10(<METRIC_NAME>{*})` |
 
-Note: The span value is the number of data points. So `ewma_10()` uses the last 10 data points to calculate the average.
+Note: The span value is weighted average age of the series. So `ewma_10()` is comparable to a 10-day rolling average.
 
 Example:
 

--- a/content/en/dashboards/functions/smoothing.md
+++ b/content/en/dashboards/functions/smoothing.md
@@ -78,7 +78,7 @@ If a metric `10 + x%10 {*}` increments itself by 1 starting from 10 until it dro
 | :----       | :-------                                                             | :---------                  |
 | `ewma_20()` | Compute the exponentially weighted moving average over a span of 20. | `ewma_20(<METRIC_NAME>{*})` |
 
-Note: The span value is the number of data points. So `ewma_20()` uses the last 20 data points to calculate the average.
+Note: The span value is weighted average age of the series. So `ewma_20()` is comparable to a 20-day rolling average.
 
 Example:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This fixes the description of "span" for EWMA to be accurate.  EWMA (logically) uses all data points (with diminishing weights for older data), so the existing description is wrong.

Unfortunately, I couldn't find a good standard description of what the span actually *is*.  The technical definition is that it sets the smoothing constant (also not a standardized term) to 2/(span+1).  I chose a description based on [this stackoverflow post](https://stats.stackexchange.com/questions/534210/what-does-span-mean-in-exponential-moving-average) which is not the most helpful, but gives some guidance on what the span does while being correct.

(See also my comment on TSQ-851)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->