### PR TITLE
SFN Legacy Lambda Support

### DIFF
--- a/content/en/serverless/step_functions/troubleshooting.md
+++ b/content/en/serverless/step_functions/troubleshooting.md
@@ -57,8 +57,6 @@ If you are using your customized way to deploy Datadog Lambda Forwarder, here ar
 
 
 #### Notes
-Lambda steps that use the legacy Lambda API cannot be merged. If your Lambda step's definition is `"Resource": "<Lambda function ARN>"` instead of `"Resource": "arn:aws:states:::lambda:invoke"`, then your step is using the legacy Lambda API.
-
 If your Lambda has the `DD_TRACE_EXTRACTOR` environment variable set, its traces cannot be merged.
 
 [1]: https://app.datadoghq.com/logs


### PR DESCRIPTION
Removes the note that says legacy Lambda API isn't supported

We recently added span linking support for this case in https://github.com/DataDog/logs-backend/pull/78707

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->