### PR TITLE
Jenkins plugin configuration: add a reference to custom log collection config in DD Agent

### DIFF
--- a/content/en/continuous_integration/pipelines/jenkins.md
+++ b/content/en/continuous_integration/pipelines/jenkins.md
@@ -48,7 +48,7 @@ This integration supports both [Agentless](#install-the-datadog-jenkins-plugin-a
 
 The Datadog Jenkins plugin can either report metrics through the Datadog Agent or directly to Datadog if an API key is provided. If you don't have a Datadog Agent running on the Jenkins controller instance, Datadog recommends installing it first by following the [Agent installation instructions][14]. Whether you choose to use Agentless mode or the Agent-based mode, you are **required** to use the plugin.
 
-If you want to report the logs of your Jenkins jobs to Datadog make sure that custom log collection over TCP is [enabled and configured][29] in the Agent.
+If you want to report the logs of your Jenkins jobs to Datadog, make sure that custom log collection over TCP is [enabled and configured][29] in the Agent.
 
 If the Jenkins controller and the Datadog Agent have been deployed to a Kubernetes cluster, Datadog recommends using the [Admission Controller][2], which automatically sets the `DD_AGENT_HOST` environment variable in the Jenkins controller pod to communicate with the local Datadog Agent.
 

--- a/content/en/continuous_integration/pipelines/jenkins.md
+++ b/content/en/continuous_integration/pipelines/jenkins.md
@@ -48,6 +48,8 @@ This integration supports both [Agentless](#install-the-datadog-jenkins-plugin-a
 
 The Datadog Jenkins plugin can either report metrics through the Datadog Agent or directly to Datadog if an API key is provided. If you don't have a Datadog Agent running on the Jenkins controller instance, Datadog recommends installing it first by following the [Agent installation instructions][14]. Whether you choose to use Agentless mode or the Agent-based mode, you are **required** to use the plugin.
 
+If you want to report the logs of your Jenkins jobs to Datadog make sure that custom log collection over TCP is [enabled and configured][29] in the Agent.
+
 If the Jenkins controller and the Datadog Agent have been deployed to a Kubernetes cluster, Datadog recommends using the [Admission Controller][2], which automatically sets the `DD_AGENT_HOST` environment variable in the Jenkins controller pod to communicate with the local Datadog Agent.
 
 <div class="alert alert-info"><strong>Note</strong>: Sending CI Visibility traces through UNIX domain sockets is not supported.</div>
@@ -1510,3 +1512,4 @@ Failed to reinitialize Datadog-Plugin Tracer, Cannot enable traces collection vi
 [26]: /glossary/#custom-span
 [27]: /logs/guide/best-practices-for-log-management/
 [28]: /continuous_integration/search/#search-for-pipelines
+[29]: /agent/logs/?tab=tcpudp#custom-log-collection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Updates Datadog Jenkins plugin configuration instructions.
The plugin may be configured to report the data - including job logs - to Datadog Agent.
In this case additional configuration changes need to be done in the Agent config.
This PR adds a reference to the relevant Agent documentation page.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->