### PR TITLE
Separate SaaS Cost Integrations Partial Into Two Rows

### DIFF
--- a/layouts/partials/cloud_cost/cost-integrations.html
+++ b/layouts/partials/cloud_cost/cost-integrations.html
@@ -12,12 +12,24 @@
 
 <div class="saas-cost-integrations">
   <div class="container cards-dd">
-    <div class="row row-cols-7 g-2 g-xl-3 justify-content-center">
-      {{ range $saas_cost_integrations }}
+    <div class="row row-cols-4 g-2 g-xl-3 justify-content-center">
+      {{ range first 4 $saas_cost_integrations }}
       <div class="col">
         <a class="card h-100" href="{{ .href }}">
           <div class="card-body text-center py-2 px-1">
-            {{ partial "img.html" (dict "root" $root "src" .src "class" "img-fluid" "alt" .name "width" "200") }}
+            {{ partial "img.html" (dict "root" $root "src" .src "class" "img-fluid" "alt" .name "width" "150") }}
+          </div>
+        </a>
+      </div>
+      {{ end }}
+    </div>
+    <br>
+    <div class="row row-cols-4 g-2 g-xl-3 justify-content-center">
+      {{ range (last 4 $saas_cost_integrations) }}
+      <div class="col">
+        <a class="card h-100" href="{{ .href }}">
+          <div class="card-body text-center py-2 px-1">
+            {{ partial "img.html" (dict "root" $root "src" .src "class" "img-fluid" "alt" .name "width" "150") }}
           </div>
         </a>
       </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Breaking up the line of 8 integration tiles into two rows of 4 for clarity.

Chat with Kari on Slack

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

docs-staging.datadoghq.com/alai97/saas-cost-integrations-image-sizing/cloud_cost_management/saas_costs