### PR TITLE
[DOCS-8447] Move Sending data for offline devices section

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
@@ -385,14 +385,6 @@ This records each request processed by the `OkHttpClient` as a resource in RUM, 
 
 You can also add an `EventListener` for the `OkHttpClient` to [automatically track resource timing][11] for third-party providers and network requests.
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
-
-Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
- 
-This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
-
 ## Track background events
 
 You can track events such as crashes and network requests when your application is in the background (for example, no active view is available). 
@@ -441,6 +433,14 @@ Usage of the local resources can be tracked by using `getRawResAsRumResource` ex
 ```kotlin
 val inputStream = context.getRawResAsRumResource(id)
 ```
+
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
+
+Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+ 
+This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
@@ -385,6 +385,14 @@ This records each request processed by the `OkHttpClient` as a resource in RUM, 
 
 You can also add an `EventListener` for the `OkHttpClient` to [automatically track resource timing][11] for third-party providers and network requests.
 
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
+
+Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+ 
+This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
+
 ## Track background events
 
 You can track events such as crashes and network requests when your application is in the background (for example, no active view is available). 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/codepush.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/codepush.md
@@ -83,14 +83,6 @@ export default function App() {
 
 As getting the CodePush version is an asynchronous step that needs to be performed before initializing the Datadog React Native SDK for RUM, there is no difference between `InitializationMode.SYNC` and `InitializationMode.ASYNC` when using `DatadogCodepushProvider`.
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
-
-Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
- 
-This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
-
 ## Upload CodePush source maps
 
 Install [`@datadog/datadog-ci`][3] as a development dependency to your project.
@@ -162,6 +154,14 @@ In order to avoid potential version clashes, the `versionSuffix` adds a dash (`-
 To obtain the `codepushVersion`, you can hardcode it or use [`CodePush.getUpdateMetadata`][4].
 
 Then, upload your source maps using the [`datadog-ci react-native upload`][5] command, and ensure the `--release-version` argument matches the one set in the SDK configuration.
+
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
+
+Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+ 
+This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
 
 ## Further reading
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/codepush.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/codepush.md
@@ -83,6 +83,14 @@ export default function App() {
 
 As getting the CodePush version is an asynchronous step that needs to be performed before initializing the Datadog React Native SDK for RUM, there is no difference between `InitializationMode.SYNC` and `InitializationMode.ASYNC` when using `DatadogCodepushProvider`.
 
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
+
+Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+ 
+This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
+
 ## Upload CodePush source maps
 
 Install [`@datadog/datadog-ci`][3] as a development dependency to your project.

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
@@ -71,7 +71,7 @@ DdRum.stopView('<view-key>', { 'custom.bar': 42 }, Date.now());
 
 #### Automatic tracking
 
-Automatic view tracking is supported for the the following modules:
+Automatic view tracking is supported for the following modules:
 
 - React Navigation: [@Datadog/mobile-react-navigation][2]
 - React Native Navigation: [@Datadog/mobile-react-native-navigation][3]
@@ -158,6 +158,14 @@ yarn add -D @datadog/datadog-ci
 Run `eas secret:create` to set `DATADOG_API_KEY` to your Datadog API key, and `DATADOG_SITE` to the host of your Datadog site (for example, `datadoghq.com`).
 
 For information about tracking Expo crashes, see [Expo Crash Reporting and Error Tracking][5].
+
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
+
+Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+ 
+This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
 
 ## Tracking Expo Router screens
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/expo.md
@@ -159,14 +159,6 @@ Run `eas secret:create` to set `DATADOG_API_KEY` to your Datadog API key, and `D
 
 For information about tracking Expo crashes, see [Expo Crash Reporting and Error Tracking][5].
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
-
-Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
- 
-This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
-
 ## Tracking Expo Router screens
 
 If you are using [Expo Router][6], track your screens in your `app/_layout.js` file:
@@ -250,6 +242,14 @@ import { DdSdkReactNative } from 'expo-datadog';
 const config = new DdSdkReactNativeConfiguration(/* your config */);
 DdSdkReactNative.initialize(config);
 ```
+
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
+
+Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+ 
+This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
 
 ## Troubleshooting
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/flutter.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/flutter.md
@@ -281,6 +281,14 @@ var observer = DatadogNavigationObserver(
 );
 ```
 
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the Flutter RUM SDK does not impact the end user's experience. If the network is not available with your application running in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+
+This means that even if users open your application while offline, no data is lost.
+
+**Note**: The data on the disk is automatically deleted if it gets too old to ensure the Flutter RUM SDK does not use too much disk space.
+
 ## Automatically track resources
 
 Use the [Datadog Tracking HTTP Client][5] package to enable automatic tracking of resources and HTTP calls from your RUM views.

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/flutter.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/flutter.md
@@ -281,14 +281,6 @@ var observer = DatadogNavigationObserver(
 );
 ```
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the Flutter RUM SDK does not impact the end user's experience. If the network is not available with your application running in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
-
-This means that even if users open your application while offline, no data is lost.
-
-**Note**: The data on the disk is automatically deleted if it gets too old to ensure the Flutter RUM SDK does not use too much disk space.
-
 ## Automatically track resources
 
 Use the [Datadog Tracking HTTP Client][5] package to enable automatic tracking of resources and HTTP calls from your RUM views.
@@ -358,6 +350,15 @@ Container(
   ),
 );
 ```
+
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the Flutter RUM SDK does not impact the end user's experience. If the network is not available with your application running in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+
+This means that even if users open your application while offline, no data is lost.
+
+**Note**: The data on the disk is automatically deleted if it gets too old to ensure the Flutter RUM SDK does not use too much disk space.
+
 
 ## Further reading
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
@@ -437,6 +437,14 @@ struct BarView: View {
 }
 ```
 
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the RUM iOS SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+
+This means that even if users open your application while offline, no data is lost.
+
+**Note**: The data on the disk is automatically discarded if it gets too old to ensure the RUM iOS SDK does not use too much disk space.
+
 ## Track background events
 
 <div class="alert alert-info"><p>Tracking background events may lead to additional sessions, which can impact billing. For questions, <a href="https://docs.datadoghq.com/help/">contact Datadog support.</a></p>

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
@@ -437,14 +437,6 @@ struct BarView: View {
 }
 ```
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the RUM iOS SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
-
-This means that even if users open your application while offline, no data is lost.
-
-**Note**: The data on the disk is automatically discarded if it gets too old to ensure the RUM iOS SDK does not use too much disk space.
-
 ## Track background events
 
 <div class="alert alert-info"><p>Tracking background events may lead to additional sessions, which can impact billing. For questions, <a href="https://docs.datadoghq.com/help/">contact Datadog support.</a></p>
@@ -468,6 +460,15 @@ RUM.enable(
 ## Track iOS errors
 
 [iOS Crash Reporting and Error Tracking][17] displays any issues in your application and the latest available errors. You can view error details and attributes including JSON in the [RUM Explorer][18].
+
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the RUM iOS SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+
+This means that even if users open your application while offline, no data is lost.
+
+**Note**: The data on the disk is automatically discarded if it gets too old to ensure the RUM iOS SDK does not use too much disk space.
+
 
 ## Supported versions
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
@@ -359,6 +359,15 @@ Use one of Datadog's integrations to automatically track views for the following
 
 If you experience any issues setting up View tracking with `@datadog/mobile-react-navigation` you can see this Datadog [example application][16] as a reference.
 
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the React Native RUM SDK does not impact the end user's experience. If the network is not available with your application running in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+
+This means that even if users open your application while offline, no data is lost.
+
+**Note**: The data on the disk is automatically deleted if it gets too old to ensure the React Native RUM SDK does not use too much disk space.
+
+
 ## Track background events
 
 <div class="alert alert-info"><p>Tracking background events may lead to additional sessions, which can impact billing. For questions, <a href="https://docs.datadoghq.com/help/">contact Datadog support.</a></p>

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/roku.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/roku.md
@@ -215,8 +215,13 @@ Whenever you perform an operation that might throw an exception, you can forward
     end try
 ```
 
+## Sending data when device is offline
 
+RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
 
+Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+ 
+This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
 
 ## Further Reading
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/unity.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/unity.md
@@ -41,7 +41,7 @@ Datadog does not support Desktop (Windows, Mac, or Linux), console, or web deplo
 
 1. Install [External Dependency Manager for Unity (EDM4U)][4]. This can be done using [Open UPM][5].
 
-2. Add the Datadog SDK Unity package from its Git URL at [https://github.com/DataDog/unity-package][6].  The package URL is `https://github.com/DataDog/unity-package.git`.
+2. Add the Datadog SDK Unity package from its Git URL at [https://github.com/DataDog/unity-package][6]. The package URL is `https://github.com/DataDog/unity-package.git`.
 
 3. Configure your project to use [Gradle templates][8], and enable both `Custom Main Template` and `Custom Gradle Properties Template`.
 
@@ -196,6 +196,14 @@ Datadog offers `DatadogTrackedWebRequest`, which is a `UnityWebRequest` wrapper 
 To enable Datadog Distributed Tracing, you must set the `First Party Hosts` in your project settings to a domain that supports distributed tracing. You can also modify the sampling rate for distributed tracing by setting the `Tracing Sampling Rate`.
 
 `First Party Hosts` does not allow wildcards, but matches any subdomains for a given domain. For example, api.example.com matches staging.api.example.com and prod.api.example.com, but not news.example.com.
+
+## Sending data when device is offline
+
+RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
+
+Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
+ 
+This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
 
 [1]: https://app.datadoghq.com/rum/application/create
 [2]: /account_management/api-app-keys/#client-tokens

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/android.md
@@ -49,14 +49,6 @@ To update the tracking consent after the SDK is initialized, call `Datadog.setTr
 - `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
 - `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In case of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. 
-
-Each batch follows the intake specification. They are sent as soon as the network is available, and the battery is high enough to ensure the Datadog SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
- 
-This means that even if users open your application while offline, no data is lost. To ensure the SDK does not use too much disk space, the data on the disk is automatically discarded if it gets too old.
-
 ## Migrating to 2.0.0
 
 If you've been using the SDK v1, there are some breaking changes introduced in version `2.0.0`. See the [migration guide][2] for more information.

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/flutter.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/flutter.md
@@ -99,14 +99,6 @@ If you are still having issues, check that your `firstPartyHosts` property is se
     ✅ Good - 'example.com', 'api.example.com', 'us1.api.sample.com'
     ❌ Bad - 'https://example.com', '*.example.com', 'us1.sample.com/api/*', 'api.sample.com/api'
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the Flutter RUM SDK does not impact the end user's experience. If the network is not available with your application running in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
-
-This means that even if users open your application while offline, no data is lost.
-
-**Note**: The data on the disk is automatically deleted if it gets too old to ensure the Flutter RUM SDK does not use too much disk space.
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/ios.md
@@ -84,14 +84,6 @@ private class YourCustomDelegateURLSessionDelegate: NSObject, URLSessionTaskDele
 * implement `URLSessionDataDelegate` and forward:
   * [`urlSession(_:dataTask:didReceive:)`][6]
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all the RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the RUM iOS SDK does not impact the end user's experience. If the network is not available while your application is in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
-
-This means that even if users open your application while offline, no data is lost.
-
-**Note**: The data on the disk is automatically discarded if it gets too old to ensure the RUM iOS SDK does not use too much disk space.
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/reactnative.md
@@ -279,14 +279,6 @@ dependencies {
 }
 ```
 
-## Sending data when device is offline
-
-RUM ensures availability of data when your user device is offline. In cases of low-network areas, or when the device battery is too low, all RUM events are first stored on the local device in batches. They are sent as soon as the network is available, and the battery is high enough to ensure the React Native RUM SDK does not impact the end user's experience. If the network is not available with your application running in the foreground, or if an upload of data fails, the batch is kept until it can be sent successfully.
-
-This means that even if users open your application while offline, no data is lost.
-
-**Note**: The data on the disk is automatically deleted if it gets too old to ensure the React Native RUM SDK does not use too much disk space.
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Moves the "Sending data when device is offline" section from Troubleshooting to Setup for all mobile SDK pages and adds to them if they weren't there before, as per [DOCS-8447](https://datadoghq.atlassian.net/browse/DOCS-8447).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8447]: https://datadoghq.atlassian.net/browse/DOCS-8447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