### PR TITLE
Update docs to recommend using `is_exact_match` instead of `is_match` for a notification routing example

### DIFF
--- a/content/en/monitors/guide/template-variable-evaluation.md
+++ b/content/en/monitors/guide/template-variable-evaluation.md
@@ -45,7 +45,7 @@ https://app.datadoghq.com/logs?from_ts={{eval "last_triggered_at_epoch-15*60*100
 
 You can combine a modulo `%` evaluation of the `last_triggered_at_epoch` variable with `{{#is_exact_match}}{{/is_exact_match}}` to customize the routing of notifications based on time of day (UTC):
 ```
-{{#is_exact_match (eval "int(last_triggered_at_epoch / 3600000 % 24)") "8" "9" "10" "11" "12" "13" }}  
+{{#is_exact_match (eval "int(last_triggered_at_epoch / 3600000 % 24)") "8" "9" "10" "11" "12" "13"}}  
 Handle that should receive notification if time is between 8AM and 1PM UTC
 {{/is_exact_match}}
 ```

--- a/content/en/monitors/guide/template-variable-evaluation.md
+++ b/content/en/monitors/guide/template-variable-evaluation.md
@@ -43,11 +43,11 @@ https://app.datadoghq.com/logs?from_ts={{eval "last_triggered_at_epoch-15*60*100
 
 ### Routing notifications to different teams based on time of day
 
-You can combine a modulo `%` evaluation of the `last_triggered_at_epoch` variable with `{{#is_match}}{{/is_match}}` to customize the routing of notifications based on time of day (UTC):
+You can combine a modulo `%` evaluation of the `last_triggered_at_epoch` variable with `{{#is_exact_match}}{{/is_exact_match}}` to customize the routing of notifications based on time of day (UTC):
 ```
-{{#is_match (eval "int(last_triggered_at_epoch / 3600000 % 24)") "14" "15" "16"}}  
-Handle that should receive notification if time is between 2PM and 5PM UTC
-{{/is_match}}
+{{#is_exact_match (eval "int(last_triggered_at_epoch / 3600000 % 24)") "8" "9" "10" "11" "12" "13" }}  
+Handle that should receive notification if time is between 8AM and 1PM UTC
+{{/is_exact_match}}
 ```
 
 **Note:** If you need to evaluate your monitor on a schedule, see [Custom Schedules][2] instead.

--- a/content/en/monitors/guide/template-variable-evaluation.md
+++ b/content/en/monitors/guide/template-variable-evaluation.md
@@ -46,7 +46,7 @@ https://app.datadoghq.com/logs?from_ts={{eval "last_triggered_at_epoch-15*60*100
 You can combine a modulo `%` evaluation of the `last_triggered_at_epoch` variable with `{{#is_exact_match}}{{/is_exact_match}}` to customize the routing of notifications based on time of day (UTC):
 ```
 {{#is_exact_match (eval "int(last_triggered_at_epoch / 3600000 % 24)") "8" "9" "10" "11" "12" "13"}}  
-Handle that should receive notification if time is between 8AM and 1PM UTC
+Handle that should receive notification if time is between 8AM and 2PM UTC
 {{/is_exact_match}}
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
There is a bug where `is_match` currently does a conversion of strings that are numeric to their numeric value back to a string - this in turn causes a bug that incorrectly matches "19" and "01". 

To avoid this, we recommend using `is_exact_match` instead for these subexpressions. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->