### PR TITLE
rum: change `site` to an optional setting

### DIFF
--- a/content/en/real_user_monitoring/browser/setup.md
+++ b/content/en/real_user_monitoring/browser/setup.md
@@ -1858,7 +1858,7 @@ The RUM application ID.
 A [Datadog client token][15].
 
 `site`
-: Required<br/>
+: Optional<br/>
 **Type**: String<br/>
 **Default**: `datadoghq.com`<br/>
 [The Datadog site parameter of your organization][16].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
It appears that the site setting is not required. This PR corrects that misunderstanding.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->