### PR TITLE
[STAL-2778] Include details about new app key scopes

### DIFF
--- a/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
@@ -34,7 +34,7 @@ Configure the following environment variables:
 | Name         | Description                                                                                                                | Required | Default         |
 |--------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
 | `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][1] and should be stored as a secret.            | Yes      |                 |
-| `DD_APP_KEY` | Your Datadog application key. This key is created by your [Datadog organization][2] and should be stored as a secret.    | Yes      |                 |
+| `DD_APP_KEY` | Your Datadog application key. This key is created by your [Datadog organization][2], should include the `code_analysis_read` scope, and be stored as a secret.    | Yes      |                 |
 | `DD_SITE`    | The [Datadog site][3] to send information to. Your Datadog site is {{< region-param key="dd_site" code="true" >}}.       | No       | `datadoghq.com` |
 
 Provide the following inputs:

--- a/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/software_composition_analysis/generic_ci_providers.md
@@ -34,7 +34,7 @@ Configure the following environment variables:
 | Name         | Description                                                                                                                | Required | Default         |
 |--------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
 | `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][1] and should be stored as a secret.            | Yes      |                 |
-| `DD_APP_KEY` | Your Datadog application key. This key is created by your [Datadog organization][2], should include the `code_analysis_read` scope, and be stored as a secret.    | Yes      |                 |
+| `DD_APP_KEY` | Your Datadog application key. This key, created by your [Datadog organization][2], should include the `code_analysis_read` scope and be stored as a secret.    | Yes      |                 |
 | `DD_SITE`    | The [Datadog site][3] to send information to. Your Datadog site is {{< region-param key="dd_site" code="true" >}}.       | No       | `datadoghq.com` |
 
 Provide the following inputs:

--- a/content/en/code_analysis/software_composition_analysis/setup.md
+++ b/content/en/code_analysis/software_composition_analysis/setup.md
@@ -41,7 +41,7 @@ To set up Datadog Software Composition Analysis, navigate to [**Software Deliver
 SCA scans can be run directly on Datadog's infrastructure. To get started, navigate to the [**Code Analysis** page][6].
 
 ### Scan in CI pipelines
-SCA can be run in your CI pipelines using the [`datadog-ci` CLI][5]. Configure your [Datadog API and application keys][3] and run SCA jobs in the respective CI provider.
+SCA can be run in your CI pipelines using the [`datadog-ci` CLI][5]. Configure your [Datadog API and application keys (requires `code_analysis_read` scope)][3] and run SCA jobs in the respective CI provider.
 
 {{< whatsnext desc="See the documentation for your CI provider:">}}
     {{< nextlink href="code_analysis/software_composition_analysis/github_actions" >}}GitHub Actions{{< /nextlink >}}

--- a/content/en/code_analysis/software_composition_analysis/setup.md
+++ b/content/en/code_analysis/software_composition_analysis/setup.md
@@ -41,7 +41,7 @@ To set up Datadog Software Composition Analysis, navigate to [**Software Deliver
 SCA scans can be run directly on Datadog's infrastructure. To get started, navigate to the [**Code Analysis** page][6].
 
 ### Scan in CI pipelines
-SCA can be run in your CI pipelines using the [`datadog-ci` CLI][5]. Configure your [Datadog API and application keys (requires `code_analysis_read` scope)][3] and run SCA jobs in the respective CI provider.
+SCA can be run in your CI pipelines using the [`datadog-ci` CLI][5]. Configure your [Datadog API and application keys (requires the `code_analysis_read` scope)][3] and run SCA jobs in the respective CI provider.
 
 {{< whatsnext desc="See the documentation for your CI provider:">}}
     {{< nextlink href="code_analysis/software_composition_analysis/github_actions" >}}GitHub Actions{{< /nextlink >}}

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -34,7 +34,7 @@ Configure the following environment variables:
 | Name         | Description                                                                                                                | Required | Default         |
 |--------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
 | `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][1] and should be stored as a secret.            | Yes      |                 |
-| `DD_APP_KEY` | Your Datadog application key. This key is created by your [Datadog organization][2] and should be stored as a secret.    | Yes      |                 |
+| `DD_APP_KEY` | Your Datadog application key. This key is created by your [Datadog organization][2], should include the `code_analysis_read` scope, and be stored as a secret.    | Yes      |                 |
 | `DD_SITE`    | The [Datadog site][3] to send information to. Your Datadog site is {{< region-param key="dd_site" code="true" >}}.       | No       | `datadoghq.com` |
 
 Provide the following inputs:

--- a/content/en/code_analysis/static_analysis/generic_ci_providers.md
+++ b/content/en/code_analysis/static_analysis/generic_ci_providers.md
@@ -34,7 +34,7 @@ Configure the following environment variables:
 | Name         | Description                                                                                                                | Required | Default         |
 |--------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
 | `DD_API_KEY` | Your Datadog API key. This key is created by your [Datadog organization][1] and should be stored as a secret.            | Yes      |                 |
-| `DD_APP_KEY` | Your Datadog application key. This key is created by your [Datadog organization][2], should include the `code_analysis_read` scope, and be stored as a secret.    | Yes      |                 |
+| `DD_APP_KEY` | Your Datadog application key. This key, created by your [Datadog organization][2], should include the `code_analysis_read` scope and be stored as a secret.  | Yes      |                 |
 | `DD_SITE`    | The [Datadog site][3] to send information to. Your Datadog site is {{< region-param key="dd_site" code="true" >}}.       | No       | `datadoghq.com` |
 
 Provide the following inputs:

--- a/content/en/code_analysis/static_analysis/setup.md
+++ b/content/en/code_analysis/static_analysis/setup.md
@@ -31,7 +31,7 @@ To set up Datadog Static Analysis, navigate to [**Software Delivery** > **Code A
 
 ## Select where to run Static Analysis scans
 ### Scan in CI pipelines
-Datadog Static Analysis runs in your CI pipelines using the [`datadog-ci` CLI][8]. Configure your [Datadog API and application keys][3] and run Static Analysis in the respective CI provider.
+Datadog Static Analysis runs in your CI pipelines using the [`datadog-ci` CLI][8]. Configure your [Datadog API and application keys (requires `code_analysis_read` scope)][3] and run Static Analysis in the respective CI provider.
 
 {{< whatsnext desc="See instructions based on your CI provider:">}}
     {{< nextlink href="code_analysis/static_analysis/circleci_orbs" >}}CircleCI Orbs{{< /nextlink >}}

--- a/content/en/code_analysis/static_analysis/setup.md
+++ b/content/en/code_analysis/static_analysis/setup.md
@@ -31,7 +31,7 @@ To set up Datadog Static Analysis, navigate to [**Software Delivery** > **Code A
 
 ## Select where to run Static Analysis scans
 ### Scan in CI pipelines
-Datadog Static Analysis runs in your CI pipelines using the [`datadog-ci` CLI][8]. Configure your [Datadog API and application keys (requires `code_analysis_read` scope)][3] and run Static Analysis in the respective CI provider.
+Datadog Static Analysis runs in your CI pipelines using the [`datadog-ci` CLI][8]. Configure your [Datadog API and application keys (requires the `code_analysis_read` scope)][3] and run Static Analysis in the respective CI provider.
 
 {{< whatsnext desc="See instructions based on your CI provider:">}}
     {{< nextlink href="code_analysis/static_analysis/circleci_orbs" >}}CircleCI Orbs{{< /nextlink >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We've added a new application scope, `code_analysis_read`, for both products, Static Analysis and Software Composition Analysis.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->