### PR TITLE
(Workflows) Exclude azure network bundle

### DIFF
--- a/local/bin/py/build/actions/workflows.py
+++ b/local/bin/py/build/actions/workflows.py
@@ -42,13 +42,13 @@ def workflows(content, content_dir):
                 
                 for action_name, action_data in get_filtered_actions(data.get('actions', {})).items():
                     action_name = re.split(r':V\d+', action_name)[0] # clean action_name. no version identifier
-                    # for each action of a bundle
-                    if should_show_action(action_data.get('stability'), data):
-                        output_file_name = data.get('name')\
+                    output_file_name = data.get('name')\
                             .replace('com.datadoghq.dd.','')\
                             .replace('com.datadoghq.','')\
                             .replace('.', '_')
-                        action_data['bundle'] = data.get('name')
+                    action_data['bundle'] = data.get('name')
+                    # for each action of a bundle
+                    if should_show_action(action_data.get('stability'), data, output_file_name):
                         action_data['bundle_title'] = data.get('title').strip()
                         action_data['source'] = data.get('icon', {}).get('integration_id', '')
                         action_data['aliases'] = [f'/workflows/actions_catalog/{output_file_name}_{action_name}'.lower()]
@@ -65,7 +65,7 @@ def workflows(content, content_dir):
                             out_file.write(output_content)
 
 
-def should_show_action(action_stability, data):
+def should_show_action(action_stability, data, output_file_name):
     """
     An 'action' should have no 'stability' key or 'stability' key equal to 'stable'
     and should not be tagged as 'internal', 'hidden' or 'deprecated'.
@@ -74,9 +74,14 @@ def should_show_action(action_stability, data):
     @param data {dict}
     @return {boolean}
     """
-    return (not action_stability or action_stability == stability) and not data.get('internal') and not data.get('hidden') and not data.get('deprecated')
-
-
+    exclusion_list = ['azure_network']
+    return (
+        (not action_stability or action_stability == stability)
+        and (not data.get('internal'))
+        and not data.get('hidden')
+        and not data.get('deprecated')
+        and output_file_name not in exclusion_list
+    )
 
 def get_filtered_actions(actions):
     """

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We think an issue with the source files in the Azure Network Workflows bundle is causing the build to run out of memory. This excludes the bundle to prevent the issue. Long-term, we'd like to stop generating these files and instead deep link to each action in the app.

I tested this on an older dd-source commit, but once a new PR is up, we should point this PR it at that branch instead for testing.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing