### PR TITLE
DOCS-7960 - secrets for dbm

### DIFF
--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -53,6 +53,9 @@ The Datadog Agent requires read-only access to the MongoDB Atlas Cluster to coll
 6. Click **Add User**.
 7. Note the username and password for the monitoring user, so you can configure the Agent.
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Install and configure the Agent
 
 To monitor your MongoDB Atlas Cluster, you must install and configure the Datadog Agent on a host that can [remotely access][1] your MongoDB Atlas Cluster. This host can be a Linux host, a Docker container, or a Kubernetes pod.

--- a/content/en/database_monitoring/setup_mongodb/selfhosted.md
+++ b/content/en/database_monitoring/setup_mongodb/selfhosted.md
@@ -151,6 +151,9 @@ db.grantRolesToUser("datadog", [
 {{% /tab %}}
 {{< /tabs >}}
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Install and configure the Agent
 
 Datadog recommends installing the Agent directly on the MongoDB host, as that enables the Agent to collect a variety of system telemetry (CPU, memory, disk, network) in addition to MongoDB specific telemetry.

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -158,6 +158,9 @@ DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ## Install and configure the Agent
 
 To monitor Aurora hosts, install the Datadog Agent in your infrastructure and configure it to connect to each instance endpoint remotely. The Agent does not need to run on the database, it only needs to connect to it. For additional Agent installation methods not mentioned here, see the [Agent installation instructions][5].
@@ -185,7 +188,7 @@ instances:
     host: '<AWS_INSTANCE_ENDPOINT>'
     port: 3306
     username: datadog
-    password: '<YOUR_CHOSEN_PASSWORD>' # from the CREATE USER step earlier
+    password: 'ENC[datadog_user_database_password]' # from the CREATE USER step earlier, stored as a secret
 
     # After adding your project and instance, configure the Datadog AWS integration to pull additional cloud data such as CPU and Memory.
     aws:
@@ -193,8 +196,6 @@ instances:
 ```
 
 <div class="alert alert-warning"><strong>Important</strong>: Use the Aurora instance endpoint here, not the cluster endpoint.</div>
-
-**Note**: Wrap your password in single quotes in case a special character is present.
 
 [Restart the Agent][3] to start sending MySQL metrics to Datadog.
 
@@ -241,17 +242,13 @@ FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AWS_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "<UNIQUEPASSWORD>"}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AWS_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "ENC[datadog_user_database_password]"}]'
 ```
 
 <div class="alert alert-warning"><strong>Important</strong>: Use the Aurora instance endpoint as the host, not the cluster endpoint.</div>
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][2] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][3] to learn how to pass the password as an environment variable.
-
 
 [1]: /agent/docker/integrations/?tab=docker
-[2]: /agent/configuration/secrets-management
-[3]: /agent/faq/template_variables/
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -276,7 +273,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
                 host: <INSTANCE_ADDRESS>
                 port: 3306
                 username: datadog
-                password: '<UNIQUE_PASSWORD>'
+                password: 'ENC[datadog_user_database_password]'
 
     clusterChecksRunner:
       enabled: true
@@ -307,7 +304,7 @@ instances:
     host: '<AWS_INSTANCE_ENDPOINT>'
     port: 3306
     username: datadog
-    password: '<UNIQUEPASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
 ```
 
 ### Configure with Kubernetes service annotations
@@ -333,7 +330,7 @@ metadata:
           "host": "<AWS_INSTANCE_ENDPOINT>",
           "port": 3306,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>"
+          "password": "ENC[datadog_user_database_password]"
         }
       ]
 spec:

--- a/content/en/database_monitoring/setup_mysql/azure.md
+++ b/content/en/database_monitoring/setup_mysql/azure.md
@@ -101,6 +101,9 @@ DELIMITER ;
 GRANT EXECUTE ON PROCEDURE <YOUR_SCHEMA>.explain_statement TO datadog@'%';
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ## Install and configure the Agent
 
 To monitor Azure hosts, install the Datadog Agent in your infrastructure and configure it to connect to each instance endpoint remotely. The Agent does not need to run on the database, it only needs to connect to it. For additional Agent installation methods not mentioned here, see the [Agent installation instructions][5].
@@ -122,7 +125,7 @@ instances:
     host: '<AZURE_INSTANCE_ENDPOINT>'
     port: 3306
     username: datadog
-    password: '<YOUR_CHOSEN_PASSWORD>' # from the CREATE USER step earlier
+    password: 'ENC[datadog_user_database_password]' # from the CREATE USER step earlier, stored as a secret
 
     # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU and Memory.
     azure:
@@ -183,17 +186,13 @@ FROM datadog/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AZURE_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "<UNIQUEPASSWORD>", "azure": {"deployment_type": "<DEPLOYMENT_TYPE>", "fully_qualified_domain_name": "<AZURE_INSTANCE_ENDPOINT>"}}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AZURE_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "ENC[datadog_user_database_password]", "azure": {"deployment_type": "<DEPLOYMENT_TYPE>", "fully_qualified_domain_name": "<AZURE_INSTANCE_ENDPOINT>"}}]'
 ```
 
 See the [MySQL integration spec][4] for additional information on setting `deployment_type` and `name` fields.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][2] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][3] on how to pass in the password as an environment variable.
-
 
 [1]: /agent/docker/integrations/?tab=docker
-[2]: /agent/configuration/secrets-management
-[3]: /agent/faq/template_variables/
 [4]: https://github.com/DataDog/integrations-core/blob/master/mysql/assets/configuration/spec.yaml#L523-L552
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
@@ -219,7 +218,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
                 host: '<AZURE_INSTANCE_ENDPOINT>'
                 port: 3306
                 username: datadog
-                password: '<UNIQUE_PASSWORD>'
+                password: 'ENC[datadog_user_database_password]'
                 azure:
                   deployment_type: '<DEPLOYMENT_TYPE>'
                   fully_qualified_domain_name: '<AZURE_INSTANCE_ENDPOINT>'
@@ -253,7 +252,7 @@ instances:
     host: '<AZURE_INSTANCE_ENDPOINT>'
     port: 3306
     username: datadog
-    password: '<UNIQUEPASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
     azure:
       deployment_type: '<DEPLOYMENT_TYPE>'
