### PR TITLE
Documenting Current Support for Span Events

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
@@ -121,8 +121,6 @@ _Minimum SDK version: 2.53.0._
 
 You can add span events using the `AddEvent` API. This method requires an `ActivityEvent`constructed with the `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span. 
 
-It requires an `ActivityEvent`, which is constructed with the following parameters:
-
 - **Name** [_required_]: A string representing the event's name.
 - **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects a `DateTimeOffset` object.
 - **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:

--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
@@ -115,9 +115,11 @@ catch(Exception e)
 }
 ```
 
-## Adding Span Events
+## Adding span events
 
-You can add span events using the `AddEvent` API. This method requires an `ActivityEvent` which is constructed using a `name` parameter and optionally accepts the `timestamp` and `attributes` parameters together. The method creates a new span event with the specified properties and associates it with the corresponding span.
+You can add span events using the `AddEvent` API. This method requires an `ActivityEvent`constructed with the `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span. 
+
+It requires an `ActivityEvent`, which is constructed with the following parameters:
 
 - **Name** [_required_]: A string representing the event's name.
 - **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects a `DateTimeOffset` object.

--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
@@ -115,6 +115,37 @@ catch(Exception e)
 }
 ```
 
+## Adding Span Events
+
+You can add span events using the `AddEvent` API. This method requires an `ActivityEvent` which is constructed using a `name` parameter and optionally accepts the `timestamp` and `attributes` parameters together. The method creates a new span event with the specified properties and associates it with the corresponding span.
+
+- **Name** [_required_]: A string representing the event's name.
+- **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects a `DateTimeOffset` object.
+- **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
+  - The key must be a non-empty string.
+  - The value can be either:
+    - A primitive type: string, Boolean, or number.
+    - A homogeneous array of primitive type values (for example, an array of strings).
+  - Nested arrays and arrays containing elements of different data types are not allowed.
+
+The following examples demonstrate different ways to add events to a span:
+
+```csharp
+var eventTags = new ActivityTagsCollection
+{
+    { "int_val", 1 },
+    { "string_val", "2" },
+    { "int_array", new int[] { 3, 4 } },
+    { "string_array", new string[] { "5", "6" } },
+    { "bool_array", new bool[] { true, false } }
+};
+
+activity.AddEvent(new ActivityEvent("Event With No Attributes"));
+activity.AddEvent(new ActivityEvent("Event With All Attributes", DateTimeOffset.Now, eventTags));
+```
+
+Read the [OpenTelemetry][15] specification for more information.
+
 ## Propagating context with headers extraction and injection
 
 You can configure the propagation of context for distributed traces by injecting and extracting headers. Read [Trace Context Propagation][14] for information.
@@ -129,3 +160,4 @@ You can configure the propagation of context for distributed traces by injecting
 [11]: /tracing/trace_collection/dd_libraries/dotnet-core/#installation-and-getting-started
 [13]: /tracing/trace_collection/single-step-apm/
 [14]: /tracing/trace_collection/trace_context_propagation/
+[15]: https://opentelemetry.io/docs/specs/otel/trace/api/#add-events

--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
@@ -117,6 +117,8 @@ catch(Exception e)
 
 ## Adding span events
 
+_Minimum SDK version: 2.53.0._
+
 You can add span events using the `AddEvent` API. This method requires an `ActivityEvent`constructed with the `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span. 
 
 It requires an `ActivityEvent`, which is constructed with the following parameters:

--- a/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/dotnet/otel.md
@@ -134,14 +134,14 @@ The following examples demonstrate different ways to add events to a span:
 var eventTags = new ActivityTagsCollection
 {
     { "int_val", 1 },
-    { "string_val", "2" },
+    { "string_val", "two" },
     { "int_array", new int[] { 3, 4 } },
     { "string_array", new string[] { "5", "6" } },
     { "bool_array", new bool[] { true, false } }
 };
 
 activity.AddEvent(new ActivityEvent("Event With No Attributes"));
-activity.AddEvent(new ActivityEvent("Event With All Attributes", DateTimeOffset.Now, eventTags));
+activity.AddEvent(new ActivityEvent("Event With Some Attributes", DateTimeOffset.Now, eventTags));
 ```
 
 Read the [OpenTelemetry][15] specification for more information.

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
@@ -134,18 +134,25 @@ sp.End()
 
 ## Adding span events
 
