### PR TITLE
Updates `websites-sources` module reference

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/DataDog/websites-modules v1.4.169 // indirect
-	github.com/DataDog/websites-sources v0.0.0-20240716143456-54de808fe213 // indirect
+	github.com/DataDog/websites-sources v0.0.0-20240730155901-b7860436c3de // indirect
 )
 
 // replace github.com/DataDog/websites-modules => /Users/matt.fitzsimmons/source/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@ github.com/DataDog/websites-modules v1.4.169 h1:dkTVhCutgyJc7ncTvgQxOU78DQd6F8NY
 github.com/DataDog/websites-modules v1.4.169/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
 github.com/DataDog/websites-sources v0.0.0-20240716143456-54de808fe213 h1:OlDom/UqAX1+IyMfNDIgBXqqmig4F0a0gzaeZRmnKVU=
 github.com/DataDog/websites-sources v0.0.0-20240716143456-54de808fe213/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=
+github.com/DataDog/websites-sources v0.0.0-20240730155901-b7860436c3de h1:kuAwTcxM53AkRLt3aLo/N6/ptM9CjIQjmk76o/pLU08=
+github.com/DataDog/websites-sources v0.0.0-20240730155901-b7860436c3de/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=


### PR DESCRIPTION
### What does this PR do? What is the motivation?
`websites-sources` version is out of date.  `HCP Terraform` integrations tile not surfacing as a result of this.

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
`HCP Terraform` tile is showing here: https://docs-staging.datadoghq.com/brian.deutsch/web-sources-bump/integrations/?q=hcp

Otherwise, no changes https://docs-staging.datadoghq.com/brian.deutsch/web-sources-bump/