### PR TITLE
Add links to component docs in OP landing page

### DIFF
--- a/content/en/observability_pipelines/_index.md
+++ b/content/en/observability_pipelines/_index.md
@@ -61,9 +61,9 @@ To set up a pipeline:
     - [Archive logs to Datadog Archives][5]
     - [Sensitive data redaction][6]
     - [Log Enrichment][7]
-1. Select and set up your source.
-1. Select and set up your destinations.
-1. Set up you processors.
+1. Select and set up your [source][10].
+1. Select and set up your [destinations][11].
+1. Set up you [processors][12].
 1. Install the Observability Pipelines Worker.
 1. Enable monitors for your pipeline.
 
@@ -134,3 +134,6 @@ After you create your pipeline, enable out-of-the box monitors to get alerted wh
 [7]: /observability_pipelines/log_enrichment/
 [8]: /observability_pipelines/set_up_pipelines/
 [9]: /observability_pipelines/advanced_configurations/
+[10]: /observability_pipelines/sources/
+[11]: /observability_pipelines/destinations/
+[12]: /observability_pipelines/processors/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->