### PR TITLE
Add indication about required permission for Quality Gates Evaluations

### DIFF
--- a/content/en/quality_gates/setup/_index.md
+++ b/content/en/quality_gates/setup/_index.md
@@ -67,7 +67,7 @@ This command:
 | Environment Variables | Description |
 |---|---|
 | `DD_API_KEY` | Point to your [Datadog API key][5]. |
-| `DD_APP_KEY` | Point to your [Datadog application key][6]. The application key must have the `Quality Gates Evaluations` permission enabled|
+| `DD_APP_KEY` | Point to your [Datadog application key][6]. The application key must have the `Quality Gates Evaluations` permission enabled.|
 | `DD_SITE` | (Optional) Point to a specific [Datadog site][12] (default value is {{< region-param key="dd_site" code="true" >}}). **Note**: `DATADOG_SITE` is not supported. |
 
 For example:

--- a/content/en/quality_gates/setup/_index.md
+++ b/content/en/quality_gates/setup/_index.md
@@ -67,7 +67,7 @@ This command:
 | Environment Variables | Description |
 |---|---|
 | `DD_API_KEY` | Point to your [Datadog API key][5]. |
-| `DD_APP_KEY` | Point to your [Datadog application key][6]. |
+| `DD_APP_KEY` | Point to your [Datadog application key][6]. The application key must have the `Quality Gates Evaluations` permission enabled|
 | `DD_SITE` | (Optional) Point to a specific [Datadog site][12] (default value is {{< region-param key="dd_site" code="true" >}}). **Note**: `DATADOG_SITE` is not supported. |
 
 For example:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Add indication about the required permission for the application keys used to trigger Quality Gates Evaluations

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->