### PR TITLE
USM: add recommended values for Bottlerocket when using Helm

### DIFF
--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -906,6 +906,21 @@ agents:
         - name: DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENABLED
           value: "true"
 ```
+
+If your cluster is using the Bottlerocket Linux distribution for its nodes, add the following to your values file:
+
+```
+agents:
+  containers:
+    systemProbe:
+      securityContext:
+        seLinuxOptions:
+          user: "system_u"
+          role: "system_r"
+          type: "spc_t"
+          level: "s0"
+```
+
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -67,6 +67,20 @@ providers:
     cos: true
 ```
 
+If your cluster is using the Bottlerocket Linux distribution for its nodes, add the following to your values file:
+
+```
+agents:
+  containers:
+    systemProbe:
+      securityContext:
+        seLinuxOptions:
+          user: "system_u"
+          role: "system_r"
+          type: "spc_t"
+          level: "s0"
+```
+
 {{% /tab %}}
 {{% tab "Operator" %}}
 
@@ -905,20 +919,6 @@ agents:
       env:
         - name: DD_SERVICE_MONITORING_CONFIG_TLS_ISTIO_ENABLED
           value: "true"
-```
-
-If your cluster is using the Bottlerocket Linux distribution for its nodes, add the following to your values file:
-
-```
-agents:
-  containers:
-    systemProbe:
-      securityContext:
-        seLinuxOptions:
-          user: "system_u"
-          role: "system_r"
-          type: "spc_t"
-          level: "s0"
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adding values to disable SELinux for the system-probe container when enabling Istio monitoring, when using the Bottlerocket distribution on Kubernetes clusters.
Istio monitoring will not work on Bottlerocket without these values.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->