### PR TITLE
Add Datadog intake to the agent and collector configs

### DIFF
--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -9,7 +9,7 @@ further_reading:
 
 {{< callout url="https://www.datadoghq.com/private-beta/agent-with-embedded-opentelemetry-collector/" btn_hidden="false" header="Join the Beta!">}}
   The Datadog Agent with embedded OpenTelemetry Collector is in private beta. To request access, fill out this form.
-{{< /callout >}} 
+{{< /callout >}}
 
 ## Overview
 
@@ -33,20 +33,6 @@ Install and set up the following on your machine:
 - Helm (v3+)
 - [Docker][50]
 - [kubectl][5]
-
-**Configuration**
-
-Configure your local Kubernetes context to point at the cluster.
-
-1. To view available contexts, run:
-   ```shell
-   kubectl config get-contexts
-   ```
-1. Configure `kubectl` to interact with your cluster:
-   ```shell
-   kubectl config use-context <your-cluster-context>
-   ```
-   Replace <your-cluster-context> with the name of your Kubernetes cluster context.
 
 ## Install the Datadog Agent with OpenTelemetry Collector
 
@@ -82,9 +68,11 @@ Use a YAML file to specify the Helm chart parameters for the [Datadog Agent char
 1. Configure the Datadog API and application key secrets:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 datadog:
+  site: {{< region-param key="dd_site" >}}
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
    {{< /code-block >}}
+   Set `datadog.site` to your [Datadog site][52]. Otherwise, it defaults to US1.
 1. Switch the Datadog Agent Docker repository to use development builds:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
@@ -110,18 +98,18 @@ datadog:
         name: otel-http
    {{< /code-block >}}
    It is required to set the `hostPort` in order for the container port to be exposed to the external network. This enables configuring the OTLP exporter to point to the IP address of the node to which the Datadog Agent is assigned.
-   
+
    If you don't want to expose the port, you can use the Agent service instead:
    1. Remove the <code>hostPort</code> entries from your <code>datadog-values.yaml</code> file.
    1. In your application's deployment file (`deployment.yaml`), configure the OTLP exporter to use the Agent service:
-      ```sh   
+      ```sh
       env:
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: 'http://<SERVICE_NAME>.<SERVICE_NAMESPACE>.svc.cluster.local'
         - name: OTEL_EXPORTER_OTLP_PROTOCOL
           value: 'grpc'
       ```
-   
+
 1. (Optional) Enable additional Datadog features:
    <div class="alert alert-danger">Enabling these features may incur additional charges. Review the <a href="https://www.datadoghq.com/pricing/">pricing page</a> and talk to your CSM before proceeding.</div>
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
@@ -158,6 +146,7 @@ agents:
     doNotCheckTag: true
 
 datadog:
+  site: {{< region-param key="dd_site" >}}
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
 
@@ -215,6 +204,7 @@ exporters:
   datadog:
     api:
       key: ${env:DD_API_KEY}
+      site: {{< region-param key="dd_site" >}}
 processors:
   infraattributes:
     cardinality: 2
@@ -271,7 +261,10 @@ exporters:
   datadog:
     api:
       key: ${env:DD_API_KEY}
+      site: {{< region-param key="dd_site" >}}
 {{< /code-block >}}
+
+Set `exporters.datadog.api.site` to your [Datadog site][52]. Otherwise, it defaults to US1.
 
 ##### Prometheus receiver
 
@@ -603,3 +596,4 @@ By default, the Datadog Agent with embedded Collector ships with the following C
 [49]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/extension/zpagesextension/README.md
 [50]: https://docs.docker.com/engine/install/
 [51]: https://github.com/DataDog/datadog-agent/blob/main/comp/otelcol/collector-contrib/impl/manifest.yaml#L7
+[52]: /getting_started/site/

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -68,11 +68,11 @@ Use a YAML file to specify the Helm chart parameters for the [Datadog Agent char
 1. Configure the Datadog API and application key secrets:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 datadog:
-  site: {{< region-param key="dd_site" >}}
+  site: datadoghq.com
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
    {{< /code-block >}}
-   Set `datadog.site` to your [Datadog site][52]. Otherwise, it defaults to US1.
+   Set `datadog.site` to your [Datadog site][52]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
 1. Switch the Datadog Agent Docker repository to use development builds:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
@@ -146,7 +146,7 @@ agents:
     doNotCheckTag: true
 
 datadog:
-  site: {{< region-param key="dd_site" >}}
+  site: datadoghq.com
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
 
@@ -204,7 +204,7 @@ exporters:
   datadog:
     api:
       key: ${env:DD_API_KEY}
-      site: {{< region-param key="dd_site" >}}
+      site: datadoghq.com
 processors:
   infraattributes:
     cardinality: 2
@@ -261,10 +261,10 @@ exporters:
   datadog:
     api:
       key: ${env:DD_API_KEY}
-      site: {{< region-param key="dd_site" >}}
+      site: datadoghq.com
 {{< /code-block >}}
 
-Set `exporters.datadog.api.site` to your [Datadog site][52]. Otherwise, it defaults to US1.
+Set `datadog.site` to your [Datadog site][52]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
 
 ##### Prometheus receiver
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

 * Add `datadog.site` config to the Agent example config
 * Add `exporters.datadog.api.site` config to the OTel Collector config
 * Remove K8S instructions (outside of the scope of the OTel docs)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes

The following doc is private -- the Datadog Agent with embedded OpenTelemetry Collector is in private beta. 

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->