### PR TITLE
Document Profiling+SSI beta k8s support

### DIFF
--- a/content/en/profiler/enabling/ssi.md
+++ b/content/en/profiler/enabling/ssi.md
@@ -15,8 +15,7 @@ how to set it up.
 ## Supported operating systems and environments
 
 SSI is supported only on Linux, for both `x86_64` and `arm64` (ARM v8) architectures. The beta
-version of Continuous Profiler with SSI works for host and container deployments. Kubernetes
-deployments are not yet supported.
+version of Continuous Profiler with SSI works for host, container, and Kubernetes deployments.
 
 Continuous Profiler with SSI can be enabled for the following languages:
 
@@ -26,10 +25,15 @@ Continuous Profiler with SSI can be enabled for the following languages:
 | Node.js  | 4.39.0+, 5.15.0+       |
 | Python   | 2.11.1+                |
 
+Kubernetes deployments require at least Datadog Agent 7.57.0. Host and container deployments can
+use 7.56.x versions of the Datadog Agent.
 
 ## Enable Continuous Profiler with SSI
 
 Continuous Profiler can be enabled as part of the SSI setup by following these steps:
+
+{{< tabs >}}
+{{% tab "Host and container" %}}
 
 1. Go to the [Agent Installation Page][2] and select one of Linux platforms or Docker.
 1. Toggle the "Enable APM Instrumentation" switch. (If there is no switch, the platform is not supported by SSI.) Toggling the switch adds the `DD_APM_INSTRUMENTATION_ENABLED=` environment variable to the installation command, configuring the installed agent to inject the tracer library into processes.
@@ -37,20 +41,78 @@ Continuous Profiler can be enabled as part of the SSI setup by following these s
 1. Add `DD_PROFILING_ENABLED=auto` as an additional environment variable after `DD_APM_INSTRUMENTATION_ENABLED` in the copied command. This turns on automatic profiler enablement for any new process worth profiling.
 1. Proceed with the rest of the installation instructions, using the modified installation command.
 
