### PR TITLE
Add alert, case management not supported on us1-fed

### DIFF
--- a/content/en/service_management/case_management/create_case.md
+++ b/content/en/service_management/case_management/create_case.md
@@ -6,6 +6,12 @@ further_reading:
   text: "View and Manage Cases"
 ---
 
+{{% site-region region="gov,ap1" %}}
+<div class="alert alert-warning">
+Case Management is not available in the {{< region-param key=dd_datacenter code="true" >}} site.
+</div>
+{{% /site-region %}}
+
 ## Overview
 
 Cases can be created [manually](#manual-case-creation), [automatically](#automatic-case-creation) from across Datadog, or [programmatically](#api) with the API. There are two types of cases: standard and security. Cases created from security signals and Sensitive Data Scanner are automatically made security cases. The security case type has all the features of the standard case type, along with a mandatory field for specifying the reason for closing a case (testing, false positive, or one time exception). 

--- a/content/en/service_management/case_management/create_notifications_and_third_party_tickets.md
+++ b/content/en/service_management/case_management/create_notifications_and_third_party_tickets.md
@@ -6,6 +6,12 @@ further_reading:
   text: "Troubleshooting third-party integrations"
 ---
 
+{{% site-region region="gov,ap1" %}}
+<div class="alert alert-warning">
+Case Management is not available in the {{< region-param key=dd_datacenter code="true" >}} site.
+</div>
+{{% /site-region %}}
+
 ## Overview
 
 Case Management provides the capability to create third-party integrations for generating notifications or tickets automatically or manually:

--- a/content/en/service_management/case_management/projects.md
+++ b/content/en/service_management/case_management/projects.md
@@ -7,6 +7,12 @@ further_reading:
   text: "Create a case"
 ---
 
+{{% site-region region="gov,ap1" %}}
+<div class="alert alert-warning">
+Case Management is not available in the {{< region-param key=dd_datacenter code="true" >}} site.
+</div>
+{{% /site-region %}}
+
 ## Overview
 
 A project is a container object that holds a set of cases. Organize your work around the groups that make sense to your organization, whether that's teams, services, or initiatives. Cases in each project are isolated from one another, helping you to focus on what's relevant. 

--- a/content/en/service_management/case_management/settings.md
+++ b/content/en/service_management/case_management/settings.md
@@ -6,6 +6,12 @@ further_reading:
   text: "Troubleshooting third-party integrations"
 ---
 
+{{% site-region region="gov,ap1" %}}
+<div class="alert alert-warning">
+Case Management is not available in the {{< region-param key=dd_datacenter code="true" >}} site.
+</div>
+{{% /site-region %}}
+
 ## Overview
 
 In Project Settings, you can manage membership, configure the auto-closing of cases, and set up third-party integrations like Jira and ServiceNow. 

--- a/content/en/service_management/case_management/troubleshooting.md
+++ b/content/en/service_management/case_management/troubleshooting.md
@@ -2,6 +2,12 @@
 title: Troubleshooting
 ---
 
+{{% site-region region="gov,ap1" %}}
+<div class="alert alert-warning">
+Case Management is not available in the {{< region-param key=dd_datacenter code="true" >}} site.
+</div>
+{{% /site-region %}}
+
 ## Overview
 
 This guide is intended to help you resolve issues with third-party integrations in Case Management. If you continue to have trouble, reach out to [Datadog support][1] for further assistance.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Case management is not supported for US1-FED, but it's only stated on the parent page, which confused customers reading the child pages.
- https://datadoghq.atlassian.net/browse/DOCS-8646

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->