### PR TITLE
Added documentation for system properties not working in Graal native images

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -374,9 +374,8 @@ You can view traces using the [Trace Explorer][9].
 
 There are known issues with accessing system properties at runtime from a binary built with Graal Native Image.
 
-Rather than passing in configuration to a native image via system properties (i.e. `-Ddd.property.name=value`), it is recommended to use environment variables (i.e. `DD_PROPERTY_NAME=value`).
-
-The exception to this rule is when enabling the profiler via passing `-J-Ddd.profiling.enabled=true` to the `native-image` tool at _build time_.
+- For runtime configuration, use environment variables (`DD_PROPERTY_NAME=value`), instead of system properties (`-Ddd.property.name=value`).
+- The exception to this rule is when enabling the profiler. In this case, pass `-J-Ddd.profiling.enabled=true` to the `native-image` tool at _build time_.
 
 ##### Native-image buildpack versions older than 5.12.2
 

--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -370,6 +370,14 @@ After completing the setup, the service should send traces to Datadog.
 You can view traces using the [Trace Explorer][9].
 
 {{% collapse-content title="Troubleshooting" level="h4" %}}
+##### Features are not enabled or configured correctly for native images
+
+There are known issues with accessing system properties at runtime from a binary built with Graal Native Image.
+
+Rather than passing in configuration to a native image via system properties (i.e. `-Ddd.property.name=value`), it is recommended to use environment variables (i.e. `DD_PROPERTY_NAME=value`).
+
+The exception to this rule is when enabling the profiler via passing `-J-Ddd.profiling.enabled=true` to the `native-image` tool at _build time_.
+
 ##### Native-image buildpack versions older than 5.12.2
 
 Older native-image buildpack versions expose the following option: `USE_NATIVE_IMAGE_JAVA_PLATFORM_MODULE_SYSTEM`.


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds troubleshooting information for a known bug with GraalVM Native Images causing the Java tracer and profiler to (silently) misconfigure

### Merge instructions
If this looks good stylistically, please merge. Feedback on clarity and conciseness are welcome.

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->