### PR TITLE
Improve the Windows Agent docs

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -53,9 +53,9 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 #### Install with the command line
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
-```powershell
-Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
-```
+    ```powershell
+    Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
+    ```
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows
@@ -83,30 +83,29 @@ When running with a gMSA, the core and APM/trace components of the Windows Agent
 
 ### Create and configure a gMSA
 1. Create a Security Group:
-
-  1. Open **Active Directory Users and Computers (ADUC)**.
-  2. Navigate to the appropriate **Organizational Unit (OU)**.
-  3. Right-click and select **New** > **Group**.
-  4. Name the group. For example, `DatadogAgentsGroup`.
-  5. Set the correct group scope for your organization. For example, **Domain local**.
-  6. Set the type to **Security**.
+   1. Open **Active Directory Users and Computers (ADUC)**.
+   2. Navigate to the appropriate **Organizational Unit (OU)**.
+   3. Right-click and select **New** > **Group**.
+   4. Name the group. For example, `DatadogAgentsGroup`.
+   5. Set the correct group scope for your organization. For example, **Domain local**.
+   6. Set the type to **Security**.
 
 2. Create the gMSA:
 
-  1. Open PowerShell with **Administrator** privileges.
-  2. Run the following command to create the gMSA, replacing `<YOUR_DOMAIN_NAME>` with your domain name:
-    ```powershell
-    New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
-    ```
+   1. Open PowerShell with **Administrator** privileges.
+   2. Run the following command to create the gMSA, replacing `<YOUR_DOMAIN_NAME>` with your domain name:
+        ```powershell
+        New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
+        ```
 
 3. Verify that the gMSA can be used on the target machine:
 
-  1. Ensure the target machine is part of the `DatadogAgentsGroup`.
-  2. On the target machine, open PowerShell and run:
-    ```powerhsell
-    Install-ADServiceAccount -Identity DatadogGMSA
-    ```
-  There should not be any errors.
+   1. Ensure the target machine is part of the `DatadogAgentsGroup`.
+   2. On the target machine, open PowerShell and run:
+        ```powerhsell
+        Install-ADServiceAccount -Identity DatadogGMSA
+        ```
+   There should not be any errors.
 
 ### Install the Agent
 
@@ -122,7 +121,8 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 #### Install with the command line
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
-   **Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
+
+**Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
   ```powershell
   Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$'
   ```

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -86,7 +86,7 @@ The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account.
 - Open Active Directory Users and Computers (ADUC).
 - Navigate to the appropriate Organizational Unit (OU).
 - Right-click and select New > Group.
-- Name the group (e.g., `DatadogAgentsGroup`), set the group scope to **Global**, and the type to **Security**.
+- Name the group (e.g., `DatadogAgentsGroup`), set the correct group scope for your organization (e.g. **Domain local**), and the type to **Security**.
 
 **2. Create the gMSA:**
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -29,7 +29,7 @@ algolia:
 
 ## Overview
 
-This page outlines the basic features of the Datadog Agent for Windows. If you haven't installed the Agent yet, see [Install the Datadog Agent](#install-the-datadog-agent) or [follow the instructions in the app][1].
+This page outlines the basic features of the Datadog Agent for Windows. If you haven't installed the Agent yet, see the installation instructions below or [follow the instructions in the app][1].
 
 ## Install the Agent
 
@@ -111,7 +111,7 @@ When running with a gMSA, the core and APM/trace components of the Windows Agent
         ```powerhsell
         Install-ADServiceAccount -Identity DatadogGMSA
         ```
-   There should not be any errors.
+      Ensure the command ran without errors.
 
 ### Install the Agent
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -64,18 +64,23 @@ Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.m
 {{% tab "Installations in Active Directory Domains" %}}
 
 When deploying the Datadog Agent in an Active Directory environment, Datadog recommends using a Group Managed Service Account (gMSA).
-Doing so can enhance security and simplify management, especially concerning password-management.
 
-The core and APM/trace components of the Windows Agent run under the Group Managed Service account configured. The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
+**Benefits of Using gMSAs**
+Using gMSA can enhance security and simplify management. Some of the benefits include:
+- Deployment accross multiple servers: Unlike traditional MSAs or sMSAs, gMSAs can be deployed accross multiple servers.
+- Automated password management: The passwords for gMSAs account are handled at the OS level, and are rotated on a regular basis without requiring manual intervention. 
+
+When running with a gMSA account the core and APM/trace components of the Windows Agent run under the account configured.
+The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
 
 ### Prerequisites
 - Active Directory environment configured.
-- Permission to create and manage Group Managed Service Accounts.
+- Permission to create and manage gMSA.
 - See further [requirements in the Microsoft documentation][4].
 
-**Note**: Advanced set up of a Group Managed Service account is beyond the scope of this documentation, please refer to [the Microsoft documentation for setting up a Group Managed Service Account in your environment][5] for more information.
+**Note**: Advanced set up of a gMSA is beyond the scope of this documentation, please refer to [the Microsoft documentation for setting up a Group Managed Service Account in your environment][5] for more information.
 
