### PR TITLE
Add documentation of Java heap histogram metrics

### DIFF
--- a/content/en/profiler/profiler_troubleshooting/java.md
+++ b/content/en/profiler/profiler_troubleshooting/java.md
@@ -73,6 +73,7 @@ jdk.OldObjectSample#enabled=true
 
 ## Enabling the heap histogram metrics
 <div class="aler alert-info">This feature requires at least Java 17.0.9 or newer and does not work with ZGC</div>
+
 To enable the heap histogram metrics, start your application with the `-Ddd.profiling.heap.histogram.enabled=true` JVM setting or the `DD_PROFILING_HEAP_HISTOGRAM_ENABLED=true` environment variable.
 
 ## Removing sensitive information from profiles


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds documentation to the heap histogram metrics since we are referring to them in the memory leak workflow but there is no public documentation about it.
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->