### PR TITLE
Modify script for processing yaml metric spec

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -267,7 +267,7 @@ class Integrations:
             glob.iglob(pattern, recursive=True)
             for pattern in content["globs"]
         ):
-            if file_name.endswith(".csv"):
+            if file_name.endswith(".csv") or file_name.endswith("metric-spec.yaml"):
                 self.process_integration_metric(file_name)
 
             elif file_name.endswith("manifest.json"):
@@ -391,8 +391,8 @@ class Integrations:
 
     def process_integration_metric(self, file_name):
         """
-        Take a single metadata csv file and convert it to yaml
-        :param file_name: path to a metadata csv file
+        Take a single metadata or metric spec file and formats it to yaml
+        :param file_name: path to a metadata csv or yaml file
         """
         if file_name.endswith("/metadata.csv") or file_name.endswith("/metric_spec.yaml"):
             key_name = basename(
@@ -698,6 +698,10 @@ class Integrations:
         tab_logic = False
         metrics = glob.glob(
             "{path}{sep}*metadata.csv".format(
+                path=dirname(file_name), sep=sep
+            )
+        ) + glob.glob(
+            "{path}{sep}*metric-spec.yaml".format(
                 path=dirname(file_name), sep=sep
             )
         )

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -160,7 +160,7 @@ class Integrations:
 
         :param key_name: integration key name for root object
         :param metric_spec_filename: path to input metric spec file
-        :param yml_filename: path to output yml file
+        :param yml_filename: path to output yaml file
         """
         yaml_data = {key_name: []}
         with open(metric_spec_filename) as f:

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -696,18 +696,21 @@ class Integrations:
             content = {}
         no_integration_issue = True
         tab_logic = False
+        # Prioritize having metric-spec.yaml over metadata.csv
         metrics = glob.glob(
-            "{path}{sep}*metadata.csv".format(
-                path=dirname(file_name), sep=sep
+                "{path}{sep}*metric-spec.yaml".format(path=dirname(file_name), sep=sep)
             )
-        ) + glob.glob(
-            "{path}{sep}*metric-spec.yaml".format(
-                path=dirname(file_name), sep=sep
+        if metrics:
+            metrics = metrics[0] if len(metrics) > 0 else None
+            metrics_exist = metrics and exists(metrics)
+        else:
+            metrics = glob.glob(
+                "{path}{sep}*metadata.csv".format(path=dirname(file_name), sep=sep)
             )
-        )
-        metrics = metrics[0] if len(metrics) > 0 else None
-        metrics_exist = (metrics and exists(metrics)
-                         and linecache.getline(metrics, 2))
+            metrics = metrics[0] if len(metrics) > 0 else None
+            metrics_exist = (
+                metrics and exists(metrics) and linecache.getline(metrics, 2)
+            )
         service_check = glob.glob("{file}.json".format(
             file=self.data_service_checks_dir + basename(dirname(file_name))))
         service_check = (

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -156,7 +156,7 @@ class Integrations:
     @staticmethod
     def format_metric_spec_yaml(key_name, metric_spec_filename, yml_filename):
         """
-        Given a file path to metric_spec.yaml file, format all metrics
+        Given a file path to metric-spec.yaml file, format all metrics
 
         :param key_name: integration key name for root object
         :param metric_spec_filename: path to input metric spec file
@@ -394,7 +394,7 @@ class Integrations:
         Take a single metadata or metric spec file and formats it to yaml
         :param file_name: path to a metadata csv or yaml file
         """
-        if file_name.endswith("/metadata.csv") or file_name.endswith("/metric_spec.yaml"):
+        if file_name.endswith("/metadata.csv") or file_name.endswith("/metric-spec.yaml"):
             key_name = basename(
                 dirname(normpath(file_name))
             )
@@ -411,7 +411,7 @@ class Integrations:
             new_file_name = "{}{}.yaml".format(
                 self.data_integrations_dir, collision_name
             )
-        if file_name.endswith("/metric_spec.yaml"):
+        if file_name.endswith("/metric-spec.yaml"):
             self.format_metric_spec_yaml(key_name, file_name, new_file_name)
         else:
             self.metric_csv_to_yaml(key_name, file_name, new_file_name)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We add a method to process `metric-spec.yaml` files instead of the standard `csv` for generating the metric tables for docs. This is for an ongoing effort to replace the usage of csv files for integrations. We also create a method to reformat the metric spec yaml files into yaml files that are used by the `get-metric-from-git` partial.

https://datadoghq.atlassian.net/browse/AWSMC-1286

**Testing:** The `format_metric_spec_yaml()` was tested to make sure the reformatted yaml files were identical to the ones produced when generated from csvs.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->