### PR TITLE
remove kubelet from outbound network connections

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -238,17 +238,14 @@ Open the following ports to benefit from all the **Agent** functionalities:
 | Product/Functionality | Port | Protocol | Description |
 | ------  | ---- | ------- | ----------- |
 | Agent<br>APM<br>Containers<br>Live Processes<br>Metrics | 443 | TCP | Most Agent data uses port 443. |
-| [Custom Agent Autoscaling][5] | 8443 | TCP |  |
-| [Kubernetes HTTP Kubelet][4] | 10255 | TCP |  |
-| [Kubernetes HTTPS Kubelet][4] | 10250 | TCP |  |
+| [Custom Agent Autoscaling][4] | 8443 | TCP |  |
 | Log collection | 10516 | TCP | Logging over TCP. See [logs endpoints][3] for other connection types. |
 | NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][2].<br>For information on troubleshooting NTP, see [NTP issues][1]. |
 
 [1]: /agent/faq/network-time-protocol-ntp-offset-issues/
 [2]: /integrations/ntp/#overview
 [3]: /logs/log_collection/#logging-endpoints
-[4]: /agent/basic_agent_usage/kubernetes/
-[5]: /containers/guide/cluster_agent_autoscaling_metrics
+[4]: /containers/guide/cluster_agent_autoscaling_metrics
 
 {{% /site-region %}}
 
@@ -258,15 +255,12 @@ Open the following ports to benefit from all the **Agent** functionalities:
 | ------  | ---- | ------- | ----------- |
 | Agent<br>APM<br>Containers<br>Live Processes<br>Metrics | 443 | TCP | Most Agent data uses port 443. |
 | [Custom Agent Autoscaling][5] | 8443 | TCP |  |
-| [Kubernetes HTTP Kubelet][4] | 10255 | TCP |  |
-| [Kubernetes HTTPS Kubelet][4] | 10250 | TCP |  |
 | Log collection | 443 | TCP | Logging over TCP. See [logs endpoints][3] for other connection types. |
 | NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][2].<br>For information on troubleshooting NTP, see [NTP issues][1]. |
 
 [1]: /agent/faq/network-time-protocol-ntp-offset-issues/
 [2]: /integrations/ntp/#overview
 [3]: /logs/log_collection/#logging-endpoints
-[4]: /agent/basic_agent_usage/kubernetes/
 
 {{% /site-region %}}
 
@@ -275,14 +269,11 @@ Open the following ports to benefit from all the **Agent** functionalities:
 | Product/Functionality | Port | Protocol | Description |
 | ------  | ---- | ------- | ----------- |
 | Agent<br>APM<br>Containers<br>Live Processes<br>Metrics | 443 | TCP | Most Agent data uses port 443. |
-| [Kubernetes HTTP Kubelet][4] | 10255 | TCP |  |
-| [Kubernetes HTTPS Kubelet][4] | 10250 | TCP |  |
 | NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][2].<br>For information on troubleshooting NTP, see [NTP issues][1]. |
 
 [1]: /agent/faq/network-time-protocol-ntp-offset-issues/
 [2]: /integrations/ntp/#overview
 [3]: /logs/log_collection/#logging-endpoints
-[4]: /agent/basic_agent_usage/kubernetes/
 
 {{% /site-region %}}
 


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Kubelet checks connect to the localhost only.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->