### PR TITLE
updates include markdown shortcode

### DIFF
--- a/config/development/config.yaml
+++ b/config/development/config.yaml
@@ -3,7 +3,7 @@ timeout: 100000
 enableGitInfo: true
 
 # default to just building english on local dev for a faster build
-disableLanguages:
-  - fr
-  - ja
-  - ko
+# disableLanguages:
+#   - fr
+#   - ja
+#   - ko

--- a/config/development/config.yaml
+++ b/config/development/config.yaml
@@ -3,7 +3,7 @@ timeout: 100000
 enableGitInfo: true
 
 # default to just building english on local dev for a faster build
-# disableLanguages:
-#   - fr
-#   - ja
-#   - ko
+disableLanguages:
+  - fr
+  - ja
+  - ko

--- a/content/en/cloud_cost_management/monitors/_index.md
+++ b/content/en/cloud_cost_management/monitors/_index.md
@@ -22,4 +22,4 @@ further_reading:
   text: "Consult your monitor status"
 ---
 
-{{< include-markdown "content/en/monitors/types/cloud_cost.md" >}}
+{{< include-markdown "monitors/types/cloud_cost" >}}

--- a/content/en/error_tracking/monitors.md
+++ b/content/en/error_tracking/monitors.md
@@ -3,4 +3,4 @@ title: Error Tracking Monitors
 description: Learn about the Error Tracking monitors.
 ---
 
-{{< include-markdown "content/en/monitors/types/error_tracking.md" >}}
+{{< include-markdown "monitors/types/error_tracking" >}}

--- a/content/en/logs/error_tracking/custom_grouping.md
+++ b/content/en/logs/error_tracking/custom_grouping.md
@@ -3,4 +3,4 @@ title: Custom Grouping
 description: Customize how error spans are grouped into issues.
 ---
 
-{{< include-markdown "content/en/error_tracking/custom_grouping.md" >}}
+{{< include-markdown "error_tracking/custom_grouping" >}}

--- a/content/en/logs/error_tracking/default_grouping.md
+++ b/content/en/logs/error_tracking/default_grouping.md
@@ -3,4 +3,4 @@ title: Default Grouping
 description: Understand how errors are grouped into issues.
 ---
 
-{{< include-markdown "content/en/error_tracking/default_grouping.md" >}}
+{{< include-markdown "error_tracking/default_grouping" >}}

--- a/content/en/logs/error_tracking/dynamic_sampling.md
+++ b/content/en/logs/error_tracking/dynamic_sampling.md
@@ -3,4 +3,4 @@ title: Error Tracking Dynamic Sampling
 description:  Learn how to use Dynamic Sampling in Error Tracking to ensure your volume isn't consumed all at once.
 ---
 
-{{< include-markdown "content/en/error_tracking/dynamic_sampling.md" >}}
+{{< include-markdown "error_tracking/dynamic_sampling" >}}

--- a/content/en/logs/error_tracking/explorer.md
+++ b/content/en/logs/error_tracking/explorer.md
@@ -7,4 +7,4 @@ further_reading:
   text: 'Learn about Error Tracking Monitors'
 ---
 
-{{< include-markdown "content/en/error_tracking/explorer.md" >}}
+{{< include-markdown "error_tracking/explorer" >}}

--- a/content/en/logs/error_tracking/issue_states.md
+++ b/content/en/logs/error_tracking/issue_states.md
@@ -2,4 +2,4 @@
 title: Issue States in Error Tracking
 ---
 
-{{< include-markdown "content/en/error_tracking/issue_states.md" >}}
+{{< include-markdown "error_tracking/issue_states" >}}

--- a/content/en/logs/error_tracking/monitors.md
+++ b/content/en/logs/error_tracking/monitors.md
@@ -3,4 +3,4 @@ title: Error Tracking Monitors
 description: Learn about the Error Tracking monitors.
 ---
 
-{{< include-markdown "content/en/monitors/types/error_tracking.md" >}}
+{{< include-markdown "monitors/types/error_tracking" >}}

--- a/content/en/logs/error_tracking/suspect_commits.md
+++ b/content/en/logs/error_tracking/suspect_commits.md
@@ -3,4 +3,4 @@ title: Suspect Commits
 disable_toc: false
 ---
 
-{{< include-markdown "content/en/error_tracking/suspect_commits.md" >}}
+{{< include-markdown "error_tracking/suspect_commits" >}}

