### PR TITLE
Add note for required detail for tag management

### DIFF
--- a/content/en/metrics/metrics-without-limits.md
+++ b/content/en/metrics/metrics-without-limits.md
@@ -49,6 +49,8 @@ Set the parameter `exclude_tags_mode: true` on the Metrics API to [create][2] an
 
 When configuring tags for counts, rates, and gauges, the most frequently queried time/space aggregation combination is available for query by default.
 
+**Note:** For tags to be managed on a metric, it must have a type declared. This is typically done when a metric is submitted, but may also be done manually using the `Edit` button for a metric in Metrics Summary.
+
 ### Configure multiple metrics at a time
 
 Optimize your custom metrics volumes by using the [bulk metric tag configuration feature][7]. To specify a namespace for your metrics, click **Configure Tags*** on Metrics Summary. You can configure all metrics matching that namespace prefix with the same allowlist of tags under ***Include tags...*** or the same blocklist of tags under ***Exclude tags...***.

--- a/content/en/metrics/metrics-without-limits.md
+++ b/content/en/metrics/metrics-without-limits.md
@@ -49,7 +49,7 @@ Set the parameter `exclude_tags_mode: true` on the Metrics API to [create][2] an
 
 When configuring tags for counts, rates, and gauges, the most frequently queried time/space aggregation combination is available for query by default.
 
-**Note:** For tags to be managed on a metric, it must have a type declared. This is typically done when a metric is submitted, but may also be done manually using the `Edit` button for a metric in Metrics Summary.
+**Note:** For tags to be managed on a metric, the metric must have a type declared. This is typically done when a metric is submitted, but may also be done manually using the `Edit` button for a metric in Metrics Summary.
 
 ### Configure multiple metrics at a time
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This came up in a [support ticket](https://datadoghq.atlassian.net/browse/METS-6039) with a customer who we found wasn't able to manage tags for their metrics because they were submitted without a data type. For reference there's [this bit in our front-end code](https://github.com/DataDog/web-ui/blob/16e9d41475877cb04ef704b183b65d8b3e5119af/javascript/datadog/metrics/components/MetricsSummary/ManageTagsModal/ManageTagsButton.tsx#L83-L86) that enforces this.

### Merge instructions

- [ x ] Please merge after reviewing