@@ -283,7 +282,7 @@ metadata:
           "host": "<AZURE_INSTANCE_ENDPOINT>",
           "port": 3306,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "azure": {
             "deployment_type": "<DEPLOYMENT_TYPE>",
             "fully_qualified_domain_name": "<AZURE_INSTANCE_ENDPOINT>"

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -151,6 +151,9 @@ DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Verify
 
 Verify the user was created successfully using the following commands, replacing `<UNIQUEPASSWORD>` with the password you created above:
@@ -189,15 +192,13 @@ instances:
     host: '<INSTANCE_ADDRESS>'
     port: 3306
     username: datadog
-    password: '<UNIQUEPASSWORD>' # from the CREATE USER step earlier
+    password: 'ENC[datadog_user_database_password]' # from the CREATE USER step earlier, stored as a secret
 
     # After adding your project and instance, configure the Datadog Google Cloud (GCP) integration to pull additional cloud data such as CPU, Memory, etc.
     gcp:
       project_id: '<PROJECT_ID>'
       instance_id: '<INSTANCE_ID>'
 ```
-
-**Note**: Wrap your password in single quotes in case a special character is present.
 
 See the [MySQL integration spec][3] for additional information on setting `project_id` and `instance_id` fields.
 
@@ -249,17 +250,13 @@ FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>", "gcp": {"project_id": "<PROJECT_ID>", "instance_id": "<INSTANCE_ID>"}}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "ENC[datadog_user_database_password]", "gcp": {"project_id": "<PROJECT_ID>", "instance_id": "<INSTANCE_ID>"}}]'
 ```
 
 See the [MySQL integration spec][2] for additional information on setting `project_id` and `instance_id` fields.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][2] on how to pass in the password as an environment variable.
-
 
 [1]: /agent/docker/integrations/?tab=docker
-[2]: /agent/faq/template_variables/
-[3]: /agent/configuration/secrets-management
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -284,7 +281,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
                 host: <INSTANCE_ADDRESS>
                 port: 3306
                 username: datadog
-                password: '<UNIQUEPASSWORD>'
+                password: 'ENC[datadog_user_database_password]'
                 gcp:
                   project_id: '<PROJECT_ID>'
                   instance_id: '<INSTANCE_ID>'
@@ -318,7 +315,7 @@ instances:
     host: '<INSTANCE_ADDRESS>'
     port: 3306
     username: datadog
-    password: '<UNIQUEPASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     # After adding your project and instance, configure the Datadog Google Cloud (GCP) integration to pull additional cloud data such as CPU, Memory, etc.
     gcp:
       project_id: '<PROJECT_ID>'
@@ -347,7 +344,7 @@ metadata:
           "host": "<INSTANCE_ADDRESS>",
           "port": 3306,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "gcp": {
             "project_id": "<PROJECT_ID>",
             "instance_id": "<INSTANCE_ID>"
@@ -366,12 +363,9 @@ See the [MySQL integration spec][4] for additional information on setting `proje
 
 The Cluster Agent automatically registers this configuration and begins running the MySQL check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][4] and declare the password using the `ENC[]` syntax.
-
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
 [3]: https://helm.sh
-[4]: /agent/configuration/secrets-management
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -156,6 +156,9 @@ DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ## Install and configure the Agent
 
 To monitor RDS hosts, install the Datadog Agent in your infrastructure and configure it to connect to each instance endpoint remotely. The Agent does not need to run on the database, it only needs to connect to it. For additional Agent installation methods not mentioned here, see the [Agent installation instructions][5].
@@ -177,14 +180,12 @@ instances:
     host: '<AWS_INSTANCE_ENDPOINT>'
     port: 3306
     username: datadog
-    password: '<YOUR_CHOSEN_PASSWORD>' # from the CREATE USER step earlier
+    password: 'ENC[datadog_user_database_password]' # from the CREATE USER step earlier, stored as a secret
 
     # After adding your project and instance, configure the Datadog AWS integration to pull additional cloud data such as CPU and Memory.
     aws:
       instance_endpoint: '<AWS_INSTANCE_ENDPOINT>'
 ```
-
-**Note**: Wrap your password in single quotes in case a special character is present.
 
 [Restart the Agent][3] to start sending MySQL metrics to Datadog.
 
@@ -230,15 +231,10 @@ FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AWS_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "<UNIQUEPASSWORD>"}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AWS_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog","password": "ENC[datadog_user_database_password]"}]'
 ```
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][2] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][3] to learn how to pass the password as an environment variable.
-
-
 [1]: /agent/docker/integrations/?tab=docker
-[2]: /agent/configuration/secrets-management
-[3]: /agent/faq/template_variables/
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -263,7 +259,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
               host: <INSTANCE_ADDRESS>
               port: 3306
               username: datadog
-              password: '<UNIQUE_PASSWORD>'
+              password: 'ENC[datadog_user_database_password]'
 
     clusterChecksRunner:
       enabled: true
@@ -294,7 +290,7 @@ instances:
     host: '<AWS_INSTANCE_ENDPOINT>'
     port: 3306
     username: datadog
-    password: '<UNIQUEPASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
 ```
 
 ### Configure with Kubernetes service annotations
@@ -320,7 +316,7 @@ metadata:
           "host": "<AWS_INSTANCE_ENDPOINT>",
           "port": 3306,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>"
+          "password": "ENC[datadog_user_database_password]"
         }
       ]
 spec:
@@ -333,12 +329,9 @@ spec:
 
 The Cluster Agent automatically registers this configuration and begins running the MySQL check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][4] and declare the password using the `ENC[]` syntax.
-
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
 [3]: https://helm.sh
-[4]: /agent/configuration/secrets-management
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/database_monitoring/setup_mysql/selfhosted.md
+++ b/content/en/database_monitoring/setup_mysql/selfhosted.md
@@ -156,6 +156,9 @@ DELIMITER ;
 GRANT EXECUTE ON PROCEDURE datadog.enable_events_statements_consumers TO datadog@'%';
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ## Install the Agent
 
 Installing the Datadog Agent also installs the MySQL check which is required for Database Monitoring on MySQL. If you haven't already installed the Agent for your MySQL database host, see the [Agent installation instructions][6].
@@ -176,10 +179,8 @@ instances:
     host: 127.0.0.1
     port: 3306
     username: datadog
