### PR TITLE
Replace monitors#create with monitors/create url link

### DIFF
--- a/content/en/account_management/billing/usage_monitor_apm.md
+++ b/content/en/account_management/billing/usage_monitor_apm.md
@@ -45,7 +45,7 @@ To reduce the number of indexed spans, check your configuration for retention fi
 [1]: https://www.datadoghq.com/pricing
 [2]: /account_management/billing/apm_distributed_tracing/
 [3]: https://app.datadoghq.com/account/usage
-[4]: https://app.datadoghq.com/monitors#create/metric
+[4]: https://app.datadoghq.com/monitors/create/metric
 [5]: /monitors/types/apm/?tab=traceanalytics#monitor-creation
 [6]: https://app.datadoghq.com/apm/traces?viz=timeseries
 [7]: /tracing/guide/trace_ingestion_volume_control/

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -395,7 +395,7 @@ After configuration is complete, [restart the Agent][11].
 [5]: /network_monitoring/performance
 [6]: /agent/guide/datadog-agent-manager-windows/
 [7]: /integrations/wmi_check/
-[8]: https://app.datadoghq.com/monitors#create/integration
+[8]: https://app.datadoghq.com/monitors/create/integration
 [9]: /infrastructure/process/?tab=linuxwindows#installation
 [10]: /agent/configuration/agent-configuration-files/#agent-main-configuration-file
 [11]: /agent/configuration/agent-commands/#restart-the-agent

--- a/content/en/getting_started/monitors/_index.md
+++ b/content/en/getting_started/monitors/_index.md
@@ -134,7 +134,7 @@ You can view Monitor Saved Views from your mobile home screen or view and mute m
 [2]: /getting_started/agent/
 [3]: https://app.datadoghq.com/account/settings/agent/latest
 [4]: https://app.datadoghq.com/infrastructure
-[5]: https://app.datadoghq.com/monitors#create/metric
+[5]: https://app.datadoghq.com/monitors/create/metric
 [6]: /integrations/disk/
 [7]: /monitors/types/metric/?tab=threshold#set-alert-conditions
 [8]: /monitors/notify/variables/

--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -471,7 +471,7 @@ Processes are normally collected at 10s resolution. While actively working with 
 [4]: /getting_started/tagging/unified_service_tagging
 [5]: https://app.datadoghq.com/process
 [6]: /monitors/types/process/
-[7]: https://app.datadoghq.com/monitors#create/live_process
+[7]: https://app.datadoghq.com/monitors/create/live_process
 [8]: /dashboards/widgets/timeseries/#pagetitle
 [9]: /infrastructure/livecontainers/
 [10]: /tracing/

--- a/content/en/monitors/manage/status.md
+++ b/content/en/monitors/manage/status.md
@@ -182,7 +182,7 @@ You can obtain a JSON export of any monitor from the monitor's status page. Clic
 [10]: https://app.datadoghq.com/event/explorer
 [11]: /account_management/audit_trail/
 [12]: https://www.datadoghq.com/blog/audit-trail-best-practices/
-[13]: https://app.datadoghq.com/monitors#create/import
+[13]: https://app.datadoghq.com/monitors/create/import
 [14]: /monitors/configuration/?tab=thresholdalert#configure-notifications-and-automations
 [30]: /monitors/manage/search/#query
 [31]: /getting_started/tagging/

--- a/content/en/monitors/types/anomaly.md
+++ b/content/en/monitors/types/anomaly.md
@@ -248,7 +248,7 @@ A standard configuration of thresholds and threshold window looks like:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/monitors#create/anomaly
+[1]: https://app.datadoghq.com/monitors/create/anomaly
 [2]: /monitors/types/metric/#define-the-metric
 [3]: /dashboards/functions/algorithms/#anomalies
 [4]: /monitors/guide/how-to-update-anomaly-monitor-timezone/

--- a/content/en/monitors/types/apm.md
+++ b/content/en/monitors/types/apm.md
@@ -127,7 +127,7 @@ For detailed instructions on the **Configure notifications and automations** sec
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /monitors/types/metric/
-[2]: https://app.datadoghq.com/monitors#create/apm
+[2]: https://app.datadoghq.com/monitors/create/apm
 [3]: /monitors/notify/
 [4]: https://app.datadoghq.com/services
 [5]: https://app.datadoghq.com/apm/map

--- a/content/en/monitors/types/composite.md
+++ b/content/en/monitors/types/composite.md
@@ -199,7 +199,7 @@ However, consider monitor `3`, a multi alert per `host,url`. Monitor `1` and mon
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/monitors#create/composite
+[1]: https://app.datadoghq.com/monitors/create/composite
 [2]: /monitors/configuration/#advanced-alert-conditions
 [3]: /monitors/notify/
 [4]: /monitors/notify/variables/?tab=is_alert#composite-monitor-variables

--- a/content/en/monitors/types/event.md
+++ b/content/en/monitors/types/event.md
@@ -93,7 +93,7 @@ The template variable is `{{event.tags.env}}`. The result of using this template
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/monitors#create/event
+[1]: https://app.datadoghq.com/monitors/create/event
 [2]: /service_management/events/explorer/searching
 [3]: /help/
 [4]: /monitors/configuration/#advanced-alert-conditions

--- a/content/en/monitors/types/forecasts.md
+++ b/content/en/monitors/types/forecasts.md
@@ -138,7 +138,7 @@ The following functions cannot be nested inside calls to the `forecast()` functi
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/monitors#create/forecast
+[1]: https://app.datadoghq.com/monitors/create/forecast
 [2]: /monitors/types/metric/#define-the-metric
 [3]: /monitors/guide/recovery-thresholds/
 [4]: /monitors/guide/how-to-update-anomaly-monitor-timezone/

