### PR TITLE
[ASCII-2204] Update the fips-proxy version to latest 1.1.4 release in docs

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -27,7 +27,7 @@ algolia:
 Amazon ECS is a scalable, high-performance container orchestration service that supports Docker containers. With the Datadog Agent, you can monitor ECS containers and tasks on every EC2 instance in your cluster.
 
 <div class="alert alert-info">
-If you want to monitor <strong>ECS on Fargate</strong>, see <a href="/integrations/ecs_fargate/">Amazon ECS on AWS Fargate</a>.  
+If you want to monitor <strong>ECS on Fargate</strong>, see <a href="/integrations/ecs_fargate/">Amazon ECS on AWS Fargate</a>.
 </div>
 
 ## Setup
@@ -44,7 +44,7 @@ The following instructions assume that you have configured an EC2 cluster. See t
 
 ### Create an ECS task definition
 
-This [ECS task definition][30] launches the Datadog Agent container with the necessary configurations. When you need to modify the Agent configuration, update this task definition and redeploy the daemon service. You can configure this task definition by using the AWS Management Console, or with the [AWS CLI][9]. 
+This [ECS task definition][30] launches the Datadog Agent container with the necessary configurations. When you need to modify the Agent configuration, update this task definition and redeploy the daemon service. You can configure this task definition by using the AWS Management Console, or with the [AWS CLI][9].
 
 The following sample is a minimal configuration for core infrastructure monitoring. However, additional Task Definition samples with various features enabled are provided in the [Setup additional Agent features](#setup-additional-agent-features) section if you want to use those instead.
 
@@ -52,17 +52,17 @@ The following sample is a minimal configuration for core infrastructure monitori
 
 1. For Linux containers, download [datadog-agent-ecs.json][20].
     - If you are using Amazon Linux 1 (AL1, formerly Amazon Linux AMI), use [datadog-agent-ecs1.json][21]
-    - If you are using Windows, use [datadog-agent-ecs-win.json][22] 
+    - If you are using Windows, use [datadog-agent-ecs-win.json][22]
 
    <div class="alert alert-info">
    These files provide minimal configuration for core infrastructure monitoring. For more sample task definition files with various features enabled, see the <a href="#set-up-additional-agent-features">Set up additional Agent features</a> section on this page.
    </div>
 2. Edit your base task definition file
     - Set the `DD_API_KEY` environment variable by replacing `<YOUR_DATADOG_API_KEY>` with the [Datadog API key][14] for your account. Alternatively, you can also [supply the ARN of a secret stored in AWS Secrets Manager][16].
-    - Set the `DD_SITE` environment variable to your [Datadog site][13]. Your site is: {{< region-param key="dd_site" code="true" >}} 
+    - Set the `DD_SITE` environment variable to your [Datadog site][13]. Your site is: {{< region-param key="dd_site" code="true" >}}
 
       <div class="alert alert-info">
-      If <code>DD_SITE</code> is not set, it defaults to the <code>US1</code> site, <code>datadoghq.com</code>. 
+      If <code>DD_SITE</code> is not set, it defaults to the <code>US1</code> site, <code>datadoghq.com</code>.
       </div>
     - Optionally, add a `DD_TAGS` environment variable to specify any additional tags.
 
@@ -283,7 +283,7 @@ To send data to the Datadog for Government site, add the `fips-proxy` sidecar co
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:1.1.3",
+            "image": "datadog/fips-proxy:1.1.4",
             "portMappings": [
                 {
                     "containerPort": 9803,

--- a/content/es/containers/amazon_ecs/_index.md
+++ b/content/es/containers/amazon_ecs/_index.md
@@ -48,7 +48,7 @@ Si no tienes un clúster de EC2 Container Service en funcionamiento, consulta la
 
 ### Crear una tarea de ECS
 
-La definición de tarea inicia el contenedor del Datadog Agent con las configuraciones necesarias. Cuando necesites modificar la configuración del Agent, actualiza esta definición de tarea y vuelve a implementar el servicio daemon como resulte necesario. Puedes configurar la definición de tarea utilizando las [herramientas de interfaz de línea de comandos de AWS][9] o la consola web de Amazon. 
+La definición de tarea inicia el contenedor del Datadog Agent con las configuraciones necesarias. Cuando necesites modificar la configuración del Agent, actualiza esta definición de tarea y vuelve a implementar el servicio daemon como resulte necesario. Puedes configurar la definición de tarea utilizando las [herramientas de interfaz de línea de comandos de AWS][9] o la consola web de Amazon.
 
 El siguiente ejemplo es una configuración mínima para la monitorización de inraestructuras básicas, aunque también tienes más ejemplos de definiciones de tareas con varias funciones activadas en la sección [Configurar las funciones adicionales del Agent](#setup-additional-agent-features) por si quieres usarlas en su lugar.
 
@@ -56,11 +56,11 @@ El siguiente ejemplo es una configuración mínima para la monitorización de in
 
 1. Para contenedores Linux, descarga [datadog-agent-ecs.json][20]
     1. Si vas a usar una AMI de Amazon Linux 1, utiliza [datadog-agent-ecs1.json][21]
-    2. Si usas Windows, utiliza [datadog-agent-ecs-win.json][22] 
+    2. Si usas Windows, utiliza [datadog-agent-ecs-win.json][22]
 
 2. Editar tu archivo de definición de tarea de base
     1. Configura `<YOUR_DATADOG_API_KEY>` con la [clave de API de Datadog][14] para tu cuenta.
-    2. Configura la variable de entorno `DD_SITE` en {{< region-param key="dd_site" code="true" >}} 
+    2. Configura la variable de entorno `DD_SITE` en {{< region-param key="dd_site" code="true" >}}
 
         **Nota**: Si la variable de entorno `DD_SITE` no está configurada explícitamente, se establece de forma predeterminada en el sitio `US` de `datadoghq.com`. Si usas alguno de los otros sitios (`EU`, `US3` o `US1-FED`) y no la configuras, se genera un mensaje de clave de API no válida. Utiliza el [selector de sitio de documentación][13] para ver la documentación correspondiente al sitio que estés usando.
 
@@ -237,7 +237,7 @@ Para enviar datos al centro de datos GOVCLOUD de Datadog, añade el contenedor l
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:1.1.3",
+            "image": "datadog/fips-proxy:1.1.4",
             "portMappings": [
                 {
                     "containerPort": 9803,

--- a/content/fr/containers/amazon_ecs/_index.md
+++ b/content/fr/containers/amazon_ecs/_index.md
@@ -29,7 +29,7 @@ title: Amazon ECS
 Amazon ECS est un service d'orchestration de conteneurs évolutif et à hautes performances qui prend en charge les conteneurs Docker. Grâce à l'Agent Datadog, vous pouvez surveiller des conteneurs et tâches ECS sur chaque instance EC2 de votre cluster.
 
 <div class="alert alert-info">
-Si vous souhaitez surveiller <strong>ECS sur Fargate</strong>, consultez la section <a href="/integrations/ecs_fargate/">Amazon ECS sur AWS Fargate</a>.  
+Si vous souhaitez surveiller <strong>ECS sur Fargate</strong>, consultez la section <a href="/integrations/ecs_fargate/">Amazon ECS sur AWS Fargate</a>.
 </div>
 
 ## Configuration
@@ -64,7 +64,7 @@ L'exemple suivant montre comment effectuer une surveillance générale de l'infr
     - Définissez la variable d'environnement `DD_SITE` sur votre [site Datadog][13], à savoir {{< region-param key="dd_site" code="true" >}}.
 
       <div class="alert alert-info">
-      If <code>DD_SITE</code> is not set, it defaults to the <code>US1</code> site, <code>datadoghq.com</code>. 
+      If <code>DD_SITE</code> is not set, it defaults to the <code>US1</code> site, <code>datadoghq.com</code>.
       </div>
     - Si vous le souhaitez, ajoutez une variable d'environnement `DD_TAGS` afin de spécifier des tags supplémentaires.
 
@@ -285,7 +285,7 @@ Pour envoyer des données à Datadog pour le site gouvernemental, ajoutez le con
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:1.1.3",
+            "image": "datadog/fips-proxy:1.1.4",
             "portMappings": [
                 {
                     "containerPort": 9803,

--- a/content/ja/containers/amazon_ecs/_index.md
+++ b/content/ja/containers/amazon_ecs/_index.md
@@ -63,7 +63,7 @@ ECS コンテナおよびタスクを監視するには、ECS クラスター内
     - ご利用の [Datadog サイト][13]を `DD_SITE` 環境変数に設定します。サイトは次のとおりです: {{< region-param key="dd_site" code="true" >}}
 
       <div class="alert alert-info">
-      If <code>DD_SITE</code> is not set, it defaults to the <code>US1</code> site, <code>datadoghq.com</code>. 
+      If <code>DD_SITE</code> is not set, it defaults to the <code>US1</code> site, <code>datadoghq.com</code>.
       </div>
     - オプションで、`DD_TAGS` 環境変数を追加して、追加のタグを指定します。
 
@@ -284,7 +284,7 @@ Agent を `awsvpc` モードで実行することは可能ですが、Datadog �
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:1.1.3",
+            "image": "datadog/fips-proxy:1.1.4",
             "portMappings": [
                 {
                     "containerPort": 9803,

--- a/content/ko/containers/amazon_ecs/_index.md
+++ b/content/ko/containers/amazon_ecs/_index.md
@@ -28,7 +28,7 @@ title: Amazon ECS
 아마존 ECS는 도커(Docker) 컨테이너를 지원하며 확장성과 성능이 뛰어난 컨테이너 오케스트레이션 서비스입니다. Datadog Agent와 함께 사용하면 클러스터 내 모든 EC2 인스턴스의 ECS 컨테이너와 작업을 모니터링할 수 있습니다.
 
 <div class="alert alert-info">
-Fargate에서 <strong>ECS를 모니터링하려면</strong>, <a href="/integrations/ecs_fargate/">AWS Fargate 기반 Amazon ECS</a>를 참조하세요.  
+Fargate에서 <strong>ECS를 모니터링하려면</strong>, <a href="/integrations/ecs_fargate/">AWS Fargate 기반 Amazon ECS</a>를 참조하세요.
 </div>
 
 ## 설정
@@ -63,7 +63,7 @@ ECS 컨테이너 및 작업을 모니터링하려면 Datadog 에이전트를 ECS
     - `DD_SITE` 환경 변수를 [Datadog 사이트][13]로 설정합니다. 귀하의 사이트는 {{< region-param key="dd_site" code="true" >}}입니다.
 
       <div class="alert alert-info">
-      If <code>DD_SITE</code> is not set, it defaults to the <code>US1</code> site, <code>datadoghq.com</code>. 
+      If <code>DD_SITE</code> is not set, it defaults to the <code>US1</code> site, <code>datadoghq.com</code>.
       </div>
     - 선택적으로 `DD_TAGS` 환경 변수를 추가하여 태그 을 추가로 지정합니다.
 
@@ -200,7 +200,7 @@ EC2 인스턴스의 보안 그룹 설정이 APM 및 DogStatsD의 포트를 공�
 }
 {{< /highlight >}}
 
-#### 네트워크 성능 모니터링 
+#### 네트워크 성능 모니터링
 
 <div class="alert alert-warning">
 이 기능은 리눅스에서만 사용할 수 있습니다.
@@ -284,7 +284,7 @@ Agent v6.10+인 경우 호스트 인스턴스의 보안 그룹이 관련 포트�
      (...)
           {
             "name": "fips-proxy",
-            "image": "datadog/fips-proxy:1.1.3",
+            "image": "datadog/fips-proxy:1.1.4",
             "portMappings": [
                 {
                     "containerPort": 9803,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

fips-proxy has [released 1.1.4](https://github.com/DataDog/fips-proxy/releases/tag/1.1.4) and this PR updates the respective documentation to mention that version instead of 1.1.3

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->