### PR TITLE
Fix env var typo

### DIFF
--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -203,7 +203,7 @@ Enhanced metrics are automatically enabled if you enable traces.
 
 ## Enable tracing
 
-Datadog generates traces from collected Cloudwatch logs. To enable this, add a `DD_TRACE_ENABLED` tag to each of your Step Functions and set the value to `true`. Alternatively, to enable tracing for **all** your Step Functions, add a `DD_STEP_FUNCTION_TRACE_ENABLED` environment variable to the Datadog Forwarder and set the value to `true`.
+Datadog generates traces from collected Cloudwatch logs. To enable this, add a `DD_TRACE_ENABLED` tag to each of your Step Functions and set the value to `true`. Alternatively, to enable tracing for **all** your Step Functions, add a `DD_STEP_FUNCTIONS_TRACE_ENABLED` environment variable to the Datadog Forwarder and set the value to `true`.
 
 Enhanced metrics are automatically enabled if you enable tracing.
 


### PR DESCRIPTION
Our installation docs say to use `DD_STEP_FUNCTION_TRACE_ENABLED` when it should be `DD_STEP_FUNCTIONS_TRACE_ENABLED`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->