### PR TITLE
Jamie/add product classifier tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ placeholders: hugpython update_pre_build
 hugpython: local/etc/requirements3.txt
 	@${PY3} -m venv --clear $@ && . $@/bin/activate && $@/bin/pip install --upgrade pip wheel && $@/bin/pip install -r $<;\
 	if [[ "$(CI_COMMIT_REF_NAME)" != "" ]]; then \
-		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.42552816-py3-none-any.whl; \
+		$@/bin/pip install https://binaries.ddbuild.io/dd-source/python/assetlib-0.0.43732323-py3-none-any.whl; \
 	fi
 
 update_pre_build: hugpython

--- a/local/bin/py/build/actions/integrations.py
+++ b/local/bin/py/build/actions/integrations.py
@@ -29,8 +29,8 @@ from actions.format_link import format_link_file
 from actions.comment_conversion import replace_comments
 
 try:
-    from assetlib.classifiers import get_all_classifier_names, get_non_deprecated_classifiers
-    CLASSIFIER_TAGS = get_all_classifier_names()
+    from assetlib.classifiers import get_customer_facing_classifiers, get_non_deprecated_classifiers
+    CLASSIFIER_TAGS = get_customer_facing_classifiers()
 except ImportError:
     CLASSIFIER_TAGS = []
     if getenv("CI_COMMIT_REF_NAME"):


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR does 2 things:

- Bump assetlib version
- Add a new getter for assetlib that will exclude some new internal-only classifier tags that were added recently

More discussion on this change can be found here: https://dd.slack.com/archives/C0DESMBQU/p1724772226680319
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->