### PR TITLE
Add note about JSP apps for RUM proxy config

### DIFF
--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -106,6 +106,13 @@ This function receives an object with the following properties:
 - `path`: the path for the Datadog requests (example: `/api/v2/rum`)
 - `parameters`: the parameters of the Datadog requests (example: `ddsource=browser&...`)
 
+**Note**:
+
+- **JSP web applications** need to use the `\` escape character for the alternative proxy setup to properly propagate these parameters to the browser. For example:
+  ```javascript
+  proxy: (options) => 'http://proxyURL:proxyPort\${options.path}?\${options.parameters}',
+  ```
+
 {{< tabs >}}
 {{% tab "NPM" %}}
 

--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -108,7 +108,7 @@ This function receives an object with the following properties:
 
 **Note**:
 
-- **JSP web applications** need to use the `\` escape character for the alternative proxy setup to properly propagate these parameters to the browser. For example:
+- **JSP web applications** need to use the `\` escape character to properly propagate these parameters to the browser. For example:
   ```javascript
   proxy: (options) => 'http://proxyURL:proxyPort\${options.path}?\${options.parameters}',
   ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds a note about needing to use the `\` escape character when setting up a RUM alternative proxy JSP web apps, as per [DOCS-8726](https://datadoghq.atlassian.net/browse/DOCS-8726).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8726]: https://datadoghq.atlassian.net/browse/DOCS-8726?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