### PR TITLE
[OTELS-306][opentelemetry] Clarify in what order resource attributes are used to determine hostnames

### DIFF
--- a/content/en/opentelemetry/schema_semantics/hostname.md
+++ b/content/en/opentelemetry/schema_semantics/hostname.md
@@ -10,7 +10,7 @@ further_reading:
 
 OpenTelemetry defines certain semantic conventions for resource attributes related to hostnames. If an OpenTelemetry Protocol (OTLP) payload for any signal type has known hostname resource attributes, Datadog honors these conventions and tries to use its value as a hostname. The default hostname resolution algorithm is built with compatibility with the rest of Datadog products in mind, but you can override it if needed.
 
-This algorithm is used in the [Datadog exporter][3] as well as the [OTLP ingest pipeline in the Datadog Agent][2]. When using the [recommended configuration][4] for the Datadog exporter, the [resource detection processor][1] adds the necessary attributes to the payload to ensure accurate hostname resolution.
+This algorithm is used in the [Datadog exporter][3] as well as the [OTLP ingest pipeline in the Datadog Agent][2]. When using the [recommended configuration][4] for the Datadog exporter, the [resource detection processor][1] adds the necessary resource attributes to the payload to ensure accurate hostname resolution.
 
 ## Conventions used to determine the hostname
 
@@ -25,7 +25,9 @@ The following sections explain each set of conventions in more detail.
 
 ### General hostname semantic conventions
 
-The `host` and `datadog.host.name` conventions are Datadog-specific conventions. They are considered first and can be used to override the hostname detected using the usual OpenTelemetry semantic conventions. Prefer using the `datadog.host.name` convention since it is namespaced, and it is less likely to conflict with other vendor-specific behavior.
+The `host` and `datadog.host.name` conventions are Datadog-specific conventions. They are considered first and can be used to override the hostname detected using the usual OpenTelemetry semantic conventions. We first check `host` and then check `datadog.host.name` if `host` was not set.
+
+Prefer using the `datadog.host.name` convention since it is namespaced, and it is less likely to conflict with other vendor-specific behavior.
 
 When using the OpenTelemetry Collector, you can use the `transform` processor to set the `datadog.host.name` convention in your pipelines. For example, to set the hostname as `my-custom-hostname` in all metrics, traces, and logs on a given pipeline, use the following configuration:
 
@@ -43,7 +45,7 @@ Don't forget to add the `transform` processor to your pipelines.
 
 ### Cloud provider-specific conventions
 
-The `cloud.provider` resource attribute is used to determine the cloud provider. Further attributes are used to determine the hostname for each specific platform. If `cloud.provider` or any of the attributes are missing, the next set of conventions is checked.
+The `cloud.provider` resource attribute is used to determine the cloud provider. Further resource attributes are used to determine the hostname for each specific platform. If `cloud.provider` or any of the expected resource attributes are missing, the next set of conventions is checked.
 
 #### Amazon Web Services
 
@@ -73,17 +75,17 @@ To get the cluster name, the following conventions are checked:
 
 1. Check `k8s.cluster.name` and use it if present.
 2. If `cloud.provider` is set to `azure`, extract the cluster name from `azure.resourcegroup.name`.
-3. If `cloud.provider` is set to `aws`, extract the cluster name from the first attribute starting with `ec2.tag.kubernetes.io/cluster/`.
+3. If `cloud.provider` is set to `aws`, extract the cluster name from the first resource attribute starting with `ec2.tag.kubernetes.io/cluster/`.
 
 ### `host.id` and `host.name`
 
-If none of the above conventions are present, the `host.id` and `host.name` resource attributes are used as-is to determine the hostname. 
+If none of the above conventions are present, the `host.id` and `host.name` resource attributes are used as-is to determine the hostname. We first check `host.id` and then check `host.name` if `host.id` was not set.
 
 **Note:** The OpenTelemetry specification allows `host.id` and `host.name` to have values that may not match those used by other Datadog products in a given environment. If using multiple Datadog products to monitor the same host, you may have to override the hostname using `datadog.host.name` to ensure consistency.
 
 ## Fallback hostname logic
 
-If no valid host names are found, the behavior varies depending on the ingestion path. 
+If no valid host names are found in the resource attributes, the behavior varies depending on the ingestion path. 
 
 {{< tabs >}}
 {{% tab "Datadog Exporter" %}}

--- a/content/en/opentelemetry/schema_semantics/hostname.md
+++ b/content/en/opentelemetry/schema_semantics/hostname.md
@@ -25,7 +25,7 @@ The following sections explain each set of conventions in more detail.
 
 ### General hostname semantic conventions
 
-The `host` and `datadog.host.name` conventions are Datadog-specific conventions. They are considered first and can be used to override the hostname detected using the usual OpenTelemetry semantic conventions. We first check `host` and then check `datadog.host.name` if `host` was not set.
+The `host` and `datadog.host.name` conventions are Datadog-specific conventions. They are considered first and can be used to override the hostname detected using the usual OpenTelemetry semantic conventions. `host` is checked first and then `datadog.host.name` is checked if `host` was not set.
 
 Prefer using the `datadog.host.name` convention since it is namespaced, and it is less likely to conflict with other vendor-specific behavior.
 
@@ -79,7 +79,7 @@ To get the cluster name, the following conventions are checked:
 
 ### `host.id` and `host.name`
 
-If none of the above conventions are present, the `host.id` and `host.name` resource attributes are used as-is to determine the hostname. We first check `host.id` and then check `host.name` if `host.id` was not set.
+If none of the above conventions are present, the `host.id` and `host.name` resource attributes are used as-is to determine the hostname. `host.id` is checked first and then `host.name` is checked if `host.id` was not set.
 
 **Note:** The OpenTelemetry specification allows `host.id` and `host.name` to have values that may not match those used by other Datadog products in a given environment. If using multiple Datadog products to monitor the same host, you may have to override the hostname using `datadog.host.name` to ensure consistency.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Clarifies in what order resource attributes are used to determine hostnames. Make sure to mention that these are 'resource attributes' explicitly everywhere. Relates to OTELS-306

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
