### PR TITLE
adding integration between coscreen an incident management

### DIFF
--- a/content/en/coscreen/_index.md
+++ b/content/en/coscreen/_index.md
@@ -112,7 +112,7 @@ To configure this integration, install the [CoScreen Chrome extension][5] and si
 
 #### CoScreen + Datadog Incident Management
 
-In [Incident Management][9], use the **Meet on CoScreen** button to start a CoScreen meeting with incident responders.
+In [Incident Management][9], use the **Meet on CoScreen** button to start a CoScreen meeting with incident responders. To configure this, go to your [Incident Management Integration Settings][10] page and toggle on **Enable click-to-join CoScreen meeting buttons**.
 
 ## Security and privacy
 
@@ -146,3 +146,4 @@ For all the details on how CoScreen enables secure collaboration, read the [CoSc
 [7]: https://www.coscreen.co/security
 [8]: /sensitive_data_scanner/
 [9]: /service_management/incident_management/
+[10]: https://app.datadoghq.com/incidents/settings#Integrations

--- a/content/en/coscreen/_index.md
+++ b/content/en/coscreen/_index.md
@@ -110,6 +110,10 @@ To install the CoScreen Slack app, go to [coscreen.co/slack][4] and click on _Ad
 
 To configure this integration, install the [CoScreen Chrome extension][5] and sign in. Open any Google Calendar event and use the **Add CoScreen** button to make the event a CoScreen meeting.
 
+#### CoScreen + Datadog Incident Management
+
+In [Incident Management][9], use the **Meet on CoScreen** button to start a CoScreen meeting with incident responders.
+
 ## Security and privacy
 
  - **Network security**
@@ -141,3 +145,4 @@ For all the details on how CoScreen enables secure collaboration, read the [CoSc
 [6]: https://www.datadoghq.com/legal/privacy/
 [7]: https://www.coscreen.co/security
 [8]: /sensitive_data_scanner/
+[9]: /service_management/incident_management/

--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -181,6 +181,7 @@ For more information about Incident Management graphs, see [Incident Management 
 In addition to integrating with [Slack][7], Incident Management also integrates with:
 
 - [PagerDuty][13] and [OpsGenie][14] to send incident notifications to your on-call engineers.
+- [CoScreen][21] to launch collaborative meetings with multi-user screen sharing, remote control, and built-in audio and video chat.
 - [Jira][15] to create a Jira ticket for an incident.
 - [Webhooks][16] to send incident notifications using webhooks (for example, [sending SMS to Twilio][17]).
 - [Statuspage][19] to create and update Statuspage incidents.
@@ -214,3 +215,4 @@ Work through an example workflow in the [Getting Started with Incident Managemen
 [18]: /getting_started/incident_management
 [19]: /integrations/statuspage/
 [20]: /integrations/servicenow/
+[21]: /coscreen


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
You can launch CoScreen meetings from an incident details page. This PR adds this information to both the CoScreen page and the Incident Management index page.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->