### PR TITLE
Fix Language Selection Bug - [WEB-5122]

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -217,11 +217,13 @@ function loadPage(newUrl) {
             }
 
             const pathName = new URL(newUrl).pathname;
-
+            
             document.querySelectorAll('.language-select-container .dropdown-menu > a.dropdown-item').forEach((ddItem) => {
                 // Replace language dropdown-item hrefs with newURL when loading pages asynchronously (selecting the left nav menu items)
                 // ensures correct path is used for language dropdown-item.
-                const newURL = ddItem.href.replace(ddItem.pathname, pathName); 
+                const noLangPath = pathName.slice(3);
+                const cutIdx = ddItem.dataset.lang !== 'en' ? 3 : 0;
+                const newURL = ddItem.href.replace(ddItem.pathname.slice(cutIdx), noLangPath); 
                 ddItem.setAttribute('href', newURL);
             })
 

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -234,7 +234,7 @@ function loadPage(newUrl) {
                 if(ddItem.dataset.lang){
                     noFtBranchNoLangddItemPathName = noFtBranchddItemPathName.slice(3)
                 }
-                console.log('REPLACER::',noLangPathName)
+                console.log('REPLACER::',noFtBranchNoLangPathName)
                 console.log('REPLACE::', noFtBranchNoLangddItemPathName)
                 console.log('')
             })

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -218,8 +218,14 @@ function loadPage(newUrl) {
 
             const pathName = new URL(newUrl).pathname;
 
-            // sets query params if code tabs are present
+            document.querySelectorAll('.language-select-container .dropdown-menu > a.dropdown-item').forEach((item) => {
+                // Replace language dropdown hrefs with new URL when laoding pages asynchronously
+                // ensures the correct path is used for the language dropdown.
+                const newURL = item.href.replace(item.pathname, pathName); 
+                item.setAttribute('href', newURL);
+            })
 
+            // sets query params if code tabs are present
             initCodeTabs();
 
             const regionSelector = document.querySelector('.js-region-select');

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -222,7 +222,7 @@ function loadPage(newUrl) {
                 // Replace language dropdown-item hrefs with newURL when loading pages asynchronously (selecting the left nav menu items)
                 // ensures correct path is used for language dropdown-item.
                 const newURL = ddItem.href.replace(ddItem.pathname, pathName); 
-                item.setAttribute('href', newURL);
+                ddItem.setAttribute('href', newURL);
             })
 
             // sets query params if code tabs are present

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -218,17 +218,25 @@ function loadPage(newUrl) {
 
             const pathName = new URL(newUrl).pathname;
             
+            // clean window pathname
+            const commitRefLen = document.documentElement.dataset.commitRef.length ? (document.documentElement.dataset.commitRef.length) + 1: 0
+            const noFtBranchPathName = pathName.slice(commitRefLen)
+            const nonEnPage = document.documentElement.lang !== 'en-US'
+            let noFtBranchNoLangPathName = noFtBranchPathName
+            if(nonEnPage){
+                noFtBranchNoLangPathName = noFtBranchPathName.slice(3)
+            }
+            
             document.querySelectorAll('.language-select-container .dropdown-menu > a.dropdown-item').forEach((ddItem) => {
-                // Replace language dropdown-item hrefs with newURL when loading pages asynchronously (selecting the left nav menu items)
-                // ensures correct path is used for language dropdown-item.
-
-                const commitRefLen = document.documentElement.dataset.commitRef.length; // adjust for preview env / branch name in path
-                const ddItemLangLen = ddItem.dataset.lang.length + 2;
-                const noLangPath = pathName.slice(commitRefLen + ddItemLangLen);
-                const cutIdx = ddItem.dataset.lang !== 'en' ? (commitRefLen + ddItemLangLen) : (commitRefLen + 1);
-                const newURL = ddItem.href.replace(ddItem.pathname.slice(cutIdx), noLangPath); 
-
-                ddItem.setAttribute('href', newURL);
+                const noFtBranchddItemPathName = ddItem.pathname.slice(commitRefLen)
+                let noFtBranchNoLangddItemPathName = noFtBranchddItemPathName
+                console.log('lang:', ddItem.dataset.lang)
+                if(ddItem.dataset.lang){
+                    noFtBranchNoLangddItemPathName = noFtBranchddItemPathName.slice(3)
+                }
+                console.log('REPLACER::',noLangPathName)
+                console.log('REPLACE::', noFtBranchNoLangddItemPathName)
+                console.log('')
             })
 
             // sets query params if code tabs are present
@@ -270,3 +278,5 @@ function loadPage(newUrl) {
 }
 
 export {loadPage};
+
+

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -218,10 +218,10 @@ function loadPage(newUrl) {
 
             const pathName = new URL(newUrl).pathname;
 
-            document.querySelectorAll('.language-select-container .dropdown-menu > a.dropdown-item').forEach((item) => {
-                // Replace language dropdown hrefs with new URL when laoding pages asynchronously
-                // ensures the correct path is used for the language dropdown.
-                const newURL = item.href.replace(item.pathname, pathName); 
+            document.querySelectorAll('.language-select-container .dropdown-menu > a.dropdown-item').forEach((ddItem) => {
+                // Replace language dropdown-item hrefs with newURL when loading pages asynchronously (selecting the left nav menu items)
+                // ensures correct path is used for language dropdown-item.
+                const newURL = ddItem.href.replace(ddItem.pathname, pathName); 
                 item.setAttribute('href', newURL);
             })
 

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -237,6 +237,9 @@ function loadPage(newUrl) {
                 console.log('REPLACER::',noFtBranchNoLangPathName)
                 console.log('REPLACE::', noFtBranchNoLangddItemPathName)
                 console.log('')
+                
+                const updatedURL = ddItem.href.replace(noFtBranchNoLangddItemPathName, noFtBranchNoLangPathName)
+                ddItem.setAttribute('href', updatedURL)
             })
 
             // sets query params if code tabs are present

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -218,27 +218,20 @@ function loadPage(newUrl) {
 
             const pathName = new URL(newUrl).pathname;
             
-            // clean window pathname
-            const commitRefLen = document.documentElement.dataset.commitRef.length ? (document.documentElement.dataset.commitRef.length) + 1: 0
-            const noFtBranchPathName = pathName.slice(commitRefLen)
-            const nonEnPage = document.documentElement.lang !== 'en-US'
-            let noFtBranchNoLangPathName = noFtBranchPathName
-            if(nonEnPage){
-                noFtBranchNoLangPathName = noFtBranchPathName.slice(3)
-            }
+            // Get and clean window pathname in order to update language dropdown items href
+            const nonEnPage = document.documentElement.lang !== 'en-US' // check if page is not in english
+            const commitRef = document.documentElement.dataset.commitRef
+            const commitRefLen = commitRef.length ? (commitRef.length + 1) : 0
+            
+            const noCommitRefPathName = pathName.slice(commitRefLen) // adjust pathname to remove commit ref if in preview env
+            const noCommitRefNoLangPathName = nonEnPage ? noCommitRefPathName.slice(3) : noCommitRefPathName // adjust pathname to remove language if not in english e.g. /ja/agent -> /agent
             
             document.querySelectorAll('.language-select-container .dropdown-menu > a.dropdown-item').forEach((ddItem) => {
-                const noFtBranchddItemPathName = ddItem.pathname.slice(commitRefLen)
-                let noFtBranchNoLangddItemPathName = noFtBranchddItemPathName
-                console.log('lang:', ddItem.dataset.lang)
-                if(ddItem.dataset.lang){
-                    noFtBranchNoLangddItemPathName = noFtBranchddItemPathName.slice(3)
-                }
-                console.log('REPLACER::',noFtBranchNoLangPathName)
-                console.log('REPLACE::', noFtBranchNoLangddItemPathName)
-                console.log('')
-                
-                const updatedURL = ddItem.href.replace(noFtBranchNoLangddItemPathName, noFtBranchNoLangPathName)
+                // Updates langauge dropdown item hrefs on asynchronous page loads
+                const noFtBranchddItemPathName = ddItem.pathname.slice(commitRefLen) // adjust dd item pathname to remove commit ref if in preview env
+                const noFtBranchNoLangddItemPathName = ddItem.dataset.lang ? noFtBranchddItemPathName.slice(3) : noFtBranchddItemPathName // adjust dd item pathname to remove language if not in english e.g. /ja/agent -> /agent
+
+                const updatedURL = ddItem.href.replace(noFtBranchNoLangddItemPathName, noCommitRefNoLangPathName)
                 ddItem.setAttribute('href', updatedURL)
             })
 

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -223,11 +223,11 @@ function loadPage(newUrl) {
                 // ensures correct path is used for language dropdown-item.
 
                 const commitRefLen = document.documentElement.dataset.commitRef.length; // adjust for preview env / branch name in path
-                const ddItemLangLen = ddItem.dataset.lang.length + 1;
+                const ddItemLangLen = ddItem.dataset.lang.length + 2;
                 const noLangPath = pathName.slice(commitRefLen + ddItemLangLen);
-                const cutIdx = ddItem.dataset.lang !== 'en' ? (commitRefLen + ddItemLangLen) : 0;
+                const cutIdx = ddItem.dataset.lang !== 'en' ? (commitRefLen + ddItemLangLen) : (commitRefLen + 1);
                 const newURL = ddItem.href.replace(ddItem.pathname.slice(cutIdx), noLangPath); 
-                
+
                 ddItem.setAttribute('href', newURL);
             })
 

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -221,9 +221,13 @@ function loadPage(newUrl) {
             document.querySelectorAll('.language-select-container .dropdown-menu > a.dropdown-item').forEach((ddItem) => {
                 // Replace language dropdown-item hrefs with newURL when loading pages asynchronously (selecting the left nav menu items)
                 // ensures correct path is used for language dropdown-item.
-                const noLangPath = pathName.slice(3);
-                const cutIdx = ddItem.dataset.lang !== 'en' ? 3 : 0;
+
+                const commitRefLen = document.documentElement.dataset.commitRef.length; // adjust for preview env / branch name in path
+                const ddItemLangLen = ddItem.dataset.lang.length + 1;
+                const noLangPath = pathName.slice(commitRefLen + ddItemLangLen);
+                const cutIdx = ddItem.dataset.lang !== 'en' ? (commitRefLen + ddItemLangLen) : 0;
                 const newURL = ddItem.href.replace(ddItem.pathname.slice(cutIdx), noLangPath); 
+                
                 ddItem.setAttribute('href', newURL);
             })
 

--- a/layouts/partials/language-region-select.html
+++ b/layouts/partials/language-region-select.html
@@ -9,11 +9,11 @@
       </button>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
         <!--  dropdown-item hrefs are updated asynchronously in async-loading.js -->
-        <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}" data-lang="{{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+        <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}" {{ if ne .Language.Lang "en" }} data-lang="{{ .Language.Lang }}"{{end}}>{{ .Language.LanguageName }}</a>
 
         <!-- Manually adding English option to non-English sites -->
         {{ if ne .Sites.First .Site }}
-          <a class="dropdown-item" href="{{ replace .Permalink (printf "/%s/" .Language.Lang) "/" }}?lang_pref=en" data-lang="en">English</a>
+          <a class="dropdown-item" href="{{ replace .Permalink (printf "/%s/" .Language.Lang) "/" }}?lang_pref=en">English</a>
         {{ end }}
 
         {{ range where .Translations "Language.Lang" "!=" "en" }}

--- a/layouts/partials/language-region-select.html
+++ b/layouts/partials/language-region-select.html
@@ -8,6 +8,7 @@
         <div class="chevron chevron-up d-none"></div>
       </button>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+        <!--  dropdown-item hrefs are updated asynchronously in async-loading.js -->
         <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
 
         <!-- Manually adding English option to non-English sites -->

--- a/layouts/partials/language-region-select.html
+++ b/layouts/partials/language-region-select.html
@@ -9,15 +9,15 @@
       </button>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
         <!--  dropdown-item hrefs are updated asynchronously in async-loading.js -->
-        <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+        <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}" data-lang="{{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
 
         <!-- Manually adding English option to non-English sites -->
         {{ if ne .Sites.First .Site }}
-          <a class="dropdown-item" href="{{ replace .Permalink (printf "/%s/" .Language.Lang) "/" }}?lang_pref=en">English</a>
+          <a class="dropdown-item" href="{{ replace .Permalink (printf "/%s/" .Language.Lang) "/" }}?lang_pref=en" data-lang="en">English</a>
         {{ end }}
 
         {{ range where .Translations "Language.Lang" "!=" "en" }}
-          <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
+          <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}" data-lang="{{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
         {{ end }}
       </div>
     </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
fixes the language-selector redirect

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-5122 
preview: https://docs-staging.datadoghq.com/stefon.simmons/fix-lang-dropdown-async-web-5122/ja/agent/basic_agent_usage/chef/
   - starting at the `/ja` link above, navigate to another page via the left nav. Change the **Language** via the language dropdown on the right. The page should redirect to translated current page instead of redirecting you to the previous page above 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->