### PR TITLE
[DOCS-8510] Remove aliases from mobile troubleshooting pages

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/android.md
@@ -1,8 +1,6 @@
 ---
 title: Troubleshooting Android SDK issues
 description: Learn how to troubleshoot issues with Android Monitoring.
-aliases:
-    - /real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/
 code_lang: android
 type: multi-code-lang
 code_lang_weight: 10

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/flutter.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/flutter.md
@@ -1,8 +1,6 @@
 ---
 title: Troubleshooting Flutter SDK issues
 description: Learn how to troubleshoot issues with Flutter Monitoring.
-aliases:
-    - /real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/
 code_lang: flutter
 type: multi-code-lang
 code_lang_weight: 30

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/ios.md
@@ -1,8 +1,6 @@
 ---
 title: Troubleshooting iOS SDK issues
 description: Learn how to troubleshoot issues with iOS Monitoring.
-aliases:
-    - /real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/
 code_lang: ios
 type: multi-code-lang
 code_lang_weight: 20

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/reactnative.md
@@ -1,8 +1,6 @@
 ---
 title: Troubleshooting React Native SDK issues
 description: Learn how to troubleshoot issues with React Native Monitoring.
-aliases:
-    - /real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/
 code_lang: reactnative
 type: multi-code-lang
 code_lang_weight: 50

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/unity.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/unity.md
@@ -1,8 +1,6 @@
 ---
 title: Troubleshooting Unity SDK Issues
 description: Learn how to troubleshoot issues with Unity Monitoring.
-aliases:
-    - /real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/
 code_lang: unity
 type: multi-code-lang
 code_lang_weight: 30


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removed the alias from each of the framework pages so that users can be directed to the landing page (correct behavior) instead of a specific framework (incorrect behavior).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->