### PR TITLE
Dogstatsd listens on IPv4 only default

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -285,7 +285,7 @@ Used for Agent services communicating with each other locally within the host on
 | ------  | ---- | ------- | ----------- |
 | [Agent browser GUI][16] | 5002 | TCP |  |
 | APM receiver | 8126 | TCP | Includes Tracing and the Profiler. |
-| [DogStatsD][18] | 8125 | UDP | Port for DogStatsD unless `dogstatsd_non_local_traffic` is set to true. This port is available on localhost: `127.0.0.1`, `::1`, `fe80::1`. |
+| [DogStatsD][18] | 8125 | UDP | Port for DogStatsD unless `dogstatsd_non_local_traffic` is set to true. This port is available on IPv4 localhost: `127.0.0.1`. |
 | go_expvar server (APM) | 5012 | TCP | For more information, see [the go_expar integration documentation][15]. |
 | go_expvar integration server | 5000 | TCP | For more information, see [the go_expar integration documentation][15]. |
 | IPC API | 5001 | TCP | Port used for Inter Process Communication (IPC). |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
As of this writing, Dogstatsd does not support dualstack e.g. listen on multiple IP addresses returned by `localhost`.
Golang library will prefer IPv4 `localhost` --> `127.0.0.1` and will only open the port on that IPv4 address.
Traffic bound for `::1` or `fe80::1` will not reach Dogstatsd and will be misconstrued as missing metrics/data

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->