### PR TITLE
Separate ArgoCD trigger into two conditions

### DIFF
--- a/content/en/continuous_delivery/deployments/argocd.md
+++ b/content/en/continuous_delivery/deployments/argocd.md
@@ -94,7 +94,9 @@ metadata:
   name: argocd-notifications-cm
 data:
   trigger.cd-visibility-trigger: |
-    - when: app.status.operationState.phase in ['Succeeded', 'Failed', 'Error', 'Running'] and app.status.health.status in ['Healthy', 'Degraded']
+    - when: app.status.operationState.phase in ['Succeeded', 'Failed', 'Error'] and app.status.health.status in ['Healthy', 'Degraded']
+      send: [cd-visibility-template]
+    - when: app.status.operationState.phase == 'Running' and app.status.health.status in ['Healthy', 'Degraded']
       send: [cd-visibility-template]
 ```
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Update the CD Visibility <> Argo CD configuration guide to separate the trigger into two sets of conditions.

This is done to cover an edge case: the Argo CD notification deduplication logic will not send the notification when the application transitions between two states that match the conditions. For example, if the application transitions from `phase: Running, health: Healthy` to `phase: Succeeded, health: Healthy`, it will only send a notification for the first state but not for the second.

Separating into these two conditions ensures the notification is sent in both cases. We can keep `Succeeded`, `Failed` and `Error` in the same condition because they are terminal states and it should not be possible to transition between them.

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
