### PR TITLE
Add frontend to Error Tracking urls

### DIFF
--- a/content/en/error_tracking/frontend/_index.md
+++ b/content/en/error_tracking/frontend/_index.md
@@ -36,11 +36,11 @@ Error Tracking simplifies debugging by grouping thousands of similar errors into
 ## Setup
 {{< whatsnext desc="To get started with Datadog Error Tracking, see the corresponding documentation:" >}}
     {{< nextlink href="error_tracking/frontend/browser" >}}Browser{{< /nextlink >}}
-    {{< nextlink href="error_tracking/mobile/android" >}}Android{{< /nextlink >}}
-    {{< nextlink href="error_tracking/mobile/ios" >}}iOS{{< /nextlink >}}
-    {{< nextlink href="error_tracking/mobile/expo" >}}Expo{{< /nextlink >}}
-    {{< nextlink href="error_tracking/mobile/reactnative" >}}React Native{{< /nextlink >}}
-    {{< nextlink href="error_tracking/mobile/flutter" >}}Flutter{{< /nextlink >}}
+    {{< nextlink href="error_tracking/frontend/mobile/android" >}}Android{{< /nextlink >}}
+    {{< nextlink href="error_tracking/frontend/mobile/ios" >}}iOS{{< /nextlink >}}
+    {{< nextlink href="error_tracking/frontend/mobile/expo" >}}Expo{{< /nextlink >}}
+    {{< nextlink href="error_tracking/frontend/mobile/reactnative" >}}React Native{{< /nextlink >}}
+    {{< nextlink href="error_tracking/frontend/mobile/flutter" >}}Flutter{{< /nextlink >}}
     {{< nextlink href="error_tracking/frontend/logs" >}}Logs{{< /nextlink >}}
 {{< /whatsnext >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds '/frontend/` to the mobile URLs so that they work

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->