### PR TITLE
Add blocked env vars for processor

### DIFF
--- a/layouts/shortcodes/observability_pipelines/processors/set_env_vars.md
+++ b/layouts/shortcodes/observability_pipelines/processors/set_env_vars.md
@@ -6,3 +6,25 @@ To set up this processor:
 1. Enter the field name for the environment variable.
 1. Enter the environment variable name.
 1. Click **Add Environment Variable** if you want to add another environment variable.
+
+##### Blocked environment variables
+
+Environment variables that match any of the following patterns are blocked from being added to log messages because the environment variable could contain sensitive data.
+
+- `CONNECTIONSTRING` / `CONNECTION-STRING` / `CONNECTION_STRING`
+- `AUTH`
+- `CERT`
+- `CLIENTID` / `CLIENT-ID` / `CLIENT_ID`
+- `CREDENTIALS`
+- `DATABASEURL` / `DATABASE-URL` / `DATABASE_URL`
+- `DBURL` / `DB-URL` / `DB_URL`
+- `KEY`
+- `OAUTH`
+- `PASSWORD`
+- `PWD`
+- `ROOT`
+- `SECRET`
+- `TOKEN`
+- `USER`
+
+The environment variable is matched to the pattern and not the literal word. For example, `PASSWORD` blocks environment variables like `USER_PASSWORD` and `PASSWORD_SECRET` from getting added to the log messages.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This is part of the OP 2.2 release.

Adds info about which env vars are blocked.

Preview: https://docs-staging.datadoghq.com/may/add-blocked-env-vars/observability_pipelines/processors/set_environment_variables#blocked-environment-variables

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->