### PR TITLE
[DOCS-8513] Hide HTTP Client docs

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4229,10 +4229,10 @@ menu:
       parent: observability_pipelines_log_volume_control
       identifier: observability_pipelines_log_volume_control_fluent
       weight: 102
-    - name: HTTP Client
-      url: observability_pipelines/log_volume_control/http_client/
-      parent: observability_pipelines_log_volume_control
-      identifier: observability_pipelines_log_volume_control_http_client
+    # - name: HTTP Client
+    #   url: observability_pipelines/log_volume_control/http_client/
+    #   parent: observability_pipelines_log_volume_control
+    #   identifier: observability_pipelines_log_volume_control_http_client
       weight: 103
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/log_volume_control/splunk_hec/
@@ -4269,10 +4269,10 @@ menu:
       parent: observability_pipelines_dual_ship_logs
       identifier: observability_pipelines_dual_ship_logs_fluent
       weight: 202
-    - name: HTTP Client
-      url: observability_pipelines/dual_ship_logs/http_client/
-      parent: observability_pipelines_dual_ship_logs
-      identifier: observability_pipelines_dual_ship_logs_http_client
+    # - name: HTTP Client
+    #   url: observability_pipelines/dual_ship_logs/http_client/
+    #   parent: observability_pipelines_dual_ship_logs
+    #   identifier: observability_pipelines_dual_ship_logs_http_client
       weight: 203
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/dual_ship_logs/splunk_hec/
@@ -4309,10 +4309,10 @@ menu:
       parent: observability_pipelines_archive_logs
       identifier: observability_pipelines_archive_logs_fluent
       weight: 302
-    - name: HTTP Client
-      url: observability_pipelines/archive_logs/http_client/
-      parent: observability_pipelines_archive_logs
-      identifier: observability_pipelines_archive_logs_http_client
+    # - name: HTTP Client
+    #   url: observability_pipelines/archive_logs/http_client/
+    #   parent: observability_pipelines_archive_logs
+    #   identifier: observability_pipelines_archive_logs_http_client
       weight: 303
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/archive_logs/splunk_hec/
@@ -4349,10 +4349,10 @@ menu:
       parent: observability_pipelines_split_logs
       identifier: observability_pipelines_split_logs_fluent
       weight: 402
-    - name: HTTP Client
-      url: observability_pipelines/split_logs/http_client/
-      parent: observability_pipelines_split_logs
-      identifier: observability_pipelines_split_logs_http_client
+    # - name: HTTP Client
+    #   url: observability_pipelines/split_logs/http_client/
+    #   parent: observability_pipelines_split_logs
+    #   identifier: observability_pipelines_split_logs_http_client
       weight: 403
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/split_logs/splunk_hec/
@@ -4389,10 +4389,10 @@ menu:
       parent: observability_pipelines_sensitive_data_redaction
       identifier: observability_pipelines_sensitive_data_redaction_fluent
       weight: 502
-    - name: HTTP Client
-      url: observability_pipelines/sensitive_data_redaction/http_client/
-      parent: observability_pipelines_sensitive_data_redaction
-      identifier: observability_pipelines_sensitive_data_redaction_http_client
+    # - name: HTTP Client
+    #   url: observability_pipelines/sensitive_data_redaction/http_client/
+    #   parent: observability_pipelines_sensitive_data_redaction
+    #   identifier: observability_pipelines_sensitive_data_redaction_http_client
       weight: 503
     - name: Splunk HTTP Event Collector
       url: observability_pipelines/sensitive_data_redaction/splunk_hec/

--- a/content/en/observability_pipelines/archive_logs/_index.md
+++ b/content/en/observability_pipelines/archive_logs/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Archive Logs to Datadog Archives
 disable_toc: false
+aliases:
+    - /observability_pipelines/archive_logs/http_client/
 ---
 
 ## Overview
@@ -16,15 +18,14 @@ Use Observability Pipelines to route ingested logs to a Amazon S3 bucket in Data
 Select a source to get started:
 
 - [Datadog Agent][1]
-- [Fluentd or Fluent Bit][2]
-- [HTTP Client][3]
+- [Fluentd or Fluent Bit][2]<!-- - [HTTP Client][3] -->
 - [Splunk HTTP Event Collector (HEC)][4]
 - [Splunk Heavy and Universal Forwarders (TCP)][5]
 - [Sumo Logic Hosted Collector][6]
 
 [1]: /observability_pipelines/archive_logs/datadog_agent
 [2]: /observability_pipelines/archive_logs/fluent
