### PR TITLE
Update Timeshift docs with "before" functions deprecation

### DIFF
--- a/content/en/dashboards/functions/timeshift.md
+++ b/content/en/dashboards/functions/timeshift.md
@@ -30,7 +30,7 @@ timeshift(avg:system.load.1{*}, -1209600)
 |:-------------------|:----------------------------------------------------------------------------------------------|:-----------------------------------|
 | `calendar_shift()` | Graph values from the previous day, week, or month from the current timestamp for the metric. | `calendar_shift(<METRIC_NAME>{*}, "<TIME_SHIFT_STRING>", "<TIME_ZONE_CODE>")` |
 
-To access the `calendar_shift()` function click the **Add function** button, select **Timeshift > Month before**. The calendar shift allows you to compare the same metric across equivalent timeframes. Here is an example of cloud cost metric `aws.cost.net.amortized` with the calendar_shift() value from two weeks ago compared to the current value.
+To access the `calendar_shift()` function click the **Add function** button, select **Timeshift > Month before**. The calendar shift allows you to compare the same metric across equivalent time frames. Below is an example of cloud cost metric `aws.cost.net.amortized` with the calendar_shift() value from two weeks ago compared to the current value.
 
 {{< img src="dashboards/functions/timeshift/calendar_shift_two_weeks.png" alt="Example of a calendar_shift() function used to compare the `aws.cost.net.amortized ` metric value from two weeks ago and the present" style="width:80%;" >}}
 

--- a/content/en/dashboards/functions/timeshift.md
+++ b/content/en/dashboards/functions/timeshift.md
@@ -8,7 +8,7 @@ further_reading:
   text: "Graph the percentage change between an earlier value and a current value."
 ---
 
-Here is a set of functions of the pattern `<TIMEPERIOD>_before()`. These functions display the values from the corresponding time period on the graph. On their own, they may not be of high value, but together with the current values they may provide useful insight into the performance of your application.
+Here is a set of functions performing a time shift of your data. These functions display the values from the corresponding time period on the graph. On their own, they may not be of high value, but together with the current values they may provide useful insight into the performance of your application.
 
 ## Timeshift
 
@@ -22,6 +22,24 @@ For example, if you wanted to use this to compare current system load with load 
 timeshift(avg:system.load.1{*}, -1209600)
 ```
 
+## Calendar shift
+
+<div class="alert alert-info">The calendar shift feature is now available for all data sources.</div>
+
+| Function           | Description                                                                                   | Example                            |
+|:-------------------|:----------------------------------------------------------------------------------------------|:-----------------------------------|
+| `calendar_shift()` | Graph values from the previous day, week, or month from the current timestamp for the metric. | `calendar_shift(<METRIC_NAME>{*}, "<TIME_SHIFT_STRING>", "<TIME_ZONE_CODE>")` |
+
+To access the `calendar_shift()` function click the **Add function** button, select **Timeshift > Month before**. The calendar shift allows you to compare the same metric across equivalent timeframes. Here is an example of cloud cost metric `aws.cost.net.amortized` with the calendar_shift() value from two weeks ago compared to the current value.
+
+{{< img src="dashboards/functions/timeshift/calendar_shift_two_weeks.png" alt="Example of a calendar_shift() function used to compare the `aws.cost.net.amortized ` metric value from two weeks ago and the present" style="width:80%;" >}}
+
+Valid `TIME_SHIFT_STRING` values are negative integers followed by "d" for days, "w" for weeks, or "mo" for months.
+Some examples are `-1d`, `-7d`, `-1mo`, `-30d`, and `-4w`.
+
+Valid `TIME_ZONE_CODE` values are the IANA time zone codes for a specific city, or `UTC`.
+For example, `UTC`, `America/New_York`, `Europe/Paris`, or `Asia/Tokyo`.
+
 ## Hour before
 
 | Function        | Description                                                            | Example                         |
@@ -34,6 +52,8 @@ Here is an example of `system.load.1` with the `hour_before()` value shown as a 
 
 ## Day before
 
+<div class="alert alert-danger">The day before feature is being deprecated. Use calendar shift with a value of "-1d" instead.</div>
+
 | Function       | Description                                                          | Example                        |
 |:---------------|:---------------------------------------------------------------------|:-------------------------------|
 | `day_before()` | Graph values from a day before the current timestamp for the metric. | `day_before(<METRIC_NAME>{*})` |
@@ -43,6 +63,8 @@ Here is an example of `nginx.net.connections` with the `day_before()` value show
 {{< img src="dashboards/functions/timeshift/simple_day_before_example.png" alt="simple day before example" style="width:80%;">}}
 
 ## Week before
+
+<div class="alert alert-danger">The week before feature is being deprecated. Use calendar shift with a value of "-7d" instead.</div>
 
 | Function        | Description                                                                    | Example                         |
 |:----------------|:-------------------------------------------------------------------------------|:--------------------------------|
@@ -54,6 +76,8 @@ Here is an example of `cassandra.db.read_count` with the `week_before()` value s
 
 ## Month before
 
+<div class="alert alert-danger">The month before feature is being deprecated. Use calendar shift with a value of "-1mo", "-30d" or "-4w" instead, depending on your use case.</div>
+
 | Function         | Description                                                                                | Example                          |
 |:-----------------|:-------------------------------------------------------------------------------------------|:---------------------------------|
 | `month_before()` | Graph values from a month (28 days / 4 weeks) before the current timestamp for the metric. | `month_before(<METRIC_NAME>{*})` |
@@ -62,18 +86,6 @@ Here is an example of `aws.ec2.cpuutilization` with the `month_before()` value s
 
 {{< img src="dashboards/functions/timeshift/simple_month_before_example.png" alt="simple month before example" style="width:80%;">}}
 
-
-## Calendar shift
-
-<div class="alert alert-info">The calendar shift feature is only available for Cloud Cost data sources on <em>private</em> dashboards.</div>
-
-| Function           | Description                                                                                   | Example                            |
-|:-------------------|:----------------------------------------------------------------------------------------------|:-----------------------------------|
-| `calendar_shift()` | Graph values from the previous day, week, or month from the current timestamp for the metric. | `calendar_shift(<METRIC_NAME>{*})` |
-
-To access the calendar_shift() function click the **Add function** button, select **Timeshift > Month before**. The calendar shift allows you to compare the same metric across equivalent timeframes. Here is an example of cloud cost metric `aws.cost.net.amortized` with the calendar_shift() value from two weeks ago compared to the current value.
-
-{{< img src="dashboards/functions/timeshift/calendar_shift_two_weeks.png" alt="Example of a calendar_shift() function used to compare the `aws.cost.net.amortized ` metric value from two weeks ago and the present" style="width:80%;" >}}
 
 ## Other functions
 

--- a/content/en/dashboards/functions/timeshift.md
+++ b/content/en/dashboards/functions/timeshift.md
@@ -24,7 +24,6 @@ timeshift(avg:system.load.1{*}, -1209600)
 
 ## Calendar shift
 
-<div class="alert alert-info">The calendar shift feature is now available for all data sources.</div>
 
 | Function           | Description                                                                                   | Example                            |
 |:-------------------|:----------------------------------------------------------------------------------------------|:-----------------------------------|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Reflecting some product changes in the documentation:
- calendar_timeshift is now available everywhere
- explain better the arguments and their possible values
- reorder the page content to make calendar_timeshift more visible
- "before" functions are being deprecated (except hour_before)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->