+[2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
+{{% /tab %}}
+{{% tab "Kubernetes with Helm Chart" %}}
+
+1. Go to the [Agent Installation Page][2] and select Kubernetes, then select Helm Chart.
+1. Open the APM dropdown and toggle the Enable APM Instrumentation switch.
+1. Add the values below to `datadog-values.yaml` in addition to those indicated by the installation page. `datadog.profiling.enabled: auto` setting turns on automatic profiler enablement for any new
+process worth profiling.
+1. Proceed with rest of the installation instructions.
+
+```
+agents:
+  image:
+    tag: latest
+clusterAgent:
+  image:
+    tag: latest
+datadog:
+  profiling:
+    enabled: auto
+```
+
+If you already have Datadog Helm Chart, ensure it is updated to at least version 3.71.0.
+Image tag "latest" is used to install a recent agent version with support for profiling as Datadog
+Helm Chart defaults to an older agent version.
+
+[2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
+{{% /tab %}}
+{{% tab "Kubernetes with Datadog Operator" %}}
+
+1. Go to the [Agent Installation Page][2] and select Kubernetes, then select Operator.
+1. Open the APM dropdown and toggle the Enable APM Instrumentation switch.
+1. Add the values below to `datadog-values.yaml` in addition to those indicated by the installation page. `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED=auto` environment variable on
+the cluster agent turns on automatic profiler enablement for any new process worth profiling.
+1. Proceed with rest of the installation instructions.
+
+```
+spec:
+  override:
+    nodeAgent:
+      image:
+        tag: latest
+    clusterAgent:
+      image:
+        tag: latest
+      env:
+        - name: DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED
+          value: "auto"
+```
+
+Image tag "latest" is used to install a recent agent version with support for profiling as Datadog
+Operator defaults to an older agent version.
+
+[2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
+{{% /tab %}}
+{{< /tabs >}}
+
 ## How does profiling work with SSI
 
-After the installation, all new processes on the host or in the container are executed with the
-`DD_PROFILING_ENABLED=auto` environment variable. Running processes will not be affected.
-The Datadog library dynamically turns on the profiler for the processes that are good profiling candidates.
+After the installation, all new processes are executed with the `DD_PROFILING_ENABLED=auto`
+environment variable. Running processes will not be affected. The Datadog library dynamically turns
+on the profiler for the processes that are good profiling candidates.
 
-The logic for identifying a process as a good candidate varies by language. For Java,
-all processes that are profiled as Java applications are usually deployed as a single Java process on a
-host. For Node and Python, profiler is only turned on if the application is running for more than 30
-seconds and has created at least one tracing span.
-SSI can also be configured to inject profiling on each and every process by using
-`DD_PROFILING_ENABLED=true`.
+The logic for identifying a process as a good candidate varies by language. For Java, all processes
+are profiled as Java applications are usually deployed as a single Java process on a host. For Node
+and Python, profiler is only turned on if the application is running for more than 30 seconds and
+has created at least one tracing span.
 
-**Note**: Datadog recommends using`DD_PROFILING_ENABLED=auto` to avoid profiling low value processes.
+SSI can also be configured to inject profiling on each and every process by using the value `true`
+instead of `auto`.
+
+**Note**: Datadog recommends using the `auto` setting to avoid profiling low value processes.
 
 # Reverting
 
@@ -58,8 +120,9 @@ The [Single Step APM Instrumentation][1] page contains instructions for removing
 instrumentation. Removing instrumentation also removes profiling.
 
 Additionally, you can disable profiling by:
-* repeating the installation instructions with `DD_PROFILING_ENABLED=false` value, or
-* removing the `DD_PROFILING_ENABLED` setting from the `/etc/environment` file on the host.
+* repeating the installation instructions using `false` value in place of `auto`, or
+* removing the `DD_PROFILING_ENABLED` setting from the `/etc/environment` file on the host, for
+  host and container deployments.
 
 Finally, you can disable profiling on a per-process basis by explicitly setting
 `DD_PROFILING_ENABLED=false` on its command line.
@@ -78,5 +141,4 @@ on a host as something other than a systemd service, or container-deployed appli
 need this extra step.
 
 [1]: /tracing/trace_collection/automatic_instrumentation/single-step-apm
-[2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
 [3]: /profiler/

--- a/content/en/profiler/enabling/ssi.md
+++ b/content/en/profiler/enabling/ssi.md
@@ -47,7 +47,7 @@ Continuous Profiler can be enabled as part of the SSI setup by following these s
 
 1. Go to the [Agent Installation Page][2] and select Kubernetes, then select Helm Chart.
 1. Open the APM dropdown and toggle the Enable APM Instrumentation switch.
-1. Add the values below to `datadog-values.yaml` in addition to those indicated by the installation page. `datadog.profiling.enabled: auto` setting turns on automatic profiler enablement for any new
+1. Add the values below to `datadog-values.yaml` in addition to those indicated by the installation page. The `datadog.profiling.enabled: auto` setting turns on automatic profiler enablement for any new
 process worth profiling.
 1. Proceed with rest of the installation instructions.
 
@@ -63,9 +63,9 @@ datadog:
     enabled: auto
 ```
 
-If you already have Datadog Helm Chart, ensure it is updated to at least version 3.71.0.
-Image tag "latest" is used to install a recent agent version with support for profiling as Datadog
-Helm Chart defaults to an older agent version.
+If you already have the Datadog Helm chart, ensure it is updated to at least version 3.71.0.
+Use the "latest" image tag to install a recent Agent version with support for profiling, as 
+the Datadog Helm chart defaults to an older Agent version.
 
 [2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
 {{% /tab %}}
@@ -73,8 +73,8 @@ Helm Chart defaults to an older agent version.
 
 1. Go to the [Agent Installation Page][2] and select Kubernetes, then select Operator.
 1. Open the APM dropdown and toggle the Enable APM Instrumentation switch.
-1. Add the values below to `datadog-values.yaml` in addition to those indicated by the installation page. `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED=auto` environment variable on
-the cluster agent turns on automatic profiler enablement for any new process worth profiling.
+1. Add the values below to `datadog-values.yaml` in addition to those indicated by the installation page. The `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_PROFILING_ENABLED=auto` environment variable on
+the Cluster Agent turns on automatic profiler enablement for any new process worth profiling.
 1. Proceed with rest of the installation instructions.
 
 ```
@@ -91,8 +91,8 @@ spec:
           value: "auto"
 ```
 
-Image tag "latest" is used to install a recent agent version with support for profiling as Datadog
-Operator defaults to an older agent version.
+Use the "latest" image tag to install a recent Agent version with support for profiling, as 
+the Datadog Operator defaults to an older Agent version.
 
 [2]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
 {{% /tab %}}
@@ -101,11 +101,11 @@ Operator defaults to an older agent version.
 ## How does profiling work with SSI
 
 After the installation, all new processes are executed with the `DD_PROFILING_ENABLED=auto`
-environment variable. Running processes will not be affected. The Datadog library dynamically turns
+environment variable. Running processes are not affected. The Datadog library dynamically turns
 on the profiler for the processes that are good profiling candidates.
 
 The logic for identifying a process as a good candidate varies by language. For Java, all processes
-are profiled as Java applications are usually deployed as a single Java process on a host. For Node
+are profiled, as Java applications are usually deployed as a single Java process on a host. For Node
 and Python, profiler is only turned on if the application is running for more than 30 seconds and
 has created at least one tracing span.
 
@@ -119,10 +119,9 @@ instead of `auto`.
 The [Single Step APM Instrumentation][1] page contains instructions for removing all
 instrumentation. Removing instrumentation also removes profiling.
 
-Additionally, you can disable profiling by:
-* repeating the installation instructions using `false` value in place of `auto`, or
-* removing the `DD_PROFILING_ENABLED` setting from the `/etc/environment` file on the host, for
-  host and container deployments.
+Additionally, you can disable profiling by taking one of the following steps:
+* Repeat the installation instructions using a `false` value in place of `auto`.
+* Remove the `DD_PROFILING_ENABLED` setting from the `/etc/environment` file on the host, for host and container deployments.
 
 Finally, you can disable profiling on a per-process basis by explicitly setting
 `DD_PROFILING_ENABLED=false` on its command line.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds documentation for enabling Profiling+SSI support on Kubernetes.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->