### PR TITLE
[NETPATH-297] Update timeout description for network path for 7.58

### DIFF
--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -1,6 +1,6 @@
 ---
 title: Setup
-description: Setting up Network Path 
+description: Setting up Network Path
 is_beta: true
 further_reading:
 - link: "/network_monitoring/network_path/list_view"
@@ -42,7 +42,7 @@ Configure network traffic paths to allow the Agent to automatically discover and
      enabled: true
    ```
 
-2. Enable `network_path` to monitor NPM connections by creating or editing the `/etc/datadog-agent/datadog.yaml` file: 
+2. Enable `network_path` to monitor NPM connections by creating or editing the `/etc/datadog-agent/datadog.yaml` file:
 
     ```yaml
     network_path:
@@ -51,7 +51,7 @@ Configure network traffic paths to allow the Agent to automatically discover and
       collector:
         workers: 10 # default 4
     ```
- 
+
     For full configuration details, reference the [example config][3], or use the following:
 
     ```yaml
@@ -82,13 +82,13 @@ Manually configure individual paths by specifying the exact endpoint you want to
      enabled: true
    ```
 
-2. Enable `network_path` to monitor new destinations from this Agent by creating or editing the `/etc/datadog-agent/conf.d/network_path.d/conf.yaml` file: 
+2. Enable `network_path` to monitor new destinations from this Agent by creating or editing the `/etc/datadog-agent/conf.d/network_path.d/conf.yaml` file:
 
    ```yaml
    init_config:
      min_collection_interval: 60 # in seconds, default 60 seconds
    instances:
-     # configure the endpoints you want to monitor, one check instance per endpoint 
+     # configure the endpoints you want to monitor, one check instance per endpoint
      - hostname: api.datadoghq.eu # endpoint hostname or IP
        protocol: TCP
        port: 443
@@ -97,7 +97,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
          - "tag_key2:tag_value2"
      ## optional configs:
      # max_ttl: 30 # max traderoute TTL, default is 30
-     # timeout: 10 # timeout in seconds of traceroute calls, default is 10s
+     # timeout: 1000 # timeout in seconds of traceroute calls, default is 1s
      - hostname: 1.1.1.1 # endpoint hostname or IP
        protocol: UDP
        port: 53
@@ -105,7 +105,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
          - "tag_key:tag_value"
          - "tag_key2:tag_value2"
     ```
- 
+
    For full configuration details, reference the [example config][4], or use the following:
 
    ```yaml
@@ -120,7 +120,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
      ## Traceroute will be run against this endpoint with a sequence of different TTL.
      #
      - hostname: <HOSTNAME_OR_IP>
-  
+
      ## @param port - uint16 - optional - default:<RANDOM PORT>
      ## The port of the destination endpoint.
      ## By default, the port is random.
@@ -131,13 +131,13 @@ Manually configure individual paths by specifying the exact endpoint you want to
      ## The maximum traceroute TTL used during path collection.
      #
      # max_ttl: 30
-  
-     ## @param timeout - uint32 - optional - default:3000
-     ## The timeout of traceroute network calls.
-     ## The timeout is in millisecond.
+
+     ## @param timeout - integer - optional - default: 1000
+     ## Specifies how much time traceroute should wait for a response
+     ## from each hop before timing out.
      #
-     # timeout: 3000
-  
+     # timeout: 1000
+
      ## @param min_collection_interval - int - optional - default:60
      ## Interval between each traceroute runs for each destination.
      # min_collection_interval: <interval_in_seconds>
@@ -163,7 +163,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
 
 3. Restart the Agent after making these configuration changes to start seeing network paths.
 
-**Note**: Network path is only supported for Linux environments. 
+**Note**: Network path is only supported for Linux environments.
 
 ## Further Reading
 

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -96,8 +96,8 @@ Manually configure individual paths by specifying the exact endpoint you want to
          - "tag_key:tag_value"
          - "tag_key2:tag_value2"
      ## optional configs:
-     # max_ttl: 30 # max traderoute TTL, default is 30
-     # timeout: 1000 # timeout in seconds of traceroute calls, default is 1s
+     # max_ttl: 30 # max traceroute TTL, default is 30
+     # timeout: 1000 # timeout in seconds per hop, default is 1s
      - hostname: 1.1.1.1 # endpoint hostname or IP
        protocol: UDP
        port: 53
@@ -133,8 +133,8 @@ Manually configure individual paths by specifying the exact endpoint you want to
      # max_ttl: 30
 
      ## @param timeout - integer - optional - default: 1000
-     ## Specifies how much time traceroute should wait for a response
-     ## from each hop before timing out.
+     ## Specifies how much time in milliseconds traceroute should
+     ## wait for a response from each hop before timing out.
      #
      # timeout: 1000
 

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -97,7 +97,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
          - "tag_key2:tag_value2"
      ## optional configs:
      # max_ttl: 30 # max traceroute TTL, default is 30
-     # timeout: 1000 # timeout in seconds per hop, default is 1s
+     # timeout: 1000 # timeout in milliseconds per hop, default is 1s
      - hostname: 1.1.1.1 # endpoint hostname or IP
        protocol: UDP
        port: 53

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -133,7 +133,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
      # max_ttl: 30
 
      ## @param timeout - integer - optional - default: 1000
-     ## Specifies how much time in milliseconds traceroute should
+     ## Specifies how much time in milliseconds the traceroute should
      ## wait for a response from each hop before timing out.
      #
      # timeout: 1000


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The meaning of the `timeout` configuration for Network Path is changing in agent 7.58.0.

The product is still in private beta so my thinking is to avoid adding any specifier about the version this applies to or any notes about the old behavior.

Agent PR associated with this change: https://github.com/DataDog/datadog-agent/pull/29092

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Please wait for agent 7.58 release before merging.

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->