### PR TITLE
[test visibility] Add known limitation to code coverage for Javascript

### DIFF
--- a/content/en/tests/code_coverage.md
+++ b/content/en/tests/code_coverage.md
@@ -29,12 +29,12 @@ Ensure that [Test Visibility][1] is already set up for your language.
 
 * `dd-trace>=3.20.0`.
 * `jest>=24.8.0`, only when run with `jest-circus`.
-* `mocha>=5.2.0`.
-* `cucumber-js>=7.0.0`.
-* Only [`Istanbul`][101] code coverage is supported.
+* `mocha>=5.2.0`, only if `all` option in `nyc` is not explicitly set to `true`.
+* `cucumber-js>=7.0.0`, only if `all` option in `nyc` is not explicitly set to `true`.
+* Only [`Istanbul`][1] code coverage is supported.
 
 
-When tests are instrumented with [Istanbul][101], the Datadog Tracer reports code coverage under the `test.code_coverage.lines_pct` tag for your test sessions automatically. To instrument tests with Istanbul, you can use [`nyc`][102].
+When tests are instrumented with [Istanbul][1], the Datadog Tracer reports code coverage under the `test.code_coverage.lines_pct` tag for your test sessions automatically. To instrument tests with Istanbul, you can use [`nyc`][2].
 
 To report total code coverage from your test sessions, follow these steps:
 
@@ -70,9 +70,13 @@ npm install --save-dev nyc
 NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-service npm run coverage
 ```
 
+### Known limitations
 
-[101]: https://istanbul.js.org/
-[102]: https://github.com/istanbuljs/nyc
+If the `all` option is set to `true` when running `nyc` (see [nyc docs][3]), the total code coverage reported in the test session does not coincide with the value reported by `nyc`. This is because it does not include uncovered files (the ones that are not touched by your tests).
+
+[1]: https://istanbul.js.org/
+[2]: https://github.com/istanbuljs/nyc
+[3]: https://github.com/istanbuljs/nyc?tab=readme-ov-file#common-configuration-options
 {{% /tab %}}
 
 {{% tab ".NET" %}}
@@ -82,7 +86,7 @@ NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-javascript-service np
 
 When code coverage is available, the Datadog Tracer (v2.31.0 or later) reports it under the `test.code_coverage.lines_pct` tag for your test sessions.
 
-If you are using [Coverlet][101] to compute your code coverage, indicate the path to the report file in the `DD_CIVISIBILITY_EXTERNAL_CODE_COVERAGE_PATH` environment variable when running `dd-trace`. The report file must be in the OpenCover or Cobertura formats. Alternatively, you can enable the Datadog Tracer's built-in code coverage calculation with the `DD_CIVISIBILITY_CODE_COVERAGE_ENABLED=true` environment variable.
+If you are using [Coverlet][1] to compute your code coverage, indicate the path to the report file in the `DD_CIVISIBILITY_EXTERNAL_CODE_COVERAGE_PATH` environment variable when running `dd-trace`. The report file must be in the OpenCover or Cobertura formats. Alternatively, you can enable the Datadog Tracer's built-in code coverage calculation with the `DD_CIVISIBILITY_CODE_COVERAGE_ENABLED=true` environment variable.
 
 ### Advanced options
 
@@ -148,7 +152,7 @@ Filters provide fine-grained control over what gets excluded using **filter expr
 #### VS code coverage options
 
 
-See [Customize code coverage analysis][102] in the Microsoft documentation for additional information.
+See [Customize code coverage analysis][2] in the Microsoft documentation for additional information.
 
 | Option                   | Summary                                                                                                                                                         |
 |:-------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -188,8 +192,8 @@ See [Customize code coverage analysis][102] in the Microsoft documentation for a
 </RunSettings>
 ```
 
-[101]: https://github.com/coverlet-coverage/coverlet
-[102]: https://learn.microsoft.com/en-us/visualstudio/test/customizing-code-coverage-analysis?view=vs-2022
+[1]: https://github.com/coverlet-coverage/coverlet
+[2]: https://learn.microsoft.com/en-us/visualstudio/test/customizing-code-coverage-analysis?view=vs-2022
 {{% /tab %}}
 {{% tab "Java" %}}
 
@@ -198,16 +202,16 @@ See [Customize code coverage analysis][102] in the Microsoft documentation for a
 
 When code coverage is available, the Datadog Tracer reports it under the `test.code_coverage.lines_pct` tag for your test sessions.
 
-[Jacoco][101] is supported as a code coverage library.
+[Jacoco][1] is supported as a code coverage library.
 
 If your project already has Jacoco configured, the Datadog Tracer instruments it and reports the coverage data to Datadog automatically.
 
 Otherwise, you can configure the tracer to add Jacoco to your test runs at runtime.
-Use `DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION` environment variable to specify which [version of Jacoco][102] you want to have injected (for example: `DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION=0.8.11`).
+Use `DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION` environment variable to specify which [version of Jacoco][2] you want to have injected (for example: `DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION=0.8.11`).
 
 
-[101]: https://www.eclemma.org/jacoco/
-[102]: https://mvnrepository.com/artifact/org.jacoco/org.jacoco.agent
+[1]: https://www.eclemma.org/jacoco/
+[2]: https://mvnrepository.com/artifact/org.jacoco/org.jacoco.agent
 {{% /tab %}}
 {{% tab "Python" %}}
 
@@ -219,12 +223,12 @@ Use `DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION` environment variable to specify whic
 * `pytest>=3.0.0`.
 * `pytest-cov>=2.7.0`.
 * `unittest>=3.8`.
-* Only [`coverage.py`][101] and [`pytest-cov`][102] code coverage are supported.
+* Only [`coverage.py`][1] and [`pytest-cov`][2] code coverage are supported.
 
 
-When tests are instrumented with [`coverage.py`][101] or [`pytest-cov`][102], the Datadog Tracer reports code coverage under the `test.code_coverage.lines_pct` tag for your test sessions automatically.
+When tests are instrumented with [`coverage.py`][1] or [`pytest-cov`][2], the Datadog Tracer reports code coverage under the `test.code_coverage.lines_pct` tag for your test sessions automatically.
 
-To report total code coverage from your test sessions with [`coverage.py`][101], follow these steps:
+To report total code coverage from your test sessions with [`coverage.py`][1], follow these steps:
 
 1. Install `coverage`:
 ```
@@ -236,7 +240,7 @@ python3 -m pip install coverage
 DD_ENV=ci DD_SERVICE=my-python-service coverage run -m pytest
 ```
 
-Alternatively, to report total code coverage from your test sessions with [`pytest-cov`][102], follow these steps:
+Alternatively, to report total code coverage from your test sessions with [`pytest-cov`][2], follow these steps:
 
 1. Install `pytest`:
 ```
@@ -253,8 +257,8 @@ python3 -m pip install pytest-cov
 DD_ENV=ci DD_SERVICE=my-python-service pytest --cov
 ```
 
-[101]: https://github.com/nedbat/coveragepy
-[102]: https://github.com/pytest-dev/pytest-cov
+[1]: https://github.com/nedbat/coveragepy
+[2]: https://github.com/pytest-dev/pytest-cov
 {{% /tab %}}
 {{% tab "JUnit Report Uploads" %}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Let users know that there's an issue with using `all` option in `nyc` (see [nyc docs](https://github.com/istanbuljs/nyc?tab=readme-ov-file#common-configuration-options)).

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
https://docs-staging.datadoghq.com/juan-fernandez/add-known-limitation-to-nyc/tests/code_coverage/?tab=javascripttypescript#known-limitations