### PR TITLE
SDCD-415: updating dora deployment documentation to clarify the optional `team` attribute

### DIFF
--- a/content/en/dora_metrics/deployments/deployment_api.md
+++ b/content/en/dora_metrics/deployments/deployment_api.md
@@ -41,7 +41,7 @@ The following attributes are required:
 - `finished_at`: The time the deployment finished.
 - `service`: The service that was deployed. If the provided service is registered in the [Service Catalog][3] with metadata set up (see [Adding Metadata][5]), the `team` of the service is automatically retrieved and associated with all metrics.
 
-The `repository_url` and `commit_sha` attributes are also required for calculating the Change Lead Time metric. You can optionally specify the `env` attribute to filter your DORA metrics by environment on the [**DORA Metrics** page][7].
+The `repository_url` and `commit_sha` attributes are also required for calculating the Change Lead Time metric. Optionally, you can specifiy a `team` attribute to associate a deployment with a different `team` than is found automatically for the service. You can also optionally specify the `env` attribute to filter your DORA metrics by environment on the [**DORA Metrics** page][7].
 
 ### Example
 {{< tabs >}}
@@ -66,7 +66,8 @@ For the following example, replace `<DD_SITE>` in the URL with {{< region-param 
           "commit_sha": "66adc9350f2cc9b250b69abddab733dd55e1a588",
           "repository_url": "https://github.com/organization/example-repository"
         },
-        "env": "prod"
+        "env": "prod",
+        "team": "backend"
       }
     }
   }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adding a line [to this page](https://docs.datadoghq.com/dora_metrics/deployments/deployment_api/?tab=apicurl) about optionally adding `team` to a request . This api currently accepts the attribute but it is not shown in the docs.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->
- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->