### PR TITLE
adding a redirect for a product URL

### DIFF
--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -6,6 +6,7 @@ aliases:
   - /security/application_security/enabling/single_step
   - /security/application_security/enabling/compatibility
   - /security/application_security/enabling
+  - /security/application_security/getting_started
 further_reading:
 - link: "/security/application_security/how-appsec-works/"
   tag: "Documentation"


### PR DESCRIPTION
in the product we have a URL that directs to non-existing page: https://docs.datadoghq.com/security/application_security/getting_started/

The frontend team will change this URL to this one — https://docs.datadoghq.com/security/application_security/.

So I'm adding the redirect for now.

### Merge instructions

- [X] Please merge after reviewing

