### PR TITLE
Fix out of date docs

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -107,8 +107,8 @@ Or, modify the `package.json` file if you typically start an application with np
     "start": "next start",
 
     // suggested command
-    "start": "node --require dd-trace/initialize ./node_modules/next start",
-    "start": "NODE_OPTIONS='--require dd-trace/initialize' ./node_modules/next start",
+    "start": "node --require dd-trace/init ./node_modules/next start",
+    "start": "NODE_OPTIONS='--require dd-trace/init' ./node_modules/next start",
 ```
 
 **Note**: The previous examples use Next.js, but the same approach applies to other frameworks with custom entry points, such as Nest.js. Adapt the commands to fit your specific framework and setup. Either command should work, but using `NODE_OPTIONS`  also applies to any child Node.js processes.


### PR DESCRIPTION
Docs still suggest starting with require dd-trace/initialize when it should be dd-trace/init.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->