### PR TITLE
Update Browser injection beta flag text

### DIFF
--- a/content/en/real_user_monitoring/browser/setup.md
+++ b/content/en/real_user_monitoring/browser/setup.md
@@ -17,8 +17,8 @@ The responsibility of keeping user data secure is shared between Datadog and dev
 
 ## Setup
 
-{{< callout url="https://www.datadoghq.com/private-beta/rum-sdk-auto-injection/" btn_hidden="false" header="Join the Beta!">}}
-RUM SDK Injection is in private beta. Complete the form to request access.
+{{< callout url="https://www.datadoghq.com/private-beta/rum-sdk-auto-injection/" btn_hidden="false" header="Try our new Browser SDK injection!">}}
+You can now auto-inject the Browser SDK in your application instead of installing it manually. Complete the form to request access to the private beta.
 {{< /callout >}}
 
 To set up RUM Browser Monitoring, create a RUM application:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates the beta flag text so it doesn't look like the entire setup page is in private beta, as per [DOCS-8778](https://datadoghq.atlassian.net/browse/DOCS-8778).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8778]: https://datadoghq.atlassian.net/browse/DOCS-8778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