### PR TITLE
[DOCS-8770] Add archive destinations to reference doc

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4670,41 +4670,56 @@ menu:
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_amazon_opensearch
       weight: 601
+    - name: Amazon S3
+      identifier: observability_pipelines_destinations_amazon_s3
+      url: observability_pipelines/destinations/amazon_s3/
+      parent: observability_pipelines_destinations
+      weight: 602
+    - name: Azure Storage
+      identifier: observability_pipelines_azure_storage
+      url: observability_pipelines/destinations/azure_storage/
+      parent: observability_pipelines_destinations
+      weight: 603
     - name: Datadog Log Management
       url: observability_pipelines/destinations/#datadog-log-management
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_datadog_log_management
-      weight: 602
+      weight: 604
     - name: Elasticsearch
       url: observability_pipelines/destinations/#elasticsearch
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_elasticsearch
-      weight: 603
+      weight: 605
     - name: Google Chronicle
       url: observability_pipelines/destinations/#google-chronicle
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_google_chronicle
-      weight: 604
+      weight: 606
+    - name: Google Cloud Storage
+      identifier: observability_pipelines_google_cloud_storage
+      url: /observability_pipelines/destinations/google_cloud_storage/
+      parent: observability_pipelines_destinations
+      weight: 607
     - name: OpenSearch
       url: observability_pipelines/destinations/#opensearch
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_opensearch
-      weight: 605
+      weight: 608
     - name: Syslog
       url: observability_pipelines/destinations/#rsyslog-or-syslog-ng
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_syslog
-      weight: 606
+      weight: 609
     - name: Splunk HEC
       url: observability_pipelines/destinations/#splunk-http-event-collector-hec
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_splunk_hec
-      weight: 607
+      weight: 610
     - name: Sumo Logic Hosted Collector
       url: observability_pipelines/destinations/#sumo-logic-hosted-collector
       parent: observability_pipelines_destinations
       identifier: observability_pipelines_sumo_logic_hosted_collector
-      weight: 608
+      weight: 611
     - name: Best Practices for Scaling Observability Pipelines
       url: observability_pipelines/best_practices_for_scaling_observability_pipelines/
       parent: observability_pipelines

--- a/content/en/observability_pipelines/destinations/_index.md
+++ b/content/en/observability_pipelines/destinations/_index.md
@@ -22,9 +22,12 @@ Select and set up your destinations when you [set up a pipeline][2]. This is ste
 
 {{< whatsnext desc="The available Observability Pipelines destinations are:" >}}
     {{< nextlink href="observability_pipelines/destinations/#amazon-opensearch" >}}Amazon OpenSearch{{< /nextlink >}}
+    {{< nextlink href="observability_pipelines/destinations/amazon_s3" >}}Amazon S3{{< /nextlink >}}
+    {{< nextlink href="observability_pipelines/destinations/azure_storage" >}}Azure Storage{{< /nextlink >}}
     {{< nextlink href="observability_pipelines/destinations/#datadog-log-management" >}}Datadog Log Management{{< /nextlink >}}
     {{< nextlink href="observability_pipelines/destinations/#elasticsearch" >}}Elasticsearch{{< /nextlink >}}
     {{< nextlink href="observability_pipelines/destinations/#google-chronicle" >}}Google Chronicle{{< /nextlink >}}
+    {{< nextlink href="observability_pipelines/destinations/google_cloud_storage" >}}Google Cloud Storage{{< /nextlink >}}
     {{< nextlink href="observability_pipelines/destinations/#opensearch" >}}OpenSearch{{< /nextlink >}}
     {{< nextlink href="observability_pipelines/destinations/#rsyslog-or-syslog-ng" >}}Rsyslog or Syslog-ng{{< /nextlink >}}
     {{< nextlink href="observability_pipelines/destinations/#splunk-http-event-collector-hec" >}}Splunk HTTP Event Collector (HEC){{< /nextlink >}}

--- a/content/en/observability_pipelines/destinations/amazon_s3.md
+++ b/content/en/observability_pipelines/destinations/amazon_s3.md
@@ -4,7 +4,7 @@ disable_toc: false
 ---
 
 
-The Amazon S3 destination is available for the [Archive Logs][1] template. Use this destination to archive your logs in Datadog-rehydratable format in an Amazon S3 bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
+The Amazon S3 destination is available for the [Archive Logs template][1]. Use this destination to archive your logs in Datadog-rehydratable format in an Amazon S3 bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
 
 ## Configure Log Archives
 

