### PR TITLE
template changes to support x-docs-curl-required

### DIFF
--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -45,7 +45,7 @@
 {{- with $parameters.queryStrings -}}
     {{- $i := 0 -}}
     {{- range . -}}
-        {{- if eq .required true -}}
+        {{- if or (eq .required true) (eq (index . "x-docs-curl-required") true) -}}
             {{- if eq $i 0 -}}
                 <span class="c1"># Required query arguments</span><br/>
             {{- end -}}
@@ -79,8 +79,10 @@
 {{- end -}}
 {{- end -}}
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1">{{ $endpoint.actionType | upper }}</span> {{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">"{{ $url }}</span>{{ else }}<span class="kn">"{{ $url }}</span>{{ end }}{{ end }}<span class="kn">{{ replace $endpoint.pathKey "{" "${" }}</span>
-{{- range $qi, $q := where $parameters.queryStrings ".required" true -}}
+{{- range $qi, $q := $parameters.queryStrings -}}
+      {{- if or (eq $q.required true) (eq (index $q "x-docs-curl-required") true) -}}
       <span class="kn">{{ cond (gt $qi 0) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}} }</span>
+      {{- end -}}
 {{- end -}}
 
 {{- /* Render authentication query parameters "?api_key=XXX" */ -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Address [APITL-1008]. Currently, query parameters are only included in the curl examples if they are marked as required. This PR handles cases where we want to include a query parameter in the curl example even if it isn't required (ex: one of two parameters is required)
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[APITL-1008]: https://datadoghq.atlassian.net/browse/APITL-1008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