### PR TITLE
Changes to Tracing Tomcat as a Windows Service

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/java.md
@@ -117,7 +117,7 @@ To enable tracing when running Tomcat on Linux:
 To enable tracing when running Tomcat as a Windows service:
 
 1. Open the "tomcat@VERSION_MAJOR@w.exe" maintenance utility located in the `./bin` directory of the Tomcat project folder.
-2. Navigate to the Java tab, and add the following to `Java Options`:
+2. Navigate to the **Java** tab, and add the following to `Java Options`:
 ```text
 -javaagent:C:\path\to\dd-java-agent.jar
 ```

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/java.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/java.md
@@ -116,27 +116,12 @@ To enable tracing when running Tomcat on Linux:
 
 To enable tracing when running Tomcat as a Windows service:
 
-1. Open a Command Prompt.
-1. Run the following command to update your Tomcat service configuration:
-    ```shell
-    tomcat8 //US//<SERVICE_NAME> --Environment="CATALINA_OPTS=%CATALINA_OPTS% -javaagent:\"c:\path\to\dd-java-agent.jar\""
-    ```
-   Replace `<SERVICE_NAME>` with the name of your Tomcat service and replace the path to `dd-java-agent.jar`.
-1. Restart your Tomcat service for changes to take effect.
-
-#### Windows (Tomcat with environment setup script)
-
-To enable tracing when running Tomcat with an environment setup script:
-
-1. Create `setenv.bat` in the `./bin` directory of the Tomcat project folder, if it doesn't already exist.
-1. Add the following to `setenv.bat`:
-   ```text
-   set CATALINA_OPTS=%CATALINA_OPTS% -javaagent:"c:\path\to\dd-java-agent.jar"
-   ```
-If the previous step doesn't work, try adding the following instead:
+1. Open the "tomcat@VERSION_MAJOR@w.exe" maintenance utility located in the `./bin` directory of the Tomcat project folder.
+2. Navigate to the Java tab, and add the following to `Java Options`:
 ```text
-set JAVA_OPTS=%JAVA_OPTS% -javaagent:"c:\path\to\dd-java-agent.jar"
+-javaagent:C:\path\to\dd-java-agent.jar
 ```
+3. Restart your Tomcat services for changes to take effect.
 
 {{% /tab %}}
 {{% tab "JBoss" %}}


### PR DESCRIPTION
The previous changes suggested were not the recommended way to pass environment variables to Tomcat according to the documentation here: https://github.com/apache/tomcat/blob/main/bin/catalina.bat which says:
WHEN RUNNING TOMCAT AS A WINDOWS SERVICE:
...
The configuration that controls Windows Services is stored in the Windows Registry, and is most conveniently maintained using the "tomcat@VERSION_MAJOR@w.exe" maintenance utility.

I tried my best to format the instructions as previously done but feel free to edit so it is more inline with how we write documentation.

### What does this PR do? What is the motivation?
Current instructions on how to trace tomcat services running as Windows Services are incorrect

### Merge instructions


- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->