--- a/content/en/monitors/types/host.md
+++ b/content/en/monitors/types/host.md
@@ -86,6 +86,6 @@ For detailed instructions on the **Configure notifications and automations** sec
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/monitors#create/host
+[1]: https://app.datadoghq.com/monitors/create/host
 [2]: /monitors/configuration/#advanced-alert-conditions
 [3]: /monitors/notify/

--- a/content/en/monitors/types/integration.md
+++ b/content/en/monitors/types/integration.md
@@ -105,7 +105,7 @@ For detailed instructions on the **Configure notifications and automations** sec
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /integrations/
-[2]: https://app.datadoghq.com/monitors#create/integration
+[2]: https://app.datadoghq.com/monitors/create/integration
 [3]: /monitors/types/metric/
 [4]: https://app.datadoghq.com/monitors/manage
 [5]: /monitors/configuration/#advanced-alert-conditions

--- a/content/en/monitors/types/log.md
+++ b/content/en/monitors/types/log.md
@@ -114,7 +114,7 @@ Include a sample of 10 logs in the alert notification:
 
 [1]: /logs/
 [2]: /logs/log_configuration/indexes/
-[3]: https://app.datadoghq.com/monitors#create/log
+[3]: https://app.datadoghq.com/monitors/create/log
 [4]: /logs/explorer/search/
 [5]: /logs/explorer/facets/
 [6]: /logs/explorer/facets/#measures

--- a/content/en/monitors/types/network.md
+++ b/content/en/monitors/types/network.md
@@ -93,7 +93,7 @@ Create a network metric monitor by following the instructions in the [metric mon
 
 [1]: /integrations/http_check/
 [2]: /integrations/tcp_check/
-[3]: https://app.datadoghq.com/monitors#create/network
+[3]: https://app.datadoghq.com/monitors/create/network
 [4]: /monitors/configuration/#advanced-alert-conditions
 [5]: /monitors/configuration/#no-data
 [6]: /monitors/configuration/#auto-resolve

--- a/content/en/monitors/types/process.md
+++ b/content/en/monitors/types/process.md
@@ -94,7 +94,7 @@ For detailed instructions on the **Configure notifications and automations** sec
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /infrastructure/process/
-[2]: https://app.datadoghq.com/monitors#create/live_process
+[2]: https://app.datadoghq.com/monitors/create/live_process
 [3]: /infrastructure/process/#search-syntax
 [4]: https://app.datadoghq.com/process
 [5]: /monitors/configuration/#advanced-alert-conditions

--- a/content/en/monitors/types/process_check.md
+++ b/content/en/monitors/types/process_check.md
@@ -84,7 +84,7 @@ For detailed instructions on the **Configure notifications and automations** sec
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /integrations/process/
-[2]: https://app.datadoghq.com/monitors#create/process
+[2]: https://app.datadoghq.com/monitors/create/process
 [3]: /monitors/configuration/#advanced-alert-conditions
 [4]: /monitors/configuration/#no-data
 [5]: /monitors/configuration/#auto-resolve

--- a/content/en/monitors/types/watchdog.md
+++ b/content/en/monitors/types/watchdog.md
@@ -47,6 +47,6 @@ For more instructions on the **Configure notifications and automations** section
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /watchdog/
-[2]: https://app.datadoghq.com/monitors#create/watchdog
+[2]: https://app.datadoghq.com/monitors/create/watchdog
 [3]: /monitors/configuration/?tab=thresholdalert#alert-grouping
 [4]: /monitors/notify/

--- a/content/en/real_user_monitoring/guide/monitor-your-rum-usage.md
+++ b/content/en/real_user_monitoring/guide/monitor-your-rum-usage.md
@@ -119,5 +119,5 @@ You are notified about the amount of sessions captured in any scope (such as the
 [1]: /account_management/billing/usage_metrics/
 [2]: https://app.datadoghq.com/dashboard/lists
 [3]: /monitors/types/anomaly/
-[4]: https://app.datadoghq.com/monitors#create/anomaly
+[4]: https://app.datadoghq.com/monitors/create/anomaly
 [5]: https://app.datadoghq.com/rum/explorer?query=%40type%3Asession

--- a/content/en/service_management/service_level_objectives/guide/slo-checklist.md
+++ b/content/en/service_management/service_level_objectives/guide/slo-checklist.md
@@ -113,7 +113,7 @@ _Example: the latency of all user requests should be less than 250 ms 99% of the
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/slo/manage
-[2]: https://app.datadoghq.com/monitors#create/metric
+[2]: https://app.datadoghq.com/monitors/create/metric
 [3]: /metrics
 [4]: /integrations
 [5]: /tracing/trace_pipeline/generate_metrics/

--- a/content/en/service_management/service_level_objectives/monitor.md
+++ b/content/en/service_management/service_level_objectives/monitor.md
@@ -129,7 +129,7 @@ SLO Replay also triggers when you change the underlying metric monitor's query t
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/monitors#create
+[1]: https://app.datadoghq.com/monitors/create
 [2]: https://app.datadoghq.com/slo
 [3]: /service_management/service_level_objectives/metric/
 [4]: /synthetics/api_tests/?tab=httptest#alert-conditions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Noticed that monitors links using the old `monitors#create` were not redirecting to the current `monitors/create` page.
- Replaced any references in the docs using the old URL to the new URL

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->