### PR TITLE
Fix highlighted lines of code in Step Function installation doc

### DIFF
--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -155,7 +155,7 @@ The `JsonMerge` [intrinsic function][1] merges the [Step Functions context objec
 
 **Example**:
 
-{{< highlight json "hl_lines=4-7" >}}
+{{< highlight json "hl_lines=5-5" >}}
 "Lambda Read From DynamoDB": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
@@ -169,7 +169,7 @@ The `JsonMerge` [intrinsic function][1] merges the [Step Functions context objec
 
 Alternatively, if you have business logic defined in the payload, you could also use the following:
 
-{{< highlight json "hl_lines=8-10" >}}
+{{< highlight json "hl_lines=7-9" >}}
 "Lambda Read From DynamoDB": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The highlighted lines in the public doc "[Install Serverless Monitoring for AWS Step Functions](https://docs.datadoghq.com/serverless/step_functions/installation/?tab=custom)" are not accurate:
<img width="481" alt="image" src="https://github.com/user-attachments/assets/33b945e1-3060-44ad-b0ed-8899d6ba98bb">
<img width="453" alt="image" src="https://github.com/user-attachments/assets/574af864-a62d-46b2-9a33-e2dbcf632e1e">

I think we should only highlight the lines that users need to add, i.e.
```
        "Payload.$": "States.JsonMerge($$, $, false)",
```
```
          "Execution.$": "$$.Execution",
          "State.$": "$$.State",
          "StateMachine.$": "$$.StateMachine"
```

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->