### PR TITLE
removes Maximum Call Stack RangeErrors

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -20,11 +20,15 @@ function loadPage(newUrl) {
         behavior: "instant"
     });
 
+    const pathName = new URL(newUrl).pathname;
+    const commitRef = document.documentElement.dataset.commitRef
+    const commitRefLen = commitRef.length ? (commitRef.length + 1) : 0
+
     let mainContent = document.getElementById('mainContent');
 
     // temp workaround for integrations page https://datadoghq.atlassian.net/browse/WEB-5018
     let isIntegrations = document.querySelector('.integrations')
-
+    
     if (mainContent && !isIntegrations) {
         const currentTOC = document.querySelector('.js-toc-container');
 
@@ -215,14 +219,10 @@ function loadPage(newUrl) {
                     sidebar.classList.remove('d-none');
                 }
             }
-
-            const pathName = new URL(newUrl).pathname;
             
-            // Get and clean window pathname in order to update language dropdown items href
+            // Clean window pathname in order to update language dropdown items href
             const nonEnPage = document.documentElement.lang !== 'en-US' // check if page is not in english
-            const commitRef = document.documentElement.dataset.commitRef
-            const commitRefLen = commitRef.length ? (commitRef.length + 1) : 0
-            
+            s
             const noCommitRefPathName = pathName.slice(commitRefLen) // adjust pathname to remove commit ref if in preview env
             const noCommitRefNoLangPathName = nonEnPage ? noCommitRefPathName.slice(3) : noCommitRefPathName // adjust pathname to remove language if not in english e.g. /ja/agent -> /agent
             
@@ -270,8 +270,9 @@ function loadPage(newUrl) {
         httpRequest.send();
     } else {
         // Integrations Pages
-        if(new URL(newUrl).pathname !== document.documentElement.dataset.relpermalink) {
-            // if switching between integrations pages, reload page
+        
+        if(pathName.slice(commitRefLen) !== document.documentElement.dataset.relpermalink) {
+            // if switching between integrations pages, reload page. adjusts the pathName to remove commit ref if in preview env.
             window.location.href = newUrl;
         }
     }

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -222,7 +222,7 @@ function loadPage(newUrl) {
             
             // Clean window pathname in order to update language dropdown items href
             const nonEnPage = document.documentElement.lang !== 'en-US' // check if page is not in english
-            s
+
             const noCommitRefPathName = pathName.slice(commitRefLen) // adjust pathname to remove commit ref if in preview env
             const noCommitRefNoLangPathName = nonEnPage ? noCommitRefPathName.slice(3) : noCommitRefPathName // adjust pathname to remove language if not in english e.g. /ja/agent -> /agent
             

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -269,7 +269,11 @@ function loadPage(newUrl) {
         httpRequest.open('GET', newUrl);
         httpRequest.send();
     } else {
-        window.location.href = newUrl;
+        // Integrations Pages
+        if(new URL(newUrl).pathname !== document.documentElement.dataset.relpermalink) {
+            // if switching between integrations pages, reload page
+            window.location.href = newUrl;
+        }
     }
 }
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes `Maximum Call Stack Size` `RangeError`s on Integrations pages.

**motivation**: [Error Tracking](https://dd-corpsite.datadoghq.com/logs/error-tracking?query=service%3Adocs%20%22call%20stack%22&et-side=data&fromUser=true&issueId=cffc54dc-0e3a-11ef-8eb2-da7ad0900002&refresh_mode=sliding&source=all&track=rum&view=spans&from_ts=1722261305264&to_ts=1722347705264&live=true). also related [PR](https://github.com/DataDog/documentation/pull/23659)
- Selecting h1-h3 headers throws errors on `integrations` pages. 
- the error occurs because the popstate on the page is being triggered on anchor clicks

**preview**: https://docs-staging.datadoghq.com/stefon.simmons/fix-broken-anchors-max-call-stack-errs/integrations/guide/source-code-integration/?tab=net#host
- click on the h1-h3 headers. no errors should show in browser console.
- navigate to other integration and non-integration pages
- check that integration tiles still filter

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->