### PR TITLE
update glob capture for metric specs

### DIFF
--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -698,8 +698,10 @@ class Integrations:
         tab_logic = False
         # Prioritize having metric-spec.yaml over metadata.csv
         metrics = glob.glob(
-                "{path}{sep}*metric-spec.yaml".format(path=dirname(file_name), sep=sep)
+            "{path}{sep}**/metric-spec.yaml".format(
+                path=dirname(file_name), sep=sep, recursive=True
             )
+        )
         if metrics:
             metrics = metrics[0] if len(metrics) > 0 else None
             metrics_exist = metrics and exists(metrics)

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -698,9 +698,7 @@ class Integrations:
         tab_logic = False
         # Prioritize having metric-spec.yaml over metadata.csv
         metrics = glob.glob(
-            "{path}{sep}**/metric-spec.yaml".format(
-                path=dirname(file_name), sep=sep, recursive=True
-            )
+            f"{dirname(file_name)}{sep}**{sep}metric-spec.yaml", recursive=True
         )
         if metrics:
             metrics = metrics[0] if len(metrics) > 0 else None


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We want metric specs files to no longer be in the base directory but in the `assets/metrics/` directory. This PR changes the captured file path to find `metric-spec.yaml`. 

```
>>> glob.glob(f"{dirname(file_name)}{sep}**{sep}metric-spec.yaml", recursive=True)
['./amazon_network_manager/assets/metrics/metric-spec.yaml']

PREVIOUS
>>> glob.glob("{path}{sep}*metric-spec.yaml".format(path=dirname(file_name), sep=sep))
[]
```

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->