### PR TITLE
[SDTEST-592] Add documentation for GitLab+CircleCI autoinstrumentation

### DIFF
--- a/content/en/tests/setup/dotnet.md
+++ b/content/en/tests/setup/dotnet.md
@@ -54,21 +54,11 @@ Supported test frameworks:
 To report test results to Datadog, you need to configure the Datadog .NET library:
 
 {{< tabs >}}
-{{% tab "Github Actions" %}}
-You can use the dedicated [Datadog Test Visibility Github Action][1] to enable Test Visibility.
-If you do so, the rest of the setup steps below can be skipped.
-
-[1]: https://github.com/marketplace/actions/configure-datadog-test-visibility
+{{% tab "CI Provider with Auto-Instrumentation Support" %}}
+{{% ci-autoinstrumentation %}}
 {{% /tab %}}
 
-{{% tab "Jenkins" %}}
-You can use [UI-based configuration][1] to enable Test Visibility for your jobs and pipelines.
-If you do so, the rest of the setup steps below can be skipped.
-
-[1]: /continuous_integration/pipelines/jenkins/#enable-with-the-jenkins-configuration-ui-1
-{{% /tab %}}
-
-{{% tab "Other cloud CI provider" %}}
+{{% tab "Other Cloud CI Provider" %}}
 <div class="alert alert-info">Agentless mode is available in Datadog .NET library versions >= 2.5.1</div>
 {{% ci-agentless %}}
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -67,21 +67,11 @@ You may follow interactive setup steps on the [Datadog site][2] or the instructi
 Configuring the Datadog Java Tracer varies depending on your CI provider.
 
 {{< tabs >}}
-{{% tab "Github Actions" %}}
-You can use the dedicated [Datadog Test Visibility Github Action][1] to enable Test Visibility.
-If you do so, you can skip the **Downloading tracer library** and **Running your tests** steps below.
-
-[1]: https://github.com/marketplace/actions/configure-datadog-test-visibility
+{{% tab "CI Provider with Auto-Instrumentation Support" %}}
+{{% ci-autoinstrumentation %}}
 {{% /tab %}}
 
-{{% tab "Jenkins" %}}
-You can use [UI-based configuration][1] to enable Test Visibility for your jobs and pipelines.
-If you do so, you can skip the "Downloading tracer library" and "Running your tests" steps below.
-
-[1]: /continuous_integration/pipelines/jenkins/#enable-with-the-jenkins-configuration-ui-1
-{{% /tab %}}
-
-{{% tab "Other cloud CI provider" %}}
+{{% tab "Other Cloud CI Provider" %}}
 {{% ci-agentless %}}
 {{% /tab %}}
 

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -46,22 +46,11 @@ The instrumentation works at runtime, so any transpilers such as TypeScript, Web
 To report test results to Datadog, you need to configure the Datadog JavaScript library:
 
 {{< tabs >}}
-{{% tab "Github Actions" %}}
-You can use the dedicated [Datadog Test Visibility Github Action][1] to enable Test Visibility.
-If you do so, the rest of the setup steps below can be skipped.
-
-[1]: https://github.com/marketplace/actions/configure-datadog-test-visibility
+{{% tab "CI Provider with Auto-Instrumentation Support" %}}
+{{% ci-autoinstrumentation %}}
 {{% /tab %}}
 
-{{% tab "Jenkins" %}}
-You can use [UI-based configuration][1] to enable Test Visibility for your jobs and pipelines.
-If you do so, the rest of the setup steps below can be skipped.
-
-[1]: /continuous_integration/pipelines/jenkins/#enable-with-the-jenkins-configuration-ui-1
-{{% /tab %}}
-
-
-{{% tab "Other cloud CI provider" %}}
+{{% tab "Other Cloud CI Provider" %}}
 <div class="alert alert-info">Agentless mode is available in Datadog JavaScript library versions >= 2.5.0</div>
 {{% ci-agentless %}}
 

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -45,22 +45,11 @@ Supported test frameworks:
 To report test results to Datadog, you need to configure the Datadog Python library:
 
 {{< tabs >}}
