### PR TITLE
Mention the Java liveheap subsampling in troubleshooting

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -26,21 +26,19 @@ CPU
 
 Allocations
 : The number of heap allocations made by each method, including allocations which were subsequently freed.<br />
-_Requires: Java 11_ 
+_Requires: Java 11_
 
 Allocated Memory
 : The amount of heap memory allocated by each method, including allocations which were subsequently freed.<br />
-_Requires: Java 11_ 
+_Requires: Java 11_
 
-Heap Live Objects
+Heap Live Objects (beta, 1.17.0+)
 : The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
 _Requires: Java 11_ <br />
-_Since: 1.17.0_
 
-Heap Live Size
+Heap Live Size (beta, 1.39.0+)
 : The amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
-_Requires: Java 11_ <br />
-_Since: 1.17.0_
+_Requires: Java 11.0.23+, 17.0.11+, 21.0.3+ or 22+_ <br />
 
 Wall Time in Native Code
 : The elapsed time spent in native code. Elapsed time includes time when code is running on CPU, waiting for I/O, and anything else that happens while the method is running. This profile does not include time spent running JVM bytecode, which is typically most of your application code.

--- a/content/en/profiler/profiler_troubleshooting/java.md
+++ b/content/en/profiler/profiler_troubleshooting/java.md
@@ -26,25 +26,9 @@ If the default setup overhead is not acceptable, you can use the profiler with m
 
 To use the minimal configuration ensure you have `dd-java-agent` version `0.70.0` then change your service invocation to the following:
 
-```shell
+```
 java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.jfr-template-override-file=minimal -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
 ```
-
-## Modify the maximum stack depth for collected stack traces
-
-If the default maximum stack depth of 512 is not sufficient for your use case, or it is causing performance issues,
-you can increase it by setting the `dd.profiling.stackdepth` system property.
-
-For example, to decrease the maximum stack depth to 256, start your service with the following JVM setting:
-
-```shell
-java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.stackdepth=256 -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
-```
-
-The same limit will be used for data collected by JFR and the Datadog profiler.
-
-**Note**: If the `-XX:FlightRecorderOptions=stackdepth=<stack-depth>` JVM argument is provided, the maximum stack depth set via the
-`dd.profiling.stackdepth` system property will be ignored in the data collected by JFR, for technical reasons.
 
 ## Increase profiler information granularity
 
@@ -55,7 +39,7 @@ If you want more granularity in your profiling data, you can specify the `compre
 
 To use the comprehensive configuration ensure you have `dd-trace-java` version `0.70.0` then change your service invocation to the following:
 
-```shell
+```
 java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.jfr-template-override-file=comprehensive -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
 ```
 
@@ -109,7 +93,8 @@ jdk.ObjectAllocationOutsideTLAB#enabled=false
 [Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
 
 ## Memory leak detection slowing down garbage collector
-
+{{< tabs >}}
+{{% tab "JFR" %}}
 To turn off memory leak detection, disable the following event in your `jfp` [override template file](#creating-and-using-a-jfr-template-override-file):
 
 ```
@@ -117,6 +102,17 @@ jdk.OldObjectSample#enabled=false
 ```
 
 [Learn how to use override templates.](#creating-and-using-a-jfr-template-override-file)
+
+{{% /tab %}}
+{{% tab "Datadog Profiler" %}}
+In case you are using the alpha feature of live heap profiling you can tune the overhead by changing the percentage
+of the tracked allocation samples.
+```shell
+# track only 10% of the allocation samples
+java -javaagent:dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.profiling.ddprof.liveheap.enabled=true -Ddd.profiling.ddprof.liveheap.sample_percent=10 -jar <YOUR_SERVICE>.jar <YOUR_SERVICE_FLAGS>
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Exceptions overwhelming the profiler
 
@@ -146,7 +142,7 @@ If your vendor is not on the list, [open a support ticket][2], as other vendors 
 Override templates let you specify profiling properties to override. However, the default settings are balanced for a good tradeoff between overhead and data density that cover most use cases. To use an override file, perform the following steps:
 
 1. Create an override file in a directory accessible by `dd-java-agent` at service invocation:
-    ```shell
+    ```
     touch dd-profiler-overrides.jfp
     ```
 
@@ -160,7 +156,7 @@ Override templates let you specify profiling properties to override. However, th
 
 3. When running your application with `dd-java-agent`, your service invocation must point to the override file with `-Ddd.profiling.jfr-template-override-file=</path/to/override.jfp>`, for example:
 
-    ```shell
+    ```
     java -javaagent:/path/to/dd-java-agent.jar -Ddd.profiling.enabled=true -Ddd.logs.injection=true -Ddd.profiling.jfr-template-override-file=</path/to/override.jfp> -jar path/to/your/app.jar
     ```
 

--- a/content/en/profiler/profiler_troubleshooting/java.md
+++ b/content/en/profiler/profiler_troubleshooting/java.md
@@ -105,7 +105,7 @@ jdk.OldObjectSample#enabled=false
 
 {{% /tab %}}
 {{% tab "Datadog Profiler" %}}
-In case you are using the alpha feature of live heap profiling you can tune the overhead by changing the percentage
+If you are using the alpha feature of live heap profiling, you can tune the overhead by changing the percentage
 of the tracked allocation samples.
 ```shell
 # track only 10% of the allocation samples


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds a section about adjusting the subsampling rate for live heap profiling in the troubleshooting guide.

Related to [PROF-10303]

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
This also subsumes changes from #18743 and makes the profile type format for Java compatible with other runtimes

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[PROF-10303]: https://datadoghq.atlassian.net/browse/PROF-10303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