### PR TITLE
Remove header from Datadog Agent shortcode and add to docs

### DIFF
--- a/content/en/observability_pipelines/archive_logs/datadog_agent.md
+++ b/content/en/observability_pipelines/archive_logs/datadog_agent.md
@@ -297,6 +297,8 @@ Follow the instructions for the cloud provider you are using to archive your log
 {{% /tab %}}
 {{< /tabs >}}
 
+## Connect the Datadog Agent to the Observability Pipelines Worker
+
 {{% observability_pipelines/log_source_configuration/datadog_agent %}}
 
 [1]: /integrations/amazon_web_services/#setup

--- a/content/en/observability_pipelines/dual_ship_logs/datadog_agent.md
+++ b/content/en/observability_pipelines/dual_ship_logs/datadog_agent.md
@@ -226,6 +226,8 @@ Enter the following information based on your selected logs destination.
 {{% /tab %}}
 {{< /tabs >}}
 
+## Connect the Datadog Agent to the Observability Pipelines Worker
+
 {{% observability_pipelines/log_source_configuration/datadog_agent %}}
 
 [1]: https://app.datadoghq.com/observability-pipelines

--- a/content/en/observability_pipelines/log_volume_control/datadog_agent.md
+++ b/content/en/observability_pipelines/log_volume_control/datadog_agent.md
@@ -226,6 +226,8 @@ Enter the following information based on your selected logs destination.
 {{% /tab %}}
 {{< /tabs >}}
 
+## Connect the Datadog Agent to the Observability Pipelines Worker
+
 {{% observability_pipelines/log_source_configuration/datadog_agent %}}
 
 [1]: https://app.datadoghq.com/observability-pipelines

--- a/content/en/observability_pipelines/sensitive_data_redaction/datadog_agent.md
+++ b/content/en/observability_pipelines/sensitive_data_redaction/datadog_agent.md
@@ -228,6 +228,8 @@ Enter the following information based on your selected logs destination.
 {{% /tab %}}
 {{< /tabs >}}
 
+## Connect the Datadog Agent to the Observability Pipelines Worker
+
 {{% observability_pipelines/log_source_configuration/datadog_agent %}}
 
 [1]: https://app.datadoghq.com/observability-pipelines

--- a/content/en/observability_pipelines/split_logs/datadog_agent.md
+++ b/content/en/observability_pipelines/split_logs/datadog_agent.md
@@ -239,6 +239,8 @@ Enter the following information based on your selected logs destination.
 {{% /tab %}}
 {{< /tabs >}}
 
+## Connect the Datadog Agent to the Observability Pipelines Worker
+
 {{% observability_pipelines/log_source_configuration/datadog_agent %}}
 
 [1]: https://app.datadoghq.com/observability-pipelines

--- a/layouts/shortcodes/observability_pipelines/log_source_configuration/datadog_agent.md
+++ b/layouts/shortcodes/observability_pipelines/log_source_configuration/datadog_agent.md
@@ -1,5 +1,3 @@
-## Connect the Datadog Agent to the Observability Pipelines Worker
-
 To send Datadog Agent logs to the Observability Pipelines Worker, update your Agent configuration with the following:
 ```
 observability_pipelines_worker:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Removes the header from the Datadog Agent shortcode and adds it to the markdown docs.

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->