### PR TITLE
Update to CODEOWNES scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,14 +1,10 @@
 *                         @DataDog/documentation
 
-/data/api/                        @DataDog/documentation
-/config/_default/menus/           @DataDog/documentation
-.github/ISSUE_TEMPLATE            @DataDog/documentation
-.github/PULL_REQUEST_TEMPLATE.md  @DataDog/documentation
-README.md                         @DataDog/documentation
-/assets/                          @DataDog/corpweb
-/data/                            @DataDog/corpweb
-/layouts/                         @DataDog/corpweb
-/config/                          @DataDog/corpweb
+# Corpweb
+assets/                           @DataDog/corpweb
+data/                             @DataDog/corpweb
+layouts/                          @DataDog/corpweb
+config/                           @DataDog/corpweb
 package.json                      @DataDog/corpweb
 go.mod                            @DataDog/corpweb
 go.sum                            @DataDog/corpweb
@@ -39,6 +35,29 @@ static-analysis.datadog.yml                             @DataDog/WebOps-Platform
 translate.yaml                                          @DataDog/WebOps-Platform
 yarn.lock                                               @DataDog/WebOps-Platform
 .yarnrc.yml                                             @DataDog/WebOps-Platform
+
+# Scoped Docs/WebOps
+.github/                                                      @DataDog/WebOps-Platform
+/data/api/                                                    @DataDog/documentation
+/config/_default/menus/                                       @DataDog/documentation
+.github/ISSUE_TEMPLATE                                        @DataDog/documentation
+.github/PULL_REQUEST_TEMPLATE.md                              @DataDog/documentation
+README.md                                                     @DataDog/documentation
+local/bin/py/vale                                             @DataDog/documentation
+.github/CODEOWNERS                                            @DataDog/WebOps-Platform @DataDog/documentation
+.github/workflows/check_cache_value.yml                       @DataDog/documentation
+.github/workflows/code-freeze.yml                             @DataDog/documentation
+.github/workflows/gif_check.yml                               @DataDog/documentation
+.github/workflows/preview_link.yml                            @DataDog/documentation
+.github/workflows/vale_linter.yml                             @DataDog/documentation
+local/bin/py/check_cache_values.py                            @DataDog/documentation
+local/bin/py/integration-finder.py                            @DataDog/documentation
+local/bin/py/missing_metrics.py                               @DataDog/documentation
+local/bin/py/preview_links.py                                 @DataDog/documentation
+local/bin/py/missing_metrics.py                               @DataDog/documentation
+local/bin/py/preview-links-template.mako                      @DataDog/documentation
+local/bin/py/build/configurations/pull_config_preview.yaml    @DataDog/WebOps-Platform @DataDog/documentation
+local/bin/py/build/configurations/pull_config.yaml            @DataDog/WebOps-Platform @DataDog/documentation
 
 # SDK versions
 .github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,7 +54,6 @@ local/bin/py/check_cache_values.py                            @DataDog/documenta
 local/bin/py/integration-finder.py                            @DataDog/documentation
 local/bin/py/missing_metrics.py                               @DataDog/documentation
 local/bin/py/preview_links.py                                 @DataDog/documentation
-local/bin/py/missing_metrics.py                               @DataDog/documentation
 local/bin/py/preview-links-template.mako                      @DataDog/documentation
 local/bin/py/build/configurations/pull_config_preview.yaml    @DataDog/WebOps-Platform @DataDog/documentation
 local/bin/py/build/configurations/pull_config.yaml            @DataDog/WebOps-Platform @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,17 @@
 *                         @DataDog/documentation
 
-/assets/                  @DataDog/corpweb @DataDog/documentation
-/data/                    @DataDog/corpweb @DataDog/documentation
-/data/api/                @DataDog/documentation
-/local/                   @DataDog/corpweb @DataDog/documentation
-/layouts/                 @DataDog/corpweb @DataDog/documentation
-/src/                     @DataDog/corpweb @DataDog/documentation
-/config/                  @DataDog/corpweb @DataDog/documentation
-/config/_default/menus/   @DataDog/documentation
-package.json              @DataDog/corpweb @DataDog/documentation
-go.mod                    @DataDog/corpweb @DataDog/documentation
-go.sum                    @DataDog/corpweb @DataDog/documentation
+/assets/                          @DataDog/corpweb
+/data/                            @DataDog/corpweb
+/data/api/                        @DataDog/documentation
+/layouts/                         @DataDog/corpweb
+/src/                             @DataDog/corpweb @DataDog/documentation
+/config/                          @DataDog/corpweb
+/config/_default/menus/           @DataDog/documentation
+package.json                      @DataDog/corpweb
+go.mod                            @DataDog/corpweb
+go.sum                            @DataDog/corpweb
+.github/ISSUE_TEMPLATE            @DataDog/documentation
+.github/PULL_REQUEST_TEMPLATE.md  @DataDog/documentation
 
 # SDK versions
 .github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation
