### PR TITLE
docs: make clear delegate type explicit that it is customer type

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
@@ -435,24 +435,24 @@ To automatically track resources (network requests) and get their timing informa
 ```swift
 URLSessionInstrumentation.enable(
     with: .init(
-        delegateClass: SessionDelegate.self
+        delegateClass: <YourSessionDelegate>.self
     )
 )
 
 let session = URLSession(
     configuration: .default,
-    delegate: SessionDelegate(),
+    delegate: <YourSessionDelegate>(),
     delegateQueue: nil
 )
 ```
 {{% /tab %}}
 {{% tab "Objective-C" %}}
 ```objective-c
-DDURLSessionInstrumentationConfiguration *config = [[DDURLSessionInstrumentationConfiguration alloc] initWithDelegateClass:[SessionDelegate class]];
+DDURLSessionInstrumentationConfiguration *config = [[DDURLSessionInstrumentationConfiguration alloc] initWithDelegateClass:[<YourSessionDelegate> class]];
 [DDURLSessionInstrumentation enableWithConfiguration:config];
 
 NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
-                                                      delegate:[[SessionDelegate alloc] init]
+                                                      delegate:[[<YourSessionDelegate> alloc] init]
                                                  delegateQueue:nil];
 ```
 {{% /tab %}}
@@ -481,13 +481,13 @@ RUM.enable(
 
 URLSessionInstrumentation.enable(
     with: .init(
-        delegateClass: SessionDelegate.self
+        delegateClass: <YourSessionDelegate>.self
     )
 )
 
 let session = URLSession(
     configuration: .default,
-    delegate: SessionDelegate(),
+    delegate: <YourSessionDelegate>(),
     delegateQueue: nil
 )
 ```
@@ -536,12 +536,12 @@ If you don't want to track requests, you can disable URLSessionInstrumentation f
 {{< tabs >}}
 {{% tab "Swift" %}}
 ```swift
-URLSessionInstrumentation.disable(delegateClass: SessionDelegate.self)
+URLSessionInstrumentation.disable(delegateClass: <YourSessionDelegate>.self)
 ```
 {{% /tab %}}
 {{% tab "Objective-C" %}}
 ```objective-c
-[DDURLSessionInstrumentation disableWithDelegateClass:[SessionDelegate class]];
+[DDURLSessionInstrumentation disableWithDelegateClass:[<YourSessionDelegate> class]];
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
@@ -347,24 +347,24 @@ To monitor requests sent from the `URLSession` instance as resources, enable `UR
 ```swift
 URLSessionInstrumentation.enable(
     with: .init(
-        delegateClass: SessionDelegate.self
+        delegateClass: <YourSessionDelegate>.self
     )
 )
 
 let session = URLSession(
     configuration: .default,
-    delegate: SessionDelegate(),
+    delegate: <YourSessionDelegate>(),
     delegateQueue: nil
 )
 ```
 {{% /tab %}}
 {{% tab "Objective-C" %}}
 ```objective-c
-DDURLSessionInstrumentationConfiguration *config = [[DDURLSessionInstrumentationConfiguration alloc] initWithDelegateClass:[SessionDelegate class]];
+DDURLSessionInstrumentationConfiguration *config = [[DDURLSessionInstrumentationConfiguration alloc] initWithDelegateClass:[<YourSessionDelegate> class]];
 [DDURLSessionInstrumentation enableWithConfiguration:config];
 
 NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
-                                                      delegate:[[SessionDelegate alloc] init]
+                                                      delegate:[[<YourSessionDelegate> alloc] init]
                                                  delegateQueue:nil];
 ```
 {{% /tab %}}
@@ -395,7 +395,7 @@ configuration.sessionSampleRate = 50;
 
 ### Instrument views
 
-The Datadog iOS SDK for RUM allows you to instrument views of `SwiftUI` applications. The instrumentation also works with hybrid `UIKit` and `SwiftUI` applications. 
+The Datadog iOS SDK for RUM allows you to instrument views of `SwiftUI` applications. The instrumentation also works with hybrid `UIKit` and `SwiftUI` applications.
 
 To instrument a `SwiftUI.View`, add the following method to your view declaration:
 
@@ -418,7 +418,7 @@ The `trackRUMView(name:)` method starts and stops a RUM view when the `SwiftUI` 
 
 ### Instrument tap actions
 
-The Datadog iOS SDK for RUM allows you to instrument tap actions of `SwiftUI` applications. The instrumentation also works with hybrid `UIKit` and `SwiftUI` applications. 
+The Datadog iOS SDK for RUM allows you to instrument tap actions of `SwiftUI` applications. The instrumentation also works with hybrid `UIKit` and `SwiftUI` applications.
 
 To instrument a tap action on a `SwiftUI.View`, add the following method to your view declaration:
 

--- a/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
+++ b/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
@@ -194,7 +194,7 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
     ```swift
     URLSessionInstrumentation.enable(
         with: .init(
-            delegateClass: SessionDelegate.self
+            delegateClass: <YourSessionDelegate>.self
         )
     )
     ```
@@ -203,7 +203,7 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
     ```swift
     let session =  URLSession(
         configuration: ...,
-        delegate: SessionDelegate(),
+        delegate: <YourSessionDelegate>(),
         delegateQueue: ...
     )
     ```

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/ios.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/ios.md
@@ -464,13 +464,13 @@ Trace.enable(
 
 URLSessionInstrumentation.enable(
     with: .init(
-        delegateClass: SessionDelegate.self,
+        delegateClass: <YourSessionDelegate>.self,
     )
 )
 
 let session = URLSession(
     configuration: .default,
-    delegate: SessionDelegate(),
+    delegate: <YourSessionDelegate>(),
     delegateQueue: nil
 )
 ```

