### PR TITLE
Update 'note' on distributions metric type doc

### DIFF
--- a/content/en/metrics/distributions.md
+++ b/content/en/metrics/distributions.md
@@ -39,7 +39,7 @@ Distributions provide enhanced query functionality and configuration options tha
 
 See the [Developer Tools section][1] for more implementation details. 
 
-**Note:** Because distributions are a new metric type, they should be instrumented under new metric names during submission to Datadog.
+**Note:** Because distributions metric data is stored differently from other types, any metric name used for a `distribution` should not be used for any other metric types.
 
 ## Enabling advanced query functionality
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Before:
> **Note:** Because distributions are a new metric type, they should be instrumented under new metric names during submission to Datadog.
After:
> **Note:** Because distributions metric data is stored differently from other types, any metric name used for a `distribution` should not be used for any other metric types.
### Merge instructions

If a metric was previously a non-distribution type and then submitted as a distribution, this can cause issues.
If a metric was previously distribution type and then submitted as a different type, this can also cause issues.
The previous note only hints towards the former.

Motivation:
- https://datadoghq.atlassian.net/wiki/spaces/TS/pages/348522308/How-To+Troubleshoot+Distribution+Metrics+Overshadowing
- https://datadog.zendesk.com/agent/tickets/1830663

<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->