### PR TITLE
Update use-community-integrations.md

### DIFF
--- a/content/en/agent/guide/use-community-integrations.md
+++ b/content/en/agent/guide/use-community-integrations.md
@@ -48,7 +48,7 @@ Use the following Dockerfile to build a custom version of the Agent that include
 
 ```dockerfile
 FROM gcr.io/datadoghq/agent:latest
-RUN datadog-agent integration install -r -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
+RUN agent integration install -r -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
 ```
 
 The `datadog-agent integration install` command (run inside Docker) issues the following harmless warning: `Error loading config: Config File "datadog" Not Found in "[/etc/datadog-agent]": warn`. You can ignore this warning.


### PR DESCRIPTION
Running
`RUN datadog-agent integration install -r -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>` causes an error

`=> ERROR [2/2] RUN datadog-agent integration install -r -t datadog-lighthouse==2.0.0                                                                  0.4s
------
 > [2/2] RUN datadog-agent integration install -r -t datadog-lighthouse==2.0.0:
#5 0.383 /bin/sh: 1: datadog-agent: not found`

Changing to 
`RUN agent integration install -r -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>` works

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Correction. Ticket: 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->