### PR TITLE
Update managed_authentication.md

### DIFF
--- a/content/en/database_monitoring/guide/managed_authentication.md
+++ b/content/en/database_monitoring/guide/managed_authentication.md
@@ -33,7 +33,7 @@ Supported authentication types and Agent versions
 ## Configure IAM authentication
 
 
-AWS supports IAM authentication to RDS and Aurora databases. At this time, only IAM authentication to database instances residing in the same account as the Datadog Agent is supported. In order to configure the Agent to connect using IAM, do the following:
+AWS supports IAM authentication to RDS and Aurora databases. Only IAM authentication to database instances residing in the same account as the Datadog Agent is supported. In order to configure the Agent to connect using IAM, do the following:
 
 
 1. Turn on IAM authentication on your [RDS][3] or [Aurora][4] instance.

--- a/content/en/database_monitoring/guide/managed_authentication.md
+++ b/content/en/database_monitoring/guide/managed_authentication.md
@@ -33,7 +33,7 @@ Supported authentication types and Agent versions
 ## Configure IAM authentication
 
 
-AWS supports IAM authentication to RDS and Aurora databases. In order to configure the Agent to connect using IAM, do the following:
+AWS supports IAM authentication to RDS and Aurora databases. At this time, only IAM authentication to database instances residing in the same account as the Datadog Agent is supported. In order to configure the Agent to connect using IAM, do the following:
 
 
 1. Turn on IAM authentication on your [RDS][3] or [Aurora][4] instance.


### PR DESCRIPTION
The current DBM integration does not provide for cross-account authentication - FR exists: FRSDBM-432

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
We need to add a note to our customers that only IAM auth to instances in the same account is possible, otherwise determining this on your own is a lengthy troubleshooting process

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
Future development for FRSDBM-432 may remove this limitation, however for now we should make it easy to find this limitation to protect customer time

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->