### PR TITLE
Update events.md - security-notification-events missing in Product-Specific Events list

### DIFF
--- a/content/en/account_management/audit_trail/events.md
+++ b/content/en/account_management/audit_trail/events.md
@@ -37,6 +37,7 @@ further_reading:
 - [Log Management](#log-management-events)
 - [Metrics](#metrics-events)
 - [Real User Monitoring](#real-user-monitoring-events)
+- [Security Notification events](#security-notification-events)
 - [Sensitive Data Scanner](#sensitive-data-scanner-events)
 - [Service Level Objectives](#service-level-objectives-slo-events)
 - [Synthetic Monitoring](#synthetic-monitoring-events)


### PR DESCRIPTION
"Security Notification events" was missing in the list of Product-Specific Events at the top of the page, which might make it a bit hard for the users to recognize this type of event.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add "Security Notification events" in the list of Product-Specific Events list at the top of the page, so that the users can recognize it exits in this category more easily.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->