### PR TITLE
Move Status page out one level

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1580,24 +1580,24 @@ menu:
       parent: monitors_manage
       identifier: monitors_manage_search
       weight: 601
-    - name: Monitor Status
-      url: monitors/manage/status/
-      parent: monitors_manage
-      identifier: monitors_manage_status
-      weight: 602
     - name: Check Summary
       url: monitors/manage/check_summary/
       parent: monitors_manage
       identifier: monitors_check_summary
       weight: 603
+    - name: Monitor Status
+      url: monitors/status/
+      parent: alerting
+      identifier: monitors_status
+      weight: 7
     - name: Monitor Settings
       url: monitors/settings/
-      weight: 7
+      weight: 8
       parent: alerting
       identifier: monitor_settings
     - name: Monitor Quality
       url: monitors/quality/
-      weight: 8
+      weight: 9
       parent: alerting
       identifier: monitor_quality
     - name: Guides

--- a/content/en/cloud_cost_management/monitors/_index.md
+++ b/content/en/cloud_cost_management/monitors/_index.md
@@ -17,7 +17,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 ---

--- a/content/en/monitors/configuration/_index.md
+++ b/content/en/monitors/configuration/_index.md
@@ -10,7 +10,7 @@ further_reading:
 - link: "/monitors/manage/"
   tag: "Documentation"
   text: "Manage monitors"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Monitor Status"
 - link: "https://www.datadoghq.com/blog/manage-monitors-with-datadog-teams/"

--- a/content/en/monitors/downtimes/_index.md
+++ b/content/en/monitors/downtimes/_index.md
@@ -192,7 +192,7 @@ Datadog can proactively mute monitors related to the manual shutdown of certain 
 [6]: /monitors/guide/suppress-alert-with-downtimes/
 [7]: /monitors/notify/#overview
 [8]: /integrations/#cat-notification
-[9]: /monitors/manage/status/
+[9]: /monitors/status/
 [10]: /service_management/events/explorer
 [11]: /api/latest/downtimes/#cancel-a-downtime
 [12]: /account_management/#preferences

--- a/content/en/monitors/guide/history_and_evaluation_graphs.md
+++ b/content/en/monitors/guide/history_and_evaluation_graphs.md
@@ -131,6 +131,6 @@ The monitor evaluation `Min` takes the minimum value of the queries over the pas
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/manage/status
+[1]: /monitors/status
 [2]: /monitors/guide/as-count-in-monitor-evaluations/
 [3]: /dashboards/widgets/query_value/

--- a/content/en/monitors/guide/monitoring-sparse-metrics.md
+++ b/content/en/monitors/guide/monitoring-sparse-metrics.md
@@ -67,7 +67,7 @@ Are you monitoring an event that needs to happen at certain times of the day, we
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /monitors/manage/status/#investigate-a-monitor-in-a-notebook
+[1]: /monitors/status/#investigate-a-monitor-in-a-notebook
 [2]: /dashboards/functions/interpolation/#default-zero
 [3]: /monitors/types/metric/?tab=threshold
 [4]: /monitors/types/metric/?tab=change

--- a/content/en/monitors/guide/troubleshooting-monitor-alerts.md
+++ b/content/en/monitors/guide/troubleshooting-monitor-alerts.md
@@ -88,7 +88,7 @@ Due to an [Opsgenie feature][19], Opsgenie will discard what is seen as a duplic
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /monitors/configuration/?tabs=thresholdalert#no-data
-[2]: /monitors/manage/status/#history
+[2]: /monitors/status/#history
 [3]: /monitors/guide/monitor-arithmetic-and-sparse-metrics/
 [4]: /monitors/configuration/?tabs=thresholdalert#auto-resolve
 [5]: /monitors/configuration/?tabs=thresholdalert#set-alert-conditions

--- a/content/en/monitors/manage/_index.md
+++ b/content/en/monitors/manage/_index.md
@@ -68,8 +68,8 @@ Monitor tags are independent of tags sent by the Agent or integrations. Add up t
 
 [1]: https://app.datadoghq.com/monitors/manage
 [2]: /monitors/manage/search/
