### PR TITLE
[DOCS-8767] Remove referencing files in kubernetes section

### DIFF
--- a/content/en/observability_pipelines/advanced_configurations.md
+++ b/content/en/observability_pipelines/advanced_configurations.md
@@ -26,7 +26,7 @@ further_reading:
 
 ## Overview
 
-This document goes over [bootstrapping the Observability Pipelines Worker](#bootstrap-options) and [referencing files in Kubernetes](#referencing-files-in-kubernetes).
+This document goes over bootstrapping the Observability Pipelines Worker.
 
 ## Bootstrap Options
 
@@ -89,44 +89,6 @@ The following is a list of bootstrap options, their related pipeline environment
 : An example proxy configuration:
 : &nbsp;&nbsp;&nbsp;&nbsp;proxy:<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled: true<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;https: https://foo.bar:3128
 : <b>Note</b>: The `DD_PROXY_HTTP(S)` and `HTTP(S)_PROXY` environment variables need to be already exported in your environment for the Worker to resolve them. They cannot be prepended to the Worker installation script.
-
-## Referencing files in Kubernetes
-
-If you are referencing files in Kubernetes for Google Cloud Storage authentication, TLS certificates for certain sources, or an enrichment table processor, you need to use `volumeMounts[*].subPath` to mount files from a `configMap` or `secret`.
-
-For example, if you have a `secret` defined as:
-
-```
-apiVersion: v1
-kind: Secret
-metadata:
-  name: my-secret
-type: Opaque
-data:
-  credentials1.json: bXktc2VjcmV0LTE=
-  credentials2.json: bXktc2VjcmV0LTI=
-```
-
-Then you need to override `extraVolumes` and `extraVolumeMounts` in the `values.yaml` file to mount the secret files to Observability Pipelines Worker pods using `subPath`:
-
-```
-# extraVolumes -- Specify additional Volumes to use.
-extraVolumes:
-  - name: my-secret-volume
-    secret:
-      secretName: my-secret
-
-# extraVolumeMounts -- Specify Additional VolumeMounts to use.
-extraVolumeMounts:
-  - name: my-secret-volume
-    mountPath: /var/lib/observability-pipelines-worker/config/credentials1.json
-    subPath: credentials1.json
-  - name: my-secret-volume
-    mountPath: /var/lib/observability-pipelines-worker/config/credentials2.json
-    subPath: credentials2.json
-```
-
-**Note**: If you override the`datadog.dataDir` parameter, you need to override the `mountPath` as well.
 
 ## Further reading
 

--- a/content/en/observability_pipelines/advanced_configurations.md
+++ b/content/en/observability_pipelines/advanced_configurations.md
@@ -26,7 +26,7 @@ further_reading:
 
 ## Overview
 
-This document goes over bootstrapping the Observability Pipelines Worker.
+This document explains bootstrapping for the Observability Pipelines Worker.
 
 ## Bootstrap Options
 

--- a/layouts/shortcodes/observability_pipelines/configure_log_archive/google_cloud_storage/instructions.md
+++ b/layouts/shortcodes/observability_pipelines/configure_log_archive/google_cloud_storage/instructions.md
@@ -11,8 +11,6 @@
 
 To authenticate the Observability Pipelines Worker for Google Cloud Storage, contact your Google Security Operations representative for a Google Developer Service Account Credential. This credential is a JSON file and must be placed under `DD_OP_DATA_DIR/config`. See [Getting API authentication credential][9092] for more information.
 
-**Note**: If you are installing the Worker in Kubernetes, see [Referencing files in Kubernetes][9097] for information on how to reference the credentials file.
-
 #### Connect the storage bucket to Datadog Log Archives
 
 1. Navigate to Datadog [Log Forwarding][9094].

--- a/layouts/shortcodes/observability_pipelines/destination_settings/chronicle.md
+++ b/layouts/shortcodes/observability_pipelines/destination_settings/chronicle.md
@@ -1,8 +1,5 @@
 To authenticate the Observability Pipelines Worker for Google Chronicle, contact your Google Security Operations representative for a Google Developer Service Account Credential. This credential is a JSON file and must be placed under `DD_OP_DATA_DIR/config`. See [Getting API authentication credential][10001] for more information.
 
-**Note**: If you are installing the Worker in Kubernetes, see [Referencing files in Kubernetes][10004] for information on how to reference the credentials file.
-
-
 To set up the Worker's Google Chronicle destination:
 
 1. Enter the customer ID for your Google Chronicle instance.
@@ -14,4 +11,3 @@ To set up the Worker's Google Chronicle destination:
 
 [10001]: https://cloud.google.com/chronicle/docs/reference/ingestion-api#getting_api_authentication_credentials
 [10003]: https://cloud.google.com/chronicle/docs/ingestion/parser-list/supported-default-parsers#with-default-parser
-[10004]: /observability_pipelines/advanced_configurations/#referencing-files-in-kubernetes

--- a/layouts/shortcodes/observability_pipelines/processors/enrichment_table.md
+++ b/layouts/shortcodes/observability_pipelines/processors/enrichment_table.md
@@ -8,7 +8,6 @@ To set up the enrichment table processor:
    - For the **File** type:
         1. Enter the file path.
         1. Enter the column name. The column name in the enrichment table is used for matching the source attribute value. See the [Enrichment file example](#enrichment-file-example).
-        <br>**Note**: If you are installing the Worker in Kubernetes, see [Referencing files in Kubernetes][10011] for information on how to reference the file.
    - For the **GeoIP** type, enter the GeoIP path.
 
 ##### Enrichment file example
@@ -37,4 +36,3 @@ merchant_info {
     "state":"Colorado"
 }
 ```
-[10011]: /observability_pipelines/advanced_configurations/#referencing-files-in-kubernetes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Removes the "Referencing files in Kubernetes" section and any links to it.

[DOCS-8767](https://datadoghq.atlassian.net/browse/DOCS-8767)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8767]: https://datadoghq.atlassian.net/browse/DOCS-8767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