### PR TITLE
(DOCS-8996) Add limits page for Workflow Automation

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -2383,11 +2383,16 @@ menu:
       parent: workflows
       identifier: workflows_test_and_debug
       weight: 8
+    - name: Limits
+      url: service_management/workflows/limits/
+      parent: workflows
+      identifier: workflows_limits
+      weight: 9
     - name: Actions Catalog
       url: service_management/workflows/actions_catalog/
       parent: workflows
       identifier: workflows_actions_catalog
-      weight: 9
+      weight: 10
     - name: App Builder
       url: service_management/app_builder/
       pre: app-builder

--- a/content/en/service_management/workflows/limits.md
+++ b/content/en/service_management/workflows/limits.md
@@ -27,22 +27,22 @@ Each organization:
 * Can execute up to 50 workflows per minute for a source (such as a specific monitor).
 * Can buffer up to 500 requests.
 
-When an organization exceeds these thresholds, pending execution requests queue up to a maximum of 500 per organization then process according to the previously described limits. For example, if a monitor triggers 500 workflow runs, only 50 are triggered in the first minute. The remaining 450 workflow runs are queued and 50 workflows are triggered every minute until all workflows have been triggered.
+When an organization exceeds a threshold, pending execution requests queue up to a maximum of 500 per organization then process according to the previously described limits. For example, if a monitor triggers 500 workflow runs, only 50 are triggered in the first minute. The remaining 450 workflow runs are queued and 50 workflows are triggered every minute until all workflows have been triggered.
 
 ### Trial accounts
 
 Each organization:
 
 * Can create up to 20 workflows per minute.
-* Can execute up to 50 workflows per 20 minute.
+* Can execute up to 50 workflows per 20 minutes.
 * Can execute up to 20 workflows per minute for a source (such as a specific monitor).
 * Can buffer up to 100 requests.
 
-When an organization exceeds these thresholds, pending execution requests queue up to a maximum of 100 per organization then process according to the previously described limits. For example, if a monitor triggers 100 workflow runs, only 50 are triggered in the first 20 minutes. The remaining 50 workflow runs are queued and trigger after 20 minutes pass.
+When an organization exceeds a threshold, pending execution requests queue up to a maximum of 100 per organization then process according to the previously described limits. For example, if a monitor triggers 100 workflow runs, only 50 are triggered in the first 20 minutes. The remaining 50 workflow runs are queued and trigger after 20 minutes pass.
 
 ## Workflow-level limits
 
-* A workflow can contain up to 100 steps. If you need more than 100 steps in a workflow, you can use the **Trigger workflow** step to [call a child workflow][2]. Use output parameters to pass the output of a child workflow back to your main workflow.
+* A workflow can contain up to 100 steps. If you need more than 100 steps in a workflow, you can use the **Trigger workflow** action to [call a child workflow][2]. Use output parameters to pass the output of a child workflow back to your main workflow.
 * A workflow can run for up to 24 hours. Workflows terminate when they attempt to run for longer than 24 hours.
 * A workflow can start up to 30 steps per minute. If you exceed this rate, steps are throttled and start at a rate of 30 per minute.
 * The sum of all step outputs for a workflow can be up to 150 MB.

--- a/content/en/service_management/workflows/limits.md
+++ b/content/en/service_management/workflows/limits.md
@@ -50,7 +50,7 @@ When an organization exceeds a threshold, pending execution requests queue up to
 
 ## End user limits
 
-Each end user can execute up to 100 actions per minute across App Builder and Workflow Automation.
+Each end user can execute up to 100 actions per minute across App Builder and Workflow Automation. When a user exceeds this threshold, workflow executions are throttled.
 
 ## Action limits
 

--- a/content/en/service_management/workflows/limits.md
+++ b/content/en/service_management/workflows/limits.md
@@ -42,7 +42,7 @@ When an organization exceeds these thresholds, pending execution requests queue 
 
 ## Workflow-level limits
 
-* A workflow can contain up to 100 steps. If you need more than 100 steps in a workflow, you can use the **Trigger workflow** step to call a child workflow. Use output parameters to pass the output of a child workflow back to your main workflow.
+* A workflow can contain up to 100 steps. If you need more than 100 steps in a workflow, you can use the **Trigger workflow** step to [call a child workflow][2]. Use output parameters to pass the output of a child workflow back to your main workflow.
 * A workflow can run for up to 24 hours. Workflows terminate when they attempt to run for longer than 24 hours.
 * A workflow can start up to 30 steps per minute. If you exceed this rate, steps are throttled and start at a rate of 30 per minute.
 * The sum of all step outputs for a workflow can be up to 150 MB.
@@ -68,4 +68,5 @@ Each end user can execute up to 100 actions per minute across App Builder and Wo
 <br>Do you have questions or feedback? Join the **#workflows** channel on the [Datadog Community Slack][9].
 
 [1]: /service_management/workflows/actions/flow_control/#for-loop
+[2]: /service_management/workflows/trigger/#trigger-a-workflow-from-a-workflow
 [9]: https://datadoghq.slack.com/

