### PR TITLE
Update control-sensitive-logs-data.md to rectify NOT query wording

### DIFF
--- a/content/en/logs/guide/control-sensitive-logs-data.md
+++ b/content/en/logs/guide/control-sensitive-logs-data.md
@@ -97,7 +97,7 @@ This step makes logs with sensitive data, both logs that already sent and logs t
 
 Use the [Data Access configuration page][17] and a sensitive outline query to define a [restriction][18] that applies to everyone in your organization. For example, the query mentioned above: `version:x.y.z source:python status:debug`.
 
-**Note:** Using **NOT** in the sensitive outline query restricts users from seeing anything BUT matching logs.
+**Note:** Using **NOT** in the sensitive outline query restricts users from the logs matching the query AND allows users to see logs that do not match the query.
 
 {{< img src="logs/guide/sensitive/sensitive_data_access.png" alt="Sensitive Data Access" style="width:80%;" >}}
 

--- a/content/en/logs/guide/control-sensitive-logs-data.md
+++ b/content/en/logs/guide/control-sensitive-logs-data.md
@@ -97,7 +97,7 @@ This step makes logs with sensitive data, both logs that already sent and logs t
 
 Use the [Data Access configuration page][17] and a sensitive outline query to define a [restriction][18] that applies to everyone in your organization. For example, the query mentioned above: `version:x.y.z source:python status:debug`.
 
-**Note:** Using **NOT** in the sensitive outline query restricts users from the logs matching the query AND allows users to see logs that do not match the query.
+**Note:** Using **NOT** in the sensitive outline query restricts users from the logs matching the query and allows users to see logs that do not match the query.
 
 {{< img src="logs/guide/sensitive/sensitive_data_access.png" alt="Sensitive Data Access" style="width:80%;" >}}
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR updates the documentation to correct an error which states that using NOT in a sensitive outline query would allow using to see anything but matching logs but using NOT actually means the opposite. Users can see all logs that do not match this query.  

Incorrect:
Note: Using NOT in the sensitive outline query restricts users from seeing anything BUT matching logs.
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Prev iewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
<img width="1181" alt="not-nginx" src="https://github.com/user-attachments/assets/612130f2-8a25-40db-afc3-81b313b0e253">
![not-nginx-filter](https://github.com/user-attachments/assets/cb6cac4f-a2b8-4221-b04a-77f2f78ce912)
![2024-09-03_11-00-44](https://github.com/user-attachments/assets/d095ced6-cf33-4021-9993-648d60abeb56)