### PR TITLE
remove https redirect wording

### DIFF
--- a/content/en/data_security/guide/tls_ciphers_deprecation.md
+++ b/content/en/data_security/guide/tls_ciphers_deprecation.md
@@ -6,8 +6,6 @@ As part of its ongoing commitment to the security and protection of its customer
 
 Beginning **April 1st, 2024**, Datadog disabled support for the following cipher suites across its public-facing applications. If you use unsupported clients to connect to Datadog after the older protocols are disabled, you will receive connection error messages.
 
-Starting **July 1st, 2024**, Datadog will force HTTP to HTTPS redirection for all intake endpoints, using an HTTP 308 response code. This change is necessary as some intake endpoints still accept plain HTTP payloads to maintain compatibility with older API clients. Ensure that your application clients can follow these redirection codes, or update their configuration to utilize HTTPS. Otherwise, you might receive connection error messages.
-
 ## Disabled Cipher Suites
 
 | Code       | IANA Name                                |


### PR DESCRIPTION
There was security discussion around [this article](https://jviide.iki.fi/http-redirects) re: returning an error rather than redirecting. Let's remove this wording until we have a concrete plan and new date.