--- a/content/en/service_management/workflows/limits.md
+++ b/content/en/service_management/workflows/limits.md
@@ -1,0 +1,72 @@
+---
+title: Limits
+description: Rate Limits for Workflow Automation
+algolia:
+  tags: ['workflow', 'workflows', 'workflow automation']
+disable_toc: false
+further_reading:
+- link: "/service_management/workflows/build"
+  tag: "Documentation"
+  text: "Build Workflows"
+---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Workflow Automation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+This page describes rate limits and throttles that apply to Workflow Automation.
+
+## Account-level limits
+
+### Paid accounts
+
+Each organization:
+
+* Can have up to 500 workflows at once.
+* Can execute up to 200 workflows per minute.
+* Can execute up to 50 workflows per minute for a source (such as a specific monitor).
+* Can buffer up to 500 requests.
+
+When an organization exceeds these thresholds, pending execution requests buffer up to a maximum of 500 per organization then process according to the previously described limits. For example, if a monitor triggers 500 workflow runs, only 50 are triggered in the first minute. The remaining 450 workflow runs are queued and 50 workflows are triggered every minute until all workflows have been triggered.
+
+### Trial accounts
+
+Each organization:
+
+* Can have up to 20 workflows at once.
+* Can execute up to 50 workflows per 20 minute.
+* Can execute up to 20 workflows per minute for a source (such as a specific monitor).
+* Can buffer up to 100 requests.
+
+When an organization exceeds these thresholds, pending execution requests buffer up to a maximum of 100 per organization then process according to the previously described limits. For example, if a monitor triggers 100 workflow runs, only 50 are triggered in the first 20 minutes. The remaining 50 workflow runs are queued and trigger after 20 minutes pass.
+
+## Workflow-level limits
+
+* A workflow can contain up to 100 steps.
+* A workflow can run for up to 24 hours. Workflows terminate when they attempt to run for longer than 24 hours.
+* A workflow can start up to 30 steps per minute. If you exceed this rate, steps are throttled and start at a rate of 30 per minute.
+* The sum of all step outputs for a workflow can be up to 150 MB.
+* A workflow's output size can be up to 500 KB.
+
+## End user limits
+
+Each end user can execute up to 100 actions per minute across App Builder and Workflow Automation.
+
+## Action limits
+
+* An action's input can be up to 15 MB.
+* An action's output can be up to 15 MB.
+* User-supplied JavaScript can be up to 10 KB.
+* Each org can execute up to 10,000 send email actions per day. If you exceed this limit, the action fails with an error message.
+* The [for loop][1] action can run for up to 2000 iterations.
+
+
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+<br>Do you have questions or feedback? Join the **#workflows** channel on the [Datadog Community Slack][9].
+
+[1]: /service_management/workflows/actions/flow_control/#for-loop
+[9]: https://datadoghq.slack.com/

--- a/content/en/service_management/workflows/limits.md
+++ b/content/en/service_management/workflows/limits.md
@@ -22,7 +22,7 @@ This page describes rate limits and throttles that apply to Workflow Automation.
 
 Each organization:
 
-* Can have up to 500 workflows at once.
+* Can create up to 500 workflows per minute.
 * Can execute up to 200 workflows per minute.
 * Can execute up to 50 workflows per minute for a source (such as a specific monitor).
 * Can buffer up to 500 requests.
@@ -33,7 +33,7 @@ When an organization exceeds these thresholds, pending execution requests queue 
 
 Each organization:
 
-* Can have up to 20 workflows at once.
+* Can create up to 20 workflows per minute.
 * Can execute up to 50 workflows per 20 minute.
 * Can execute up to 20 workflows per minute for a source (such as a specific monitor).
 * Can buffer up to 100 requests.

--- a/content/en/service_management/workflows/limits.md
+++ b/content/en/service_management/workflows/limits.md
@@ -42,7 +42,7 @@ When an organization exceeds these thresholds, pending execution requests queue 
 
 ## Workflow-level limits
 
-* A workflow can contain up to 100 steps.
+* A workflow can contain up to 100 steps. If you need more than 100 steps in a workflow, you can use the **Trigger workflow** step to call a child workflow. Use output parameters to pass the output of a child workflow back to your main workflow.
 * A workflow can run for up to 24 hours. Workflows terminate when they attempt to run for longer than 24 hours.
 * A workflow can start up to 30 steps per minute. If you exceed this rate, steps are throttled and start at a rate of 30 per minute.
 * The sum of all step outputs for a workflow can be up to 150 MB.
@@ -58,8 +58,7 @@ Each end user can execute up to 100 actions per minute across App Builder and Wo
 * An action's output can be up to 15 MB.
 * User-supplied JavaScript can be up to 10 KB.
 * Each org can execute up to 10,000 send email actions per day. If you exceed this limit, the action fails with an error message.
-* The [for loop][1] action can run for up to 2000 iterations.
-
+* The [for loop][1] action can run for up to 2000 iterations. If you need more than 2000 iterations, you can partition your input into sets of 2000 and compute them in parallel.
 
 
 ## Further Reading