-Add span events using the `AddEvent` API. Event name is a required first field, along with optional input for event timestamp and event attributes.
-In the following example, `oteltrace` is an alias for the go.opentelemetry.io/otel/trace package, and `time` references the Go Standard Library time package. These packages must be imported in order to use this example.
+Add span events using the `AddEvent` API. Event name is a required first field, along with optional input for event `timestamp` and event `attributes`.
+In the following example, `oteltrace` is an alias for the go.opentelemetry.io/otel/trace package, this package must be imported in order to use this example.
 
+- **Name** [_required_]: A string representing the event's name.
+- **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
+  - The key must be a non-empty string.
+  - The value can be either:
+    - A primitive type: string, Boolean, or number.
+    - A homogeneous array of primitive type values (for example, an array of strings).
+  - Nested arrays and arrays containing elements of different data types are not allowed.
+- **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects a `Time` object.
+  
 ```go
 // Start a span.
 ctx, span := t.Start(context.Background(), "span_name")
 // Add an event.
-span.AddEvent("event1")
-// Add an event with a timestamp.
-span.AddEvent("event2", oteltrace.WithTimestamp(time.Now()))
+span.AddEvent("Event Name")
 // Add an event with span attributes.
-span.AddEvent("event3", oteltrace.WithAttributes(attribute.String("key1", "value"), attribute.Int("key2", 1234)))
+span.AddEvent("Event Name", oteltrace.WithAttributes(attribute.Int("int_val", 1), attribute.String("string_val", "2"), attribute.Int64Slice("int_array", []int64{3, 4}), attribute.StringSlice("string_array", []string{"5", "6"}), attribute.BoolSlice("bool_array", []bool{false, true})))
 s.End()
 ```
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
@@ -150,7 +150,7 @@ span.End()
 ## Adding Span Events
 
 Add span events using the `AddEvent` API. Event name is a required first field, along with optional input for event `timestamp` and event `attributes`.
-In the following example, `oteltrace` is an alias for the go.opentelemetry.io/otel/trace package, this package must be imported in order to use this example.
+In the following example, `oteltrace` is an alias for the go.opentelemetry.io/otel/trace package and `attribute` refers to the go.opentelemetry.io/otel/attribute package. These packages must be imported in order to use this example.
 
 - **Name** [_required_]: A string representing the event's name.
 - **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
@@ -132,7 +132,22 @@ sp.End()
 
 ```
 
-## Adding span events
+## Adding spans
+
+Unlike other Datadog tracing libraries, when tracing Go applications, Datadog recommends that you explicitly manage and pass the Go context of your spans. This approach ensures accurate span relationships and meaningful tracing. For more information, see the [Go context library documentation][16] or documentation for any third-party libraries integrated with your application.
+
+```go
+// Can only be done after the setup steps.
+
+// Here we can leverage context.Context to pass in Datadog-specifc start span options,
+// like 'ddtracer.Measured()'
+ctx, span := t.Start(
+	ddotel.ContextWithStartOptions(context.Background(), ddtracer.Measured()), "span_name")
+
+span.End()
+```
+
+## Adding Span Events
 
 Add span events using the `AddEvent` API. Event name is a required first field, along with optional input for event `timestamp` and event `attributes`.
 In the following example, `oteltrace` is an alias for the go.opentelemetry.io/otel/trace package, this package must be imported in order to use this example.
@@ -149,27 +164,11 @@ In the following example, `oteltrace` is an alias for the go.opentelemetry.io/ot
 ```go
 // Start a span.
 ctx, span := t.Start(context.Background(), "span_name")
