### PR TITLE
Update minimum version of dd-trace-go for otel dropin support to 1.67.0

### DIFF
--- a/content/en/opentelemetry/interoperability/instrumentation_libraries.md
+++ b/content/en/opentelemetry/interoperability/instrumentation_libraries.md
@@ -45,7 +45,7 @@ Datadog SDKs implement the OpenTelemetry API by overriding the default implement
 | Java     | 1.35.0                   |
 | Python   | 2.10.0                   |
 | Ruby     | 2.1.0                    |
-| Go       | 1.65.0                   |
+| Go       | 1.67.0                   |
 | Node.js  | 4.3.0                    |
 | PHP      | 0.94.0                   |
 | .NET     | 2.53.0                   |


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Updates the minimum required version for otel drop in support for dd-trace-go to 1.67.0. Span events was added in 1.67.0.
Context: https://datadoghq.atlassian.net/browse/APMAPI-167 and https://github.com/DataDog/dd-trace-go/pull/2780


### Merge instructions
- [ ] Please merge after reviewing

### Additional notes

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->