### PR TITLE
(DOCS-9067) Add Lambda runtime note

### DIFF
--- a/content/en/getting_started/integrations/aws.md
+++ b/content/en/getting_started/integrations/aws.md
@@ -40,6 +40,8 @@ After the initial connection is established, you can enable individual AWS servi
 
 This process can be repeated for as many AWS accounts as necessary, or you can also use the [API][3], [AWS CLI][4], or [Terraform][5] to set up multiple accounts at once. For more information, read the [Datadog-Amazon CloudFormation guide][6].
 
+**Note**: AWS Lambda is [deprecating the Python 3.8 runtime][59] on October 14, 2024. Datadog's CloudFormation template only supports creation and deletion, see [Modifying the runtime environment][60] for guidance on updating the runtime for existing functions.
+
 ## Prerequisites
 
 Before getting started, ensure you have the following prerequisites:
@@ -276,5 +278,5 @@ If you encounter the error `Datadog is not authorized to perform sts:AssumeRole`
 [56]: /security/default_rules/#cat-posture-management-infra
 [57]: /integrations/guide/aws-integration-troubleshooting/
 [58]: /integrations/ecs_fargate/?tab=webui#installation-for-aws-batch
-
-
+[59]: https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html#runtimes-supported
+[60]: https://docs.aws.amazon.com/lambda/latest/dg/runtimes-modify.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds a note about the upcoming deprecation of Python 3.8 as a supported runtime for AWS Lambda.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->