### PR TITLE
Add Flex Logs Starter to docs

### DIFF
--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -52,8 +52,9 @@ Use the spectrum of log types shown in the image below to determine when to use 
 
 Compute is the querying capacity to run queries for Flex Logs. It is used when querying logs in the Flex Logs tier. It is not used for ingestion or when only searching Standard Indexing logs. The available compute tiers are:
 
-<div class="alert alert-warning">The compute sizes available for US3, US5, AP1, US1-FED are XS and S.</div>
+<div class="alert alert-warning">The compute sizes available for US3, US5, AP1, US1-FED are Starter, XS and S.</div>
 
+- Starter
 - Extra small (XS)
 - Small (S)
 - Medium (M)
@@ -79,13 +80,14 @@ Consider the following factors when deciding on a compute tier:
 The number of logs stored in the Flex tier has the largest impact on the size needed to performantly query the data. Datadog recommends the following compute sizes based on log volume:
 | Size                                      | Volume (events stored)   |
 | ----------------------------------------- | ------------------------ |
-| Extra Small (XS)                          | 20 - 50 billion          |
+| Starter                                   | < 10 billion             |
+| Extra Small (XS)                          | 10 - 50 billion          |
 | Small (S)                                 | 50 - 200 billion         |
 | Medium (M)                                | 200 - 500 billion        |
 | Large (L)                                 | 500 billion - 1 trillion |
 | Contact your [Customer Success Manager][7]| 1T+                      |
 
-Compute tiers are billed at a flat rate. See the [pricing page][6] for more information.
+Scalable (XS, S, M, L) compute tiers are billed at a flat rate. Flex Logs Starter is billed at a bundled storage+compute rate. See the [pricing page][6] for more information.
 
 ## Enable and disable Flex Logs
 
@@ -93,11 +95,7 @@ You can enable or disable Flex Logs at the organization level. You must have the
 
 If Flex Logs is part of your contract, the compute options available on your contract is shown in the UI.
 
-If Flex Logs is not in your contract, you can enable Flex Logs through the self-serve onboarding option. For self-serve Flex Logs, choose from the following compute sizes:
-
-- Starter
-- Extra Small
-- Small
+If Flex Logs is not in your contract, you can enable Flex Logs Starter through the self-serve onboarding option.
 
 To enable Flex Logs:
 1. Navigate to the [Flex Logs Control][5] page.
@@ -120,7 +118,7 @@ To disable Flex Logs:
 If you select one of the scalable compute options for Flex Logs (for example, XS, S, M, or L), you can upgrade or downgrade your compute size on the [Flex Logs Control][5] page.
 
 **Notes**:
-- Only compute options on your contract are made available. If Flex Logs is not in your contract, select between the XS and S compute options.
+- Only compute options on your contract are made available. 
 - A compute instance can be upgraded at any time.
 - A compute instance can be downgraded once per 15 days.
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Flex Logs Starter will be the only compute that can be enabled as part of the GA but there are no docs that describes what it is in the docs. It’s a bit of a unique case compared to the other sizes since the pricing for it is a single, bundled volume + compute cost vs the decoupled cost of everything else.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->