### PR TITLE
[dbm] update dbm mongodb beta installation script to include guides to DD_SITE

### DIFF
--- a/layouts/shortcodes/dbm-mongodb-agent-beta-install-docker.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-beta-install-docker.md
@@ -1,9 +1,14 @@
 To install the beta version of the containerized Datadog Agent, run the following command.
+Replace `<DD_API_KEY>` with your [Datadog API key][1] and `<DD_SITE>` with your [Datadog site][2].
 
 ```shell
 # Override the following environment variables
 export DD_API_KEY=<DD_API_KEY>
+export DD_SITE=<DD_SITE>
 export DD_AGENT_VERSION=7.56.0-dbm-mongo-1.3
 
 docker pull "datadog/agent:${DD_AGENT_VERSION}"
 ```
+
+[1]: /account_management/api-app-keys/
+[2]: /getting_started/site/

--- a/layouts/shortcodes/dbm-mongodb-agent-beta-install-kubernetes.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-beta-install-kubernetes.md
@@ -1,8 +1,10 @@
 To install the beta version of the Datadog Agent on Kubernetes, run the following command.
+Replace `<DD_API_KEY>` with your [Datadog API key][1] and `<DD_SITE>` with your [Datadog site][2].
 
 ```shell
 # Override the following environment variables
 export DD_API_KEY=<DD_API_KEY>
+export DD_SITE=<DD_SITE>
 
 helm repo add datadog https://helm.datadoghq.com
 helm repo update
@@ -21,3 +23,5 @@ datadog:
 
 ```
 
+[1]: /account_management/api-app-keys/
+[2]: /getting_started/site/

--- a/layouts/shortcodes/dbm-mongodb-agent-beta-install-linux.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-beta-install-linux.md
@@ -1,4 +1,5 @@
 To install the beta version of the Datadog Agent on a Linux host, run the following command.
+Replace `<DD_API_KEY>` with your [Datadog API key][1] and `<DD_SITE>` with your [Datadog site][2].
 
 ```shell
 # Override the following environment variables
@@ -7,5 +8,8 @@ export DD_AGENT_DIST_CHANNEL=beta
 export DD_AGENT_MAJOR_VERSION=7
 export DD_AGENT_MINOR_VERSION="56.0~dbm~mongo~1.3"
 
-DD_API_KEY=<DD_API_KEY> DD_SITE="datadoghq.com" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+DD_API_KEY=<DD_API_KEY> DD_SITE=<DD_SITE> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
 ```
+
+[1]: /account_management/api-app-keys/
+[2]: /getting_started/site/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR updates the DBM for MongoDB beta agent installation script to include guides to change DD_SITE. This change makes the beta customers (especially those on trials and has not installed datadog-agent before) aware of the need of choosing right DD_SITE the first time they install the agent. We've noticed a customer in us3 was getting API key errors due to DD_SITE set to `datadoghq.com`

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->