### PR TITLE
[SVLS-5280][incident-29739] Update docs to simplify serverless-init .NET tracer installation

### DIFF
--- a/layouts/shortcodes/svl-init-dotnet.md
+++ b/layouts/shortcodes/svl-init-dotnet.md
@@ -1,8 +1,8 @@
 Add the following instructions and arguments to your Dockerfile.
 
 ```dockerfile
+# For alpine or arm64 builds, refer to the explanation section
 COPY --from=datadog/serverless-init:1 / /app/
-# For alpine or arm64 builds, refer to tracer installation of the explanation section
 RUN chmod +x /app/dotnet.sh && /app/dotnet.sh
 
 ENV DD_SERVICE=datadog-demo-run-dotnet
@@ -58,8 +58,8 @@ CMD ["dotnet", "helloworld.dll"]
 If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
 ```dockerfile
-COPY --from=datadog/serverless-init:1 / /app/
 # For alpine or arm64 builds, refer to tracer installation of the explanation section
+COPY --from=datadog/serverless-init:1 / /app/
 RUN chmod +x /app/dotnet.sh && /app/dotnet.sh
 
 ENV DD_SERVICE=datadog-demo-run-dotnet
@@ -71,8 +71,8 @@ CMD ["/app/datadog-init", "dotnet", "helloworld.dll"]
 If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
 ```dockerfile
-COPY --from=datadog/serverless-init:1 / /app/
 # For alpine or arm64 builds, refer to tracer installation of the explanation section
+COPY --from=datadog/serverless-init:1 / /app/
 RUN chmod +x /app/dotnet.sh && /app/dotnet.sh
 
 ENV DD_SERVICE=datadog-demo-run-dotnet

--- a/layouts/shortcodes/svl-init-dotnet.md
+++ b/layouts/shortcodes/svl-init-dotnet.md
@@ -3,7 +3,7 @@ Add the following instructions and arguments to your Dockerfile.
 ```dockerfile
 COPY --from=datadog/serverless-init:1 / /app/
 # For alpine or arm64 builds, refer to tracer installation of the explanation section
-RUN chmod u+x /app/dotnet.sh && /app/dotnet.sh
+RUN chmod +x /app/dotnet.sh && /app/dotnet.sh
 
 ENV DD_SERVICE=datadog-demo-run-dotnet
 ENV DD_ENV=datadog-demo
@@ -22,7 +22,7 @@ CMD ["dotnet", "helloworld.dll"]
 2. Copy the Datadog .NET tracer into your Docker image.
    For linux/amd64, include the following:
    ```dockerfile
-   RUN chmod u+x /app/dotnet.sh && /app/dotnet.sh
+   RUN chmod +x /app/dotnet.sh && /app/dotnet.sh
    ```
 
    For other architecture types, configure your Dockerfile like so:
@@ -60,7 +60,7 @@ If you already have an entrypoint defined inside your Dockerfile, you can instea
 ```dockerfile
 COPY --from=datadog/serverless-init:1 / /app/
 # For alpine or arm64 builds, refer to tracer installation of the explanation section
-RUN chmod u+x /app/dotnet.sh && /app/dotnet.sh
+RUN chmod +x /app/dotnet.sh && /app/dotnet.sh
 
 ENV DD_SERVICE=datadog-demo-run-dotnet
 ENV DD_ENV=datadog-demo
@@ -73,7 +73,7 @@ If you require your entrypoint to be instrumented as well, you can swap your ent
 ```dockerfile
 COPY --from=datadog/serverless-init:1 / /app/
 # For alpine or arm64 builds, refer to tracer installation of the explanation section
-RUN chmod u+x /app/dotnet.sh && /app/dotnet.sh
+RUN chmod +x /app/dotnet.sh && /app/dotnet.sh
 
 ENV DD_SERVICE=datadog-demo-run-dotnet
 ENV DD_ENV=datadog-demo

