### PR TITLE
[web-5165] pin websites-sources module to main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,6 +157,7 @@ build_preview:
     - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - make update_websites_sources_module
+    - cat go.mod
     - build_site
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,6 @@ build_preview:
     - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - make update_websites_sources_module
-    - cat go.mod
     - build_site
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,6 +157,7 @@ build_preview:
     - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - make update_websites_sources_module
+    - cat go.mod
     - build_site
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks
@@ -343,7 +344,6 @@ build_live:
     - make vector_data
     - yarn run prebuild
     - make update_websites_sources_module
-    - cat go.mod
     - build_site
     - in-isolation deploy_site
     - in-isolation create_artifact

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,6 @@ build_preview:
     - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
     - make update_websites_sources_module
-    - cat go.mod
     - build_site
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks
@@ -343,6 +342,7 @@ build_live:
     - make dependencies
     - make vector_data
     - yarn run prebuild
+    - make update_websites_sources_module
     - build_site
     - in-isolation deploy_site
     - in-isolation create_artifact

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,6 +156,7 @@ build_preview:
     - make config
     - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
     - yarn run prebuild
+    - make update_websites_sources_module
     - build_site
     # remove service_checks json as we don't need to s3 push that..
     - rm -rf data/service_checks

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -343,6 +343,7 @@ build_live:
     - make vector_data
     - yarn run prebuild
     - make update_websites_sources_module
+    - cat go.mod
     - build_site
     - in-isolation deploy_site
     - in-isolation create_artifact

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ server:
 
 # Download all dependencies and run the site
 start: dependencies ## Build and run docs including external content.
+	@make update_websites_sources_module
 	@make server
 
 # Skip downloading any dependencies and run the site (hugo needs at the least node)
@@ -202,6 +203,8 @@ all-examples: $(foreach repo,$(EXAMPLES_REPOS),$(addprefix examples/, $(patsubst
 clean-examples: $(foreach repo,$(EXAMPLES_REPOS),$(addprefix examples/, $(patsubst datadog-api-client-%,clean-%-examples,$(repo))))
 	@rm -rf examples
 
+update_websites_sources_module:
+	hugo mod get -x github.com/DataDog/websites-sources@main
 
 # Function that will clone a repo or sparse clone a repo
 # If the dir already exists it will attempt to update it instead

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ clean-examples: $(foreach repo,$(EXAMPLES_REPOS),$(addprefix examples/, $(patsub
 	@rm -rf examples
 
 update_websites_sources_module:
-	node_modules/hugo-bin/vendor/hugo mod get -x github.com/DataDog/websites-sources@main
+	node_modules/hugo-bin/vendor/hugo mod get github.com/DataDog/websites-sources@main
 
 # Function that will clone a repo or sparse clone a repo
 # If the dir already exists it will attempt to update it instead

--- a/Makefile
+++ b/Makefile
@@ -205,6 +205,7 @@ clean-examples: $(foreach repo,$(EXAMPLES_REPOS),$(addprefix examples/, $(patsub
 
 update_websites_sources_module:
 	node_modules/hugo-bin/vendor/hugo mod get github.com/DataDog/websites-sources@main
+	node_modules/hugo-bin/vendor/hugo mod clean
 
 # Function that will clone a repo or sparse clone a repo
 # If the dir already exists it will attempt to update it instead

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,7 @@ clean-examples: $(foreach repo,$(EXAMPLES_REPOS),$(addprefix examples/, $(patsub
 update_websites_sources_module:
 	node_modules/hugo-bin/vendor/hugo mod get github.com/DataDog/websites-sources@main
 	node_modules/hugo-bin/vendor/hugo mod clean
+	cat go.mod
 
 # Function that will clone a repo or sparse clone a repo
 # If the dir already exists it will attempt to update it instead

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ clean-examples: $(foreach repo,$(EXAMPLES_REPOS),$(addprefix examples/, $(patsub
 	@rm -rf examples
 
 update_websites_sources_module:
-	hugo mod get -x github.com/DataDog/websites-sources@main
+	node_modules/hugo-bin/vendor/hugo mod get -x github.com/DataDog/websites-sources@main
 
 # Function that will clone a repo or sparse clone a repo
 # If the dir already exists it will attempt to update it instead


### PR DESCRIPTION
### What does this PR do? What is the motivation?
this PR ensures we are always pulling in the latest data from `websites-sources` as part of the docs build.    Currently it's a manual process where we pull the latest module reference, commit it, and make a PR which needs to be reviewed by websites and docs.   There are PRs merged daily in `websites-sources` which contain relevant data (specifically to integrations at the moment).  We have seen questions and complaints about delays in integration tiles surfacing in the Docs site after publishing; this should address those issues.

One item to note is how this change affects local dev flow.   `go.sum` and `go.mod` need to be checked in due to the inclusion of `websites-modules`.   Running `make start` locally will download the latest from `websites-sources`, but may also cause changes to the go files.  Because the CI will always attempt to pull latest, committing these changes to the `go.mod` and `go.sum` files should not be problematic, but will still require a review from the platform team.

### Merge instructions
- [x] Please merge after websites reviewing

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/WEB-5165-websites-sources-pin

- in [the preview site](https://docs-staging.datadoghq.com/brian.deutsch/WEB-5165-websites-sources-pin/integrations/?q=hcp) confirm the `HCP Terraform` tile surfaces.   [in live](https://docs.datadoghq.com/integrations/?q=hcp) it is currently not present.
- [in this gitlab run](https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/596505396#L418) confirm the commit hash is upgraded (ending in `1ca9e`).     this is different than [the hash currently in prod](https://github.com/DataDog/documentation/blob/master/go.mod#L7).