### PR TITLE
[ci-visibility] Add troubleshooting section for missing gitlab variables

### DIFF
--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -38,11 +38,15 @@ The pipeline page only displays pipelines with no Git information, or pipelines 
 
 Missing stages or jobs in the _Pipeline Details_ page might be due to a wrong configuration. Make sure that the pipeline name stored in the stage or job executions matches the **same** name of their parent pipeline. If you are using custom pipelines, refer to the [public API endpoint specification][15].
 
+## Missing variables in Gitlab pipelines
+
+[User-defined variables in Gitlab][16] should be reported in the field `@ci.parameters`. This information is only present in some cases like downstream pipelines, and may be missing for the rest of the cases since Gitlab [does not always report this information][17] to Datadog.
+
 ### Limitations on running pipelines
 
 #### Delivery of webhook events is not guaranteed by CI providers
 
-Running pipelines support relies on data sent from CI providers indicating execution status. If this data is not available, executions marked as `Running` in Datadog may have already finished. 
+Running pipelines support relies on data sent from CI providers indicating execution status. If this data is not available, executions marked as `Running` in Datadog may have already finished.
 
 #### Maximum duration for a pipeline execution
 
@@ -67,3 +71,5 @@ A pipeline execution can maintain `Running` status for a maximum of three days. 
 [13]: /api/latest/ci-visibility-pipelines/#send-pipeline-event
 [14]: /continuous_integration/tests/#supported-features
 [15]: /continuous_integration/pipelines/#supported-features
+[16]: https://docs.gitlab.com/ee/ci/variables/#define-a-cicd-variable-in-the-gitlab-ciyml-file
+[17]: https://gitlab.com/gitlab-org/gitlab/-/issues/29539

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -40,7 +40,7 @@ Missing stages or jobs in the _Pipeline Details_ page might be due to a wrong co
 
 ## Missing variables in Gitlab pipelines
 
-[User-defined variables in Gitlab][16] should be reported in the field `@ci.parameters`. This information is only present in some cases like downstream pipelines, and may be missing for the rest of the cases since Gitlab [does not always report this information][17] to Datadog.
+[User-defined variables in Gitlab][16] should be reported in the field `@ci.parameters` in CI Visibility. However, this information is only present in some cases like downstream pipelines, and may be missing for the rest of the cases since Gitlab [does not always report this information][17] to Datadog.
 
 ### Limitations on running pipelines
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Gitlab variables sometimes do not get reported to us due to a Gitlab bug. Added a troubleshooting section referring the gitlab issue.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->