### PR TITLE
Fix sharded cluster reference for Replica Set --  mongodbatlas.md

### DIFF
--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -73,7 +73,7 @@ To get the individual MongoDB instance hostname and port, you can use the `dig` 
 
 ##### Replica set members
 
-For a Non Sharded (Replica set) cluster with the SRV connection string `mongodb+srv://XXXXX.XXX.mongodb.net/`:
+For a non-sharded (replica set) cluster with the SRV connection string `mongodb+srv://XXXXX.XXX.mongodb.net/`:
 
 {{< code-block lang="shell" >}}
 dig +short SRV _mongodb._tcp.XXXXX.XXX.mongodb.net

--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -73,7 +73,7 @@ To get the individual MongoDB instance hostname and port, you can use the `dig` 
 
 ##### Replica set members
 
-For a sharded cluster with the SRV connection string `mongodb+srv://XXXXX.XXX.mongodb.net/`:
+For a Non Sharded (Replica set) cluster with the SRV connection string `mongodb+srv://XXXXX.XXX.mongodb.net/`:
 
 {{< code-block lang="shell" >}}
 dig +short SRV _mongodb._tcp.XXXXX.XXX.mongodb.net


### PR DESCRIPTION
Fixed a typo where "Sharded cluster" is mentioned in the Replica Set tab

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The PR is to fix a typo where the word "Sharded cluster" is used instead of "Replica set" 
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->