### PR TITLE
Remove view related metrics from CSM Vulnerabilities troubleshooting

### DIFF
--- a/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
+++ b/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
@@ -46,15 +46,6 @@ ERROR | (pkg/workloadmeta/collectors/internal/containerd/image_sbom_trivy.go:80 
 
 The workaround for this issue is to set the configuration option `discard_unpacked_layers=false` in the containerd configuration file.
 
-## View related metrics
-
-1. Go to **[Metrics > Summary][4]** in Datadog.
-2. Search for the following metrics to aid in troubleshooting:
-    -  `datadog.agent.sbom_attempts`: Tracks sbom collection attempts by `source` and `type`.
-    -  `datadog.agent.sbom_generation_duration`: Measures the time that it takes to generate SBOMs in seconds.
-    -  `datadog.agent.sbom_errors`: Number of sbom failures by `source`, `type`, and `reason`.
-    -  `datadog.agent.export_size`: The size of the archive written on disk. 
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes the View Related Metrics entry from the CSM Vulnerabilities troubleshooting page.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->