### PR TITLE
security/appsec/threats/add-user-info.md: expanding remote config disablement

### DIFF
--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -765,7 +765,7 @@ The following modes are deprecated:
 
 ## Disabling user activity event tracking 
 
-To disable automated user activity detection through your [ASM service catalog][14],  change the automatic tracking mode evironment variable `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE` to `disabled` on the service you want to deactivate. All modes only affect automated instrumentation and require [Remote Configuration][15] to be enabled. 
+To disable automated user activity detection through your [ASM service catalog][14], change the automatic tracking mode evironment variable `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE` to `disabled` on the service you want to deactivate. All modes only affect automated instrumentation and require [Remote Configuration][15] to be enabled. 
 
 For manual configuration, you can set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
 

--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -765,7 +765,7 @@ The following modes are deprecated:
 
 ## Disabling user activity event tracking 
 
-To disable automated user activity detection through your [ASM service catalog][14], change the automatic tracking mode evironment variable `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE` to `disabled` on the service you want to deactivate. All modes only affect automated instrumentation and require [Remote Configuration][15] to be enabled. 
+To disable automated user activity detection through your [ASM service catalog][14], change the automatic tracking mode environment variable `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE` to `disabled` on the service you want to deactivate. All modes only affect automated instrumentation and require [Remote Configuration][15] to be enabled. 
 
 For manual configuration, you can set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
 

--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -763,7 +763,7 @@ The following modes are deprecated:
 
 ## Disabling automatic user activity event tracking 
 
-You can disable automated user activity detection through your [ASM service catalog][14] by changing the automatic instrumentation mode to `disabled` on the service you want to deactivate.
+You can disable automated user activity detection through your [ASM service catalog][14] by changing the automatic instrumentation mode to `disabled` on the service you want to deactivate. This requires [Remote Configuration][15] to be enabled, but you can otherwise set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
 
 You can also set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
 

--- a/content/en/security/application_security/threats/add-user-info.md
+++ b/content/en/security/application_security/threats/add-user-info.md
@@ -744,6 +744,8 @@ Automatic user activity tracking offers the following modes:
 
 <div class="alert alert-info">All modes only affect automated instrumentation. The modes don't apply to manual collection. Manual collection is configured using an SDK, and those settings are not overridden by automated instrumentation.</div>
 
+### Manual configuration
+
 Datadog libraries allow you to configure auto-instrumentation by using the `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE` environment variable with the short name for the mode: `ident`|`anon`|`disabled`.
 
 The default mode is `identification` mode (short name: `ident`).
@@ -761,11 +763,11 @@ The following modes are deprecated:
 
 **Note**: There could be cases in which the trace library won't be able to extract any information from the user event. The event would be reported with empty metadata. In those cases, use the [SDK](#adding-business-logic-information-login-success-login-failure-any-business-logic-to-traces) to manually instrument the user events.
 
-## Disabling automatic user activity event tracking 
+## Disabling user activity event tracking 
 
-You can disable automated user activity detection through your [ASM service catalog][14] by changing the automatic instrumentation mode to `disabled` on the service you want to deactivate. This requires [Remote Configuration][15] to be enabled, but you can otherwise set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
+To disable automated user activity detection through your [ASM service catalog][14],  change the automatic tracking mode evironment variable `DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE` to `disabled` on the service you want to deactivate. All modes only affect automated instrumentation and require [Remote Configuration][15] to be enabled. 
 
-You can also set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
+For manual configuration, you can set the environment variable `DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED` to `false` on your service and restart it. This must be set on the application hosting the Datadog Tracing Library, and not on the Datadog Agent.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Clarify remote configuration is required to remotely disable automated user id collection

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->