### PR TITLE
[SDTEST-579] Ruby ITR: remove beta, add instruction on how to temporarily disable ITR with env variable, expand unskippable tests section

### DIFF
--- a/content/en/intelligent_test_runner/setup/ruby.md
+++ b/content/en/intelligent_test_runner/setup/ruby.md
@@ -12,8 +12,6 @@ further_reading:
       text: "Troubleshooting CI Visibility"
 ---
 
-{{< beta-callout url="#" btn_hidden="true" >}}Intelligent Test Runner for Ruby in beta.{{< /beta-callout >}}
-
 ## Compatibility
 
 Intelligent Test Runner is only supported in the following versions and testing frameworks:
@@ -36,8 +34,6 @@ Prior to setting up Intelligent Test Runner, set up [Test Visibility for Ruby][1
 
 ## Run tests with the Intelligent Test Runner enabled
 
-<div class="alert alert-info">Setting <code>DD_CIVISIBILITY_ITR_ENABLED</code> to true is required while the Intelligent Test Runner support for Ruby is in beta. </div>
-
 {{< tabs >}}
 
 {{% tab "On-Premises CI Provider (Datadog Agent)" %}}
@@ -45,7 +41,7 @@ Prior to setting up Intelligent Test Runner, set up [Test Visibility for Ruby][1
 After completing setup, run your tests as you normally do:
 
 {{< code-block lang="shell" >}}
-DD_CIVISIBILITY_ITR_ENABLED="true" DD_ENV=ci DD_SERVICE=my-app bundle exec rake test
+DD_ENV=ci DD_SERVICE=my-app bundle exec rake test
 {{< /code-block >}}
 
 {{% /tab %}}
@@ -55,7 +51,7 @@ DD_CIVISIBILITY_ITR_ENABLED="true" DD_ENV=ci DD_SERVICE=my-app bundle exec rake 
 After completing setup, run your tests as you normally do:
 
 {{< code-block lang="shell" >}}
-DD_CIVISIBILITY_ITR_ENABLED="true" DD_ENV=ci DD_SERVICE=my-app DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_API_KEY=$DD_API_KEY bundle exec rake test
+DD_ENV=ci DD_SERVICE=my-app DD_CIVISIBILITY_AGENTLESS_ENABLED=true DD_API_KEY=$DD_API_KEY bundle exec rake test
 {{< /code-block >}}
 
 {{% /tab %}}
@@ -74,7 +70,9 @@ Examples include:
 * Tests that read data from text files
 * Tests that interact with APIs outside of the code being tested (such as remote REST APIs)
 * Tests that run external processes
-* Tests that use threads or fork process (code coverage tracks only code executed in main thread)
+* Tests that depend on global shared state (for example, caches created by a different test or process)
+* Tests that use forked processes (per test code coverage only collects coverage for the main process)
+* Integration tests that use capybara or selenium-webdriver
 
 Designating tests as unskippable ensures that the Intelligent Test Runner runs them regardless of coverage data.
 
@@ -171,6 +169,14 @@ end
 
 {{% /tab %}}
 {{< /tabs >}}
+
+### Temporarily disabling the Intelligent Test Runner
+
+The Intelligent Test Runner can be disabled locally by setting the `DD_CIVISIBILITY_ITR_ENABLED` environment variable to `false` or `0`.
+
+`DD_CIVISIBILITY_ITR_ENABLED` (Optional)
+: Enable the Intelligent Test Runner coverage and test skipping features<br />
+**Default**: `(true)`
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Intelligent test runner for Ruby is out of beta, so we want to reflect that and:
- remove information that ITR is in beta
- remove requiremeent to set specific env variable to enable ITR
- add instruction on temporarily disabling ITR if needed
- expand instruction on unskippable tests with a couple more use cases

### Merge instructions

- [x] Please merge after reviewing

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->