### PR TITLE
WEB-5256 - Fix names for links on ja integrations

### DIFF
--- a/content/ja/integrations/container.md
+++ b/content/ja/integrations/container.md
@@ -36,7 +36,7 @@ integration_title: コンテナ
 integration_version: ''
 is_public: true
 manifest_version: 2.0.0
-name: コンテナ
+name: container
 public_title: コンテナ
 short_description: コンテナのメトリクスを Datadog で追跡
 supported_os:

--- a/content/ja/integrations/network.md
+++ b/content/ja/integrations/network.md
@@ -32,7 +32,7 @@ integration_title: Network
 integration_version: 3.3.0
 is_public: true
 manifest_version: 2.0.0
-name: ネットワーク
+name: network
 public_title: Network
 short_description: 送受信バイト数およびパケット数、接続状態、ラウンドトリップ回数などを追跡
 supported_os:

--- a/content/ja/integrations/process.md
+++ b/content/ja/integrations/process.md
@@ -1,5 +1,5 @@
 ---
-app_id: システム
+app_id: system
 app_uuid: 43bff15c-c943-4153-a0dc-25bb557ac763
 assets:
   integration:
@@ -13,7 +13,7 @@ assets:
       prefix: system.
     service_checks:
       metadata_path: assets/service_checks.json
-    source_type_name: プロセス
+    source_type_name: Process
 author:
   homepage: https://www.datadoghq.com
   name: Datadog
@@ -26,13 +26,13 @@ dependencies:
 - https://github.com/DataDog/integrations-core/blob/master/process/README.md
 display_on_public_website: true
 draft: false
-git_integration_title: プロセス
-integration_id: システム
+git_integration_title: process
+integration_id: system
 integration_title: プロセス
 integration_version: 3.4.0
 is_public: true
 manifest_version: 2.0.0
-name: プロセス
+name: process
 public_title: プロセス
 short_description: 実行中のプロセスのメトリクスをキャプチャし、ステータスを監視します。
 supported_os:

--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -28,7 +28,7 @@
   {{- $s.SetInMap $path "id" $k -}}
   {{- $s.SetInMap $path "name" ($v.Params.name | default ($v.File.TranslationBaseName | lower))  -}}
   {{- $s.SetInMap $path "item_class" "" -}}
-  {{- $s.SetInMap $path "redirect" (print "integrations/" (($v.Params.name | lower) | default ($v.File.TranslationBaseName | lower)) "/") -}}
+  {{- $s.SetInMap $path "redirect" (print "integrations/" (($enpage.Params.name | lower) | default ($v.File.TranslationBaseName | lower)) "/") -}}
   {{- $s.SetInMap $path "blurb" ($v.Params.description | default $v.Params.short_description) -}}
   {{- $s.SetInMap $path "public_title" ($v.Title | default $v.Params.public_title) -}}
   {{- $s.SetInMap $path "is_marketplace" (in $enpage.Params.categories "marketplace") -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

https://datadoghq.atlassian.net/browse/WEB-5256
Fixes 3 integrations that are linking to non existing pages because they are using the translation in the url
Updates the template to also rely on the english name for the url, so this won't matter if this comes back in the future.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes

Clicking the tile in the results should go to a page:
https://docs-staging.datadoghq.com/david.jones/web-5256/ja/integrations/?q=%E3%83%97%E3%83%AD%E3%82%BB%E3%82%B9

The following links should work
https://docs-staging.datadoghq.com/david.jones/web-5256/ja/integrations/container/
https://docs-staging.datadoghq.com/david.jones/web-5256/ja/integrations/network/
https://docs-staging.datadoghq.com/david.jones/web-5256/ja/integrations/process/