### PR TITLE
Clarify status remapper requirement

### DIFF
--- a/content/en/logs/log_configuration/processors.md
+++ b/content/en/logs/log_configuration/processors.md
@@ -153,7 +153,7 @@ Each incoming status value is mapped as follows:
 * Strings beginning with **emerg** or **f** (case-insensitive) map to **emerg (0)**
 * Strings beginning with **a** (case-insensitive) map to **alert (1)**
 * Strings beginning with **c** (case-insensitive) map to **critical (2)**
-* Strings beginning with **e** (case-insensitive)—that do not match `emerg`—map to **error (3)**
+* Strings beginning with **err** (case-insensitive) map to **error (3)**
 * Strings beginning with **w** (case-insensitive) map to **warning (4)**
 * Strings beginning with **n** (case-insensitive) map to **notice (5)**
 * Strings beginning with **i** (case-insensitive) map to **info (6)**


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Clarify status remapper that starts with `err` maps to ERROR
- [DOCS-8003](https://datadoghq.atlassian.net/browse/DOCS-8003)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- Pending Logs team approval

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8003]: https://datadoghq.atlassian.net/browse/DOCS-8003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