### PR TITLE
Consistent tab order for CCM integrations 

### DIFF
--- a/content/en/cloud_cost_management/saas_costs.md
+++ b/content/en/cloud_cost_management/saas_costs.md
@@ -251,17 +251,6 @@ The following table contains a non-exhaustive list of out-of-the-box tags associ
 | `network_access_type` | Network access type for the cluster. Possible values are `INTERNET`, `TRANSIT_GATEWAY`, `PRIVATE_LINK`, and `PEERED_VPC`. |
 | `product` | Product name. Possible values include `KAFKA`, `CONNECT`, `KSQL`, `AUDIT_LOG`, `STREAM_GOVERNANCE`, `CLUSTER_LINK`, `CUSTOM_CONNECT`, `FLINK`, `SUPPORT_CLOUD_BASIC`, `SUPPORT_CLOUD_DEVELOPER`, `SUPPORT_CLOUD_BUSINESS`, and `SUPPORT_CLOUD_PREMIER`. |
 
-{{% /tab %}}
-{{% tab "Elastic Cloud" %}}
-| Tag Name | Tag Description |
-|---|---
-| `name` | The unique identifier of the Elastic Cloud resource. |
-| `price_per_hour` | The cost of the Elastic Cloud resource per hour. |
-| `kind` | The type of resource. |
-
-{{% /tab %}}
-{{% tab "MongoDB" %}}
-
 | Tag Name | Tag Description |
 |---|---|
 | `invoice_id` | The unique identifier of the invoice. |
@@ -287,6 +276,17 @@ The following table contains a non-exhaustive list of out-of-the-box tags associ
 | `service_type` | Type of usage. Possible service types include:<br>- **automatic_clustering**: Refer to Automatic Clustering.<br>- **cloud_services**: Refer to Cloud service credit usage.<br>- **data_transfer**: Refer to Understanding data transfer cost.<br>- **logging**: Refer to Logging and Tracing Overview.<br>- **materialized_view**: Refer to Working with Materialized Views.<br>- **replication**: Refer to Introduction to replication and failover across multiple accounts.<br>- **query_acceleration**: Refer to Using the Query Acceleration Service.<br>- **search_optimization**: Refer to Search Optimization Service.<br>- **serverless_task**: Refer to Introduction to tasks.<br>- **snowpipe**: Refer to Snowpipe.<br>- **snowpipe_streaming**: Refer to Snowpipe Streaming.<br>- **storage**: Refer to Understanding storage cost.<br>- **warehouse_metering**: Refer to Virtual warehouse credit usage. Does not indicate usage of serverless or cloud services compute. |
 | `rating_type` | Indicates how the usage in the record is rated, or priced. Possible values include:<br>- **compute**<br>- **data_transfer**<br>- **storage**<br>- **Other** |
 | `billing_type` | Indicates what is being charged or credited. Possible billing types include:<br>- **consumption**: Usage associated with compute credits, storage costs, and data transfer costs.<br>- **rebate**: Usage covered by the credits awarded to the organization when it shared data with another organization.<br>- **priority support**: Charges for priority support services. This charge is associated with a stipulation in a contract, not with an account.<br>- **vps_deployment_fee**: Charges for a Virtual Private Snowflake deployment.<br>- **support_credit**: Snowflake Support credited the account to reverse charges attributed to an issue in Snowflake. |
+
+{{% /tab %}}
+{{% tab "Elastic Cloud" %}}
+| Tag Name | Tag Description |
+|---|---
+| `name` | The unique identifier of the Elastic Cloud resource. |
+| `price_per_hour` | The cost of the Elastic Cloud resource per hour. |
+| `kind` | The type of resource. |
+
+{{% /tab %}}
+{{% tab "MongoDB" %}}
 
 {{% /tab %}}
 {{% tab "OpenAI" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Fix tab order of Elastic Cloud for consistency between config and data collected sections. This does not include any text updates. 


<img width="615" alt="Screenshot 2024-08-15 at 9 36 02 AM" src="https://github.com/user-attachments/assets/b1d60c05-2ca9-432d-a09e-7c3aac78904a">

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->