### PR TITLE
Fixing broken link in Scorecards docs

### DIFF
--- a/content/en/service_catalog/scorecards/custom_rules.md
+++ b/content/en/service_catalog/scorecards/custom_rules.md
@@ -52,7 +52,7 @@ To evaluate and add custom rules in the Scorecards UI:
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /scorecards/scorecard_configuration/
+[1]: /service_catalog/scorecards/scorecard_configuration/
 [2]: /api/latest/service-scorecards/
 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->