-// Add an event.
-span.AddEvent("Event Name")
-// Add an event with span attributes.
-span.AddEvent("Event Name", oteltrace.WithAttributes(attribute.Int("int_val", 1), attribute.String("string_val", "2"), attribute.Int64Slice("int_array", []int64{3, 4}), attribute.StringSlice("string_array", []string{"5", "6"}), attribute.BoolSlice("bool_array", []bool{false, true})))
+span.AddEvent("Event With No Attributes")
+span.AddEvent("Event With Some Attributes", oteltrace.WithAttributes(attribute.Int("int_val", 1), attribute.String("string_val", "two"), attribute.Int64Slice("int_array", []int64{3, 4}), attribute.StringSlice("string_array", []string{"5", "6"}), attribute.BoolSlice("bool_array", []bool{false, true})))
 s.End()
 ```
-
-## Adding spans
-
-Unlike other Datadog tracing libraries, when tracing Go applications, Datadog recommends that you explicitly manage and pass the Go context of your spans. This approach ensures accurate span relationships and meaningful tracing. For more information, see the [Go context library documentation][16] or documentation for any third-party libraries integrated with your application.
-
-```go
-// Can only be done after the setup steps.
-
-// Here we can leverage context.Context to pass in Datadog-specifc start span options,
-// like 'ddtracer.Measured()'
-ctx, span := t.Start(
-	ddotel.ContextWithStartOptions(context.Background(), ddtracer.Measured()), "span_name")
-
-span.End()
-```
+Read the [OpenTelemetry][17] specification for more information.
 
 ## Trace client and Agent configuration
 
@@ -199,3 +198,4 @@ Traces can be excluded based on their resource name, to remove synthetic traffic
 [14]: /tracing/security
 [15]: /tracing/glossary/#trace
 [16]: https://pkg.go.dev/context
+[17]: https://opentelemetry.io/docs/specs/otel/trace/api/#add-events

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
@@ -163,7 +163,7 @@ In the following example, `oteltrace` is an alias for the go.opentelemetry.io/ot
   
 ```go
 // Start a span.
