### PR TITLE
Fix debug symbols typos related to React Native

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/expo.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/expo.md
@@ -108,7 +108,7 @@ To test your implementation:
 3. For obfuscated error reports that do not result in a crash, you can verify symbolication and deobfuscation in [**Error Tracking**][1].
 4. For crashes, after the crash happens, restart your application and wait for the React Native SDK to upload the crash report in [**Error Tracking**][1].
 
-To make sure your sourcemaps are correctly sent and linked to your application, you can also generate crashes with the [`react-native-performance-limiter`][14] package.
+To make sure your source maps are correctly sent and linked to your application, you can also generate crashes with the [`react-native-performance-limiter`][14] package.
 
 Install it with yarn or npm then re-install your pods:
 
@@ -127,7 +127,7 @@ const crashApp = () => {
 };
 ```
 
-Re-build your application for release to send the new sourcemaps, trigger the crash and wait on the [Error Tracking][1] page for the error to appear.
+Re-build your application for release to send the new source maps, trigger the crash and wait on the [Error Tracking][1] page for the error to appear.
 ```
 
 ## Additional configuration options
@@ -158,7 +158,7 @@ If you want to disable **all file uploads**, remove `expo-datadog` from the list
 
 ### Using Expo with Datadog and Sentry
 
-Both Datadog and Sentry config plugins use regular expressions to modify the "Bundle React Native code and images" iOS build phase to send the sourcemap. This can make your EAS builds fail with a `error: Found argument 'datadog-ci' which wasn't expected, or isn't valid in this context` error.
+Both Datadog and Sentry config plugins use regular expressions to modify the "Bundle React Native code and images" iOS build phase to send the source map. This can make your EAS builds fail with a `error: Found argument 'datadog-ci' which wasn't expected, or isn't valid in this context` error.
 
 To use both plugins, make sure to add the `expo-datadog` plugin first in order in your `app.json` file:
 

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -27,7 +27,7 @@ Enable React Native Crash Reporting and Error Tracking to get comprehensive cras
 -   Symbolicated React Native (JavaScript and native iOS or Android) crash reports
 -   Trend analysis with React Native Error Tracking
 
-In order to symbolicate your stack traces, manually upload your mapping files into Datadog.
+In order to symbolicate your stack traces, manually upload your source maps and native debug symbols into Datadog.
 
 Your crash reports appear in [**Error Tracking**][1].
 
@@ -53,14 +53,14 @@ config.nativeCrashReportEnabled = true; // enable native crash reporting
 
 ## Get deobfuscated stack traces
 
-Mapping files are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding mapping files. This ensures that regardless of when the mapping file was uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
+Debug symbols are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding dDebug symbols. This ensures that regardless of when the debug symbols were uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
 
 For React Native applications, the matching of stack traces and sourcemaps relies on a combination of the `service`, `version`, `bundle_name`, and `platform` fields. Out of all sourcemaps that match with these fields, Datadog uses the one with the highest `build_number` value.
 
 In order to make your application's size smaller, its code is minified when it is built for release. To link errors to your actual code, you need to upload the following symbolication files:
 
--   JavaScript source map for your iOS JavaScript bundle
--   JavaScript source map for your Android JavaScript bundle
+-   JavaScript source maps for your iOS JavaScript bundle
+-   JavaScript source maps for your Android JavaScript bundle
 -   dSYMs for your iOS native code
 -   Proguard mapping files if you have enabled code obfuscation for your Android native code
 

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -53,7 +53,7 @@ config.nativeCrashReportEnabled = true; // enable native crash reporting
 
 ## Get deobfuscated stack traces
 
-Debug symbols are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding dDebug symbols. This ensures that regardless of when the debug symbols were uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
+Debug symbols are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding debug symbols. This ensures that regardless of when the debug symbols were uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
 
 For React Native applications, the matching of stack traces and source maps relies on a combination of the `service`, `version`, `bundle_name`, and `platform` fields. Out of all source maps that match with these fields, Datadog uses the one with the highest `build_number` value.
 

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -55,7 +55,7 @@ config.nativeCrashReportEnabled = true; // enable native crash reporting
 
 Debug symbols are used to deobfuscate stack traces, which helps in debugging errors. Using a unique build ID that gets generated, Datadog automatically matches the correct stack traces with the corresponding dDebug symbols. This ensures that regardless of when the debug symbols were uploaded (either during pre-production or production builds), the correct information is available for efficient QA processes when reviewing crashes and errors reported in Datadog.
 
-For React Native applications, the matching of stack traces and sourcemaps relies on a combination of the `service`, `version`, `bundle_name`, and `platform` fields. Out of all sourcemaps that match with these fields, Datadog uses the one with the highest `build_number` value.
+For React Native applications, the matching of stack traces and source maps relies on a combination of the `service`, `version`, `bundle_name`, and `platform` fields. Out of all source maps that match with these fields, Datadog uses the one with the highest `build_number` value.
 
 In order to make your application's size smaller, its code is minified when it is built for release. To link errors to your actual code, you need to upload the following symbolication files:
 
@@ -86,9 +86,9 @@ Options for the `datadog-ci react-native xcode` command are available on the [co
 
 #### Specifying a custom release version
 
-Use the `DATADOG_RELEASE_VERSION` environment variable to specify a different release version for your sourcemaps, starting from `@datadog/mobile-react-native@2.3.5` and `@datadog/datadog-ci@v2.37.0`.
+Use the `DATADOG_RELEASE_VERSION` environment variable to specify a different release version for your source maps, starting from `@datadog/mobile-react-native@2.3.5` and `@datadog/datadog-ci@v2.37.0`.
 
-When the SDK is initialized with a version suffix, you must manually override the release version in order for the sourcemap and build versions to match.
+When the SDK is initialized with a version suffix, you must manually override the release version in order for the source map and build versions to match.
 
 ## Limitations
 
@@ -136,7 +136,7 @@ To test your implementation:
 3. For obfuscated error reports that do not result in a crash, you can verify symbolication and deobfuscation in [**Error Tracking**][1].
 4. For crashes, after the crash happens, restart your application and wait for the React Native SDK to upload the crash report in [**Error Tracking**][1].
 
-To make sure your sourcemaps are correctly sent and linked to your application, you can also generate crashes with the [`react-native-performance-limiter`][14] package.
+To make sure your source maps are correctly sent and linked to your application, you can also generate crashes with the [`react-native-performance-limiter`][14] package.
 
 Install it with yarn or npm then re-install your pods:
 
@@ -155,7 +155,7 @@ const crashApp = () => {
 };
 ```
 
-Re-build your application for release to send the new sourcemaps, trigger the crash and wait on the [Error Tracking][1] page for the error to appear.
+Re-build your application for release to send the new source maps, trigger the crash and wait on the [Error Tracking][1] page for the error to appear.
 
 To test your dSYMs and Proguard mapping files upload, crash the native main thread instead:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR fixes some typos on the React Native and expo docs:
- Write `source map(s)` instead of `sourcemap(s)` to remain consistent with Web UI
- Use "debug symbols" as a generic term

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->