### PR TITLE
docs: Add PHP OpenAI compatibility & doc

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -164,6 +164,7 @@ To request support for additional datastores, contact our awesome [support team]
 | Curl              | *(Any Supported PHP)*      | All supported PHP versions |
 | Guzzle            | 5.x, 6.x, 7.x              | All supported PHP versions |
 | Laravel Queue     | Laravel supported versions | All supported PHP versions |
+| [OpenAI][11]      | OpenAI supported versions  | All supported PHP versions |
 
 
 To request support for additional libraries, contact our awesome [support team][3].
@@ -196,3 +197,4 @@ If the application invokes `pcntl_unshare(CLONE_NEWUSER);` and the tracer is ins
 [8]: https://man7.org/linux/man-pages/man2/unshare.2.html
 [9]: /tracing/trace_collection/library_config/php/#environment-variable-configuration
 [10]: https://github.com/php-amqplib/php-amqplib
+[11]: https://github.com/openai-php/client

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -488,6 +488,42 @@ The `'full'` option enables connection between database spans with database quer
 **Default**: `true`<br>
 Datadog may collect [environmental and diagnostic information about your system][16] to improve the product. When false, this telemetry data will not be collected.
 
+`DD_OPENAI_SERVICE`
+: **INI**: `datadog.openai.service`<br>
+**Default**: `DD_SERVICE`<br>
+The service name reported by default for OpenAI requests.
+
+`DD_OPENAI_LOGS_ENABLED` (beta)
+: **INI**: `datadog.openai.logs_enabled`<br>
+**Default**: `false`<br>
+Enable collection of prompts and completions as logs. You can adjust the rate of prompts and completions collected using the sample rate configuration described below.
+
+`DD_OPENAI_METRICS_ENABLED`
+: **INI**: `datadog.openai.metrics_enabled`<br>
+**Default**: `true`<br>
+Enable collection of OpenAI metrics.<br>
+If the Datadog Agent is configured to use a non-default StatsD hostname or port, use `DD_DOGSTATSD_URL` to configure the OpenAI metrics collection.
+
+`DD_OPENAI_SPAN_CHAR_LIMIT` (beta)
+: **INI**: `datadog.openai.span_char_limit`<br>
+**Default**: `128`<br>
+Configure the maximum number of characters for the following data within span tags:
+- Prompt inputs and completions
+- Message inputs and completions
+- Embedding inputs
+
+Text exceeding the maximum number of characters is truncated to the character limit and has `...` appended to the end.
+
+`DD_OPENAI_SPAN_PROMPT_COMPLETION_SAMPLE_RATE` (beta)
+: **INI**: `datadog.openai.span_prompt_completion_sample_rate`<br>
+**Default**: `1.0`<br>
+Configure the sample rate for the collection of prompts and completions as span tags.
+
+`DD_OPENAI_LOG_PROMPT_COMPLETION_SAMPLE_RATE` (beta)
+: **INI**: `datadog.openai.log_prompt_completion_sample_rate`<br>
+**Default**: `0.1`<br>
+Configure the sample rate for the collection of prompts and completions as logs.
+
 #### Integration names
 
 The table below specifies the default service names for each integration. Change the service names with `DD_SERVICE_MAPPING`.
@@ -495,7 +531,7 @@ The table below specifies the default service names for each integration. Change
 Use the name when setting integration-specific configuration such as, `DD_TRACE_<INTEGRATION>_ENABLED`, for example: Laravel is `DD_TRACE_LARAVEL_ENABLED`.
 
 | Integration   | Service Name    |
-| ------------- | --------------- |
+|---------------| --------------- |
 | AMQP          | `amqp`          |
 | CakePHP       | `cakephp`       |
 | CodeIgniter   | `codeigniter`   |
@@ -513,6 +549,7 @@ Use the name when setting integration-specific configuration such as, `DD_TRACE_
 | MongoDB       | `mongodb`       |
 | Mysqli        | `mysqli`        |
 | Nette         | `nette`         |
+| OpenAI        | `openai`        |
 | PCNTL         | `pcntl`         |
 | PDO           | `pdo`           |
 | PhpRedis      | `phpredis`      |

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -508,9 +508,10 @@ If the Datadog Agent is configured to use a non-default StatsD hostname or port,
 : **INI**: `datadog.openai.span_char_limit`<br>
 **Default**: `128`<br>
 Configure the maximum number of characters for the following data within span tags:
-- Prompt inputs and completions
-- Message inputs and completions
-- Embedding inputs
+
+  - Prompt inputs and completions
+  - Message inputs and completions
+  - Embedding inputs
 
 Text exceeding the maximum number of characters is truncated to the character limit and has `...` appended to the end.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The implementation of the OpenAI Integration was just merged in the PHP Tracing Library: https://github.com/DataDog/dd-trace-php/pull/2685

This updates the corresponding public doc.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->