### PR TITLE
Update auto_conf.md

### DIFF
--- a/content/en/containers/guide/auto_conf.md
+++ b/content/en/containers/guide/auto_conf.md
@@ -101,9 +101,11 @@ To disable auto configuration integration(s) with the Operator, add the `DD_IGNO
 ```yaml
   override:
     nodeAgent:
-      env:
-        - name: DD_IGNORE_AUTOCONF
-          value: "redisdb istio"
+      containers: 
+        agent:
+          env:
+            - name: DD_IGNORE_AUTOCONF
+              value: "redisdb istio"
 ```
 {{% /tab %}}
 {{% tab "DaemonSet" %}}


### PR DESCRIPTION
Customer asked for a detailed example: https://datadog.zendesk.com/agent/tickets/1775321

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Add the env var DD_IGNORE_AUTOCONF on the agent. Here is an example of this configuration with the operator deployment:
```
override:
      nodeAgent:
        containers: 
          agent: 
            env:
              - name: "DD_IGNORE_AUTOCONF"
                value: "consul"
```
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->