--- a/content/en/product_analytics/analytics_explorer/search_syntax.md
+++ b/content/en/product_analytics/analytics_explorer/search_syntax.md
@@ -6,4 +6,4 @@ further_reading:
   text: "Understand your application usage at a glance"
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/explorer/search_syntax.md" >}}
+{{< include-markdown "real_user_monitoring/explorer/search_syntax" >}}

--- a/content/en/product_analytics/session_replay/browser/developer_tools.md
+++ b/content/en/product_analytics/session_replay/browser/developer_tools.md
@@ -7,4 +7,4 @@ further_reading:
       text: Browser Session Replay
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/session_replay/browser/developer_tools.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/browser/developer_tools" >}}

--- a/content/en/product_analytics/session_replay/browser/privacy_options.md
+++ b/content/en/product_analytics/session_replay/browser/privacy_options.md
@@ -10,4 +10,4 @@ further_reading:
       text: "Obfuscate user data with Session Replay default privacy settings"
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/session_replay/browser/privacy_options.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/browser/privacy_options" >}}

--- a/content/en/product_analytics/session_replay/browser/troubleshooting.md
+++ b/content/en/product_analytics/session_replay/browser/troubleshooting.md
@@ -13,4 +13,4 @@ further_reading:
   text: 'Detect and aggregate CSP violations with Datadog'
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/session_replay/browser/troubleshooting.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/browser/troubleshooting" >}}

--- a/content/en/product_analytics/session_replay/mobile/_index.md
+++ b/content/en/product_analytics/session_replay/mobile/_index.md
@@ -8,4 +8,4 @@ further_reading:
       text: Session Replay
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/session_replay/mobile/_index.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/mobile" >}}

--- a/content/en/product_analytics/session_replay/mobile/app_performance.md
+++ b/content/en/product_analytics/session_replay/mobile/app_performance.md
@@ -20,4 +20,4 @@ further_reading:
       text: Session Replay
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/session_replay/mobile/app_performance.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/mobile/app_performance" >}}

--- a/content/en/product_analytics/session_replay/mobile/privacy_options.md
+++ b/content/en/product_analytics/session_replay/mobile/privacy_options.md
@@ -19,4 +19,4 @@ further_reading:
       text: Session Replay
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/session_replay/mobile/privacy_options.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/mobile/privacy_options" >}}

--- a/content/en/product_analytics/session_replay/mobile/setup_and_configuration.md
+++ b/content/en/product_analytics/session_replay/mobile/setup_and_configuration.md
@@ -20,4 +20,4 @@ further_reading:
       text: Session Replay
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/session_replay/mobile/setup_and_configuration.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/mobile/setup_and_configuration" >}}

--- a/content/en/product_analytics/session_replay/mobile/troubleshooting.md
+++ b/content/en/product_analytics/session_replay/mobile/troubleshooting.md
@@ -20,4 +20,4 @@ further_reading:
       text: Session Replay
 ---
 
-{{< include-markdown "content/en/real_user_monitoring/session_replay/mobile/troubleshooting.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/mobile/troubleshooting" >}}

--- a/content/en/product_analytics/session_replay/playlists.md
+++ b/content/en/product_analytics/session_replay/playlists.md
@@ -7,4 +7,4 @@ further_reading:
       tag: Documentation
       text: Session Replay
 ---
-{{< include-markdown "content/en/real_user_monitoring/session_replay/playlists.md" >}}
+{{< include-markdown "real_user_monitoring/session_replay/playlists" >}}

--- a/content/en/real_user_monitoring/error_tracking/custom_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/custom_grouping.md
@@ -3,4 +3,4 @@ title: Custom Grouping
 description: Customize how error spans are grouped into issues.
 ---
 
-{{< include-markdown "content/en/error_tracking/custom_grouping.md" >}}
+{{< include-markdown "error_tracking/custom_grouping" >}}

--- a/content/en/real_user_monitoring/error_tracking/default_grouping.md
+++ b/content/en/real_user_monitoring/error_tracking/default_grouping.md
@@ -3,4 +3,4 @@ title: Default Grouping
 description: Understand how errors are grouped into issues.
 ---
 
-{{< include-markdown "content/en/error_tracking/default_grouping.md" >}}
+{{< include-markdown "error_tracking/default_grouping" >}}

--- a/content/en/real_user_monitoring/error_tracking/explorer.md
+++ b/content/en/real_user_monitoring/error_tracking/explorer.md
@@ -7,4 +7,4 @@ further_reading:
   text: 'Learn about Error Tracking Monitors'
 ---
 
