### PR TITLE
add alias to standalone frontend

### DIFF
--- a/content/en/error_tracking/frontend/_index.md
+++ b/content/en/error_tracking/frontend/_index.md
@@ -2,6 +2,8 @@
 title: Frontend Error Tracking
 is_beta: true
 private: false
+aliases:
+  - /error_tracking/standalone_frontend/
 further_reading:
   - link: '/error_tracking/standalone_frontend/collecting_browser_errors/'
     tag: Documentation

--- a/content/en/error_tracking/frontend/logs.md
+++ b/content/en/error_tracking/frontend/logs.md
@@ -1,6 +1,8 @@
 ---
 title: Track Browser and Mobile Error Logs
 description: Learn how to track browser and mobile errors from your logs.
+aliases:
+  - /error_tracking/standalone_frontend/logs
 is_beta: false
 further_reading:
   - link: 'https://www.datadoghq.com/blog/error-tracking/'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds an alias to the standalone error tracking docs that didn't have one.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->