### PR TITLE
add new permissions required outside the secaudit

### DIFF
--- a/layouts/shortcodes/aws-permissions.md
+++ b/layouts/shortcodes/aws-permissions.md
@@ -101,4 +101,33 @@ The following permissions included in the policy document use wild cards such as
 ```
 ### AWS Security Audit Policy
 
-To use <a href="https://docs.datadoghq.com/integrations/amazon_web_services/#resource-collection" target="_blank">resource collection</a>, attach AWS's managed <a href="https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/SecurityAudit" target="_blank">SecurityAudit Policy</a> to your Datadog IAM role.
+To use <a href="https://docs.datadoghq.com/integrations/amazon_web_services/#resource-collection" target="_blank">resource collection</a>, attach AWS's managed <a href="https://console.aws.amazon.com/iam/home#policies/arn:aws:iam::aws:policy/SecurityAudit" target="_blank">SecurityAudit Policy</a> and the following permisssions to your Datadog IAM role.
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "backup:ListRecoveryPointsByBackupVault",
+                "cassandra:Select",
+                "ec2:GetSnapshotBlockPublicAccessState",
+                "glacier:GetVaultNotifications",
+                "glue:ListRegistries",
+                "lightsail:GetInstancePortStates",
+                "savingsplans:DescribeSavingsPlanRates",
+                "savingsplans:DescribeSavingsPlans",
+                "timestream:DescribeEndpoints",
+                "waf-regional:ListRuleGroups",
+                "waf-regional:ListRules",
+                "waf:ListRuleGroups",
+                "waf:ListRules",
+                "wafv2:GetIPSet",
+                "wafv2:GetRegexPatternSet"
+            ],
+            "Effect": "Allow",
+            "Resource": "*"
+        }
+    ]
+}
+```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
We recently added support for additional resources that require permissions outside the Security Audit policy. We want to add these to our documentation so customers can add these additional permissions when turning on Resource Collection.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->


<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->