### PR TITLE
[DOCS-9134] fixing link and changing verbiage

### DIFF
--- a/content/en/synthetics/guide/browser-tests-passkeys.md
+++ b/content/en/synthetics/guide/browser-tests-passkeys.md
@@ -22,7 +22,7 @@ You can use passkeys as a replacement for a username and password, or as a secon
 
 ## Create your Virtual Authenticator global variable
 
-Passkeys in Synthetic Monitoring are handled by Virtual Authenticator global variables. To create a Virtual Authenticator global variable storing your passkeys, see the [**Global Variables** section in Synthetic Monitoring & Continuous Testing Settings][4].
+Passkeys in Synthetic Monitoring are handled by Virtual Authenticator global variables. To create a Virtual Authenticator global variable storing your passkeys, see the [**Global Variables - Virtual Authenticator** section in Synthetic Monitoring ][4].
 
 {{< img src="synthetics/guide/browser-tests-passkeys/new-variable-virtual-authenticator.png" alt="Create a Virtual Authenticator global variable" style="width:70%;" >}}
 
@@ -66,5 +66,5 @@ You can either:
 [1]: https://app.datadoghq.com/synthetics/settings/variables
 [2]: /account_management/rbac/?tab=datadogapplication#custom-roles
 [3]: /synthetics/browser_tests/
-[4]: /synthetics/settings/?tab=virtualauthenticator
+[4]: /synthetics/platform/settings?tab=virtualauthenticator#global-variables
 [5]: /synthetics/browser_tests#use-global-variables

--- a/content/en/synthetics/guide/browser-tests-passkeys.md
+++ b/content/en/synthetics/guide/browser-tests-passkeys.md
@@ -52,8 +52,11 @@ To test a login flow using a passkey in your [browser tests][3], you need to fir
 
 You can either:
 
-- Complete the registration flow from within the recorder, but without recording the registration steps, or
-- Create a test that embeds both steps for the registration and login flows.
+- Create a test that embeds both steps for the registration and login flows, or
+
+- Complete the registration flow from within the recorder, but without recording the registration steps
+
+**Note**: To avoid creating a new user for each test scenario involving passkey authentication, it's recommended to combine user creation and authentication in the same step.
 
 1. [Import your virtual authenticator global variable][5]. 
 2. Navigate to the page to login with your passkey. When recording your test, Datadog automatically logs in using the passkey previously registered on the web application with the selected virtual authenticator.

--- a/content/en/synthetics/guide/browser-tests-passkeys.md
+++ b/content/en/synthetics/guide/browser-tests-passkeys.md
@@ -50,10 +50,9 @@ To test a registration flow using passkeys in your [browser tests][3]:
 
 To test a login flow using a passkey in your [browser tests][3], you need to first register your Datadog passkey on the web application (see section above). This is required once per passkey and application.
 
-You can either:
+Choose one of the following options:
 
-- Create a test that embeds both steps for the registration and login flows, or
-
+- Create a test that embeds both steps for the registration and login flows
 - Complete the registration flow from within the recorder, but without recording the registration steps
 
 **Note**: To avoid creating a new user for each test scenario involving passkey authentication, it's recommended to combine user creation and authentication in the same step.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
[DOCS-9134](https://datadoghq.atlassian.net/browse/DOCS-9134)

This cleans up a link to Virtual Authenticator and adds a note to help the user understand the recommendation to combine user creation and authentication in the same step.
 
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-9134]: https://datadoghq.atlassian.net/browse/DOCS-9134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