### PR TITLE
removing logs requirement from snmp traps

### DIFF
--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -17,13 +17,7 @@ Datadog Agent v7.37+ supports listening for SNMP Traps, enabling you to set up [
 
 ## Configuration
 
-1. The SNMP Trap functionality sends data as logs to Datadog. To receive this data, ensure that log collection is enabled by adding the following configuration to your `datadog.yaml` file.
-
-   ```yaml
-   logs_enabled: true # Traps are forwarded as logs and can be found in the Log Explorer with a `source:snmp-traps` query.
-   ```
-
-2. In addition to enabling log collection on your Agent, to enable listening for SNMP Traps, add the following to your `datadog.yaml` file:
+1. To enable listening for SNMP Traps, add the following to your `datadog.yaml` file:
 
    ```yaml
    network_devices:
@@ -55,10 +49,11 @@ Datadog Agent v7.37+ supports listening for SNMP Traps, enabling you to set up [
 
    **Note**: Multiple v3 users and passwords are supported as of Datadog Agent `7.51` or higher.
 
-3. Search for `source:snmp_traps` in the [Log Explorer][5] to locate SNMP trap data:
+2. Once configured, SNMP traps are forwarded as logs and can be found in the logs explorer for `source:snmp_traps` in the [Log Explorer][5] to locate SNMP trap data:
 
   {{< img src="network_device_monitoring/snmp/snmp_logs_2.png" alt="Log Explorer showing `source:snmp_traps` with an SNMP Trap log line selected, highlighting the Network Device tag" style="width:90%" >}}
 
+**Note**: Even though SNMP traps are _forwarded as logs_, `logs_enabled` does **not** need to be set to true.
 
 ## Device namespaces
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Confirmed with Engineering that `logs_enabled` is **NOT** required for SNMP traps, hence this needs removed from the docs, and I'll follow up with Support on this.

https://dd.slack.com/archives/C01C4E552HJ/p1725993735132729?thread_ts=1725986381.723309&cid=C01C4E552HJ


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->