### PR TITLE
[SVLS] Add descriptions for three new serverless warnings 

### DIFF
--- a/content/en/serverless/guide/serverless_warnings.md
+++ b/content/en/serverless/guide/serverless_warnings.md
@@ -100,6 +100,24 @@ Attack attempts were detected targeting the serverless application.
 
 **Resolution:** Investigate the attack attempts in ASM by clicking the **Security Signals** button to determine how to respond. If immediate action is needed, you can block the attacking IP in your WAF through the [Workflows integration][11].
 
+### Under provisioned
+
+CPU utilization for this function averaged more than 80%. This means your function may benefit from additional CPU resources.
+
+**Resolution:** Consider increasing the amount of allocated memory on your Lambda function. Increasing the amount of memory scales available CPU resources. Note this may affect your AWS bill.
+
+### Overallocated provisioned concurrency
+
+The function's provisioned concurrency utilization was below 60%. According to AWS, provisioned concurrency is best optimized for cost when utilization is consistently greater than 60%.
+
+**Resolution:** Consider decreasing the amount of configured provisioned concurrency for your function.
+
+### Deprecated runtime
+
+The function's runtime is no longer supported.
+
+**Resolution:** Upgrade to the latest runtime to ensure you are up to date on the latest security, performance, and reliability standards.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/serverless/guide/serverless_warnings.md
+++ b/content/en/serverless/guide/serverless_warnings.md
@@ -102,19 +102,19 @@ Attack attempts were detected targeting the serverless application.
 
 ### Under provisioned
 
-CPU utilization for this function averaged more than 80%. This means your function may benefit from additional CPU resources.
+CPU utilization for this function averaged more than 80%. This means your function may see increased performance from additional CPU resources.
 
-**Resolution:** Consider increasing the amount of allocated memory on your Lambda function. Increasing the amount of memory scales available CPU resources. Note this may affect your AWS bill.
+**Resolution:** Consider increasing the amount of [allocated memory][12] on your Lambda function. Increasing the amount of memory scales available CPU resources. Note this may affect your AWS bill.
 
 ### Overallocated provisioned concurrency
 
-The function's provisioned concurrency utilization was below 60%. According to AWS, provisioned concurrency is best optimized for cost when utilization is consistently greater than 60%.
+The function's provisioned concurrency utilization was below 60%. According to AWS, [provisioned concurrency is best optimized for cost when utilization is consistently greater than 60%][13].
 
 **Resolution:** Consider decreasing the amount of configured provisioned concurrency for your function.
 
 ### Deprecated runtime
 
-The function's runtime is no longer supported.
+The function's runtime is [no longer supported][14].
 
 **Resolution:** Upgrade to the latest runtime to ensure you are up to date on the latest security, performance, and reliability standards.
 

--- a/content/en/serverless/guide/serverless_warnings.md
+++ b/content/en/serverless/guide/serverless_warnings.md
@@ -133,3 +133,6 @@ The function's runtime is [no longer supported][14].
 [9]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html
 [10]: /integrations/amazon_lambda/#metrics
 [11]: https://app.datadoghq.com/workflow/blueprints?selected_category=SECURITY
+[12]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-memory.html
+[13]: https://aws.amazon.com/blogs/compute/optimizing-your-aws-lambda-costs-part-1/
+[14]: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR adds three new serverless warnings to our docs: overallocated provisioned concurrency, under provisioned, and deprecated runtime. These three warnings will be added to the UI shortly after this docs update.  

The overallocated provisioned concurrency warning is generated when provisioned concurrency utilization for a function is consistently below 60% and can help customers optimize their functions for cost.

The under provisioned warning is generated when a function's CPU utilization consistently averages above 80%.

The deprecated runtime warning is generated when a function is using a deprecated runtime as outlined in https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-deprecated.


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->