--- a/layouts/shortcodes/svl-init-dotnet.md
+++ b/layouts/shortcodes/svl-init-dotnet.md
@@ -1,12 +1,10 @@
 Add the following instructions and arguments to your Dockerfile.
 
 ```dockerfile
-COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-# For arm64 use datadog-dotnet-apm-2.57.0.arm64.tar.gz
-# For alpine use datadog-dotnet-apm-2.57.0-musl.tar.gz
-ARG TRACER_VERSION
-ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz /tmp/datadog-dotnet-apm.tar.gz
-RUN mkdir -p /dd_tracer/dotnet/ && tar -xzvf /tmp/datadog-dotnet-apm.tar.gz -C /dd_tracer/dotnet/ && rm /tmp/datadog-dotnet-apm.tar.gz
+COPY --from=datadog/serverless-init:1 / /app/
+# For alpine or arm64 builds, refer to tracer installation of the explanation section
+RUN chmod u+x /app/dotnet.sh && /app/dotnet.sh
+
 ENV DD_SERVICE=datadog-demo-run-dotnet
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -18,10 +16,16 @@ CMD ["dotnet", "helloworld.dll"]
 
 1. Copy the Datadog `serverless-init` into your Docker image.
    ```dockerfile
-   COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
+   COPY --from=datadog/serverless-init:1 / /app/
    ```
 
 2. Copy the Datadog .NET tracer into your Docker image.
+   For linux/amd64, include the following:
+   ```dockerfile
+   RUN chmod u+x /app/dotnet.sh && /app/dotnet.sh
+   ```
+
+   For other architecture types, configure your Dockerfile like so:
    ```dockerfile
    # For arm64 use datadog-dotnet-apm-2.57.0.arm64.tar.gz
    # For alpine use datadog-dotnet-apm-2.57.0-musl.tar.gz
@@ -54,12 +58,10 @@ CMD ["dotnet", "helloworld.dll"]
 If you already have an entrypoint defined inside your Dockerfile, you can instead modify the CMD argument.
 
 ```dockerfile
-COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-# For arm64 use datadog-dotnet-apm-2.57.0.arm64.tar.gz
-# For alpine use datadog-dotnet-apm-2.57.0-musl.tar.gz
-ARG TRACER_VERSION
-ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz /tmp/datadog-dotnet-apm.tar.gz
-RUN mkdir -p /dd_tracer/dotnet/ && tar -xzvf /tmp/datadog-dotnet-apm.tar.gz -C /dd_tracer/dotnet/ && rm /tmp/datadog-dotnet-apm.tar.gz
+COPY --from=datadog/serverless-init:1 / /app/
+# For alpine or arm64 builds, refer to tracer installation of the explanation section
+RUN chmod u+x /app/dotnet.sh && /app/dotnet.sh
+
 ENV DD_SERVICE=datadog-demo-run-dotnet
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1
@@ -69,12 +71,10 @@ CMD ["/app/datadog-init", "dotnet", "helloworld.dll"]
 If you require your entrypoint to be instrumented as well, you can swap your entrypoint and CMD arguments instead. For more information, see [How `serverless-init` works](#how-serverless-init-works).
 
 ```dockerfile
-COPY --from=datadog/serverless-init:1 /datadog-init /app/datadog-init
-# For arm64 use datadog-dotnet-apm-2.57.0.arm64.tar.gz
-# For alpine use datadog-dotnet-apm-2.57.0-musl.tar.gz
-ARG TRACER_VERSION
-ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz /tmp/datadog-dotnet-apm.tar.gz
-RUN mkdir -p /dd_tracer/dotnet/ && tar -xzvf /tmp/datadog-dotnet-apm.tar.gz -C /dd_tracer/dotnet/ && rm /tmp/datadog-dotnet-apm.tar.gz
+COPY --from=datadog/serverless-init:1 / /app/
+# For alpine or arm64 builds, refer to tracer installation of the explanation section
+RUN chmod u+x /app/dotnet.sh && /app/dotnet.sh
+
 ENV DD_SERVICE=datadog-demo-run-dotnet
 ENV DD_ENV=datadog-demo
 ENV DD_VERSION=1


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This should follow changes made here: https://github.com/DataDog/datadog-lambda-extension/pull/366 

https://docs-staging.datadoghq.com/dylan/sls-init-dotnet/serverless/google_cloud_run/?code-lang=dotnet

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->