-ctx, span := t.StartSpan(context.Background(), "span_name")
+ctx, span := tracer.StartSpan(context.Background(), "span_name")
 span.AddEvent("Event With No Attributes")
 span.AddEvent("Event With Some Attributes", oteltrace.WithAttributes(attribute.Int("int_val", 1), attribute.String("string_val", "two"), attribute.Int64Slice("int_array", []int64{3, 4}), attribute.StringSlice("string_array", []string{"5", "6"}), attribute.BoolSlice("bool_array", []bool{false, true})))
 span.Finish()

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
@@ -163,10 +163,10 @@ In the following example, `oteltrace` is an alias for the go.opentelemetry.io/ot
   
 ```go
 // Start a span.
-ctx, span := t.Start(context.Background(), "span_name")
+ctx, span := t.StartSpan(context.Background(), "span_name")
 span.AddEvent("Event With No Attributes")
 span.AddEvent("Event With Some Attributes", oteltrace.WithAttributes(attribute.Int("int_val", 1), attribute.String("string_val", "two"), attribute.Int64Slice("int_array", []int64{3, 4}), attribute.StringSlice("string_array", []string{"5", "6"}), attribute.BoolSlice("bool_array", []bool{false, true})))
-s.End()
+span.Finish()
 ```
 Read the [OpenTelemetry][17] specification for more information.
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
@@ -147,10 +147,9 @@ ctx, span := t.Start(
 span.End()
 ```
 
-## Adding Span Events
+## Adding span events
 
-Add span events using the `AddEvent` API. Event name is a required first field, along with optional input for event `timestamp` and event `attributes`.
-In the following example, `oteltrace` is an alias for the go.opentelemetry.io/otel/trace package and `attribute` refers to the go.opentelemetry.io/otel/attribute package. These packages must be imported in order to use this example.
+You can add span events using the `AddEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
 - **Name** [_required_]: A string representing the event's name.
 - **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
@@ -161,6 +160,8 @@ In the following example, `oteltrace` is an alias for the go.opentelemetry.io/ot
   - Nested arrays and arrays containing elements of different data types are not allowed.
 - **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects a `Time` object.
   
+In the following example, `oteltrace` is an alias for the go.opentelemetry.io/otel/trace package and `attribute` refers to the go.opentelemetry.io/otel/attribute package. These packages must be imported in order to use this example.
+
 ```go
 // Start a span.
 ctx, span := tracer.StartSpan(context.Background(), "span_name")

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/otel.md
@@ -149,6 +149,8 @@ span.End()
 
 ## Adding span events
 
+_Minimum SDK version: 1.67.0._
+
 You can add span events using the `AddEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
 - **Name** [_required_]: A string representing the event's name.

--- a/content/en/tracing/trace_collection/custom_instrumentation/nodejs/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/nodejs/otel.md
@@ -103,6 +103,8 @@ function performTask(iterations, param1, param2) {
 
 ## Adding span events
 
+_Minimum SDK version: 5.17.0 & 4.41.0._
+
 You can add span events using the `addEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
 - **Name** [_required_]: A string representing the event's name.

--- a/content/en/tracing/trace_collection/custom_instrumentation/nodejs/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/nodejs/otel.md
@@ -87,21 +87,20 @@ function processData(i, param1, param2) {
 
 You can add span events using the `addEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
-- **Name**: A string representing the event's name.
-- **Timestamp**: A UNIX timestamp representing the event's occurrence time.
-- **Attributes**: Zero or more key-value pairs with the following properties:
+- **Name** [_required_]: A string representing the event's name.
+- **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
   - The key must be a non-empty string.
   - The value can be either:
     - A primitive type: string, Boolean, or number.
     - A homogeneous array of primitive type values (for example, an array of strings).
   - Nested arrays and arrays containing elements of different data types are not allowed.
+- **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects a `TimeInput` object.
 
 The following examples demonstrate different ways to add events to a span:
 
 ```js
-span.addEvent('Web page unresponsive', { 'error.code': '403', 'unknown values': [1, ['h', 'a', [false]]] }, 1714536311886)
-span.addEvent('Web page loaded')
-span.addEvent('Button changed color', { colors: [112, 215, 70], 'response.time': 134.3, success: true })
+span.addEvent('Event Name')
+span.addEvent('Event Name', {"int_val": 1, "string_val": "2", "int_array": [3, 4], "string_array": ["5", "6"], "bool_array": [true, false]})
 ```
 
 Read the [OpenTelemetry][6] specification for more information.
@@ -113,7 +112,6 @@ To record exceptions, use the `recordException` API. This method requires an exc
 The following examples demonstrate different ways to record exceptions:
 
 ```js
-span.recordException(new TestError(), Date.now())
 span.recordException(new TestError())
 ```
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/nodejs/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/nodejs/otel.md
@@ -82,41 +82,6 @@ function processData(i, param1, param2) {
 }
 {{< /highlight >}}
 
-
-## Adding span events
-
-You can add span events using the `addEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
-
-- **Name** [_required_]: A string representing the event's name.
-- **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
-  - The key must be a non-empty string.
-  - The value can be either:
-    - A primitive type: string, Boolean, or number.
-    - A homogeneous array of primitive type values (for example, an array of strings).
-  - Nested arrays and arrays containing elements of different data types are not allowed.
-- **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects a `TimeInput` object.
-
-The following examples demonstrate different ways to add events to a span:
-
-```js
-span.addEvent('Event Name')
-span.addEvent('Event Name', {"int_val": 1, "string_val": "2", "int_array": [3, 4], "string_array": ["5", "6"], "bool_array": [true, false]})
-```
-
-Read the [OpenTelemetry][6] specification for more information.
-
-### Record exceptions
-
-To record exceptions, use the `recordException` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
-
-The following examples demonstrate different ways to record exceptions:
-
-```js
-span.recordException(new TestError())
-```
-
-Read the [OpenTelemetry][7] specification for more information.
-
 ## Creating spans
 
 To create a new span and properly close it, use the `startActiveSpan` method:
@@ -135,6 +100,40 @@ function performTask(iterations, param1, param2) {
   });
 }
 {{< /highlight >}}
+
+## Adding Span Events
+
+You can add span events using the `addEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
+
+- **Name** [_required_]: A string representing the event's name.
+- **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
+  - The key must be a non-empty string.
+  - The value can be either:
+    - A primitive type: string, Boolean, or number.
+    - A homogeneous array of primitive type values (for example, an array of strings).
+  - Nested arrays and arrays containing elements of different data types are not allowed.
+- **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects a `TimeInput` object.
+
+The following examples demonstrate different ways to add events to a span:
+
+```js
+span.addEvent('Event With No Attributes')
+span.addEvent('Event With Some Attributes', {"int_val": 1, "string_val": "two", "int_array": [3, 4], "string_array": ["5", "6"], "bool_array": [true, false]})
+```
+
+Read the [OpenTelemetry][6] specification for more information.
+
+### Recording Exceptions
+
+To record exceptions, use the `recordException` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
+
+The following examples demonstrate different ways to record exceptions:
+
+```js
+span.recordException(new TestError())
+```
+
+Read the [OpenTelemetry][7] specification for more information.
 
 ## Filtering requests
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/nodejs/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/nodejs/otel.md
@@ -101,7 +101,7 @@ function performTask(iterations, param1, param2) {
 }
 {{< /highlight >}}
 
-## Adding Span Events
+## Adding span events
 
 You can add span events using the `addEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
@@ -123,9 +123,9 @@ span.addEvent('Event With Some Attributes', {"int_val": 1, "string_val": "two", 
 
 Read the [OpenTelemetry][6] specification for more information.
 
-### Recording Exceptions
+### Recording exceptions
 
-To record exceptions, use the `recordException` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
+To record exceptions, use the `recordException` API. This method requires an `exception` parameter and optionally accepts a UNIX `timestamp` parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
 
 The following examples demonstrate different ways to record exceptions:
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/php/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php/otel.md
@@ -101,7 +101,7 @@ $span->end();
 
 ```
 
-## Adding Span Events
+## Adding span events
 
 You can add span events using the `addEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
@@ -132,9 +132,9 @@ $span->addEvent(
 
 Read the [OpenTelemetry][14] specification for more information.
 
-### Recording Exceptions
+### Recording exceptions
 
-To record exceptions, use the `recordException` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
+To record exceptions, use the `recordException` API. This method requires an `exception` parameter and optionally accepts a UNIX `timestamp` parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
 
 The following examples demonstrate different ways to record exceptions:
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/php/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php/otel.md
@@ -119,10 +119,10 @@ The following examples demonstrate different ways to add events to a span:
 ```php
 $span->addEvent("Event With No Attributes");
 $span->addEvent(
-    "Event With All Attributes", 
+    "Event With Some Attributes", 
     [ 
         'int_val' => 1, 
-        'string_val' => "2", 
+        'string_val' => "two", 
         'int_array' => [3, 4], 
         'string_array' => ["5", "6"],
         'bool_array' => [true, false]
@@ -132,7 +132,7 @@ $span->addEvent(
 
 Read the [OpenTelemetry][14] specification for more information.
 
-### Record exceptions
+### Recording Exceptions
 
 To record exceptions, use the `recordException` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/php/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php/otel.md
@@ -101,6 +101,50 @@ $span->end();
 
 ```
 
+## Adding Span Events
+
+You can add span events using the `addEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
+
+- **Name** [_required_]: A string representing the event's name.
+- **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
+  - The key must be a non-empty string.
+  - The value can be either:
+    - A primitive type: string, Boolean, or number.
+    - A homogeneous array of primitive type values (for example, an array of strings).
+  - Nested arrays and arrays containing elements of different data types are not allowed.
+- **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects `nanoseconds`.
+
+The following examples demonstrate different ways to add events to a span:
+
+```php
+$span->addEvent("Event With No Attributes");
+$span->addEvent(
+    "Event With All Attributes", 
+    [ 
+        'int_val' => 1, 
+        'string_val' => "2", 
+        'int_array' => [3, 4], 
+        'string_array' => ["5", "6"],
+        'bool_array' => [true, false]
+    ]
+);
+```
+
+Read the [OpenTelemetry][14] specification for more information.
+
+### Record exceptions
+
+To record exceptions, use the `recordException` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
+
+The following examples demonstrate different ways to record exceptions:
+
+```php
+$span->recordException(new \Exception("Error Message"));
+$span->recordException(new \Exception("Error Message"), [ "status" => "failed" ]);
+```
+
+Read the [OpenTelemetry][15] specification for more information.
+
 ## Accessing active spans
 
 To access the currently active span:
@@ -116,3 +160,5 @@ $span = OpenTelemetry\API\Trace\Span::getCurrent();
 [5]: https://opentelemetry.io/docs/instrumentation/php/manual/
 [6]: /tracing/trace_collection/dd_libraries/php#getting-started
 [13]: https://opentelemetry.io/docs/languages/php/instrumentation/#instrumentation-setup
+[14]: https://opentelemetry.io/docs/specs/otel/trace/api/#add-events
+[15]: https://opentelemetry.io/docs/specs/otel/trace/api/#record-exception

--- a/content/en/tracing/trace_collection/custom_instrumentation/php/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/php/otel.md
@@ -103,6 +103,8 @@ $span->end();
 
 ## Adding span events
 
+_Minimum SDK version: 1.3.0._
+
 You can add span events using the `addEvent` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
 - **Name** [_required_]: A string representing the event's name.

--- a/content/en/tracing/trace_collection/custom_instrumentation/python/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/python/otel.md
@@ -85,12 +85,12 @@ The following examples demonstrate different ways to add events to a span:
 
 ```python
 span.add_event("Event With No Attributes")
-span.add_event("Event With All Attributes", {"int_val": 1, "string_val": "2", "int_array": [3, 4], "string_array": ["5", "6"], "bool_array": [True, False]})
+span.add_event("Event With Some Attributes", {"int_val": 1, "string_val": "two", "int_array": [3, 4], "string_array": ["5", "6"], "bool_array": [True, False]})
 ```
 
 Read the [OpenTelemetry][2] specification for more information.
 
-### Record exceptions
+### Recording Exceptions
 
 To record exceptions, use the `record_exception` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/python/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/python/otel.md
@@ -68,7 +68,7 @@ current_span = trace.get_current_span()
 current_span.set_attribute("attribute_key1", 1)
 ```
 
-## Adding Span Events
+## Adding span events
 
 You can add span events using the `add_event` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
@@ -90,9 +90,9 @@ span.add_event("Event With Some Attributes", {"int_val": 1, "string_val": "two",
 
 Read the [OpenTelemetry][2] specification for more information.
 
-### Recording Exceptions
+### Recording exceptions
 
-To record exceptions, use the `record_exception` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
+To record exceptions, use the `record_exception` API. This method requires an `exception` parameter and optionally accepts a UNIX `timestamp` parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
 
 The following examples demonstrate different ways to record exceptions:
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/python/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/python/otel.md
@@ -70,6 +70,8 @@ current_span.set_attribute("attribute_key1", 1)
 
 ## Adding span events
 
+_Minimum SDK version: 2.9.0._
+
 You can add span events using the `add_event` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
 - **Name** [_required_]: A string representing the event's name.

--- a/content/en/tracing/trace_collection/custom_instrumentation/python/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/python/otel.md
@@ -68,8 +68,45 @@ current_span = trace.get_current_span()
 current_span.set_attribute("attribute_key1", 1)
 ```
 
+## Adding Span Events
+
+You can add span events using the `add_event` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
+
+- **Name** [_required_]: A string representing the event's name.
+- **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
+  - The key must be a non-empty string.
+  - The value can be either:
+    - A primitive type: string, Boolean, or number.
+    - A homogeneous array of primitive type values (for example, an array of strings).
+  - Nested arrays and arrays containing elements of different data types are not allowed.
+- **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects `microseconds`.
+
+The following examples demonstrate different ways to add events to a span:
+
+```python
+span.add_event("Event With No Attributes")
+span.add_event("Event With All Attributes", {"int_val": 1, "string_val": "2", "int_array": [3, 4], "string_array": ["5", "6"], "bool_array": [True, False]})
+```
+
+Read the [OpenTelemetry][2] specification for more information.
+
+### Record exceptions
+
+To record exceptions, use the `record_exception` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
+
+The following examples demonstrate different ways to record exceptions:
+
+```python
+span.record_exception(Exception("Error Message"))
+span.record_exception(Exception("Error Message"), {"status": "failed"})
+```
+
+Read the [OpenTelemetry][3] specification for more information.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/setup/python/
+[2]: https://opentelemetry.io/docs/specs/otel/trace/api/#add-events
+[3]: https://opentelemetry.io/docs/specs/otel/trace/api/#record-exception

--- a/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
@@ -69,7 +69,7 @@ The following OpenTelemetry features implemented in the Datadog library as noted
 
 Datadog combines these OpenTelemetry spans with other Datadog APM spans into a single trace of your application. It supports [integration instrumentation][7] and [OpenTelemetry Automatic instrumentation][8] also.
 
-## Adding Span Events
+## Adding span events
 
 You can add span events using the `add_event` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
@@ -94,13 +94,16 @@ span.add_event(
 
 Read the [OpenTelemetry][13] specification for more information.
 
-### Recording Exceptions
+### Recording exceptions
 
-To record exceptions, use the `record_exception` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
+To record exceptions, use the `record_exception` API. This method requires an `exception` parameter and optionally accepts a UNIX `timestamp` parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
 
 The following examples demonstrate different ways to record exceptions:
 
 ```ruby
+span.record_exception(
+  StandardError.new('Error Message')
+)
 span.record_exception(
   StandardError.new('Error Message'),
   attributes: { 'status' => 'failed' }

--- a/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
@@ -88,13 +88,13 @@ The following examples demonstrate different ways to add events to a span:
 span.add_event('Event With No Attributes')
 span.add_event(
   'Event With All Attributes',
-  attributes: { 'int_val' => 1, 'string_val' => '2', 'int_array' => [3, 4], 'string_array' => ['5', '6'], 'bool_array' => [false, true]}
+  attributes: { 'int_val' => 1, 'string_val' => 'two', 'int_array' => [3, 4], 'string_array' => ['5', '6'], 'bool_array' => [false, true]}
 )
 ```
 
 Read the [OpenTelemetry][13] specification for more information.
 
-### Record exceptions
+### Recording Exceptions
 
 To record exceptions, use the `record_exception` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
@@ -69,6 +69,46 @@ The following OpenTelemetry features implemented in the Datadog library as noted
 
 Datadog combines these OpenTelemetry spans with other Datadog APM spans into a single trace of your application. It supports [integration instrumentation][7] and [OpenTelemetry Automatic instrumentation][8] also.
 
+## Adding Span Events
+
+You can add span events using the `add_event` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
+
+- **Name** [_required_]: A string representing the event's name.
+- **Attributes** [_optional_]: Zero or more key-value pairs with the following properties:
+  - The key must be a non-empty string.
+  - The value can be either:
+    - A primitive type: string, Boolean, or number.
+    - A homogeneous array of primitive type values (for example, an array of strings).
+  - Nested arrays and arrays containing elements of different data types are not allowed.
+- **Timestamp** [_optional_]: A UNIX timestamp representing the event's occurrence time, expects `seconds(Float)`.
+
+The following examples demonstrate different ways to add events to a span:
+
+```ruby
+span.add_event('Event With No Attributes')
+span.add_event(
+  'Event With All Attributes',
+  attributes: { 'int_val' => 1, 'string_val' => '2', 'int_array' => [3, 4], 'string_array' => ['5', '6'], 'bool_array' => [false, true]}
+)
+```
+
+Read the [OpenTelemetry][13] specification for more information.
+
+### Record exceptions
+
+To record exceptions, use the `record_exception` API. This method requires an exception parameter and optionally accepts a UNIX timestamp parameter. It creates a new span event that includes standardized exception attributes and associates it with the corresponding span.
+
+The following examples demonstrate different ways to record exceptions:
+
+```ruby
+span.record_exception(
+  StandardError.new('Error Message'),
+  attributes: { 'status' => 'failed' }
+)
+```
+
+Read the [OpenTelemetry][14] specification for more information.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -84,3 +124,5 @@ Datadog combines these OpenTelemetry spans with other Datadog APM spans into a s
 [9]: /tracing/trace_collection/trace_context_propagation/
 [10]: /tracing/trace_collection/dd_libraries/ruby/#custom-logging
 [12]: /opentelemetry/guide/otel_api_tracing_interoperability/
+[13]: https://opentelemetry.io/docs/specs/otel/trace/api/#add-events
+[14]: https://opentelemetry.io/docs/specs/otel/trace/api/#record-exception

--- a/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
@@ -71,6 +71,8 @@ Datadog combines these OpenTelemetry spans with other Datadog APM spans into a s
 
 ## Adding span events
 
+_Minimum SDK version: 2.3.0._
+
 You can add span events using the `add_event` API. This method requires a `name` parameter and optionally accepts `attributes` and `timestamp` parameters. The method creates a new span event with the specified properties and associates it with the corresponding span.
 
 - **Name** [_required_]: A string representing the event's name.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Documents support for OTEL SpanEvents and provides examples of how to use the APIs so that OTEL users can simply add then to their spans and view in DD.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->