### PR TITLE
 Update auto_conf.md - override section in Datadog operator `datadog-agent.yaml`

### DIFF
--- a/content/en/containers/guide/auto_conf.md
+++ b/content/en/containers/guide/auto_conf.md
@@ -74,9 +74,11 @@ spec:
 
   override:
     nodeAgent:
-      env: 
-        name: DD_IGNORE_AUTOCONF
-        value: redisdb istio
+      containers: 
+        agent:
+          env:
+            - name: DD_IGNORE_AUTOCONF
+              value: "redisdb istio"
 ```
 
 Then, apply the new configuration.


### PR DESCRIPTION
Adding more explicit example for override section in Datadog operator `datadog-agent.yaml`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Per customer's request adding more explicit example: https://datadog.zendesk.com/agent/tickets/1775321
https://docs.datadoghq.com/containers/guide/auto_conf/?tab=datadogoperator#disable-auto-configuration

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->