### PR TITLE
docs(aws): Adding GetRuleGroup for wafv2

### DIFF
--- a/layouts/shortcodes/aws-resource-collection.md
+++ b/layouts/shortcodes/aws-resource-collection.md
@@ -24,7 +24,8 @@ For the most **complete** security coverage that Datadog can provide, Datadog re
                 "waf:ListRuleGroups",
                 "waf:ListRules",
                 "wafv2:GetIPSet",
-                "wafv2:GetRegexPatternSet"
+                "wafv2:GetRegexPatternSet",
+                "wafv2:GetRuleGroup"
             ],
             "Effect": "Allow",
             "Resource": "*"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fix a missing permission for AWS resource crawler.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->