-{{% tab "Github Actions" %}}
-You can use the dedicated [Datadog Test Visibility Github Action][1] to enable Test Visibility.
-If you do so, the rest of the setup steps below can be skipped.
-
-[1]: https://github.com/marketplace/actions/configure-datadog-test-visibility
+{{% tab "CI Provider with Auto-Instrumentation Support" %}}
+{{% ci-autoinstrumentation %}}
 {{% /tab %}}
 
-{{% tab "Jenkins" %}}
-You can use [UI-based configuration][1] to enable Test Visibility for your jobs and pipelines.
-If you do so, the rest of the setup steps below can be skipped.
-
-[1]: /continuous_integration/pipelines/jenkins/#enable-with-the-jenkins-configuration-ui-1
-{{% /tab %}}
-
-
-{{% tab "Other cloud CI provider" %}}
+{{% tab "Other Cloud CI Provider" %}}
 {{% ci-agentless %}}
 {{% /tab %}}
 

--- a/layouts/shortcodes/ci-autoinstrumentation.md
+++ b/layouts/shortcodes/ci-autoinstrumentation.md
@@ -2,7 +2,7 @@ We support auto-instrumentation for the following CI providers:
 | CI Provider | Auto-Instrumentation method |
 |---|---|
 | GitHub Actions | [Datadog Test Visibility Github Action][1] |
-| Jenkins | [UI-based configuration][2] |
+| Jenkins | [UI-based configuration][2] with Datadog Jenkins plugin |
 | GitLab | [Datadog Test Visibility GitLab Script][3] |
 | CircleCI | [Datadog Test Visibility CircleCI Orb][4] |
 

--- a/layouts/shortcodes/ci-autoinstrumentation.md
+++ b/layouts/shortcodes/ci-autoinstrumentation.md
@@ -1,0 +1,14 @@
+We support auto-instrumentation for the following CI providers:
+| CI Provider | Auto-Instrumentation method |
+|---|---|
+| GitHub Actions | [Datadog Test Visibility Github Action][1] |
+| Jenkins | [UI-based configuration][2] |
+| GitLab | [Datadog Test Visibility GitLab Script][3] |
+| CircleCI | [Datadog Test Visibility CircleCI Orb][4] |
+
+If you are using autoinstrumentation for one of these providers, the rest of the setup steps below can be skipped.
+
+[1]: https://github.com/marketplace/actions/configure-datadog-test-visibility
+[2]: /continuous_integration/pipelines/jenkins/#enable-with-the-jenkins-configuration-ui-1
+[3]: https://github.com/DataDog/test-visibility-gitlab-script
+[4]: https://circleci.com/orbs/registry/orb/datadog/test-visibility-circleci-orb

--- a/layouts/shortcodes/ci-autoinstrumentation.md
+++ b/layouts/shortcodes/ci-autoinstrumentation.md
@@ -6,7 +6,7 @@ We support auto-instrumentation for the following CI providers:
 | GitLab | [Datadog Test Visibility GitLab Script][3] |
 | CircleCI | [Datadog Test Visibility CircleCI Orb][4] |
 
-If you are using autoinstrumentation for one of these providers, the rest of the setup steps below can be skipped.
+If you are using auto-instrumentation for one of these providers, you can skip the rest of the setup steps below.
 
 [1]: https://github.com/marketplace/actions/configure-datadog-test-visibility
 [2]: /continuous_integration/pipelines/jenkins/#enable-with-the-jenkins-configuration-ui-1


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This patch adds documentation for GitLab and CircleCI test visibility autoinstrumentation. This also unifies this new docs with the existing GitHub actions + Jenkins autoinstrumentation docs.

**This won't be merged until we've released the CircleCI autoinstrumentation**

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing