### PR TITLE
Update single-step-apm.md

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm.md
@@ -59,7 +59,7 @@ For a Docker Linux container:
 
 1. Run the one-line installation command:
    ```shell
-   bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_docker_injection.sh)"
+   DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
    ```
 2. Configure the Agent in Docker:
    ```shell
@@ -241,7 +241,7 @@ By default, enabling APM on your server installs support for Java, Python, Ruby,
 For example, to install support for only v1.25.0 of the Java tracing library and the latest Python tracing library, add the following to the installation command:
 
 ```shell
-DD_APM_INSTRUMENTATION_LIBRARIES="java:1.25.0,python" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_docker_injection.sh)"
+DD_APM_INSTRUMENTATION_ENABLED=docker DD_APM_INSTRUMENTATION_LIBRARIES="java:1.25.0,python" bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
 ```
 
 You can optionally provide a version number for the tracing library by placing a colon after the language name and specifying the tracing library version. If you don't specify a version, it defaults to the latest version. Language names are comma-separated.


### PR DESCRIPTION
Updating the single step for docker

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The PR updates the script/command for single step for docker from: 
`bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_docker_injection.sh)"`
to
`DD_APM_INSTRUMENTATION_ENABLED=docker bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"`

This is approved by the APM Onboarding team cc: @Kyle-Verhoog 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->