### PR TITLE
Remove "At a minimum" from permission suggestion

### DIFF
--- a/content/en/security/threats/workload_security_rules/custom_rules.md
+++ b/content/en/security/threats/workload_security_rules/custom_rules.md
@@ -122,7 +122,7 @@ Next, use the following instructions to upload the policy file to each host.
 {{< tabs >}}
 {{% tab "Host" %}}
 
-Copy the `default.policy` file to the target host in the `{$DD_AGENT}/runtime-security.d` folder. At a minimum, the file must have `read` and `write` access for the `dd-agent` user on the host. This may require use of a utility such as SCP or FTP.
+Copy the `default.policy` file to the target host in the `{$DD_AGENT}/runtime-security.d` folder. The file must have `read` and `write` access for the `dd-agent` user on the host. This may require use of a utility such as SCP or FTP.
 
 To apply the changes, restart the [Datadog Agent][1].
 


### PR DESCRIPTION
Remediating [VULN-7645](https://datadoghq.atlassian.net/browse/VULN-7645) by removing "At a minumum" which could mislead users to give too much permission to their custom rules file.

[VULN-7645]: https://datadoghq.atlassian.net/browse/VULN-7645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