### PR TITLE
Fix 404-ing link in Service Catalog docs

### DIFF
--- a/content/en/service_catalog/service_definitions/_index.md
+++ b/content/en/service_catalog/service_definitions/_index.md
@@ -135,4 +135,4 @@ The [JSON schema for Datadog service definitions][15] is registered with the ope
 [12]: https://app.datadoghq.com/personal-settings/profile
 [13]: http://json-schema.org/
 [14]: https://www.schemastore.org/json/
-[15]: https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/version.schema.json
+[15]: https://raw.githubusercontent.com/DataDog/schema/refs/heads/main/service-catalog/service.schema.json


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fix URL linked to "[JSON schema for Datadog service definitions](https://raw.githubusercontent.com/DataDog/schema/main/service-catalog/version.schema.json)"

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->