-### Create and Configure a Group Managed Service Account
+### Create and Configure a gMSA
 **1. Create a Security Group:**
 
 - Open Active Directory Users and Computers (ADUC).
@@ -83,17 +88,17 @@ The core and APM/trace components of the Windows Agent run under the Group Manag
 - Right-click and select New > Group.
 - Name the group (e.g., `DatadogAgentsGroup`), set the group scope to **Global**, and the type to **Security**.
 
-**2. Create the Group Managed Service Account:**
+**2. Create the gMSA:**
 
 - Open PowerShell with **Administrator** privileges.
-- Run the following command to create the Group Managed Service Account:
+- Run the following command to create the gMSA:
 ```powershell
 New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
 ```
 
 Replace <YOUR_DOMAIN_NAME> with your domain name.
 
-**3. Install the Group Managed Service Account on the Target Machine:**
+**3. Install the gMSA on the Target Machine:**
 
 - Ensure the target machine is part of the `DatadogAgentsGroup`.
 - On the target machine, open PowerShell and run:
@@ -108,7 +113,7 @@ Download the [Datadog Agent installer][1] to install the latest version of the A
 #### Install via the GUI
 - Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
 - Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].
-- When prompted for the "Datadog Agent User Account", enter the username of the Group Managed Service Account (e.g., `<YOUR_DOMAIN_NAME>\DatadogGMSA$`) and **no password**.
+- When prompted for the "Datadog Agent User Account", enter the username of the gMSA (e.g., `<YOUR_DOMAIN_NAME>\DatadogGMSA$`) and **no password**.
 - When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
 #### Install with the command line:
@@ -117,7 +122,10 @@ Download the [Datadog Agent installer][1] to install the latest version of the A
 ```powershell
 Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$'
 ```
-**note:** Replace `DatadogGMSA$` with the username of your Group Managed Service Account, it **must end with a $ symbol.**
+**note:** Replace `DatadogGMSA$` with the username of your gMSA, it **must end with a $ symbol.**
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Installation Configuration Options 
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -43,17 +43,16 @@ This page outlines the basic features of the Datadog Agent for Windows. If you h
 
 The core and APM/trace components of the Windows Agent run under the `ddagentuser` account. The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
 
+#### Install with the GUI
+1. Download the [Datadog Agent installer][4] to install the latest version of the Agent.
+2. Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
+3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][5].
 
-   <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json">installer list</a>.</div>
-
-#### Install via the GUI
-- Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
-- Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].
-- When the install finishes, you are given the option to launch the Datadog Agent Manager.
+When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
 #### Install with the command line
-- Open PowerShell with **Administrator** privileges.
-- Run the following command to install the Datadog Agent:
+1. Open PowerShell with **Administrator** privileges.
+2. Run the following command to install the Datadog Agent:
 ```powershell
 Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
 ```
@@ -61,6 +60,8 @@ Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.m
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows
 [3]: /agent/faq/windows-agent-ddagent-user/
+[4]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
+[5]: https://app.datadoghq.com/organization-settings/api-keys
 
 {{% /tab %}}
 {{% tab "Installation in Active Directory Domains" %}}
@@ -80,47 +81,50 @@ When running with a gMSA, the core and APM/trace components of the Windows Agent
 
 **Note**: For a comprehensive understanding of setting up gMSAs, see [Microsoft's Group Managed Service Accounts Overview][5].
 
-### Create and Configure a gMSA
+### Create and configure a gMSA
 1. Create a Security Group:
 
-- Open Active Directory Users and Computers (ADUC).
-- Navigate to the appropriate Organizational Unit (OU).
-- Right-click and select New > Group.
-- Name the group (e.g., `DatadogAgentsGroup`), set the correct group scope for your organization (e.g. **Domain local**), and the type to **Security**.
+  1. Open **Active Directory Users and Computers (ADUC)**.
+  2. Navigate to the appropriate **Organizational Unit (OU)**.
+  3. Right-click and select **New** > **Group**.
+  4. Name the group. For example, `DatadogAgentsGroup`.
+  5. Set the correct group scope for your organization. For example, **Domain local**.
+  6. Set the type to **Security**.
 
 2. Create the gMSA:
 
   1. Open PowerShell with **Administrator** privileges.
-  1. Run the following command to create the gMSA, replacing `<YOUR_DOMAIN_NAME>` with your domain name:
-      ```powershell
-      New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
-      ```
-
+  2. Run the following command to create the gMSA, replacing `<YOUR_DOMAIN_NAME>` with your domain name:
+    ```powershell
+    New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
+    ```
 
 3. Install the gMSA on the Target Machine:
 
-- Ensure the target machine is part of the `DatadogAgentsGroup`.
-- On the target machine, open PowerShell and run:
-```powerhsell
-Install-ADServiceAccount -Identity DatadogGMSA
-```
+  1. Ensure the target machine is part of the `DatadogAgentsGroup`.
+  2. On the target machine, open PowerShell and run:
+    ```powerhsell
+    Install-ADServiceAccount -Identity DatadogGMSA
+    ```
+
 ### Install the Agent
 
    <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json">installer list</a>.</div>
 
 #### Install via the GUI
-- Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
-- Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].
-- When prompted for the "Datadog Agent User Account", enter the username of the gMSA (e.g., `<YOUR_DOMAIN_NAME>\DatadogGMSA$`) and **no password**.
+1. Download the [Datadog Agent installer][1] to install the latest version of the Agent.
+2. Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
+3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].
+4. When prompted for the "Datadog Agent User Account", enter the username of the gMSA. For example, `<YOUR_DOMAIN_NAME>\DatadogGMSA$` and **no password**.
 When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
 #### Install with the command line
 1. Open PowerShell with **Administrator** privileges.
