### PR TITLE
[test-visibility] do not offer auto instrumentation for cypress

### DIFF
--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -49,7 +49,9 @@ To report test results to Datadog, you need to configure the Datadog JavaScript 
 {{% tab "CI Provider with Auto-Instrumentation Support" %}}
 {{% ci-autoinstrumentation %}}
 
-**Note:** Auto-instrumentation is not supported for Cypress tests. To instrument Cypress tests, follow the manual instrumentation steps outlined below:
+<div class="alert alert-warning">
+  <strong>Note</strong>: Auto-instrumentation is not supported for Cypress tests. To instrument Cypress tests, follow the manual instrumentation steps outlined below.
+</div>
 
 {{% /tab %}}
 

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -48,6 +48,9 @@ To report test results to Datadog, you need to configure the Datadog JavaScript 
 {{< tabs >}}
 {{% tab "CI Provider with Auto-Instrumentation Support" %}}
 {{% ci-autoinstrumentation %}}
+
+**Note:** Auto-instrumentation is not supported for Cypress tests. To instrument Cypress tests, follow the manual instrumentation steps outlined below:
+
 {{% /tab %}}
 
 {{% tab "Other Cloud CI Provider" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Cypress does not support autoinstrumentation, as it does not work with NODE_OPTIONS, so we are adding a note for this.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

![Screenshot 2024-09-05 at 18 39 10](https://github.com/user-attachments/assets/39491b54-88c3-499a-b75b-3ccd6f4bb99d)