--- a/content/en/service_management/workflows/limits.md
+++ b/content/en/service_management/workflows/limits.md
@@ -48,10 +48,6 @@ When an organization exceeds a threshold, pending execution requests queue up to
 * The sum of all step outputs for a workflow can be up to 150 MB.
 * A workflow's output size can be up to 500 KB.
 
-## End user limits
-
-Each end user can execute up to 100 actions per minute across App Builder and Workflow Automation. When a user exceeds this threshold, workflow executions are throttled.
-
 ## Action limits
 
 * An action's input can be up to 15 MB.

--- a/content/en/service_management/workflows/limits.md
+++ b/content/en/service_management/workflows/limits.md
@@ -27,7 +27,7 @@ Each organization:
 * Can execute up to 50 workflows per minute for a source (such as a specific monitor).
 * Can buffer up to 500 requests.
 
-When an organization exceeds these thresholds, pending execution requests buffer up to a maximum of 500 per organization then process according to the previously described limits. For example, if a monitor triggers 500 workflow runs, only 50 are triggered in the first minute. The remaining 450 workflow runs are queued and 50 workflows are triggered every minute until all workflows have been triggered.
+When an organization exceeds these thresholds, pending execution requests queue up to a maximum of 500 per organization then process according to the previously described limits. For example, if a monitor triggers 500 workflow runs, only 50 are triggered in the first minute. The remaining 450 workflow runs are queued and 50 workflows are triggered every minute until all workflows have been triggered.
 
 ### Trial accounts
 
@@ -38,7 +38,7 @@ Each organization:
 * Can execute up to 20 workflows per minute for a source (such as a specific monitor).
 * Can buffer up to 100 requests.
 
-When an organization exceeds these thresholds, pending execution requests buffer up to a maximum of 100 per organization then process according to the previously described limits. For example, if a monitor triggers 100 workflow runs, only 50 are triggered in the first 20 minutes. The remaining 50 workflow runs are queued and trigger after 20 minutes pass.
+When an organization exceeds these thresholds, pending execution requests queue up to a maximum of 100 per organization then process according to the previously described limits. For example, if a monitor triggers 100 workflow runs, only 50 are triggered in the first 20 minutes. The remaining 50 workflow runs are queued and trigger after 20 minutes pass.
 
 ## Workflow-level limits
 

--- a/content/en/service_management/workflows/trigger.md
+++ b/content/en/service_management/workflows/trigger.md
@@ -202,6 +202,8 @@ If the child workflow has [input parameters][5], these parameters appear as requ
 
 {{< img src="service_management/workflows/trigger-workflow-step.png" alt="The service_name input parameter is required in the child workflow" style="width:100%;" >}}
 
+You can also pass the result of a child workflow back to the parent workflow by defining **Output parameters** in the child workflow. The **Trigger workflow** step in the parent workflow retrieves the output parameters from the child workflow.
+
 ## Run history
 
 After you trigger a workflow, the workflow page switches to the workflow's **Run History**. Click **Configuration** or **Run History** in the top-left to switch between the configuration and run history views. Use run history to watch the progress of a triggered workflow or [debug a failed step][13].

--- a/content/en/service_management/workflows/trigger.md
+++ b/content/en/service_management/workflows/trigger.md
@@ -202,7 +202,7 @@ If the child workflow has [input parameters][5], these parameters appear as requ
 
 {{< img src="service_management/workflows/trigger-workflow-step.png" alt="The service_name input parameter is required in the child workflow" style="width:100%;" >}}
 
-You can also pass the result of a child workflow back to the parent workflow by defining **Output parameters** in the child workflow. The **Trigger Workflow** step in the parent workflow retrieves the output parameters from the child workflow.
+You can also pass the result of a child workflow back to the parent workflow by defining **Output parameters** in the child workflow. Use the `WorkflowOutputs` context variable in the parent workflow to retrieve the output parameters of the child workflow. For example, given a child workflow named `Example_workflow` with an output parameter named `exampleList`, use `Steps.Example_workflow.workflowOutputs.exampleList` to access the result of the child workflow.
 
 ## Run history
 

--- a/content/en/service_management/workflows/trigger.md
+++ b/content/en/service_management/workflows/trigger.md
@@ -202,7 +202,7 @@ If the child workflow has [input parameters][5], these parameters appear as requ
 
 {{< img src="service_management/workflows/trigger-workflow-step.png" alt="The service_name input parameter is required in the child workflow" style="width:100%;" >}}
 
-You can also pass the result of a child workflow back to the parent workflow by defining **Output parameters** in the child workflow. The **Trigger workflow** step in the parent workflow retrieves the output parameters from the child workflow.
+You can also pass the result of a child workflow back to the parent workflow by defining **Output parameters** in the child workflow. The **Trigger Workflow** step in the parent workflow retrieves the output parameters from the child workflow.
 
 ## Run history
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Add a page for workflow automation rate limits and throttles

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->