-    password: '<YOUR_CHOSEN_PASSWORD>' # from the CREATE USER step earlier
+    password: 'ENC[datadog_user_database_password]' # from the CREATE USER step earlier
 ```
-
-**Note**: Wrap your password in single quotes in case a special character is present.
 
 Note that the `datadog` user should be set up in the MySQL integration configuration as `host: 127.0.0.1` instead of `localhost`. Alternatively, you may also use `sock`.
 

--- a/content/en/database_monitoring/setup_oracle/autonomous_database.md
+++ b/content/en/database_monitoring/setup_oracle/autonomous_database.md
@@ -83,6 +83,9 @@ grant select on cdb_data_files to datadog;
 grant select on dba_data_files to datadog;
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Install the Agent
 
 See the [DBM Setup Architecture][12] documentation to determine where to install the Agent. The Agent doesn't require any external Oracle clients.
@@ -105,7 +108,7 @@ instances:
   - server: '<HOST_1>:<PORT>'
     service_name: "<SERVICE_NAME>" # The Oracle CDB service name
     username: 'datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     protocol: TCPS
     wallet: <YOUR_WALLET_DIRECTORY>
     dbm: true
@@ -115,7 +118,7 @@ instances:
   - server: '<HOST_2>:<PORT>'
     service_name: "<SERVICE_NAME>" # The Oracle CDB service name
     username: 'datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     protocol: TCPS
     wallet: <YOUR_WALLET_DIRECTORY>
     dbm: true

--- a/content/en/database_monitoring/setup_oracle/exadata.md
+++ b/content/en/database_monitoring/setup_oracle/exadata.md
@@ -42,6 +42,9 @@ Complete the following to enable Database Monitoring with your Oracle database:
 
 {{% dbm-create-oracle-user %}}
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Install the Agent
 
 See the [DBM Setup Architecture][12] documentation to determine where to install the Agent. The Agent doesn't require any external Oracle clients.

--- a/content/en/database_monitoring/setup_oracle/rac.md
+++ b/content/en/database_monitoring/setup_oracle/rac.md
@@ -42,6 +42,9 @@ Complete the following to enable Database Monitoring with your Oracle database:
 
 {{% dbm-create-oracle-user %}}
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Install the Agent
 
 See the [DBM Setup Architecture][12] documentation to determine where to install the Agent. The Agent doesn't require any external Oracle clients.
@@ -60,7 +63,7 @@ instances:
   - server: '<RAC_NODE_1>:<PORT>'
     service_name: "<CDB_SERVICE_NAME>" # The Oracle CDB service name
     username: 'c##datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbm: true
     tags:  # Optional
       - rac_cluster:<CLUSTER_NAME>
@@ -69,7 +72,7 @@ instances:
   - server: '<RAC_NODE_2>:<PORT>'
     service_name: "<CDB_SERVICE_NAME>" # The Oracle CDB service name
     username: 'c##datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbm: true
     tags:  # Optional
       - rac_cluster:<CLUSTER_NAME>

--- a/content/en/database_monitoring/setup_oracle/rds.md
+++ b/content/en/database_monitoring/setup_oracle/rds.md
@@ -79,6 +79,8 @@ exec rdsadmin.rdsadmin_util.grant_sys_object('DBA_OBJECTS','DATADOG','SELECT',p_
 exec rdsadmin.rdsadmin_util.grant_sys_object('CDB_DATA_FILES','DATADOG','SELECT',p_grant_option => false);
 exec rdsadmin.rdsadmin_util.grant_sys_object('DBA_DATA_FILES','DATADOG','SELECT',p_grant_option => false);
 ```
+### Securely store your password
+{{% dbm-secret %}}
 
 ### Install the Agent
 
@@ -98,7 +100,7 @@ instances:
   - server: '<RDS_INSTANCE_ENDPOINT_1>:<PORT>'
     service_name: "<SERVICE_NAME>" # The Oracle CDB service name
     username: 'datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbm: true
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
@@ -106,7 +108,7 @@ instances:
   - server: '<RDS_INSTANCE_ENDPOINT_2>:<PORT>'
     service_name: "<SERVICE_NAME>" # The Oracle CDB service name
     username: 'datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbm: true
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'

--- a/content/en/database_monitoring/setup_oracle/selfhosted.md
+++ b/content/en/database_monitoring/setup_oracle/selfhosted.md
@@ -87,6 +87,9 @@ Log on as `sysdba`, and grant the following permissions:
 
 {{< /tabs >}}
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Create a view
 
 Log on as `sysdba`, create a new `view` in the `sysdba` schema, and give the Agent user access to it:
@@ -125,7 +128,7 @@ instances:
   - server: '<HOSTNAME_1>:<PORT>'
     service_name: "<CDB_SERVICE_NAME>" # The Oracle CDB service name
     username: 'c##datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbm: true
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
@@ -133,7 +136,7 @@ instances:
   - server: '<HOSTNAME_2>:<PORT>'
     service_name: "<CDB_SERVICE_NAME>" # The Oracle CDB service name
     username: 'c##datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbm: true
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'

--- a/content/en/database_monitoring/setup_postgres/alloydb.md
+++ b/content/en/database_monitoring/setup_postgres/alloydb.md
@@ -102,6 +102,9 @@ RETURNS NULL ON NULL INPUT
 SECURITY DEFINER;
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Verify
 
 To verify the permissions are correct, run the following commands to confirm the Agent user is able to connect to the database and read the core tables:
@@ -140,7 +143,7 @@ To configure Database Monitoring metrics collection for an Agent running on a ho
        host: '<INSTANCE_ADDRESS>'
        port: 5432
        username: datadog
-       password: '<PASSWORD>'
+       password: 'ENC[datadog_user_database_password]'
        ## Optional: Connect to a different database if needed for `custom_queries`
        # dbname: '<DB_NAME>'
 
