### PR TITLE
(maint) Prevent workflow from failing on no-op

### DIFF
--- a/.github/workflows/bump_synthetics_worker_version.yml
+++ b/.github/workflows/bump_synthetics_worker_version.yml
@@ -22,13 +22,15 @@ jobs:
       - run: pip install requests semver defusedxml
 
       - name: Find latest synthetic-worker version
+        id: write-synthetics-worker-version
         run: |
-          python local/bin/py/version_getter.py
+          python local/bin/py/version_getter.py   
       
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
       - name: Write version
+        if: steps.write-synthetics-worker-version.outputs.new_version == 'true'
         run: |-
           git config user.name documentation-ci
           git config user.email documentation-ci@datadoghq.com
@@ -38,6 +40,7 @@ jobs:
       
       - uses: actions/github-script@v7
         name: Propose change with latest versions
+        if: steps.write-synthetics-worker-version.outputs.new_version == 'true'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string

--- a/.github/workflows/bump_synthetics_worker_version.yml
+++ b/.github/workflows/bump_synthetics_worker_version.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Find latest synthetic-worker version
         id: write-synthetics-worker-version
         run: |
-          python local/bin/py/version_getter.py   
+          python local/bin/py/version_getter.py
+      
+      - name: echo new version
+        run: echo ${{ steps.write-synthetics-worker-version.outputs.new_version }}
       
       - uses: actions/checkout@v4
         with:

--- a/local/bin/py/version_getter.py
+++ b/local/bin/py/version_getter.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import re
+import os
 import json
 from io import StringIO
 import requests
@@ -60,11 +61,24 @@ Gets the latest version tag from the public oss mirror
 Currently only supports synthetics-windows-pl
 '''
 if __name__ == "__main__":
+    github_output = os.getenv('GITHUB_OUTPUT')
     PRODUCTS = ["synthetics-windows-pl"]
     data = get_data()
     keys = get_keys(data)
+    try:
+        current_versions = json.load(open('data/synthetics_worker_versions.json'))
+    except:
+        current_versions = {}
+    print(current_versions)
     final_versions = get_versions(keys)
+    
     print(final_versions)
     
-    with open('data/synthetics_worker_versions.json', 'w') as f:
-        f.write(json.dumps(final_versions, indent=4, sort_keys=True))
+    if current_versions != final_versions:
+        with open('data/synthetics_worker_versions.json', 'w') as f:
+            f.write(json.dumps(final_versions, indent=4, sort_keys=True))
+        with open(github_output, 'a', encoding='utf-8') as f:
+            f.write('new_version=true')    
+    else:
+        with open(github_output, 'a', encoding='utf-8') as f:
+            f.write('new_version=false')

--- a/local/bin/py/version_getter.py
+++ b/local/bin/py/version_getter.py
@@ -69,16 +69,16 @@ if __name__ == "__main__":
         current_versions = json.load(open('data/synthetics_worker_versions.json'))
     except:
         current_versions = {}
-    print(current_versions)
     final_versions = get_versions(keys)
     
-    print(final_versions)
-    
     if current_versions != final_versions:
+        print("New version detected!")
+        print(final_versions)
         with open('data/synthetics_worker_versions.json', 'w') as f:
             f.write(json.dumps(final_versions, indent=4, sort_keys=True))
         with open(github_output, 'a', encoding='utf-8') as f:
             f.write('new_version=true')    
     else:
         with open(github_output, 'a', encoding='utf-8') as f:
+            print("No new version detected")
             f.write('new_version=false')


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The workflow that updates the synthetic-worker version was failing on the `commit` command when it didn't find any changes to the target file. Although the workflow wasn't broken (it just exited if no change was found), this behavior was confusing. This PR checks the existing version and writes a GitHub output variable that we can use to conditionally run the `commit` and `push` steps in the workflow. This should prevent the workflow from failing if there's nothing to commit.

test run: https://github.com/DataDog/documentation/actions/runs/11147491598/job/30981945184

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->