### PR TITLE
Remove service validation for DORA deployments from APIs

### DIFF
--- a/content/en/dora_metrics/deployments/deployment_api.md
+++ b/content/en/dora_metrics/deployments/deployment_api.md
@@ -34,12 +34,12 @@ further_reading:
 
 ## Overview
 
-To send your own deployment events, use the [DORA Metrics API][1] or the [`datadog-ci dora deployment`][2] command. 
+To send your own deployment events, use the [DORA Metrics API][1] or the [`datadog-ci dora deployment`][2] command.
 
 The following attributes are required:
 - `started_at`: The time the deployment started.
 - `finished_at`: The time the deployment finished.
-- `service`: The service that was deployed. The provided service must be registered in the [Service Catalog][3] (see [Adding Entries to Service Catalog][4]) with metadata set up (see [Adding Metadata][5]). The `team` ownership of the service is automatically inferred from the Service Catalog and associated with all metrics.
+- `service`: The service that was deployed. If the provided service is registered in the [Service Catalog][3] with metadata set up (see [Adding Metadata][5]), the `team` of the service is automatically retrieved and associated with all metrics.
 
 The `repository_url` and `commit_sha` attributes are also required for calculating the Change Lead Time metric. You can optionally specify the `env` attribute to filter your DORA metrics by environment on the [**DORA Metrics** page][7].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Remove service validation for DORA deployments from APIs

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->