### PR TITLE
Update minimum dd-trace-java version required for Dynamic Instrumentation Autocomplete and Search

### DIFF
--- a/content/en/dynamic_instrumentation/symdb/java.md
+++ b/content/en/dynamic_instrumentation/symdb/java.md
@@ -13,7 +13,7 @@ Autocomplete and search are in public beta.
 ## Requirements
 
 - [Dynamic Instrumentation][1] is enabled for your service.
-- Tracing library [`dd-trace-java`][6] 1.34.0 or higher is installed.
+- Tracing library [`dd-trace-java`][6] 1.39.1 or higher is installed.
 
 ## Installation
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?

Update minimum dd-trace-java version required for Dynamic Instrumentation Autocomplete and Search to 1.39.1

### Merge instructions
Please wait for the reviewers I specified before merging. 
