### PR TITLE
Fix typo in Troubleshooting React Native SDK docs

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/reactnative.md
@@ -29,7 +29,7 @@ Sometimes, no data is sent due to a small misstep in the configuration.
 Here are some common things to check for:
 
 - Ensure your `clientToken` and `applicationId` are correct.
-- Make sure you have not set `sessionSamplingRate` to something other than 100 (100 is the default value), or else your session might be sent.
+- Make sure you have not set `sessionSamplingRate` to something other than 100 (100 is the default value), or else your session might not be sent.
 - If you've set up a `Proxy` in the Datadog configuration, check that it has been correctly configured.
 - Check that you are **tracking views** (all events must be attached to a view) and **sending events**.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Proposed change: 

Make sure you have not set `sessionSamplingRate` to something other than 100 (100 is the default value), or else your session might not be sent.

Previously: 

Make sure you have not set `sessionSamplingRate` to something other than 100 (100 is the default value), or else your session might be sent.

### Merge instructions

- [X] Please merge after reviewing