### PR TITLE
Add alert on disabling metric collection

### DIFF
--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -4,6 +4,8 @@ aliases:
   - /logs/faq/how-to-set-up-only-logs
 ---
 
+<div class="alert alert-danger">Infrastructure Monitoring is a prerequisite to using APM. If you are an APM customer, do not turn off metric collection so that you don't lose critical telemetry and value.</div>
+
 To disable payloads, you must be running Agent v6.4+. This disables metric data submission (including Custom Metrics) so that hosts stop showing up in Datadog. Follow these steps:
 
 {{< tabs >}}

--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -4,7 +4,7 @@ aliases:
   - /logs/faq/how-to-set-up-only-logs
 ---
 
-<div class="alert alert-danger">Infrastructure Monitoring is a prerequisite to using APM. If you are an APM customer, do not turn off metric collection so that you don't lose critical telemetry and value.</div>
+<div class="alert alert-danger">Infrastructure Monitoring is a prerequisite to using APM. If you are an APM customer, do not turn off metric collection or you might lose critical telemetry and metric collection information.</div>
 
 To disable payloads, you must be running Agent v6.4+. This disables metric data submission (including Custom Metrics) so that hosts stop showing up in Datadog. Follow these steps:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Add a danger alert for APM customers, so they don't disable metric collection
- Requested by PM

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->