### PR TITLE
adjust logo grid rows and alignment - [WEB-5185]

### DIFF
--- a/layouts/partials/continuous_integration/ci-pipelines-getting-started.html
+++ b/layouts/partials/continuous_integration/ci-pipelines-getting-started.html
@@ -1,73 +1,69 @@
 <div class="ci-visibility-providers">
   <div class="container cards-dd">
       <div class="row g-2 g-xl-3 justify-content-sm-center">
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/awscodepipeline/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/aws-codepipeline_small.svg" "class" "img-fluid" "alt" "aws codepipeline" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/azure/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/azuredevops_small.svg" "class" "img-fluid" "alt" "azure devops extension" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/buildkite/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/buildkite_small.svg" "class" "img-fluid" "alt" "buildkite" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-      </div>
-      <div class="row g-2 g-xl-3 justify-content-sm-center">
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/circleci/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/circleci.png" "class" "img-fluid" "alt" "circleci orb" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/codefresh/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/codefresh_small.svg" "class" "img-fluid" "alt" "codefresh" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/github/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/github_small.svg" "class" "img-fluid" "alt" "github actions" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-      </div>
-      <div class="row g-2 g-xl-3 justify-content-sm-center">
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/gitlab/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/gitlab_small.svg" "class" "img-fluid" "alt" "gitlab" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/jenkins/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/jenkins.png" "class" "img-fluid" "alt" "jenkins" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-          <div class="col-md-4">
-              <a class="card h-100" href="/continuous_integration/pipelines/teamcity/">
-                  <div class="card-body text-center py-2 px-1">
-                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/teamcity_small.svg" "class" "img-fluid" "alt" "teamcity" "width" "150") }}
-                  </div>
-              </a>
-          </div>
-      </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/awscodepipeline/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/aws-codepipeline_small.svg" "class" "img-fluid" "alt" "aws codepipeline" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/azure/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/azuredevops_small.svg" "class" "img-fluid" "alt" "azure devops extension" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/buildkite/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/buildkite_small.svg" "class" "img-fluid" "alt" "buildkite" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/circleci/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/circleci.png" "class" "img-fluid" "alt" "circleci orb" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/codefresh/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/codefresh_small.svg" "class" "img-fluid" "alt" "codefresh" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/github/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/github_small.svg" "class" "img-fluid" "alt" "github actions" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/gitlab/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/gitlab_small.svg" "class" "img-fluid" "alt" "gitlab" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/jenkins/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/jenkins.png" "class" "img-fluid" "alt" "jenkins" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col-md-4">
+                <a class="card h-100" href="/continuous_integration/pipelines/teamcity/">
+                    <div class="card-body text-center py-2 px-1 d-flex align-items-center justify-content-center">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/teamcity_small.svg" "class" "img-fluid" "alt" "teamcity" "width" "150") }}
+                    </div>
+                </a>
+            </div>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
adjust `continuous_integration/ci-pipelines-getting-started` partial template styles
   - instead of 3 `.row`s, have one `.row` with multiple columns
motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-5185
preview: https://docs-staging.datadoghq.com/stefon.simmons/logo-styling-fix-web5185

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after Corp review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->