### PR TITLE
[DOCS-8447] Add missing APIs for Android SDK

### DIFF
--- a/content/en/real_user_monitoring/guide/monitor-kiosk-sessions-using-rum.md
+++ b/content/en/real_user_monitoring/guide/monitor-kiosk-sessions-using-rum.md
@@ -28,7 +28,7 @@ The `stopSession()` method differs depending on your installation method.
 {{% tab "NPM" %}}
 
 ```javascript
-datadogRum.stopSession()
+GlobalRumMonitor.get().stopSession()
 ```
 
 {{% /tab %}}

--- a/content/en/real_user_monitoring/guide/monitor-kiosk-sessions-using-rum.md
+++ b/content/en/real_user_monitoring/guide/monitor-kiosk-sessions-using-rum.md
@@ -28,7 +28,7 @@ The `stopSession()` method differs depending on your installation method.
 {{% tab "NPM" %}}
 
 ```javascript
-GlobalRumMonitor.get().stopSession()
+datadogRum.stopSession()
 ```
 
 {{% /tab %}}
@@ -80,7 +80,7 @@ RUMMonitor.shared().stopSession()
 This feature requires RUM Android SDK version >= 1.19.0. See installation instructions [here][1]. 
 
 ```kotlin
-GlobalRum.get().stopSession()
+GlobalRumMonitor.get().stopSession()
 ```
 
 [1]: https://docs.datadoghq.com/real_user_monitoring/android/

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
@@ -298,6 +298,12 @@ You can use the following methods in `Configuration.Builder` when creating the D
 `useSite(DatadogSite)` 
 : Switches target data to EU1, US1, US3, US5, US1_FED and AP1 sites.
 
+`setFirstPartyHostsWithHeaderType`
+: Sets the list of first party hosts and specifies the type of HTTP headers used for distributed tracing.
+
+`useSite` 
+: Switches target data to a Datadog EU1, US1, US3, US5, US1_FED or AP1 site.
+
 `setBatchSize([SMALL|MEDIUM|LARGE])` 
 : Defines the individual batch size for requests sent to Datadog.
 
@@ -307,11 +313,23 @@ You can use the following methods in `Configuration.Builder` when creating the D
 `setBatchProcessingLevel(LOW|MEDIUM|HIGH)` 
 : Defines the number of batches sent in each upload cycle.
 
+`setAdditionalConfiguration`
+: Allows you to provide additional configuration values that can be used by the SDK.
+
+`setProxy`
+: Enables a custom proxy for uploading tracked data to Datadog's intake.
+
 `setEncryption(Encryption)` 
 : Set an encryption function applied to data stored locally on the device.
 
 `setCrashReportsEnabled(Boolean)` 
 : Enable or disable the collection of JVM crashes.
+
+`setPersistenceStategyFactory`
+: Allows you to use a custom persistence strategy.
+
+`setCrashReportsEnabled`
+: Allows you to control whether JVM crashes are tracked or not. The default value is `true`.
 
 `setBackpressureStrategy(BackPressureStrategy)` 
 : Define the strategy the SDK uses when handling large volumes of data and internal queues are full.
@@ -330,6 +348,12 @@ You can use the following methods in `RumConfiguration.Builder` when creating th
 `trackNonFatalAnrs(Boolean)` 
 : Enables tracking non-fatal ANRs. This is enabled by default on Android API 29 and below, and disabled by default on Android API 30 and above.
 
+`setBatchSize([SMALL|MEDIUM|LARGE])` 
+: Defines the individual batch size for requests sent to Datadog.
+
+`setUploadFrequency([FREQUENT|AVERAGE|RARE])` 
+: Defines the frequency for requests made to Datadog endpoints (if requests are available).
+
 `setVitalsUpdateFrequency([FREQUENT|AVERAGE|RARE|NEVER])` 
 : Sets the preferred frequency for collecting mobile vitals.
 
@@ -341,6 +365,53 @@ You can use the following methods in `RumConfiguration.Builder` when creating th
 
 `setSessionListener(RumSessionListener)` 
 : Sets a listener to be notified on when a new RUM Session starts.
