### PR TITLE
Add reference link for full-text search

### DIFF
--- a/content/en/logs/explorer/search.md
+++ b/content/en/logs/explorer/search.md
@@ -19,7 +19,7 @@ further_reading:
 
 While information from individual logs can be useful visualized as a list, sometimes valuable information can be accessed through aggregation. To access this information, search for logs in the [Log Explorer][5] and display them as timeseries, top lists, tree maps, pie charts, or tables.
 
-Log Explorer search consists of a time range and a search query, mixing `key:value` and full-text search. 
+Log Explorer search consists of a time range and a search query, mixing `key:value` and [full-text search][6]. 
 
 ## Search query
 
@@ -27,7 +27,7 @@ For example, to filter on logs produced by a web store service, with an error st
 
 {{< img src="logs/explorer/search_filter.png" alt="Create a search query in the Log Explorer that filters for error logs of rejected payments for a web store service" style="width:100%;" >}}
 
-[Indexed Logs][1] support both full-text search and `key:value` search queries.
+[Indexed Logs][1] support both [full-text search][6] and `key:value` search queries.
 
 **Note**: `key:value` queries **do not** require that you [declare a facet][2] beforehand.
 
@@ -94,3 +94,4 @@ You can interact with the search bar with your mouse, as well as by using keyboa
 [3]: /logs/search-syntax
 [4]: /dashboards/guide/custom_time_frames
 [5]: /logs/explorer/
+[6]: https://en.wikipedia.org/wiki/Full-text_search

--- a/content/en/logs/explorer/search.md
+++ b/content/en/logs/explorer/search.md
@@ -19,7 +19,7 @@ further_reading:
 
 While information from individual logs can be useful visualized as a list, sometimes valuable information can be accessed through aggregation. To access this information, search for logs in the [Log Explorer][5] and display them as timeseries, top lists, tree maps, pie charts, or tables.
 
-Log Explorer search consists of a time range and a search query, mixing `key:value` and [full-text search][6]. 
+Log Explorer search consists of a time range and a search query, mixing `key:value` and [full-text search][6].  **Note**: Full-text search supports searching texts in logs.  It utilizes n-gram and morphemic analysis. If precision is required, search with `key:value`.
 
 ## Search query
 

--- a/content/en/logs/explorer/search.md
+++ b/content/en/logs/explorer/search.md
@@ -19,7 +19,7 @@ further_reading:
 
 While information from individual logs can be useful visualized as a list, sometimes valuable information can be accessed through aggregation. To access this information, search for logs in the [Log Explorer][5] and display them as timeseries, top lists, tree maps, pie charts, or tables.
 
-Log Explorer search consists of a time range and a search query, mixing `key:value` and [full-text search][6].  **Note**: Full-text search supports searching texts in logs.  It utilizes n-gram and morphemic analysis. If precision is required, search with `key:value`.
+Log Explorer search consists of a time range and a search query, mixing `key:value` and [full-text search][6].
 
 ## Search query
 
@@ -94,4 +94,4 @@ You can interact with the search bar with your mouse, as well as by using keyboa
 [3]: /logs/search-syntax
 [4]: /dashboards/guide/custom_time_frames
 [5]: /logs/explorer/
-[6]: https://en.wikipedia.org/wiki/Full-text_search
+[6]: /logs/explorer/search_syntax/#full-text-search


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Hyperlink logs full-text search to the wikipedia definition of what a full-text search is.
[DOCS-8388](https://datadoghq.atlassian.net/browse/DOCS-8388)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Do not merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8388]: https://datadoghq.atlassian.net/browse/DOCS-8388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