-{{< include-markdown "content/en/error_tracking/explorer.md" >}}
+{{< include-markdown "error_tracking/explorer" >}}

--- a/content/en/real_user_monitoring/error_tracking/issue_states.md
+++ b/content/en/real_user_monitoring/error_tracking/issue_states.md
@@ -2,4 +2,4 @@
 title: Issue States in Error Tracking
 ---
 
-{{< include-markdown "content/en/error_tracking/issue_states.md" >}}
+{{< include-markdown "error_tracking/issue_states" >}}

--- a/content/en/real_user_monitoring/error_tracking/monitors.md
+++ b/content/en/real_user_monitoring/error_tracking/monitors.md
@@ -3,4 +3,4 @@ title: Error Tracking Monitors
 description: Learn about the Error Tracking monitors.
 ---
 
-{{< include-markdown "content/en/monitors/types/error_tracking.md" >}}
+{{< include-markdown "monitors/types/error_tracking" >}}

--- a/content/en/real_user_monitoring/error_tracking/suspect_commits.md
+++ b/content/en/real_user_monitoring/error_tracking/suspect_commits.md
@@ -3,4 +3,4 @@ title: Suspect Commits
 disable_toc: false
 ---
 
-{{< include-markdown "content/en/error_tracking/suspect_commits.md" >}}
+{{< include-markdown "error_tracking/suspect_commits" >}}

--- a/content/en/security/cloud_security_management/setup/serverless.md
+++ b/content/en/security/cloud_security_management/setup/serverless.md
@@ -2,4 +2,4 @@
 title: AWS Fargate Configuration Guide for Datadog Security
 ---
 
-{{< include-markdown "content/en/security/guide/aws_fargate_config_guide.md" >}}
+{{< include-markdown "security/guide/aws_fargate_config_guide" >}}

--- a/content/en/service_management/app_builder/private_actions/_index.md
+++ b/content/en/service_management/app_builder/private_actions/_index.md
@@ -3,5 +3,5 @@ title: Private Actions
 disable_toc: false
 ---
 
-{{< include-markdown "content/en/service_management/workflows/private_actions/_index.md" >}}
+{{< include-markdown "service_management/workflows/private_actions" >}}
 

--- a/content/en/service_management/app_builder/private_actions/private_action_credentials.md
+++ b/content/en/service_management/app_builder/private_actions/private_action_credentials.md
@@ -4,4 +4,4 @@ title: Handling Private Action Credentials
 disable_toc: false
 ---
 
-{{< include-markdown "content/en/service_management/workflows/private_actions/private_action_credentials.md" >}}
+{{< include-markdown "service_management/workflows/private_actions/private_action_credentials" >}}

--- a/content/en/tracing/error_tracking/custom_grouping.md
+++ b/content/en/tracing/error_tracking/custom_grouping.md
@@ -3,4 +3,4 @@ title: Custom Grouping
 description: Customize how error spans are grouped into issues.
 ---
 
-{{< include-markdown "content/en/error_tracking/custom_grouping.md" >}}
+{{< include-markdown "error_tracking/custom_grouping" >}}

--- a/content/en/tracing/error_tracking/default_grouping.md
+++ b/content/en/tracing/error_tracking/default_grouping.md
@@ -3,4 +3,4 @@ title: Default Grouping
 description: Understand how errors are grouped into issues.
 ---
 
-{{< include-markdown "content/en/error_tracking/default_grouping.md" >}}
+{{< include-markdown "error_tracking/default_grouping" >}}

--- a/content/en/tracing/error_tracking/explorer.md
+++ b/content/en/tracing/error_tracking/explorer.md
@@ -7,4 +7,4 @@ further_reading:
   text: 'Learn about Error Tracking Monitors'
 ---
 
-{{< include-markdown "content/en/error_tracking/explorer.md" >}}
+{{< include-markdown "error_tracking/explorer" >}}

--- a/content/en/tracing/error_tracking/issue_states.md
+++ b/content/en/tracing/error_tracking/issue_states.md
@@ -2,4 +2,4 @@
 title: Issue States in Error Tracking
 ---
 
-{{< include-markdown "content/en/error_tracking/issue_states.md" >}}
+{{< include-markdown "error_tracking/issue_states" >}}

