### PR TITLE
Update instructions to run osv-scanner

### DIFF
--- a/content/en/code_analysis/faq/_index.md
+++ b/content/en/code_analysis/faq/_index.md
@@ -76,7 +76,7 @@ Datadog's static analyzer is available under an open source license and the code
 
 ### Does the analyzer runs on Windows?
 
-The Datadog Static Analyzer supports Windows since version 0.4.1.
+The Datadog Static Analyzer version 0.4.1 or higher is supported on Windows.
 
 ## Software Composition Analysis
 

--- a/content/en/code_analysis/faq/_index.md
+++ b/content/en/code_analysis/faq/_index.md
@@ -76,7 +76,7 @@ Datadog's static analyzer is available under an open source license and the code
 
 ### Does the analyzer runs on Windows?
 
-The Datadog Static Analyzer runs only on UNIX-based systems. An open feature request to support Windows can be [tracked on GitHub](https://github.com/DataDog/datadog-static-analyzer/issues/476).
+The Datadog Static Analyzer supports Windows since version 0.4.1.
 
 ## Software Composition Analysis
 

--- a/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
@@ -22,7 +22,7 @@ Code Analysis is in public beta.
 
 ## Overview
 
-If you don't use GitHub Actions, you can run the Datadog CLI directly in your CI pipeline platform. 
+If you don't use GitHub Actions, you can run the Datadog CLI directly in your CI pipeline platform.
 
 Prerequisites:
 
@@ -48,7 +48,7 @@ Provide the following inputs:
 ```bash
 # Set the Datadog site to send information to
 export DD_SITE="{{< region-param key="dd_site" code="true" >}}"
-                        
+
 # Install dependencies
 npm install -g @datadog/datadog-ci
 
@@ -59,13 +59,13 @@ DATADOG_OSV_SCANNER_URL=https://github.com/DataDog/osv-scanner/releases/latest/d
 # Install OSV Scanner
 mkdir /osv-scanner
 curl -L -o /osv-scanner/osv-scanner.zip $DATADOG_OSV_SCANNER_URL
-cd /osv-scanner && unzip osv-scanner.zip
+unzip /osv-scanner/osv-scanner.zip -d /osv-scanner
 chmod 755 /osv-scanner/osv-scanner
 
-# Output OSC Scanner results
+# Run OSV Scanner and scan your dependencies
 /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-5 --paths-relative-to-scan-dir  --output=/tmp/sbom.json /path/to/repository
 
-# Upload results
+# Upload results to Datadog
 datadog-ci sbom upload --service "my-app" --env "ci" /tmp/sbom.json
 ```
 


### PR DESCRIPTION
1. Our instructions to run `osv-scanner` can be confusing. We are updating them to avoid any confusion for our customers.
2. Windows is now supported, updating the FAQ for it.