### PR TITLE
[Private Beta] Use the stable images for the Agent with embedded OTel Collector

### DIFF
--- a/content/en/opentelemetry/agent/agent_with_custom_components.md
+++ b/content/en/opentelemetry/agent/agent_with_custom_components.md
@@ -9,7 +9,7 @@ further_reading:
 
 {{< callout url="https://www.datadoghq.com/private-beta/agent-with-embedded-opentelemetry-collector/" btn_hidden="false" header="Join the Beta!">}}
   The Datadog Agent with embedded OpenTelemetry Collector is in private beta. To request access, fill out this form.
-{{< /callout >}} 
+{{< /callout >}}
 
 This guide explains how to build a Datadog Agent image with additional OpenTelemetry components not included in the default Datadog Agent. To see a list of components already included in the Agent by default, see [Included components][1].
 
@@ -17,13 +17,13 @@ This guide explains how to build a Datadog Agent image with additional OpenTelem
 
 To complete this guide, you need the following:
 
-- [Docker][2] 
-- GitHub and access to the [Datadog Agent][3] source code.   
+- [Docker][2]
+- GitHub and access to the [Datadog Agent][3] source code.
 - The OpenTelemetry components you plan to include in the Agent must be compatible with embedded OpenTelemetry Collector version.
 
 **Recommended**:
 
-- Familiarity with [building a custom collector][4] and [OpenTelemetry Collector Builder][5] (OCB).  
+- Familiarity with [building a custom collector][4] and [OpenTelemetry Collector Builder][5] (OCB).
 - Basic understanding of the [Go](https://go.dev/) compilation process and [Go modules](https://go.dev/blog/using-go-modules).
 
 ## Download the Dockerfile
@@ -37,12 +37,12 @@ Download the Dockerfile template:
    ```
 2. Download the Dockerfile
    ```shell
-   curl -o Dockerfile https://raw.githubusercontent.com/DataDog/datadog-agent/main/Dockerfiles/agent-ot/Dockerfile.agent-otel 
+   curl -o Dockerfile https://raw.githubusercontent.com/DataDog/datadog-agent/main/Dockerfiles/agent-ot/Dockerfile.agent-otel
    ```
 
 The Dockerfile:
 
-- Creates a [multi-stage build][6] with Ubuntu 24.04 and `datadog/agent-dev:nightly-ot-beta-main-jmx`.
+- Creates a [multi-stage build][6] with Ubuntu 24.04 and `datadog/agent:7.57.0-v1.0-ot-beta-jmx`.
 - Installs Go, Python, and necessary dependencies.
 - Downloads and unpacks the Datadog Agent source code.
 - Creates a virtual environment and installs required Python packages.
@@ -56,7 +56,7 @@ Create and customize an OpenTelemetry Collector Builder (OCB) manifest file, whi
    ```shell
    curl -o manifest.yaml https://raw.githubusercontent.com/DataDog/datadog-agent/main/comp/otelcol/collector-contrib/impl/manifest.yaml
    ```
-2. Open the `manifest.yaml` file and add the additional OpenTelemetry components to the corresponding sections (extensions, exporters, processors, receivers, or connectors).  
+2. Open the `manifest.yaml` file and add the additional OpenTelemetry components to the corresponding sections (extensions, exporters, processors, receivers, or connectors).
    The highlighted line in this example adds a [metrics transform processor][7]:
    {{< highlight json "hl_lines=19" >}}
 dist:
@@ -68,11 +68,11 @@ dist:
   otelcol_version: 0.104.0
 
 extensions:
-# You will see a list of extensions already included by Datadog 
+# You will see a list of extensions already included by Datadog
 # Add your desired extensions here
 
 exporters:
-# You will see a list of exporters already included by Datadog 
+# You will see a list of exporters already included by Datadog
 # Add your desired exporters here
 
 processors:
@@ -91,10 +91,10 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.104.0
 
 connectors:
-# You will see a list of connectors already included by Datadog 
+# You will see a list of connectors already included by Datadog
 # Add your desired connectors here
 {{< /highlight >}}
-1. Save your changes to the manifest file. 
+1. Save your changes to the manifest file.
 
 ## Build and push the Agent image
 
@@ -108,8 +108,8 @@ Build your custom Datadog Agent image and push it to a container registry.
    ```shell
    docker tag agent-otel <IMAGE-NAME>/<IMAGE-TAG>
    docker push <IMAGE-NAME>/<IMAGE-TAG>
-   ``` 
-   Replace `<IMAGE-NAME>` and `<IMAGE-TAG>` with your image name and desired tag. If the target repository is not Docker Hub, you need to include the repository name. 
+   ```
+   Replace `<IMAGE-NAME>` and `<IMAGE-TAG>` with your image name and desired tag. If the target repository is not Docker Hub, you need to include the repository name.
 3. For a Helm chart installation, set the image tag in your values file:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
@@ -119,12 +119,12 @@ agents:
     doNotCheckTag: true
    {{< /code-block >}}
    Replace `<YOUR-REPO>` and `<IMAGE-TAG>` with your repository name and desired image tag.
-   
+
 ## Test and validate
 
 Create a sample configuration file and run your custom Agent to ensure everything is working correctly.
 
-1. Create a sample OpenTelemetry configuration file with the additional components.  
+1. Create a sample OpenTelemetry configuration file with the additional components.
   The following example configures an additional [metrics transform processor][7]:
    ```yaml
    receivers:
@@ -134,32 +134,32 @@ Create a sample configuration file and run your custom Agent to ensure everythin
            endpoint: "0.0.0.0:4318"
          grpc:
            endpoint: "0.0.0.0:4317"
-   
+
    processors:
      batch:
        send_batch_max_size: 1000
        send_batch_size: 100
        timeout: 10s
-     # Rename system.cpu.usage to system.cpu.usage_time  
+     # Rename system.cpu.usage to system.cpu.usage_time
      metricstransform:
        transforms:
          - include: system.cpu.usage
            action: update
            new_name: system.cpu.usage_time
-   
+
    exporters:
      datadog:
        api:
          site: ${env:DD_SITE}
          key: ${env:DD_API_KEY}
-   
+
    connectors:
        datadog/connector:
            traces:
              compute_top_level_by_span_kind: true
              peer_tags_aggregation: true
              compute_stats_by_span_kind: true
-   
+
    service:
      pipelines:
        metrics:
@@ -191,7 +191,7 @@ Create a sample configuration file and run your custom Agent to ensure everythin
      --entrypoint otel-agent \
      agent-otel --config /config.yaml
    ```
-3. If the Agent starts, then the build process was successful. 
+3. If the Agent starts, then the build process was successful.
 
 You can now use this new image to install the Agent. This enables Datadog monitoring capabilities along with the additional OpenTelemetry components you've added.
 
@@ -239,7 +239,7 @@ no space left on device
 
 **Solution**: Clear up Docker space:
 ```shell
-docker system prune -a 
+docker system prune -a
 ```
 
 ## Further reading

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -77,8 +77,8 @@ datadog:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
   image:
-    repository: datadog/agent-dev
-    tag: nightly-ot-beta-main-jmx
+    repository: datadog/agent
+    tag: 7.57.0-v1.0-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
@@ -141,8 +141,8 @@ Your `datadog-values.yaml` file should look something like this:
 {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="false" >}}
 agents:
   image:
