### PR TITLE
opentelemetry(apm): document .NET drop in support

### DIFF
--- a/content/en/opentelemetry/interoperability/instrumentation_libraries.md
+++ b/content/en/opentelemetry/interoperability/instrumentation_libraries.md
@@ -228,7 +228,7 @@ To use Opentelemetry instrumentation libraries with the Datadog .NET SDK:
 
 | Library           | Versions | NuGet package                     | Integration Name     | Setup instructions            |
 | ----------------- | -------- | --------------------------------- | -------------------- | ----------------------------- |
-| Azure Service Bus | 7.14.0+ | [`Azure.Messaging.ServiceBus`][2]  | `AzureServiceBus`    | See `Azure SDK` section below |
+| Azure Service Bus | 7.14.0+ | [Azure.Messaging.ServiceBus][2]  | `AzureServiceBus`    | See `Azure SDK` section below |
 
 ### Azure SDK
 

--- a/content/en/opentelemetry/interoperability/instrumentation_libraries.md
+++ b/content/en/opentelemetry/interoperability/instrumentation_libraries.md
@@ -211,13 +211,33 @@ func hello(w http.ResponseWriter, req *http.Request) {
 
 {{% /tab %}} -->
 
-<!-- {{% tab ".NET" %}}
+{{% tab ".NET" %}}
 
 ## Compatibility requirements
 
+The Datadog .NET SDK supports library instrumentations that come with [built-in OpenTelemetry support][1].
+
 ## Setup
 
-{{% /tab %}} -->
+To use Opentelemetry instrumentation libraries with the Datadog .NET SDK:
+
+1. Set the `DD_TRACE_OTEL_ENABLED` environment variable to `true`.
+2. Follow the steps to configure each library, if any, to generate OpenTelemetry-compatible instrumentation via `ActivitySource`
+
+## Verified OpenTelemetry Instrumentation Libraries
+
+| Library           | Versions | NuGet package                     | Integration Name     | Setup instructions            |
+| ----------------- | -------- | --------------------------------- | -------------------- | ----------------------------- |
+| Azure Service Bus | 7.14.0+ | [`Azure.Messaging.ServiceBus`][2]  | `AzureServiceBus`    | See `Azure SDK` section below |
+
+### Azure SDK
+
+The Azure SDK provides built-in OpenTelemetry support. Enable it by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable to `true` or by setting the `Azure.Experimental.EnableActivitySource` context switch to `true` in your application code. See [Azure SDK documentation][3] for more details.
+
+[1]: https://opentelemetry.io/docs/languages/net/libraries/#use-natively-instrumented-libraries
+[2]: https://www.nuget.org/packages/Azure.Messaging.ServiceBus
+[3]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#enabling-experimental-tracing-features
+{{% /tab %}}
 
 {{< /tabs >}}
 

--- a/content/en/tracing/trace_collection/compatibility/dotnet-core.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-core.md
@@ -90,19 +90,7 @@ The [latest version of the .NET Tracer][4] can automatically instrument the foll
 | SQL Server                      | `System.Data` 4.0.0+</br>`System.Data.SqlClient` 4.0.0+</br>`Microsoft.Data.SqlClient` 1.0.0+        | `SqlClient`          |
 | WebClient / WebRequest          | `System.Net.Requests` 4.0+                                                                           | `WebRequest`         |
 
-Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (for example, [activity based tracing][13]). If not, Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
-
-## OpenTelemetry based integrations
-
-Some libraries provide built in [Activity based tracing][13]. This is the same mechanism the OpenTelemetry project relies on. By setting `DD_TRACE_OTEL_ENABLED` to `true`, the .NET tracer will automatically resurface traces provided by the libraries themselves. This is possible since [version 2.21.0][4]. Here are a list of libraries that are tested with this setup (more libraries provide such tracing though, they aren't yet expliciitly tested).
-
-| Framework or library            | NuGet package                                                                 | Integration Name     | Specific instructions         |
-| ------------------------------- | ----------------------------------------------------------------------------- | -------------------- | ----------------------------- |
-| Azure Service Bus               | `Azure.Messaging.ServiceBus` 7.14.0+                                          | `AzureServiceBus`    | See `Azure SDK` section below |
-
-### Azure SDK
-
-Azure SDK provides built-in OpenTelemetry support. Enable it by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable to `true` or by setting the `Azure.Experimental.EnableActivitySource` context switch to `true` in your application code. See [Azure SDK documentation][14] for more details.
+Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (see [Using OpenTelemetry Instrumentation Libraries][13] for more details). If not, Datadog is continually adding additional support. [Check with the Datadog team][5] for help.
 
 ## End of life .NET runtime versions
 
@@ -164,8 +152,7 @@ Version updates imply the following changes to runtime support:
 [10]: https://www.datadoghq.com/support/
 [11]: https://semver.org/
 [12]: https://www.nuget.org/packages/Datadog.Trace.Trimming/
-[13]: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing
-[14]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#enabling-experimental-tracing-features
+[13]: /opentelemetry/interoperability/instrumentation_libraries/?tab=dotnet
 [15]: https://github.com/dotnet/runtime/pull/73760
 [16]: https://github.com/dotnet/runtime/issues/11885
 [17]: https://github.com/dotnet/runtime/issues/85777

--- a/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/compatibility/dotnet-framework.md
@@ -93,23 +93,7 @@ The [latest version of the .NET Tracer][5] can automatically instrument the foll
 | WCF (server)                    | built-in                                                                                  | `Wcf`                |
 | WebClient / WebRequest          | built-in                                                                                  | `WebRequest`         |
 
-Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (for example, [activity based tracing][11]). If not, Datadog is continually adding additional support. [Check with the Datadog team][6] for help.
-
-## OpenTelemetry based integrations
-
-Some libraries provide built-in [Activity based tracing][11]. This is the same mechanism that OpenTelemetry is based on.
-
-For these libraries, set `DD_TRACE_OTEL_ENABLED` to `true`, and the .NET tracer automatically captures traces their traces. This is supported since [version 2.21.0][4].
-
-The following list of libraries have been tested with this setup:
-
-| Framework or library            | NuGet package                                                                 | Integration Name     | Specific instructions         |
-| ------------------------------- | ----------------------------------------------------------------------------- | -------------------- | ----------------------------- |
-| Azure Service Bus               | `Azure.Messaging.ServiceBus` 7.14.0+                                          | `AzureServiceBus`    | See `Azure SDK` section below |
-
-### Azure SDK
-
-Azure SDK provides built-in OpenTelemetry support. Enable it by setting the `AZURE_EXPERIMENTAL_ENABLE_ACTIVITY_SOURCE` environment variable to `true` or by setting the `Azure.Experimental.EnableActivitySource` context switch to `true` in your application code. See [Azure SDK documentation][12] for more details.
+Don't see the library you're looking for? First, check if the library produces observability data compatible with OpenTelemetry (see [Using OpenTelemetry Instrumentation Libraries][11] for more details). If not, Datadog is continually adding additional support. [Check with the Datadog team][6] for help.
 
 ## Supported Datadog Agent versions
 
@@ -156,5 +140,4 @@ Version updates imply the following changes to runtime support:
 [8]: /agent/basic_agent_usage/?tab=agentv5
 [9]: https://www.datadoghq.com/support/
 [10]: https://semver.org/
-[11]: https://learn.microsoft.com/en-us/dotnet/core/diagnostics/distributed-tracing
-[12]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#enabling-experimental-tracing-features
+[11]: /opentelemetry/interoperability/instrumentation_libraries/?tab=dotnet


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Documents .NET drop in support for the OpenTelemetry API.

Note: We previously had this page in our regular tracing library compatibility page so most of the content was simply moved to this new central location.

### Merge instructions
- [x] Wait until #24257 is merged, to avoid merge conflicts
- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->