### PR TITLE
Revert "Document tracer flares"

### DIFF
--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -24,7 +24,7 @@ This page covers:
 - [Sending a flare from the Datadog site](#send-a-flare-from-the-datadog-site) using Remote Configuration.
 - [Manual submission](#manual-submission).
 
-A flare gathers all of the Agent's configuration files and logs into an archive file. It removes sensitive information, including passwords, API keys, Proxy credentials, and SNMP community strings. If APM is enabled, the flare includes [tracer debug logs][4] when available.
+A flare gathers all of the Agent's configuration files and logs into an archive file. It removes sensitive information, including passwords, API keys, Proxy credentials, and SNMP community strings.
 
 The Datadog Agent is completely open source, which allows you to [verify the code's behavior][1]. If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
 
@@ -155,4 +155,4 @@ kubectl cp datadog-<pod-name>:tmp/datadog-agent-<date-of-the-flare>.zip flare.zi
 [1]: https://github.com/DataDog/datadog-agent/tree/main/pkg/flare
 [2]: /agent/fleet_automation/
 [3]: /agent/remote_config#enabling-remote-configuration
-[4]: /tracing/troubleshooting/tracer_debug_logs/?code-lang=dotnet#data-collected
+

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -6,29 +6,7 @@ further_reading:
   text: "Troubleshooting APM Connection Errors"
 ---
 
-## Automated debug log collection
-
-<div class="alert alert-warning">Automated debug logs are supported for Node.js and .NET only. For other languages, use <a href="/tracing/troubleshooting/tracer_debug_logs/#manual-debug-log-collection">manual debug log collection</a> instead.</div>
-
-A flare allows you to send necessary troubleshooting information to the Datadog support team, including tracer logs, with sensitive data removed. Flares are useful for troubleshooting issues like high CPU usage, high memory usage, and missing spans.
-
-### Prerequisites
-
-- [Remote Configuration][3] must be enabled.
-- Your API key must be configured for Remote Configuration.
-- You must have a supported tracer version:
-  - Node.js: `5.15.0` or greater, or `4.39.0` or greater
-  - .NET: `2.46.0` or greater
-
-### Send a flare
-
-To send a flare from the Datadog site, make sure you've enabled [Fleet Automation][4] and [Remote Configuration][5] on the Agent.
-
-{{% remote-flare %}}
-
-{{< img src="agent/fleet_automation/fleet-automation-flares2.png" alt="The Send Ticket button launches a form to send a flare for an existing or new support ticket" style="width:60%;" >}}
-
-## Manual debug log collection
+## Enable debug mode
 
 Use Datadog debug settings to diagnose issues or audit trace data. Datadog does not recommend that you enable debug mode in production systems because it increases the number of events that are sent to your loggers. Use debug mode for debugging purposes only.
 
@@ -504,6 +482,3 @@ Available starting in 0.98.0:
 
 [1]: /help/
 [2]: /agent/troubleshooting/#send-a-flare
-[3]: /agent/remote_config
-[4]: /agent/fleet_automation/
-[5]: /agent/remote_config#enabling-remote-configuration


### PR DESCRIPTION
Reverts DataDog/documentation#22047.

This feature is not working properly due to a bug, so I was asked to remove the documentation for the time being.

Please merge after reviewing, thank you!