### PR TITLE
(DOCS-8619) App Builder - move from build to expressions

### DIFF
--- a/content/en/service_management/app_builder/build.md
+++ b/content/en/service_management/app_builder/build.md
@@ -74,13 +74,7 @@ UI components can trigger reactions on an [Event][11].
 
 [Queries][12] populate your app with data from Datadog APIs or supported integrations. They take inputs from other queries or from UI components and return outputs for use in other queries or in UI components.
 
-### Variables
-
-Use app variables to pass data from one part of your app to another. Additionally, you can use app variables to pass in data from your dashboard using [dashboard template variables][3].
-
-Variables are enclosed in braces and are preceded by a dollar sign (`${}`). To use a variable, enter the query or UI component name. Access the child fields using dot notation. For example, if you have a select component named `select0` and you want to access its default value field, use the syntax `${select0.defaultValue}`. If you're not sure what to enter as a variable, type `${` to open a suggestion menu with all available variables.
-
-{{< img src="service_management/app_builder/app-builder-variable.mp4" alt="If you're not sure what to enter as a variable, type ${ to open a suggestion menu with all available variables" video=true >}}
+You can use [Javascript Expressions][]
 
 ### Interact with an app in JSON
 

--- a/content/en/service_management/app_builder/build.md
+++ b/content/en/service_management/app_builder/build.md
@@ -74,7 +74,7 @@ UI components can trigger reactions on an [Event][11].
 
 [Queries][12] populate your app with data from Datadog APIs or supported integrations. They take inputs from other queries or from UI components and return outputs for use in other queries or in UI components.
 
-You can use [Javascript Expressions][]
+You can use [Javascript Expressions][13] anywhere in App Builder to create custom interactions between the different parts of your app.
 
 ### Interact with an app in JSON
 
@@ -112,3 +112,4 @@ The **Switch to GUI** option in the settings menu takes you back to the GUI edit
 [10]: https://app.datadoghq.com/app-builder/action-catalog
 [11]: /service_management/app_builder/events
 [12]: /service_management/app_builder/queries
+[13]: /service_management/app_builder/expressions

--- a/content/en/service_management/app_builder/expressions.md
+++ b/content/en/service_management/app_builder/expressions.md
@@ -13,8 +13,6 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-### Variables
-
 You can use JavaScript (JS) expressions anywhere in App Builder to create custom interactions between the different parts of your app. As you begin an expression, App Builder offers autocomplete suggestions based on the existing queries and components in your app. Click on an autocomplete suggestion to use it in your expression, or use the arrow keys on your keyboard and make a selection with the Enter key.
 
 {{< img src="service_management/app_builder/app-builder-variable.mp4" alt="If you're not sure what to enter as a variable, type ${ to open a suggestion menu with all available variables" video=true >}}

--- a/content/en/service_management/app_builder/expressions.md
+++ b/content/en/service_management/app_builder/expressions.md
@@ -15,7 +15,7 @@ further_reading:
 
 You can use JavaScript (JS) expressions anywhere in App Builder to create custom interactions between the different parts of your app. As you begin an expression, App Builder offers autocomplete suggestions based on the existing queries and components in your app. Click on an autocomplete suggestion to use it in your expression, or use the arrow keys on your keyboard and make a selection with the Enter key.
 
-{{< img src="service_management/app_builder/app-builder-variable.mp4" alt="If you're not sure what to enter as a variable, type ${ to open a suggestion menu with all available variables" video=true >}}
+{{< img src="service_management/app_builder/app-builder-variable.mp4" alt="If you're not sure what to enter as an expression, type ${ to open a suggestion menu with all available expressions" video=true >}}
 
 Some fields, like [post-query transformation][1], display a code editor by default and accept plain JS. In all other fields, enclose your JS expressions in `${}`. For example, to interpolate the values of two text input components named `textInput0` and `textInput1` into the **Content** property of a text component (and add an exclamation mark), use the expression `${textInput0.value} ${textInput1.value}!`.
 

--- a/content/en/service_management/app_builder/expressions.md
+++ b/content/en/service_management/app_builder/expressions.md
@@ -13,7 +13,11 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-You can use JavaScript (JS) expressions anywhere in App Builder to create custom interactions between the different parts of your app. As you type an expression, App Builder offers autocomplete suggestions based on the existing queries and components in your app. Click on an autocomplete suggestion to use it in your expression, or use the arrow keys on your keyboard and make a selection with the Enter key.
+### Variables
+
+You can use JavaScript (JS) expressions anywhere in App Builder to create custom interactions between the different parts of your app. As you begin an expression, App Builder offers autocomplete suggestions based on the existing queries and components in your app. Click on an autocomplete suggestion to use it in your expression, or use the arrow keys on your keyboard and make a selection with the Enter key.
+
+{{< img src="service_management/app_builder/app-builder-variable.mp4" alt="If you're not sure what to enter as a variable, type ${ to open a suggestion menu with all available variables" video=true >}}
 
 Some fields, like [post-query transformation][1], display a code editor by default and accept plain JS. In all other fields, enclose your JS expressions in `${}`. For example, to interpolate the values of two text input components named `textInput0` and `textInput1` into the **Content** property of a text component (and add an exclamation mark), use the expression `${textInput0.value} ${textInput1.value}!`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

* Moves relevant expressions image (previously labeled as to do with "variables", which is wrong) to the expressions page.
* Adds a link from Build Apps to Expressions

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->