-1. Run the following command to install the Datadog Agent:
+2. Run the following command to install the Datadog Agent:
    **Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
-```powershell
-Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$'
-```
+  ```powershell
+  Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$'
+  ```
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -31,9 +31,9 @@ algolia:
 
 This page outlines the basic features of the Datadog Agent for Windows. If you haven't installed the Agent yet, see [Install the Datadog Agent](#install-the-datadog-agent) or [follow the instructions in the app][1].
 
-## Install the Datadog Agent
+## Install the Agent
 
-**Requirements**
+### Requirements
 - **Windows version**: Windows Server 2016 or later, or Windows 10 or later. See the Agent Supported Platforms documentation for [supported OS versions][2].
 - **Datadog account**: Ensure you have access to a Datadog account and have your Datadog API key.
 - **Administrator privileges**: Administrator access is required on the Windows machine.
@@ -43,14 +43,14 @@ This page outlines the basic features of the Datadog Agent for Windows. If you h
 
 The core and APM/trace components of the Windows Agent run under the `ddagentuser` account. The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
 
-#### Install with the GUI
+### Install with the GUI
 1. Download the [Datadog Agent installer][4] to install the latest version of the Agent.
 2. Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
 3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][5].
 
 When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
-#### Install with the command line
+### Install with the command line
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
     ```powershell
@@ -136,7 +136,7 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 {{% /tab %}}
 {{< /tabs >}}
 
-##### Installation configuration options 
+#### Installation configuration options 
 
 Each of the following configuration options can be added as a property to the command line when installing the Agent on Windows. For additional Agent configuration options, see [more Agent configuration options](#more-agent-configuration-options).  
 
@@ -159,7 +159,7 @@ Each of the following configuration options can be added as a property to the co
 - Some Agent components require a kernel driver to collect data. To know if a kernel driver is required for your component, see its documentation page or search for `kernel driver` in the associated Agent configuration files.
 - If a valid `datadog.yaml` is found, that file takes precedence over all specified command line options.
 
-##### More Agent configuration options
+#### More Agent configuration options
 
 Each of the following configuration options can be added as a property to the command line when installing the Agent on Windows. 
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -34,6 +34,7 @@ This page outlines the basic features of the Datadog Agent for Windows. If you h
 ## Install the Agent
 
 ### Requirements
+
 - **Windows version**: Windows Server 2016 or later, or Windows 10 or later. See the Agent Supported Platforms documentation for [supported OS versions][2].
 - **Datadog account**: Ensure you have access to a Datadog account and have your Datadog API key.
 - **Administrator privileges**: Administrator access is required on the Windows machine.
@@ -44,6 +45,7 @@ This page outlines the basic features of the Datadog Agent for Windows. If you h
 The core and APM/trace components of the Windows Agent run under the `ddagentuser` account. The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
 
 ### Install with the GUI
+
 1. Download the [Datadog Agent installer][4] to install the latest version of the Agent.
 2. Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
 3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][5].
@@ -51,6 +53,7 @@ The core and APM/trace components of the Windows Agent run under the `ddagentuse
 When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
 ### Install with the command line
