### PR TITLE
Move Metrics section out of shortcode

### DIFF
--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -218,8 +218,13 @@ To collect more comprehensive database metrics from MongoDB Atlas, install the [
 
 ## Data Collected
 
+### Metrics
+
+Refer to the [MongoDB integration documentation][4] for a comprehensive list of metrics collected by the MongoDB integration.
+
 {{% dbm-mongodb-agent-data-collected %}}
 
 [1]: /database_monitoring/architecture/#cloud-managed-databases
 [2]: /account_management/api-app-keys/
 [3]: /integrations/mongodb_atlas/
+[4]: /integrations/mongodb_atlas/#metrics

--- a/content/en/database_monitoring/setup_mongodb/selfhosted.md
+++ b/content/en/database_monitoring/setup_mongodb/selfhosted.md
@@ -207,6 +207,10 @@ The Database Monitoring feature for MongoDB is available in the beta version of 
 
 ## Data Collected
 
+### Metrics
+
+Refer to the [MongoDB integration documentation][2] for a comprehensive list of metrics collected by the MongoDB integration.
+
 {{% dbm-mongodb-agent-data-collected %}}
 
 [1]: /account_management/api-app-keys/

--- a/layouts/shortcodes/dbm-mongodb-agent-data-collected.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-data-collected.md
@@ -1,7 +1,3 @@
-### Metrics
-
-Refer to the [MongoDB integration documentation][2] for a comprehensive list of metrics collected by the MongoDB integration.
-
 ### Slow Operations
 
 Database Monitoring for MongoDB captures slow operations from either MongoDB slow query logs or the `system.profile` collection. Slow operations are defined as those taking longer than the `slowms` threshold set in your MongoDB configuration.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The Metrics section of the DBM MongoDB data collected shortcode appears in two articles. Each article requires the link in the Metrics section to point to a different URL. That's not possible, so as an alternative solution, we've decided to move the section outside of the shortcode.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->