### PR TITLE
[web-5210] remove sections from docs search links

### DIFF
--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -4,7 +4,7 @@ import { truncateContent, truncateContentAtHighlight } from "../../helpers/trunc
 export function getHitData(hit, searchQuery = '') {
     const title = hit.title ? hit.title : hit.type;
     const cleanRelPermalink =
-        hit.language == 'en' ? hit.relpermalink : hit.relpermalink.replace(`/${hit.language}/`, '');
+        hit.language == 'en' ? hit.distinct_base_url : hit.distinct_base_url.replace(`/${hit.language}/`, '');
 
     const matchingWordsArray = getFilteredMatchingWords(searchQuery).map(word => replaceSpecialCharacters(word))
     const joinedMatchingWordsFromSearch = matchingWordsArray.join('|');

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -10,7 +10,8 @@ export function getHitData(hit, searchQuery = '') {
     const joinedMatchingWordsFromSearch = matchingWordsArray.join('|');
     const regexQry = new RegExp(`(${joinedMatchingWordsFromSearch})`, 'gi');
     const highlightTitle = (hit._highlightResult.title.value || title);
-    const highlightContent = (hit._highlightResult.content.value || '');
+    const highlightContent = cleanContent((hit._highlightResult.content.value || ''));
+    
 
     return {
         relpermalink: cleanRelPermalink,
@@ -20,6 +21,14 @@ export function getHitData(hit, searchQuery = '') {
         section_header: hit.section_header || null,
         highlighted_content: handleHighlightingSearchResultContent(highlightContent, regexQry)
     };
+}
+
+const cleanContent = (content) => {
+    // remove alert where the product is not available for the user's datadog site
+    // this is surfacing more now that we are using full page results and this alert is at the top of the file
+    // this is temporary
+    const regex = /.*\sis not supported for your selected Datadog site \(\)/gm;
+    return content.replace(regex, '')
 }
 
 /* 

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -11,7 +11,6 @@ export function getHitData(hit, searchQuery = '') {
     const regexQry = new RegExp(`(${joinedMatchingWordsFromSearch})`, 'gi');
     const highlightTitle = (hit._highlightResult.title.value || title);
     const highlightContent = (hit._highlightResult.content.value || '');
-    
 
     return {
         relpermalink: cleanRelPermalink,
@@ -21,14 +20,6 @@ export function getHitData(hit, searchQuery = '') {
         section_header: hit.section_header || null,
         highlighted_content: handleHighlightingSearchResultContent(highlightContent, regexQry)
     };
-}
-
-const cleanContent = (content) => {
-    // remove alert where the product is not available for the user's datadog site
-    // this is surfacing more now that we are using full page results and this alert is at the top of the file
-    // this is temporary
-    const regex = /.*\sis not supported for your selected Datadog site \(\)/gm;
-    return content.replace(regex, '')
 }
 
 /* 

--- a/assets/scripts/components/algolia/getHitData.js
+++ b/assets/scripts/components/algolia/getHitData.js
@@ -10,7 +10,7 @@ export function getHitData(hit, searchQuery = '') {
     const joinedMatchingWordsFromSearch = matchingWordsArray.join('|');
     const regexQry = new RegExp(`(${joinedMatchingWordsFromSearch})`, 'gi');
     const highlightTitle = (hit._highlightResult.title.value || title);
-    const highlightContent = cleanContent((hit._highlightResult.content.value || ''));
+    const highlightContent = (hit._highlightResult.content.value || '');
     
 
     return {

--- a/assets/scripts/components/algolia/searchbarHits.js
+++ b/assets/scripts/components/algolia/searchbarHits.js
@@ -89,14 +89,13 @@ const renderHits = (renderOptions, isFirstRender) => {
                 const hit = getHitData(item, renderOptions.results.query);
                 const displayContent = getSnippetForDisplay(hit, false);
                 const cleanRelpermalink = `${basePathName}${hit.relpermalink}`.replace('//', '/');
-                const section_header = hit.section_header ? `&raquo; ${hit.section_header}` : '';
 
                 return `
                     <li class="ais-Hits-item">
                         <a href="${cleanRelpermalink}" target="_blank" rel="noopener noreferrer">
                             <p class="ais-Hits-subcategory">${hit.subcategory}</p>
                             <div>
-                                <p class="ais-Hits-title"><strong>${hit.title} ${section_header}</strong></p>
+                                <p class="ais-Hits-title"><strong>${hit.title}</strong></p>
                                 <p class="ais-Hits-content">${displayContent}</p>
                             </div>
                         </a>

--- a/assets/scripts/components/algolia/searchpageHits.js
+++ b/assets/scripts/components/algolia/searchpageHits.js
@@ -21,14 +21,9 @@ const renderHits = (renderOptions, isFirstRender) => {
         const category = `<p class="ais-Hits-category">${hit.category}</p>`;
         const subcategory = `<p class="ais-Hits-subcategory">${hit.subcategory}</p>`;
         const pageTitle = `<p class="ais-Hits-title">${hit.title}</p>`;
-        const baseTitleHierarchy =
-            hit.subcategory === hit.title.replace(/(<mark>|<\/mark>)/gm, '')
+        return hit.subcategory === hit.title.replace(/(<mark>|<\/mark>)/gm, '')
                 ? `${category}${spacer}${pageTitle}`
                 : `${category}${spacer}${subcategory}${spacer}${pageTitle}`;
-
-        return hit.section_header
-            ? `${baseTitleHierarchy}${spacer}<p class="ais-Hits-title">${hit.section_header}</p>`
-            : `${baseTitleHierarchy}`;
     };
 
     // Returns a bunch of <li>s

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -28,7 +28,8 @@
                 {{ end }}
             {{ end }}
 
-            {{- $content = replaceRE `(\w|\s)*\sis not supported for your selected Datadog site \(\)` "" $content 1 -}}
+            {{- /* remove "is not supported" alert content which appears at the beginning of some markdown files */ -}}
+            {{- $content = replaceRE `(\w|\s)*\s(is not supported for your selected Datadog site \(\))(.|\s)` "" $content 1 -}}
 
             {{- /* record for each individual section (split by h2 header) */ -}}
             {{ partial "algolia/page-sections.json" (dict "context" $hugo_context "page" $page "title" $title "category" $category "subcategory" $subcategory "rank" $rank) }}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -44,6 +44,7 @@
                 "category" $category
                 "subcategory" $subcategory
                 "rank" $rank
