### PR TITLE
Remove un-implemented metric

### DIFF
--- a/content/en/serverless/step_functions/enhanced-metrics.md
+++ b/content/en/serverless/step_functions/enhanced-metrics.md
@@ -30,9 +30,6 @@ The following enhanced Step Functions metrics are available.
 `aws.states.enhanced.task.execution.task_duration`
 : Distribution of the durations of individual tasks.
 
-`aws.states.enhanced.task.execution.tasks_timed_out`
-: Counts the total number of tasks that timed out.
-
 `aws.states.enhanced.state.run_duration`
 : Gauge for durations of a state's runs.
 


### PR DESCRIPTION
The `aws.states.enhanced.task.execution.tasks_timed_out` enhanced metric isn't implemented in the Reducer

Removing from our docs until we add this feature

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->