### PR TITLE
Make Dynamic Sampling docs public

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1925,26 +1925,31 @@ menu:
       parent: error_tracking
       identifier: error_tracking_suspect_commits
       weight: 6
+    - name: Dynamic Sampling
+      url: error_tracking/dynamic_sampling
+      parent: error_tracking
+      identifier: error_tracking_dynamic_sampling
+      weight: 7
     - name: APM
       url: error_tracking/apm
       parent: error_tracking
       identifier: error_tracking_apm
-      weight: 7
+      weight: 8
     - name: Logs
       url: error_tracking/logs
       parent: error_tracking
       identifier: error_tracking_logs
-      weight: 8
+      weight: 9
     - name: Real User Monitoring
       url: error_tracking/rum
       parent: error_tracking
       identifier: error_tracking_rum
-      weight: 9
+      weight: 10
     - name: Troubleshooting
       url: error_tracking/troubleshooting
       parent: error_tracking
       identifier: error_tracking_troubleshooting
-      weight: 10
+      weight: 11
     - name: Service Level Objectives
       url: service_management/service_level_objectives/
       pre: slos

--- a/content/en/error_tracking/dynamic_sampling.md
+++ b/content/en/error_tracking/dynamic_sampling.md
@@ -1,7 +1,7 @@
 ---
 title: Error Tracking Dynamic Sampling
 is_beta: false
-private: true
+private: false
 description: Learn about how Dynamic Sampling in Error Tracking can make sure that your volume isn't consumed all at once.
 further_reading:
 - link: '/logs/error_tracking/manage_data_collection'


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Makes the Error Tracking Dynamic Sampling page public and adds a menu item.

This page was private because the feature was still being rolled out. It has now been rolled out to all customers, so it can be published.

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->