### PR TITLE
Broken Images on GRPC Testing Page

### DIFF
--- a/content/en/synthetics/api_tests/grpc_tests.md
+++ b/content/en/synthetics/api_tests/grpc_tests.md
@@ -52,7 +52,7 @@ After choosing to create a `gRPC` test, define your test's request.
 
    For a behavior check, specify the **Server Reflection** or [upload a **Proto File**][101] that defines your gRPC server. Select a method and include a request message. Datadog does not support streaming methods.
    
-   {{< img src="synthetics/api_tests/grpc_behavior_check_test.png" alt="Define gRPC request" style="width:90%;" >}}
+{{< img src="synthetics/api_tests/grpc_behavior_check_test.png" alt="Define gRPC request" style="width:90%;" >}}
    
    [101]: https://grpc.io/docs/what-is-grpc/introduction/#working-with-protocol-buffers
 
@@ -61,7 +61,7 @@ After choosing to create a `gRPC` test, define your test's request.
 
    For a health check, enter the name of the service. Leave this field blank if you want to send a health check on the gRPC server.
 
-   {{< img src="synthetics/api_tests/grpc_health_check_test.png" alt="Define gRPC request" style="width:90%;" >}}
+{{< img src="synthetics/api_tests/grpc_health_check_test.png" alt="Define gRPC request" style="width:90%;" >}}
    
    {{% /tab %}}
    {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Images aren't rendering inside some indented tabs. Un-indent the image shortcode to fix.

![image](https://github.com/user-attachments/assets/8f5d921a-baee-4c6c-b1b4-d8259dd97c62)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->