### PR TITLE
add `WEBSITE` variable for tests

### DIFF
--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -56,5 +56,5 @@ jobs:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
           config_path: 'repo/datadog-ci.preview.json'
-          # Override the DOCS_SITE variable to point to the preview site whereever referenced in the synthetics test
-          variables: 'DOCS_SITE=https://docs-staging.datadoghq.com/${{env.CI_COMMIT_REF_NAME}}/'
+          # Override the WEBSITE variable to point to the preview site whereever referenced in the synthetics test
+          variables: 'WEBSITE=https://docs-staging.datadoghq.com/${{env.CI_COMMIT_REF_NAME}}/'

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -56,4 +56,5 @@ jobs:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
           config_path: 'repo/datadog-ci.preview.json'
+          # Override the DOCS_PREVIEW_SITE variable to point to the preview site whereever referenced in the synthetics test
           variables: 'DOCS_PREVIEW_SITE=https://docs-staging.datadoghq.com/${{env.CI_COMMIT_REF_NAME}}/'

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -56,5 +56,5 @@ jobs:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
           config_path: 'repo/datadog-ci.preview.json'
-          # Override the DOCS_PREVIEW_SITE variable to point to the preview site whereever referenced in the synthetics test
-          variables: 'DOCS_PREVIEW_SITE=https://docs-staging.datadoghq.com/${{env.CI_COMMIT_REF_NAME}}/'
+          # Override the DOCS_SITE variable to point to the preview site whereever referenced in the synthetics test
+          variables: 'DOCS_SITE=https://docs-staging.datadoghq.com/${{env.CI_COMMIT_REF_NAME}}/'

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -56,3 +56,4 @@ jobs:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
           config_path: 'repo/datadog-ci.preview.json'
+          variables: 'DOCS_PREVIEW_SITE=https://docs-staging.datadoghq.com/$CI_COMMIT_REF_NAME'

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -56,4 +56,4 @@ jobs:
           api_key: ${{secrets.DD_API_KEY}}
           app_key: ${{secrets.DD_APP_KEY}}
           config_path: 'repo/datadog-ci.preview.json'
-          variables: 'DOCS_PREVIEW_SITE=https://docs-staging.datadoghq.com/$CI_COMMIT_REF_NAME'
+          variables: 'DOCS_PREVIEW_SITE=https://docs-staging.datadoghq.com/${{env.CI_COMMIT_REF_NAME}}/'

--- a/datadog-ci.preview.json
+++ b/datadog-ci.preview.json
@@ -6,5 +6,6 @@
   },
   "subdomain": "dd-corpsite",
   "timeout": 220000,
-  "headers": {"gitlab":  "true"}
+  "headers": {"gitlab":  "true"},
+  "variables": {"DOCS_PREVIEW_SITE": "https://docs-staging.datadoghq.com/{{CI_COMMIT_REF_NAME}}"}
 }

--- a/datadog-ci.preview.json
+++ b/datadog-ci.preview.json
@@ -6,6 +6,5 @@
   },
   "subdomain": "dd-corpsite",
   "timeout": 220000,
-  "headers": {"gitlab":  "true"},
-  "variables": {"DOCS_PREVIEW_SITE": "https://docs-staging.datadoghq.com/{{CI_COMMIT_REF_NAME}}"}
+  "headers": {"gitlab":  "true"}
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Updates synthetics test configuration. Adds an override for the new `WEBSITE` environment variable.
   - sets `WEBSITE` to be `https://docs-staging.datadoghq.com/${{env.CI_COMMIT_REF_NAME}}/` when a test is triggered via the **Preview Synthetic Github workflow** (CI pipeline)
       - **NOTE**: should set this variable to `https://docs.datadoghq.com/` in your Datadog synthetic test if referenced

motivation:  comment: https://datadoghq.atlassian.net/browse/WEB-5329?focusedCommentId=1899923 
   - Browser tests should test the same site.
   - should allow the `Navigate to URL` step of our synthetics tests to be a dynamic docs url.
 
preview: [test yq3-qs9-b8k](https://dd-corpsite.datadoghq.com/synthetics/details/yq3-qs9-b8k?from_ts=1727030282240&to_ts=1727116682240&live=true) 
   - Triggering via **Preview Synthetic Github** workflow, should test the preview site only. See steps 0 (startURL) and 4 (Navigate to URL) [here](https://dd-corpsite.datadoghq.com/synthetics/details/yq3-qs9-b8k/result/2129436293678741655).
   -  **Run Test Now** and it should test the live site only 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after CorpWeb review

### Additional notes
<!-- Anything else we should know when reviewing?-->
next steps:
  - reference this variable in all tests triggered by this workflow
 
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->