### PR TITLE
Update 99datadog-windows.config example

### DIFF
--- a/static/config/99datadog-windows.config
+++ b/static/config/99datadog-windows.config
@@ -17,5 +17,5 @@ commands:
   02_setup-APM1: # Stop IIS
     command: net stop /y was
 
-  03_setup-APM2: # Starts w3svc for the purpose of setting up tracing on IIS
+  03_setup-APM2: # Starts IIS
     command: net start w3svc

--- a/static/config/99datadog-windows.config
+++ b/static/config/99datadog-windows.config
@@ -14,7 +14,7 @@ commands:
     command: start /wait msiexec /qn /i datadog-agent-7-latest.amd64.msi APIKEY="YOUR API KEY" SITE="datadoghq.com"
     cwd: c:/Datadog
 
-  02_setup-APM1: # Stops was for the purpose of setting up tracing on IIS
+  02_setup-APM1: # Stop IIS
     command: net stop /y was
 
   03_setup-APM2: # Starts w3svc for the purpose of setting up tracing on IIS

--- a/static/config/99datadog-windows.config
+++ b/static/config/99datadog-windows.config
@@ -1,7 +1,7 @@
 # .ebextensions/99datadog-windows.config
 packages:
-  msi:
-    DotnetAPM: https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.8.0/datadog-dotnet-apm-2.8.0-x64.msi
+  msi: # Find the applicable msi at https://github.com/DataDog/dd-trace-dotnet/releases
+    DotnetAPM: https://github.com/DataDog/dd-trace-dotnet/releases/download/v<VERSION>/datadog-dotnet-apm-<VERSION>-x64.msi
 files:
   "c:\\Datadog\\datadog-agent-7-latest.amd64.msi":
     source: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
@@ -14,8 +14,8 @@ commands:
     command: start /wait msiexec /qn /i datadog-agent-7-latest.amd64.msi APIKEY="YOUR API KEY" SITE="datadoghq.com"
     cwd: c:/Datadog
 
-  02_setup-APM1:
+  02_setup-APM1: # Stops was for the purpose of setting up tracing on IIS
     command: net stop /y was
 
-  03_setup-APM2:
+  03_setup-APM2: # Starts w3svc for the purpose of setting up tracing on IIS
     command: net start w3svc


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The example for dd-trace-dotnet was hardcoded. 

Since there's no "latest" msi endpoint today, it needs to be updated manually but the previous example didn't make that clear. 

I updated the instructions to make it clear to find the applicable msi, and also explain that `02_setup-APM1` and `03_setup-APM2` are just examples for tracing IIS.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->