### PR TITLE
Generated by websites-modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module documentation
 go 1.14
 
 require (
-	github.com/DataDog/websites-modules v1.4.175 // indirect
+	github.com/DataDog/websites-modules v1.5.1-0.20240904144744-b1db18f65ba2 // indirect
 	github.com/DataDog/websites-sources v0.0.0-20240828113530-52633d72da19 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/DataDog/websites-modules v1.4.175 h1:NJMATxRle0gXsaImE6jjZV/WuN3tTH1kWONXyOadeQ0=
-github.com/DataDog/websites-modules v1.4.175/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.5.1-0.20240904144744-b1db18f65ba2 h1:SDO0DuPL2I1MvgDEoHMjCmnyLb2LjmZWznRMv/urnGw=
+github.com/DataDog/websites-modules v1.5.1-0.20240904144744-b1db18f65ba2/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
 github.com/DataDog/websites-sources v0.0.0-20240828113530-52633d72da19 h1:hWHa2AWZnGf9rTTp8EgCcQ12blRDGAkzru8mcm8WJ3M=
 github.com/DataDog/websites-sources v0.0.0-20240828113530-52633d72da19/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
makes available 2 new icons `building-block` and `organization` from websites modules


preview: https://docs-staging.datadoghq.com/websites-modules/generated/355/
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->