### PR TITLE
remove references to aggr and metrics from DDSQL Editor docs

### DIFF
--- a/content/en/ddsql_editor/reference/tags.md
+++ b/content/en/ddsql_editor/reference/tags.md
@@ -23,31 +23,29 @@ As a consequence of this behavior, the `IN` operator with tags works as "overlap
 To perform a strict comparison, cast the tag reference to a string, or compare it against a group literal in an outer query. For example, a query like
 
 {{< code-block lang="sql" >}}
-AGGR avg('system.load.1') WHERE team='logs' GROUP BY team
+SELECT * FROM host WHERE team='logs' GROUP BY team;
 {{< /code-block >}}
 
 May return the following result:
 
-| Timeseries | Team             |
-|------------|------------------|
-| [...]      | logs             |
-| [...]      | logs,team2       |
-| [...]      | logs,team3,team4 |
-| [...]      | logs,team2,team4 |
+| team             |
+|------------------|
+| logs             |
+| logs,team2       |
+| logs,team3,team4 |
+| logs,team2,team4 |
 
 To instead match only on `logs`, use this query:
 
 {{< code-block lang="sql" >}}
-SELECT *
-FROM (AGGR avg('system.load.1') WHERE team='logs' GROUP BY team)
-WHERE team={'logs'}
+SELECT * FROM host WHERE team={'logs'} GROUP BY team;
 {{< /code-block >}}
 
 This stricter comparison returns only one result:
 
-| Timeseries | Team             |
-|------------|------------------|
-| [...]      | logs             |
+| team             |
+|------------------|
+| logs             |
 
 ## Implicit tag references
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR removes references to `metrics` tables and `aggr` syntax from the public docs. The `metrics` data source is not exposed by default, and `aggr` is an internal-only syntax in the process of being deprecated.

### Merge instructions
- [x] Please merge after reviewing