### PR TITLE
Update npm installation example code

### DIFF
--- a/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
+++ b/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
@@ -74,7 +74,7 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
       //  version: '1.0.0',
       allowedTracingUrls: ["https://api.example.com", /https:\/\/.*\.my-api-domain\.com/, (url) => url.startsWith("https://api.example.com")]
       sessionSampleRate: 100,
-      sessionReplaySampleRate: 100, // if not included, the default is 100
+      sessionReplaySampleRate: 100, // if not specified, defaults to 100
       trackResources: true,
       trackLongTasks: true,
       trackUserInteractions: true,

--- a/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
+++ b/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
@@ -66,11 +66,18 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
     import { datadogRum } from '@datadog/browser-rum'
 
     datadogRum.init({
-        applicationId: '<DATADOG_APPLICATION_ID>',
-        clientToken: '<DATADOG_CLIENT_TOKEN>',
-        ...otherConfig,
-        service: "my-web-application",
-        allowedTracingUrls: ["https://api.example.com", /https:\/\/.*\.my-api-domain\.com/, (url) => url.startsWith("https://api.example.com")]
+      clientToken: '<CLIENT_TOKEN>',
+      applicationId: '<APPLICATION_ID>',
+      site: 'datadoghq.com',
+      //  service: 'my-web-application',
+      //  env: 'production',
+      //  version: '1.0.0',
+      allowedTracingUrls: ["https://api.example.com", /https:\/\/.*\.my-api-domain\.com/, (url) => url.startsWith("https://api.example.com")]
+      sessionSampleRate: 100,
+      sessionReplaySampleRate: 100, // if not included, the default is 100
+      trackResources: true,
+      trackLongTasks: true,
+      trackUserInteractions: true,
     })
     ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Motivation would be [this support ticket](https://datadog.zendesk.com/agent/tickets/1843263). A customer thought that setting UST parameters like service wasn't supported for the CDN installation method because they were commented out.

Our [primary installation instructions](https://docs.datadoghq.com/real_user_monitoring/browser/setup/#npm) have these optional parameters commented out for all installation methods. The goal of the change is to be consistent with the primary installation instructions so customers don't read too deeply into the examples thinking there should be a difference when one isn't explicitly noted.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ x ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->