### PR TITLE
DOCS-8729 Software Composition Analysis Update

### DIFF
--- a/content/en/code_analysis/software_composition_analysis/_index.md
+++ b/content/en/code_analysis/software_composition_analysis/_index.md
@@ -39,15 +39,10 @@ Software Composition Analysis (SCA) scans open source libraries imported into re
 SCA scans can be run directly through Datadog or in your CI pipelines using [Code Analysis][3] to detect library vulnerabilities before they reach production. Datadog also offers runtime detection through [Datadog Application Security][1].
 
 ## Set up Software Composition Analysis
+
 SCA supports scanning for libraries in the following languages and technologies:
 
-- .NET
-- Go
-- JVM
-- Node.js
-- PHP
-- Python
-- Ruby
+{{< partial name="code_analysis/sca-getting-started.html" >}}
 
 To get started, set up Software Composition Analysis on the [**Code Analysis** page][2] or see the [Setup documentation][3].
 

--- a/layouts/partials/code_analysis/languages-getting-started.html
+++ b/layouts/partials/code_analysis/languages-getting-started.html
@@ -19,7 +19,7 @@
       <div class="col">
         <a class="card h-100" href="/code_analysis/static_analysis_rules?languages=TypeScript">
           <div class="card-body text-center py-2 px-1 d-flex justify-content-center align-items-center">
-            {{ partial "img.html" (dict "root" . "src" "integrations_logos/typescript_large.svg" "class" "img-fluid" "alt" "typescript" "width" "100") }}
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/typescript_large.svg" "class" "img-fluid" "alt" "typescript" "width" "50") }}
           </div>
         </a>
       </div>

--- a/layouts/partials/code_analysis/sca-getting-started.html
+++ b/layouts/partials/code_analysis/sca-getting-started.html
@@ -1,0 +1,33 @@
+{{ $root := . }}
+{{ $supported_languages := slice
+    (dict "name" "Python" "href" "/code_analysis/software_composition_analysis#lockfiles" "src" "integrations_logos/python_avatar.svg" "width" "50")
+    (dict "name" "JavaScript" "href" "/code_analysis/software_composition_analysis#lockfiles" "src" "integrations_logos/javascript_large.png" "width" "50")
+    (dict "name" "Java" "href" "/code_analysis/software_composition_analysis#lockfiles" "src" "integrations_logos/java_avatar.svg" "width" "50")
+    (dict "name" "CSharp" "href" "/code_analysis/software_composition_analysis#lockfiles" "src" "integrations_logos/dotnet_avatar.svg" "width" "50")
+    (dict "name" "Go" "href" "/code_analysis/software_composition_analysis#lockfiles" "src" "integrations_logos/golang-avatar.png" "width" "60")
+    (dict "name" "Rust" "href" "/code_analysis/software_composition_analysis#lockfiles" "src" "integrations_logos/rust.png" "width" "60")
+    (dict "name" "Ruby" "href" "/code_analysis/software_composition_analysis#lockfiles" "src" "integrations_logos/ruby_avatar.svg" "width" "45")
+    (dict "name" "PHP" "href" "/code_analysis/software_composition_analysis#lockfiles" "src" "integrations_logos/php_opcache.png" "width" "80")
+    (dict "name" "Other" "href" "/code_analysis/software_composition_analysis/generic_ci_providers" "src" "integrations_logos/datadog_avatar.svg" "width" "50")
+}}
+
+<div class="sca-supported-languages">
+  <div class="container cards-dd">
+    <div class="row justify-content-center">
+      {{ range $index, $lang := $supported_languages }}
+        <div class="col">
+          <a class="card h-100" href="{{ $lang.href }}">
+            <div class="card-body text-center py-2 px-1 d-flex justify-content-center align-items-center">
+              {{ partial "img.html" (dict "root" $root "src" $lang.src "class" "img-fluid" "alt" $lang.name "width" $lang.width) }}
+            </div>
+          </a>
+        </div>
+        {{ if eq (mod (add $index 1) 3) 0 }}
+          </div>
+          <br>
+          <div class="row justify-content-center">
+        {{ end }}
+      {{ end }}
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Add a language partial for the SCA product landing page + adjusts the TS size for Static Analysis partial.

Received feedback that the bulleted list of supported languages was confusing on the [SCA landing page](https://docs.datadoghq.com/code_analysis/software_composition_analysis/#set-up-software-composition-analysis) so we are adding a partial here to display the supported languages for SCA, which is different from Static Analysis.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->