### PR TITLE
small note added azure-logging-guide.md

### DIFF
--- a/content/en/logs/guide/azure-logging-guide.md
+++ b/content/en/logs/guide/azure-logging-guide.md
@@ -10,13 +10,11 @@ further_reading:
 
 Use this guide to set up logging from your Azure subscriptions to Datadog.
 
-Datadog recommends sending logs from Azure to Datadog with the Agent or DaemonSet. For some resources it may not be possible. In these cases, you can create a log forwarding pipeline using an Azure Event Hub to collect [Azure Platform Logs][2]. For resources that cannot stream Azure Platform Logs to an Event Hub, you can use the Blob Storage forwarding option.
+Datadog recommends sending logs from Azure to Datadog with the Agent or DaemonSet. For some resources it may not be possible. In these cases, you can create a log forwarding pipeline using an Azure Event Hub to collect [Azure Platform Logs][2]. For resources that cannot stream Azure Platform Logs to an Event Hub, you can use the Blob Storage forwarding option. To collect logs from Azure Log Analytics workspaces, you must use the Azure Event Hub process.
 
 **All sites**: All Datadog sites can use the steps on this page to send Azure logs to Datadog.
 
 **US3**: If your organization is on the Datadog US3 site, you can use the Azure Native integration to simplify configuration for your Azure log forwarding. Datadog recommends using this method when possible. Configuration is done through the [Datadog resource in Azure][5]. This replaces the Azure Event Hub process for log forwarding. See the [Azure Native Logging Guide][4] for more information.
-
-**Note**: To collect logs from Azure Log Analytics workspaces, you must use the Azure Event Hub process.
 
 {{< tabs >}}
 

--- a/content/en/logs/guide/azure-logging-guide.md
+++ b/content/en/logs/guide/azure-logging-guide.md
@@ -16,6 +16,8 @@ Datadog recommends sending logs from Azure to Datadog with the Agent or DaemonSe
 
 **US3**: If your organization is on the Datadog US3 site, you can use the Azure Native integration to simplify configuration for your Azure log forwarding. Datadog recommends using this method when possible. Configuration is done through the [Datadog resource in Azure][5]. This replaces the Azure Event Hub process for log forwarding. See the [Azure Native Logging Guide][4] for more information.
 
+**Note**: To collect logs from Azure Log Analytics workspaces, you must use the Azure Event Hub process.
+
 {{< tabs >}}
 
 {{% tab "Automated Installation" %}}


### PR DESCRIPTION
adding small note of clarification, due to customer suggestion.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
this PR adds a small note that clarifies a type of log that is not able to be sent to datadog via the native process, per a customer request:

"Specifically this verbiage: "Configuration is done through the [Datadog resource in Azure](https://learn.microsoft.com/en-us/azure/partner-solutions/datadog/overview). This replaces the Azure Event Hub process for log forwarding. See the [Azure Native Logging Guide](https://docs.datadoghq.com/logs/guide/azure-native-logging-guide/) for more information." 

That led me to believe I can just get logs from my Log analytics workspace directly into Datadog without using event hub."

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->