--- a/content/en/observability_pipelines/destinations/amazon_s3.md
+++ b/content/en/observability_pipelines/destinations/amazon_s3.md
@@ -1,0 +1,53 @@
+---
+title: Amazon S3 Destination
+disable_toc: false
+---
+
+
+The Amazon S3 destination is available for the [Archive Logs][1] template. Use this destination to archive your logs in Datadog-rehydratable format in an Amazon S3 bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
+
+## Configure Log Archives
+
+If you already have a Datadog Log Archive configured for Observability Pipelines, skip to [Set up the destination for your pipeline](#set-up-the-destination-in-the-pipeline).
+
+You need to have Datadog's [AWS integration][2] installed to set up Datadog Log Archives.
+
+{{% observability_pipelines/configure_log_archive/amazon_s3/instructions %}}
+
+{{< tabs >}}
+{{% tab "Docker" %}}
+
+{{% observability_pipelines/configure_log_archive/amazon_s3/docker %}}
+
+{{% /tab %}}
+{{% tab "Amazon EKS" %}}
+
+{{% observability_pipelines/configure_log_archive/amazon_s3/amazon_eks %}}
+
+{{% /tab %}}
+{{% tab "Linux (APT)" %}}
+
+{{% observability_pipelines/configure_log_archive/amazon_s3/linux_apt %}}
+
+{{% /tab %}}
+{{% tab "Linux (RPM)" %}}
+
+{{% observability_pipelines/configure_log_archive/amazon_s3/linux_rpm %}}
+
+{{% /tab %}}
+{{< /tabs >}}
+
+{{% observability_pipelines/configure_log_archive/amazon_s3/connect_s3_to_datadog_log_archives %}}
+
+## Set up the destination for your pipeline
+
+Set up the Amazon S3 destination and its environment variables when you [set up an Archive Logs pipeline][1]. The information below is configured in the pipelines UI.
+
+{{% observability_pipelines/destination_settings/datadog_archives_amazon_s3 %}}
+
+### Set the environment variables
+
+{{% observability_pipelines/destination_env_vars/datadog_archives_amazon_s3 %}}
+
+[1]: /observability_pipelines/archive_logs/
+[2]: /integrations/amazon_web_services/#setup

--- a/content/en/observability_pipelines/destinations/azure_storage.md
+++ b/content/en/observability_pipelines/destinations/azure_storage.md
@@ -1,0 +1,27 @@
+---
+title: Azure Storage Destination
+disable_toc: false
+---
+
+The Azure Storage destination is available for the [Archive Logs][1] template. Use this destination to archive your logs in Datadog-rehydratable format in an Azure Storage bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
+
+## Configure Log Archives
+
+If you already have a Datadog Log Archive configured for Observability Pipelines, skip to [Set up the destination for your pipeline](#set-up-the-destination-for-your-pipeline).
+
+You need to have Datadog's [Google Cloud Platform integration][2] installed to set up Datadog Log Archives.
+
+{{% observability_pipelines/configure_log_archive/azure_storage/instructions %}}
+
+## Set up the destination for your pipeline
+
+Set up the Amazon S3 destination and its environment variables when you [set up an Archive Logs pipeline][1]. The information below is configured in the pipelines UI.
+
+{{% observability_pipelines/destination_settings/datadog_archives_azure_storage %}}
+
+### Set the environment variables
+
+{{% observability_pipelines/destination_env_vars/datadog_archives_azure_storage %}}
+
+[1]: /observability_pipelines/archive_logs/
+[2]: /integrations/google_cloud_platform/#setup

--- a/content/en/observability_pipelines/destinations/azure_storage.md
+++ b/content/en/observability_pipelines/destinations/azure_storage.md
@@ -3,7 +3,7 @@ title: Azure Storage Destination
 disable_toc: false
 ---
 
-The Azure Storage destination is available for the [Archive Logs][1] template. Use this destination to archive your logs in Datadog-rehydratable format in an Azure Storage bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
+The Azure Storage destination is available for the [Archive Logs template][1]. Use this destination to archive your logs in Datadog-rehydratable format in an Azure Storage bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
 
 ## Configure Log Archives
 

--- a/content/en/observability_pipelines/destinations/google_cloud_storage.md
+++ b/content/en/observability_pipelines/destinations/google_cloud_storage.md
@@ -1,0 +1,27 @@
+---
+title: Google Cloud Storage Destination
+disable_toc: false
+---
+
+The Google Cloud Storage destination is available for the [Archive Logs][1] template. Use this destination to archive your logs in Datadog-rehydratable format in an Google Cloud Storage bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
+
+## Configure Log Archives
+
+If you already have a Datadog Log Archive configured for Observability Pipelines, skip to [Set up the destination for your pipeline](#set-up-the-destination-for-your-pipeline).
+
+You need to have Datadog's [Google Cloud Platform integration][2] installed to set up Datadog Log Archives.
+
+{{% observability_pipelines/configure_log_archive/google_cloud_storage/instructions %}}
+
+## Set up the destination for your pipeline
+
+Set up the Amazon S3 destination and its environment variables when you [set up an Archive Logs pipeline][1]. The information below is configured in the pipelines UI.
+
+{{% observability_pipelines/destination_settings/datadog_archives_google_cloud_storage %}}
+
+### Set the environment variables
+
+{{% observability_pipelines/destination_env_vars/datadog_archives_google_cloud_storage %}}
+
+[1]: /observability_pipelines/archive_logs/
+[2]: /integrations/google_cloud_platform/#setup

--- a/content/en/observability_pipelines/destinations/google_cloud_storage.md
+++ b/content/en/observability_pipelines/destinations/google_cloud_storage.md
@@ -3,7 +3,7 @@ title: Google Cloud Storage Destination
 disable_toc: false
 ---
 
-The Google Cloud Storage destination is available for the [Archive Logs][1] template. Use this destination to archive your logs in Datadog-rehydratable format in an Google Cloud Storage bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
+The Google Cloud Storage destination is available for the [Archive Logs template][1]. Use this destination to archive your logs in Datadog-rehydratable format in an Google Cloud Storage bucket. You need to set up Datadog Log Archives, if you haven't already, and then set up the destination in the pipeline UI.
 
 ## Configure Log Archives
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds Amazon S3, Google Cloud Storage, and Azure Storage destinations to the OP Destinations reference doc.

[DOCS-8770](https://datadoghq.atlassian.net/browse/DOCS-8770)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->