### PR TITLE
revert #24466 - fix local image builds 

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -108,10 +108,14 @@ module:
     - source: content/ko
       target: content
       lang: ko
+    - source: static
+      target: static
     - source: layouts
       target: layouts
     - source: data
       target: data
+    - source: static
+      target: assets
     - source: assets
       target: assets
     - source: i18n
@@ -123,12 +127,6 @@ module:
       target: "assets/node_modules/datadog-rum.js"
     - source: "./node_modules/@datadog/browser-logs/bundle/datadog-logs.js"
       target: "assets/node_modules/datadog-logs.js"
-    ## exclude images from virtual file system static/ folder. images are being Fingerprinted by hugo
-    - source: static
-      target: static
-      excludeFiles: images
-    - source: static/images
-      target: assets/images
 
 security:
   funcs:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
revert changes here: https://github.com/DataDog/documentation/pull/24466/files
  - need to investigate issues with icons and some images not building locally
 
preview: https://docs-staging.datadoghq.com/stefon.simmons/revert-asset-mount-changes/
- [https://docs-staging.datadoghq.com/stefon.simmons/revert-asset-mount-changes/account_management/audit_trail/](https://docs-staging.datadoghq.com/stefon.simmons/revert-asset-mount-changes/account_management/audit_trail/)
- https://docs-staging.datadoghq.com/stefon.simmons/revert-asset-mount-changes/account_management/org_settings/cross_org_visibility/

check that images including icons are loading locally and in preview

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->