### PR TITLE
update web modules and add on-call icon

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -2176,7 +2176,7 @@ menu:
       weight: 10
     - name: On-Call
       url: service_management/on-call/
-      pre: incidents
+      pre: on-call
       parent: service_management_heading
       identifier: oncall
       weight: 30000

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module documentation
 go 1.14
 
 require (
-	github.com/DataDog/websites-modules v1.4.187 // indirect
+	github.com/DataDog/websites-modules v1.4.188 // indirect
 	github.com/DataDog/websites-sources v0.0.0-20240828113530-52633d72da19 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/DataDog/websites-modules v1.4.187 h1:I0CwJobhsK54qJe2QL44S3kfBJEa/7G2LFTu6j837IE=
-github.com/DataDog/websites-modules v1.4.187/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.4.188 h1:qiZ3rmYV8M+nh1OBKzXlhpfAQIMANNT+9IPJVUpsdtg=
+github.com/DataDog/websites-modules v1.4.188/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
 github.com/DataDog/websites-sources v0.0.0-20240828113530-52633d72da19 h1:hWHa2AWZnGf9rTTp8EgCcQ12blRDGAkzru8mcm8WJ3M=
 github.com/DataDog/websites-sources v0.0.0-20240828113530-52633d72da19/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
update websites-modules and use the `on-call` icon

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

motivation: https://datadoghq.atlassian.net/browse/WEB-5395
   - this change was reverted ([reference](https://github.com/DataDog/documentation/pull/25599)) but should be good to go live now.
 
preview: https://docs-staging.datadoghq.com/stefon.simmons/iupdate-web-modules-version/service_management/on-call/
   - new icon should show in left nav next to `On-Call`

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->