### PR TITLE
[SVLS] Add warning for deprecated runtime

### DIFF
--- a/content/en/serverless/guide/serverless_warnings.md
+++ b/content/en/serverless/guide/serverless_warnings.md
@@ -100,6 +100,12 @@ Attack attempts were detected targeting the serverless application.
 
 **Resolution:** Investigate the attack attempts in ASM by clicking the **Security Signals** button to determine how to respond. If immediate action is needed, you can block the attacking IP in your WAF through the [Workflows integration][11].
 
+### Deprecated runtime
+
+The function's runtime is no longer supported.
+
+**Resolution:** Upgrade to the latest runtime to ensure you are up to date on the latest security, performance, and reliability standards.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR adds a new "Deprecated runtime" warning to the serverless documentation. This warning is generated when a function is using a deprecated runtime as outlined in https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated. The related PR to add the insight in web-ui is here: https://github.com/DataDog/web-ui/pull/149304

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->