+                "order" -1
             ) }}
 
             {{ if $tags }}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -28,6 +28,8 @@
                 {{ end }}
             {{ end }}
 
+            {{- $content = replaceRE `(\w|\s)*\sis not supported for your selected Datadog site \(\)` "" $content 1 -}}
+
             {{- /* record for each individual section (split by h2 header) */ -}}
             {{ partial "algolia/page-sections.json" (dict "context" $hugo_context "page" $page "title" $title "category" $category "subcategory" $subcategory "rank" $rank) }}
 

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -33,7 +33,7 @@ const updateSettings = (index) => {
             'unordered(content)'
         ],
         ranking: ['words', 'filters', 'typo', 'attribute', 'proximity', 'exact', 'custom'],
-        customRanking: ['desc(rank)', 'asc(order)'],
+        customRanking: ['desc(rank)', 'order(asc)'],
         attributesToHighlight: ['title', 'section_header', 'content', 'tags'],
         attributesForFaceting: ['language', 'searchable(tags)'],
         attributesToSnippet: ['content:20'],

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -33,7 +33,7 @@ const updateSettings = (index) => {
             'unordered(content)'
         ],
         ranking: ['words', 'filters', 'typo', 'attribute', 'proximity', 'exact', 'custom'],
-        customRanking: ['desc(rank)', 'order(asc)'],
+        customRanking: ['desc(rank)', 'asc(order)'],
         attributesToHighlight: ['title', 'section_header', 'content', 'tags'],
         attributesForFaceting: ['language', 'searchable(tags)'],
         attributesToSnippet: ['content:20'],

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -21,10 +21,9 @@ const getIndexName = () => {
 };
 
 const updateSettings = (index) => {
-    // Distinct: true means don't duplicate results.
-    // attributeForDistinct: using a page's base_url (without the anchor) to group results for the same page.
-    // This means we aren't returning every section of the same page as different results.
-    // custom ranking by order means when relevant we return the "Overview" or first section of a page.
+    // Distinct: true allows us to return a single result for each page despite indexing each section inidivdually.
+    // We use the page's base_url (without the anchor) to group together multiple results for one page using "attributeForDistinct"
+    // Custom ranking by order allows us to return the full page result whenever possible (we assign -1 order to full page results)
     const settings = {
         searchableAttributes: [
             'unordered(tags)',

--- a/local/bin/js/algolia-index-sync.js
+++ b/local/bin/js/algolia-index-sync.js
@@ -21,6 +21,10 @@ const getIndexName = () => {
 };
 
 const updateSettings = (index) => {
+    // Distinct: true means don't duplicate results.
+    // attributeForDistinct: using a page's base_url (without the anchor) to group results for the same page.
+    // This means we aren't returning every section of the same page as different results.
+    // custom ranking by order means when relevant we return the "Overview" or first section of a page.
     const settings = {
         searchableAttributes: [
             'unordered(tags)',
@@ -29,7 +33,7 @@ const updateSettings = (index) => {
             'unordered(content)'
         ],
         ranking: ['words', 'filters', 'typo', 'attribute', 'proximity', 'exact', 'custom'],
-        customRanking: ['desc(rank)'],
+        customRanking: ['desc(rank)', 'asc(order)'],
         attributesToHighlight: ['title', 'section_header', 'content', 'tags'],
         attributesForFaceting: ['language', 'searchable(tags)'],
         attributesToSnippet: ['content:20'],


### PR DESCRIPTION
### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/WEB-5210

Currently we show search results down to the section which doesn't always make sense.  For example, [this search](https://docs.datadoghq.com/search/?s=azure) for `Azure`, it's leading the user to the `Troubleshooting` section which doesn't make sense based on their search. 
 Discussed w/ the team and we felt like these results are likely providing more confusion than value to the customer.

This PR is removing all section results in favor of showing full page results in the UI to remove any confusion.

### Merge instructions
- [x] Please merge after websites reviewing

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/web-5210-section-results/search/?s=azure
https://docs-staging.datadoghq.com/brian.deutsch/web-5210-section-results/search/?s=unified%20service%20tags