### PR TITLE
nsollecito/code tabs anchors

### DIFF
--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -4,7 +4,7 @@ import { redirectToRegion, hideTOCItems } from '../region-redirects';
 import { initCopyCode } from './copy-code';
 import { initializeIntegrations } from './integrations';
 import { initializeGroupedListings } from './grouped-item-listings';
-import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
+import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, chromeHashFix } from '../helpers/helpers';
 import configDocs from '../config/config-docs';
 import { redirectCodeLang, addCodeTabEventListeners, addCodeBlockVisibilityToggleEventListeners, activateCodeLangNav, toggleMultiCodeLangNav } from './code-languages'; // eslint-disable-line import/no-cycle
 import { loadInstantSearch } from './algolia';
@@ -237,6 +237,7 @@ function loadPage(newUrl) {
 
             // sets query params if code tabs are present
             initCodeTabs();
+            chromeHashFix();
 
             const regionSelector = document.querySelector('.js-region-select');
 

--- a/assets/scripts/components/async-loading.js
+++ b/assets/scripts/components/async-loading.js
@@ -4,7 +4,7 @@ import { redirectToRegion, hideTOCItems } from '../region-redirects';
 import { initCopyCode } from './copy-code';
 import { initializeIntegrations } from './integrations';
 import { initializeGroupedListings } from './grouped-item-listings';
-import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, chromeHashFix } from '../helpers/helpers';
+import {updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName } from '../helpers/helpers';
 import configDocs from '../config/config-docs';
 import { redirectCodeLang, addCodeTabEventListeners, addCodeBlockVisibilityToggleEventListeners, activateCodeLangNav, toggleMultiCodeLangNav } from './code-languages'; // eslint-disable-line import/no-cycle
 import { loadInstantSearch } from './algolia';
@@ -237,7 +237,6 @@ function loadPage(newUrl) {
 
             // sets query params if code tabs are present
             initCodeTabs();
-            chromeHashFix();
 
             const regionSelector = document.querySelector('.js-region-select');
 

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -80,6 +80,15 @@ const initCodeTabs = () => {
         updateUrl(activeLang)
     }
 
+    const scrollToAnchor = (tab, anchorname) => {
+        const anchor = document.querySelectorAll(`[data-lang='${tab}'] ${anchorname}`)[0];
+        console.log('tab: ', tab);
+        console.log('scrolling to anchor: ', anchor);
+        if (anchor) {
+            anchor.scrollIntoView();
+        }
+    }
+
     const activateTabsOnLoad = () => {
         const firstTab = document.querySelectorAll('.code-tabs .nav-tabs a').item(0)
         if (tabQueryParameter) {
@@ -87,6 +96,10 @@ const initCodeTabs = () => {
 
             if (selectedLanguageTab) {
                 activateCodeTab(selectedLanguageTab)
+
+                if (window.location.hash) {
+                    scrollToAnchor(tabQueryParameter, window.location.hash);
+                }
             }else{
                 activateCodeTab(firstTab)
             }

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -81,11 +81,13 @@ const initCodeTabs = () => {
     }
 
     const scrollToAnchor = (tab, anchorname) => {
-        const anchor = document.querySelectorAll(`[data-lang='${tab}'] ${anchorname}`)[0];
+        const anchor = document.querySelector(`[data-lang='${tab}'] ${anchorname}`);
         console.log('tab: ', tab);
         console.log('scrolling to anchor: ', anchor);
         if (anchor) {
             anchor.scrollIntoView();
+        } else {
+            document.querySelector(anchorname).scrollIntoView();
         }
     }
 
@@ -96,9 +98,10 @@ const initCodeTabs = () => {
 
             if (selectedLanguageTab) {
                 activateCodeTab(selectedLanguageTab)
-
                 if (window.location.hash) {
-                    scrollToAnchor(tabQueryParameter, window.location.hash);
+                    setTimeout(function () {
+                        scrollToAnchor(tabQueryParameter, window.location.hash);
+                    }, 300);
                 }
             }else{
                 activateCodeTab(firstTab)

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -1,5 +1,5 @@
 import { getQueryParameterByName } from '../helpers/browser';
-import { getCookieByName } from '../helpers/helpers';
+import { getCookieByName, chromeHashFix } from '../helpers/helpers';
 import regionConfig from '../config/regions.config';
 
 const initCodeTabs = () => {
@@ -81,7 +81,7 @@ const initCodeTabs = () => {
     }
 
     const scrollToAnchor = (tab, anchorname) => {
-        const anchor = document.querySelector(`[data-lang='${tab}'] ${anchorname}`);
+        const anchor = document.querySelectorAll(`[data-lang='${tab}'] ${anchorname}`)[0];
         console.log('tab: ', tab);
         console.log('scrolling to anchor: ', anchor);
         if (anchor) {
@@ -101,15 +101,17 @@ const initCodeTabs = () => {
                 if (window.location.hash) {
                     setTimeout(function () {
                         scrollToAnchor(tabQueryParameter, window.location.hash);
-                    }, 350);
+                    }, 300);
                 }
             }else{
                 activateCodeTab(firstTab)
+                chromeHashFix();
             }
         } else {
             if (codeTabsList.length > 0) {
                 activateCodeTab(firstTab)
             }
+            chromeHashFix();
         }
     }
 
@@ -230,4 +232,4 @@ const initCodeTabs = () => {
     init()
 }
 
-export default initCodeTabs;
+export default initCodeTabs

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -101,7 +101,7 @@ const initCodeTabs = () => {
                 if (window.location.hash) {
                     setTimeout(function () {
                         scrollToAnchor(tabQueryParameter, window.location.hash);
-                    }, 300);
+                    }, 350);
                 }
             }else{
                 activateCodeTab(firstTab)

--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -250,6 +250,6 @@ window.addEventListener('load', () => {
             const hash = window.location.hash;
             window.location.hash = '';
             window.location.hash = hash;
-        }, 300);
+        }, 200);
     }
 });

