### PR TITLE
DOCS-8867 Remove Duplicate Content on Static Analysis and Software Composition Analysis Landing Pages

### DIFF
--- a/content/en/code_analysis/_index.md
+++ b/content/en/code_analysis/_index.md
@@ -105,7 +105,7 @@ You can configure a GitHub App by using the [GitHub integration tile][7] and set
 
 For more information, see the [Source Code Integration documentation][10].
 
-## Static Analysis integrations
+## Explore Static Analysis integrations
 
 With Static Analysis, you can receive automated feedback on poor coding practices and security vulnerabilities on the code you write [directly in an IDE][11] such as [VS Code][3] or [IntelliJ & PyCharm][4], and in your [pull requests on GitHub][5]. 
 

--- a/content/en/code_analysis/software_composition_analysis/_index.md
+++ b/content/en/code_analysis/software_composition_analysis/_index.md
@@ -64,14 +64,6 @@ SCA scans libraries contained in your lockfiles. The following lockfiles are sup
 | Python (poetry) | `poetry.lock`                            |
 | Ruby (bundler)  | `Gemfile.lock`                           |
 
-## Integrate Software Composition Analysis into your software development lifecycle
-
-### CI providers
-{{< whatsnext desc="You can run SCA on any CI platform provider of your choice. See provider-specific documentation to set up SCA in your CI pipelines:">}}
-    {{< nextlink href="code_analysis/software_composition_analysis/github_actions" >}}GitHub Actions{{< /nextlink >}}
-    {{< nextlink href="code_analysis/software_composition_analysis/generic_ci_providers" >}}Generic CI Providers{{< /nextlink >}}
-{{< /whatsnext >}}
-
 ## Search and filter results
 
 <div class="alert alert-info">Datadog Software Composition Analysis can find vulnerable libraries across the software development lifecycle (SDLC). Code Analysis summarizes results found by directly scanning your repositories. To view all vulnerabilities found in repositories and at runtime consolidated together, see <a href="/security/application_security/software_composition_analysis" target="_blank">Application Security</a> for more details.</div>

--- a/content/en/code_analysis/static_analysis/_index.md
+++ b/content/en/code_analysis/static_analysis/_index.md
@@ -49,27 +49,6 @@ Static Analysis supports scanning for poor coding practices and security vulnera
 
 To get started, you can set up Static Analysis on the [**Code Analysis** page][1] or see the [Setup documentation][9].
 
-## Integrate Static Analysis into your software development lifecycle
-
-### CI providers
-{{< whatsnext desc="You can run Static Analysis on any CI platform provider of your choice. See provider-specific documentation to set up Static Analysis in your CI pipelines:">}}
-    {{< nextlink href="code_analysis/static_analysis/circleci_orbs" >}}CircleCI Orbs{{< /nextlink >}}
-    {{< nextlink href="code_analysis/static_analysis/github_actions" >}}GitHub Actions{{< /nextlink >}}
-    {{< nextlink href="code_analysis/static_analysis/generic_ci_providers" >}}Other CI Providers{{< /nextlink >}}
-{{< /whatsnext >}}
-
-### Source code management
-{{< whatsnext desc="During code reviews on GitHub, Datadog can automatically flag Static Analysis violations in pull requests by adding inline review comments on the relevant line(s) of code. When applicable, Datadog also provides suggested fixes that can be applied directly in the pull request. You can also open a pull request directly from Datadog to fix a vulnerability or quality issue." >}}
-    {{< nextlink href="static_analysis/github_pull_requests" >}}GitHub Pull Requests{{< /nextlink >}}
-{{< /whatsnext >}}
-
-### IDEs
-{{< whatsnext desc="You can identify code vulnerabilities in real time as you edit a file in your Integrated Development Environment (IDE). See integration-specific documentation for more information:">}}
-    {{< nextlink href="developers/ide_plugins/idea/" >}}Datadog Plugin for JetBrains IDEs{{< /nextlink >}}
-    {{< nextlink href="developers/ide_plugins/vscode/#static-analysis" >}}Datadog Extension for Visual Studio Code{{< /nextlink >}}
-    {{< nextlink href="developers/ide_plugins/visual_studio/#static-analysis" >}}Datadog Extension for Visual Studio{{< /nextlink >}}
-{{< /whatsnext >}}
-
 ## Search and filter results
 
 After you configure your CI pipelines to run the Datadog Static Analyzer, violations are summarized per repository on the [**Code Analysis Repositories** page][1]. Click on a repository to analyze **Code Vulnerabilities** and **Code Quality** results from Static Analysis. 

--- a/content/en/code_analysis/static_analysis/setup.md
+++ b/content/en/code_analysis/static_analysis/setup.md
@@ -31,7 +31,7 @@ To set up Datadog Static Analysis, navigate to [**Software Delivery** > **Code A
 
 ## Select where to run Static Analysis scans
 ### Scan in CI pipelines
-Datadog Static Analysis runs in your CI pipelines using the [`datadog-ci` CLI][8]. Configure your [Datadog API and application keys (requires the `code_analysis_read` scope)][3] and run Static Analysis in the respective CI provider.
+Datadog Static Analysis runs in your CI pipelines using the [`datadog-ci` CLI][8]. Configure your [Datadog API and application keys (requires the `code_analysis_read` scope)][4] and run Static Analysis in the respective CI provider.
 
 {{< whatsnext desc="See instructions based on your CI provider:">}}
     {{< nextlink href="code_analysis/static_analysis/circleci_orbs" >}}CircleCI Orbs{{< /nextlink >}}
@@ -252,7 +252,7 @@ To upload a SARIF report:
 
 Diff-aware scanning enables Datadog's static analyzer to only scan the files modified by a commit in a feature branch. It accelerates scan time significantly by not having the analysis run on every file in the repository for every scan. To enable diff-aware scanning in your CI pipeline, follow these steps:
 
-1. Make sure your `DD_APP_KEY`, `DD_SITE` and `DD_API_KEY` variables are set in your CI pipeline.
+1. Make sure your `DD_APP_KEY`, `DD_SITE`, and `DD_API_KEY` variables are set in your CI pipeline.
 2. Add a call to `datadog-ci git-metadata upload` before invoking the static analyzer. This command ensures that Git metadata is available to the Datadog backend. Git metadata is required to calculate the number of files to analyze.
 3. Ensure that the datadog-static-analyzer is invoked with the flag `--diff-aware`.
 
@@ -265,13 +265,21 @@ datadog-static-analyzer -i /path/to/directory -g -o sarif.json -f sarif –-diff
 
 **Note:** When a diff-aware scan cannot be completed, the entire directory is scanned.
 
+## Integrate Static Analysis in an IDE
+
+You can identify code vulnerabilities in real time as you edit a file in your Integrated Development Environment (IDE). By integrating Static Analysis with your IDE, you can access immediate feedback on code quality and security issues as you write code.
+
+1. Install the relevant plugin or extension for your IDE from the [IDE Plugins documentation][3].
+1. Configure Static Analysis within the IDE.
+1. Open a project and check for real-time feedback.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/ci/setup/code-analysis
 [2]: https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=sarif
-[3]: /developers/ide_plugins/idea/#static-analysis
+[3]: /code_analysis/ide_plugins
 [4]: /account_management/api-app-keys/
 [6]: /code_analysis/static_analysis_rules
 [7]: /getting_started/site/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Removing ## Integrate Static Analysis into your software development lifecycle and ## Integrate Software Composition Analysis into your software development lifecycle partial lists.

Discussed in #sw-delivery-docs on Slack.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->