### PR TITLE
[dbm] bump up dbm for mongodb beta agent version

### DIFF
--- a/layouts/shortcodes/dbm-mongodb-agent-beta-install-docker.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-beta-install-docker.md
@@ -5,7 +5,7 @@ Replace `<DD_API_KEY>` with your [Datadog API key][1] and `<DD_SITE>` with your 
 # Override the following environment variables
 export DD_API_KEY=<DD_API_KEY>
 export DD_SITE=<DD_SITE>
-export DD_AGENT_VERSION=7.56.0-dbm-mongo-1.4
+export DD_AGENT_VERSION=7.57.0-dbm-mongo-1.5
 
 docker pull "datadog/agent:${DD_AGENT_VERSION}"
 ```

--- a/layouts/shortcodes/dbm-mongodb-agent-beta-install-kubernetes.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-beta-install-kubernetes.md
@@ -17,7 +17,7 @@ Create a `values.yaml` file with the following content:
 datadog:
   agents:
     image:
-      tag: 7.56.0-dbm-mongo-1.4
+      tag: 7.57.0-dbm-mongo-1.5
   registry: datadog/agent
   apiKeyExistingSecret: datadog-secret
 

--- a/layouts/shortcodes/dbm-mongodb-agent-beta-install-linux.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-beta-install-linux.md
@@ -6,7 +6,7 @@ Replace `<DD_API_KEY>` with your [Datadog API key][1] and `<DD_SITE>` with your 
 export DD_REPO_URL=datad0g.com
 export DD_AGENT_DIST_CHANNEL=beta
 export DD_AGENT_MAJOR_VERSION=7
-export DD_AGENT_MINOR_VERSION="56.0~dbm~mongo~1.4"
+export DD_AGENT_MINOR_VERSION="57.0~dbm~mongo~1.5"
 
 DD_API_KEY=<DD_API_KEY> DD_SITE=<DD_SITE> bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
 ```

--- a/layouts/shortcodes/dbm-mongodb-agent-setup-docker.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-setup-docker.md
@@ -8,7 +8,7 @@ Add the configuration details for the MongoDB check from the previous step in th
 
 ```shell
 export DD_API_KEY=<DD_API_KEY>
-export DD_AGENT_VERSION=7.56.0-dbm-mongo-1.4
+export DD_AGENT_VERSION=7.57.0-dbm-mongo-1.5
 
 docker run -e "DD_API_KEY=${DD_API_KEY}" \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \

--- a/layouts/shortcodes/dbm-mongodb-agent-setup-kubernetes.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-setup-kubernetes.md
@@ -14,7 +14,7 @@ helm install <RELEASE_NAME> \
   --set 'datadog.apiKey=<DATADOG_API_KEY>' \
   --set 'clusterAgent.enabled=true' \
   --set 'clusterChecksRunner.enabled=true' \
-  --set "clusterAgent.confd.mongo\.yaml=cluster_check: true
+  --set 'clusterAgent.confd.mongo\.yaml=cluster_check: true
 init_config:
 instances:
   - hosts:
@@ -25,9 +25,11 @@ instances:
       authSource: admin
     dbm: true
     cluster_name: <MONGO_CLUSTER_NAME>
+    reported_database_hostname: <DATABASE_HOSTNAME_OVERRIDE>
     database_autodiscovery:
       enabled: true
-    reported_database_hostname: <DATABASE_HOSTNAME_OVERRIDE>" \
+    additional_metrics: ["metrics.commands", "tcmalloc", "top", "collection"]
+    collections_indexes_stats: true' \
   datadog/datadog
 ```
 
@@ -50,6 +52,8 @@ instances:
     reported_database_hostname: <DATABASE_HOSTNAME_OVERRIDE>
     database_autodiscovery:
       enabled: true
+    additional_metrics: ["metrics.commands", "tcmalloc", "top", "collection"]
+    collections_indexes_stats: true
 ```
 
 ### Configure with Kubernetes service annotations


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR bumps up dbm for mongodb beta agent to `7.57.0-dbm-mongo-1.5`

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->