### PR TITLE
Explain how to enable profiling for Go programs built with Orchestrion

### DIFF
--- a/content/en/profiler/enabling/go.md
+++ b/content/en/profiler/enabling/go.md
@@ -82,9 +82,7 @@ To begin profiling applications:
 
 **Note**: By default, only the CPU and Heap profiles are enabled. Use [profiler.WithProfileTypes][11] to enable additional [profile types][12].
 
-If you have automatically instrumented your Go application with [Orchestrion][20],
-the continuous profiler code will already be added to your application.
-Enable the profiler at run time by setting the environment variable `DD_PROFILING_ENABLED=true`.
+If you automatically instrument your Go application with [Orchestrion][20], it adds the continuous profiler code to your application. To enable the profiler at run time, set the environment variable `DD_PROFILING_ENABLED=true`.
 
 ## Configuration
 

--- a/content/en/profiler/enabling/go.md
+++ b/content/en/profiler/enabling/go.md
@@ -82,6 +82,10 @@ To begin profiling applications:
 
 **Note**: By default, only the CPU and Heap profiles are enabled. Use [profiler.WithProfileTypes][11] to enable additional [profile types][12].
 
+If you have automatically instrumented your Go application with [Orchestrion][20],
+the continuous profiler code will already be added to your application.
+Enable the profiler at run time by setting the environment variable `DD_PROFILING_ENABLED=true`.
+
 ## Configuration
 
 You can set profiler parameters in code with these functions:
@@ -155,3 +159,4 @@ The [Getting Started with Profiler][17] guide takes a sample service with a perf
 [17]: /getting_started/profiler/
 [18]: /profiler/enabling/supported_versions/
 [19]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
+[20]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/go

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
@@ -166,6 +166,11 @@ handler := func(w http.ResponseWriter, r *http.Request) {
 
 You can use the [tracing library][4] in your Orchestrion-built application. This is useful for instrumenting frameworks not yet supported by Orchestrion. However, be aware that this may result in duplicated trace spans in the future as Orchestrion support expands. Review the [release notes][11] when updating your `orchestrion` dependency to stay informed about new features and adjust your manual instrumentation as necessary.
 
+#### Use the continuous profiler
+
+Your Orchestrion-built application includes [continuous profiler][12] instrumentation.
+To enable the profiler, set the environment variable `DD_PROFILING_ENABLED=true` at run time.
+
 ### Supported frameworks
 
 | Library                             | Minimum orchestrion version   |
@@ -205,3 +210,4 @@ You can use the [tracing library][4] in your Orchestrion-built application. This
 [9]: https://www.datadoghq.com/support/
 [10]: https://pkg.go.dev/cmd/go#hdr-Modules__module_versions__and_more
 [11]: https://github.com/DataDog/orchestrion/releases
+[12]: /profiler


### PR DESCRIPTION
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Orchestrion adds code to start the continuous profiler to Go programs.
It needs to be enabled at run time by setting the
`DD_PROFILING_ENABLED=true` environment variable. Explain this in both the
Orchestrion and profiler doc pages.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
