### PR TITLE
Remove notes & links section

### DIFF
--- a/content/en/service_management/incident_management/_index.md
+++ b/content/en/service_management/incident_management/_index.md
@@ -64,7 +64,6 @@ When you create an incident, an incident modal comes up. This modal has several 
 | Incident Commander | This person is assigned as the leader of the incident investigation. |
 | Attributes (Teams) | Assign the appropriate group of users to an incident using [Datadog Teams][9]. Members of the assigned team are automatically invited to the Slack channels. |
 | Notifications | Specify a user, Slack channel or external email to send notifications of this incident to.  |
-| Notes & Links | You can customize the description of each severity level to fit the requirements of your organization. Include links to graphs, monitors, or security signals for additional awareness. |
 
 ### Updating the incident and the incident timeline
 


### PR DESCRIPTION
We are removing notes and links section for incident declaration: https://github.com/DataDog/web-ui/pull/155588

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR removes the `Notes & Links` section of incident app guidelines. We are removing this section from incident declaration.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->