### PR TITLE
removes duplicate images in build folder - [WEB-5144]

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -114,8 +114,6 @@ module:
       target: layouts
     - source: data
       target: data
-    - source: static
-      target: assets
     - source: assets
       target: assets
     - source: i18n

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -108,8 +108,6 @@ module:
     - source: content/ko
       target: content
       lang: ko
-    - source: static
-      target: static
     - source: layouts
       target: layouts
     - source: data
@@ -125,6 +123,12 @@ module:
       target: "assets/node_modules/datadog-rum.js"
     - source: "./node_modules/@datadog/browser-logs/bundle/datadog-logs.js"
       target: "assets/node_modules/datadog-logs.js"
+    ## exclude images from virtual file system static/ folder. images are being Fingerprinted by hugo
+    - source: static
+      target: static
+      excludeFiles: images
+    - source: static/images
+      target: assets/images
 
 security:
   funcs:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
specifies that `static/images` should be mounted to the `assets/images` directory in the hugo virtual filesystem before building files.

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-5144
preview: e.g. https://docs-staging.datadoghq.com/stefon.simmons/rm-dup-mounted-images/account_management/audit_trail/
   - check on pages with images. there should be no broken images on the page. 
   - check that image `srcset` attribute file name is still [fingerprinted](https://gohugo.io/hugo-pipes/fingerprint/) (`attributes.14eb439122bddb3283b02721dea0ff5c.png`) for cache busting.
   ```html
   <img class="img-fluid" srcset="https://datadog-docs-staging.imgix.net/images/account_management/audit_logs/attributes.14eb439122bddb3283b02721dea0ff5c.png?auto=format" style="width:50%" alt="Audit Trail in the Organization Settings menu">
   ```
  - check that local build (`public/images`) has only fingerprinted images.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after Corp review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->