@@ -199,7 +202,7 @@ FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>", "gcp": {"project_id": "<PROJECT_ID>", "instance_id": "<INSTANCE_ID>"}}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "ENC[datadog_user_database_password]", "gcp": {"project_id": "<PROJECT_ID>", "instance_id": "<INSTANCE_ID>"}}]'
 ```
 
 See the [Postgres integration spec][2] for additional information on setting `project_id` and `instance_id` fields.
@@ -235,7 +238,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
             host: <INSTANCE_ADDRESS>
             port: 5432
             username: datadog
-            password: '<UNIQUE_PASSWORD>'
+            password: 'ENC[datadog_user_database_password]'
             gcp:
               project_id: '<PROJECT_ID>'
               instance_id: '<INSTANCE_ID>'
@@ -276,7 +279,7 @@ instances:
     host: '<INSTANCE_ADDRESS>'
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
     gcp:
       project_id: '<PROJECT_ID>'
@@ -305,7 +308,7 @@ metadata:
           "host": "<INSTANCE_ADDRESS>",
           "port": 5432,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "gcp": {
             "project_id": "<PROJECT_ID>",
             "instance_id": "<INSTANCE_ID>"

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -137,6 +137,9 @@ RETURNS NULL ON NULL INPUT
 SECURITY DEFINER;
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Verify
 
 To verify the permissions are correct, run the following commands to confirm the Agent user is able to connect to the database and read the core tables:
@@ -205,7 +208,7 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
        host: '<AWS_INSTANCE_ENDPOINT>'
        port: 5432
        username: datadog
-       password: '<PASSWORD>'
+       password: 'ENC[datadog_user_database_password]'
        aws:
          instance_endpoint: '<AWS_INSTANCE_ENDPOINT>'
          region: '<REGION>'
@@ -270,7 +273,7 @@ FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AWS_INSTANCE_ENDPOINT>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>"}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AWS_INSTANCE_ENDPOINT>", "port": 5432,"username": "datadog","password": "ENC[datadog_user_database_password]"}]'
 ```
 
 <div class="alert alert-warning"><strong>Important</strong>: Use the Aurora instance endpoint as the host, not the cluster endpoint.</div>
@@ -282,12 +285,8 @@ pg_stat_statements_view: datadog.pg_stat_statements()
 pg_stat_activity_view: datadog.pg_stat_activity()
 ```
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][2] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][3] to learn how to pass the password as an environment variable.
-
 
 [1]: /agent/docker/integrations/?tab=docker
-[2]: /agent/configuration/secrets-management
-[3]: /agent/faq/template_variables/
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -312,7 +311,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
               host: '<AWS_INSTANCE_ENDPOINT>'
               port: 5432
               username: datadog
-              password: '<PASSWORD>'
+              password: 'ENC[datadog_user_database_password]'
               ## Required: For Postgres 9.6, uncomment these lines to use the functions created in the setup
               # pg_stat_statements_view: datadog.pg_stat_statements()
               # pg_stat_activity_view: datadog.pg_stat_activity()
@@ -363,7 +362,7 @@ metadata:
           "host": "<AWS_INSTANCE_ENDPOINT>",
           "port": 5432,
           "username": "datadog",
-          "password": "<UNIQUE_PASSWORD>"
+          "password": "ENC[datadog_user_database_password]"
         }
       ]
 spec:
@@ -390,14 +389,14 @@ metadata:
             { 
               "dbm":true, 
               "host":"your-host-1.us-east-2.rds.amazonaws.com", 
-              "password":"<UNIQUE_PASSWORD>", 
+              "password":"ENC[datadog_user_database_password]", 
               "port":5432, 
               "username":"<USERNAME>" 
             }, 
             { 
               "dbm":true, 
               "host":"your-host-2.us-east-2.rds.amazonaws.com", 
-              "password":"<UNIQUE_PASSWORD>", 
+              "password":"ENC[datadog_user_database_password]", 
               "port":5432, 
               "username": "<USERNAME>" 
             } 

--- a/content/en/database_monitoring/setup_postgres/azure.md
+++ b/content/en/database_monitoring/setup_postgres/azure.md
@@ -185,6 +185,9 @@ RETURNS NULL ON NULL INPUT
 SECURITY DEFINER;
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Verify
 
 To verify the permissions are correct, run the following commands to confirm the Agent user is able to connect to the database and read the core tables:
@@ -245,7 +248,7 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
        host: '<AZURE_INSTANCE_ENDPOINT>'
        port: 5432
        username: 'datadog@<AZURE_INSTANCE_ENDPOINT>'
-       password: '<PASSWORD>'
+       password: 'ENC[datadog_user_database_password]'
        ssl: 'require'
        ## Required for Postgres 9.6: Uncomment these lines to use the functions created in the setup
        # pg_stat_statements_view: datadog.pg_stat_statements()
@@ -315,7 +318,7 @@ FROM datadog/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AZURE_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog@<AZURE_INSTANCE_ENDPOINT>","password": "<UNIQUEPASSWORD>", "ssl": "require", "azure": {"deployment_type": "<DEPLOYMENT_TYPE>", "name": "<AZURE_INSTANCE_ENDPOINT>"}}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AZURE_INSTANCE_ENDPOINT>", "port": 3306,"username": "datadog@<AZURE_INSTANCE_ENDPOINT>","password": "ENC[datadog_user_database_password]", "ssl": "require", "azure": {"deployment_type": "<DEPLOYMENT_TYPE>", "name": "<AZURE_INSTANCE_ENDPOINT>"}}]'
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -327,13 +330,8 @@ pg_stat_activity_view: datadog.pg_stat_activity()
 
 See the [Postgres integration spec][2] for additional information on setting `deployment_type` and `name` fields.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][4] on how to pass the password in as an environment variable.
-
-
 [1]: /agent/docker/integrations/?tab=docker
-[2]: https://github.com/DataDog/integrations-core/blob/master/postgres/assets/configuration/spec.yaml#L446-L474
-[3]: /agent/configuration/secrets-management
-[4]: /agent/faq/template_variables/
+[2]: https://github.com/DataDog/integrations-core/blob/master/postgres/assets/configuration/spec.yaml#L446-L47
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -358,7 +356,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
               host: <AZURE_INSTANCE_ENDPOINT>
               port: 5432
               username: 'datadog@<AZURE_INSTANCE_ENDPOINT>'
-              password: '<UNIQUE_PASSWORD>'
+              password: 'ENC[datadog_user_database_password]'
               ssl: 'require'
               azure:
                 deployment_type: '<DEPLOYMENT_TYPE>'
@@ -400,7 +398,7 @@ instances:
     host: '<AZURE_INSTANCE_ENDPOINT>'
     port: 5432
     username: 'datadog@<AZURE_INSTANCE_ENDPOINT>'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     ssl: "require"
     # After adding your project and instance, configure the Datadog Azure integration to pull additional cloud data such as CPU, Memory, etc.
     azure:
@@ -435,7 +433,7 @@ metadata:
           "host": "<AZURE_INSTANCE_ENDPOINT>",
           "port": 5432,
           "username": "datadog@<AZURE_INSTANCE_ENDPOINT>",
-          "password": "<UNIQUEPASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "ssl": "require",
           "azure": {
             "deployment_type": "<DEPLOYMENT_TYPE>",

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -102,6 +102,9 @@ RETURNS NULL ON NULL INPUT
 SECURITY DEFINER;
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Verify
 
 To verify the permissions are correct, run the following commands to confirm the Agent user is able to connect to the database and read the core tables:
@@ -140,7 +143,7 @@ To configure Database Monitoring metrics collection for an Agent running on a ho
        host: '<INSTANCE_ADDRESS>'
        port: 5432
        username: datadog
-       password: '<PASSWORD>'
+       password: 'ENC[datadog_user_database_password]'
        ## Optional: Connect to a different database if needed for `custom_queries`
        # dbname: '<DB_NAME>'
 
@@ -199,18 +202,13 @@ FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>", "gcp": {"project_id": "<PROJECT_ID>", "instance_id": "<INSTANCE_ID>"}}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<INSTANCE_ADDRESS>", "port": 5432,"username": "datadog","password": "ENC[datadog_user_database_password]", "gcp": {"project_id": "<PROJECT_ID>", "instance_id": "<INSTANCE_ID>"}}]'
 ```
 
 See the [Postgres integration spec][2] for additional information on setting `project_id` and `instance_id` fields.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][3] and declare the password using the `ENC[]` syntax, or see the [Autodiscovery template variables documentation][4] on how to pass in the password as an environment variable.
