### PR TITLE
Process merge label removal

### DIFF
--- a/.github/workflows/process_label_removal.yml
+++ b/.github/workflows/process_label_removal.yml
@@ -1,0 +1,24 @@
+name: Process label removal
+on: 
+  pull_request:
+    types:
+      - unlabeled
+
+jobs:
+  notify-docs-if-approved:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'Do Not Merge'
+    name: Process removal of 'Do Not Merge' label
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.DOCS_GH_APP_ID }}
+          private-key: ${{ secrets.DOCS_GH_APP_PRIVATE_KEY }}
+      - name: Notify Slack if PR is already approved
+        uses: DataDog/github-actions/external-actor-on-team-approved-pr@v2.2.0
+        with: 
+          github-token: ${{ steps.generate-token.outputs.token }}
+          slack-webhook-url: ${{ secrets.MERGE_READINESS_SLACK_WEBHOOK_URL }}
+          team-slug: "documentation"

--- a/.github/workflows/process_label_removal.yml
+++ b/.github/workflows/process_label_removal.yml
@@ -3,7 +3,8 @@ on:
   pull_request:
     types:
       - unlabeled
-
+permissions:
+  contents: read
 jobs:
   notify-docs-if-approved:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This adds a GitHub workflow to notify the docs team if the "Do Not Merge" label on a docs-approved PR is removed by someone external to the team.

### Merge instructions
I've tested this in the docs-actions-sandbox, and verified that it meets the criteria in the security checklist. Most of the work is done by an external action that I've previously tested and shipped. 

I'd love a second pair of eyes on the [security checklist](https://datadoghq.atlassian.net/wiki/spaces/SECENG/pages/3300001636/GitHub+Actions+security+checklist), though, in case I missed anything.

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->