### PR TITLE
Clarify lack of support for Serverless environments

### DIFF
--- a/content/en/tracing/guide/setting_primary_tags_to_scope.md
+++ b/content/en/tracing/guide/setting_primary_tags_to_scope.md
@@ -80,6 +80,8 @@ Go to the [APM Settings][6] page to define, change, or remove your primary tags.
 * Changes may take up to two hours to be reflected in the UI.
 * The tracer always adds `resource`, `name`, and `service` tags to spans. Datadog recommends never adding these as host level tags to avoid confusion.
 * The second primary tag supports up to 30 unique values. See [APM Data Volume Guidelines][9] for details.
+* Adding second primary tags is currently not supported for Serverless environments.
+ 
 
 If you change a previously set primary tag, be aware of the following:
 


### PR DESCRIPTION
This update is to clarify our lack of support for second primary tags in Serverless environments.

Related to ticket: https://datadog.zendesk.com/agent/tickets/1786704

and the following FRs:
* https://datadoghq.atlassian.net/browse/FRAPMS-3726
* https://datadoghq.atlassian.net/browse/FRAPMS-990

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
please see details above

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->