@@ -48,7 +49,7 @@ layouts/shortcodes/integration-assets-reference.md                          @Dat
 layouts/shortcodes/integration_categories.md                                @Datadog/marketplace-product-management @DataDog/documentation
 
 # Websites Platform (Devops)
-.github/workflows                                       @DataDog/WebOps-Platform
+.github/                                                @DataDog/WebOps-Platform
 .gitlab-ci.yml                                          @DataDog/WebOps-Platform
 Makefile                                                @DataDog/WebOps-Platform
 translate.yaml                                          @DataDog/WebOps-Platform
@@ -57,6 +58,14 @@ docker-compose-docs.yml                                 @DataDog/WebOps-Platform
 .htmltest.yml                                           @DataDog/WebOps-Platform
 datadog-ci.preview.json                                 @DataDog/WebOps-Platform
 general.preview.synthetics.json                         @DataDog/WebOps-Platform
+/local/                                                 @DataDog/WebOps-Platform
+.gitignore                                              @DataDog/WebOps-Platform
+.gitattributes                                          @DataDog/WebOps-Platform
+.nvmrc                                                  @DataDog/WebOps-Platform
+babel.config.js                                         @DataDog/WebOps-Platform
+postcss.config.js                                       @DataDog/WebOps-Platform
+prettier.config.js                                      @DataDog/WebOps-Platform
+data/reference/                                         @DataDog/WebOps-Platform
 
 # Cloud Cost Management
 documentation/content/en/cloud_cost_management/*.md              @DataDog/cloud-cost-management-visibility @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,7 +60,7 @@ local/bin/py/build/configurations/pull_config.yaml            @DataDog/WebOps-Pl
 data/sdk_versions.json                                        @Datadog/documentation
 
 # SDK versions
-.github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation
+.github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation 
 /data/sdk_versions.json               @DataDog/api-clients @DataDog/documentation
 
 # Serverless

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,7 @@
 /config/_default/menus/           @DataDog/documentation
 .github/ISSUE_TEMPLATE            @DataDog/documentation
 .github/PULL_REQUEST_TEMPLATE.md  @DataDog/documentation
+README.md                         @DataDog/documentation
 /assets/                          @DataDog/corpweb
 /data/                            @DataDog/corpweb
 /layouts/                         @DataDog/corpweb
@@ -13,6 +14,31 @@ go.mod                            @DataDog/corpweb
 go.sum                            @DataDog/corpweb
 i18n/                             @DataDog/corpweb
 archetypes/                       @DataDog/corpweb
+
+# Websites Platform
+babel.config.js                                         @DataDog/WebOps-Platform
+data/reference/                                         @DataDog/WebOps-Platform
+datadog-ci.preview.json                                 @DataDog/WebOps-Platform
+docker-compose-docs.yml                                 @DataDog/WebOps-Platform
+.general.preview.synthetics.json                        @DataDog/WebOps-Platform
+.gitattributes                                          @DataDog/WebOps-Platform
+.gitignore                                              @DataDog/WebOps-Platform
+.github/                                                @DataDog/WebOps-Platform
+.gitlab-ci.yml                                          @DataDog/WebOps-Platform
+.htmltest.yml                                           @DataDog/WebOps-Platform
+jest.config.js                                          @DataDog/WebOps-Platform
+.local/                                                 @DataDog/WebOps-Platform
+Makefile                                                @DataDog/WebOps-Platform
+Makefile.config.example                                 @DataDog/WebOps-Platform
+.nvmrc                                                  @DataDog/WebOps-Platform
+postcss.config.js                                       @DataDog/WebOps-Platform
+.prettierignore                                         @DataDog/WebOps-Platform
+prettier.config.js                                      @DataDog/WebOps-Platform
+static-analysis.datadog.yml                             @DataDog/WebOps-Platform
+.translate                                              @DataDog/WebOps-Platform
+translate.yaml                                          @DataDog/WebOps-Platform
+yarn.lock                                               @DataDog/WebOps-Platform
+.yarnrc.yml                                             @DataDog/WebOps-Platform
 
 # SDK versions
 .github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation
@@ -48,25 +74,6 @@ content/en/developers/integrations/check_references.md                          
 layouts/shortcodes/integration-assets.md                                    @Datadog/marketplace-product-management @DataDog/documentation
 layouts/shortcodes/integration-assets-reference.md                          @Datadog/marketplace-product-management @DataDog/documentation
 layouts/shortcodes/integration_categories.md                                @Datadog/marketplace-product-management @DataDog/documentation
-
-# Websites Platform
-.github/                                                @DataDog/WebOps-Platform
-.gitlab-ci.yml                                          @DataDog/WebOps-Platform
-Makefile                                                @DataDog/WebOps-Platform
-translate.yaml                                          @DataDog/WebOps-Platform
-.translate                                              @DataDog/WebOps-Platform
-docker-compose-docs.yml                                 @DataDog/WebOps-Platform
-.htmltest.yml                                           @DataDog/WebOps-Platform
-datadog-ci.preview.json                                 @DataDog/WebOps-Platform
-general.preview.synthetics.json                         @DataDog/WebOps-Platform
-/local/                                                 @DataDog/WebOps-Platform
-.gitignore                                              @DataDog/WebOps-Platform
-.gitattributes                                          @DataDog/WebOps-Platform
-.nvmrc                                                  @DataDog/WebOps-Platform
-babel.config.js                                         @DataDog/WebOps-Platform
-postcss.config.js                                       @DataDog/WebOps-Platform
-prettier.config.js                                      @DataDog/WebOps-Platform
-data/reference/                                         @DataDog/WebOps-Platform
 
 # Cloud Cost Management
 documentation/content/en/cloud_cost_management/*.md              @DataDog/cloud-cost-management-visibility @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,6 +57,7 @@ local/bin/py/preview_links.py                                 @DataDog/documenta
 local/bin/py/preview-links-template.mako                      @DataDog/documentation
 local/bin/py/build/configurations/pull_config_preview.yaml    @DataDog/WebOps-Platform @DataDog/documentation
 local/bin/py/build/configurations/pull_config.yaml            @DataDog/WebOps-Platform @DataDog/documentation
+data/sdk_versions.json                                        @Datadog/documentation
 
 # SDK versions
 .github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,18 @@
 *                         @DataDog/documentation
 
+/data/api/                        @DataDog/documentation
+/config/_default/menus/           @DataDog/documentation
+.github/ISSUE_TEMPLATE            @DataDog/documentation
+.github/PULL_REQUEST_TEMPLATE.md  @DataDog/documentation
 /assets/                          @DataDog/corpweb
 /data/                            @DataDog/corpweb
-/data/api/                        @DataDog/documentation
 /layouts/                         @DataDog/corpweb
-/src/                             @DataDog/corpweb @DataDog/documentation
 /config/                          @DataDog/corpweb
-/config/_default/menus/           @DataDog/documentation
 package.json                      @DataDog/corpweb
 go.mod                            @DataDog/corpweb
 go.sum                            @DataDog/corpweb
-.github/ISSUE_TEMPLATE            @DataDog/documentation
-.github/PULL_REQUEST_TEMPLATE.md  @DataDog/documentation
+i18n/                             @DataDog/corpweb
+archetypes/                       @DataDog/corpweb
 
 # SDK versions
 .github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation
@@ -48,7 +49,7 @@ layouts/shortcodes/integration-assets.md                                    @Dat
 layouts/shortcodes/integration-assets-reference.md                          @Datadog/marketplace-product-management @DataDog/documentation
 layouts/shortcodes/integration_categories.md                                @Datadog/marketplace-product-management @DataDog/documentation
 
-# Websites Platform (Devops)
+# Websites Platform
 .github/                                                @DataDog/WebOps-Platform
 .gitlab-ci.yml                                          @DataDog/WebOps-Platform
 Makefile                                                @DataDog/WebOps-Platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -60,7 +60,7 @@ local/bin/py/build/configurations/pull_config.yaml            @DataDog/WebOps-Pl
 data/sdk_versions.json                                        @Datadog/documentation
 
 # SDK versions
-.github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation 
+.github/workflows/bump_versions.yml   @DataDog/api-clients @DataDog/documentation @DataDog/WebOps-Platform
 /data/sdk_versions.json               @DataDog/api-clients @DataDog/documentation
 
 # Serverless


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Updates the codeowner file to scope specific paths to webops platform
- Removes the dual codeowners from website build and configuration files
- Moves the webops platform section under the top docs/corpweb section (making things easier to navigate/find)
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
After incident web-incident-30 we discovered that the websites team had some blindspots as well as missing approvals from pull requests that altered the way build scripts run. Due to github limitations, if there are 2 codeowners for a file, it will accept an either/or approval instead of requiring both to merge. This is a first step in a larger remediation around how approvals are required.
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->