### PR TITLE
Add list of new template variables available for Error Tracking monitor alert message

### DIFF
--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -112,7 +112,7 @@ For more information about advanced alert options such as evaluation frequency, 
 To display triggering tags in the notification title, click **Include triggering tags in notification title**.
 
 In addition to [matching attribute variables][7], the following Error Tracking specific variables are available
-on alert message notifications:
+for alert message notifications:
 
 * `{{issue.attributes.error.type}}`
 * `{{issue.attributes.error.message}}`

--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -111,6 +111,17 @@ For more information about advanced alert options such as evaluation frequency, 
 
 To display triggering tags in the notification title, click **Include triggering tags in notification title**.
 
+In addition to [matching attribute variables][7], the following Error Tracking specific variables are available
+on alert message notifications:
+
+* `{{issue.attributes.error.type}}`
+* `{{issue.attributes.error.message}}`
+* `{{issue.attributes.error.stack}}`
+* `{{issue.attributes.error.file}}`
+* `{{issue.attributes.error.is_crash}}`
+* `{{issue.attributes.error.category}}`
+* `{{issue.attributes.error.handling}}`
+
 For more information about the **Configure notifications and automations** section, see [Notifications][5].
 
 
@@ -130,3 +141,4 @@ Error Tracking monitors use [Issue States][2] to ensure that your alerts stay fo
 [4]: /monitors/configuration/#advanced-alert-conditions
 [5]: /monitors/notify/
 [6]: /logs/
+[7]: /monitors/notify/variables/#matching-attributetag-variables


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We're adding "unified" template variables to Error Tracking monitors.
This PR adds the list of additional template variables available for alert messages for Error Tracking monitors only.

The backend's not deployed yet, please don't merge upon approval.
Will explicitly ask for it, thanks.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->