### PR TITLE
docs(php): Yii v1.1 is NOT supported

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -117,7 +117,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 | Slim           | 2.x, 3.x, 4.x                           | All supported PHP versions  | Framework-level instrumentation |
 | Symfony        | 2.x, 3.3, 3.4, 4.x, 5.x, 6.x, 7.x       | All supported PHP versions  | Framework-level instrumentation |
 | WordPress      | 4.x, 5.x, 6.x                           | All supported PHP versions  | Framework-level instrumentation |
-| Yii            | 1.1, 2.0                                | All supported PHP versions  | Framework-level instrumentation |
+| Yii            | 2.0                                     | All supported PHP versions  | Framework-level instrumentation |
 | Zend Framework | 1.12, 1.21                              | All supported PHP versions  | Framework-level instrumentation |
 | Zend Framework | 2.x                                     | All supported PHP versions  | Generic web tracing             |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

For more granular details, please take a look at the motivating escalation: [APMS-13221](https://datadoghq.atlassian.net/browse/APMS-13221?focusedCommentId=1894494)

TLDR is that this version was marked as supported long ago while it never was, and nobody complained ever since :-)

This PR updates the doc to reflect the reality.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[APMS-13221]: https://datadoghq.atlassian.net/browse/APMS-13221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