### PR TITLE
Use `$input` instead of `Read-Host` for PowerShell secret example

### DIFF
--- a/content/en/agent/configuration/secrets-management.md
+++ b/content/en/agent/configuration/secrets-management.md
@@ -206,7 +206,7 @@ func main() {
 {{% /tab %}}
 {{% tab "PowerShell" %}}
 ```powershell
-$secretsJson = Read-Host | ConvertFrom-Json
+$secretsJson = $input | ConvertFrom-Json
 $secrets = @{}
 for ($index = 0; $index -lt $secretsJson.secrets.count; $index++) {
     $secretKey = $secretsJson.secrets[$index]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR updates the PowerShell sample code documentation to read from the special variable `$input` instead of `Read-Host`.
Indeed, this matches the behavior expected by the Agent, because `Read-Host` does not support piping input.

https://datadoghq.atlassian.net/browse/WINA-1095

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->