### PR TITLE
Update admission_controller.md

### DIFF
--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -176,7 +176,7 @@ Starting from Datadog Cluster Agent v1.20.0, the Datadog Admission Controller ca
 
 This feature can be configured by setting `admission_controller.inject_config.mode` or by defining a Pod-specific mode using the `admission.datadoghq.com/config.mode` Pod label.
 
-Starting from Helm chart v3.22.0 and Datadog Operator v1.1.0, the communication mode will automatically be set to `socket` if either APM socket or DSD socket is enabled.
+Starting from Helm chart v3.22.0 and Datadog Operator v1.1.0, the communication mode is automatically set to `socket` if either APM socket or DSD socket is enabled.
 
 Possible options:
 | Mode               | Description                                                                                                       |

--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -176,6 +176,8 @@ Starting from Datadog Cluster Agent v1.20.0, the Datadog Admission Controller ca
 
 This feature can be configured by setting `admission_controller.inject_config.mode` or by defining a Pod-specific mode using the `admission.datadoghq.com/config.mode` Pod label.
 
+Starting from Helm chart v3.22.0 and Datadog Operator v1.1.0, the communication mode will automatically be set to `socket` if either APM socket or DSD socket is enabled.
+
 Possible options:
 | Mode               | Description                                                                                                       |
 |--------------------|-------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Clarifies the admission controller communication mode settings for helm and the operator when apm or dsd socket is enabled

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->