+
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
     ```powershell
@@ -75,6 +78,7 @@ Using gMSA can enhance security and simplify management. Some of the benefits in
 When running with a gMSA, the core and APM/trace components of the Windows Agent run under the configured account. The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
 
 ### Prerequisites
+
 - An Active Directory environment
 - Permission to create and manage gMSAs
 - See further [requirements in the Microsoft documentation][4].
@@ -82,6 +86,7 @@ When running with a gMSA, the core and APM/trace components of the Windows Agent
 **Note**: For a comprehensive understanding of setting up gMSAs, see [Microsoft's Group Managed Service Accounts Overview][5].
 
 ### Create and configure a gMSA
+
 1. Create a Security Group:
    1. Open **Active Directory Users and Computers (ADUC)**.
    2. Navigate to the appropriate **Organizational Unit (OU)**.
@@ -90,13 +95,14 @@ When running with a gMSA, the core and APM/trace components of the Windows Agent
    5. Set the correct group scope for your organization. For example, **Domain local**.
    6. Set the type to **Security**.
 
-2. Create the gMSA:
 
+2. Create the gMSA:
    1. Open PowerShell with **Administrator** privileges.
    2. Run the following command to create the gMSA, replacing `<YOUR_DOMAIN_NAME>` with your domain name:
         ```powershell
         New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
         ```
+
 
 3. Verify that the gMSA can be used on the target machine:
 
@@ -112,6 +118,7 @@ When running with a gMSA, the core and APM/trace components of the Windows Agent
    <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json">installer list</a>.</div>
 
 #### Install via the GUI
+
 1. Download the [Datadog Agent installer][1] to install the latest version of the Agent.
 2. Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
 3. Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].
@@ -119,6 +126,7 @@ When running with a gMSA, the core and APM/trace components of the Windows Agent
 When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
 #### Install with the command line
+
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
 
@@ -180,6 +188,7 @@ Each of the following configuration options can be added as a property to the co
 | `EC2_USE_WINDOWS_PREFIX_DETECTION`          | Boolean | Use the EC2 instance id for Windows hosts on EC2. _(v7.28.0+)_                                                                                                                                                                      |
 | [DEPRECATED] `ADDLOCAL` | String | Enable additional Agent component. Setting to `"MainApplication,NPM"` causes the driver component for [Network Performance Monitoring][5] to be installed. _(version 7.44.0 and previous)_ |
 
+**Note:**
 Agent 7 only supports Python 3. Before upgrading, confirm that your custom checks are compatible with Python 3. See the [Python 3 Custom Check Migration][13] guide for more information. If you're not using custom checks or have already confirmed their compatibility, upgrade normally.
 
 If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a more recent version of Agent 5 (>= 5.12.0 but < 6.0.0) using the [EXE installer][14] and then upgrade to Datadog Agent version >= 6.

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -27,8 +27,6 @@ algolia:
   tags: ['install', 'installing', 'uninstall', 'uninstalling', 'windows']
 ---
 
-# Setup
-
 If you haven't installed the Datadog Agent yet, see below or the [in-app installation instructions][1]. 
 
 ## Installation
@@ -53,7 +51,7 @@ Download the [Datadog Agent installer][1] to install the latest version of the A
 - Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].
 - When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
-#### Install with the command line:
+#### Install with the command line
 - Open PowerShell with **Administrator** privileges.
 - Run the following command to install the Datadog Agent:
 ```powershell
@@ -61,7 +59,7 @@ Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.m
 ```
 
 {{% /tab %}}
-{{% tab "Installations in Active Directory Domains" %}}
+{{% tab "Installation in Active Directory Domains" %}}
 
 When deploying the Datadog Agent in an Active Directory environment, Datadog recommends using a Group Managed Service Account (gMSA).
 
@@ -96,7 +94,7 @@ The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account.
 New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
 ```
 
-Replace <YOUR_DOMAIN_NAME> with your domain name.
+Replace `<YOUR_DOMAIN_NAME>` with your domain name.
 
 **3. Install the gMSA on the Target Machine:**
 
@@ -116,7 +114,7 @@ Download the [Datadog Agent installer][1] to install the latest version of the A
 - When prompted for the "Datadog Agent User Account", enter the username of the gMSA (e.g., `<YOUR_DOMAIN_NAME>\DatadogGMSA$`) and **no password**.
 - When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
-#### Install with the command line:
+#### Install with the command line
 - Open PowerShell with **Administrator** privileges.
 - Run the following command to install the Datadog Agent:
 ```powershell
@@ -127,7 +125,7 @@ Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.m
 {{% /tab %}}
 {{< /tabs >}}
 
-## Installation Configuration Options 
+##### Installation Configuration Options 
 
 Each of the following configuration options can be added as a property to the command line when installing the Agent on Windows. For additional Agent configuration options, see [more Agent configuration options](#more-agent-configuration-options).  
 
@@ -150,7 +148,7 @@ Each of the following configuration options can be added as a property to the co
 - Some Agent components require a kernel driver to collect data. To know if a kernel driver is required for your component, see its documentation page or search for `kernel driver` in the associated Agent configuration files.
 - If a valid `datadog.yaml` is found, that file takes precedence over all specified command line options.
 
-## More Agent configuration options
+##### More Agent configuration options
 
 Each of the following configuration options can be added as a property to the command line when installing the Agent on Windows. 
 
@@ -184,15 +182,15 @@ If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a mo
 [1]: /agent/guide/python-3/
 [2]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.exe
 
-## Installation log files
+#### Installation log files
 
 You can find Agent installation log files at `%TEMP%\MSI*.LOG`.
 
-## Validation
+#### Validation
 
 To verify your installation, follow the instructions in the [Agent Status and Information](#agent-status-and-information) section.
 
-# Agent commands
+## Agent commands
 
 The execution of the Agent is controlled by the Windows Service Control Manager.
 
@@ -237,7 +235,7 @@ The execution of the Agent is controlled by the Windows Service Control Manager.
     "%ProgramFiles%\Datadog\Datadog Agent\bin\agent.exe" flare
     ```
 
