### PR TITLE
Add note about the newer plugin name variable

### DIFF
--- a/content/en/logs/guide/aws-eks-fargate-logs-with-kinesis-data-firehose.md
+++ b/content/en/logs/guide/aws-eks-fargate-logs-with-kinesis-data-firehose.md
@@ -55,7 +55,7 @@ kubectl create namespace aws-observability
 
 2. Create the following Kubernetes ConfigMap for Fluent Bit as `aws-logging-configmap.yaml`. Substitute the name of your delivery stream.
 
-<div class="alert alert-info">For the new higher performance <a href="https://docs.fluentbit.io/manual/pipeline/outputs/firehose">Kinesis Fireshose plugin</a> use the plugin name <code>kinesis_firehose</code> instead of <code>amazon_data_firehose</code>. </div>
+<div class="alert alert-info">For the new higher performance <a href="https://docs.fluentbit.io/manual/pipeline/outputs/firehose">Kinesis Firehose plugin</a> use the plugin name <code>kinesis_firehose</code> instead of <code>amazon_data_firehose</code>. </div>
 
 {{< code-block lang="yaml" filename="" disable_copy="false" collapsible="false" >}}
 apiVersion: v1

--- a/content/en/logs/guide/aws-eks-fargate-logs-with-kinesis-data-firehose.md
+++ b/content/en/logs/guide/aws-eks-fargate-logs-with-kinesis-data-firehose.md
@@ -55,6 +55,8 @@ kubectl create namespace aws-observability
 
 2. Create the following Kubernetes ConfigMap for Fluent Bit as `aws-logging-configmap.yaml`. Substitute the name of your delivery stream.
 
+<div class="alert alert-info">For the new higher performance <a href="https://docs.fluentbit.io/manual/pipeline/outputs/firehose">Kinesis Fireshose plugin</a> use the plugin name <code>kinesis_firehose</code> instead of <code>amazon_data_firehose</code>. </div>
+
 {{< code-block lang="yaml" filename="" disable_copy="false" collapsible="false" >}}
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add a note so users that are on the newer Kinesis Firehose plugin know to use the `kinesis_firehose` variable.

https://datadoghq.atlassian.net/browse/DOCS-8011

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->