### PR TITLE
(DOCS-8744) - document App Builder tab and text area components

### DIFF
--- a/content/en/service_management/app_builder/components/_index.md
+++ b/content/en/service_management/app_builder/components/_index.md
@@ -64,7 +64,7 @@ Event
 : **Value**: click
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, open url, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, open url, download file, set state variable value
 
 For more information on events, see [Events][1].
 
@@ -176,7 +176,7 @@ Event
 : **Value**: change<br>
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 For more information on events, see [Events][1].
 
@@ -274,7 +274,7 @@ Event
 : **Value**: change
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 For more information on events, see [Events][1].
 
@@ -310,7 +310,7 @@ Event
 : **Values**: toggleOpen, close, open
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 State Function
 : setIsOpen<br>
@@ -370,7 +370,7 @@ Event
 : **Value**: change
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 State Function
 : setValue<br>
@@ -436,7 +436,7 @@ Event
 : **Value**: change
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 State Function
 : setValue<br>
@@ -484,7 +484,7 @@ Event
 : **Values**: change, submit
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 State Function
 : setValue<br>
@@ -557,7 +557,7 @@ Event
 : **Value**: change
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 State Function
 : setValue<br>
@@ -575,6 +575,62 @@ To view this component in context, see the [Metrics Explorer & Monitors Builder]
 {{% /collapse-content %}}
 
 
+{{% collapse-content title="Tab" level="h3" %}}
+Tab components have the following properties.
+
+### Tabs
+
+A list of tab views. Use the **+ (plus)** to add additional views.
+
+
+### Style
+
+Style
+: The coloring style used for the tab component.<br>
+**Provided values**: Default, purple, pink, orange, red, green
+
+Alignment
+: The way the tabs are aligned within the tab component.<br>
+**Provided values**: Horizontal (→), vertical (↓)
+
+Impact
+: Controls whether the selected tab's background is fully colored or only a small band at the bottom is colored.<br>
+**Provided values**: High, low
+
+
+### Appearance
+
+Hide Tabs
+: Controls whether the tab markers are displayed.<br>
+**Provided values**: on, off
+
+Hide Body
+: Controls whether the body of the tabs are displayed.<br>
+**Provided values**: on, off
+
+Is Visible
+: Determines whether the component is visible to the end-user. In edit mode, all components remain visible.<br>
+**Provided values**: on, off
+
+### Events
+
+Event
+: **Value**: change
+
+Reaction
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
+
+State Function
+: setTabIndex<br>
+**Example**: `tab0.setTabIndex(0)` sets the value of the `tab0` component to the first tab.
+
+For more information on events, see [Events][1].
+
+### Inspect data
+
+Displays property and value pairs in JSON format.
+
+{{% /collapse-content %}}
 
 {{% collapse-content title="Table" level="h3" %}}
 Table components have the following properties.
@@ -677,7 +733,7 @@ Event
 : **Values**: pageChange, tableRowClick
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 State Functions
 : setSelectedRow<br>
@@ -738,6 +794,50 @@ To view this component in context, see the [Metrics Explorer & Monitors Builder]
 {{% /collapse-content %}}
 
 
+{{% collapse-content title="Text area" level="h3" %}}
+Text area components have the following properties.
+
+Label
+: The text that displays at the top of the component.<br>
+**Value**: string or expression
+
+Default value
+: The value that is selected when the text area loads.<br>
+**Value**: string or expression
+
+Placeholder text
+: The text that displays when no value is entered.<br>
+**Value**: string or expression
+
+### Appearance
+
+Is Disabled
+: Applies disabled styling and removes interactions.<br>
+**Provided values**: on, off
+
+Is Visible
+: Determines whether the component is visible to the end-user. In edit mode, all components remain visible.<br>
+**Provided values**: on, off
+
+### Events
+
+Event
+: **Values**: change, submit
+
+Reaction
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
+
+State Function
+: setValue<br>
+**Example**: `textArea0.setValue("text")` sets the value of the `textArea0` component to `"text"`.
+
+For more information on events, see [Events][1].
+
+### Inspect data
+
+Displays property and value pairs in JSON format.
+{{% /collapse-content %}}
+
 
 {{% collapse-content title="Text input" level="h3" %}}
 Text input components have the following properties.
@@ -770,7 +870,7 @@ Event
 : **Values**: change, submit
 
 Reaction
-: **Values**: custom, set component state, trigger query, open modal, close modal, download file
+: **Values**: custom, set component state, trigger query, open modal, close modal, download file, set state variable value
 
 State Function
 : setValue<br>

--- a/content/en/service_management/app_builder/events.md
+++ b/content/en/service_management/app_builder/events.md
@@ -26,25 +26,25 @@ For example, the [GitHub PR summarizer][2] blueprint uses a **Summarize** button
 
 App Builder provides functions for some types of app state changes on specific components.
 
-setValue
-: Sets the value of an element to the value that you provide to the function.<br>
-**Examples**: See the [Components][1] documentation page sections for the **number input**, **radio button**, **search**, **select**, **text area**, and **text input** components.
-
 setIsOpen
 : Sets the status of a modal to open or closed based on the boolean value that you provide.<br>
 **Example**: See the [Components][1] documentation page section for the **modal** component.
 
-setTabIndex
-: Sets the `selectedTabIndex` property of the table component to the tab index that you specify.<br>
-**Example**: See the [Components][1] documentation page section for the **tab** component.
+setPageIndex
+: Sets the `pageIndex` property of the table component to the page that you specify. Works with the server side pagination type.<br>
+**Example**: See the [Components][1] documentation page section for the **table** component.
 
 setSelectedRow
 : Sets the `selectedRow` property of the table component to the row that you specify.<br>
 **Example**: See the [Components][1] documentation page section for the **table** component.
 
-setPageIndex
-: Sets the `pageIndex` property of the table component to the page that you specify. Works with the server side pagination type.<br>
-**Example**: See the [Components][1] documentation page section for the **table** component.
+setTabIndex
+: Sets the `selectedTabIndex` property of the table component to the tab index that you specify.<br>
+**Example**: See the [Components][1] documentation page section for the **tab** component.
+
+setValue
+: Sets the value of an element to the value that you provide to the function.<br>
+**Examples**: See the [Components][1] documentation page sections for the **number input**, **radio button**, **search**, **select**, **text area**, and **text input** components.
 
 To see what state functions are available for a given component, see [Components][1].
 

--- a/content/en/service_management/app_builder/events.md
+++ b/content/en/service_management/app_builder/events.md
@@ -28,11 +28,15 @@ App Builder provides functions for some types of app state changes on specific c
 
 setValue
 : Sets the value of an element to the value that you provide to the function.<br>
-**Examples**: See the [Components][1] documentation page sections for the **number input**, **radio button**, **search**, **select**, and **text input** components.
+**Examples**: See the [Components][1] documentation page sections for the **number input**, **radio button**, **search**, **select**, **text area**, and **text input** components.
 
 setIsOpen
 : Sets the status of a modal to open or closed based on the boolean value that you provide.<br>
 **Example**: See the [Components][1] documentation page section for the **modal** component.
+
+setTabIndex
+: Sets the `selectedTabIndex` property of the table component to the tab index that you specify.<br>
+**Example**: See the [Components][1] documentation page section for the **tab** component.
 
 setSelectedRow
 : Sets the `selectedRow` property of the table component to the row that you specify.<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

* Documents tab and text area components on Components page
* Adds related content to Events page
* Adds event reaction item to misc places on Components page where there is a new option

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->