### PR TITLE
Add details about sampling impact on trace metrics

### DIFF
--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -131,7 +131,7 @@ Very few tracing libraries support this setting, and using it is generally not r
 
 ### OpenTelemetry sampling
 
-The OpenTelemetry SDK’s native sampling mechanisms lower the number of spans sent to the Datadog collector, resulting in sampled and potentially inaccurate trace metrics.
+The OpenTelemetry SDK's native sampling mechanisms lower the number of spans sent to the Datadog collector, resulting in sampled and potentially inaccurate trace metrics.
 
 ### XRay sampling
 

--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -119,6 +119,25 @@ This metric does not support percentile aggregations. Read the [Latency Distribu
 **Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
+## Sampling Impact on Trace Metrics
+
+In most cases, trace metrics are calculated based on all application traffic. However, with certain trace ingestion sampling configurations, the metrics will represent only a subset of all requests:
+
+### Application-side sampling 
+
+Some tracing libraries support application-side sampling, which reduces the number of spans before they are sent to the Datadog Agent. For example, the Ruby tracing library offers application-side sampling to lower performance overhead. However, this can affect trace metrics, as the Datadog Agent needs all spans to calculate accurate metrics. 
+
+Very few tracing libraries support this setting, and using it is generally not recommended.
+
+### OpenTelemetry sampling
+
+The OpenTelemetry SDK’s native sampling mechanisms lower the number of spans sent to the Datadog collector, resulting in sampled and potentially inaccurate trace metrics.
+
+### XRay sampling
+
+XRay spans are sampled before they are sent to Datadog, which means trace metrics will not reflect all traffic.
+
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -121,7 +121,7 @@ This metric does not support percentile aggregations. Read the [Latency Distribu
 
 ## Sampling impact on trace metrics
 
-In most cases, trace metrics are calculated based on all application traffic. However, with certain trace ingestion sampling configurations, the metrics will represent only a subset of all requests:
+In most cases, trace metrics are calculated based on all application traffic. However, with certain trace ingestion sampling configurations, the metrics represent only a subset of all requests.
 
 ### Application-side sampling 
 

--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -135,7 +135,7 @@ The OpenTelemetry SDK’s native sampling mechanisms lower the number of spans s
 
 ### XRay sampling
 
-XRay spans are sampled before they are sent to Datadog, which means trace metrics will not reflect all traffic.
+XRay spans are sampled before they are sent to Datadog, which means trace metrics might not reflect all traffic.
 
 
 ## Further Reading

--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -119,7 +119,7 @@ This metric does not support percentile aggregations. Read the [Latency Distribu
 **Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `http.status_class`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
-## Sampling Impact on Trace Metrics
+## Sampling impact on trace metrics
 
 In most cases, trace metrics are calculated based on all application traffic. However, with certain trace ingestion sampling configurations, the metrics will represent only a subset of all requests:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/DOCS-8345

Update trace metrics page to reflect the fact that in some cases, 100% of application traffic is NOT used for metrics. Pulled info from this Confluence page: https://datadoghq.atlassian.net/wiki/spaces/TS/pages/558104577/APM+Trace+metrics#Sampling-Impact-on-Trace-Metrics

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->