### PR TITLE
Adjust tabs for DD_IGNORE_AUTOCONF examples

### DIFF
--- a/content/en/containers/guide/auto_conf.md
+++ b/content/en/containers/guide/auto_conf.md
@@ -60,7 +60,7 @@ The following examples disable auto-configuration for the Redis and Istio integr
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
 
-In your `datadog-agent.yaml`, use `override.nodeAgent.env` to set the `DD_IGNORE_AUTOCONF` environment variable.
+In your `datadog-agent.yaml`, use `override.nodeAgent.containers.agent.env` to set the `DD_IGNORE_AUTOCONF` environment variable in the `agent` container.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -90,28 +90,14 @@ Add `datadog.ignoreAutoconfig` to your `datadog-values.yaml`:
 
 ```yaml
 datadog:
- #List of integration(s) to ignore auto_conf.yaml.
+  #List of integration(s) to ignore auto_conf.yaml.
   ignoreAutoConfig:
     - redisdb
     - istio
 ```
 {{% /tab %}}
-{{% tab "Operator" %}}
-
-To disable auto configuration integration(s) with the Operator, add the `DD_IGNORE_AUTOCONF` variable to your `datadog-agent.yaml` file:
-
-```yaml
-  override:
-    nodeAgent:
-      containers: 
-        agent:
-          env:
-            - name: DD_IGNORE_AUTOCONF
-              value: "redisdb istio"
-```
-{{% /tab %}}
-{{% tab "DaemonSet" %}}
-To disable auto configuration integration(s) with your DaemonSet, add the `DD_IGNORE_AUTOCONF` variable to your Agent manifest:
+{{% tab "Containerized Agent" %}}
+To disable auto configuration integration(s) with your containerized agent (manual DaemonSet, Docker, ECS), add the `DD_IGNORE_AUTOCONF` environment variable:
 
 ```yaml
 DD_IGNORE_AUTOCONF="redisdb istio"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Main motivation we currently have the duplicate "Datadog Operator" and "Operator" tab. So remove the "Operator" tab. Also renamed the "DaemonSet" to "Containerized Agent" to better match manual DaemonSet, Docker, or ECS setups. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

See live doc: https://docs.datadoghq.com/containers/guide/auto_conf/?tab=datadogoperator#disable-auto-configuration

Preview doc: https://docs-staging.datadoghq.com/jack.davenport/adjust_ignore_tabs/containers/guide/auto_conf

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->