-
-
 [1]: /agent/docker/integrations/?tab=docker
 [2]: https://github.com/DataDog/integrations-core/blob/master/postgres/assets/configuration/spec.yaml#L417-L444
-[3]: /agent/configuration/secrets-management
-[4]: /agent/faq/template_variables/
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
@@ -235,7 +233,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
             host: <INSTANCE_ADDRESS>
             port: 5432
             username: datadog
-            password: '<UNIQUE_PASSWORD>'
+            password: 'ENC[datadog_user_database_password]'
             gcp:
               project_id: '<PROJECT_ID>'
               instance_id: '<INSTANCE_ID>'
@@ -276,7 +274,7 @@ instances:
     host: '<INSTANCE_ADDRESS>'
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     # After adding your project and instance, configure the Datadog GCP integration to pull additional cloud data such as CPU, Memory, etc.
     gcp:
       project_id: '<PROJECT_ID>'
@@ -305,7 +303,7 @@ metadata:
           "host": "<INSTANCE_ADDRESS>",
           "port": 5432,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "gcp": {
             "project_id": "<PROJECT_ID>",
             "instance_id": "<INSTANCE_ID>"
@@ -324,13 +322,11 @@ See the [Postgres integration spec][4] for additional information on setting `pr
 
 The Cluster Agent automatically registers this configuration and begin running the Postgres check.
 
-To avoid exposing the `datadog` user's password in plain text, use the Agent's [secret management package][5] and declare the password using the `ENC[]` syntax.
 
 [1]: /agent/cluster_agent
 [2]: /agent/cluster_agent/clusterchecks/
 [3]: https://helm.sh
 [4]: https://github.com/DataDog/integrations-core/blob/master/postgres/assets/configuration/spec.yaml#L417-L444
-[5]: /agent/configuration/secrets-management
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/database_monitoring/setup_postgres/rds.md
+++ b/content/en/database_monitoring/setup_postgres/rds.md
@@ -161,6 +161,9 @@ RETURNS NULL ON NULL INPUT
 SECURITY DEFINER;
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Verify
 
 To verify the permissions are correct, run the following commands to confirm the Agent user is able to connect to the database and read the core tables:
@@ -221,7 +224,7 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
        host: '<AWS_INSTANCE_ENDPOINT>'
        port: 5432
        username: datadog
-       password: '<PASSWORD>'
+       password: 'ENC[datadog_user_database_password]'
        tags:
          - "dbinstanceidentifier:<DB_INSTANCE_NAME>"
        ## Required for Postgres 9.6: Uncomment these lines to use the functions created in the setup
@@ -317,7 +320,7 @@ FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'
-LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AWS_INSTANCE_ENDPOINT>", "port": 5432,"username": "datadog","password": "<UNIQUEPASSWORD>","tags": ["dbinstanceidentifier:<DB_INSTANCE_NAME>"]}]'
+LABEL "com.datadoghq.ad.instances"='[{"dbm": true, "host": "<AWS_INSTANCE_ENDPOINT>", "port": 5432,"username": "datadog","password": "ENC[datadog_user_database_password]","tags": ["dbinstanceidentifier:<DB_INSTANCE_NAME>"]}]'
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -357,7 +360,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
             host: <INSTANCE_ADDRESS>
             port: 5432
             username: datadog
-            password: '<UNIQUE_PASSWORD>'
+            password: 'ENC[datadog_user_database_password]'
             tags:
               - 'dbinstanceidentifier:<DB_INSTANCE_NAME>'
 
@@ -397,7 +400,7 @@ instances:
     host: '<AWS_INSTANCE_ENDPOINT>'
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     tags:
       - dbinstanceidentifier:<DB_INSTANCE_NAME>
     ## Required: For Postgres 9.6, uncomment these lines to use the functions created in the setup
@@ -428,7 +431,7 @@ metadata:
           "host": "<AWS_INSTANCE_ENDPOINT>",
           "port": 5432,
           "username": "datadog",
-          "password": "<UNIQUEPASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "tags": [
             "dbinstanceidentifier:<DB_INSTANCE_NAME>"
           ]

--- a/content/en/database_monitoring/setup_postgres/selfhosted.md
+++ b/content/en/database_monitoring/setup_postgres/selfhosted.md
@@ -158,6 +158,9 @@ RETURNS NULL ON NULL INPUT
 SECURITY DEFINER;
 ```
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Verify
 
 To verify the permissions are correct, run the following commands to confirm the Agent user is able to connect to the database and read the core tables:
@@ -218,7 +221,7 @@ Installing the Datadog Agent also installs the Postgres check which is required 
        host: localhost
        port: 5432
        username: datadog
-       password: '<PASSWORD>'
+       password: 'ENC[datadog_user_database_password]'
        ## Optional: Connect to a different database if needed for `custom_queries`
        # dbname: '<DB_NAME>'
    ```
@@ -233,7 +236,7 @@ Installing the Datadog Agent also installs the Postgres check which is required 
        host: localhost
        port: 5432
        username: datadog
-       password: '<PASSWORD>'
+       password: 'ENC[datadog_user_database_password]'
        pg_stat_statements_view: datadog.pg_stat_statements()
        pg_stat_activity_view: datadog.pg_stat_activity()
        ## Optional: Connect to a different database if needed for `custom_queries`

--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -121,6 +121,9 @@ For [SQL Server on Windows Azure VM][1] follow the [Setting Up Database Monitori
 
 {{< /tabs >}}
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ## Install and configure the Agent
 
 Because Azure does not grant direct host access, the Datadog Agent must be installed on a separate host where it is able to talk to the SQL Server host. There are several options for installing and running the Agent.
@@ -138,7 +141,7 @@ instances:
   - dbm: true
     host: '<HOSTNAME>,<SQL_PORT>'
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     tags:  # Optional
@@ -211,7 +214,7 @@ instances:
   - dbm: true
     host: '<HOSTNAME>,<SQL_PORT>'
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: odbc
     driver: '<Driver from the `odbcinst.ini` file>'
     tags:  # Optional
@@ -314,7 +317,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
           - dbm: true
             host: <HOSTNAME>,1433
             username: datadog
-            password: '<PASSWORD>'
+            password: 'ENC[datadog_user_database_password]'
             connector: 'odbc'
             driver: 'ODBC Driver 18 for SQL Server'
             include_ao_metrics: true  # Optional: For AlwaysOn users
@@ -353,7 +356,7 @@ instances:
   - dbm: true
     host: '<HOSTNAME>,<SQL_PORT>'
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: "odbc"
     driver: "ODBC Driver 18 for SQL Server"
     tags:  # Optional
@@ -384,7 +387,7 @@ metadata:
           "dbm": true,
           "host": "<HOSTNAME>,<SQL_PORT>",
           "username": "datadog",
-          "password": "<PASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "connector": "odbc",
           "driver": "ODBC Driver 18 for SQL Server",
           "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional

--- a/content/en/database_monitoring/setup_sql_server/gcsql.md
+++ b/content/en/database_monitoring/setup_sql_server/gcsql.md
@@ -80,6 +80,9 @@ To use [Windows Authentication][4], set `connection_string: "Trusted_Connection=
 
 Use the `service` and `env` tags to link your database telemetry to other telemetry through a common tagging scheme. See [Unified Service Tagging][5] on how these tags are used throughout Datadog.
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ### Supported Drivers
 
 #### Microsoft ADO
@@ -135,7 +138,7 @@ instances:
   - dbm: true
     host: '<HOSTNAME>,<SQL_PORT>'
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: odbc
     driver: '<Driver from the `odbcinst.ini` file>'
     tags:  # Optional
@@ -239,7 +242,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
             host: <HOSTNAME>
             port: 1433
             username: datadog
-            password: '<PASSWORD>'
+            password: 'ENC[datadog_user_database_password]'
             connector: 'odbc'
             driver: 'ODBC Driver 18 for SQL Server'
             tags:  # Optional
@@ -278,7 +281,7 @@ instances:
     host: '<HOSTNAME>'
     port: <SQL_PORT>
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: "odbc"
     driver: "ODBC Driver 18 for SQL Server"
     tags:  # Optional
@@ -310,7 +313,7 @@ metadata:
           "host": "<HOSTNAME>",
           "port": <SQL_PORT>,
           "username": "datadog",
-          "password": "<PASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "connector": "odbc",
           "driver": "ODBC Driver 18 for SQL Server",
           "tags": ["service:<CUSTOM_SERVICE>", "env:<CUSTOM_ENV>"],  # Optional

--- a/content/en/database_monitoring/setup_sql_server/rds.md
+++ b/content/en/database_monitoring/setup_sql_server/rds.md
@@ -63,6 +63,9 @@ CREATE USER datadog FOR LOGIN datadog;
 
 This is required because RDS does not permit granting `CONNECT ANY DATABASE`. The Datadog Agent needs to connect to each database to collect database-specific file I/O statistics.
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ## Install the Agent
 
 Because AWS does not grant direct host access, the Datadog Agent must be installed on a separate host where it is able to talk to the SQL Server host. There are several options for installing and running the Agent.

--- a/content/en/database_monitoring/setup_sql_server/selfhosted.md
+++ b/content/en/database_monitoring/setup_sql_server/selfhosted.md
@@ -73,6 +73,9 @@ CREATE USER datadog FOR LOGIN datadog;
 {{% /tab %}}
 {{< /tabs >}}
 
+### Securely store your password
+{{% dbm-secret %}}
+
 ## Install the Agent
 
 It's recommended to install the agent directly on the SQL Server host as that enables the agent to collect a variety of system telemetry (CPU, memory, disk, network) in addition to SQL Server specific telemetry.

--- a/layouts/shortcodes/dbm-mongodb-agent-config-replica-set.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-config-replica-set.md
@@ -21,7 +21,7 @@ instances:
     ## @param password - string - optional
     ## The password to use for authentication.
     #
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
 
     ## @param options - mapping - optional
     ## Connection options. For a complete list, see:
@@ -115,7 +115,7 @@ instances:
   - hosts:
       - <HOST_REPLICA_1>:<PORT>  # Primary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -129,7 +129,7 @@ instances:
   - hosts:
       - <HOST_REPLICA_2>:<PORT>  # Secondary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -143,7 +143,7 @@ instances:
   - hosts:
       - <HOST_REPLICA_3>:<PORT>  # Secondary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true

--- a/layouts/shortcodes/dbm-mongodb-agent-config-sharded-cluster.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-config-sharded-cluster.md
@@ -24,7 +24,7 @@ instances:
     ## @param password - string - optional
     ## The password to use for authentication.
     #
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
 
     ## @param options - mapping - optional
     ## Connection options. For a complete list, see:
@@ -105,7 +105,7 @@ instances:
   - hosts:
       - <HOST_MONGOS>:<PORT>
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -119,7 +119,7 @@ instances:
   - hosts:
       - <HOST_SHARD1_1>:<PORT>  # Primary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -133,7 +133,7 @@ instances:
   - hosts:
       - <HOST_SHARD1_2>:<PORT>  # Secondary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -147,7 +147,7 @@ instances:
   - hosts:
       - <HOST_SHARD1_3>:<PORT>  # Secondary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -162,7 +162,7 @@ instances:
   - hosts:
       - <HOST_SHARD2_1>:<PORT>  # Primary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -176,7 +176,7 @@ instances:
   - hosts:
       - <HOST_SHARD2_2>:<PORT>  # Secondary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -190,7 +190,7 @@ instances:
   - hosts:
       - <HOST_SHARD2_3>:<PORT>  # Secondary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     tls: true
@@ -205,7 +205,7 @@ instances:
   - hosts:
       - <HOST_CONFIG_1>:<PORT>  # Primary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     database: config
     options:
       authSource: admin
@@ -216,7 +216,7 @@ instances:
   - hosts:
       - <HOST_CONFIG_2>:<PORT>  # Secondary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     database: config
     options:
       authSource: admin
@@ -227,7 +227,7 @@ instances:
   - hosts:
       - <HOST_CONFIG_3>:<PORT>  # Secondary node
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     database: config
     options:
       authSource: admin

--- a/layouts/shortcodes/dbm-mongodb-agent-config-standalone.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-config-standalone.md
@@ -19,7 +19,7 @@ instances:
     ## @param password - string - optional
     ## The password to use for authentication.
     #
-    password: <UNIQUEPASSWORD>
+    password: "ENC[datadog_user_database_password]"
 
     ## @param options - mapping - optional
     ## Connection options. For a complete list, see:

--- a/layouts/shortcodes/dbm-mongodb-agent-setup-kubernetes.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-setup-kubernetes.md
@@ -42,7 +42,7 @@ instances:
   - hosts:
       - <HOST>:<PORT>
     username: datadog
-    password: <UNIQUE_PASSWORD>
+    password: "ENC[datadog_user_database_password]"
     options:
       authSource: admin
     dbm: true
@@ -70,7 +70,7 @@ metadata:
         "instances": [{
           "hosts": ["<HOST>:<PORT>"],
           "username": "datadog",
-          "password": "<UNIQUE_PASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "options": {
             "authSource": "admin"
           },

--- a/layouts/shortcodes/dbm-mysql-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-mysql-agent-config-examples.md
@@ -9,7 +9,7 @@ instances:
     host: example-service-primary.example-host.com
     port: 3306
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
@@ -18,7 +18,7 @@ instances:
     host: example-service-replica-1.example-host.com
     port: 3306
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     options:
       replication: true
     tags:
@@ -29,7 +29,7 @@ instances:
     host: example-service-replica-2.example-host.com
     port: 3306
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     options:
       replication: true
     tags:
@@ -37,18 +37,6 @@ instances:
       - 'team:team-discovery'
       - 'service:example-service'
     [...]
-```
-
-### Storing passwords securely
-While it is possible to declare passwords directly in the Agent configuration files, it is a more secure practice to encrypt and store database credentials elsewhere using secret management software such as [Vault](https://www.vaultproject.io/). The Agent is able to read these credentials using the `ENC[]` syntax. Review the [secrets management documentation](/agent/configuration/secrets-management/) for the required setup to store these credentials. The following example shows how to declare and use those credentials:
-```yaml
-init_config:
-instances:
-  - dbm: true
-    host: localhost
-    port: 3306
-    username: datadog
-    password: 'ENC[datadog_user_database_password]'
 ```
 
 ### Running custom queries
@@ -60,7 +48,7 @@ instances:
     host: localhost
     port: 3306
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     custom_queries:
     - query: SELECT age, salary, hours_worked, name FROM hr.employees;
       columns:
@@ -84,12 +72,12 @@ instances:
     host: localhost
     port: 5000
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     reported_hostname: example-service-primary
   - dbm: true
     host: localhost
     port: 5001
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     reported_hostname: example-service-replica-1
 ```

--- a/layouts/shortcodes/dbm-oracle-selfhosted-config.md
+++ b/layouts/shortcodes/dbm-oracle-selfhosted-config.md
@@ -4,7 +4,7 @@ instances:
   - server: '<HOSTNAME_1>:<PORT>'
     service_name: "<SERVICE_NAME>" # The Oracle DB service name
     username: 'datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbm: true
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'
@@ -12,7 +12,7 @@ instances:
   - server: '<HOSTNAME_2>:<PORT>'
     service_name: "<SERVICE_NAME>" # The Oracle DB service name
     username: 'datadog'
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbm: true
     tags:  # Optional
       - 'service:<CUSTOM_SERVICE>'

--- a/layouts/shortcodes/dbm-postgres-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-postgres-agent-config-examples.md
@@ -8,7 +8,7 @@ instances:
     host: example-service-primary.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
@@ -17,7 +17,7 @@ instances:
     host: example-service–replica-1.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
@@ -26,7 +26,7 @@ instances:
     host: example-service–replica-2.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
@@ -43,7 +43,7 @@ instances:
     host: example-service-primary.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     database_autodiscovery:
       enabled: true
       # Optionally, set the include field to specify
@@ -57,19 +57,6 @@ instances:
       - 'service:example-service'
 ```
 
-### Storing passwords securely
-While it is possible to declare passwords directly in the Agent configuration files, it is a more secure practice to encrypt and store database credentials elsewhere using secret management software such as [Vault](https://www.vaultproject.io/). The Agent is able to read these credentials using the `ENC[]` syntax. Review the [secrets management documentation](/agent/configuration/secrets-management/) for the required setup to store these credentials. The following example shows how to declare and use those credentials:
-```yaml
-init_config:
-instances:
-  - dbm: true
-    host: localhost
-    port: 5432
-    username: datadog
-    password: 'ENC[datadog_user_database_password]'
-```
-
-
 ### Running custom queries
 To collect custom metrics, use the `custom_queries` option. See the sample [postgres.d/conf.yaml](https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example) for more details.
 ```yaml
@@ -79,7 +66,7 @@ instances:
     host: localhost
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     custom_queries:
     - metric_prefix: employee
       query: SELECT age, salary, hours_worked, name FROM hr.employees;
@@ -109,7 +96,7 @@ instances:
     host: example-service-primary.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     database_autodiscovery:
       enabled: true
       exclude:
@@ -122,7 +109,7 @@ instances:
   - host: example-service-primary.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbname: users
     dbstrict: true
     relations:
@@ -135,7 +122,7 @@ instances:
   - host: example-service-primary.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbname: inventory
     dbstrict: true
     relations:
@@ -157,7 +144,7 @@ instances:
     host: example-service-primary.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     dbname: users
     dbstrict: true
     collect_schemas:
@@ -171,7 +158,7 @@ instances:
     host: example-service–replica-1.example-host.com
     port: 5432
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     database_autodiscovery:
       enabled: true
     collect_schemas:
@@ -191,12 +178,12 @@ instances:
     host: localhost
     port: 5000
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     reported_hostname: example-service-primary
   - dbm: true
     host: localhost
     port: 5001
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     reported_hostname: example-service-replica-1
 ```

--- a/layouts/shortcodes/dbm-secret.md
+++ b/layouts/shortcodes/dbm-secret.md
@@ -1,3 +1,3 @@
-Store your password using secret management software such as [Vault](https://www.vaultproject.io/). You can then reference this password as `ENC[<SECRET_NAME>]`: for example, `ENC[datadog_user_database_password]`. See [Secrets Management](/agent/configuration/secrets-management/) for more information.
+Store your password using secret management software such as [Vault](https://www.vaultproject.io/). You can then reference this password as `ENC[<SECRET_NAME>]` in your Agent configuration files: for example, `ENC[datadog_user_database_password]`. See [Secrets Management](/agent/configuration/secrets-management/) for more information.
 
 The examples on this page use `datadog_user_database_password` to refer to the name of the secret where your password is stored. It is possible to reference your password in plain text, but this is not recommended.

--- a/layouts/shortcodes/dbm-secret.md
+++ b/layouts/shortcodes/dbm-secret.md
@@ -1,0 +1,3 @@
+Store your password using secret management software such as [Vault](https://www.vaultproject.io/). You can then reference this password as `ENC[<SECRET_NAME>]`: for example, `ENC[datadog_user_database_password]`. See [Secrets Management](/agent/configuration/secrets-management/) for more information.
+
+The examples on this page use `datadog_user_database_password` to refer to the name of the secret where your password is stored. It is possible to reference your password in plain text, but this is not recommended.

--- a/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-config-examples.md
@@ -29,7 +29,7 @@
       - dbm: true
         host: 'localhost,1433'
         username: datadog
-        password: '<PASSWORD>'
+        password: 'ENC[datadog_user_database_password]'
         connector: 'odbc'
         driver: '{ODBC Driver 18 for SQL Server}' # This is the section header of odbcinst.ini
         dsn: 'datadog' # This is the section header of odbc.ini
@@ -45,7 +45,7 @@ instances:
   - dbm: true
     host: 'shopist-prod,1433'
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     include_ao_metrics: true  # If Availability Groups is enabled
@@ -63,7 +63,7 @@ instances:
     username: datadog
     connector: adodbapi
     adoprovider: MSOLEDBSQL
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
@@ -73,7 +73,7 @@ instances:
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
@@ -83,25 +83,12 @@ instances:
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     tags:
       - 'env:prod'
       - 'team:team-discovery'
       - 'service:example-service'
     [...]
-```
-
-### Storing passwords securely
-While it is possible to declare passwords directly in the Agent configuration files, it is a more secure practice to encrypt and store database credentials elsewhere using secret management software such as [Vault](https://www.vaultproject.io/). The Agent is able to read these credentials using the `ENC[]` syntax. Review the [secrets management documentation](/agent/configuration/secrets-management/) for the required setup to store these credentials. The following example shows how to declare and use those credentials:
-```yaml
-init_config:
-instances:
-  - dbm: true
-    host: 'localhost,1433'
-    connector: adodbapi
-    adoprovider: MSOLEDBSQL
-    username: datadog
-    password: 'ENC[datadog_user_database_password]'
 ```
 
 ### Running custom queries
@@ -114,7 +101,7 @@ instances:
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     custom_queries:
     - query: SELECT age, salary, hours_worked, name FROM hr.employees;
       columns:
@@ -139,14 +126,14 @@ instances:
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     reported_hostname: products-primary
   - dbm: true
     host: 'localhost,1433'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     reported_hostname: products-replica-1
 ```
 

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-kubernetes.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-kubernetes.md
@@ -20,7 +20,7 @@ instances:
   - dbm: true
     host: <HOSTNAME>\,1433
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: 'odbc'
     driver: 'FreeTDS'
     include_ao_metrics: true  # Optional: For AlwaysOn users
@@ -42,7 +42,7 @@ instances:
     host: '<HOSTNAME>'
     port: <SQL_PORT>
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: 'odbc'
     driver: 'FreeTDS'
     include_ao_metrics: true  # Optional: For AlwaysOn users
@@ -71,7 +71,7 @@ metadata:
           "host": "<HOSTNAME>",
           "port": "<SQL_PORT>",
           "username": "datadog",
-          "password": "<PASSWORD>",
+          "password": "ENC[datadog_user_database_password]",
           "connector": "odbc",
           "driver": "FreeTDS",
           "include_ao_metrics": true,  # Optional: For AlwaysOn users

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-linux.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-linux.md
@@ -12,7 +12,7 @@ instances:
   - dbm: true
     host: '<HOSTNAME>,<SQL_PORT>'
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: odbc
     driver: '<Driver from the `odbcinst.ini` file>'
     include_ao_metrics: true  # Optional: For AlwaysOn users

--- a/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
+++ b/layouts/shortcodes/dbm-sqlserver-agent-setup-windows.md
@@ -8,7 +8,7 @@ instances:
   - dbm: true
     host: '<HOSTNAME>,<SQL_PORT>'
     username: datadog
-    password: '<PASSWORD>'
+    password: 'ENC[datadog_user_database_password]'
     connector: adodbapi
     adoprovider: MSOLEDBSQL
     include_ao_metrics: true  # Optional: For AlwaysOn users


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Previously, the DBM docs defaulted to providing passwords in plaintext. After some feedback, it was determined that the docs should default to referencing these passwords as secrets with the `ENC[]` syntax.

This PR:
 - adds a "store your passwords in a secret management solution" setup step to all pages
 - makes config file snippets (not when stuff is passed through command line) use `ENC[]` by default
 - removes sections that had said "you can also use secrets" that make it sound optional

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->