### PR TITLE
Update Flex Logs docs to include retention length options

### DIFF
--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -127,7 +127,7 @@ If you select one of the scalable compute options for Flex Logs (for example, XS
 
 ## Configure storage tiers
 
-Flex Logs is set up within log index configurations. [Index filters][1] that apply to that index also apply to Flex Logs.
+Flex Logs is set up within log index configurations. [Index filters][1] that apply to that index also apply to Flex Logs. With Flex Logs Starter, you can store logs for 6, 12, or 15 months. With a scalable compute option, you can store logs for 30-450 days. 
 
 Configure Flex Tier in the [Logs Index Configuration][2] page:
 


### PR DESCRIPTION
Update Flex Logs docs to include retention length options, these currently only exist in the pricing page

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->