--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -242,14 +242,3 @@ window.addEventListener('scroll', () => {
 
 DOMReady(handleAPIPage);
 
-// Fixes Chrome issue where pages with hash params are not scrolling to anchor
-window.addEventListener('load', () => {
-    const isChrome = /Chrome/.test(navigator.userAgent);
-    if (window.location.hash && isChrome) {
-        setTimeout(function () {
-            const hash = window.location.hash;
-            window.location.hash = '';
-            window.location.hash = hash;
-        }, 300);
-    }
-});

--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -243,13 +243,13 @@ window.addEventListener('scroll', () => {
 DOMReady(handleAPIPage);
 
 // Fixes Chrome issue where pages with hash params are not scrolling to anchor
-// window.addEventListener('load', () => {
-//     const isChrome = /Chrome/.test(navigator.userAgent);
-//     if (window.location.hash && isChrome) {
-//         setTimeout(function () {
-//             const hash = window.location.hash;
-//             window.location.hash = '';
-//             window.location.hash = hash;
-//         }, 300);
-//     }
-// });
+window.addEventListener('load', () => {
+    const isChrome = /Chrome/.test(navigator.userAgent);
+    if (window.location.hash && isChrome) {
+        setTimeout(function () {
+            const hash = window.location.hash;
+            window.location.hash = '';
+            window.location.hash = hash;
+        }, 300);
+    }
+});

--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -250,6 +250,6 @@ window.addEventListener('load', () => {
             const hash = window.location.hash;
             window.location.hash = '';
             window.location.hash = hash;
-        }, 200);
+        }, 300);
     }
 });

--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -1,6 +1,7 @@
 import { scrollTop } from '../helpers/scrollTop';
 import { bodyClassContains } from '../helpers/helpers';
 import { DOMReady } from '../helpers/documentReady';
+import { getQueryParameterByName } from '../helpers/browser';
 
 let sidenavMapping = [];
 let tocContainer = document.querySelector('.js-toc-container');
@@ -242,13 +243,13 @@ window.addEventListener('scroll', () => {
 DOMReady(handleAPIPage);
 
 // Fixes Chrome issue where pages with hash params are not scrolling to anchor
-window.addEventListener('load', () => {
-    const isChrome = /Chrome/.test(navigator.userAgent);
-    if (window.location.hash && isChrome) {
-        setTimeout(function () {
-            const hash = window.location.hash;
-            window.location.hash = '';
-            window.location.hash = hash;
-        }, 300);
-    }
-});
+// window.addEventListener('load', () => {
+//     const isChrome = /Chrome/.test(navigator.userAgent);
+//     if (window.location.hash && isChrome) {
+//         setTimeout(function () {
+//             const hash = window.location.hash;
+//             window.location.hash = '';
+//             window.location.hash = hash;
+//         }, 300);
+//     }
+// });

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -1,5 +1,5 @@
 import configDocs from './config/config-docs';
-import { updateMainContentAnchors, gtag } from './helpers/helpers';
+import { updateMainContentAnchors, gtag, chromeHashFix } from './helpers/helpers';
 import { bodyClassContains } from './helpers/helpers';
 import { DOMReady } from './helpers/documentReady';
 import { initializeIntegrations } from './components/integrations';
@@ -122,6 +122,8 @@ const doOnLoad = () => {
 
     if (document.querySelector('.code-tabs')) {
         initCodeTabs();
+    } else {
+        chromeHashFix();
     }
 };
 

--- a/assets/scripts/helpers/helpers.js
+++ b/assets/scripts/helpers/helpers.js
@@ -52,6 +52,17 @@ const getCookieByName = (name) => {
     return value;
 };
 
+const chromeHashFix = () => {
+    const isChrome = /Chrome/.test(navigator.userAgent);
+    if (window.location.hash && isChrome) {
+        setTimeout(function () {
+            const hash = window.location.hash;
+            window.location.hash = '';
+            window.location.hash = hash;
+        }, 300);
+    }
+}
+
 const bodyClassContains = (string) => document.body.classList.contains(string);
 
-export { updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, bodyClassContains };
+export { updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, bodyClassContains, chromeHashFix };


### PR DESCRIPTION
### What does this PR do? What is the motivation?

1. Fix page not scrolling to anchors that are inside tabs
2. Move chrome scrolling fix to a function so that it can be used multiple places
3. Only run chrome scrolling fix if tab-based scrolling isn’t in effect to avoid conflicts

https://datadoghq.atlassian.net/browse/WEB-5120

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
All of these preview links should successfully scroll to the related IDs on the page.

https://docs-staging.datadoghq.com/nsollecito/code-tabs-anchors/continuous_delivery/deployments/#use-deployment-data
https://docs-staging.datadoghq.com/nsollecito/code-tabs-anchors/observability_pipelines/log_volume_control/fluent/?tab=dedupe#path-notation-example
https://docs-staging.datadoghq.com/nsollecito/code-tabs-anchors/observability_pipelines/log_volume_control/fluent/?tab=dedupe#install-the-observability-pipelines-worker