### PR TITLE
Update distributions.md

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -544,58 +544,6 @@ agents:
 
 No specific configuration is required.
 
-To enable container monitoring, add the following (`containerd` check):
-
-{{< tabs >}}
-{{% tab "Datadog Operator" %}}
-
-DatadogAgent Kubernetes Resource:
-
-```yaml
-kind: DatadogAgent
-apiVersion: datadoghq.com/v2alpha1
-metadata:
-  name: datadog
-spec:
-  features:
-    admissionController:
-      enabled: false
-    externalMetricsServer:
-      enabled: false
-      useDatadogMetrics: false
-  global:
-    credentials:
-      apiKey: <DATADOG_API_KEY>
-      appKey: <DATADOG_APP_KEY>
-    criSocketPath: /run/dockershim.sock
-  override:
-    clusterAgent:
-      image:
-        name: gcr.io/datadoghq/cluster-agent:latest
-```
-
-{{% /tab %}}
-{{% tab "Helm" %}}
-
-Custom `datadog-values.yaml`:
-
-```yaml
-datadog:
-  apiKey: <DATADOG_API_KEY>
-  appKey: <DATADOG_APP_KEY>
-  criSocketPath: /run/dockershim.sock
-  env:
-    - name: DD_AUTOCONFIG_INCLUDE_FEATURES
-      value: "containerd"
-```
-
-{{% /tab %}}
-
-{{< /tabs >}}
-
-More `datadog-values.yaml` examples can be found in the [Helm chart repository][3].
-More `datadog-agent.yaml` examples can be found in the [Datadog Operator repository][4].
-
 ## vSphere Tanzu Kubernetes Grid (TKG) {#TKG}
 
 TKG requires some small configuration changes, shown below. For example, setting a toleration is required for the controller to schedule the Node Agent on the `master` nodes.


### PR DESCRIPTION
"With the announcement of support for Kubernetes version 1.20.8, the container runtime used by Container Engine for Kubernetes changes from Docker to CRI-O".

As such, any containerd check will fail within OKE clusters.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
I'm working with a customer who discovered our current K8s distro OKE documentation, and added the recommended code snippet to their Helm chart. After doing so, they faced an agent error highlighting an inability to run the containerd check. It appears this is due to containerd/Docker no longer being the runtime leveraged by OKE: https://docs.oracle.com/en-us/iaas/Content/ContEng/Concepts/contengaboutk8sversions.htm#previouslysupportedk8sversions__notes-1-20

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ x ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->