### PR TITLE
[dbm] update dbm for mongodb doc to point user to the mongo cluster view

### DIFF
--- a/layouts/shortcodes/dbm-mongodb-agent-setup-docker.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-setup-docker.md
@@ -36,9 +36,9 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 
 ### Validate
 
-[Run the Agent's status subcommand][1002] and look for `mongo` under the **Checks** section. Navigate to the [Databases][1003] page in Datadog to get started.
+[Run the Agent's status subcommand][1002] and look for `mongo` under the **Checks** section. Navigate to the [Database Monitoring for MongoDB][1003] page in Datadog to get started.
 
 [1000]: /agent/faq/template_variables/
 [1001]: https://github.com/DataDog/integrations-core/blob/master/mongo/datadog_checks/mongo/data/conf.yaml.example
 [1002]: /agent/configuration/agent-commands/#agent-status-and-information
-[1003]: https://app.datadoghq.com/databases
+[1003]: https://app.datadoghq.com/databases/list?listView=mongo

--- a/layouts/shortcodes/dbm-mongodb-agent-setup-kubernetes.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-setup-kubernetes.md
@@ -95,7 +95,13 @@ The Cluster Agent automatically registers this configuration and begins running 
 
 To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][2003] and declare the password using the `ENC[]` syntax.
 
+### Validate
+
+[Run the Agent's status subcommand][2004] and look for `mongo` under the **Checks** section. Navigate to the [Database Monitoring for MongoDB][2005] page in Datadog to get started.
+
 [2000]: /agent/cluster_agent
 [2001]: /agent/cluster_agent/clusterchecks/
 [2002]: https://helm.sh
 [2003]: /agent/configuration/secrets-management
+[2004]: /agent/configuration/agent-commands/#agent-status-and-information
+[2005]: https://app.datadoghq.com/databases/list?listView=mongo

--- a/layouts/shortcodes/dbm-mongodb-agent-setup-linux.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-setup-linux.md
@@ -4,9 +4,9 @@ Once all Agent configuration is complete, [restart the Datadog Agent][4003].
 
 ### Validate
 
-[Run the Agent's status subcommand][4001] and look for `mongo` under the **Checks** section. Navigate to the [Databases][4002] page in Datadog to get started.
+[Run the Agent's status subcommand][4001] and look for `mongo` under the **Checks** section. Navigate to the [Database Monitoring for MongoDB][4002] page in Datadog to get started.
 
 [4000]: https://github.com/DataDog/integrations-core/blob/master/mongo/datadog_checks/mongo/data/conf.yaml.example
 [4001]: /agent/configuration/agent-commands/#agent-status-and-information
-[4002]: https://app.datadoghq.com/databases
+[4002]: https://app.datadoghq.com/databases/list?listView=mongo
 [4003]: /agent/configuration/agent-commands/?tab=agentv6v7#restart-the-agent


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR updates DBM for MongoDB documentation to point user directly to the new DBM for MongoDB cluster view after setup.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->