### PR TITLE
[CI Visibility] .NET auto test retries feature

### DIFF
--- a/content/en/tests/auto_test_retries/_index.md
+++ b/content/en/tests/auto_test_retries/_index.md
@@ -28,6 +28,7 @@ Ensure [Test Visibility][1] is configured for your test runs.
 * dd-trace-java >= 1.34.0
 * dd-trace-js >= v5.19.0 and dd-trace-js >= v4.43.0
 * datadog-ci-rb >= 1.4.0
+* dd-trace-dotnet >= 3.4.0
 
 ### Configuration
 
@@ -69,6 +70,22 @@ This behavior can be fine-tuned with the following environment variables:
 {{% /tab %}}
 
 {{% tab "Ruby" %}}
+After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
+
+{{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}
+
+The default behavior of the feature is to retry any failing test case up to 5 times.
+This behavior can be fine-tuned with the following environment variables:
+
+* `DD_CIVISIBILITY_FLAKY_RETRY_ENABLED` - set to 0 or false to explicitly disable retries even if the remote setting is enabled (default: true)
+* `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` - a non-negative number to change the maximum number of retries per test case (default: 5).
+* `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` - a non-negative number to set the maximum total number of failed tests to retry (default: 1000)
+
+
+[1]: /tests/explorer/
+{{% /tab %}}
+
+{{% tab ".NET" %}}
 After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}

--- a/content/en/tests/auto_test_retries/_index.md
+++ b/content/en/tests/auto_test_retries/_index.md
@@ -35,7 +35,7 @@ Ensure [Test Visibility][1] is configured for your test runs.
 {{< tabs >}}
 
 {{% tab "Java" %}}
-After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
+After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][4].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}
 
@@ -50,7 +50,7 @@ This behavior can be fine-tuned with the following environment variables:
 {{% /tab %}}
 
 {{% tab "Javascript" %}}
-After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
+After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][4].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}
 
@@ -70,7 +70,7 @@ This behavior can be fine-tuned with the following environment variables:
 {{% /tab %}}
 
 {{% tab "Ruby" %}}
-After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
+After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][4].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}
 
@@ -86,7 +86,7 @@ This behavior can be fine-tuned with the following environment variables:
 {{% /tab %}}
 
 {{% tab ".NET" %}}
-After you set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
+After you set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][4].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries enabled in Test Service Settings." style="width:100%" >}}
 

--- a/content/en/tests/auto_test_retries/_index.md
+++ b/content/en/tests/auto_test_retries/_index.md
@@ -35,7 +35,7 @@ Ensure [Test Visibility][1] is configured for your test runs.
 {{< tabs >}}
 
 {{% tab "Java" %}}
-After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][4].
+After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}
 
@@ -45,12 +45,12 @@ This behavior can be fine-tuned with the following environment variables:
 * `DD_CIVISIBILITY_FLAKY_RETRY_ONLY_KNOWN_FLAKES` - if this environment variable is set to `true`, only the test cases that Test Visibility considers [flaky][2] are retried.
 * `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` - can be set to any non-negative number to change the maximum number of retries per test case.
 
-[1]: /tests/explorer/
+[1]: https://app.datadoghq.com/ci/settings/test-service
 [2]: /tests/guides/flaky_test_management/
 {{% /tab %}}
 
 {{% tab "Javascript" %}}
-After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][4].
+After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}
 
@@ -64,13 +64,13 @@ This behavior can be fine-tuned with the following environment variables:
 
 [jest-image-snapshot][2] is incompatible with `jest.retryTimes` unless `customSnapshotIdentifier` is passed (see [jest-image-snapshot docs][3]) to `toMatchImageSnapshot`. Therefore, auto test retries do not work unless `customSnapshotIdentifier` is used.
 
-[1]: /tests/explorer/
+[1]: https://app.datadoghq.com/ci/settings/test-service
 [2]: https://www.npmjs.com/package/jest-image-snapshot
 [3]: https://github.com/americanexpress/jest-image-snapshot?tab=readme-ov-file#jestretrytimes
 {{% /tab %}}
 
 {{% tab "Ruby" %}}
-After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][4].
+After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}
 
@@ -82,11 +82,11 @@ This behavior can be fine-tuned with the following environment variables:
 * `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` - a non-negative number to set the maximum total number of failed tests to retry (default: 1000)
 
 
-[1]: /tests/explorer/
+[1]: https://app.datadoghq.com/ci/settings/test-service
 {{% /tab %}}
 
 {{% tab ".NET" %}}
-After you set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][4].
+After you set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
 
 {{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries enabled in Test Service Settings." style="width:100%" >}}
 
@@ -98,7 +98,7 @@ Customize the Auto Test Retries with the following environment variables:
 * `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` - a non-negative number to set the maximum total number of failed tests to retry (default: 1000)
 
 
-[1]: /tests/explorer/
+[1]: https://app.datadoghq.com/ci/settings/test-service
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/tests/auto_test_retries/_index.md
+++ b/content/en/tests/auto_test_retries/_index.md
@@ -86,14 +86,14 @@ This behavior can be fine-tuned with the following environment variables:
 {{% /tab %}}
 
 {{% tab ".NET" %}}
-After you have set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
+After you set up Test Visibility, you can configure Auto Test Retries from the [Test Service Settings page][1].
 
-{{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries in Test Service Settings." style="width:100%" >}}
+{{< img src="continuous_integration/auto_test_retries_test_settings.png" alt="Auto Test Retries enabled in Test Service Settings." style="width:100%" >}}
 
-The default behavior of the feature is to retry any failing test case up to 5 times.
-This behavior can be fine-tuned with the following environment variables:
+By default, the feature retries any failing test case up to 5 times.
+Customize the Auto Test Retries with the following environment variables:
 
-* `DD_CIVISIBILITY_FLAKY_RETRY_ENABLED` - set to 0 or false to explicitly disable retries even if the remote setting is enabled (default: true)
+* `DD_CIVISIBILITY_FLAKY_RETRY_ENABLED` - set to `0` or `false` to explicitly disable retries even if the remote setting is enabled (default: true)
 * `DD_CIVISIBILITY_FLAKY_RETRY_COUNT` - a non-negative number to change the maximum number of retries per test case (default: 5).
 * `DD_CIVISIBILITY_TOTAL_FLAKY_RETRY_COUNT` - a non-negative number to set the maximum total number of failed tests to retry (default: 1000)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The PR adds the .NET tab for the automatic test retries feature in Test Visibility.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->