### PR TITLE
Update ruby.md

### DIFF
--- a/content/en/security/application_security/threats/setup/compatibility/ruby.md
+++ b/content/en/security/application_security/threats/setup/compatibility/ruby.md
@@ -17,7 +17,7 @@ The following application security capabilities are supported in the Ruby librar
 | Software Composition Analysis (SCA) | 1.11.0 |
 | Code Security        | not supported |
 | Automatic user activity event tracking | 1.14.0 |
-| API Security | 1.15.0 |
+| API Security | not supported |
 
 The minimum tracer version to get all supported application security capabilities for Ruby is 1.15.0.
 


### PR DESCRIPTION
In the ASM Threats compatibility page, API Security capability is currently “not supported” for Ruby. It is listed as 1.15.0 but that is incorrect

### Merge instructions

- [X] Please merge after reviewing