-    repository: datadog/agent-dev
-    tag: nightly-ot-beta-main-jmx
+    repository: datadog/agent
+    tag: 7.57.0-v1.0-ot-beta-jmx
     doNotCheckTag: true
 
 datadog:

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -187,8 +187,8 @@ datadog:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
   image:
-    repository: datadog/agent-dev
-    tag: nightly-ot-beta-main-jmx
+    repository: datadog/agent
+    tag: 7.57.0-v1.0-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
@@ -251,8 +251,8 @@ Your `datadog-values.yaml` file should look something like this:
 {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="false" >}}
 agents:
   image:
-    repository: datadog/agent-dev
-    tag: nightly-ot-beta-main-jmx
+    repository: datadog/agent
+    tag: 7.57.0-v1.0-ot-beta-jmx
     doNotCheckTag: true
 
 datadog:
@@ -295,7 +295,7 @@ datadog:
      --set-file datadog.otelCollector.config=collector-config.yaml
    ```
 1. Navigate to **Integrations** > **Fleet Automation**.
-1. Select the **OTel Collector Version** facet. 
+1. Select the **OTel Collector Version** facet.
 1. Select an Agent and inspect its configuration to verify the new Agent with OpenTelemetry Collector is installed successfully.
 
 ## Configure your application


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Replace the Agent `datadog/agent-dev:nightly-*` images with the stable `datadog/agent:7-ot-*` images.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes

Following docs are private -- the Agent with embedded OTel Collector is in Private Beta

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->