-[3]: /monitors/manage/status/#mute
-[4]: /monitors/manage/status/#resolve
+[3]: /monitors/status/#mute
+[4]: /monitors/status/#resolve
 [5]: /account_management/teams/
 [6]: /mobile/#monitors
 [7]: https://apps.apple.com/app/datadog/id1391380318

--- a/content/en/monitors/manage/search.md
+++ b/content/en/monitors/manage/search.md
@@ -92,7 +92,7 @@ From the default view entry in the Views panel:
 * **Update** your default view with the current parameters.
 * **Reset** your default view to Datadog's defaults for a fresh restart.
 
-[1]: /monitors/manage/status/#properties
+[1]: /monitors/status/#properties
 [2]: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-query-string-query.html#query-string-syntax
 [3]: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/query-dsl-query-string-query.html#_fuzziness
 [4]: /monitors/

--- a/content/en/monitors/status.md
+++ b/content/en/monitors/status.md
@@ -3,6 +3,7 @@ title: Monitor Status
 description: "Get an overview of your monitor status over time"
 aliases:
 - /monitors/monitor_status/
+- /monitors/manage/status
 further_reading:
 - link: "/monitors/"
   tag: "Documentation"

--- a/content/en/monitors/types/anomaly.md
+++ b/content/en/monitors/types/anomaly.md
@@ -12,7 +12,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 - link: "dashboards/functions/algorithms/#anomalies"
@@ -259,7 +259,7 @@ A standard configuration of thresholds and threshold window looks like:
 [9]: /monitors/types/metric/#data-window
 [10]: /monitors/notify/
 [11]: /api/v1/monitors/#create-a-monitor
-[12]: /monitors/manage/status/#settings
+[12]: /monitors/status/#settings
 [13]: mailto:billing@datadoghq.com
 [14]: /api/v1/monitors/
 [15]: /monitors/guide/anomaly-monitor/

--- a/content/en/monitors/types/apm.md
+++ b/content/en/monitors/types/apm.md
@@ -14,7 +14,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---

--- a/content/en/monitors/types/change-alert.md
+++ b/content/en/monitors/types/change-alert.md
@@ -95,7 +95,7 @@ This is a break down of the query with the following conditions:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /monitors/configuration/#evaluation-window
-[2]: /monitors/manage/status/#investigate-a-monitor-in-a-notebook
+[2]: /monitors/status/#investigate-a-monitor-in-a-notebook
 [3]: /dashboards/functions/timeshift/
 [7]: /monitors/notify/
 [8]: /monitors/configuration/?tab=thresholdalert#configure-notifications-and-automations

--- a/content/en/monitors/types/ci.md
+++ b/content/en/monitors/types/ci.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 - link: "https://www.datadoghq.com/blog/configure-pipeline-alerts-with-ci-monitors/"

--- a/content/en/monitors/types/cloud_cost.md
+++ b/content/en/monitors/types/cloud_cost.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 - link: "https://www.datadoghq.com/blog/ccm-cost-monitors/"

--- a/content/en/monitors/types/composite.md
+++ b/content/en/monitors/types/composite.md
@@ -12,7 +12,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---

--- a/content/en/monitors/types/custom_check.md
+++ b/content/en/monitors/types/custom_check.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 ---
@@ -59,7 +59,7 @@ Set up the check alert:
     * Choose how many consecutive runs with the `OK` status resolve the alert. For example, to ensure an issue is fixed, resolve the monitor on `4` `OK` statuses.
 
 
-[1]: /monitors/manage/status
+[1]: /monitors/status
 {{% /tab %}}
 {{% tab "Cluster Alert" %}}
 

--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -16,7 +16,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---

--- a/content/en/monitors/types/event.md
+++ b/content/en/monitors/types/event.md
@@ -14,7 +14,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---

--- a/content/en/monitors/types/forecasts.md
+++ b/content/en/monitors/types/forecasts.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 ---
@@ -147,5 +147,5 @@ The following functions cannot be nested inside calls to the `forecast()` functi
 [7]: /monitors/types/metric/#data-window
 [8]: /monitors/notify/
 [9]: /api/v1/monitors/#create-a-monitor
-[10]: /monitors/manage/status/#settings
+[10]: /monitors/status/#settings
 [11]: /api/v1/monitors/

--- a/content/en/monitors/types/host.md
+++ b/content/en/monitors/types/host.md
@@ -14,7 +14,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 ---

