### PR TITLE
changing DD_INSTRUMENTATION_TELEMETRY_ENABLED to DD_APM_TELEMETRY_ENABLED

### DIFF
--- a/content/en/tracing/configure_data_security/_index.md
+++ b/content/en/tracing/configure_data_security/_index.md
@@ -624,7 +624,7 @@ apm_config:
 {{% tab "Environment variables" %}}
 
 ```bash
-export DD_INSTRUMENTATION_TELEMETRY_ENABLED=false
+export DD_APM_TELEMETRY_ENABLED=false
 ```
 
 {{% /tab %}}


### PR DESCRIPTION
DD_INSTRUMENTATION_TELEMETRY_ENABLED is not a valid config option. changing to the correct env var

- [x] Please merge after reviewing