-# Configuration
+## Configuration
 
 Use the [Datadog Agent Manager][6] to enable, disable, and configure checks. Restart the Agent for your changes to be applied.
 
@@ -251,17 +249,17 @@ Configuration files for integrations are in:
 
 **Note**: `ProgramData` is a hidden folder.
 
-# Uninstall the Agent
+## Uninstall the Agent
 
 There are two different methods to uninstall the Agent on Windows. Both methods remove the Agent, but do not remove the `C:\ProgramData\Datadog` configuration folder on the host.
 
-## Add or remove programs
+### Add or remove programs
 
 1. Press **CTRL** and **Esc** or use the Windows key to run Windows Search.
 1. Search for `add` and click **Add or remove programs**.
 1. Search for `Datadog Agent` and click **Uninstall**.
 
-## PowerShell
+### PowerShell
 
 **Note:** Enable WinRM to use the commands below.
 
@@ -272,9 +270,9 @@ $productCode = (@(Get-ChildItem -Path "HKLM:SOFTWARE\Microsoft\Windows\CurrentVe
 start-process msiexec -Wait -ArgumentList ('/log', 'C:\uninst.log', '/q', '/x', "$productCode", 'REBOOT=ReallySuppress')
 {{< /code-block >}}
 
-# Troubleshooting
+## Troubleshooting
 
-## Agent status and information
+### Agent status and information
 
 To verify the Agent is running, check if the `DatadogAgent` service in the Services panel is listed as *Started*. A process called *Datadog Metrics Agent* (`agent.exe`) should also exist in the Task Manager.
 
@@ -300,13 +298,13 @@ or cmd.exe:
 "%ProgramFiles%\Datadog\Datadog Agent\bin\agent.exe" status
 ```
 
-## Logs location
+### Logs location
 
 The Agent logs are located in `C:\ProgramData\Datadog\logs\agent.log`.
 
 **Note**: `ProgramData` is a hidden folder.
 
-## Send a flare
+### Send a flare
 
 * Navigate to [http://127.0.0.1:5002][12] to display the Datadog Agent Manager.
 
@@ -332,9 +330,9 @@ or cmd.exe:
 
 {{< img src="agent/basic_agent_usage/windows/windows_flare_agent_6.png" alt="Windows flare with Agent 6" style="width:75%;">}}
 
-# Use cases
+## Use cases
 
-##  Monitoring a Windows service
+###  Monitoring a Windows service
 
 On your target host, launch the Datadog Agent Manager and select the "Windows Service" integration from the list. There is an out-of-the-box example; however, this example uses DHCP.
 
@@ -350,13 +348,13 @@ Also, whenever you modify an integration, the Datadog service needs to be restar
 
 For Services, Datadog doesn't track the metrics—only their availability. (For metrics, use the [Process](#monitoring-windows-processes) or [WMI][7] integration). To set up a Monitor, select the [Integration monitor type][8] then search for **Windows Service**. From *Integration Status -> Pick Monitor Scope*, choose the service you would like to monitor.
 
-## Monitoring system load for Windows
+### Monitoring system load for Windows
 
 The Datadog Agent collects a large number of system metrics by default. The most commonly used system metrics are `system.load.*` but these metrics are **Unix** specific.
 
 While Windows does not offer the `system.load.*` metrics, an equivalent option that's available by default is `system.proc.queue.length`. This metric shows the number of threads observed as delayed in the processor ready queue that are waiting to be executed.
 
-## Monitoring Windows processes
+### Monitoring Windows processes
 
 You can monitor Windows processes with [Live Process Monitoring][9]. To enable this on Windows, edit the [Agent main configuration file][10] by setting the following parameter to true:
 
@@ -369,7 +367,7 @@ process_config:
 
 After configuration is complete, [restart the Agent][11].
 
-# Further reading
+## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -31,7 +31,7 @@ If you haven't installed the Datadog Agent yet, see below or the [in-app install
 
 ## Installation
 
-### Requirements
+**Requirements**
 - **Windows version**: Windows Server 2016 or later, or Windows 10 or later. See the Agent Supported Platforms documentation for [supported OS versions][2].
 - **Datadog account**: Ensure you have access to a Datadog account and have your Datadog API key.
 - **Administrator privileges**: Administrator access is required on the Windows machine.
@@ -57,6 +57,10 @@ Download the [Datadog Agent installer][1] to install the latest version of the A
 ```powershell
 Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
 ```
+
+[1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
+[2]: /agent/supported_platforms/?tab=windows
+[3]: /agent/faq/windows-agent-ddagent-user/
 
 {{% /tab %}}
 {{% tab "Installation in Active Directory Domains" %}}
@@ -122,6 +126,12 @@ Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.m
 ```
 **note:** Replace `DatadogGMSA$` with the username of your gMSA, it **must end with a $ symbol.**
 
+[1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
+[2]: /agent/supported_platforms/?tab=windows
+[3]: /agent/faq/windows-agent-ddagent-user/
+[4]: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/group-managed-service-accounts/group-managed-service-accounts/group-managed-service-accounts-overview#software-requirements
+[5]: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/group-managed-service-accounts/group-managed-service-accounts/getting-started-with-group-managed-service-accounts
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -162,25 +172,16 @@ Each of the following configuration options can be added as a property to the co
 | `PROCESS_ENABLED`                           | String  | Enable (`"true"`) or disable (`"false"`) the Process Agent in the configuration file. The Process Agent is disabled by default.                                                                                                     |
 | `HOSTNAME_FQDN_ENABLED`                     | String  | Enable (`"true"`) or disable (`"false"`) the usage of FQDN for the Agent hostname. It is equivalent to set `hostname_fqdn` in the Agent configuration file. The usage of FQDN for the hostname is disabled by default. _(v6.20.0+)_ |
 | `CMD_PORT`                                  | Number  | A valid port number between 0 and 65534. The Datadog Agent exposes a command API on port 5001. If that port is already in use by another program, the default may be overridden here.                                               |
-| `PROXY_HOST`                                | String  | If using a proxy, sets your proxy host. [Learn more about using a proxy with the Datadog Agent][2].                                                                                                                                 |
-| `PROXY_PORT`                                | Number  | If using a proxy, sets your proxy port. [Learn more about using a proxy with the Datadog Agent][2].                                                                                                                                 |
-| `PROXY_USER`                                | String  | If using a proxy, sets your proxy user. [Learn more about using a proxy with the Datadog Agent][2].                                                                                                                                 |
-| `PROXY_PASSWORD`                            | String  | If using a proxy, sets your proxy password. For the process/container Agent, this variable is required for passing in an authentication password and cannot be renamed. [Learn more about using a proxy with the Datadog Agent][2]. |
+| `PROXY_HOST`                                | String  | If using a proxy, sets your proxy host. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
+| `PROXY_PORT`                                | Number  | If using a proxy, sets your proxy port. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
+| `PROXY_USER`                                | String  | If using a proxy, sets your proxy user. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
+| `PROXY_PASSWORD`                            | String  | If using a proxy, sets your proxy password. For the process/container Agent, this variable is required for passing in an authentication password and cannot be renamed. [Learn more about using a proxy with the Datadog Agent][4]. |
 | `EC2_USE_WINDOWS_PREFIX_DETECTION`          | Boolean | Use the EC2 instance id for Windows hosts on EC2. _(v7.28.0+)_                                                                                                                                                                      |
-| [DEPRECATED] `ADDLOCAL` | String | Enable additional agent component. Setting to `"MainApplication,NPM"` causes the driver component for [Network Performance Monitoring][4] to be installed. _(version 7.44.0 and previous)_ |
+| [DEPRECATED] `ADDLOCAL` | String | Enable additional agent component. Setting to `"MainApplication,NPM"` causes the driver component for [Network Performance Monitoring][5] to be installed. _(version 7.44.0 and previous)_ |
 
+Agent 7 only supports Python 3. Before upgrading, confirm that your custom checks are compatible with Python 3. See the [Python 3 Custom Check Migration][13] guide for more information. If you're not using custom checks or have already confirmed their compatibility, upgrade normally.
 
-[1]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
-[2]: /agent/configuration/proxy/
-[3]: /agent/faq/windows-agent-ddagent-user/
-[4]: /network_monitoring/performance
-
-Agent 7 only supports Python 3. Before upgrading, confirm that your custom checks are compatible with Python 3. See the [Python 3 Custom Check Migration][1] guide for more information. If you're not using custom checks or have already confirmed their compatibility, upgrade using the [GUI](?tab=gui) or [Command line](?tab=commandline) instructions.
-
-If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a more recent version of Agent 5 (>= 5.12.0 but < 6.0.0) using the [EXE installer][2] and then upgrade to Datadog Agent version >= 6.
-
-[1]: /agent/guide/python-3/
-[2]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.exe
+If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a more recent version of Agent 5 (>= 5.12.0 but < 6.0.0) using the [EXE installer][14] and then upgrade to Datadog Agent version >= 6.
 
 #### Installation log files
 
@@ -375,8 +376,8 @@ After configuration is complete, [restart the Agent][11].
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows
 [3]: /agent/faq/windows-agent-ddagent-user/
-[4]: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/group-managed-service-accounts/group-managed-service-accounts/group-managed-service-accounts-overview#software-requirements
-[5]: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/group-managed-service-accounts/group-managed-service-accounts/getting-started-with-group-managed-service-accounts
+[4]: /agent/configuration/proxy/
+[5]: /network_monitoring/performance
 [6]: /agent/guide/datadog-agent-manager-windows/
 [7]: /integrations/wmi_check/
 [8]: https://app.datadoghq.com/monitors#create/integration
@@ -384,3 +385,5 @@ After configuration is complete, [restart the Agent][11].
 [10]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 [11]: /agent/configuration/agent-commands/#restart-the-agent
 [12]: http://127.0.0.1:5002
+[13]: /agent/guide/python-3/
+[14]: https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-latest.exe

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -99,13 +99,14 @@ When running with a gMSA, the core and APM/trace components of the Windows Agent
     New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
     ```
 
-3. Install the gMSA on the Target Machine:
+3. Verify that the gMSA can be used on the target machine:
 
   1. Ensure the target machine is part of the `DatadogAgentsGroup`.
   2. On the target machine, open PowerShell and run:
     ```powerhsell
     Install-ADServiceAccount -Identity DatadogGMSA
     ```
+  There should not be any errors.
 
 ### Install the Agent
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -27,9 +27,11 @@ algolia:
   tags: ['install', 'installing', 'uninstall', 'uninstalling', 'windows']
 ---
 
-If you haven't installed the Datadog Agent yet, see below or the [in-app installation instructions][1]. 
+## Overview
 
-## Installation
+This page outlines the basic features of the Datadog Agent for Windows. If you haven't installed the Agent yet, see [Install the Datadog Agent](#install-the-datadog-agent) or [follow the instructions in the app][1].
+
+## Install the Datadog Agent
 
 **Requirements**
 - **Windows version**: Windows Server 2016 or later, or Windows 10 or later. See the Agent Supported Platforms documentation for [supported OS versions][2].
@@ -41,8 +43,6 @@ If you haven't installed the Datadog Agent yet, see below or the [in-app install
 
 The core and APM/trace components of the Windows Agent run under the `ddagentuser` account. The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
 
-### Install the Datadog Agent
-Download the [Datadog Agent installer][1] to install the latest version of the Agent.
 
    <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json">installer list</a>.</div>
 
@@ -67,48 +67,44 @@ Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.m
 
 When deploying the Datadog Agent in an Active Directory environment, Datadog recommends using a Group Managed Service Account (gMSA).
 
-**Benefits of Using gMSAs**
 Using gMSA can enhance security and simplify management. Some of the benefits include:
-- Deployment accross multiple servers: Unlike traditional MSAs or sMSAs, gMSAs can be deployed accross multiple servers.
-- Automated password management: The passwords for gMSAs account are handled at the OS level, and are rotated on a regular basis without requiring manual intervention. 
+- Deployment across multiple servers: Unlike traditional Managed Service Accounts (MSAs) or standalone Managed Service Accounts (sMSAs), gMSAs can be deployed across multiple servers.
+- Automated password management: The passwords for gMSAs are handled at the operating system level, and are rotated on a regular basis without requiring manual intervention. 
 
-When running with a gMSA account the core and APM/trace components of the Windows Agent run under the account configured.
-The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
+When running with a gMSA, the core and APM/trace components of the Windows Agent run under the configured account. The Live Processes component, if enabled, runs under the `LOCAL_SYSTEM` account. Learn more about the [Datadog Windows Agent User][3].
 
 ### Prerequisites
-- Active Directory environment configured.
-- Permission to create and manage gMSA.
+- An Active Directory environment
+- Permission to create and manage gMSAs
 - See further [requirements in the Microsoft documentation][4].
 
-**Note**: Advanced set up of a gMSA is beyond the scope of this documentation, please refer to [the Microsoft documentation for setting up a Group Managed Service Account in your environment][5] for more information.
+**Note**: For a comprehensive understanding of setting up gMSAs, see [Microsoft's Group Managed Service Accounts Overview][5].
 
 ### Create and Configure a gMSA
-**1. Create a Security Group:**
+1. Create a Security Group:
 
 - Open Active Directory Users and Computers (ADUC).
 - Navigate to the appropriate Organizational Unit (OU).
 - Right-click and select New > Group.
 - Name the group (e.g., `DatadogAgentsGroup`), set the correct group scope for your organization (e.g. **Domain local**), and the type to **Security**.
 
-**2. Create the gMSA:**
+2. Create the gMSA:
 
-- Open PowerShell with **Administrator** privileges.
-- Run the following command to create the gMSA:
-```powershell
-New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
-```
+  1. Open PowerShell with **Administrator** privileges.
+  1. Run the following command to create the gMSA, replacing `<YOUR_DOMAIN_NAME>` with your domain name:
+      ```powershell
+      New-ADServiceAccount -Name DatadogGMSA -DNSHostName <YOUR_DOMAIN_NAME> -PrincipalsAllowedToRetrieveManagedPassword DatadogAgentsGroup
+      ```
 
-Replace `<YOUR_DOMAIN_NAME>` with your domain name.
 
-**3. Install the gMSA on the Target Machine:**
+3. Install the gMSA on the Target Machine:
 
 - Ensure the target machine is part of the `DatadogAgentsGroup`.
 - On the target machine, open PowerShell and run:
 ```powerhsell
 Install-ADServiceAccount -Identity DatadogGMSA
 ```
-### Install the Datadog Agent
-Download the [Datadog Agent installer][1] to install the latest version of the Agent.
+### Install the Agent
 
    <div class="alert alert-info">If you need to install a specific version of the Agent, see the <a href="https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json">installer list</a>.</div>
 
@@ -116,15 +112,15 @@ Download the [Datadog Agent installer][1] to install the latest version of the A
 - Run the installer by opening `datadog-agent-7-latest.amd64.msi`. When prompted, enter your Administrator credentials.
 - Follow the prompts, accept the license agreement, and enter your [Datadog API key][2].
 - When prompted for the "Datadog Agent User Account", enter the username of the gMSA (e.g., `<YOUR_DOMAIN_NAME>\DatadogGMSA$`) and **no password**.
-- When the install finishes, you are given the option to launch the Datadog Agent Manager.
+When the install finishes, you are given the option to launch the Datadog Agent Manager.
 
 #### Install with the command line
-- Open PowerShell with **Administrator** privileges.
-- Run the following command to install the Datadog Agent:
+1. Open PowerShell with **Administrator** privileges.
+1. Run the following command to install the Datadog Agent:
+   **Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
 ```powershell
 Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$'
 ```
-**note:** Replace `DatadogGMSA$` with the username of your gMSA, it **must end with a $ symbol.**
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows
@@ -135,7 +131,7 @@ Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.m
 {{% /tab %}}
 {{< /tabs >}}
 
-##### Installation Configuration Options 
+##### Installation configuration options 
 
 Each of the following configuration options can be added as a property to the command line when installing the Agent on Windows. For additional Agent configuration options, see [more Agent configuration options](#more-agent-configuration-options).  
 
@@ -172,12 +168,12 @@ Each of the following configuration options can be added as a property to the co
 | `PROCESS_ENABLED`                           | String  | Enable (`"true"`) or disable (`"false"`) the Process Agent in the configuration file. The Process Agent is disabled by default.                                                                                                     |
 | `HOSTNAME_FQDN_ENABLED`                     | String  | Enable (`"true"`) or disable (`"false"`) the usage of FQDN for the Agent hostname. It is equivalent to set `hostname_fqdn` in the Agent configuration file. The usage of FQDN for the hostname is disabled by default. _(v6.20.0+)_ |
 | `CMD_PORT`                                  | Number  | A valid port number between 0 and 65534. The Datadog Agent exposes a command API on port 5001. If that port is already in use by another program, the default may be overridden here.                                               |
-| `PROXY_HOST`                                | String  | If using a proxy, sets your proxy host. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
-| `PROXY_PORT`                                | Number  | If using a proxy, sets your proxy port. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
-| `PROXY_USER`                                | String  | If using a proxy, sets your proxy user. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
-| `PROXY_PASSWORD`                            | String  | If using a proxy, sets your proxy password. For the process/container Agent, this variable is required for passing in an authentication password and cannot be renamed. [Learn more about using a proxy with the Datadog Agent][4]. |
+| `PROXY_HOST`                                | String  | (If using a proxy) sets your proxy host. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
+| `PROXY_PORT`                                | Number  | (If using a proxy) sets your proxy port. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
+| `PROXY_USER`                                | String  | (If using a proxy) sets your proxy user. [Learn more about using a proxy with the Datadog Agent][4].                                                                                                                                 |
+| `PROXY_PASSWORD`                            | String  | (If using a proxy) sets your proxy password. For the process/container Agent, this variable is required for passing in an authentication password and cannot be renamed. [Learn more about using a proxy with the Datadog Agent][4]. |
 | `EC2_USE_WINDOWS_PREFIX_DETECTION`          | Boolean | Use the EC2 instance id for Windows hosts on EC2. _(v7.28.0+)_                                                                                                                                                                      |
-| [DEPRECATED] `ADDLOCAL` | String | Enable additional agent component. Setting to `"MainApplication,NPM"` causes the driver component for [Network Performance Monitoring][5] to be installed. _(version 7.44.0 and previous)_ |
+| [DEPRECATED] `ADDLOCAL` | String | Enable additional Agent component. Setting to `"MainApplication,NPM"` causes the driver component for [Network Performance Monitoring][5] to be installed. _(version 7.44.0 and previous)_ |
 
 Agent 7 only supports Python 3. Before upgrading, confirm that your custom checks are compatible with Python 3. See the [Python 3 Custom Check Migration][13] guide for more information. If you're not using custom checks or have already confirmed their compatibility, upgrade normally.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR re-works the "Basic Agent Usage" page for Windows to emphasize the 2 different critical pathways a customer can take to install the Datadog Agent.

Therefore, it de-emphasizes the importance of installing via GUI or command line by removing them from the tabs and instead replacing them with the `Standard` installation and `Domain` installation.

Some simple steps to setup a `Group Managed Service Account` was added, and this can be moved to its own guide if necessary.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->