### PR TITLE
security/appsec/threats/add-user-info.md: add remote config disablement

### DIFF
--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -761,11 +761,11 @@ The following modes are deprecated:
 
 **Note**: There could be cases in which the trace library won't be able to extract any information from the user event. The event would be reported with empty metadata. In those cases, use the [SDK](#adding-business-logic-information-login-success-login-failure-any-business-logic-to-traces) to manually instrument the user events.
 
-## Disabling automatic user activity event tracking
+## Disabling automatic user activity event tracking 
 
-If you wish to disable the detection of these events, you should set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false`. This should be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
+You can disable automated user activity detection trough your [ASM service catalog][14], changing the automatic instrumentation mode to `disabled` on the service you want to deactivate.
 
-The previous environment variable was named `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING`.
+You can also set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
 
 ## Further Reading
 
@@ -782,3 +782,4 @@ The previous environment variable was named `DD_APPSEC_AUTOMATED_USER_EVENTS_TRA
 [11]: https://guid.one/guid
 [12]: /security/default_rules/appsec-ato-bf/
 [13]: /security/default_rules/distributed-ato-ua-asn/
+[14]: https://app.datadoghq.com/security/appsec/inventory/services?tab=capabilities

--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -763,7 +763,7 @@ The following modes are deprecated:
 
 ## Disabling automatic user activity event tracking 
 
-You can disable automated user activity detection trough your [ASM service catalog][14], changing the automatic instrumentation mode to `disabled` on the service you want to deactivate.
+You can disable automated user activity detection through your [ASM service catalog][14] by changing the automatic instrumentation mode to `disabled` on the service you want to deactivate.
 
 You can also set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Document we can disable auto-user-id collection with remote config.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->