### PR TITLE
Changing private beta callout to "in Preview"

### DIFF
--- a/content/en/network_monitoring/devices/guide/device_profiles.md
+++ b/content/en/network_monitoring/devices/guide/device_profiles.md
@@ -16,7 +16,7 @@ further_reading:
 {{< /site-region >}}
 
 {{< callout url="https://www.datadoghq.com/private-beta/easily-onboard-and-start-monitoring-network-devices-to-datadog/" >}}
-  Device Onboarding is in preview. Use this form to request access.
+  Device Onboarding is in Preview. Use this form to request access.
 {{< /callout >}}
 
 ## Overview

--- a/content/en/network_monitoring/devices/guide/device_profiles.md
+++ b/content/en/network_monitoring/devices/guide/device_profiles.md
@@ -16,7 +16,7 @@ further_reading:
 {{< /site-region >}}
 
 {{< callout url="https://www.datadoghq.com/private-beta/easily-onboard-and-start-monitoring-network-devices-to-datadog/" >}}
-  Device Onboarding is in private beta. Use this form to request access.
+  Device Onboarding is in Preview. Use this form to request access.
 {{< /callout >}}
 
 ## Overview

--- a/content/en/network_monitoring/devices/guide/device_profiles.md
+++ b/content/en/network_monitoring/devices/guide/device_profiles.md
@@ -16,7 +16,7 @@ further_reading:
 {{< /site-region >}}
 
 {{< callout url="https://www.datadoghq.com/private-beta/easily-onboard-and-start-monitoring-network-devices-to-datadog/" >}}
-  Device Onboarding is in Preview. Use this form to request access.
+  Device Onboarding is in preview. Use this form to request access.
 {{< /callout >}}
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Changing private beta callout to "in Preview"
This one has no discrepancy in the app as far as labels are concerned, I was waiting on the form URL to update but per last update on this issue, these can still be merged in the time being.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->