### PR TITLE
 SCICM-2609

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -171,7 +171,7 @@ If you are using a host, you have two options.
 
 <div class="alert alert-info">The .NET client library version 2.24.1 or later is required.</div>
 
-As a first step, ensure that your .pdb files are deployed alongside your .NET assemblies (.dll or .exe) in the same folder. 
+As a first step, ensure that your `.pdb` files are deployed alongside your .NET assemblies (`.dll` or `.exe`) in the same folder. 
 Then, follow the rest of the instructions based on your specific deployment model:
 
 #### Containers

--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -171,6 +171,9 @@ If you are using a host, you have two options.
 
 <div class="alert alert-info">The .NET client library version 2.24.1 or later is required.</div>
 
+As a first step, ensure that your .pdb files are deployed alongside your .NET assemblies (.dll or .exe) in the same folder. 
+Then, follow the rest of the instructions based on your specific deployment model:
+
 #### Containers
 
 If you are using Docker containers, you have three options: using Docker, using Microsoft SourceLink, or configuring your application with `DD_GIT_*` environment variables.

--- a/layouts/shortcodes/sci-microsoft-sourcelink.md
+++ b/layouts/shortcodes/sci-microsoft-sourcelink.md
@@ -10,8 +10,6 @@ If you are using [Microsoft SourceLink][101], Datadog can extract the git commit
    | Azure DevOps | [Microsoft.SourceLink.AzureRepos.Git][105] |
    | Azure DevOps Server | [Microsoft.SourceLink.AzureDevOpsServer.Git][106] |
 
-1. Ensure that your `.pdb` files are deployed alongside your .NET assemblies (`.dll` or `.exe`) in the same folder.
-
 [101]: https://github.com/dotnet/sourcelink
 [102]: https://www.nuget.org/packages/Microsoft.SourceLink.GitHub
 [103]: https://www.nuget.org/packages/Microsoft.SourceLink.Bitbucket


### PR DESCRIPTION

### What does this PR do? What is the motivation?
Put the the instructions on .pdb files at the top level of .NET instructions (previously they only appear under SourceLink, which is misleading as without .pdbs, we will not have any file path / line number information available, and so Source Code Integration would provide a degraded experience.

### Merge instructions

Please wait for review from @jminuscula before merging.