### PR TITLE
Add context to cluster agent commands

### DIFF
--- a/content/en/agent/configuration/agent-commands.md
+++ b/content/en/agent/configuration/agent-commands.md
@@ -76,7 +76,7 @@ List of commands to display the status of the Datadog Agent:
 | macOS           | `launchctl list com.datadoghq.agent` *or* through the systray app             |
 | Source          | `sudo service datadog-agent status`                                           |
 | Windows         | See the [Windows Agent documentation][5].                                     |
-| Cluster Agent (Kubernetes) | `datadog-cluster-agent status`                                     |
+| [Cluster Agent (Kubernetes)][8] | `datadog-cluster-agent status`                                     |
 
 ### Agent information
 
@@ -91,7 +91,7 @@ List of commands to display the status of your Datadog Agent and enabled integra
 | macOS      | `datadog-agent status` or through the [web GUI][4]   |
 | Source     | `sudo datadog-agent status`                          |
 | Windows    | See the [Windows Agent documentation][5].            |
-| Cluster Agent (Kubernetes) | `datadog-cluster-agent status`       |
+| [Cluster Agent (Kubernetes)][8] | `datadog-cluster-agent status`       |
 
 A properly configured integration is displayed under **Running Checks** with no warnings or errors, as seen below:
 
@@ -154,3 +154,4 @@ Some options have flags and options detailed under `--help`. For example, use he
 [5]: /agent/basic_agent_usage/windows/#status-and-information
 [6]: /agent/troubleshooting/config/
 [7]: /agent/troubleshooting/send_a_flare/
+[8]: /containers/cluster_agent/_index.md

--- a/content/en/agent/configuration/agent-commands.md
+++ b/content/en/agent/configuration/agent-commands.md
@@ -75,8 +75,8 @@ List of commands to display the status of the Datadog Agent:
 | Kubernetes      | `kubectl exec -it <POD_NAME> -- s6-svstat /var/run/s6/services/agent/`        |
 | macOS           | `launchctl list com.datadoghq.agent` *or* through the systray app             |
 | Source          | `sudo service datadog-agent status`                                           |
-| Windows         | See the [Windows Agent documentation][5].                                     |
-| [Cluster Agent (Kubernetes)][8] | `datadog-cluster-agent status`                                     |
+| Windows         | See the [Windows Agent documentation][4].                                     |
+| [Cluster Agent (Kubernetes)][5] | `datadog-cluster-agent status`                                     |
 
 ### Agent information
 
@@ -88,10 +88,10 @@ List of commands to display the status of your Datadog Agent and enabled integra
 | Linux      | `sudo datadog-agent status`                          |
 | Docker     | `sudo docker exec -it <CONTAINER_NAME> agent status` |
 | Kubernetes | `kubectl exec -it <POD_NAME> -- agent status`        |
-| macOS      | `datadog-agent status` or through the [web GUI][4]   |
+| macOS      | `datadog-agent status` or through the [web GUI][6]   |
 | Source     | `sudo datadog-agent status`                          |
-| Windows    | See the [Windows Agent documentation][5].            |
-| [Cluster Agent (Kubernetes)][8] | `datadog-cluster-agent status`       |
+| Windows    | See the [Windows Agent documentation][4].            |
+| [Cluster Agent (Kubernetes)][5] | `datadog-cluster-agent status`       |
 
 A properly configured integration is displayed under **Running Checks** with no warnings or errors, as seen below:
 
@@ -127,10 +127,10 @@ Some options have flags and options detailed under `--help`. For example, use he
 | Subcommand        | Notes                                                                       |
 |-------------------|-----------------------------------------------------------------------------|
 | `check`           | Run the specified check.                                                    |
-| `config`          | [Runtime configuration management][6].                                      |
+| `config`          | [Runtime configuration management][7].                                      |
 | `configcheck`     | Print all configurations loaded & resolved of a running Agent.              |
 | `diagnose`        | Execute connectivity diagnosis on your system.                              |
-| `flare`           | [Collect a flare and send it to Datadog][7].                                |
+| `flare`           | [Collect a flare and send it to Datadog][8].                                |
 | `health`          | Print the current Agent health.                                             |
 | `help`            | Help about any command.                                                     |
 | `hostname`        | Print the hostname used by the Agent.                                       |
@@ -150,8 +150,8 @@ Some options have flags and options detailed under `--help`. For example, use he
 [1]: /agent/
 [2]: /agent/docker/
 [3]: /agent/basic_agent_usage/windows/
