### PR TITLE
Replace error.msg attribute with error.message

### DIFF
--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -422,7 +422,7 @@ apm_config:
     - name: "error.stack"
       pattern: "(?s).*"
     # Replace series of numbers in error messages
-    - name: "error.msg"
+    - name: "error.message"
       pattern: "[0-9]{10}"
       repl: "[REDACTED]"
 ```
@@ -452,7 +452,7 @@ DD_APM_REPLACE_TAGS=[
         "pattern": "(?s).*"
       },
       {
-        "name": "error.msg",
+        "name": "error.message",
         "pattern": "[0-9]{10}",
         "repl": "[REDACTED]"
       }
@@ -490,7 +490,7 @@ Set the `DD_APM_REPLACE_TAGS` environment variable:
               "pattern": "(?s).*"
             },
             {
-              "name": "error.msg",
+              "name": "error.message",
               "pattern": "[0-9]{10}",
               "repl": "[REDACTED]"
             }
@@ -539,7 +539,7 @@ agents:
 {{% tab "docker-compose" %}}
 
 ```docker-compose.yaml
-- DD_APM_REPLACE_TAGS=[{"name":"http.url","pattern":"token/(.*)","repl":"?"},{"name":"resource.name","pattern":"(.*)\/$","repl":"$1"},{"name":"*","pattern":"foo","repl":"bar"},{"name":"error.stack","pattern":"(?s).*"},{"name":"error.msg","pattern":"[0-9]{10}","repl":"[REDACTED]"}]
+- DD_APM_REPLACE_TAGS=[{"name":"http.url","pattern":"token/(.*)","repl":"?"},{"name":"resource.name","pattern":"(.*)\/$","repl":"$1"},{"name":"*","pattern":"foo","repl":"bar"},{"name":"error.stack","pattern":"(?s).*"},{"name":"error.message","pattern":"[0-9]{10}","repl":"[REDACTED]"}]
 ```
 
 {{% /tab %}}

--- a/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/cpp/dd-api.md
@@ -108,7 +108,7 @@ span. For example:
 span.set_error(true);
 ```
 
-Add more specific information about the error by setting any combination of `error.msg`, `error.stack`, or `error.type` by using respectively `Span::set_error_message`, `Span::set_error_stack` and `Span::set_error_type`. See [Error Tracking][4] for more information about error tags.
+Add more specific information about the error by setting any combination of `error.message`, `error.stack`, or `error.type` by using respectively `Span::set_error_message`, `Span::set_error_stack` and `Span::set_error_type`. See [Error Tracking][4] for more information about error tags.
 
 An example of adding a combination of error tags:
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet/dd-api.md
@@ -197,7 +197,7 @@ catch(Exception e)
 ```
 
 This sets the following tags on the span:
-- `"error.msg":exception.Message`
+- `"error.message":exception.Message`
 - `"error.stack":exception.ToString()`
 - `"error.type":exception.GetType().ToString()`
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
@@ -109,7 +109,7 @@ try
 catch(Exception e)
 {
     activity?.SetTag("error", 1);
-    activity?.SetTag("error.msg", exception.Message);
+    activity?.SetTag("error.message", exception.Message);
     activity?.SetTag("error.stack", exception.ToString());
     activity?.SetTag("error.type", exception.GetType().ToString());
 }

--- a/content/en/tracing/trace_collection/custom_instrumentation/nodejs/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/nodejs/dd-api.md
@@ -112,7 +112,7 @@ To learn more, read [API details for individual plugins][1].
 
 {{% tab "Errors" %}}
 
-Errors can be added to a span with the special `error` tag that supports error objects. This splits the error into three tags: `error.type`, `error.msg`, and `error.stack`.
+Errors can be added to a span with the special `error` tag that supports error objects. This splits the error into three tags: `error.type`, `error.message`, and `error.stack`.
 
 ```javascript
 try {

--- a/content/en/tracing/trace_collection/custom_instrumentation/php/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php/dd-api.md
@@ -397,7 +397,7 @@ function doRiskyThing() {
 );
 ```
 
-Set the `error.msg` tag to manually flag a span as erroneous.
+Set the `error.message` tag to manually flag a span as erroneous.
 
 ```php
 <?php
@@ -410,7 +410,7 @@ function doRiskyThing() {
     'doRiskyThing',
     function(\DDTrace\SpanData $span, $args, $retval) {
         if ($retval === SOME_ERROR_CODE) {
-            $span->meta['error.msg'] = 'Foo error';
+            $span->meta['error.message'] = 'Foo error';
             // Optional:
             $span->meta['error.type'] = 'CustomError';
             $span->meta['error.stack'] = (new \Exception)->getTraceAsString();

--- a/content/en/tracing/troubleshooting/_index.md
+++ b/content/en/tracing/troubleshooting/_index.md
@@ -185,7 +185,7 @@ A span can show this message for two possible reasons:
 - The span contains an unhandled exception.
 - An HTTP response within the span returned an HTTP status code between 400 and 599.
 
-When an exception is handled in a try/catch block, `error.msg`, `error.type`, and `error.stack` span tags are not populated. To populate the detailed error span tags, use [Custom Instrumentation][18] code.
+When an exception is handled in a try/catch block, `error.message`, `error.type`, and `error.stack` span tags are not populated. To populate the detailed error span tags, use [Custom Instrumentation][18] code.
 
 {{% /collapse-content %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- error.msg is now error.message.
- Replace remaining references in the docs.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->