### PR TITLE
Add alert that TCP is not supported for US5 or AP1

### DIFF
--- a/content/en/integrations/nxlog.md
+++ b/content/en/integrations/nxlog.md
@@ -28,6 +28,10 @@ Configure NXLog to gather logs from your host, containers, & services.
 
 ### Log collection
 
+{{< site-region region="gov,ap1" >}}
+<div class="alert alert-warning">The TCP endpoint is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 {{< tabs >}}
 {{% tab "Datadog US site" %}}
 

--- a/content/en/integrations/nxlog.md
+++ b/content/en/integrations/nxlog.md
@@ -28,7 +28,7 @@ Configure NXLog to gather logs from your host, containers, & services.
 
 ### Log collection
 
-{{< site-region region="gov,ap1" >}}
+{{< site-region region="gov,us5,ap1" >}}
 <div class="alert alert-warning">The TCP endpoint is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- TCP is not supported for US5 or AP1 regions
- [DOCS-6643](https://datadoghq.atlassian.net/browse/DOCS-6643)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-6643]: https://datadoghq.atlassian.net/browse/DOCS-6643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