### PR TITLE
Include Receiver Endpoints and Datadog Connector in Config Examples

### DIFF
--- a/content/en/opentelemetry/collector_exporter/configuration.md
+++ b/content/en/opentelemetry/collector_exporter/configuration.md
@@ -9,13 +9,238 @@ further_reading:
   text: "OpenTelemetry Collector Configuration"
 ---
 
-## OpenTelemetry Collector configuration
+The OpenTelemetry Collector receives, processes, and exports telemetry data from your applications. To send this data to Datadog, you need to configure several components within the Collector:
 
-To learn more about configuring the Collector, read the [OpenTelemetry Collector Configuration][3] documentation.
+- [Datadog Exporter][1]: Forwards trace, metric, and logs data from OpenTelemetry SDKs on to Datadog (without the Datadog Agent).
+- [Datadog Connector][29]: Calculates Trace Metrics from collected span data.
+
+## Setting up the OpenTelemetry Collector
+
+To run the OpenTelemetry Collector with the Datadog Exporter and Datadog Connector:
+
+### Step 1 - Download the OpenTelemetry Collector
+
+Download the latest release of the OpenTelemetry Collector Contrib distribution, from [the project's repository][3].
+
+### Step 2 - Configure the Datadog Exporter and Connector
+
+To use the Datadog Exporter, add it to your [OpenTelemetry Collector configuration][4]. Create a configuration file and name it `collector.yaml`. Use the example file which provides a basic configuration that is ready to use after you set your Datadog API key as the `DD_API_KEY` environment variable:
+
+{{< code-block lang="yaml" filename="collector.yaml" collapsible="true" >}}
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+  # The hostmetrics receiver is required to get correct infrastructure metrics in Datadog.
+  hostmetrics:
+    collection_interval: 10s
+    scrapers:
+      paging:
+        metrics:
+          system.paging.utilization:
+            enabled: true
+      cpu:
+        metrics:
+          system.cpu.utilization:
+            enabled: true
+      disk:
+      filesystem:
+        metrics:
+          system.filesystem.utilization:
+            enabled: true
+      load:
+      memory:
+      network:
+      processes:
+  # The prometheus receiver scrapes metrics needed for the OpenTelemetry Collector Dashboard.
+  prometheus:
+    config:
+      scrape_configs:
+      - job_name: 'otelcol'
+        scrape_interval: 10s
+        static_configs:
+        - targets: ['0.0.0.0:8888']
+
+  filelog:
+    include_file_path: true
+    poll_interval: 500ms
+    include:
+      - /var/log/**/*example*/*.log
+
+processors:
+  batch:
+    send_batch_max_size: 100
+    send_batch_size: 10
+    timeout: 10s
+
+connectors:
+  datadog/connector:
+
+exporters:
+  datadog/exporter:
+    api:
+      site: <DD_SITE>
+      key: ${env:DD_API_KEY}
+
+service:
+  pipelines:
+    metrics:
+      receivers: [hostmetrics, prometheus, otlp]
+      processors: [batch]
+      exporters: [datadog]
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [datadog/connector, datadog/exporter]
+    logs:
+      receivers: [otlp, filelog]
+      processors: [batch]
+      exporters: [datadog]
+{{< /code-block >}}
+
+Where `<DD_SITE>` is your site, {{< region-param key="dd_site" code="true" >}}.
+
+The above configuration enables the receiving of OTLP data from OpenTelemetry instrumentation libraries over HTTP and gRPC, and sets up a [batch processor][5], which is mandatory for any non-development environment. Note that you may get `413 - Request Entity Too Large` errors if you batch too much telemetry data in the batch processor.
+
+The exact configuration of the batch processor depends on your specific workload as well as the signal types. Datadog intake has different payload size limits for the 3 signal types:
+- Trace intake: 3.2MB
+- Log intake: [5MB uncompressed][6]
+- Metrics V2 intake: [500KB or 5MB after decompression][7]
+
+#### Advanced configuration
+
+[This fully documented example configuration file][8] illustrates all possible configuration options for the Datadog Exporter. There may be other options relevant to your deployment, such as `api::site` or the ones on the `host_metadata` section.
+
+### Step 3 - Configure your application
+
+To get better metadata for traces and for smooth integration with Datadog:
+
+- **Use resource detectors**: If they are provided by the language SDK, attach container information as resource attributes. For example, in Go, use the [`WithContainer()`][9] resource option.
+
+- **Apply [Unified Service Tagging][10]**: Make sure you've configured your application with the appropriate resource attributes for unified service tagging. This ties Datadog telemetry together with tags for service name, deployment environment, and service version. The application should set these tags using the OpenTelemetry semantic conventions: `service.name`, `deployment.environment`, and `service.version`.
+
+### Step 4 - Configure the logger for your application
+
+{{< img src="logs/log_collection/otel_collector_logs.png" alt="A diagram showing the host, container, or application sending data to the filelog receiver in the collector and the Datadog Exporter in the collector sending the data to the Datadog backend" style="width:100%;">}}
+
+Since the OpenTelemetry SDKs' logging functionality is not fully supported (see your specific language in the [OpenTelemetry documentation][11] for more information), Datadog recommends using a standard logging library for your application. Follow the language-specific [Log Collection documentation][12] to set up the appropriate logger in your application. Datadog strongly encourages setting up your logging library to output your logs in JSON to avoid the need for [custom parsing rules][13].
+
+#### Configure the filelog receiver
+
+Configure the filelog receiver using [operators][14]. For example, if there is a service `checkoutservice` that is writing logs to `/var/log/pods/services/checkout/0.log`, a sample log might look like this:
+
+```
+{"level":"info","message":"order confirmation email sent to \"jack@example.com\"","service":"checkoutservice","span_id":"197492ff2b4e1c65","timestamp":"2022-10-10T22:17:14.841359661Z","trace_id":"e12c408e028299900d48a9dd29b0dc4c"}
+```
+
+Example filelog configuration:
+
+```
+filelog:
+   include:
+     - /var/log/pods/**/*checkout*/*.log
+   start_at: end
+   poll_interval: 500ms
+   operators:
+     - id: parse_log
+       type: json_parser
+       parse_from: body
+     - id: trace
+       type: trace_parser
+       trace_id:
+         parse_from: attributes.trace_id
+       span_id:
+         parse_from: attributes.span_id
+   attributes:
+     ddtags: env:staging
+```
+
+- `include`: The list of files the receiver tails
+- `start_at: end`: Indicates to read new content that is being written
+- `poll_internal`: Sets the poll frequency
+- Operators:
+    - `json_parser`: Parses JSON logs. By default, the filelog receiver converts each log line into a log record, which is the `body` of the logs' [data model][15]. Then, the `json_parser` converts the JSON body into attributes in the data model.
+    - `trace_parser`: Extract the `trace_id` and `span_id` from the log to correlate logs and traces in Datadog.
+
+#### Remap OTel's `service.name` attribute to `service` for logs
+
+For Datadog Exporter versions 0.83.0 and later, the `service` field of OTel logs is populated as [OTel semantic convention][25] `service.name`. However, `service.name` is not one of the default [service attributes][26] in Datadog's log preprocessing.
+
+To get the `service` field correctly populated in your logs, you can specify `service.name` to be the source of a log's service by setting a [log service remapper processor][27].
+
+{{% collapse-content title="Optional: Using Kubernetes" level="h4" %}}
+
+There are multiple ways to deploy the OpenTelemetry Collector and Datadog Exporter in a Kubernetes infrastructure. For the filelog receiver to work, the [Agent/DaemonSet deployment][16] is the recommended deployment method.
+
+In containerized environments, applications write logs to `stdout` or `stderr`. Kubernetes collects the logs and writes them to a standard location. You need to mount the location on the host node into the Collector for the filelog receiver. Below is an [extension example][17] with the mounts required for sending logs.
+
+```
+apiVersion: apps/v1
+metadata:
+  name: otel-agent
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-collector
+    spec:
+      containers:
+        - name: collector
+          command:
+            - "/otelcol-contrib"
+            - "--config=/conf/otel-agent-config.yaml"
+          image: otel/opentelemetry-collector-contrib:0.71.0
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            # The k8s.pod.ip is used to associate pods for k8sattributes
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: "k8s.pod.ip=$(POD_IP)"
+          ports:
+            - containerPort: 4318 # default port for OpenTelemetry HTTP receiver.
+              hostPort: 4318
+            - containerPort: 4317 # default port for OpenTelemetry gRPC receiver.
+              hostPort: 4317
+            - containerPort: 8888 # Default endpoint for querying metrics.
+          volumeMounts:
+            - name: otel-agent-config-vol
+              mountPath: /conf
+            - name: varlogpods
+              mountPath: /var/log/pods
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+      volumes:
+        - name: otel-agent-config-vol
+          configMap:
+            name: otel-agent-conf
+            items:
+              - key: otel-agent-config
+                path: otel-agent-config.yaml
+        # Mount nodes log file location.
+        - name: varlogpods
+          hostPath:
+            path: /var/log/pods
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+```
+
+{{% /collapse-content %}}
 
 ## Out-of-the-box Datadog Exporter configuration
 
-You can find working examples of out-of-the-box configuration for Datadog Exporter in the [`exporter/datadogexporter/examples` folder][5] in the OpenTelemetry Collector Contrib project. See the full configuration example file, [`ootb-ec2.yaml`][4]. Configure each of the following components to suit your needs:
+You can find working examples of out-of-the-box configuration for Datadog Exporter in the [`exporter/datadogexporter/examples` folder][31] in the OpenTelemetry Collector Contrib project. See the full configuration example file, [`ootb-ec2.yaml`][30]. Configure each of the following components to suit your needs:
 
 {{< whatsnext desc=" " >}}
     {{< nextlink href="/opentelemetry/collector_exporter/otlp_receiver/" >}}OTLP Receiver{{< /nextlink >}}
@@ -27,6 +252,37 @@ You can find working examples of out-of-the-box configuration for Datadog Export
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[3]: https://opentelemetry.io/docs/collector/configuration/
-[4]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/ootb-ec2.yaml
-[5]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/
+[1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
+[2]: /tracing/other_telemetry/connect_logs_and_traces/opentelemetry
+[3]: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest
+[4]: https://opentelemetry.io/docs/collector/configuration/
+[5]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
+[6]: https://docs.datadoghq.com/api/latest/logs/
+[7]: https://docs.datadoghq.com/api/latest/metrics/#submit-metrics
+[8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml
+[9]: https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#WithContainer
+[10]: /getting_started/tagging/unified_service_tagging/
+[11]: https://opentelemetry.io/docs/instrumentation/
+[12]: /logs/log_collection/?tab=host
+[13]: /logs/log_configuration/parsing/
+[14]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/pkg/stanza/docs/operators
+[15]: https://opentelemetry.io/docs/reference/specification/logs/data-model/
+[16]: https://opentelemetry.io/docs/collector/deployment/#agent
+[17]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/k8s-chart/daemonset.yaml
+[18]: /tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=python
+[19]: https://opentelemetry.io/docs/reference/specification/resource/sdk/#sdk-provided-resource-attributes
+[20]: https://opentelemetry.io/docs/collector/deployment/
+[21]: https://app.datadoghq.com/integrations/otel
+[22]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
+[23]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver
+[24]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver
+[25]: https://opentelemetry.io/docs/specs/semconv/resource/#service
+[26]: https://docs.datadoghq.com/logs/log_configuration/pipelines/?tab=service#service-attribute
+[27]: https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#service-remapper
+[28]: /opentelemetry/schema_semantics/hostname/
+[29]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/datadogconnector
+
+
+
+[30]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/ootb-ec2.yaml
+[31]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/

--- a/content/en/opentelemetry/collector_exporter/configuration.md
+++ b/content/en/opentelemetry/collector_exporter/configuration.md
@@ -253,7 +253,6 @@ You can find working examples of out-of-the-box configuration for Datadog Export
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/datadogexporter
-[2]: /tracing/other_telemetry/connect_logs_and_traces/opentelemetry
 [3]: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/latest
 [4]: https://opentelemetry.io/docs/collector/configuration/
 [5]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
@@ -269,20 +268,10 @@ You can find working examples of out-of-the-box configuration for Datadog Export
 [15]: https://opentelemetry.io/docs/reference/specification/logs/data-model/
 [16]: https://opentelemetry.io/docs/collector/deployment/#agent
 [17]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/k8s-chart/daemonset.yaml
-[18]: /tracing/other_telemetry/connect_logs_and_traces/opentelemetry/?tab=python
-[19]: https://opentelemetry.io/docs/reference/specification/resource/sdk/#sdk-provided-resource-attributes
-[20]: https://opentelemetry.io/docs/collector/deployment/
-[21]: https://app.datadoghq.com/integrations/otel
-[22]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
-[23]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver
-[24]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver
 [25]: https://opentelemetry.io/docs/specs/semconv/resource/#service
 [26]: https://docs.datadoghq.com/logs/log_configuration/pipelines/?tab=service#service-attribute
 [27]: https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#service-remapper
 [28]: /opentelemetry/schema_semantics/hostname/
 [29]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/datadogconnector
-
-
-
 [30]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/ootb-ec2.yaml
 [31]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/

--- a/content/en/opentelemetry/collector_exporter/configuration.md
+++ b/content/en/opentelemetry/collector_exporter/configuration.md
@@ -26,7 +26,9 @@ Download the latest release of the OpenTelemetry Collector Contrib distribution,
 
 To use the Datadog Exporter, add it to your [OpenTelemetry Collector configuration][4]. Create a configuration file and name it `collector.yaml`. Use the example file which provides a basic configuration that is ready to use after you set your Datadog API key as the `DD_API_KEY` environment variable:
 
-{{< code-block lang="yaml" filename="collector.yaml" collapsible="true" >}}
+{{% otel-endpoint-note %}}
+
+```yaml
 receivers:
   otlp:
     protocols:
@@ -82,7 +84,7 @@ connectors:
 exporters:
   datadog/exporter:
     api:
-      site: <DD_SITE>
+      site: {{< region-param key="dd_site" >}}
       key: ${env:DD_API_KEY}
 
 service:
@@ -99,9 +101,7 @@ service:
       receivers: [otlp, filelog]
       processors: [batch]
       exporters: [datadog]
-{{< /code-block >}}
-
-Where `<DD_SITE>` is your site, {{< region-param key="dd_site" code="true" >}}.
+```
 
 The above configuration enables the receiving of OTLP data from OpenTelemetry instrumentation libraries over HTTP and gRPC, and sets up a [batch processor][5], which is mandatory for any non-development environment. Note that you may get `413 - Request Entity Too Large` errors if you batch too much telemetry data in the batch processor.
 

--- a/content/en/opentelemetry/collector_exporter/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/collector_exporter/otel_collector_datadog_exporter.md
@@ -1,5 +1,5 @@
 ---
-title: OpenTelemetry Collector Datadog Exporter
+title: OpenTelemetry Collector
 aliases:
 - /tracing/setup_overview/open_standards/otel_collector_datadog_exporter/
 - /tracing/trace_collection/open_standards/otel_collector_datadog_exporter/
@@ -19,19 +19,22 @@ further_reading:
   text: "OTLP Metrics Types"
 ---
 
-The OpenTelemetry Collector is a vendor-agnostic agent process for collecting and exporting telemetry data emitted by many processes. The [Datadog Exporter][1] for the OpenTelemetry Collector allows you to forward trace, metric, and logs data from OpenTelemetry SDKs on to Datadog (without the Datadog Agent). It works with all supported languages, and you can [connect those OpenTelemetry trace data with application logs][2].
+The OpenTelemetry Collector receives, processes, and exports telemetry data from your applications. To send this data to Datadog, you need to configure several components within the Collector:
+
+- [Datadog Exporter][1]: Forwards trace, metric, and logs data from OpenTelemetry SDKs on to Datadog (without the Datadog Agent).
+- [Datadog Connector][29]: Calculates Trace Metrics from collected span data.
 
 {{< img src="metrics/otel/datadog_exporter.png" alt="Application Instrumented Library, Cloud Integrations, and Other Monitoring Solutions (for example Prometheus) -> Datadog Exporter inside OpenTelemetry Collector -> Datadog" style="width:100%;">}}
 
-## Setting up the OpenTelemetry Collector with the Datadog Exporter
+## Setting up the OpenTelemetry Collector
 
-To run the OpenTelemetry Collector along with the Datadog Exporter:
+To run the OpenTelemetry Collector with the Datadog Exporter and Datadog Connector:
 
 ### Step 1 - Download the OpenTelemetry Collector
 
 Download the latest release of the OpenTelemetry Collector Contrib distribution, from [the project's repository][3].
 
-### Step 2 - Configure the Datadog Exporter
+### Step 2 - Configure the Datadog Exporter and Connector
 
 To use the Datadog Exporter, add it to your [OpenTelemetry Collector configuration][4]. Create a configuration file and name it `collector.yaml`. Use the example file which provides a basic configuration that is ready to use after you set your Datadog API key as the `DD_API_KEY` environment variable:
 
@@ -40,7 +43,9 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
       grpc:
+        endpoint: 0.0.0.0:4317
   # The hostmetrics receiver is required to get correct infrastructure metrics in Datadog.
   hostmetrics:
     collection_interval: 10s
@@ -83,8 +88,11 @@ processors:
     send_batch_size: 10
     timeout: 10s
 
+connectors:
+  datadog/connector:
+
 exporters:
-  datadog:
+  datadog/exporter:
     api:
       site: <DD_SITE>
       key: ${env:DD_API_KEY}
@@ -98,7 +106,7 @@ service:
     traces:
       receivers: [otlp]
       processors: [batch]
-      exporters: [datadog]
+      exporters: [datadog/connector, datadog/exporter]
     logs:
       receivers: [otlp, filelog]
       processors: [batch]
@@ -130,7 +138,7 @@ To get better metadata for traces and for smooth integration with Datadog:
 
 {{< img src="logs/log_collection/otel_collector_logs.png" alt="A diagram showing the host, container, or application sending data to the filelog receiver in the collector and the Datadog Exporter in the collector sending the data to the Datadog backend" style="width:100%;">}}
 
-Since the OpenTelemetry SDKs' logging functionality is not fully supported (see your specific language in the [OpenTelemetry documentation][11] for more information), Datadog recommends using a standard logging library for your application. Follow the language-specific [Log Collection documentation][12] to set up the appropriate logger in your application. Datadog strongly encourages setting up your logging library to output your logs in JSON to avoid the need for [custom parsing rules][13]. 
+Since the OpenTelemetry SDKs' logging functionality is not fully supported (see your specific language in the [OpenTelemetry documentation][11] for more information), Datadog recommends using a standard logging library for your application. Follow the language-specific [Log Collection documentation][12] to set up the appropriate logger in your application. Datadog strongly encourages setting up your logging library to output your logs in JSON to avoid the need for [custom parsing rules][13].
 
 #### Configure the filelog receiver
 
@@ -162,12 +170,12 @@ filelog:
      ddtags: env:staging
 ```
 
-- `include`: The list of files the receiver tails 
-- `start_at: end`: Indicates to read new content that is being written 
-- `poll_internal`: Sets the poll frequency 
+- `include`: The list of files the receiver tails
+- `start_at: end`: Indicates to read new content that is being written
+- `poll_internal`: Sets the poll frequency
 - Operators:
     - `json_parser`: Parses JSON logs. By default, the filelog receiver converts each log line into a log record, which is the `body` of the logs' [data model][15]. Then, the `json_parser` converts the JSON body into attributes in the data model.
-    - `trace_parser`: Extract the `trace_id` and `span_id` from the log to correlate logs and traces in Datadog. 
+    - `trace_parser`: Extract the `trace_id` and `span_id` from the log to correlate logs and traces in Datadog.
 
 #### Remap OTel's `service.name` attribute to `service` for logs
 
@@ -180,7 +188,7 @@ To get the `service` field correctly populated in your logs, you can specify `se
 
 There are multiple ways to deploy the OpenTelemetry Collector and Datadog Exporter in a Kubernetes infrastructure. For the filelog receiver to work, the [Agent/DaemonSet deployment][16] is the recommended deployment method.
 
-In containerized environments, applications write logs to `stdout` or `stderr`. Kubernetes collects the logs and writes them to a standard location. You need to mount the location on the host node into the Collector for the filelog receiver. Below is an [extension example][17] with the mounts required for sending logs. 
+In containerized environments, applications write logs to `stdout` or `stderr`. Kubernetes collects the logs and writes them to a standard location. You need to mount the location on the host node into the Collector for the filelog receiver. Below is an [extension example][17] with the mounts required for sending logs.
 
 ```
 apiVersion: apps/v1
@@ -349,7 +357,7 @@ Using a DaemonSet is the most common and recommended way to configure OpenTeleme
    ```
 
    This ensures that [Kubernetes Attributes Processor][4] which is used in [the config map][5] is able to extract the necessary metadata to attach to traces. There are additional [roles][6] that need to be set to allow access to this metadata. [The example][1] is complete, ready to use, and has the correct roles set up.
-  
+
 3. Provide your [application container][7]. To configure your application container, ensure that the correct OTLP endpoint hostname is used. The OpenTelemetry Collector runs as a DaemonSet, so the current host needs to be targeted. Set your application container's `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable correctly, as in the [example chart][8]:
 
    ```yaml
@@ -415,7 +423,7 @@ To deploy the OpenTelemetry Collector and Datadog Exporter in a Kubernetes Gatew
    ```
 
    This ensures that [Kubernetes Attributes Processor][4] which is used in [the config map][5] is able to extract the necessary metadata to attach to traces. There are additional [roles][6] that need to be set to allow access to this metadata. [The example][1] is complete, ready to use, and has the correct roles set up.
-  
+
 3. Provide your [application container][7]. To configure your application container, ensure that the correct OTLP endpoint hostname is used. The OpenTelemetry Collector runs as a DaemonSet, so the current host needs to be targeted. Set your application container's `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable correctly, as in the [example chart][8]:
 
    ```yaml
@@ -459,7 +467,7 @@ To deploy the OpenTelemetry Collector and Datadog Exporter in a Kubernetes Gatew
    # ...
    ```
 
-   This ensures that each agent forwards its data via the OTLP protocol to the Collector Gateway. 
+   This ensures that each agent forwards its data via the OTLP protocol to the Collector Gateway.
 
 6. Replace `GATEWAY_HOSTNAME` with the address of your OpenTelemetry Collector Gateway.
 
@@ -510,7 +518,7 @@ To use the OpenTelemetry Operator:
 1. Follow the [official documentation for deploying the OpenTelemetry Operator][1]. As described there, deploy the certificate manager in addition to the Operator.
 
 2. Configure the Operator using one of the OpenTelemetry Collector standard Kubernetes configurations:
-   * [Daemonset deployment][2] - Use the DaemonSet deployment if you want to ensure you receive host metrics. 
+   * [Daemonset deployment][2] - Use the DaemonSet deployment if you want to ensure you receive host metrics.
    * [Gateway deployment][3]
 
    For example:
@@ -534,8 +542,10 @@ To use the OpenTelemetry Operator:
        receivers:
          otlp:
            protocols:
-             grpc:
              http:
+               endpoint: 0.0.0.0:4318
+             grpc:
+               endpoint: 0.0.0.0:4317
        hostmetrics:
          collection_interval: 10s
          scrapers:
@@ -561,6 +571,8 @@ To use the OpenTelemetry Operator:
            send_batch_max_size: 100
            send_batch_size: 10
            timeout: 10s
+       connectors:
+         datadog/connector:
        exporters:
          datadog:
            api:
@@ -645,7 +657,7 @@ Use the following configuration to enable additional attributes on the Docker St
         enabled: true
 ```
 
-The minimum required OpenTelemetry Collector version that supports this feature is v0.78.0. 
+The minimum required OpenTelemetry Collector version that supports this feature is v0.78.0.
 
 ## Further reading
 
@@ -679,3 +691,4 @@ The minimum required OpenTelemetry Collector version that supports this feature 
 [26]: https://docs.datadoghq.com/logs/log_configuration/pipelines/?tab=service#service-attribute
 [27]: https://docs.datadoghq.com/logs/log_configuration/processors/?tab=ui#service-remapper
 [28]: /opentelemetry/schema_semantics/hostname/
+[29]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/datadogconnector

--- a/content/en/opentelemetry/collector_exporter/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/collector_exporter/otel_collector_datadog_exporter.md
@@ -38,7 +38,9 @@ Download the latest release of the OpenTelemetry Collector Contrib distribution,
 
 To use the Datadog Exporter, add it to your [OpenTelemetry Collector configuration][4]. Create a configuration file and name it `collector.yaml`. Use the example file which provides a basic configuration that is ready to use after you set your Datadog API key as the `DD_API_KEY` environment variable:
 
-{{< code-block lang="yaml" filename="collector.yaml" collapsible="true" >}}
+{{% otel-endpoint-note %}}
+
+```yaml
 receivers:
   otlp:
     protocols:
@@ -94,7 +96,7 @@ connectors:
 exporters:
   datadog/exporter:
     api:
-      site: <DD_SITE>
+      site: {{< region-param key="dd_site" >}}
       key: ${env:DD_API_KEY}
 
 service:
@@ -111,9 +113,7 @@ service:
       receivers: [otlp, filelog]
       processors: [batch]
       exporters: [datadog]
-{{< /code-block >}}
-
-Where `<DD_SITE>` is your site, {{< region-param key="dd_site" code="true" >}}.
+```
 
 The above configuration enables the receiving of OTLP data from OpenTelemetry instrumentation libraries over HTTP and gRPC, and sets up a [batch processor][5], which is mandatory for any non-development environment. Note that you may get `413 - Request Entity Too Large` errors if you batch too much telemetry data in the batch processor.
 

--- a/content/en/opentelemetry/collector_exporter/otlp_receiver.md
+++ b/content/en/opentelemetry/collector_exporter/otlp_receiver.md
@@ -19,14 +19,16 @@ For more information, see the OpenTelemetry project documentation for the [OTLP 
 
 Add the following lines to your Collector configuration:
 
+{{% otel-endpoint-note %}}
+
 ```yaml
 receivers:
   otlp:
    protocols:
       http:
-       endpoint: "localhost:4318"
+       endpoint: "0.0.0.0:4318"
       grpc:
-       endpoint: "localhost:4317"
+       endpoint: "0.0.0.0:4317"
 ```
 
 ## Data collected
@@ -71,7 +73,7 @@ Resource attributes:
      -> k8s.replicaset.name: Str(opentelemetry-demo-shippingservice-7f9b565549)
      -> kube_app_component: Str(shippingservice)
 ScopeSpans #0
-ScopeSpans SchemaURL: 
+ScopeSpans SchemaURL:
 InstrumentationScope opentelemetry-otlp 0.11.0
 Span #0
     Trace ID       : c4f6d4a8831a5d7b95727da5443ad8a4
@@ -82,7 +84,7 @@ Span #0
     Start time     : 2023-11-20 12:56:26.401728438 +0000 UTC
     End time       : 2023-11-20 12:56:26.403518138 +0000 UTC
     Status code    : Unset
-    Status message : 
+    Status message :
 Attributes:
      -> http.host: Str(opentelemetry-demo-quoteservice)
      -> http.url: Str(http://opentelemetry-demo-quoteservice:8080/getquote)
@@ -127,13 +129,13 @@ Resource attributes:
      -> kube_app_instance: Str(opentelemetry-collector)
      -> k8s.pod.name: Str(opentelemetry-collector-agent-4dm92)
 ScopeMetrics #0
-ScopeMetrics SchemaURL: 
+ScopeMetrics SchemaURL:
 InstrumentationScope otelcol/prometheusreceiver 0.88.0-dev
 Metric #0
 Descriptor:
      -> Name: otelcol_exporter_queue_capacity
      -> Description: Fixed capacity of the retry queue (in batches)
-     -> Unit: 
+     -> Unit:
      -> DataType: Gauge
 NumberDataPoints #0
 Data point attributes:
@@ -171,12 +173,12 @@ Resource attributes:
      -> kube_app_instance: Str(opentelemetry-collector)
      -> k8s.pod.start_time: Str(2023-11-20T12:53:23Z)
 ScopeLogs #0
-ScopeLogs SchemaURL: 
-InstrumentationScope  
+ScopeLogs SchemaURL:
+InstrumentationScope
 LogRecord #0
 ObservedTimestamp: 2023-11-20 13:02:04.332021519 +0000 UTC
 Timestamp: 2023-11-20 13:01:46.095736502 +0000 UTC
-SeverityText: 
+SeverityText:
 SeverityNumber: Unspecified(0)
 Body: Str( return wrapped_send(self, request, **kwargs))
 Attributes:
@@ -184,8 +186,8 @@ Attributes:
      -> time: Str(2023-11-20T13:01:46.095736502Z)
      -> logtag: Str(F)
      -> log.iostream: Str(stderr)
-Trace ID: 
-Span ID: 
+Trace ID:
+Span ID:
 Flags: 0
 ```
 

--- a/content/en/opentelemetry/guide/migration.md
+++ b/content/en/opentelemetry/guide/migration.md
@@ -60,7 +60,9 @@ receivers:
   otlp:
     protocols:
       http:
+        endpoint: 0.0.0.0:4318
       grpc:
+        endpoint: 0.0.0.0:4317
 processors:
   batch:
 connectors:

--- a/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
@@ -37,6 +37,8 @@ Read the OpenTelemetry instrumentation documentation to understand how to point 
 
 OTLP ingestion is off by default, and you can turn it on by updating your `datadog.yaml` file configuration or by setting environment variables. The following `datadog.yaml` configurations enable endpoints on the default ports.
 
+{{% otel-endpoint-note %}}
+
 For gRPC, default port 4317:
 
 ```yaml
@@ -44,7 +46,7 @@ otlp_config:
   receiver:
     protocols:
       grpc:
-        endpoint: localhost:4317
+        endpoint: 0.0.0.0:4317
 ```
 For HTTP, default port 4318:
 
@@ -53,7 +55,7 @@ otlp_config:
   receiver:
     protocols:
       http:
-        endpoint: localhost:4318
+        endpoint: 0.0.0.0:4318
 ```
 
 Alternatively, configure the endpoints by providing the port through the environment variables:

--- a/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
@@ -165,6 +165,7 @@ OTLP logs ingestion on the Datadog Agent is disabled by default so that you don'
     receiver:
       protocols:
         grpc:
+          endpoint: 0.0.0.0:4317
           enabled: true
    ```
 
@@ -174,6 +175,7 @@ OTLP logs ingestion on the Datadog Agent is disabled by default so that you don'
     receiver:
       protocols:
         http:
+          endpoint: 0.0.0.0:4318
           enabled: true
    ```
 

--- a/layouts/shortcodes/otel-endpoint-note.md
+++ b/layouts/shortcodes/otel-endpoint-note.md
@@ -1,0 +1,4 @@
+<div class="alert alert-warning">
+The following examples use <code>0.0.0.0</code> as the endpoint address for convenience. This allows connections from any network interface. For enhanced security, especially in local deployments, consider using <code>localhost</code> instead.<br><br>
+For more information on secure endpoint configuration, see the <a href="https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/security-best-practices.md#safeguards-against-denial-of-service-attacks">OpenTelemetry security documentation</a>.
+</div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Our configuration examples are missing the Datadog Connector and endpoints. Added where missing.
- The Configuration page in the left-nav is seemingly missing non-OOTB config. Copied content back into Configuration page. (Note: Need to clean up this duplicated content in another PR).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

**Note for Docs reviewer**: The content in `/opentelemetry/collector_exporter/configuration.md` is not new. It's duplicated, so it doesn't need an editorial review.

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->