### PR TITLE
Clean docs about tracking consent in Mobile RUM SDKs

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/flutter.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/flutter.md
@@ -323,22 +323,6 @@ You can access the RUM session ID at runtime without waiting for the `sessionSta
 final sessionId = await DatadogSdk.instance.rum?.getCurrentSessionId()
 ```
 
-## Set tracking consent (GDPR & CCPA compliance)
-
-In order to be compliant with data protection and privacy policies, the Flutter RUM SDK requires the tracking consent value at initialization.
-
-The `trackingConsent` setting can be one of the following values:
-
-1. `TrackingConsent.pending`: The Flutter RUM SDK starts collecting and batching the data but does not send it to Datadog. The Flutter RUM SDK waits for the new tracking consent value to decide what to do with the batched data.
-2. `TrackingConsent.granted`: The Flutter RUM SDK starts collecting the data and sends it to Datadog.
-3. `TrackingConsent.notGranted`: The Flutter RUM SDK does not collect any data. No logs, traces, or RUM events are sent to Datadog.
-
-To change the tracking consent value after the Flutter RUM SDK is initialized, use the `DatadogSdk.setTrackingConsent` API call. The Flutter RUM SDK changes its behavior according to the new value.
-
-For example, if the current tracking consent is `TrackingConsent.pending` and you change the value to `TrackingConsent.granted`, the Flutter RUM SDK sends all previously recorded and future data to Datadog.
-
-Likewise, if you change the value from `TrackingConsent.pending` to `TrackingConsent.notGranted`, the Flutter RUM SDK wipes all data and does not collect any future data.
-
 ## Flutter-specific performance metrics
 
 To enable the collection of Flutter-specific performance metrics, set `reportFlutterPerformance: true` in `DatadogRumConfiguration`. Widget build and raster times are displayed in [Mobile Vitals][17].

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/ios.md
@@ -708,23 +708,6 @@ RumMonitor.shared().currentSessionID(completion: { sessionId in
 })
 ```
 
-## Set tracking consent (GDPR compliance)
-
-To be compliant with the GDPR regulation, the RUM iOS SDK requires the tracking consent value at initialization.
-
-The `trackingConsent` setting can be one of the following values:
-
-1. `.pending`: The RUM iOS SDK starts collecting and batching the data but does not send it to Datadog. The RUM iOS SDK waits for the new tracking consent value to decide what to do with the batched data.
-2. `.granted`: The RUM iOS SDK starts collecting the data and sends it to Datadog.
-3. `.notGranted`: The RUM iOS SDK does not collect any data. No logs, traces, or RUM events are sent to Datadog.
-
-To change the tracking consent value after the RUM iOS SDK is initialized, use the `Datadog.set(trackingConsent:)` API call. The RUM iOS SDK changes its behavior according to the new value.
-
-For example, if the current tracking consent is `.pending`:
-
-- If you change the value to `.granted`, the RUM iOS SDK sends all current and future data to Datadog;
-- If you change the value to `.notGranted`, the RUM iOS SDK wipes all current data and does not collect future data.
-
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
@@ -308,6 +308,23 @@ val rumConfig = RumConfiguration.Builder(applicationId)
 Rum.enable(rumConfig)
 ```
 
+### Set tracking consent (GDPR compliance)
+
+To be compliant with the GDPR regulation, the SDK requires the tracking consent value at initialization.
+Tracking consent can be one of the following values:
+
+- `TrackingConsent.PENDING`: (Default) The SDK starts collecting and batching the data but does not send it to the
+ collection endpoint. The SDK waits for the new tracking consent value to decide what to do with the batched data.
+- `TrackingConsent.GRANTED`: The SDK starts collecting the data and sends it to the data collection endpoint.
+- `TrackingConsent.NOT_GRANTED`: The SDK does not collect any data. You are not able to manually send any logs, traces, or
+ RUM events.
+
+To update the tracking consent after the SDK is initialized, call `Datadog.setTrackingConsent(<NEW CONSENT>)`. The SDK changes its behavior according to the new consent. For example, if the current tracking consent is `TrackingConsent.PENDING` and you update it to:
+
+- `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
+- `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
+
+
 ### Enable RUM feature to start sending data
 
 {{< tabs >}}