-[3]: /observability_pipelines/archive_logs/http_client
+<!-- [3]: /observability_pipelines/archive_logs/http_client -->
 [4]: /observability_pipelines/archive_logs/splunk_hec
 [5]: /observability_pipelines/archive_logs/splunk_tcp
 [6]: /observability_pipelines/archive_logs/sumo_logic_hosted_collector

--- a/content/en/observability_pipelines/archive_logs/http_client.md
+++ b/content/en/observability_pipelines/archive_logs/http_client.md
@@ -1,6 +1,7 @@
 ---
 title: Archive Logs for HTTP Client
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/observability_pipelines/dual_ship_logs/_index.md
+++ b/content/en/observability_pipelines/dual_ship_logs/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Dual Ship Logs
 disable_toc: false
+aliases:
+    - /observability_pipelines/dual_ship_logs/http_client/
 ---
 
 ## Overview
@@ -12,8 +14,7 @@ As your infrastructure and your organization scales, so does your log volume, th
 Select a source to get started:
 
 - [Datadog Agent][1]
-- [Fluentd or Fluent Bit][2]
-- [HTTP Client][3]
+- [Fluentd or Fluent Bit][2]<!-- - [HTTP Client][3] -->
 - [Splunk HTTP Event Collector (HEC)][4]
 - [Splunk Heavy and Universal Forwarders (TCP)][5]
 - [Sumo Logic Hosted Collector][6]
@@ -21,7 +22,7 @@ Select a source to get started:
 
 [1]: /observability_pipelines/dual_ship_logs/datadog_agent
 [2]: /observability_pipelines/dual_ship_logs/fluent
-[3]: /observability_pipelines/dual_ship_logs/http_client
+<!-- [3]: /observability_pipelines/dual_ship_logs/http_client -->
 [4]: /observability_pipelines/dual_ship_logs/splunk_hec
 [5]: /observability_pipelines/dual_ship_logs/splunk_tcp
 [6]: /observability_pipelines/dual_ship_logs/sumo_logic_hosted_collector

--- a/content/en/observability_pipelines/dual_ship_logs/http_client.md
+++ b/content/en/observability_pipelines/dual_ship_logs/http_client.md
@@ -1,6 +1,7 @@
 ---
 title: Dual Ship Logs for HTTP Client
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/observability_pipelines/log_volume_control/_index.md
+++ b/content/en/observability_pipelines/log_volume_control/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Log Volume Control
 disable_toc: false
+aliases:
+    - /observability_pipelines/log_volume_control/http_client/
 ---
 
 ## Overview
@@ -18,8 +20,7 @@ As your infrastructure and applications grow, so does your log volume and the co
 Select a log source to get started:
 
 - [Datadog Agent][1]
-- [Fluentd or Fluent Bit][2]
-- [HTTP Client][3]
+- [Fluentd or Fluent Bit][2]<!-- - [HTTP Client][3] -->
 - [Splunk HTTP Event Collector (HEC)][4]
 - [Splunk Heavy and Universal Forwarders (TCP)][5]
 - [Sumo Logic Hosted Collector][6]
@@ -27,7 +28,7 @@ Select a log source to get started:
 
 [1]: /observability_pipelines/log_volume_control/datadog_agent
 [2]: /observability_pipelines/log_volume_control/fluent
-[3]: /observability_pipelines/log_volume_control/http_client
+<!-- [3]: /observability_pipelines/log_volume_control/http_client -->
 [4]: /observability_pipelines/log_volume_control/splunk_hec
 [5]: /observability_pipelines/log_volume_control/splunk_tcp
 [6]: /observability_pipelines/log_volume_control/sumo_logic_hosted_collector

--- a/content/en/observability_pipelines/log_volume_control/http_client.md
+++ b/content/en/observability_pipelines/log_volume_control/http_client.md
@@ -1,6 +1,7 @@
 ---
 title: Log Volume Control for HTTP Client
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/observability_pipelines/sensitive_data_redaction/_index.md
+++ b/content/en/observability_pipelines/sensitive_data_redaction/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Sensitive Data Redaction
 disable_toc: false
