### PR TITLE
Remove duplicate key in site params YAML

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -76,7 +76,6 @@ code_language_ids:
     ios: iOS
     expo: Expo
     flutter: Flutter
-    otel: OTel
     reactnative: React Native
     codepush: CodePush
     roku: Roku


### PR DESCRIPTION
Removing a YAML key that is causing parse errors in the customizable docs project. The removal should have no impact, as the removed key was being overwritten by another instance of the same key later in the block.

I verified this change with websites first, see the [Slack thread](https://dd.slack.com/archives/C3CT8QA11/p1725644441643029).

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->