### PR TITLE
Clarification for diff-aware scanning

### DIFF
--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -87,7 +87,11 @@ datadog-ci sarif upload /tmp/report.sarif --service <service> --env <env>
 
 ## Diff-aware scanning
 
-Diff-aware scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
+Diff-aware scanning is a feature that enables Datadog Static Analysis to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. The first scan performed, as well as default branch scans, always produce an analysis of the full repository (not diff-aware). 
+
+If you are using GitHub Actions, diff-aware scanning is enabled by default.
+
+For other CI providers, follow these steps to enable diff-aware scanning:
 
 1. Make sure your `DD_APP_KEY`, `DD_SITE` and `DD_API_KEY` variables are set in your CI pipeline.
 2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that Git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Add clarification for diff-aware scanning:
- first scan always a full scan
- all scans on default branch are full scans
- enabled by default for github actions

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ x ] Please merge after reviewing

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->