### PR TITLE
Docs8396/add terraform params

### DIFF
--- a/content/en/integrations/guide/azure-programmatic-management.md
+++ b/content/en/integrations/guide/azure-programmatic-management.md
@@ -148,7 +148,7 @@ The protected settings include:
 {{% /tab %}}
 {{< /tabs >}}
 
-See the [Virtual Machine Extension resource][10] in the Terraform registry for more information about the available arguments.  
+See the [Virtual Machine Extension resource][10] in the Terraform registry for more information about the available arguments.
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/en/integrations/guide/azure-programmatic-management.md
+++ b/content/en/integrations/guide/azure-programmatic-management.md
@@ -79,7 +79,28 @@ You can use Terraform to create and manage the Datadog Agent extension. Follow t
 2. Apply any desired [Agent configurations][12].
 3. For Windows Server 2008, Vista, and newer, save the `%ProgramData%\Datadog` folder as a zip file. For Linux, save the `/etc/datadog-agent` folder as a zip file.
 4. Upload the file to blob storage.
-5. Reference the blob storage URL in the Terraform block to create the VM extension:
+5. Reference the blob storage URL in the Terraform block with the `agentConfiguration` parameter to create the VM extension.
+
+#### Extension settings
+
+The Azure Extension can accept both normal settings and protected settings.
+
+The normal settings include:
+
+| Variable | Type | Description  |
+|----------|------|--------------|
+| `site` | String | Set the Datadog intake site, for example: `SITE=`{{< region-param key="dd_site" code="true">}} |
+| `agentVersion` | String | The Agent version to install, following the format `x.y.z` or `latest` |
+| `agentConfiguration` | URI | (optional) URL to the Azure blob containing the Agent configuration as a zip. |
+| `agentConfigurationChecksum` | String | The SHA256 checksum of the Agent configuration zip file, mandatory if `agentConfiguration` is specified. |
+
+The protected settings include:
+
+| Variable | Type | Description  |
+|----------|------|--------------|
+| `api_key`| String | Adds the Datadog API KEY to the configuration file. |
+
+**Note**: If `agentConfiguration` and `api_key` are specified at the same time, the API key found in the `agentConfiguration` takes precedence.
 
 {{< tabs >}}
 {{% tab "Windows" %}}
@@ -127,7 +148,7 @@ You can use Terraform to create and manage the Datadog Agent extension. Follow t
 {{% /tab %}}
 {{< /tabs >}}
 
-See the [Virtual Machine Extension resource][10] in the Terraform registry for more information about the available arguments.
+See the [Virtual Machine Extension resource][10] in the Terraform registry for more information about the available arguments. 
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/en/integrations/guide/azure-programmatic-management.md
+++ b/content/en/integrations/guide/azure-programmatic-management.md
@@ -148,7 +148,7 @@ The protected settings include:
 {{% /tab %}}
 {{< /tabs >}}
 
-See the [Virtual Machine Extension resource][10] in the Terraform registry for more information about the available arguments. 
+See the [Virtual Machine Extension resource][10] in the Terraform registry for more information about the available arguments.  
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/en/integrations/guide/powershell-command-to-install-azure-datadog-extension.md
+++ b/content/en/integrations/guide/powershell-command-to-install-azure-datadog-extension.md
@@ -40,7 +40,7 @@ The normal settings include:
 |----------|------|--------------|
 | `site` | String | Set the Datadog intake site, for example: `SITE=`{{< region-param key="dd_site" code="true">}} |
 | `agentVersion` | String | The Agent version to install, following the format `x.y.z` or `latest` |
-| `agentConfiguration` | URI | (optional) Url to the Azure blob contaning the Agent configuration as a zip. |
+| `agentConfiguration` | URI | (optional) URI to the Azure blob containing the Agent configuration as a zip file. |
 | `agentConfigurationChecksum` | String | The SHA256 checksum of the Agent configuration zip file, mandatory if `agentConfiguration` is specified. |
 
 The protected settings include:
@@ -89,7 +89,7 @@ The normal settings include:
 |----------|------|--------------|
 | `site` | String | Set the Datadog intake site, for example: `SITE=`{{< region-param key="dd_site" code="true">}} |
 | `agentVersion` | String | The Agent version to install, following the format `x.y.z` or `latest` |
-| `agentConfiguration` | URI | (optional) URI to the Azure blob containing the Agent configuration as a zip. |
+| `agentConfiguration` | URI | (optional) URI to the Azure blob containing the Agent configuration as a zip file. |
 | `agentConfigurationChecksum` | String | The SHA256 checksum of the Agent configuration zip file, mandatory if `agentConfiguration` is specified. |
 
 The protected settings include:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- Add a section describing parameters that can be used for configuring the Datadog Agent Azure VM extension.
- Correct some minor copy issues in an Azure guide

**Editorial note**: The use of a `region-param` shortcode in the table negates the possibility of the table becoming its own shortcode

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->