### PR TITLE
Ignoring apm resource - user_agent - C++

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -129,7 +129,7 @@ On the backend, Datadog creates and adds the following span tags to spans after 
 | **Name**                       | **Remap from**                                                                                        |
 |--------------------------------|-------------------------------------------------------------------------------------------------------|
 | `http.route`                   | `aspnet_core.route` - .NET<br>`aspnet.route` - .NET<br>`laravel.route` - PHP<br>`symfony.route` - PHP |
-| `http.useragent`               | `user_agent` - Java                                                                                   |
+| `http.useragent`               | `user_agent` - Java, C++                                                                                   |
 | `http.url_details.queryString` | `http.query.string` - Python                                                                          |
 
 #### Database


### PR DESCRIPTION
### What does this PR do? What is the motivation?
C++ tracer also writes user_agent instead of http.useragent
[APMS-12915](https://datadoghq.atlassian.net/browse/APMS-12915)


### Merge instructions

- [x ] Please merge after reviewing


[APMS-12915]: https://datadoghq.atlassian.net/browse/APMS-12915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