### PR TITLE
[PROF-10127] Ruby profiler allocations and heap config improvements

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -112,6 +112,38 @@ end
 
 7. A minute or two after starting your Ruby application, your profiles will show up on the [Datadog APM > Profiler page][5].
 
+## Configuration
+
+These settings apply to the latest profiler release.
+
+You can configure the profiler using the following environment variables:
+
+| Environment variable                          | Type    | Description                                                                                                                             |
+| --------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `DD_PROFILING_ENABLED`                        | Boolean | If set to `true`, enables the profiler. Defaults to `false`.                                                                            |
+| `DD_PROFILING_ALLOCATION_ENABLED`             | Boolean | Set to `true` to enable allocation profiling. It requires the profiler to be enabled already. Defaults to `false`.                      |
+| `DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
+| `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to `false`. |
+| `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
+| `DD_ENV`                                      | String  | The [environment][10] name, for example: `production`.                                                                                  |
+| `DD_SERVICE`                                  | String  | The [service][10] name, for example, `web-backend`.                                                                                     |
+| `DD_VERSION`                                  | String  | The [version][10] of your service.                                                                                                      |
+| `DD_TAGS`                                     | String  | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.          |
+
+Alternatively, you can set profiler parameters in code with these functions, inside a `Datadog.configure` block:
+
+| Environment variable                                  | Type    | Description                                                                                                                             |
+| ----------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `c.profiling.enabled`                                 | Boolean | If set to `true`, enables the profiler. Defaults to `false`.                                                                            |
+| `c.profiling.allocation_enabled`                      | Boolean | Set to `true` to enable allocation profiling. It requires the profiler to be enabled already. Defaults to `false`.                      |
+| `c.profiling.advanced.experimental_heap_enabled`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
+| `c.profiling.advanced.experimental_heap_size_enabled` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to `false`. |
+| `c.profiling.advanced.no_signals_workaround_enabled`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
+| `c.env`                                               | String  | The [environment][10] name, for example: `production`.                                                                                  |
+| `c.service`                                           | String  | The [service][10] name, for example, `web-backend`.                                                                                     |
+| `c.version`                                           | String  | The [version][10] of your service.                                                                                                      |
+| `c.tags`                                              | Hash    | Tags to apply to an uploaded profile.                                                                                                   |
+
 ## Not sure what to do next?
 
 The [Getting Started with Profiler][6] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
@@ -126,6 +158,8 @@ The [Getting Started with Profiler][6] guide takes a sample service with a perfo
 [4]: /integrations/guide/source-code-integration/?tab=ruby
 [5]: https://app.datadoghq.com/profiling
 [6]: /getting_started/profiler/
+[10]: /getting_started/tagging/unified_service_tagging
 [12]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
 [13]: /profiler/connect_traces_and_profiles/#break-down-code-performance-by-api-endpoints
 [14]: /profiler/enabling/supported_versions/
+[15]: /profiler/profiler_troubleshooting/ruby/#unexpected-failures-or-errors-from-ruby-gems-that-use-native-extensions

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -158,7 +158,7 @@ Wall Time
 
 Allocations (v2.3.0+)
 : The number of objects allocated by each method during the profiling period (default: 60s), including allocations which were subsequently freed. This is useful for investigating garbage collection load.<br />
-_Requires:_ [Manual enablement][3]
+_Requires:_ [Manual enablement][2]
 
 Heap Live Objects (alpha, v2.3.0+)
 : The number of objects allocated by each method in heap memory that have not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
@@ -169,8 +169,7 @@ Heap Live Size (alpha, v2.3.0+)
 _Requires: Ruby 2.7+_ and [manual enablement][2]
 
 [1]: /profiler/enabling/ruby/#requirements
-[2]: https://github.com/DataDog/dd-trace-rb/releases/tag/v1.19.0#:~:text=You%20can%20enable%20these%20features%3A
-[3]: https://github.com/DataDog/dd-trace-rb/releases/tag/v1.21.0
+[2]: /profiler/enabling/ruby/#configuration
 {{< /programming-lang >}}
 {{< programming-lang lang="nodejs" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates the Ruby profiler enabling page to add a "Configuration" section, similar to the ones we have for Java/.net/Go (I've even copy-pasted a few of the descriptions that are the same).

This section has a few standard settings we've supported for a long time, and, crucially, it documents the flags needed to enable Ruby allocation and heap profiling.

We previously were linking to the library release notes to document how to enable these features.

We would like to have this config be more prominent in the docs.

I've also updated the profile types page to link to this new info.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->