### PR TITLE
[CWS] improve kernel version support table (4.14+)

### DIFF
--- a/content/en/security/threats/supported_linux_distributions.md
+++ b/content/en/security/threats/supported_linux_distributions.md
@@ -4,20 +4,21 @@ title: CSM Threats Supported Linux Distributions
 
 Cloud Security Management Threats supports the following Linux distributions:
 
-| Linux Distributions          | Supported Versions                |
-|------------------------------|-----------------------------------|
-| Ubuntu LTS                   | 18.04, 20.04, 22.04               |
-| Debian                       | 10 or later                       |
-| Amazon Linux 2               | Kernels 4.15, 5.4, 5.10, and 2023 |
-| SUSE Linux Enterprise Server | 12 and 15                         |
-| Red Hat Enterprise Linux     | 7, 8, and 9                       |
-| Oracle Linux                 | 7, 8, and 9                       |
-| CentOS                       | 7                                 |
+| Linux Distributions          | Supported Versions                      |
+|------------------------------|-----------------------------------------|
+| Ubuntu LTS                   | 18.04, 20.04, 22.04                     |
+| Debian                       | 10 or later                             |
+| Amazon Linux 2               | Kernels 4.14 and higher                 |
+| Amazon Linux 2023            | All versions                            |
+| SUSE Linux Enterprise Server | 12 and 15                               |
+| Red Hat Enterprise Linux     | 7, 8, and 9                             |
+| Oracle Linux                 | 7, 8, and 9                             |
+| CentOS                       | 7                                       |
 
 **Notes:**
 
 - Custom kernel builds are not supported.
 - For compatibility with a custom Kubernetes network plugin like Cilium or Calico, see the [Troubleshooting Cloud Security Management Threats][1].
-- Data collection is done using eBPF, so Datadog minimally requires platforms that have underlying Linux kernel versions of 4.15.0+ or have eBPF features backported.
+- Data collection is done using eBPF, so Datadog minimally requires platforms that have underlying Linux kernel versions of 4.14.0+ or have eBPF features backported (for example Centos/RHEL 7 with kernel 3.10 has eBPF features backported and is supported).
 
 [1]: /security/cloud_security_management/troubleshooting/threats

--- a/content/en/security/threats/supported_linux_distributions.md
+++ b/content/en/security/threats/supported_linux_distributions.md
@@ -19,6 +19,6 @@ Cloud Security Management Threats supports the following Linux distributions:
 
 - Custom kernel builds are not supported.
 - For compatibility with a custom Kubernetes network plugin like Cilium or Calico, see the [Troubleshooting Cloud Security Management Threats][1].
-- Data collection is done using eBPF, so Datadog minimally requires platforms that have underlying Linux kernel versions of 4.14.0+ or have eBPF features backported (for example Centos/RHEL 7 with kernel 3.10 has eBPF features backported and is supported).
+- Data collection is done using eBPF, so Datadog requires, at minimum, platforms that have underlying Linux kernel versions of 4.14.0+ or have eBPF features backported (for example, Centos/RHEL 7 with kernel 3.10 has eBPF features backported, so it is supported).
 
 [1]: /security/cloud_security_management/troubleshooting/threats


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?


CWS now supports kernels 4.14 and higher. This PR improves the supported kernel support table to make it clearer which OS and kernels are supported.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->