### PR TITLE
change Agent version for namespace labels support

### DIFF
--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -383,7 +383,7 @@ DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS='{"*":"<PREFIX>_%%annotation%%"}'
 
 ### Namespace labels as tags
 
-Starting with Agent v7.27+, the Agent can collect labels for a given namespace and use them as tags to attach to all metrics, traces, and logs emitted by all pods in this namespace:
+Starting with Agent 7.55.0+, the Agent can collect labels for a given namespace and use them as tags to attach to all metrics, traces, and logs emitted by all pods in this namespace:
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}


### PR DESCRIPTION
DOCS-8739

### What does this PR do? What is the motivation?

updates the Agent version number that supports namespace labels as tags.

### Merge instructions


- [X] Please merge after reviewing

