### PR TITLE
Fix Python version in Python Code Security

### DIFF
--- a/layouts/shortcodes/asm-libraries-capabilities.md
+++ b/layouts/shortcodes/asm-libraries-capabilities.md
@@ -8,7 +8,7 @@ The following ASM capabilities are supported relative to each language's tracing
 | Threat Protection                      | 1.9.0   | 2.26.0   | 4.0.0                                            | 1.10.0        | v1.50.0         | 1.11.0        | 0.86.0        |
 | Customize response to blocked requests | 1.11.0  | 2.27.0   | 4.1.0                                            | 1.19.0        | v1.53.0         | 1.15.0        | 0.86.0        |
 | Software Composition Analysis (SCA)    | 1.1.4   | 2.16.0   | 4.0.0                                            | 1.5.0         | 1.49.0          | 1.11.0        | 0.90.0        |
-| Code Security                          | 1.15.0  | 2.42.0   | 4.18.0                                           | 2.93          | not supported   | not supported | not supported |
+| Code Security                          | 1.15.0  | 2.42.0   | 4.18.0                                           | 2.9.3         | not supported   | not supported | not supported |
 | Automatic user activity event tracking | 1.20.0  | 2.32.0   | 4.4.0                                            | 1.17.0        | not supported   | 1.14.0        | 0.89.0        |
 
 Select your application language for details about framework compatibility and feature support.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Fix the Python version for the minimal Code Security supported version from "2.93" to "2.9.3".

### Merge instructions


- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->