### PR TITLE
Add Info Alert to Correlating OpenTelemetry Traces and Logs

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -21,7 +21,7 @@ further_reading:
   text: 'Ease troubleshooting with cross product correlation.'
 ---
 
-<div class="alert alert-info">If you are using the latest versions of Datadog tracing libraries, Datadog automatically links OpenTelemetry traces and logs using <code>TraceId</code> or <code>SpanId</code>. If you're using older versions, follow the steps on this page to manually correlate traces and logs.</div>
+<div class="alert alert-info">If you are using the latest versions of Datadog tracing libraries, Datadog automatically links OpenTelemetry traces and logs using <code>TraceId</code>. If you're using older versions, follow the steps on this page to manually correlate traces and logs.</div>
 
 Connecting OpenTelemetry language SDK logs and traces within Datadog is similar to connecting [Datadog SDK logs and traces][1], with a few additional steps:
 

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -21,7 +21,7 @@ further_reading:
   text: 'Ease troubleshooting with cross product correlation.'
 ---
 
-<div class="alert alert-info">If you are using the latest versions of Datadog tracing libraries, Datadog automatically links OpenTelemetry traces and logs using <code>TraceId</code> or <code>SpanId</code>. If you're using olders versions, follow the steps on this page to manually correlate traces and logs.</div>
+<div class="alert alert-info">If you are using the latest versions of Datadog tracing libraries, Datadog automatically links OpenTelemetry traces and logs using <code>TraceId</code> or <code>SpanId</code>. If you're using older versions, follow the steps on this page to manually correlate traces and logs.</div>
 
 Connecting OpenTelemetry language SDK logs and traces within Datadog is similar to connecting [Datadog SDK logs and traces][1], with a few additional steps:
 

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -21,6 +21,8 @@ further_reading:
   text: 'Ease troubleshooting with cross product correlation.'
 ---
 
+<div class="alert alert-info">If you are using the latest versions of Datadog tracing libraries, Datadog automatically links OpenTelemetry traces and logs using <code>TraceId</code> or <code>SpanId</code>. If you're using olders versions, follow the steps on this page to manually correlate traces and logs.</div>
+
 Connecting OpenTelemetry language SDK logs and traces within Datadog is similar to connecting [Datadog SDK logs and traces][1], with a few additional steps:
 
 1. OpenTelemetry `TraceId` and `SpanId` properties differ from Datadog conventions. Therefore it's necessary to translate `TraceId` and `SpanId` from their OpenTelemetry formats ([a 128bit unsigned int and 64bit unsigned int represented as a 32-hex-character and 16-hex-character lowercase string, respectively][2]) into their Datadog Formats([a 64bit unsigned int][3]). 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

* The latest tracing library versions support 128-bit IDs.
* So, OTel traces and logs should be automatically correlated.
* Add note that the manual steps on this page are only required for older versions.

**Open questions**
* When did this change happen?

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->