### PR TITLE
revert docs page -> remove edge support

### DIFF
--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -168,7 +168,7 @@ For more information, see [Using Synthetic Test Monitors][7].
 
 ## Record your steps
 
-Tests can be recorded from [Google Chrome][8] and [Microsoft Edge][18]. To record your test, download the [Datadog Record Test extension][9].
+Tests can be only recorded from [Google Chrome][8]. To record your test, download the [Datadog Record Test extension for Google Chrome][9].
 
 You can switch tabs in a browser test recording in order to perform an action on your application (such as clicking on a link that opens another tab) and add another test step. Your browser test must interact with the page first (through a click) before it can perform an [assertion][10]. By recording all of the test steps, the browser test can switch tabs automatically at test execution.
 
@@ -219,5 +219,4 @@ You can restrict access to a browser test based on the roles in your organizatio
 [15]: /continuous_testing/environments/proxy_firewall_vpn
 [16]: /synthetics/guide/browser-tests-passkeys
 [17]: /monitors/notify/variables/?tab=is_alert#conditional-variables
-[18]: https://www.microsoft.com/edge/download
 [19] https://www.loc.gov/standards/iso639-2/php/code_list.php


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Remove recorder support for edge browsers as this is something we cannot provide support for. 

### Merge instructions
N/A

- [ ] Please merge after reviewing

### Additional notes
N/A
