### PR TITLE
add conditional to page reload and scroll

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -12,13 +12,15 @@ import { loadInstantSearch } from './algolia';
 const { env } = document.documentElement.dataset;
 const { gaTag } = configDocs[env];
 
-function loadPage(newUrl) {
-    // scroll to top of page on new page load
-    window.scroll({
-        top: 0,
-        left: 0,
-        behavior: "instant"
-    });
+function loadPage(newUrl, hashCheck = true) {
+    if (hashCheck) {
+        // only scroll to the top of the page if no conditions are fulfilled from datadog-docs.js ln 411-417
+        window.scrollTo({
+            top: 0,
+            left: 0,
+            behavior: "instant"
+        })
+    }
 
     let mainContent = document.getElementById('mainContent');
 

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -406,12 +406,21 @@ function replaceURL(inputUrl) {
     }
     return inputUrl.replace('https://www.docs.datadoghq.com', thisurl);
 }
+let hashChangeCheck = false;
+
+window.addEventListener('hashchange', (e) => {
+    const newHash = e.newURL.split('#')[1];
+    const oldHash = e.oldURL.split('#')[1];
+    if (window.location.hash && ((!oldHash && newHash) || ((newHash && oldHash) && (newHash === oldHash)))) {
+        hashChangeCheck = true;
+    }
+})
 
 window.addEventListener(
     'popstate',
     function (event) {
         setMobileNav();
-        loadPage(window.location.href);
+        loadPage(window.location.href, !hashChangeCheck);
         closeNav();
         getPathElement();
     }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fixes a bug on Safari and Firefox where using the righthand side table of contents would not work properly and improves reactivity across all browsers
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->