### PR TITLE
[SVLS] Add warning for function reaching maximum duration

### DIFF
--- a/content/en/serverless/guide/serverless_warnings.md
+++ b/content/en/serverless/guide/serverless_warnings.md
@@ -124,7 +124,7 @@ At least one invocation in the selected time range approached the maximum durati
 
 [Distributed tracing][7] can help you pinpoint slow API calls in your application.
 
-**Resolution:** Lambda functions running for close to the maximum timeout limit of 15 minutes are at risk of being killed by the Lambda runtime. This could lead to slow or failed responses to incoming requests. Consider improving the performance of your Lambda, using smaller lambdas in a Step Function, or moving your workload to a longer running environment like ECS Fargate.
+**Resolution:** Lambda functions approaching the maximum timeout limit of 15 minutes risk termination by the Lambda runtime. This could lead to slow or failed responses to incoming requests. Consider improving the performance of your Lambda function, using smaller lambdas in a Step Function, or moving your workload to a longer running environment like ECS Fargate.
 
 ## Further Reading
 

--- a/content/en/serverless/guide/serverless_warnings.md
+++ b/content/en/serverless/guide/serverless_warnings.md
@@ -118,6 +118,14 @@ The function's runtime is [no longer supported][14].
 
 **Resolution:** Upgrade to the latest runtime to ensure you are up to date on the latest security, performance, and reliability standards.
 
+### Reaching maximum duration
+
+At least one invocation in the selected time range approached the maximum duration limit of 15 minutes.
+
+[Distributed tracing][7] can help you pinpoint slow API calls in your application.
+
+**Resolution:** Lambda functions running for close to the maximum timeout limit of 15 minutes are at risk of being killed by the Lambda runtime. This could lead to slow or failed responses to incoming requests. Consider improving the performance of your Lambda, using smaller lambdas in a Step Function, or moving your workload to a longer running environment like ECS Fargate.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR adds a new "Reaching Maximum Duration" warning to the serverless documentation. This warning is generated when a function's invocation approached the maximum duration limit of 15 minutes. The related PR to add the insight in web-ui is here: https://github.com/DataDog/web-ui/pull/158680/

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->