### PR TITLE
Switch additionalConfigs to string

### DIFF
--- a/content/en/containers/kubernetes/prometheus.md
+++ b/content/en/containers/kubernetes/prometheus.md
@@ -348,7 +348,7 @@ spec:
     prometheusScrape:
       enabled: true
       enableServiceEndpoints: true
-      additionalConfigs:
+      additionalConfigs: |-
         - autodiscovery:
             kubernetes_container_names:
               - my-app


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Corrects example in documentation to use string type. This matches the example found [here](https://github.com/DataDog/datadog-operator/blob/main/examples/datadogagent/datadog-agent-with-prometheus-autodiscovery-advanced-config.yaml#L10).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->