### PR TITLE
Use correct sample rate range in RUM docs

### DIFF
--- a/content/en/real_user_monitoring/guide/best-practices-for-rum-sampling.md
+++ b/content/en/real_user_monitoring/guide/best-practices-for-rum-sampling.md
@@ -21,7 +21,7 @@ This guide walks you through best practices for RUM sampling so you can capture 
 Sessions are randomly sampled based on the percentage listed in the [SDK configuration][1]. To that end, make sure to use the correct configuration variable names for the SDK version being used.
 
 ### Configure the sampling rate
-Before each new user session, the SDK draws a random floating-point number between 0 and 1, which is then compared to the value set in the SDK configuration. If the random number is lower than the value set in the SDK configuration, the session is kept and events start being collected. If the value is higher, the session is not kept and events are not collected until the end of the session.
+Before each new user session, the SDK draws a random floating-point number between 0 and 100, which is then compared to the value set in the SDK configuration. If the random number is lower than the value set in the SDK configuration, the session is kept and events start being collected. If the value is higher, the session is not kept and events are not collected until the end of the session.
 
 You can set the sampling rate with the SDK ([Browser][2], [Android][3], [iOS][4], [React Native][5], [Flutter][6], [Roku][7]), then deploy it in the application code.
 

--- a/content/en/real_user_monitoring/guide/best-practices-for-rum-sampling.md
+++ b/content/en/real_user_monitoring/guide/best-practices-for-rum-sampling.md
@@ -21,7 +21,7 @@ This guide walks you through best practices for RUM sampling so you can capture 
 Sessions are randomly sampled based on the percentage listed in the [SDK configuration][1]. To that end, make sure to use the correct configuration variable names for the SDK version being used.
 
 ### Configure the sampling rate
-Before each new user session, the SDK draws a random floating-point number between 0 and 100, which is then compared to the value set in the SDK configuration. If the random number is lower than the value set in the SDK configuration, the session is kept and events start being collected. If the value is higher, the session is not kept and events are not collected until the end of the session.
+Before each new user session, the SDK draws a random floating-point number between 0 and 100, which is then compared to the value set in the SDK configuration. If the random number is lower than the value set in the SDK configuration, the session is kept and events start being collected. If the random number is higher, the session is not kept and events are not collected until the end of the session.
 
 You can set the sampling rate with the SDK ([Browser][2], [Android][3], [iOS][4], [React Native][5], [Flutter][6], [Roku][7]), then deploy it in the application code.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Sample rate is specified as a range between 0 to 1 in the best practice article, but the actual code and documentation specifies it as a range between 0 to 100.

This change aligns the numbers to be consistent.

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
N/A