### PR TITLE
[OTEL-2071] OTel semantic mapping deployment.environment.name to env

### DIFF
--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -489,7 +489,7 @@ When using OpenTelemetry, map the following [resource attributes][16] to their c
 | `service.name` | `service` |
 | `service.version` | `version` |
 
-* `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][3]
+* `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][17]
 * `deployment.environment.name` is supported in Datadog Agent 7.58.0+ and Datadog exporter v0.110.0+
 
 <div class="alert alert-warning">Datadog-specific environment variables like <code>DD_SERVICE</code>, <code>DD_ENV</code> or <code>DD_VERSION</code> are not supported out of the box in your OpenTelemetry configuration.</div>
@@ -566,3 +566,4 @@ processors:
 [14]: https://www.ansible.com/
 [15]: /serverless/configuration/#connect-telemetry-using-tags
 [16]: https://opentelemetry.io/docs/languages/js/resources/
+[17]: https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -484,13 +484,13 @@ When using OpenTelemetry, map the following [resource attributes][16] to their c
 
 | OpenTelemetry convention | Datadog convention |
 | --- | --- |
-| `deployment.environment`* | `env` |
-| `deployment.environment.name`* | `env` |
+| `deployment.environment` <sup>1</sup>  | `env` |
+| `deployment.environment.name` <sup>2</sup> | `env` |
 | `service.name` | `service` |
 | `service.version` | `version` |
 
-* `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][17]
-* `deployment.environment.name` is supported in Datadog Agent 7.58.0+ and Datadog exporter v0.110.0+
+1: `deployment.environment` is deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][17].  
+2: `deployment.environment.name` is supported in Datadog Agent 7.58.0+ and Datadog Exporter v0.110.0+.
 
 <div class="alert alert-warning">Datadog-specific environment variables like <code>DD_SERVICE</code>, <code>DD_ENV</code> or <code>DD_VERSION</code> are not supported out of the box in your OpenTelemetry configuration.</div>
 

--- a/content/en/getting_started/tagging/unified_service_tagging.md
+++ b/content/en/getting_started/tagging/unified_service_tagging.md
@@ -484,9 +484,13 @@ When using OpenTelemetry, map the following [resource attributes][16] to their c
 
 | OpenTelemetry convention | Datadog convention |
 | --- | --- |
-| `deployment.environment` | `env` |
+| `deployment.environment`* | `env` |
+| `deployment.environment.name`* | `env` |
 | `service.name` | `service` |
 | `service.version` | `version` |
+
+* `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][3]
+* `deployment.environment.name` is supported in Datadog Agent 7.58.0+ and Datadog exporter v0.110.0+
 
 <div class="alert alert-warning">Datadog-specific environment variables like <code>DD_SERVICE</code>, <code>DD_ENV</code> or <code>DD_VERSION</code> are not supported out of the box in your OpenTelemetry configuration.</div>
 

--- a/content/en/opentelemetry/interoperability/environment_variable_support.md
+++ b/content/en/opentelemetry/interoperability/environment_variable_support.md
@@ -82,7 +82,7 @@ Metrics exporter to be used<br>
 : ****Datadog convention****: `DD_TAGS` <br>
 Key-value pairs to be used as resource attributes. See [Resource semantic conventions][11] for details<br>
 **Notes**: Only the first 10 key-value pairs are used; the subsequent values are dropped<br>
-`deployment.environment` maps to the `DD_ENV` environment variable<br>
+`deployment.environment` and `deployment.environment.name` map to the `DD_ENV` environment variable<br>
 `service.name` maps to the `DD_SERVICE` environment variable<br>
 `service.version` maps to the `DD_VERSION` environment variable<br>
 

--- a/content/en/opentelemetry/schema_semantics/semantic_mapping.md
+++ b/content/en/opentelemetry/schema_semantics/semantic_mapping.md
@@ -20,15 +20,15 @@ OpenTelemetry makes use of a number of [semantic conventions][1] that specify na
 
 | OpenTelemetry convention | Datadog convention |
 | --- | --- |
-| `deployment.environment`* | `env` |
-| `deployment.environment.name`* | `env` |
+| `deployment.environment` <sup>1</sup>  | `env` |
+| `deployment.environment.name` <sup>2</sup> | `env` |
 | `service.name` | `service` |
 | `service.version` | `version` |
 
 For more information, see [Unified Service Tagging][2].
 
-* `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][4]
-* `deployment.environment.name` is supported in Datadog Agent 7.58.0+ and Datadog exporter v0.110.0+
+1: `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][4]  
+2: `deployment.environment.name` is supported in Datadog Agent 7.58.0+ and Datadog Exporter v0.110.0+
 
 ### Containers
 

--- a/content/en/opentelemetry/schema_semantics/semantic_mapping.md
+++ b/content/en/opentelemetry/schema_semantics/semantic_mapping.md
@@ -27,7 +27,7 @@ OpenTelemetry makes use of a number of [semantic conventions][1] that specify na
 
 For more information, see [Unified Service Tagging][2].
 
-* `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][3]
+* `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][4]
 * `deployment.environment.name` is supported in Datadog Agent 7.58.0+ and Datadog exporter v0.110.0+
 
 ### Containers
@@ -145,3 +145,4 @@ Enabling this option adds both the OpenTelemetry resource attributes and the Dat
 [1]: https://opentelemetry.io/docs/concepts/semantic-conventions/
 [2]: /getting_started/tagging/unified_service_tagging#opentelemetry
 [3]: https://opentelemetry.io/docs/specs/semconv/resource/container/
+[4]: https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0

--- a/content/en/opentelemetry/schema_semantics/semantic_mapping.md
+++ b/content/en/opentelemetry/schema_semantics/semantic_mapping.md
@@ -20,11 +20,15 @@ OpenTelemetry makes use of a number of [semantic conventions][1] that specify na
 
 | OpenTelemetry convention | Datadog convention |
 | --- | --- |
-| `deployment.environment` | `env` |
+| `deployment.environment`* | `env` |
+| `deployment.environment.name`* | `env` |
 | `service.name` | `service` |
 | `service.version` | `version` |
 
 For more information, see [Unified Service Tagging][2].
+
+* `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0][3]
+* `deployment.environment.name` is supported in Datadog Agent 7.58.0+ and Datadog exporter v0.110.0+
 
 ### Containers
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Add semantic mapping of the new OTel semantic convention `deployment.environment.name` -> `env`

The old convention `deployment.environment` has been deprecated in favor of `deployment.environment.name` in [OpenTelemetry semantic conventions v1.27.0](https://github.com/open-telemetry/semantic-conventions/releases/tag/v1.27.0). 

Datadog agent supports the new convention starting 7.58.0
Datadog exporter supports the new convention starting v0.110.0

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

> :warning: Do not merge until new Agent and Exporter release.

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

For now the old convention `deployment.environment` is still preferred in the examples as it works in all previous Datadog agent and Datadog exporter versions.