### PR TITLE
adjust learning center callout styles

### DIFF
--- a/assets/styles/components/_learning-center-callout.scss
+++ b/assets/styles/components/_learning-center-callout.scss
@@ -5,6 +5,7 @@
 
     .card-content {
         @media(min-width: 768px) {
+            display: flex;
             column-gap: 20px;
         }
         img {

--- a/assets/styles/components/_learning-center-callout.scss
+++ b/assets/styles/components/_learning-center-callout.scss
@@ -5,7 +5,6 @@
 
     .card-content {
         @media(min-width: 768px) {
-            display: flex;
             column-gap: 20px;
         }
         img {

--- a/layouts/shortcodes/learning-center-callout.html
+++ b/layouts/shortcodes/learning-center-callout.html
@@ -13,7 +13,7 @@
 <div class="card learning-center-callout mb-4">
 
     <div class="card-body p-2 d-flex flex-column">
-        <div class="card-content">
+        <div class="card-content d-flex">
             {{ if ne $hide_image "true" }}
             <img class="img-fluid mb-2 mb-md-0" src="{{ .Site.Params.img_url}}images/learning-center-bits-logo-2.png" alt="learning center">
             {{ end }}

--- a/layouts/shortcodes/learning-center-callout.html
+++ b/layouts/shortcodes/learning-center-callout.html
@@ -13,11 +13,11 @@
 <div class="card learning-center-callout mb-4">
 
     <div class="card-body p-2 d-flex flex-column">
-        <div class="card-content d-flex">
+        <div class="card-content">
             {{ if ne $hide_image "true" }}
             <img class="img-fluid mb-2 mb-md-0" src="{{ .Site.Params.img_url}}images/learning-center-bits-logo-2.png" alt="learning center">
             {{ end }}
-            <div>
+            <div class="d-flex flex-column">
                 <h5 class="card-title text-black mt-0 mb-1">{{$header}}</h5>
                 <p class="card-text mb-2">{{.Inner}}</p>
             </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
fixes the `learning-center-callout` styles.

motivation: https://datadoghq.atlassian.net/browse/WEB-5348
  - a `<div>` in the callout overextended it's container and overlapped an alert box link in mobile view making it not clickable.

preview: 
  - https://docs-staging.datadoghq.com/stefon.simmons/fix-learning-center-callout/continuous_integration/
    - callout without image
  - https://docs-staging.datadoghq.com/stefon.simmons/fix-learning-center-callout/containers/kubernetes/apm/?tab=datadogoperator 
     - callout with image

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->