### PR TITLE
[SDCI] add message about gitlab test settings potentially failing

### DIFF
--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -1,5 +1,4 @@
 ---
-
 title: Set up Tracing on a GitLab Pipeline
 aliases:
   - /continuous_integration/setup_pipelines/gitlab
@@ -158,7 +157,7 @@ Fill in the integration configuration settings:
 **Default**: (empty, no additional tags)<br/>
 **Note**: Available only in GitLab.com and GitLab >= 14.8 self-hosted.
 
-You can test the integration with the **Test settings** button (only available when configuring the integration on a project). After it's successful, click **Save changes** to finish the integration set up. Some customers have reported that the **Test settings** button sometimes fails. In this case, click **Save changes** and check that the first webhooks that are sent are successful by looking at the history in the "Recent events" section below.
+You can test the integration with the **Test settings** button (only available when configuring the integration on a project). After it's successful, click **Save changes** to finish the integration set up. If the button fails, click **Save changes** and check that the first webhooks sent are successful by looking at the history in the "Recent events" section below.
 
 
 #### Integrate with Datadog Teams


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We had reports from customers that the validation through "Test settings" was failing but everything was working after saving. I prefer to add this to the documentation in case customers stop the setup because of it.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->