### PR TITLE
Anthony dgx/make ip allowlist available from pro plus plan

### DIFF
--- a/content/en/account_management/org_settings/ip_allowlist.md
+++ b/content/en/account_management/org_settings/ip_allowlist.md
@@ -3,7 +3,7 @@ title: IP Allowlist
 ---
 
 {{< callout url="/help/" header="Get Started with IP Allowlist" >}}
-The IP allowlist feature is available for customers on Pro + and Entreprise plans only. Request access by contacting support.
+The IP allowlist feature is exclusively available to customers on the pro+ and enterprise plans. To request access, please contact support.
 {{< /callout >}}
 
 ## Overview

--- a/content/en/account_management/org_settings/ip_allowlist.md
+++ b/content/en/account_management/org_settings/ip_allowlist.md
@@ -3,7 +3,7 @@ title: IP Allowlist
 ---
 
 {{< callout url="/help/" header="Get Started with IP Allowlist" >}}
-The IP allowlist feature is available for customers on an enterprise plan only. Request access by contacting support.
+The IP allowlist feature is available for customers on Pro + and Entreprise plans only. Request access by contacting support.
 {{< /callout >}}
 
 ## Overview

--- a/data/api/v2/translate_tags.json
+++ b/data/api/v2/translate_tags.json
@@ -77,7 +77,7 @@
   },
   "ip-allowlist": {
     "name": "IP Allowlist",
-    "description": "The IP allowlist API is used to manage the IP addresses that\ncan access the Datadog API and web UI. It does not block\naccess to intake APIs or public dashboards.\n\nThis is an enterprise-only feature. Request access by\ncontacting Datadog support, or see the [IP Allowlist page](https://docs.datadoghq.com/account_management/org_settings/ip_allowlist/) for more information."
+    "description": "The IP allowlist API is used to manage the IP addresses that\ncan access the Datadog API and web UI. It does not block\naccess to intake APIs or public dashboards.\n\nThis feature is available only on the pro+ and enterprise plans. Request access by\ncontacting Datadog support, or see the [IP Allowlist page](https://docs.datadoghq.com/account_management/org_settings/ip_allowlist/) for more information."
   },
   "incident-services": {
     "name": "Incident Services",


### PR DESCRIPTION
IP Allowlist is now a feature available for customers on Infra Pro + and Infra Entreprise plans. I'm updating our documentation to reflect that update.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We're currently updating the list of features available in our Infrastructure plans to better meet customers' needs and expectations.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->