### PR TITLE
Fix anchor links in Best Practices for Logs Japanese docs

### DIFF
--- a/content/ja/logs/guide/best-practices-for-log-management.md
+++ b/content/ja/logs/guide/best-practices-for-log-management.md
@@ -23,15 +23,15 @@ Datadog ログ管理は、ログの収集、処理、アーカイブ、探索、
 
 Therefore, this guide walks you through various Log Management best practices and account configurations that provide you flexibility in governance, usage attribution, and budget control. More specifically, how to:
 
-- [複数のインデックスを設定し、ログをセグメント化する](#set-up-multiple-indexes-for-log-segmentation)
-- [長期保存のための複数のアーカイブを設定する](#set-up-multiple-archives-for-long-term-storage)
-- [カスタムロールの RBAC を設定する](#set-up-rbac-for-custom-roles)
+- [複数のインデックスを設定し、ログをセグメント化する](#ログセグメンテーションのための複数のインデックスを設定する)
+- [長期保存のための複数のアーカイブを設定する](#長期保存のための複数のアーカイブを設定する)
+- [カスタムロールの RBAC を設定する](#カスタムロールの-rbac-を設定する)
 
 また、このガイドでは、ログの使用量を監視する方法について、以下のように説明します。
 
-- [予期せぬログトラフィックの急増にアラートを出す](#alert-on-unexpected-log-traffic-spikes)
-- [インデックス化されたログに対して、ボリュームがしきい値を超えた場合にアラートを出す](#alert-when-an-indexed-log-volume-passes-a-specified-threshold)
-- [大容量ログの除外フィルターを設定する](#set-up-exclusion-filters-on-high-volume-logs)
+- [予期せぬログトラフィックの急増にアラートを出す](#予期せぬログトラフィックの急増に対するアラート)
+- [インデックス化されたログに対して、ボリュームがしきい値を超えた場合にアラートを出す](#インデックス化されたログボリュームが指定されたしきい値を超えた場合のアラート)
+- [大容量ログの除外フィルターを設定する](#大量ログの除外フィルターを設定する)
 
 If you want to transform your logs or redact sensitive data in your logs before they leave your environment, see how to [aggregate, process, and transform your log data with Observability Pipelines][29].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
DOCS-8769. 

A problem was reported with the anchor links not working in the Japanese Best Practices for Logs article. In Transifex, the links were already reviewed; however, the actual anchor links are still in English. I unreviewed the strings and added a comment asking for the anchor links to be translated into Japanese. In the meantime, this PR is to fix the anchor links while we wait for the translators to update the doc.

Staging preview: https://docs-staging.datadoghq.com/deforest/fix-anchor-links-ja-docs/ja/logs/guide/best-practices-for-log-management

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->