### PR TITLE
Remove missed reference to Agent 7 in upgrade documentation

### DIFF
--- a/content/en/agent/guide/upgrade_between_minor_versions.md
+++ b/content/en/agent/guide/upgrade_between_minor_versions.md
@@ -13,11 +13,11 @@ aliases:
 
 The recommended way to upgrade between minor versions of the Agent is to use the `install_script_agent7.sh` script. The following commands work on all supported Linux distributions.
 
-Upgrading to a given Agent 7 minor version:
+Upgrading to a given Agent minor version:
 
 : `DD_AGENT_MINOR_VERSION=<target_minor> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
 
-Upgrading to the latest Agent 7 minor version:
+Upgrading to the latest Agent minor version:
 
 : `bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

In https://github.com/DataDog/documentation/pull/24164 the linux tab had left Agent 7 in the text, this PR fixes this error.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->