+
+You can use the following methods in `RumConfiguration.Builder` when creating the RUM configuration to enable RUM features:
+
+`setSessionSampleRate(<sampleRate>)` 
+: Sets the RUM sessions sample rate. (A value of 0 means no RUM events are sent. A value of 100 means all sessions are kept.)
+
+`setTelemetrySampleRate`
+: The sampling rate for the SDK internal telemetry utilized by Datadog. This must be a value between `0` and `100`. By default, this is set to `20`.
+
+`trackUserInteractions`
+: Enables tracking user interactions (such as tap, scroll, or swipe). The parameter also allows you to add custom attributes to the RUM Action events based on the widget with which the user interacted.
+
+`disableUserInteractionTracking`
+: Disables the user interaction automatic tracker.
+
+`useViewTrackingStrategy`
+: Sets the automatic view tracking strategy the SDK uses. See [Automatically track views](#automatically-track-views) for more information.
+
+`trackLongTasks`
+: Enable long operations on the main thread to be tracked automatically. See [Automatically track long tasks](#automatically-track-long-tasks) for more information.
+
+`setViewEventMapper`
+: Sets the ViewEventMapper for the RUM ViewEvent. You can use this interface implementation to modify the ViewEvent attributes before serialization.
+
+`setResourceEventMapper`
+: Sets the EventMapper for the RUM ResourceEvent. You can use this interface implementation to modify the ResourceEvent attributes before serialization.
+
+`setActionEventMapper`
+: Sets the EventMapper for the RUM ActionEvent. You can use this inteface implementation to modify the ActionEvent attributes before serialization.
+
+`setErrorEventMapper`
+: Sets the EventMapper for the RUM ErrorEvent. you can use this interface implementation to modify the ErrorEvent attributes before serialization.
+
+`setLongTaskEventMapper`
+: Sets the EventMapper for the RUM LongTaskEvent. You can use this interface implementation to modify the LongTaskEvent attributes before serialization.
+
+`trackBackgroundEvents`
+: Enable/disable tracking RUM events when no activity is happening in the foreground. By default, background events are not tracked. Enabling this feature might increase the number of sessions tracked, and therefore your billing.
+
+`trackFrustrations`
+: Enable/disable tracking of frustration signals.
+
+`setVitalsUpdateFrequency`
+: Allows you to specify the frequency at which to update the mobile vitals data provided in the RUM ViewEvent.
+
+`useCustomEndpoint`
+: Use RUM to target a custom server.
  
 ### Automatically track views
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android.md
@@ -222,7 +222,7 @@ You can use the `StopInstance` API to stop the SDK instance assigned to the give
 
 ### Control event buildup
 
-Many operations, such as data processing and event input/output, are queued in background threads. To handle edge cases where the queue has grown so much that there could be delayed processing, high memory usage, or Application Not Responding (ANR) errors.
+Many operations, such as data processing and event input/output, are queued in background threads to handle edge cases where the queue has grown so much that there could be delayed processing, high memory usage, or Application Not Responding (ANR) errors.
 
 You can control the buildup of events on the SDK with the `setBackpressureStrategy` API. This API ignores new tasks if a queue reaches 1024 items.
 
@@ -248,7 +248,20 @@ You can define the minimum log level (priority) to send events to Datadog in a l
 
 ## Track custom global attributes
 
-In addition to the [default RUM attributes][3] captured by the RUM Android SDK automatically, you can choose to add additional contextual information, such as custom attributes, to your RUM events to enrich your observability within Da                                                       |
+In addition to the [default RUM attributes][3] captured by the RUM Android SDK automatically, you can choose to add additional contextual information, such as custom attributes, to your RUM events to enrich your observability within Datadog. Custom attributes allow you to filter and group information about observed user behavior (such as cart value, merchant tier, or ad campaign) with code-level information (such as backend services, session timeline, error logs, and network health).
+
+### Track User Sessions
+
+Adding user information to your RUM sessions makes it easy to:
+* Follow the journey of a given user
+* Know which users are the most impacted by errors
+* Monitor performance for your most important users
+
+{{< img src="real_user_monitoring/browser/advanced_configuration/user-api.png" alt="User API in RUM UI" >}}
+
+The following attributes are **optional**, you should provide **at least one** of them:
+
+| Attribute  | Type | Description                                                                                              |
 |------------|------|----------------------------------------------------------------------------------------------------|
 | usr.id    | String | Unique user identifier.                                                                                  |
 | usr.name  | String | User friendly name, displayed by default in the RUM UI.                                                  |

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/data_collected/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/data_collected/android.md
@@ -68,7 +68,7 @@ The following device-related attributes are attached automatically to all events
 | `device.brand`  | string | The device brand as reported by the device (System User-Agent).  |
 | `device.model`   | string | The device model as reported by the device (System User-Agent).    |
 | `device.name` | string | The device name as reported by the device (System User-Agent).  |
-| `device.architecture` | string | The CPU architecture of the device. |
+| `device.architecture` | string | The CPU architecture of the device that is reporting the error. |
 
 ### Connectivity
 
@@ -144,7 +144,7 @@ Metrics are quantifiable values that can be used for measurements related to the
 | `session.last_view.name` | string | Name of the last view of the session. |
 | `session.ip` | string | IP address of the session extracted from the TCP connection of the intake. If you want to stop collecting this attribute, change the setting in your [application details][8]. |
 | `session.useragent` | string | System user agent info to interpret device info.  |
-| `session.has_replay` | boolean | Indicates if the session has a Session Replay recording attached. |
+| `session.has_replay` | boolean | Indicates if the session has a captured Session Replay recording attached to visually play the user experience. |
 
 ### View metrics
 
@@ -220,9 +220,9 @@ Network errors include information about failing HTTP requests. The following fa
 | `error.resource.provider.name`      | string | The resource provider name. Default is `unknown`.                                            |
 | `error.resource.provider.domain`      | string | The resource provider domain.                                            |
 | `error.resource.provider.type`      | string | The resource provider type (for example, `first-party`, `cdn`, `ad`, or `analytics`).                                            |
-| `error.is_crash` | string | Overrides the default RUM error source `is_crash` with a custom one. |
-| error.category | string | The specific category of the error. This provides a high-level grouping for different types of errors. Possible values are `ANR` or `Exception` |
-| `error.file` | string | File where the error has been found. |
+| `error.is_crash` | boolean | Indicates whether the error caused the application to crash. |
+| error.category | string | The high-level grouping for the type of error. Possible values are `ANR` or `Exception` |
+| `error.file` | string | File where the error happened for the Error Tracking issue. |
 
 ### Action timing metrics
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/data_collected/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/data_collected/android.md
@@ -68,6 +68,7 @@ The following device-related attributes are attached automatically to all events
 | `device.brand`  | string | The device brand as reported by the device (System User-Agent).  |
 | `device.model`   | string | The device model as reported by the device (System User-Agent).    |
 | `device.name` | string | The device name as reported by the device (System User-Agent).  |
+| `device.architecture` | string | The CPU architecture of the device. |
 
 ### Connectivity
 
@@ -143,6 +144,7 @@ Metrics are quantifiable values that can be used for measurements related to the
 | `session.last_view.name` | string | Name of the last view of the session. |
 | `session.ip` | string | IP address of the session extracted from the TCP connection of the intake. If you want to stop collecting this attribute, change the setting in your [application details][8]. |
 | `session.useragent` | string | System user agent info to interpret device info.  |
+| `session.has_replay` | boolean | Indicates if the session has a Session Replay recording attached. |
 
 ### View metrics
 
@@ -218,6 +220,9 @@ Network errors include information about failing HTTP requests. The following fa
 | `error.resource.provider.name`      | string | The resource provider name. Default is `unknown`.                                            |
 | `error.resource.provider.domain`      | string | The resource provider domain.                                            |
 | `error.resource.provider.type`      | string | The resource provider type (for example, `first-party`, `cdn`, `ad`, or `analytics`).                                            |
+| `error.is_crash` | string | Overrides the default RUM error source `is_crash` with a custom one. |
+| error.category | string | The specific category of the error. This provides a high-level grouping for different types of errors. Possible values are `ANR` or `Exception` |
+| `error.file` | string | File where the error has been found. |
 
 ### Action timing metrics
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/data_collected/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/data_collected/android.md
@@ -206,7 +206,9 @@ Front-end errors are collected with Real User Monitoring (RUM). The error messag
 | `error.message` | string | A concise, human-readable one-line message explaining the event. |
 | `error.stack`   | string | The stack trace or complementary information about the error.     |
 | `error.issue_id`   | string | The stack trace or complementary information about the error.     |
-
+| `error.category` | string | The high-level grouping for the type of error. Possible values are `ANR` or `Exception` |
+| `error.file` | string | File where the error happened for the Error Tracking issue. |
+| `error.is_crash` | boolean | Indicates whether the error caused the application to crash. |
 
 ### Network errors 
 
@@ -220,9 +222,6 @@ Network errors include information about failing HTTP requests. The following fa
 | `error.resource.provider.name`      | string | The resource provider name. Default is `unknown`.                                            |
 | `error.resource.provider.domain`      | string | The resource provider domain.                                            |
 | `error.resource.provider.type`      | string | The resource provider type (for example, `first-party`, `cdn`, `ad`, or `analytics`).                                            |
-| `error.is_crash` | boolean | Indicates whether the error caused the application to crash. |
-| error.category | string | The high-level grouping for the type of error. Possible values are `ANR` or `Exception` |
-| `error.file` | string | File where the error happened for the Error Tracking issue. |
 
 ### Action timing metrics
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds the missing APIs for Android SDK to the following pages, as per [DOCS-8447](https://datadoghq.atlassian.net/browse/DOCS-8447):
- https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/setup/android/?tab=kotlin
- https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android/?tab=kotlin
- https://docs.datadoghq.com/real_user_monitoring/guide/monitor-kiosk-sessions-using-rum/?tab=android

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Should be validated by the RUM mobile team prior to merging.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8447]: https://datadoghq.atlassian.net/browse/DOCS-8447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