### PR TITLE
[NDM] Fix source for SNMP traps docs

### DIFF
--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -49,9 +49,9 @@ Datadog Agent v7.37+ supports listening for SNMP Traps, enabling you to set up [
 
    **Note**: Multiple v3 users and passwords are supported as of Datadog Agent `7.51` or higher.
 
-2. Once configured, SNMP traps are forwarded as logs and can be found in the [Log Explorer][5] with the following search query: `source:snmp_traps`.
+2. Once configured, SNMP traps are forwarded as logs and can be found in the [Log Explorer][5] with the following search query: `source:snmp-traps`.
 
-  {{< img src="network_device_monitoring/snmp/snmp_logs_2.png" alt="Log Explorer showing `source:snmp_traps` with an SNMP Trap log line selected, highlighting the Network Device tag" style="width:90%" >}}
+  {{< img src="network_device_monitoring/snmp/snmp_logs_2.png" alt="Log Explorer showing `source:snmp-traps` with an SNMP Trap log line selected, highlighting the Network Device tag" style="width:90%" >}}
 
 **Note**: Even though SNMP traps are _forwarded as logs_, `logs_enabled` does **not** need to be set to `true`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

https://dd.slack.com/archives/C0245LJKD5F/p1727860554119579
on the support-ndm channel on Slack, there was a message about not seeing traps appear - after some digging i realized the docs have a typo (`source:snmp_traps`) vs `source:snmp-traps`

Cleaning it up so it doesn't happen again 😅 
Example on [Staging](https://dd.datad0g.com/logs?query=source%3Asnmp-traps%20&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1727902120496&to_ts=1727903020496&live=true) with the right source ID

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->