### PR TITLE
DOCS-8682 Custom Costs Update

### DIFF
--- a/assets/scripts/config/regions.config.js
+++ b/assets/scripts/config/regions.config.js
@@ -266,5 +266,13 @@ export default {
      us3: `https://trace.agent.us3.datadoghq.com/api/v0.2/traces`,
      us5: `https://trace.agent.us5.datadoghq.com/api/v0.2/traces`,
      eu: `https://trace.agent.datadoghq.eu/api/v0.2/traces`
+    },
+    custom_costs_endpoint: {
+      us: 'api.datadoghq.com/api/v2/cost/custom_costs',
+      us3: 'api.us3.datadoghq.com/api/v2/cost/custom_costs',
+      us5: 'api.us5.datadoghq.com/api/v2/cost/custom_costs',
+      eu: 'api.datadoghq.eu/api/v2/cost/custom_costs.',
+      ap1: 'api.ap1.datadoghq.com/api/v2/cost/custom_costs',
+      gov: 'The custom costs endpoint for GOV is not supported.'
     }  
 };

--- a/content/en/cloud_cost_management/custom.md
+++ b/content/en/cloud_cost_management/custom.md
@@ -230,47 +230,40 @@ In this example, an additional `Tags` object property has been added with two ke
 
 ### Configure Custom Costs
 
-After your data is formatted to the requirements above, upload your CSV and JSON files to Cloud Cost Management on [the **Custom Costs Uploaded Files** page][3] or programmatically by using the API.
+After your data is formatted to the requirements above, upload your CSV and JSON files to Cloud Cost Management on the [**Custom Costs Files** page][3] or programmatically by using the API.
 
-{{< tabs >}}
-{{% tab "UI" %}}
+In Datadog:
 
-Navigate to [**Infrastructure > Cloud Costs > Settings > Cost Files**][101]. Select **Cost Files** from the Settings dropdown.
+1. Navigate to [**Infrastructure > Cloud Costs > Settings > Custom Costs**][3]. 
+1. Click the **+ Upload Costs** button.
 
-{{< img src="cloud_cost/upload_file.png" alt="Upload a CSV or JSON file to Datadog" style="width:80%" >}}
+   {{< img src="cloud_cost/upload_file.png" alt="Upload a CSV or JSON file to Datadog" style="width:80%" >}}
 
-[101]: https://app.datadoghq.com/cost/settings/cost-files
+To send a file programmatically, use the `PUT api/v2/cost/custom_costs` API endpoint.
 
-{{% /tab %}}
-{{% tab "API (file)" %}}
-
-To send a file, use the `PUT api/v2/cost/custom_costs` API endpoint.
-
-Example with cURL:
+For example, using cURL:
 
 ```curl
-curl -L -X PUT "api.datadoghq.com/api/v2/cost/custom_costs/" \
+curl -L -X PUT "{{< region-param key="custom_costs_endpoint" >}}" \
 -H "Content-Type: multipart/form-data" \
 -H "DD-API-KEY: ${DD_API_KEY}" \
 -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
 -F "file=${file};type=text/json"
 ```
-{{% /tab %}}
-{{% tab "API (request)" %}}
 
-Use the `PUT api/v2/cost/custom_costs` endpoint to send the content of the file with the API .
+To send the content of the file programmatically, use the `PUT api/v2/cost/custom_costs` endpoint.
+
+For example, using cURL:
 
 ```curl
-curl -L -X PUT "api.datadoghq.com/api/v2/cost/custom_costs/" \
+curl -L -X PUT "{{< region-param key="custom_costs_endpoint" >}}" \
 -H "Content-Type: application/json" \
 -H "DD-API-KEY: ${DD_API_KEY}" \
 -H "DD-APPLICATION-KEY: ${DD_APP_KEY}" \
 -d '${file_content}'
 ```
-{{% /tab %}}
-{{< /tabs >}}
 
-Cost data appears after 24 hours.
+Cost data appears in Datadog after 24 hours.
 
 ## Cost metric types
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Removed the tabs so we can use the dynamic site region selector for the API endpoints in the code snippets in the Configure Custom Costs section.

When you click `US3` in the site region selector, the values for `api.datadoghq.com` should change to `api.us3.datadoghq.com/api/v2/cost/custom_costs` in the code snippets.

Discussion with Natasha and Dave on Slack

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->