--- a/content/es/tracing/trace_collection/automatic_instrumentation/dd_libraries/ios.md
+++ b/content/es/tracing/trace_collection/automatic_instrumentation/dd_libraries/ios.md
@@ -464,13 +464,13 @@ Trace.enable(
 
 URLSessionInstrumentation.enable(
     with: .init(
-        delegateClass: SessionDelegate.self,
+        delegateClass: <YourSessionDelegate>.self,
     )
 )
 
 let session = URLSession(
     configuration: .default,
-    delegate: SessionDelegate(),
+    delegate: <YourSessionDelegate>(),
     delegateQueue: nil
 )
 ```

--- a/content/ko/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
+++ b/content/ko/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
@@ -267,7 +267,7 @@ Datadog 구성을 생성할 때 `Datadog.Configuration`에서 다음 속성을 �
 : 데이터를 받을 Datadog 서버 엔드포인트 설정.
 
 `batchSize`
-: Datadog에 업로드되는 배치 데이터의 선호하는 크기를 설정합니다. 이 값은 RUM iOS SDK가 처리하는 요청 수와 크기에 영향을 줍니다(배치가 적으면 각 요청의 크기가 적어지나 요청 수가 많아짐). `.small`, `.medium`, `.large` 값을 사용할 수 있습니다. 
+: Datadog에 업로드되는 배치 데이터의 선호하는 크기를 설정합니다. 이 값은 RUM iOS SDK가 처리하는 요청 수와 크기에 영향을 줍니다(배치가 적으면 각 요청의 크기가 적어지나 요청 수가 많아짐). `.small`, `.medium`, `.large` 값을 사용할 수 있습니다.
 
 `uploadFrequency`
 : Datadog에 데이터를 업로드하는 선호 주기를 설정합니다. 값은 `.frequent`, `.average`, `.rare`를 포함해 선택할 수 있습니다.
@@ -374,7 +374,7 @@ class YourCustomPredicate: UIKitRUMViewsPredicate {
 
 앱의 아키텍처에 따라 더 역동적인 솔루션을 사용할 수도 있습니다.
 
-예를 들어 보기 컨트롤러가 일관되게 `accessibilityLabel`를 사용한다면 접근성 레이블값으로 보기 이름을 지정할 수 있습니다. 
+예를 들어 보기 컨트롤러가 일관되게 `accessibilityLabel`를 사용한다면 접근성 레이블값으로 보기 이름을 지정할 수 있습니다.
 
 {{< tabs >}}
 {{% tab "Swift" %}}
@@ -427,13 +427,13 @@ class YourCustomPredicate: UIKitRUMViewsPredicate {
 ```swift
 URLSessionInstrumentation.enable(
     with: .init(
-        delegateClass: SessionDelegate.self
+        delegateClass: <YourSessionDelegate>.self
     )
 )
 
 let session = URLSession(
     configuration: .default,
-    delegate: SessionDelegate(),
+    delegate: <YourSessionDelegate>(),
     delegateQueue: nil
 )
 ```
@@ -473,13 +473,13 @@ RUM.enable(
 
 URLSessionInstrumentation.enable(
     with: .init(
-        delegateClass: SessionDelegate.self
+        delegateClass: <YourSessionDelegate>.self
     )
 )
 
 let session = URLSession(
     configuration: .default,
-    delegate: SessionDelegate(),
+    delegate: <YourSessionDelegate>(),
     delegateQueue: nil
 )
 ```
@@ -503,7 +503,7 @@ DDRUMURLSessionTracking *urlSessionTracking = [DDRUMURLSessionTracking new];
 {{% /tab %}}
 {{< /tabs >}}
 
-커스텀 속성을 리소스에 추가하려면 RUM을 활성화할 때 `URLSessionTracking.resourceAttributesProvider` 옵션을 사용하세요. 속성 제공자 클로저를 설정하면 추가 속성을 반환해 추적된 리소스에 연결할 수 있습니다. 
+커스텀 속성을 리소스에 추가하려면 RUM을 활성화할 때 `URLSessionTracking.resourceAttributesProvider` 옵션을 사용하세요. 속성 제공자 클로저를 설정하면 추가 속성을 반환해 추적된 리소스에 연결할 수 있습니다.
 
 예를 들어 HTTP 요청과 응답 헤더를 RUM 리소스에 추가할 수 있습니다.
 
@@ -529,7 +529,7 @@ RUM.enable(
 {{% tab "Swift" %}}
 ```swift
 ```swift
-URLSessionInstrumentation.disable(delegateClass: SessionDelegate.self)
+URLSessionInstrumentation.disable(delegateClass: <YourSessionDelegate>.self)
 ```
 {{% /tab %}}
 {{% tab "Objective-C" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Some customers get confused that `SessionDelegate` is something we provide from docs.

Made it explicit with name and `<` & `>`

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->