### PR TITLE
[Profiling][.NET]Remove single-step instrumentation tab from .NET Profiler instructions

### DIFF
--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -176,25 +176,6 @@ To install the .NET Profiler per-webapp:
 [1]: https://app.datadoghq.com/profiling
 {{% /tab %}}
 
-{{% tab "Linux with Single Step Instrumentation" %}}
-
-1. With [Single Step Instrumentation][2], set the following required environment variables for automatic instrumentation to attach to your application:
-
-   ```
-   LD_PRELOAD=/opt/datadog/apm/library/dotnet/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so
-   DD_PROFILING_ENABLED=1
-   DD_ENV=production
-   DD_VERSION=1.2.3
-   ```
-
-2. For standalone applications, manually restart the application as you normally would.
-
-3. A minute or two after starting your application, your profiles appear on the [Datadog APM > Profiler page][1].
-
-[1]: https://app.datadoghq.com/profiling
-[2]: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/?tab=singlestepinstrumentationbeta
-{{% /tab %}}
-
 {{% tab "Internet Information Services (IIS)" %}}
 
 3. Set needed environment variables to configure and enable Profiler.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Removes the profiling SSI enablement instructions for .NET, as this scenario isn't yet supported

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->