### PR TITLE
[test visibility] Remove beta flag from testing manual API for Javascript

### DIFF
--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -619,11 +619,7 @@ For more information about `service` and `env` reserved tags, see [Unified Servi
 ## Manual testing API
 
 <div class="alert alert-warning">
-  <strong>Note</strong>: To use the manual testing API, you must pass <code>DD_CIVISIBILITY_MANUAL_API_ENABLED=1</code> as an environment variable.
-</div>
-
-<div class="alert alert-warning">
-  <strong>Note</strong>: The manual testing API is in <strong>beta</strong>, so its API might change. It is available starting in <code>dd-trace</code> versions <code>4.4.0</code>, <code>3.25.0</code>, and <code>2.38.0</code>.
+  <strong>Note</strong>: The manual testing API is available starting in <code>dd-trace</code> versions <code>5.23.0</code> and <code>4.47.0</code>.
 </div>
 
 If you use Jest, Mocha, Cypress, Playwright, Cucumber, or Vitest, **do not use the manual testing API**, as CI Visibility automatically instruments them and sends the test results to Datadog. The manual testing API is **incompatible** with already supported testing frameworks.
@@ -728,7 +724,7 @@ The payload to be published is a dictionary `<string, string|number>` of tags or
 When the test start and end channels are in your code, run your testing framework like you normally do, including the following environment variables:
 
 ```shell
-NODE_OPTIONS="-r dd-trace/ci/init" DD_CIVISIBILITY_MANUAL_API_ENABLED=1 DD_ENV=ci DD_SERVICE=my-custom-framework-tests yarn run-my-test-framework
+NODE_OPTIONS="-r dd-trace/ci/init" DD_ENV=ci DD_SERVICE=my-custom-framework-tests yarn run-my-test-framework
 ```
 
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Let users know that they no longer need to pass `DD_CIVISIBILITY_MANUAL_API_ENABLED` to use the manual testing API.

### Merge instructions

- [x] Please merge after reviewing

### Additional notes

https://docs-staging.datadoghq.com/juan-fernandez/remove-beta-from-manual-api/tests/setup/javascript/?tab=ciproviderwithautoinstrumentationsupport#manual-testing-api
