### PR TITLE
Update AWS Resource Exclusion Wording

### DIFF
--- a/content/en/account_management/billing/aws.md
+++ b/content/en/account_management/billing/aws.md
@@ -18,7 +18,8 @@ Other AWS resources such as ELB, RDS, and DynamoDB are not part of monthly infra
 
 You can limit the AWS metrics collected for some services to specific resources. On the [Datadog-AWS integration page][3], select the AWS account and click on the **Metric Collection** tab. Under **Limit Metric Collection to Specific Resources** you can then limit metrics for one or more of EC2, Lambda, ELB, Application ELB, Network ELB, RDS, SQS, and CloudWatch custom metrics.
 Ensure that the tags added to this section are assigned to the corresponding resources on AWS.
-**Note**: If using exclusion notation (`!`) , ensure the resource lacks the specified tag.
+
+**Note**: If using exclusion notation (`!`), ensure the resource lacks the specified tag.
 
 {{< img src="account_management/billing/aws-resource-exclusion.png" alt="The metric collection tab of an AWS account within the Datadog AWS integration page showing the option to limit metric collection to specific resources with a dropdown menu to select AWS service and a field to add tags in key:value format" >}}
 

--- a/content/en/account_management/billing/aws.md
+++ b/content/en/account_management/billing/aws.md
@@ -16,7 +16,9 @@ Other AWS resources such as ELB, RDS, and DynamoDB are not part of monthly infra
 
 ## AWS resource exclusion
 
-You can limit the AWS metrics collected for some services to specific resources. On the [Datadog-AWS integration page][3], select the AWS account and click on the **Metric Collection** tab. Under **Limit Metric Collection to Specific Resources** you can then exclude metrics for one or more of EC2, Lambda, ELB, Application ELB, Network ELB, RDS, SQS, and CloudWatch custom metrics.
+You can limit the AWS metrics collected for some services to specific resources. On the [Datadog-AWS integration page][3], select the AWS account and click on the **Metric Collection** tab. Under **Limit Metric Collection to Specific Resources** you can then limit metrics for one or more of EC2, Lambda, ELB, Application ELB, Network ELB, RDS, SQS, and CloudWatch custom metrics.
+Ensure that the tags added to this section are assigned to the corresponding resources on AWS.
+**Note**: If using exclusion notation (`!`) , ensure the resource lacks the specified tag.
 
 {{< img src="account_management/billing/aws-resource-exclusion.png" alt="The metric collection tab of an AWS account within the Datadog AWS integration page showing the option to limit metric collection to specific resources with a dropdown menu to select AWS service and a field to add tags in key:value format" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The current wording doesn't explain that the tags set in the Limit Metric Collection correspond with tags set on the AWS resource. This has led to confusion with customers and I think specifying that the tags need to be set on the AWS tile **and** on the AWS resource(s) would help prevent confusion.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->