### PR TITLE
Remove reference to missing image

### DIFF
--- a/content/en/database_monitoring/database_hosts.md
+++ b/content/en/database_monitoring/database_hosts.md
@@ -57,13 +57,9 @@ On the **Metrics** tab of the host details panel, you can view and filter metric
 
 ## Active connections
 
-The **Active Connections** tab of the host details panel displays the live queries being executed on the host.
+The **Active Connections** tab of the host details panel displays the live queries being executed on the host. Click on a query statement to open a panel that includes event attributes, related traces, and other relevant details.
 
 {{< img src="database_monitoring/db-list-active-connections-2.png" alt="The Active Connections tab of the details panel for a single database host on the Databases page" style="width:90%;" >}}
-
-Click on a query statement to open a panel that includes event attributes, related traces, and other relevant details.
-
-{{< img src="database_monitoring/db-list-active-connection-details-2.png" alt="Details panel for an individual active connection" style="width:90%;" >}}
 
 ## Schema
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Remove a reference to an image that isn't in the repo. I wrote the original PR that introduces the issue, and both images were still on my machine. In looking at them, it seems one image was intended to replace the other, they have nearly identical contents but the one I've kept in this PR includes an expanded details pane.

DOCS-8755

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->