### PR TITLE
MNTS-90869 - Update template-variable-evaluation.md

### DIFF
--- a/content/en/monitors/guide/template-variable-evaluation.md
+++ b/content/en/monitors/guide/template-variable-evaluation.md
@@ -43,10 +43,10 @@ https://app.datadoghq.com/logs?from_ts={{eval "last_triggered_at_epoch-15*60*100
 
 ### Routing notifications to different teams based on time of day
 
-You can combine a modulo `%` evaluation of the `last_triggered_at_epoch` variable with `{{#is_match}}{{/is_match}}` to customize the routing of notifications based on time of day:
+You can combine a modulo `%` evaluation of the `last_triggered_at_epoch` variable with `{{#is_match}}{{/is_match}}` to customize the routing of notifications based on time of day (UTC):
 ```
 {{#is_match (eval "int(last_triggered_at_epoch / 3600000 % 24)") "14" "15" "16"}}  
-Handle that should receive notification if time is between 2PM and 5PM
+Handle that should receive notification if time is between 2PM and 5PM UTC
 {{/is_match}}
 ```
 


### PR DESCRIPTION
Clarifying that last_triggered_at_epoch is UTC based

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

https://datadoghq.atlassian.net/browse/MNTS-90869
Clarifying that last_triggered_at_epoch is UTC based, as that may be confusing if users are expected to route a notification at a certain time of day

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->