### PR TITLE
fix dropped link reference number

### DIFF
--- a/content/en/service_management/workflows/build.md
+++ b/content/en/service_management/workflows/build.md
@@ -89,7 +89,7 @@ Published workflows accrue costs based on workflow executions. For more informat
 
 ## Variables and parameters
 
-For information on using variables and parameters in your workflows, see [Variables and parameters][].
+For information on using variables and parameters in your workflows, see [Variables and parameters][12].
 
 ## Workflow notifications
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a link ref number that was mistakenly left off.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->