### PR TITLE
DOCS-8586 - helm config indentation fix

### DIFF
--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -307,7 +307,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
         postgres.yaml: -|
           cluster_check: true
           init_config:
-            instances:
+          instances:
             - dbm: true
               host: '<AWS_INSTANCE_ENDPOINT>'
               port: 5432


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
As raised by support (and verified via [other docs](https://docs.datadoghq.com/containers/kubernetes/integrations/?tab=helm)), `instances` should be on the same level as `init_config`. Other lines are indented properly.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->