### PR TITLE
[STAL-2612] docs: add php ruleset names to static analysis rulesets

### DIFF
--- a/content/en/code_analysis/static_analysis_rules/_index.md
+++ b/content/en/code_analysis/static_analysis_rules/_index.md
@@ -87,6 +87,18 @@ rulesets:
     title: "React specific linting rules"
     description: |
       This plugin exports a `recommended` configuration that enforces React good practices.
+  php-best-practices:
+    title: "Follow best practices for writing PHP code"
+    description: |
+      Rules to enforce PHP best practices, enhancing code style, preventing bugs, and promoting performant, maintainable, and efficient PHP code.
+  php-code-style:
+    title: "Enforce PHP code style"
+    description: |
+      Rules to enforce PHP code style.
+  php-security:
+    title: "Security rules for PHP"
+    description: |
+      Rules focused on finding security issues in your PHP code.
   python-best-practices:
     title: "Follow best practices for writing Python code"
     description: |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds the PHP ruleset names to the static analysis rulesets

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

Related:
https://github.com/DataDog/datadog-static-analyzer-rule-docs/pull/63
https://github.com/DataDog/datadog-static-analyzer-rule-docs/pull/64
https://github.com/DataDog/datadog-static-analyzer-rule-docs/pull/65

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->