@@ -451,7 +468,7 @@ This means that even if users open your application while offline, no data is lo
 [3]: /account_management/api-app-keys/#api-keys
 [4]: /account_management/api-app-keys/#client-tokens
 [5]: /real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android/#automatically-track-views
-[6]: /real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/#set-tracking-consent-gdpr-compliance
+[6]: #set-tracking-consent-gdpr-compliance
 [7]: /real_user_monitoring/mobile_and_tv_monitoring/advanced_configuration/android/#initialization-parameters
 [8]: /real_user_monitoring/error_tracking/android/#upload-your-mapping-file
 [9]: https://square.github.io/okhttp/interceptors/

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/flutter.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/flutter.md
@@ -200,7 +200,7 @@ final config = DatadogConfiguration(
 );
 ```
 
-### Set tracking consent
+### Set tracking consent (GDPR compliance)
 
 To be compliant with the GDPR regulation, the Datadog Flutter SDK requires the `trackingConsent` value at initialization.
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/ios.md
@@ -304,6 +304,46 @@ configuration.site = [DDSite ap1];
 
 The RUM iOS SDK automatically tracks user sessions depending on options provided at the SDK initialization. To add GDPR compliance for your EU users and other [initialization parameters][14] to the SDK configuration, see the [Set tracking consent documentation][15].
 
+### Sample RUM sessions
+
+To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM iOS SDK][16] as a percentage between 0 and 100.
+
+For example, to only keep 50% of sessions use:
+
+{{< tabs >}}
+{{% tab "Swift" %}}
+```swift
+let configuration = RUM.Configuration(
+    applicationID: "<rum application id>",
+    sessionSampleRate: 50
+)
+```
+{{% /tab %}}
+{{% tab "Objective-C" %}}
+```objective-c
+DDRUMConfiguration *configuration = [[DDRUMConfiguration alloc] initWithApplicationID:@"<rum application id>"];
+configuration.sessionSampleRate = 50;
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+### Set tracking consent (GDPR compliance)
+
+To be compliant with the GDPR regulation, the RUM iOS SDK requires the tracking consent value at initialization.
+
+The `trackingConsent` setting can be one of the following values:
+
+1. `.pending`: The RUM iOS SDK starts collecting and batching the data but does not send it to Datadog. The RUM iOS SDK waits for the new tracking consent value to decide what to do with the batched data.
+2. `.granted`: The RUM iOS SDK starts collecting the data and sends it to Datadog.
+3. `.notGranted`: The RUM iOS SDK does not collect any data. No logs, traces, or RUM events are sent to Datadog.
+
+To change the tracking consent value after the RUM iOS SDK is initialized, use the `Datadog.set(trackingConsent:)` API call. The RUM iOS SDK changes its behavior according to the new value.
+
+For example, if the current tracking consent is `.pending`:
+
+- If you change the value to `.granted`, the RUM iOS SDK sends all current and future data to Datadog;
+- If you change the value to `.notGranted`, the RUM iOS SDK wipes all current data and does not collect future data.
+
 ### Initialize the RUM Monitor and enable `URLSessionInstrumentation`
 
 Configure and register the RUM Monitor. You only need to do it once, usually in your `AppDelegate` code:
@@ -368,28 +408,6 @@ NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConf
 {{% /tab %}}
 {{< /tabs >}}
 
-### Sample RUM sessions
-
-To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM iOS SDK][16] as a percentage between 0 and 100.
-
-For example, to only keep 50% of sessions use:
-
-{{< tabs >}}
-{{% tab "Swift" %}}
-```swift
-let configuration = RUM.Configuration(
-    applicationID: "<rum application id>",
-    sessionSampleRate: 50
-)
-```
-{{% /tab %}}
-{{% tab "Objective-C" %}}
-```objective-c
-DDRUMConfiguration *configuration = [[DDRUMConfiguration alloc] initWithApplicationID:@"<rum application id>"];
-configuration.sessionSampleRate = 50;
-```
-{{% /tab %}}
-{{< /tabs >}}
 
 ### Instrument views
 
