### PR TITLE
CCM add text on cost monitor evaluation delay period

### DIFF
--- a/content/en/monitors/types/cloud_cost.md
+++ b/content/en/monitors/types/cloud_cost.md
@@ -27,7 +27,7 @@ Get proactive notifications on cost changes to help mitigate unexpected cloud sp
 
 In order to configure Cloud Cost monitors, you need to have [Cloud Cost Management][1] set up. After it's set up, you can configure monitors to alert when costs increase or decrease.
 
-Cloud Cost monitors are evaluated with a 48 hour delayed evaluation window, because Cloud Cost data is not guaranteed to be available until 48 hours after usage. For example, a monitor with a lookback of 7 days being evaluated on January 15 will examine cost data from January 6 through January 13.
+Cloud Cost monitors are evaluated with a 48 hour delayed evaluation window, because Cloud Cost data is not guaranteed to be available until 48 hours after usage. For example, a monitor with a lookback of 7 days being evaluated on January 15 examines cost data from January 6 through January 13.
 
 ## Monitor creation
 

--- a/content/en/monitors/types/cloud_cost.md
+++ b/content/en/monitors/types/cloud_cost.md
@@ -27,6 +27,8 @@ Get proactive notifications on cost changes to help mitigate unexpected cloud sp
 
 In order to configure Cloud Cost monitors, you need to have [Cloud Cost Management][1] set up. After it's set up, you can configure monitors to alert when costs increase or decrease.
 
+Cloud Cost monitors are evaluated with a 48 hour delayed evaluation window, because Cloud Cost data is not guaranteed to be available until 48 hours after usage. For example, a monitor with a lookback of 7 days being evaluated on January 15 will examine cost data from January 6 through January 13.
+
 ## Monitor creation
 
 To create a Cloud Cost monitor in Datadog, use the main navigation: **Monitors** --> **New Monitor** --> **Cloud Cost**.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
There was a recent support issue caused because this delay is not documented or otherwise clear to end users. They were comparing the values reported by the monitor to their own dashboards and metric explorer. This is also important if they use templated links to dashboards in their monitor template.

### Merge instructions

- [x] Please merge after reviewing

