### PR TITLE
(Agent) Fix GUI port

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -37,7 +37,7 @@ Use the Datadog Agent Manager GUI to:
 - Add or edit Agent checks
 - Send flares
 
-The Datadog Agent Manager GUI is enabled by default on Windows and macOS, and runs on port `5052`. Use the `datadog-agent launch-gui` command to open the GUI in your default web browser.
+The Datadog Agent Manager GUI is enabled by default on Windows and macOS, and runs on port `5002`. Use the `datadog-agent launch-gui` command to open the GUI in your default web browser.
 
 You can change the GUI's default port in your `datadog.yaml` configuration file. To disable the GUI, set the port's value to `-1`. On Linux, the GUI is disabled by default.
 

--- a/content/es/agent/basic_agent_usage/_index.md
+++ b/content/es/agent/basic_agent_usage/_index.md
@@ -37,7 +37,7 @@ Utiliza la GUI del Datadog Agent Manager para:
 - Añadir o editar los checks del Agent
 - Enviar flares
 
-La GUI del Datadog Agent Manager se encuentra habilitada por defecto en Windows y macOS, y se ejecuta en el puerto `5052`. Utiliza el comando `datadog-agent launch-gui` para abrir la GUI en tu navegador web predeterminado.
+La GUI del Datadog Agent Manager se encuentra habilitada por defecto en Windows y macOS, y se ejecuta en el puerto `5002`. Utiliza el comando `datadog-agent launch-gui` para abrir la GUI en tu navegador web predeterminado.
 
 Puedes cambiar el puerto predeterminado de la GUI en tu archivo de configuración `datadog.yaml`. Para deshabilitar la GUI, establece el valor del puerto en `-1`. En Linux, la GUI se encuentra deshabilitada por defecto.
 

--- a/content/fr/agent/basic_agent_usage/_index.md
+++ b/content/fr/agent/basic_agent_usage/_index.md
@@ -37,7 +37,7 @@ L'interface graphique Datadog Agent Manager vous permet d'accomplir ce qui sui
 - Ajouter ou modifier des checks d'Agent
 - Envoyer des flares
 
-L'interface graphique Datadog Agent Manager est activée par défaut sous Windows et macOS. Elle s'exécute sur le port `5052`. La commande `datadog-agent launch-gui` vous permet d'ouvrir l'interface graphique dans votre navigateur Web par défaut.
+L'interface graphique Datadog Agent Manager est activée par défaut sous Windows et macOS. Elle s'exécute sur le port `5002`. La commande `datadog-agent launch-gui` vous permet d'ouvrir l'interface graphique dans votre navigateur Web par défaut.
 
 Vous pouvez modifier le port par défaut de l'interface graphique depuis le fichier de configuration `datadog.yaml`. Pour désactiver l'interface graphique, définissez la valeur du port sur `-1`. Sous Linux, l'interface graphique est désactivée par défaut.
 

--- a/content/ko/agent/basic_agent_usage/_index.md
+++ b/content/ko/agent/basic_agent_usage/_index.md
@@ -37,7 +37,7 @@ Datadog 에이전트 관리자 GUI를 사용하거나 명령줄로 에이전트 
 - 에이전트 점검 추가 또는 수정하기
 - 플레어 전송
 
-Datadog 에이전트 관리자 GUI는 윈도우즈(Windows) 및 macOS에서 기본값으로 활성화되며 포트 `5052`에서 실행됩니다. 기본 웹 브라우저에서 `datadog-agent launch-gui` 명령으로 GUI를 열 수 있습니다.
+Datadog 에이전트 관리자 GUI는 윈도우즈(Windows) 및 macOS에서 기본값으로 활성화되며 포트 `5002`에서 실행됩니다. 기본 웹 브라우저에서 `datadog-agent launch-gui` 명령으로 GUI를 열 수 있습니다.
 
 `datadog.yaml` 설정 파일에서 GUI 기본 포트를 변경할 수 있습니다. GUI를 비활성화하려면 포트 값을 `-1`로 설정합니다. Linux에서는 GUI가 기본값으로 비활성화되어 있습니다.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The correct port is 5002.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->