### PR TITLE
TeamCity configuration parameters should not have Password type

### DIFF
--- a/content/en/continuous_integration/pipelines/teamcity.md
+++ b/content/en/continuous_integration/pipelines/teamcity.md
@@ -29,7 +29,7 @@ Set up tracing in TeamCity to collect data about your pipeline executions, debug
 | [Queue time][15] | Queue time | View the amount of time pipeline jobs sit in the queue before processing. |
 | [Pipeline failure reasons][16] | Pipeline failure reasons | Identify pipeline failure reasons from error messages. |
 
-The following TeamCity versions are supported: 
+The following TeamCity versions are supported:
 
 - TeamCity >= 2021.2 or later
 
@@ -52,8 +52,8 @@ the VCS Root attached and the [VCS Trigger][13] configured.
    * **datadog.ci.enabled**: `true` (`false`
    can be used to disable the plugin for a specific project).
 
-   These configuration parameters can be added either to TeamCity subprojects
-   or to the [TeamCity Root Project][10]. When added to the Root project, they are propagated
+   These configuration parameters should not have type **Password**, as that prevents the plugin from correctly reading their values.
+   They can be added either to TeamCity subprojects or to the [TeamCity Root Project][10]. When added to the Root project, they are propagated
    to all its subprojects. For example, to enable the plugin for all projects, add **datadog.ci.enabled** with the
    value `true` to the Root Project. More information on defining configuration parameters
    is available in the [TeamCity Project Hierarchy][9] documentation.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
TeamCity configuration parameters should not have Password type

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->