--- a/content/en/monitors/types/integration.md
+++ b/content/en/monitors/types/integration.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---
@@ -72,7 +72,7 @@ Set up the check alert:
     Choose how many consecutive runs with the `OK` status resolve the alert.
 
 
-[1]: /monitors/manage/status
+[1]: /monitors/status
 {{% /tab %}}
 {{% tab "Cluster Alert" %}}
 

--- a/content/en/monitors/types/log.md
+++ b/content/en/monitors/types/log.md
@@ -13,7 +13,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 - link: "https://www.datadoghq.com/blog/cidr-queries-datadog-log-management/"

--- a/content/en/monitors/types/metric.md
+++ b/content/en/monitors/types/metric.md
@@ -12,7 +12,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 - link: "/monitors/types/change-alert"

--- a/content/en/monitors/types/netflow.md
+++ b/content/en/monitors/types/netflow.md
@@ -10,7 +10,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---

--- a/content/en/monitors/types/network.md
+++ b/content/en/monitors/types/network.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule downtime to mute a monitor."
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---

--- a/content/en/monitors/types/network_performance.md
+++ b/content/en/monitors/types/network_performance.md
@@ -10,7 +10,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 - link: "/monitors/recommended/"

--- a/content/en/monitors/types/outlier.md
+++ b/content/en/monitors/types/outlier.md
@@ -12,7 +12,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 - link: "/watchdog/insights/"
@@ -122,4 +122,4 @@ The outlier algorithms are set up to identify groups that are behaving different
 [3]: /monitors/configuration/#advanced-alert-conditions
 [4]: /monitors/notify/
 [5]: /api/v1/monitors/#create-a-monitor
-[6]: /monitors/manage/status/#settings
+[6]: /monitors/status/#settings

--- a/content/en/monitors/types/process.md
+++ b/content/en/monitors/types/process.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 - link: "https://www.datadoghq.com/blog/monitor-fargate-processes/"

--- a/content/en/monitors/types/process_check.md
+++ b/content/en/monitors/types/process_check.md
@@ -11,7 +11,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---

--- a/content/en/monitors/types/real_user_monitoring.md
+++ b/content/en/monitors/types/real_user_monitoring.md
@@ -13,7 +13,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Check your monitor status"
 ---

--- a/content/en/monitors/types/service_check.md
+++ b/content/en/monitors/types/service_check.md
@@ -12,7 +12,7 @@ further_reading:
 - link: "/monitors/downtimes/"
   tag: "Documentation"
   text: "Schedule a downtime to mute a monitor"
-- link: "/monitors/manage/status/"
+- link: "/monitors/status/"
   tag: "Documentation"
   text: "Consult your monitor status"
 ---
@@ -60,7 +60,7 @@ Set up the check alert:
     * Choose how many consecutive runs with the `OK` status resolve the alert. For example, to ensure an issue is fixed, resolve the monitor on `4` `OK` statuses.
 
 
-[1]: /monitors/manage/status
+[1]: /monitors/status
 {{% /tab %}}
 {{% tab "Cluster Alert" %}}
 

--- a/content/en/service_management/case_management/create_case.md
+++ b/content/en/service_management/case_management/create_case.md
@@ -59,7 +59,7 @@ Create a case through the [API endpoint][5].
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/cases
-[2]: /monitors/manage/status/
+[2]: /monitors/status/
 [3]: /monitors/notify/variables/?tab=is_alert#conditional-variables
 [4]: https://app.datadoghq.com/cases/settings
 [5]: /api/latest/case-management/#create-a-case

--- a/content/en/tracing/services/resource_page.md
+++ b/content/en/tracing/services/resource_page.md
@@ -111,7 +111,7 @@ Consult the list of [traces][7] associated with this resource in the [Trace sear
 [2]: /tracing/glossary/
 [3]: /tracing/glossary/#trace
 [4]: /dashboards/
-[5]: /monitors/manage/status/
+[5]: /monitors/status/
 [6]: /tracing/glossary/#spans
 [7]: /tracing/trace_explorer/trace_view/
 [8]: /tracing/search/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Move the monitor status page out one level
- PM requested this change, no new content or updates in this change

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->