### PR TITLE
(DOCS-8707) - query order of operations

### DIFF
--- a/content/en/service_management/app_builder/queries.md
+++ b/content/en/service_management/app_builder/queries.md
@@ -121,12 +121,11 @@ When executing a query, App Builder performs the following steps in the order li
    **Note**: If more than one query request occurs within the debounce interval, all requests except the last execution request are canceled.  
 4. Executes the query.
 5. Stores the raw query response in `query.rawOutputs`.  
-6. In parallel:
-   * Computes any expressions in the app that depend on data from the query output.
-   * Runs any post query transformation and sets `query.outputs` equal to the result. This process takes a snapshot of app data and passes it to the post query transformation.  
+6. Runs any post query transformation and sets `query.outputs` equal to the result. This process takes a snapshot of app data and passes it to the post query transformation.  
    **Note**: Post query transformations should be pure functions without side effects. For example, do not update a state variable in your post query transformation.
-7. Runs all **Reactions** from the app's **Events**, in the order in which they are defined in the UI. This involves taking a snapshot of the app which is used throughout the reaction's run. A new snapshot is taken before each reaction runs, and changes made by a previous reaction are visible to a subsequent reaction.
-8. If there is a **Polling interval** set, schedules the query to re-run the defined number of milliseconds in the future.
+7. Computes any expressions in the app that depend on data from the query output.
+8. Runs all **Reactions** from the app's **Events**, in the order in which they are defined in the UI. This involves taking a snapshot of the app which is used throughout the reaction's run. A new snapshot is taken before each reaction runs, and changes made by a previous reaction are visible to a subsequent reaction.
+9. If there is a **Polling interval** set, schedules the query to re-run the defined number of milliseconds in the future.
 
 
 ## Example apps

--- a/content/en/service_management/app_builder/queries.md
+++ b/content/en/service_management/app_builder/queries.md
@@ -111,6 +111,23 @@ To provide mocked outputs manually, perform the following steps:
 {{% /collapse-content %}} 
 
 
+## Order of operations
+
+When executing a query, App Builder performs the following steps in the order listed:
+
+1. Checks if there is a **Condition** expression for the query, and if so, checks that the condition is met. If it is not, execution stops.
+2. Evaluates any expressions in **Inputs** to determine the input data for the query.
+3. If the **Debounce** property is set, delays execution for the interval defined by the debounce value. If query inputs or their dependencies update during this time, the current query execution is stopped, and a new one starts from the beginning using the updated inputs.
+   **Note**: If more than one query request occurs within the debounce interval, all requests except the last execution request are canceled.  
+4. Executes the query.
+5. Stores the raw query response in `query.rawOutputs`.  
+6. In parallel:
+   * Computes any expressions in the app that depend on data from the query output.
+   * Runs any post query transformation and sets `query.outputs` equal to the result. This process takes a snapshot of app data and passes it to the post query transformation.  
+   **Note**: Post query transformations should be pure functions without side effects. For example, do not update a state variable in your post query transformation.
+7. Runs all **Reactions** from the app's **Events**, in the order in which they are defined in the UI. This involves taking a snapshot of the app which is used throughout the reaction's run. A new snapshot is taken before each reaction runs, and changes made by a previous reaction are visible to a subsequent reaction.
+8. If there is a **Polling interval** set, schedules the query to re-run the defined number of milliseconds in the future.
+
 
 ## Example apps
 

--- a/content/en/service_management/app_builder/queries.md
+++ b/content/en/service_management/app_builder/queries.md
@@ -117,11 +117,11 @@ When executing a query, App Builder performs the following steps in the order li
 
 1. Checks if there is a **Condition** expression for the query, and if so, checks that the condition is met. If it is not, execution stops.
 2. Evaluates any expressions in **Inputs** to determine the input data for the query.
-3. If the **Debounce** property is set, delays execution for the interval defined by the debounce value. If query inputs or their dependencies update during this time, the current query execution is stopped, and a new one starts from the beginning using the updated inputs.
+3. If the **Debounce** property is set, delays execution for the interval defined by the debounce value. If query inputs or their dependencies update during this time, the current query execution is stopped, and a new one starts from the beginning using the updated inputs.<br>
    **Note**: If more than one query request occurs within the debounce interval, all requests except the last execution request are canceled.  
 4. Executes the query.
 5. Stores the raw query response in `query.rawOutputs`.  
-6. Runs any post query transformation and sets `query.outputs` equal to the result. This process takes a snapshot of app data and passes it to the post query transformation.  
+6. Runs any post query transformation and sets `query.outputs` equal to the result. This process takes a snapshot of app data and passes it to the post query transformation.<br>
    **Note**: Post query transformations should be pure functions without side effects. For example, do not update a state variable in your post query transformation.
 7. Computes any expressions in the app that depend on data from the query output.
 8. Runs all **Reactions** from the app's **Events**, in the order in which they are defined in the UI. This involves taking a snapshot of the app which is used throughout the reaction's run. A new snapshot is taken before each reaction runs, and changes made by a previous reaction are visible to a subsequent reaction.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds the order of operations for query execution.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->