-[4]: /agent/basic_agent_usage/#gui
-[5]: /agent/basic_agent_usage/windows/#status-and-information
-[6]: /agent/troubleshooting/config/
-[7]: /agent/troubleshooting/send_a_flare/
-[8]: /containers/cluster_agent/_index.md
+[4]: /agent/basic_agent_usage/windows/#status-and-information
+[5]: /containers/cluster_agent/_index.md
+[6]: /agent/basic_agent_usage/#gui
+[7]: /agent/troubleshooting/config/
+[8]: /agent/troubleshooting/send_a_flare/

--- a/content/en/agent/configuration/agent-commands.md
+++ b/content/en/agent/configuration/agent-commands.md
@@ -151,7 +151,7 @@ Some options have flags and options detailed under `--help`. For example, use he
 [2]: /agent/docker/
 [3]: /agent/basic_agent_usage/windows/
 [4]: /agent/basic_agent_usage/windows/#status-and-information
-[5]: /containers/cluster_agent/_index.md
+[5]: /containers/cluster_agent/
 [6]: /agent/basic_agent_usage/#gui
 [7]: /agent/troubleshooting/config/
 [8]: /agent/troubleshooting/send_a_flare/

--- a/content/en/containers/cluster_agent/_index.md
+++ b/content/en/containers/cluster_agent/_index.md
@@ -56,7 +56,7 @@ Some features related to later Kubernetes versions require a minimum Datadog Age
 {{< /whatsnext >}}
 
 ## Monitoring the Cluster Agent
-The Datadog Agent includes an integration that automatically monitors the Cluster Agent. This runs on the regular Datadog Agent pod that is on the same node as the Cluster Agent. Refer to the [Datadog Cluster Agent integration documentation][4] for details.
+The Datadog Agent includes an integration that automatically monitors the Cluster Agent. This runs on the regular Datadog Agent pod that is on the same node as the Cluster Agent. It will not run in the Cluster Agent itself. Refer to the [Datadog Cluster Agent integration documentation][4] for details.
 
 ## Further Reading
 

--- a/content/en/containers/cluster_agent/_index.md
+++ b/content/en/containers/cluster_agent/_index.md
@@ -56,7 +56,7 @@ Some features related to later Kubernetes versions require a minimum Datadog Age
 {{< /whatsnext >}}
 
 ## Monitoring the Cluster Agent
-The Datadog Agent includes an integration that automatically monitors the Cluster Agent. This runs on the regular Datadog Agent pod that is on the same node as the Cluster Agent. It will not run in the Cluster Agent itself. Refer to the [Datadog Cluster Agent integration documentation][4] for details.
+The Datadog Agent includes an integration that automatically monitors the Cluster Agent. The integration runs on the regular Datadog Agent pod that is on the same node as the Cluster Agent. It will not run in the Cluster Agent itself. Refer to the [Datadog Cluster Agent integration documentation][4] for details.
 
 ## Further Reading
 

--- a/content/en/containers/cluster_agent/_index.md
+++ b/content/en/containers/cluster_agent/_index.md
@@ -55,6 +55,9 @@ Some features related to later Kubernetes versions require a minimum Datadog Age
     {{< nextlink href="/agent/cluster_agent/troubleshooting" >}}<u>Cluster Agent Troubleshooting</u>: Find troubleshooting information for the Datadog Cluster Agent.{{< /nextlink >}}
 {{< /whatsnext >}}
 
+## Monitoring the Cluster Agent
+The Datadog Agent includes an integration that automatically monitors the Cluster Agent. This runs on the regular Datadog Agent pod that is on the same node as the Cluster Agent. Refer to the [Datadog Cluster Agent integration documentation][4] for details.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -62,3 +65,4 @@ Some features related to later Kubernetes versions require a minimum Datadog Age
 [1]: /containers/guide/cluster_agent_autoscaling_metrics
 [2]: https://hub.docker.com/r/datadog/cluster-agent
 [3]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
+[4]: https://docs.datadoghq.com/integrations/datadog_cluster_agent/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The motivation started with a [customer Zendesk ticket](https://datadog.zendesk.com/agent/tickets/1795585). The feedback there was there was confusion about getting the status of the Cluster Agent. The user expected to see the Datadog Cluster Agent integration there.

This update provides:
- A link from the Agent Status documentation to the Cluster Agent documentation
- A section in the Cluster Agent documentation clarifying how we monitor the Cluster Agent using the integration, and
- A link to the Cluster Agent integration documentation.

I'm also editing the Cluster Agent integration docs to provide similar information

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->