### PR TITLE
Add docs for ddtags in OTel logs

### DIFF
--- a/content/en/opentelemetry/integrations/log_collection.md
+++ b/content/en/opentelemetry/integrations/log_collection.md
@@ -85,11 +85,12 @@ filelog:
 ### Custom tags
 In order to add custom Datadog tags to logs, set the `ddtags` attribute on the logs. For example, this can be done with the [transform processor][3]:
 ```yaml
-transform:
-  log_statements:
-    - context: log
-      statements:
-        - set(attributes["ddtags"], "first_custom:tag, second_custom:tag")
+processors:
+  transform:
+    log_statements:
+      - context: log
+        statements:
+          - set(attributes["ddtags"], "first_custom:tag, second_custom:tag")
 ```
 
 ## Data collected

--- a/content/en/opentelemetry/integrations/log_collection.md
+++ b/content/en/opentelemetry/integrations/log_collection.md
@@ -82,6 +82,16 @@ filelog:
 
 {{< /tabs >}}
 
+### Custom tags
+In order to add custom Datadog tags to logs, set the `ddtags` attribute on the logs. For example, this can be done with the [transform processor][3]:
+```yaml
+transform:
+  log_statements:
+    - context: log
+      statements:
+        - set(attributes["ddtags"], "first_custom:tag, second_custom:tag")
+```
+
 ## Data collected
 
 Logs from the configured files.
@@ -141,3 +151,4 @@ Flags: 0
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
 [2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/logs.yaml
+[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add docs for adding custom tags to OTel logs through the ddtags attribute. Corresponding collector docs: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34439

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->