### PR TITLE
[ML-OB] clarify agentless env var

### DIFF
--- a/content/en/llm_observability/quickstart.md
+++ b/content/en/llm_observability/quickstart.md
@@ -66,7 +66,7 @@ To generate an LLM Observability trace, you can run a Python script.
 
    For more information about required environment variables, see [the SDK documentation][9]. 
    
-   **Note**: `DD_LLMOBS_AGENTLESS_ENABLED` is only required if you do not have the Datadog Agent running. If the agent is running in your production environment, make sure this environment variable is unset.
+   **Note**: `DD_LLMOBS_AGENTLESS_ENABLED` is only required if you do not have the Datadog Agent running. If the Agent is running in your production environment, make sure this environment variable is unset.
 
 1. View the trace of your LLM call on the **Traces** tab [of the **LLM Observability** page][3] in Datadog.
 

--- a/content/en/llm_observability/quickstart.md
+++ b/content/en/llm_observability/quickstart.md
@@ -64,7 +64,9 @@ To generate an LLM Observability trace, you can run a Python script.
    DD_LLMOBS_AGENTLESS_ENABLED=1 ddtrace-run python quickstart.py
    ```
 
-   For more information about required environment variables, see [the SDK documentation][9]. Note that `DD_LLMOBS_AGENTLESS_ENABLED` is only required if you do not have the Datadog Agent running. If the agent is running in your production environment, make sure this environment variable is unset.
+   For more information about required environment variables, see [the SDK documentation][9]. 
+   
+   **Note**: `DD_LLMOBS_AGENTLESS_ENABLED` is only required if you do not have the Datadog Agent running. If the agent is running in your production environment, make sure this environment variable is unset.
 
 1. View the trace of your LLM call on the **Traces** tab [of the **LLM Observability** page][3] in Datadog.
 

--- a/content/en/llm_observability/quickstart.md
+++ b/content/en/llm_observability/quickstart.md
@@ -64,7 +64,7 @@ To generate an LLM Observability trace, you can run a Python script.
    DD_LLMOBS_AGENTLESS_ENABLED=1 ddtrace-run python quickstart.py
    ```
 
-   For more information about required environment variables, see [the SDK documentation][9].
+   For more information about required environment variables, see [the SDK documentation][9]. Note that `DD_LLMOBS_AGENTLESS_ENABLED` is only required if you do not have the Datadog Agent running. If the agent is running in your production environment, make sure this environment variable is unset.
 
 1. View the trace of your LLM call on the **Traces** tab [of the **LLM Observability** page][3] in Datadog.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The quickstart is the main entrypoint for people using LLM Obs. Customers tend to copy & paste env var setup from examples. We added `DD_LLMOBS_AGENTLESS_ENABLED` to the quickstart command because someone running the quickstart script locally may not have the agent up and running. 

Add a clarification so that they don't set env var in production environments where the agent is running

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->