@@ -490,7 +508,7 @@ See [Supported versions][19] for a list operating system versions and platforms 
 [12]: /account_management/api-app-keys/#client-tokens
 [13]: /getting_started/tagging/using_tags/#rum--session-replay
 [14]: /real_user_monitoring/ios/advanced_configuration/#initialization-parameters
-[15]: /real_user_monitoring/ios/advanced_configuration/#set-tracking-consent-gdpr-compliance
+[15]: #set-tracking-consent-gdpr-compliance
 [16]: https://github.com/DataDog/dd-sdk-ios
 [17]: /real_user_monitoring/error_tracking/ios/
 [18]: /real_user_monitoring/explorer/

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/setup/reactnative.md
@@ -297,6 +297,23 @@ export default function App() {
 
 To control the data your application sends to Datadog RUM, you can specify a sampling rate for RUM sessions while [initializing the RUM React Native SDK][18] as a percentage between 0 and 100. You can specify the rate with the `config.sessionSamplingRate` parameter.
 
+### Set tracking consent (GDPR compliance)
+
+To be compliant with the GDPR regulation, the RUM React Native SDK requires the tracking consent value at initialization.
+
+The `trackingConsent` setting can be one of the following values:
+
+1. `.PENDING`: The RUM React Native SDK starts collecting and batching the data but does not send it to Datadog. The RUM iOReact NativeS SDK waits for the new tracking consent value to decide what to do with the batched data.
+2. `.GRANTED`: The RUM React Native SDK starts collecting the data and sends it to Datadog.
+3. `.NOTGRANTED`: The RUM iReact NativeOS SDK does not collect any data. No logs, traces, or RUM events are sent to Datadog.
+
+To change the tracking consent value after the RUM React Native SDK is initialized, use the `Datadog.set(trackingConsent:)` API call. The RUM React Native SDK changes its behavior according to the new value.
+
+For example, if the current tracking consent is `.PENDING`:
+
+- If you change the value to `.GRANTED`, the RUM React Native SDK sends all current and future data to Datadog;
+- If you change the value to `.NOTGRANTED`, the RUM React Native SDK wipes all current data and does not collect future data.
+
 ### Override the reported version
 
 By default, the Datadog React Native SDK reports the `version` as the commercial version of your app (for example, "1.2.44").

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/android.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/android.md
@@ -33,22 +33,6 @@ When writing your application, you can enable development logs by calling the `s
 Datadog.setVerbosity(Log.INFO)
 ```
 
-## Set tracking consent (GDPR compliance)
-
-To be compliant with the GDPR regulation, the SDK requires the tracking consent value at initialization.
-Tracking consent can be one of the following values:
-
-- `TrackingConsent.PENDING`: (Default) The SDK starts collecting and batching the data but does not send it to the
- collection endpoint. The SDK waits for the new tracking consent value to decide what to do with the batched data.
-- `TrackingConsent.GRANTED`: The SDK starts collecting the data and sends it to the data collection endpoint.
-- `TrackingConsent.NOT_GRANTED`: The SDK does not collect any data. You are not able to manually send any logs, traces, or
- RUM events.
-
-To update the tracking consent after the SDK is initialized, call `Datadog.setTrackingConsent(<NEW CONSENT>)`. The SDK changes its behavior according to the new consent. For example, if the current tracking consent is `TrackingConsent.PENDING` and you update it to:
-
-- `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
-- `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
-
 ## Migrating to 2.0.0
 
 If you've been using the SDK v1, there are some breaking changes introduced in version `2.0.0`. See the [migration guide][2] for more information.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR makes our doc consistent across our different SDKs, by putting the tracking consent information in the setup page and under the Session sampling paragraph

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->