--- a/content/en/tracing/error_tracking/monitors.md
+++ b/content/en/tracing/error_tracking/monitors.md
@@ -3,4 +3,4 @@ title: Error Tracking Monitors
 description: Learn about the Error Tracking monitors.
 ---
 
-{{< include-markdown "content/en/monitors/types/error_tracking.md" >}}
+{{< include-markdown "monitors/types/error_tracking" >}}

--- a/content/en/tracing/error_tracking/suspect_commits.md
+++ b/content/en/tracing/error_tracking/suspect_commits.md
@@ -3,4 +3,4 @@ title: Suspect Commits
 disable_toc: false
 ---
 
-{{< include-markdown "content/en/error_tracking/suspect_commits.md" >}}
+{{< include-markdown "error_tracking/suspect_commits" >}}

--- a/content/en/tracing/other_telemetry/synthetics/_index.md
+++ b/content/en/tracing/other_telemetry/synthetics/_index.md
@@ -13,4 +13,4 @@ further_reading:
     text: 'Ease troubleshooting with cross product correlation.'
 ---
 
-{{< include-markdown "content/en/synthetics/platform/apm/_index.md" >}}
+{{< include-markdown "synthetics/platform/apm" >}}

--- a/content/es/logs/error_tracking/default_grouping.md
+++ b/content/es/logs/error_tracking/default_grouping.md
@@ -3,4 +3,4 @@ description: Comprender cómo se agrupan los errores en incidencias.
 title: Agrupación predeterminada
 ---
 
-{{< include-markdown "content/en/error_tracking/default_grouping.md" >}}
+{{< include-markdown "error_tracking/default_grouping" >}}

--- a/content/es/logs/error_tracking/explorer.md
+++ b/content/es/logs/error_tracking/explorer.md
@@ -7,4 +7,4 @@ further_reading:
 title: Error Tracking Explorer
 ---
 
-{{< include-markdown "content/en/error_tracking/explorer.md" >}}
+{{< include-markdown "error_tracking/explorer" >}}

--- a/content/es/logs/error_tracking/issue_states.md
+++ b/content/es/logs/error_tracking/issue_states.md
@@ -2,4 +2,4 @@
 title: Estados de emisión en el rastreo de errores
 ---
 
-{{< include-markdown "content/en/error_tracking/issue_states.md" >}}
+{{< include-markdown "error_tracking/issue_states" >}}

--- a/content/es/logs/error_tracking/suspect_commits.md
+++ b/content/es/logs/error_tracking/suspect_commits.md
@@ -3,4 +3,4 @@ disable_toc: false
 title: Confirmaciones sospechosas
 ---
 
-{{< include-markdown "content/en/error_tracking/suspect_commits.md" >}}
+{{< include-markdown "error_tracking/suspect_commits" >}}

--- a/layouts/shortcodes/include-markdown.html
+++ b/layouts/shortcodes/include-markdown.html
@@ -1,6 +1,4 @@
 {{- $page := .Get 0 -}}
-{{- $page = replace $page "content/en/" "" -}}
-{{- $page = replace $page ".md" "" -}}
 
 {{- with .Site.GetPage $page -}}
     {{ .Content }}

--- a/layouts/shortcodes/include-markdown.html
+++ b/layouts/shortcodes/include-markdown.html
@@ -1,9 +1,9 @@
-{{- $file := .Get 0 -}}
+{{- $page := .Get 0 -}}
+{{- $page = replace $page "content/en/" "" -}}
+{{- $page = replace $page ".md" "" -}}
 
-{{- if fileExists $file -}}
-    {{- with .Site.GetPage $file -}}
-        {{ .Content }}
-    {{- end -}}
+{{- with .Site.GetPage $page -}}
+    {{ .Content }}
 {{- else -}}
-    {{ printf "File %s not found" $file }}
+    {{ errorf "[include-markdown shortcode] Page %s not found" $page }}
 {{- end -}}

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
### What does this PR do? What is the motivation?
updates `include-markdown` shortcode to look for the page path instead of file path as `site.GetPage` doesn't work with file paths

### Merge instructions
- [ ] Please merge after reviewing

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/include-markdown-shortcode/tracing/error_tracking/explorer/
https://docs-staging.datadoghq.com/brian.deutsch/include-markdown-shortcode/product_analytics/session_replay/mobile
https://docs-staging.datadoghq.com/brian.deutsch/include-markdown-shortcode/tracing/error_tracking/monitors/

etc.  also check translated versions as well.