### PR TITLE
[Error-Tracking]: Logs uses `error.kind` not `error.type`

### DIFF
--- a/content/en/logs/error_tracking/backend.md
+++ b/content/en/logs/error_tracking/backend.md
@@ -29,7 +29,7 @@ To configure inline code snippets in issues, set up the [source code integration
 
 To enable Error Tracking, logs must include both of the following:
 
-- either an `error.type` or `error.stack` field
+- either an `error.kind` or `error.stack` field
 - a status level of `ERROR`, `CRITICAL`, `ALERT`, or `EMERGENCY`
 
 The remaining attributes listed below are optional, but their presence improves error grouping.

--- a/content/en/logs/error_tracking/backend.md
+++ b/content/en/logs/error_tracking/backend.md
@@ -29,7 +29,7 @@ To configure inline code snippets in issues, set up the [source code integration
 
 To enable Error Tracking, logs must include both of the following:
 
-- either an `error.kind` or `error.stack` field
+- Either an `error.kind` or `error.stack` field. **Note**: if using `error.stack`, it must be a valid stack trace.
 - a status level of `ERROR`, `CRITICAL`, `ALERT`, or `EMERGENCY`
 
 The remaining attributes listed below are optional, but their presence improves error grouping.

--- a/content/en/logs/error_tracking/backend.md
+++ b/content/en/logs/error_tracking/backend.md
@@ -30,7 +30,7 @@ To configure inline code snippets in issues, set up the [source code integration
 To enable Error Tracking, logs must include both of the following:
 
 - Either an `error.kind` or `error.stack` field. **Note**: if using `error.stack`, it must be a valid stack trace.
-- a status level of `ERROR`, `CRITICAL`, `ALERT`, or `EMERGENCY`
+- A status level of `ERROR`, `CRITICAL`, `ALERT`, or `EMERGENCY`.
 
 The remaining attributes listed below are optional, but their presence improves error grouping.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Error-Tracking looks for `error.kind` not `error.type` https://github.com/DataDog/logs-backend/blob/prod/domains/event-platform/libs/processing/processing-common/src/main/java/com/dd/logs/processing/processors/errortracking/rawevent/LogsRawEventMapper.java#L64

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->