### PR TITLE
Fix links and add aliases

### DIFF
--- a/content/en/security/cloud_security_management/agentless_scanning/_index.md
+++ b/content/en/security/cloud_security_management/agentless_scanning/_index.md
@@ -6,10 +6,10 @@ further_reading:
   - link: "/security/cloud_security_management/setup/agentless_scanning/quick_start"
     tag: "Documentation"
     text: "Agentless Scanning Quick Start for Cloud Security Management"
-  - link: "/security/cloud_security_management/guide/agentless_terraform"
+  - link: "/security/cloud_security_management/setup/agentless_scanning/terraform"
     tag: "Documentation"
     text: "Setting up Agentless Scanning using Terraform"
-  - link: "/security/cloud_security_management/guide/agentless_aws_integration"
+  - link: "/security/cloud_security_management/setup/agentless_scanning/cloudformation"
     tag: "Documentation"
     text: "Setting up Agentless Scanning with the AWS Integration"
   - link: "https://www.datadoghq.com/blog/agentless-scanning/"
@@ -124,7 +124,7 @@ To establish estimates on scanner costs, reach out to your [Datadog Customer Suc
 [3]: https://cyclonedx.org/
 [4]: /security/cloud_security_management/setup/agentless_scanning/quick_start#prerequisites
 [5]: https://app.datadoghq.com/security/csm/vm
-[6]: /security/cloud_security_management/guide/agentless_terraform
+[6]: /security/cloud_security_management/setup/agentless_scanning/terraform
 [7]: mailto:success@datadoghq.com
 [8]: /sensitive_data_scanner
 [9]: /security/cloud_security_management

--- a/content/en/security/cloud_security_management/agentless_scanning/deployment_methods.md
+++ b/content/en/security/cloud_security_management/agentless_scanning/deployment_methods.md
@@ -7,10 +7,10 @@ further_reading:
   - link: "/security/cloud_security_management/setup/agentless_scanning/quick_start"
     tag: "Documentation"
     text: "Agentless Scanning Quick Start for Cloud Security Management"
-  - link: "/security/cloud_security_management/guide/agentless_terraform"
+  - link: "/security/cloud_security_management/setup/agentless_scanning/terraform"
     tag: "Documentation"
     text: "Setting up Agentless Scanning using Terraform"
-  - link: "/security/cloud_security_management/guide/agentless_aws_integration"
+  - link: "/security/cloud_security_management/setup/agentless_scanning/cloudformation"
     tag: "Documentation"
     text: "Setting up Agentless Scanning with the AWS Integration"
 ---

--- a/content/en/security/cloud_security_management/setup/agentless_scanning/cloudformation.md
+++ b/content/en/security/cloud_security_management/setup/agentless_scanning/cloudformation.md
@@ -10,6 +10,8 @@ further_reading:
   - link: "/security/cloud_security_management/setup/agentless_scanning/terraform"
     tag: "Documentation"
     text: "Setting up Agentless Scanning using Terraform"
+aliases:
+  - /security/cloud_security_management/guide/agentless_aws_integration
 ---
 
 If you've already [set up Cloud Security Management][3] and want to add a new AWS account or enable [Agentless Scanning][1] on an existing integrated AWS account, you can use either [Terraform][2] or AWS CloudFormation. This article provides detailed instructions for the AWS CloudFormation approach.

--- a/content/en/security/cloud_security_management/setup/agentless_scanning/terraform.md
+++ b/content/en/security/cloud_security_management/setup/agentless_scanning/terraform.md
@@ -10,6 +10,8 @@ further_reading:
   - link: "/security/cloud_security_management/setup/agentless_scanning/cloudformation"
     tag: "Documentation"
     text: "Setting up Agentless Scanning using AWS CloudFormation"
+aliases:
+  - /security/cloud_security_management/guide/agentless_terraform
 ---
 
 If you've already set up Cloud Security Management and want to add a new AWS account or enable [Agentless Scanning][1] on an existing integrated AWS account, you can use either Terraform or [AWS CloudFormation][2]. This article provides detailed instructions for the Terraform approach.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fixes a couple of broken links in Further Reading sections. These links were relics from a previous version of the docs info architecture (albeit, one that was never actually published). Just to be safe, I added aliases for the broken links.

These were the two links that were broken (should now redirect):

- https://docs.datadoghq.com/security/cloud_security_management/guide/agentless_aws_integration
- https://docs.datadoghq.com/security/cloud_security_management/guide/agentless_terraform

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->