+aliases:
+    - /observability_pipelines/sensitive_data_redaction/http_client/
 ---
 
 ## Overview
@@ -14,8 +16,7 @@ Use the Observability Pipelines Worker to identify, tag, and optionally redact o
 Select a log source to get started:
 
 - [Datadog Agent][1]
-- [Fluentd or Fluent Bit][2]
-- [HTTP Client][3]
+- [Fluentd or Fluent Bit][2]<!-- - [HTTP Client][3] -->
 - [Splunk HTTP Event Collector (HEC)][4]
 - [Splunk Heavy and Universal Forwarders (TCP)][5]
 - [Sumo Logic Hosted Collector][6]
@@ -23,7 +24,7 @@ Select a log source to get started:
 
 [1]: /observability_pipelines/sensitive_data_redaction/datadog_agent
 [2]: /observability_pipelines/sensitive_data_redaction/fluent
-[3]: /observability_pipelines/sensitive_data_redaction/http_client
+<!-- [3]: /observability_pipelines/sensitive_data_redaction/http_client -->
 [4]: /observability_pipelines/sensitive_data_redaction/splunk_hec
 [5]: /observability_pipelines/sensitive_data_redaction/splunk_tcp
 [6]: /observability_pipelines/sensitive_data_redaction/sumo_logic_hosted_collector

--- a/content/en/observability_pipelines/sensitive_data_redaction/http_client.md
+++ b/content/en/observability_pipelines/sensitive_data_redaction/http_client.md
@@ -1,6 +1,7 @@
 ---
 title: Sensitive Data Redaction for HTTP Client
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/observability_pipelines/split_logs/_index.md
+++ b/content/en/observability_pipelines/split_logs/_index.md
@@ -1,6 +1,8 @@
 ---
 title: Split Logs
 disable_toc: false
+aliases:
+    - /observability_pipelines/split_logs/http_client/
 ---
 
 ## Overview
@@ -12,8 +14,7 @@ Often, organizations need to send their logs to multiple products for different 
 Select your log source to get started:
 
 - [Datadog Agent][1]
-- [Fluentd or Fluent Bit][2]
-- [HTTP Client][3]
+- [Fluentd or Fluent Bit][2]<!-- - [HTTP Client][3] -->
 - [Splunk HTTP Event Collector (HEC)][4]
 - [Splunk Heavy and Universal Forwarders (TCP)][5]
 - [Sumo Logic Hosted Collector][6]
@@ -21,7 +22,7 @@ Select your log source to get started:
 
 [1]: /observability_pipelines/split_logs/datadog_agent
 [2]: /observability_pipelines/split_logs/fluent
-[3]: /observability_pipelines/split_logs/http_client
+<!-- [3]: /observability_pipelines/split_logs/http_client -->
 [4]: /observability_pipelines/split_logs/splunk_hec
 [5]: /observability_pipelines/split_logs/splunk_tcp
 [6]: /observability_pipelines/split_logs/sumo_logic_hosted_collector

--- a/content/en/observability_pipelines/split_logs/http_client.md
+++ b/content/en/observability_pipelines/split_logs/http_client.md
@@ -1,6 +1,8 @@
 ---
 title: Split Logs for HTTP Client
 disable_toc: false
+aliases:
+    - /observability_pipelines/split_logs/http_client/
 ---
 
 ## Overview

--- a/content/en/observability_pipelines/split_logs/http_client.md
+++ b/content/en/observability_pipelines/split_logs/http_client.md
@@ -3,6 +3,7 @@ title: Split Logs for HTTP Client
 disable_toc: false
 aliases:
     - /observability_pipelines/split_logs/http_client/
+private: true
 ---
 
 ## Overview

--- a/content/en/observability_pipelines/split_logs/http_client.md
+++ b/content/en/observability_pipelines/split_logs/http_client.md
@@ -1,8 +1,6 @@
 ---
 title: Split Logs for HTTP Client
 disable_toc: false
-aliases:
-    - /observability_pipelines/split_logs/http_client/
 private: true
 ---
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Hide docs. Eng request.
- Removes from the nav
- Removes from the use case index pages
- Adds aliases to the HTTP doc in the use case index pages.
- Adds private to frontmatter.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->