### PR TITLE
Update Network Analytics to remove private beta features

### DIFF
--- a/content/en/network_monitoring/performance/network_analytics.md
+++ b/content/en/network_monitoring/performance/network_analytics.md
@@ -154,13 +154,8 @@ The following TCP metrics are available:
 | **TCP Retransmits** | TCP Retransmits represent detected failures that are retransmitted to ensure delivery. Measured in count of retransmits from the client. |
 | **TCP Latency** | Measured as TCP smoothed round-trip time, that is, the time between a TCP frame being sent and acknowledged. |
 | **TCP Jitter** | Measured as TCP smoothed round-trip time variance. |
-| **TCP Timeouts** (Private Beta) | The number of TCP connections that timed out from the perspective of the operating system. This can indicate general connectivity and latency issues.  |
-| **TCP Refusals** (Private Beta) | The number of TCP connections that were refused by the server. Typically this indicates an attempt to connect to an IP/Port that isn’t receiving connections, or a firewall/security misconfiguration. |
-| **TCP Resets** (Private Beta) | The number of TCP connections that were reset by the server.  |
 | **Established Connections** | The number of TCP connections in an established state. Measured in connections per second from the client. |
 | **Closed Connections** | The number of TCP connections in a closed state. Measured in connections per second from the client. |
-
-<div class="alert alert-warning">TCP Timeouts, Refusals, and Resets are in private beta. Reach out to your Datadog representative to request access. Once you've signed up, follow the <a href="/network_monitoring/performance/setup/?tab=agentlinux#failed-connections-private-beta">instructions</a> to enable the feature on your agent.</div>
 
 All metrics are instrumented from the perspective of the `client` side of the connection when available, or the server if not.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Per the PM these features are going straight to GA in the near future, but we need to remove them from the docs for now as we can't sign up customers at the moment for the private beta, so the PM requested to remove this section from the docs until its ready for GA.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->