### PR TITLE
Add IAST section to ASM homepage

### DIFF
--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -78,6 +78,10 @@ In the [Security Signals Explorer][6], click on any security signal to see what 
 
 [Software Composition Analysis (SCA)][8] shows you when your services are at risk because they use or have dependencies on open source libraries that have known vulnerabilities. Investigate vulnerability findings and secure your software by following remediation advice or researching the cause of the vulnerability.
 
+## Detect vulnerabilities in your application's code
+
+[Code Security][9] identifies code-level vulnerabilities in your services and provides actionable insights and recommended fixes. It uses an Interactive Application Security Testing (IAST) approach to find vulnerabilities within your application code. IAST uses instrumentation embedded in your code like application performance monitoring (APM) and it enables Datadog to identify vulnerabilities using legitimate application traffic instead of relying on external tests that could require extra configuration or periodic scheduling.
+
 ## Next steps
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -89,3 +93,4 @@ In the [Security Signals Explorer][6], click on any security signal to see what 
 [6]: https://app.datadoghq.com/security
 [7]: https://dashcon.io/appsec
 [8]: /security/application_security/software_composition_analysis/
+[9]: /security/application_security/code_security/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Add a section on Code Security to the Application Security Management homepage. Code Security is only present in the navigation, but being one of the major branches of this product, it should be more visible from the homepage.

Copy provided by @gorkavicente. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->