### PR TITLE
Update incident commander assignment copy

### DIFF
--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -95,7 +95,7 @@ Once you have the [Datadog integration enabled on Slack][7], from any Slack chan
 
 In the creation modal, you add a descriptive title, select whether customers were impacted (yes, no, or unknown) and select a severity level (1-5, unknown).
 
-If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander. If the person declaring an incident is not a member of a Datadog account, then the IC becomes unassigned. The Incident Commander (IC) can be changed on the [incidents page][1] later if necessary.
+If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander (IC). If the person declaring an incident is not a member of a Datadog account, then the IC becomes unassigned. The IC can be changed on the [incidents page][1] later if necessary.
 
 After you declare an incident from Slack, it generates an incident channel.
 

--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -97,7 +97,7 @@ In the creation modal, you add a descriptive title, select whether customers wer
 
 If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander. If the person declaring an incident is not a member of a Datadog account and anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned. The Incident Commander (IC) can be changed on the [incidents page][1] later if necessary.
 
-Once you declare an incident from Slack, it generates an incident channel.
+After you declare an incident from Slack, it generates an incident channel.
 
 {{< img src="service_management/incidents/from-slack.png" alt="Create in incident from Slack" style="width:60%;">}}
 

--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -95,7 +95,7 @@ Once you have the [Datadog integration enabled on Slack][7], from any Slack chan
 
 In the creation modal, you add a descriptive title, select whether customers were impacted (yes, no, or unknown) and select a severity level (1-5, unknown).
 
-If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user will become the Incident Commander. The Incident Commander (IC) can be changed later in-app if necessary. If the person declaring an incident is not a member of a Datadog account _and_ anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned and can be assigned to another IC in-app.
+If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user will become the Incident Commander. The Incident Commander (IC) can be changed later in-app if necessary. If the person declaring an incident is not a member of a Datadog account and anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned and can be assigned to another IC in-app.
 
 Once you declare an incident from Slack, it generates an incident channel.
 

--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -95,7 +95,7 @@ Once you have the [Datadog integration enabled on Slack][7], from any Slack chan
 
 In the creation modal, you add a descriptive title, select whether customers were impacted (yes, no, or unknown) and select a severity level (1-5, unknown).
 
-If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander. If the person declaring an incident is not a member of a Datadog account and anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned. The Incident Commander (IC) can be changed later in-app if necessary.
+If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander. If the person declaring an incident is not a member of a Datadog account and anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned. The Incident Commander (IC) can be changed on the [incidents page][1] later if necessary.
 
 Once you declare an incident from Slack, it generates an incident channel.
 

--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -95,7 +95,7 @@ Once you have the [Datadog integration enabled on Slack][7], from any Slack chan
 
 In the creation modal, you add a descriptive title, select whether customers were impacted (yes, no, or unknown) and select a severity level (1-5, unknown).
 
-If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander (IC). If the person declaring an incident is not a member of a Datadog account, then the IC becomes unassigned. The IC can be changed on the [incidents page][1] later if necessary.
+If the user declaring the incident has connected their Slack to their Datadog account, then by default that user becomes the Incident Commander (IC). If the person declaring an incident is not a member of a Datadog account, then the IC is unassigned. You can change the IC on the [incidents page][1] later if necessary.
 
 After you declare an incident from Slack, it generates an incident channel.
 

--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -95,7 +95,7 @@ Once you have the [Datadog integration enabled on Slack][7], from any Slack chan
 
 In the creation modal, you add a descriptive title, select whether customers were impacted (yes, no, or unknown) and select a severity level (1-5, unknown).
 
-If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user will become the Incident Commander. The Incident Commander (IC) can be changed later in-app if necessary. If the person declaring an incident is not a member of a Datadog account and anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned and can be assigned to another IC in-app.
+If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander. If the person declaring an incident is not a member of a Datadog account and anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned. The Incident Commander (IC) can be changed later in-app if necessary.
 
 Once you declare an incident from Slack, it generates an incident channel.
 

--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -95,17 +95,13 @@ Once you have the [Datadog integration enabled on Slack][7], from any Slack chan
 
 In the creation modal, you add a descriptive title, select whether customers were impacted (yes, no, or unknown) and select a severity level (1-5, unknown).
 
-If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user will become the Incident Commander. The Incident Commander (IC) can be changed later in-app if necessary. If the person declaring an incident is not a member of a Datadog account, then the IC is assigned to a generic `Slack app user` and can be assigned to another IC in-app.
-
-Read more about using the Datadog Slack App [here][8].
-
-{{< img src="service_management/incidents/from-slack.png" alt="Create in incident from Slack" style="width:60%;">}}
-
-If the user declaring the incident is a part of your Datadog account, then that user becomes the Incident Commander (IC) by default. If the person declaring an incident is not part of your Datadog account, then the IC is assigned to a generic `Slack app user`. The IC can be changed on the [incidents page][1] in the Datadog app.
+If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user will become the Incident Commander. The Incident Commander (IC) can be changed later in-app if necessary. If the person declaring an incident is not a member of a Datadog account _and_ anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned and can be assigned to another IC in-app.
 
 Once you declare an incident from Slack, it generates an incident channel.
 
-For more information about the Datadog Slack integration, check out [the docs][7].
+{{< img src="service_management/incidents/from-slack.png" alt="Create in incident from Slack" style="width:60%;">}}
+
+Read more about using the Datadog Slack App [here][8].
 
 {{< site-region region="eu" >}}
 For {{< region-param key="dd_site_name" >}} customers who use Slack, stay informed about the Slack app by filing a ticket at https://help.datadoghq.com/.

--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -95,7 +95,7 @@ Once you have the [Datadog integration enabled on Slack][7], from any Slack chan
 
 In the creation modal, you add a descriptive title, select whether customers were impacted (yes, no, or unknown) and select a severity level (1-5, unknown).
 
-If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander. If the person declaring an incident is not a member of a Datadog account and anonymous Slack declaration is enabled in incident settings, then the IC becomes unassigned. The Incident Commander (IC) can be changed on the [incidents page][1] later if necessary.
+If the user declaring the incident has connected their Slack to their Datadog account, then, by default, that user becomes the Incident Commander. If the person declaring an incident is not a member of a Datadog account, then the IC becomes unassigned. The Incident Commander (IC) can be changed on the [incidents page][1] later if necessary.
 
 After you declare an incident from Slack, it generates an incident channel.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This document is outdated. When an incident is declared by a Slack user without a connected Datadog account, the incident commander simply becomes unassigned- not 'Slack app user'. I also mentioned that users must enable anonymous declaration in settings before this is even possible. Open to feedback on that wording since the actual setting is named: **Allow users to declare incidents without a connected Slack account**

I removed some redundant copy as well.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
Updating in response to a customer support [ticket](https://datadoghq.atlassian.net/browse/SOCE-1291) that was confused by the documentation here and the actual behavior of incidents declared from Slack.