### PR TITLE
Conditionally hide image in learning center callout

### DIFF
--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -37,7 +37,7 @@ cascade:
 {{< /site-region >}}
 
 
-{{< learning-center-callout header="Join an enablement webinar session" hide_image="true" btn_title="Sign Up" btn_url="https://www.datadoghq.com/technical-enablement/sessions/?tags.topics-0=Cloud+Cost+Management">}}
+{{< learning-center-callout header="Join an enablement webinar session" btn_title="Sign Up" btn_url="https://www.datadoghq.com/technical-enablement/sessions/?tags.topics-0=Cloud+Cost+Management">}}
   Explore your cloud provider costs and correlate them with real-time telemetry data. Gain actionable insights and alerts on where your cloud costs are coming from, how they are changing, and where to find potential optimizations.
 {{< /learning-center-callout >}}
 

--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -3,7 +3,6 @@ title: Cloud Cost Management
 aliases:
   - /infrastructure/cloud_cost_management
   - /integrations/cloudability
-hide_callout_image: true
 further_reading:
   - link: "https://www.datadoghq.com/blog/control-your-cloud-spend-with-datadog-cloud-cost-management/"
     tag: "Blog"
@@ -38,7 +37,7 @@ cascade:
 {{< /site-region >}}
 
 
-{{< learning-center-callout header="Join an enablement webinar session" btn_title="Sign Up" btn_url="https://www.datadoghq.com/technical-enablement/sessions/?tags.topics-0=Cloud+Cost+Management">}}
+{{< learning-center-callout header="Join an enablement webinar session" hide_image="true" btn_title="Sign Up" btn_url="https://www.datadoghq.com/technical-enablement/sessions/?tags.topics-0=Cloud+Cost+Management">}}
   Explore your cloud provider costs and correlate them with real-time telemetry data. Gain actionable insights and alerts on where your cloud costs are coming from, how they are changing, and where to find potential optimizations.
 {{< /learning-center-callout >}}
 

--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -3,6 +3,7 @@ title: Cloud Cost Management
 aliases:
   - /infrastructure/cloud_cost_management
   - /integrations/cloudability
+hide_callout_image: true
 further_reading:
   - link: "https://www.datadoghq.com/blog/control-your-cloud-spend-with-datadog-cloud-cost-management/"
     tag: "Blog"

--- a/layouts/shortcodes/learning-center-callout.html
+++ b/layouts/shortcodes/learning-center-callout.html
@@ -5,14 +5,16 @@
     .Inner: string - content of the callout
 */}}
 
+{{ $hide_image := .Get "hide_image" | default false }}
 {{ $btn_title := .Get "btn_title" }}
 {{ $btn_url := .Get "btn_url" }}
 {{- $header := .Get "header" -}}
+
 <div class="card learning-center-callout mb-4">
 
     <div class="card-body p-2 d-flex flex-column">
         <div class="card-content">
-            {{ if ne .Params.hide_callout_image true}}
+            {{ if ne $hide_image "true" }}
             <img class="img-fluid mb-2 mb-md-0" src="{{ .Site.Params.img_url}}images/learning-center-bits-logo-2.png" alt="learning center">
             {{ end }}
             <div>

--- a/layouts/shortcodes/learning-center-callout.html
+++ b/layouts/shortcodes/learning-center-callout.html
@@ -12,7 +12,9 @@
 
     <div class="card-body p-2 d-flex flex-column">
         <div class="card-content">
+            {{ if ne .Params.hide_callout_image true}}
             <img class="img-fluid mb-2 mb-md-0" src="{{ .Site.Params.img_url}}images/learning-center-bits-logo-2.png" alt="learning center">
+            {{ end }}
             <div>
                 <h5 class="card-title text-black mt-0 mb-1">{{$header}}</h5>
                 <p class="card-text mb-2">{{.Inner}}</p>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds a front matter param to hide the image in the learning center callout
https://datadoghq.atlassian.net/browse/WEB-5081

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

Preview
https://docs-staging.datadoghq.com/ccole/learning-center-callout-update/cloud_cost_management/

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->