### PR TITLE
Update sample configs for 7.57.2 Agent/Helm Chart 3.73.2

### DIFF
--- a/static/resources/yaml/datadog-agent-aks.yaml
+++ b/static/resources/yaml/datadog-agent-aks.yaml
@@ -6,7 +6,7 @@ automountServiceAccountToken: true
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-3.32.4"
+    chart: "datadog-3.73.2"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -48,6 +48,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -73,6 +74,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -90,6 +96,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "f6769015-2f56-484e-b430-d9f621467726"
+  install_time: "1728322709"
+---
 # Source: datadog/templates/cluster-agent-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -106,6 +124,7 @@ rules:
       - nodes
       - namespaces
       - componentstatuses
+      - limitranges
     verbs:
       - get
       - list
@@ -231,6 +250,7 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
+      - networkpolicies
     verbs:
       - list
       - get
@@ -242,6 +262,14 @@ rules:
       - rolebindings
       - clusterroles
       - clusterrolebindings
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - storageclasses
     verbs:
       - list
       - get
@@ -265,22 +293,23 @@ rules:
   - apiGroups:
       - admissionregistration.k8s.io
     resources:
+      - validatingwebhookconfigurations
       - mutatingwebhookconfigurations
-    verbs: ["get", "list", "watch", "update", "create"]
+    resourceNames:
+      - "datadog-webhook"
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs: ["create"]
   - apiGroups: ["batch"]
     resources: ["jobs", "cronjobs"]
     verbs: ["get"]
   - apiGroups: ["apps"]
     resources: ["statefulsets", "replicasets", "deployments", "daemonsets"]
     verbs: ["get"]
-  - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
-    verbs:
-      - use
-    resourceNames:
-      - datadog-cluster-agent
   - apiGroups:
       - "security.openshift.io"
     resources:
@@ -302,6 +331,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -495,7 +525,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-3.32.4"
+    chart: "datadog-3.73.2"
     release: "datadog"
     heritage: "Helm"
 spec:
@@ -504,6 +534,8 @@ spec:
   ports:
     - port: 443
       targetPort: 8000
+      name: datadog-webhook
+      protocol: TCP
 ---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
@@ -520,6 +552,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
@@ -529,7 +562,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -538,22 +571,37 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -572,7 +620,7 @@ spec:
                   name: datadog-cluster-agent
                   key: token
             - name: DD_APM_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_LOGS_ENABLED
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -589,24 +637,33 @@ spec:
               value: "clusterchecks endpointschecks"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "true"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
             - name: DD_KUBELET_CLIENT_CA
               value: "/etc/kubernetes/certs/kubeletserver.crt"
           volumeMounts:
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: installinfo
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to /tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
@@ -652,8 +709,18 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -662,22 +729,27 @@ spec:
               name: traceport
               protocol: TCP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -699,10 +771,28 @@ spec:
               value: "/var/run/datadog/apm.socket"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
               readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: /etc/datadog-agent/auth
               readOnly: true
@@ -714,9 +804,6 @@ spec:
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW for tmp directory
@@ -737,27 +824,32 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -767,8 +859,16 @@ spec:
                 secretKeyRef:
                   name: datadog-cluster-agent
                   key: token
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
             - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
               value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -781,21 +881,20 @@ spec:
             - name: config
               mountPath: /etc/datadog-agent
               readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: /etc/datadog-agent/auth
               readOnly: true
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false # Need RW for UDS DSD socket
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
@@ -817,7 +916,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -828,7 +927,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -851,22 +950,27 @@ spec:
               mountPropagation: None
               readOnly: true
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
           resources: {}
       volumes:
         - name: auth-token
@@ -939,6 +1043,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent
       name: datadog-cluster-agent
       annotations: {}
@@ -947,12 +1052,12 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/cluster-agent:7.45.0"
+          image: "gcr.io/datadoghq/cluster-agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - cp
-          args:
             - -r
+          args:
             - /etc/datadog-agent
             - /opt
           volumeMounts:
@@ -960,7 +1065,7 @@ spec:
               mountPath: /opt/datadog-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:7.45.0"
+          image: "gcr.io/datadoghq/cluster-agent:7.57.2"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -969,6 +1074,9 @@ spec:
               protocol: TCP
             - containerPort: 5000
               name: agentmetrics
+              protocol: TCP
+            - containerPort: 8000
+              name: datadog-webhook
               protocol: TCP
           env:
             - name: DD_POD_NAME
@@ -983,10 +1091,16 @@ spec:
                   name: "datadog"
                   key: api-key
                   optional: true
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_ADMISSION_CONTROLLER_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
+              value: "datadog-webhook"
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
               value: "false"
             - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
@@ -997,6 +1111,10 @@ spec:
               value: datadog
             - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
               value: "Ignore"
+            - name: DD_ADMISSION_CONTROLLER_PORT
+              value: "8000"
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1007,6 +1125,8 @@ spec:
               value: "INFO"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_LEADER_LEASE_NAME
               value: datadog-leader-election
             - name: DD_CLUSTER_AGENT_TOKEN_NAME
@@ -1034,6 +1154,23 @@ spec:
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
               value: "true"
+            - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
+              value: "false"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -1048,6 +1185,16 @@ spec:
             failureThreshold: 6
             httpGet:
               path: /ready
+              port: 5556
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
               port: 5556
               scheme: HTTP
             initialDelaySeconds: 15
@@ -1092,6 +1239,8 @@ spec:
             items:
               - key: kubernetes_state_core.yaml.default
                 path: kubernetes_state_core.yaml.default
+              - key: kubernetes_apiserver.yaml
+                path: kubernetes_apiserver.yaml
         - name: config
           emptyDir: {}
       affinity:

--- a/static/resources/yaml/datadog-agent-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-all-features.yaml
@@ -6,7 +6,7 @@ automountServiceAccountToken: true
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-3.32.4"
+    chart: "datadog-3.73.2"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -48,6 +48,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -73,6 +74,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -90,6 +96,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "621abf04-5901-4e05-beeb-b1b0458a045d"
+  install_time: "1728322709"
+---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -98,7 +116,7 @@ metadata:
   namespace: default
   labels: {}
 data:
-  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: true\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\ndata_streams_config:\n  enabled: false\nruntime_security_config:\n  enabled: true\n  fim_enabled: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n"
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: true\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\nruntime_security_config:\n  enabled: true\n  fim_enabled: false\n  use_secruntime_track: true\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: true \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -345,6 +363,7 @@ rules:
       - nodes
       - namespaces
       - componentstatuses
+      - limitranges
     verbs:
       - get
       - list
@@ -470,6 +489,7 @@ rules:
       - networking.k8s.io
     resources:
       - ingresses
+      - networkpolicies
     verbs:
       - list
       - get
@@ -481,6 +501,14 @@ rules:
       - rolebindings
       - clusterroles
       - clusterrolebindings
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - "storage.k8s.io"
+    resources:
+      - storageclasses
     verbs:
       - list
       - get
@@ -504,8 +532,17 @@ rules:
   - apiGroups:
       - admissionregistration.k8s.io
     resources:
+      - validatingwebhookconfigurations
       - mutatingwebhookconfigurations
-    verbs: ["get", "list", "watch", "update", "create"]
+    resourceNames:
+      - "datadog-webhook"
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
+    verbs: ["create"]
   - apiGroups: ["batch"]
     resources: ["jobs", "cronjobs"]
     verbs: ["get"]
@@ -520,14 +557,6 @@ rules:
     verbs:
       - list
   - apiGroups:
-      - "policy"
-    resources:
-      - podsecuritypolicies
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - rbac.authorization.k8s.io
     resources:
       - clusterrolebindings
@@ -540,14 +569,6 @@ rules:
       - networkpolicies
     verbs:
       - list
-  - apiGroups:
-      - policy
-    resources:
-      - podsecuritypolicies
-    verbs:
-      - use
-    resourceNames:
-      - datadog-cluster-agent
   - apiGroups:
       - "security.openshift.io"
     resources:
@@ -569,6 +590,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -762,7 +784,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-3.32.4"
+    chart: "datadog-3.73.2"
     release: "datadog"
     heritage: "Helm"
 spec:
@@ -771,6 +793,8 @@ spec:
   ports:
     - port: 443
       targetPort: 8000
+      name: datadog-webhook
+      protocol: TCP
 ---
 # Source: datadog/templates/daemonset.yaml
 apiVersion: apps/v1
@@ -787,6 +811,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations:
@@ -797,7 +822,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -806,22 +831,37 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -840,7 +880,7 @@ spec:
                   name: datadog-cluster-agent
                   key: token
             - name: DD_APM_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_LOGS_ENABLED
               value: "true"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -857,22 +897,31 @@ spec:
               value: "clusterchecks endpointschecks"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "true"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "true"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: installinfo
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to /tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
@@ -938,8 +987,18 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -949,22 +1008,27 @@ spec:
               name: traceport
               protocol: TCP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -986,10 +1050,28 @@ spec:
               value: "/var/run/datadog/apm.socket"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
               readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: /etc/datadog-agent/auth
               readOnly: true
@@ -1001,9 +1083,6 @@ spec:
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW for tmp directory
@@ -1021,27 +1100,32 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1051,10 +1135,16 @@ spec:
                 secretKeyRef:
                   name: datadog-cluster-agent
                   key: token
-            - name: DD_PROCESS_AGENT_ENABLED
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
               value: "true"
             - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
               value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -1069,21 +1159,20 @@ spec:
             - name: config
               mountPath: /etc/datadog-agent
               readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: /etc/datadog-agent/auth
               readOnly: true
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false # Need RW for UDS DSD socket
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
@@ -1108,7 +1197,7 @@ spec:
               subPath: system-probe.yaml
               readOnly: true
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1128,22 +1217,27 @@ spec:
               localhostProfile: system-probe
           command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
           resources: {}
@@ -1177,7 +1271,6 @@ spec:
               readOnly: true
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: etc-redhat-release
               mountPath: /host/etc/redhat-release
@@ -1189,7 +1282,7 @@ spec:
               mountPath: /host/etc/lsb-release
               readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -1197,22 +1290,27 @@ spec:
           command: ["security-agent", "start", "-c=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "true"
             - name: DD_CLUSTER_AGENT_KUBERNETES_SERVICE_NAME
@@ -1228,6 +1326,10 @@ spec:
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_CHECK_INTERVAL
               value: "20m"
+            - name: DD_COMPLIANCE_CONFIG_XCCDF_ENABLED
+              value: "true"
+            - name: DD_COMPLIANCE_CONFIG_HOST_BENCHMARKS_ENABLED
+              value: "true"
             - name: HOST_ROOT
               value: /host/root
             - name: DD_RUNTIME_SECURITY_CONFIG_ENABLED
@@ -1236,27 +1338,28 @@ spec:
               value: "/etc/datadog-agent/runtime-security.d"
             - name: DD_RUNTIME_SECURITY_CONFIG_SOCKET
               value: /var/run/sysprobe/runtime-security.sock
+            - name: DD_RUNTIME_SECURITY_CONFIG_USE_SECRUNTIME_TRACK
+              value: "true"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
               readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: /etc/datadog-agent/auth
               readOnly: true
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false # Need RW for UDS DSD socket
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
@@ -1286,7 +1389,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -1297,7 +1400,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -1324,25 +1427,30 @@ spec:
               subPath: system-probe.yaml
               readOnly: true
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - cp
@@ -1387,6 +1495,9 @@ spec:
         - hostPath:
             path: /etc/lsb-release
           name: etc-lsb-release
+        - hostPath:
+            path: /etc/system-release
+          name: etc-system-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate
@@ -1466,6 +1577,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog-cluster-agent
       name: datadog-cluster-agent
       annotations: {}
@@ -1474,12 +1586,12 @@ spec:
       automountServiceAccountToken: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/cluster-agent:7.45.0"
+          image: "gcr.io/datadoghq/cluster-agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - cp
-          args:
             - -r
+          args:
             - /etc/datadog-agent
             - /opt
           volumeMounts:
@@ -1487,7 +1599,7 @@ spec:
               mountPath: /opt/datadog-agent
       containers:
         - name: cluster-agent
-          image: "gcr.io/datadoghq/cluster-agent:7.45.0"
+          image: "gcr.io/datadoghq/cluster-agent:7.57.2"
           imagePullPolicy: IfNotPresent
           resources: {}
           ports:
@@ -1496,6 +1608,9 @@ spec:
               protocol: TCP
             - containerPort: 5000
               name: agentmetrics
+              protocol: TCP
+            - containerPort: 8000
+              name: datadog-webhook
               protocol: TCP
           env:
             - name: DD_POD_NAME
@@ -1510,10 +1625,16 @@ spec:
                   name: "datadog"
                   key: api-key
                   optional: true
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_ADMISSION_CONTROLLER_ENABLED
               value: "true"
+            - name: DD_ADMISSION_CONTROLLER_WEBHOOK_NAME
+              value: "datadog-webhook"
             - name: DD_ADMISSION_CONTROLLER_MUTATE_UNLABELLED
               value: "false"
             - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
@@ -1524,6 +1645,10 @@ spec:
               value: datadog
             - name: DD_ADMISSION_CONTROLLER_FAILURE_POLICY
               value: "Ignore"
+            - name: DD_ADMISSION_CONTROLLER_PORT
+              value: "8000"
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "false"
             - name: DD_CLUSTER_CHECKS_ENABLED
               value: "true"
             - name: DD_EXTRA_CONFIG_PROVIDERS
@@ -1534,6 +1659,8 @@ spec:
               value: "INFO"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_LEADER_LEASE_NAME
               value: datadog-leader-election
             - name: DD_CLUSTER_AGENT_TOKEN_NAME
@@ -1561,10 +1688,27 @@ spec:
               value: "true"
             - name: DD_ORCHESTRATOR_EXPLORER_CONTAINER_SCRUBBING_ENABLED
               value: "true"
+            - name: DD_CLUSTER_AGENT_LANGUAGE_DETECTION_PATCHER_ENABLED
+              value: "false"
             - name: DD_COMPLIANCE_CONFIG_ENABLED
               value: "true"
             - name: DD_COMPLIANCE_CONFIG_CHECK_INTERVAL
               value: "20m"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           livenessProbe:
             failureThreshold: 6
             httpGet:
@@ -1579,6 +1723,16 @@ spec:
             failureThreshold: 6
             httpGet:
               path: /ready
+              port: 5556
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
               port: 5556
               scheme: HTTP
             initialDelaySeconds: 15
@@ -1623,6 +1777,8 @@ spec:
             items:
               - key: kubernetes_state_core.yaml.default
                 path: kubernetes_state_core.yaml.default
+              - key: kubernetes_apiserver.yaml
+                path: kubernetes_apiserver.yaml
         - name: config
           emptyDir: {}
       affinity:

--- a/static/resources/yaml/datadog-agent-apm.yaml
+++ b/static/resources/yaml/datadog-agent-apm.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "ba4ab35f-a802-4cd9-b3a0-c6c8792e8e69"
+  install_time: "1728322710"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,6 +204,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
@@ -194,7 +214,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -203,22 +223,37 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -229,10 +264,12 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_LOGS_ENABLED
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -247,22 +284,31 @@ spec:
               value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: installinfo
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to /tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
@@ -305,8 +351,18 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -316,22 +372,27 @@ spec:
               name: traceport
               protocol: TCP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
             - name: DD_LOG_LEVEL
@@ -346,10 +407,28 @@ spec:
               value: "/var/run/datadog/apm.socket"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
               readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: /etc/datadog-agent/auth
               readOnly: true
@@ -361,9 +440,6 @@ spec:
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW for tmp directory
@@ -380,9 +456,90 @@ spec:
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+        - name: process-agent
+          image: "gcr.io/datadoghq/agent:7.57.2"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: dsdsocket
+              mountPath: /var/run/datadog
+              readOnly: false # Need RW for UDS DSD socket
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW to write to tmp directory
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -393,7 +550,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -416,24 +573,31 @@ spec:
               mountPropagation: None
               readOnly: true
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
           resources: {}
       volumes:
         - name: auth-token
@@ -466,6 +630,9 @@ spec:
           name: apmsocket
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
         - hostPath:
             path: /var/run
           name: runtimesocketdir

--- a/static/resources/yaml/datadog-agent-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-logs-apm.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "8760a5ac-33c3-42a1-a742-94dce5854b0f"
+  install_time: "1728322710"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,6 +204,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
@@ -194,7 +214,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -203,22 +223,37 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -229,10 +264,12 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_LOGS_ENABLED
               value: "true"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -247,22 +284,31 @@ spec:
               value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: installinfo
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to /tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
@@ -321,8 +367,18 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -332,22 +388,27 @@ spec:
               name: traceport
               protocol: TCP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
             - name: DD_LOG_LEVEL
@@ -362,10 +423,28 @@ spec:
               value: "/var/run/datadog/apm.socket"
             - name: DD_DOGSTATSD_SOCKET
               value: "/var/run/datadog/dsd.socket"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           volumeMounts:
             - name: config
               mountPath: /etc/datadog-agent
               readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: /etc/datadog-agent/auth
               readOnly: true
@@ -377,9 +456,6 @@ spec:
               mountPath: /host/sys/fs/cgroup
               mountPropagation: None
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW for tmp directory
@@ -396,9 +472,90 @@ spec:
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+        - name: process-agent
+          image: "gcr.io/datadoghq/agent:7.57.2"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: dsdsocket
+              mountPath: /var/run/datadog
+              readOnly: false # Need RW for UDS DSD socket
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW to write to tmp directory
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -409,7 +566,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -432,24 +589,31 @@ spec:
               mountPropagation: None
               readOnly: true
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
           resources: {}
       volumes:
         - name: auth-token
@@ -482,6 +646,9 @@ spec:
           name: apmsocket
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
         - hostPath:
             path: /var/lib/datadog-agent/logs
           name: pointerdir

--- a/static/resources/yaml/datadog-agent-logs.yaml
+++ b/static/resources/yaml/datadog-agent-logs.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "5df23335-19ea-460f-8e68-d633e06460d8"
+  install_time: "1728322711"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,6 +204,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
@@ -194,7 +214,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -203,22 +223,37 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -229,6 +264,8 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
@@ -247,22 +284,31 @@ spec:
               value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: installinfo
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to /tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
@@ -321,9 +367,100 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+        - name: process-agent
+          image: "gcr.io/datadoghq/agent:7.57.2"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: dsdsocket
+              mountPath: /var/run/datadog
+              readOnly: false # Need RW for UDS DSD socket
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW to write to tmp directory
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -334,7 +471,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -357,24 +494,31 @@ spec:
               mountPropagation: None
               readOnly: true
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
           resources: {}
       volumes:
         - name: auth-token
@@ -403,6 +547,9 @@ spec:
           name: dsdsocket
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
         - hostPath:
             path: /var/lib/datadog-agent/logs
           name: pointerdir

--- a/static/resources/yaml/datadog-agent-npm.yaml
+++ b/static/resources/yaml/datadog-agent-npm.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "4677ff21-6d28-4cad-b6fb-ccce2069bf24"
+  install_time: "1728322712"
+---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -74,7 +92,7 @@ metadata:
   namespace: default
   labels: {}
 data:
-  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: true\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\ndata_streams_config:\n  enabled: false\nruntime_security_config:\n  enabled: false\n  fim_enabled: false\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n"
+  system-probe.yaml: "system_probe_config:\n  enabled: true\n  debug_port:  0\n  sysprobe_socket: /var/run/sysprobe/sysprobe.sock\n  enable_conntrack: true\n  bpf_debug: false\n  enable_tcp_queue_length: false\n  enable_oom_kill: false\n  collect_dns_stats: true\n  max_tracked_connections: 131072\n  conntrack_max_state_size: 131072\n  runtime_compiler_output_dir: /var/tmp/datadog-agent/system-probe/build\n  kernel_header_download_dir: /var/tmp/datadog-agent/system-probe/kernel-headers\n  apt_config_dir: /host/etc/apt\n  yum_repos_dir: /host/etc/yum.repos.d\n  zypper_repos_dir: /host/etc/zypp/repos.d\n  btf_path: \nnetwork_config:\n  enabled: true\n  conntrack_init_timeout: 10s\nservice_monitoring_config:\n  enabled: false\nruntime_security_config:\n  enabled: false\n  fim_enabled: false\n  use_secruntime_track: true\n  socket: /var/run/sysprobe/runtime-security.sock\n  policies:\n    dir: /etc/datadog-agent/runtime-security.d\n  syscall_monitor:\n    enabled: false\n  network:\n    enabled: true\n  remote_configuration:\n    enabled: false \n  activity_dump:\n    enabled: true\n    traced_cgroups_count: 3\n    cgroup_dump_timeout: 20\n    cgroup_wait_list_size:  0\n    path_merge:\n      enabled: false\n\n  security_profile:\n    enabled: true\n    anomaly_detection:\n      enabled: true\n    auto_suppression:\n      enabled: true\n"
 ---
 # Source: datadog/templates/system-probe-configmap.yaml
 apiVersion: v1
@@ -316,6 +334,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -424,6 +443,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations:
@@ -434,7 +454,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -443,22 +463,37 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -469,6 +504,8 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
@@ -487,22 +524,31 @@ spec:
               value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: installinfo
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to /tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
@@ -552,32 +598,55 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
           resources: {}
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
             - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
               value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -592,21 +661,20 @@ spec:
             - name: config
               mountPath: /etc/datadog-agent
               readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: /etc/datadog-agent/auth
               readOnly: true
             - name: dsdsocket
               mountPath: /var/run/datadog
               readOnly: false # Need RW for UDS DSD socket
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: runtimesocketdir
               mountPath: /host/var/run
@@ -631,7 +699,7 @@ spec:
               subPath: system-probe.yaml
               readOnly: true
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -651,22 +719,27 @@ spec:
               localhostProfile: system-probe
           command: ["/opt/datadog-agent/embedded/bin/system-probe", "--config=/etc/datadog-agent/system-probe.yaml"]
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
           resources: {}
@@ -700,7 +773,6 @@ spec:
               readOnly: true
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: etc-redhat-release
               mountPath: /host/etc/redhat-release
@@ -713,7 +785,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -724,7 +796,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -751,27 +823,34 @@ spec:
               subPath: system-probe.yaml
               readOnly: true
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - cp
@@ -816,6 +895,9 @@ spec:
         - hostPath:
             path: /etc/lsb-release
           name: etc-lsb-release
+        - hostPath:
+            path: /etc/system-release
+          name: etc-system-release
         - hostPath:
             path: /var/run/datadog/
             type: DirectoryOrCreate

--- a/static/resources/yaml/datadog-agent-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-vanilla.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "91d8fc38-b63d-4e6e-806f-44f3d1a890ad"
+  install_time: "1728322712"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,6 +204,7 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
@@ -194,7 +214,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -203,22 +223,37 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -229,6 +264,8 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
@@ -247,22 +284,31 @@ spec:
               value: "/var/run/datadog/dsd.socket"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
             - name: installinfo
               subPath: install_info
               mountPath: /etc/datadog-agent/install_info
               readOnly: true
-            - name: logdatadog
-              mountPath: /var/log/datadog
-              readOnly: false # Need RW to write logs
             - name: tmpdir
               mountPath: /tmp
               readOnly: false # Need RW to write to /tmp directory
             - name: os-release-file
               mountPath: /host/etc/os-release
-              mountPropagation: None
               readOnly: true
             - name: config
               mountPath: /etc/datadog-agent
@@ -305,9 +351,100 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+        - name: process-agent
+          image: "gcr.io/datadoghq/agent:7.57.2"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "--cfgpath=/etc/datadog-agent/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_PROCESS_CONFIG_RUN_IN_CORE_AGENT_ENABLED
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_DOGSTATSD_SOCKET
+              value: "/var/run/datadog/dsd.socket"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/datadog-agent
+              readOnly: true
+            - name: logdatadog
+              mountPath: /var/log/datadog
+              readOnly: false # Need RW to write logs
+            - name: auth-token
+              mountPath: /etc/datadog-agent/auth
+              readOnly: true
+            - name: dsdsocket
+              mountPath: /var/run/datadog
+              readOnly: false # Need RW for UDS DSD socket
+            - name: tmpdir
+              mountPath: /tmp
+              readOnly: false # Need RW to write to tmp directory
+            - name: os-release-file
+              mountPath: /host/etc/os-release
+              readOnly: true
+            - name: runtimesocketdir
+              mountPath: /host/var/run
+              mountPropagation: None
+              readOnly: true
+            - name: cgroups
+              mountPath: /host/sys/fs/cgroup
+              mountPropagation: None
+              readOnly: true
+            - name: passwd
+              mountPath: /etc/passwd
+              readOnly: true
+            - name: procdir
+              mountPath: /host/proc
+              mountPropagation: None
+              readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -318,7 +455,7 @@ spec:
               readOnly: false # Need RW for config path
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command:
             - bash
@@ -341,24 +478,31 @@ spec:
               mountPropagation: None
               readOnly: true
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: /etc/datadog-agent/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
           resources: {}
       volumes:
         - name: auth-token
@@ -387,6 +531,9 @@ spec:
           name: dsdsocket
         - name: s6-run
           emptyDir: {}
+        - hostPath:
+            path: /etc/passwd
+          name: passwd
         - hostPath:
             path: /var/run
           name: runtimesocketdir

--- a/static/resources/yaml/datadog-agent-windows-all-features.yaml
+++ b/static/resources/yaml/datadog-agent-windows-all-features.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "af5b2bf4-4878-422f-85b7-1b1d00824816"
+  install_time: "1728322713"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,13 +204,14 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -200,22 +220,35 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -226,10 +259,12 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_LOGS_ENABLED
               value: "true"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -242,9 +277,22 @@ spec:
               value: "5555"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: false # Need RW to mount to config path
@@ -284,8 +332,18 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -295,22 +353,27 @@ spec:
               name: traceport
               protocol: TCP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
             - name: DD_LOG_LEVEL
@@ -321,10 +384,28 @@ spec:
               value: "true"
             - name: DD_APM_RECEIVER_PORT
               value: "8126"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: true
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: C:/ProgramData/Datadog/auth
               readOnly: true
@@ -339,33 +420,42 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
-            - name: DD_PROCESS_AGENT_ENABLED
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
               value: "true"
             - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
               value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_SYSTEM_PROBE_ENABLED
@@ -378,13 +468,16 @@ spec:
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: true
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: runtimesocket
               mountPath: \\.\pipe\docker_engine
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -400,7 +493,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -414,22 +507,27 @@ spec:
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
           resources: {}
       volumes:
         - name: auth-token
@@ -457,6 +555,8 @@ spec:
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket
+        - name: logdatadog
+          emptyDir: {}
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-apm.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "79d95573-b77b-4032-99ba-8466dd436237"
+  install_time: "1728322714"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,13 +204,14 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -200,22 +220,35 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -226,10 +259,12 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_LOGS_ENABLED
               value: "false"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -242,9 +277,22 @@ spec:
               value: "5555"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: false # Need RW to mount to config path
@@ -275,8 +323,18 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -286,22 +344,27 @@ spec:
               name: traceport
               protocol: TCP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
             - name: DD_LOG_LEVEL
@@ -312,10 +375,28 @@ spec:
               value: "true"
             - name: DD_APM_RECEIVER_PORT
               value: "8126"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: true
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: C:/ProgramData/Datadog/auth
               readOnly: true
@@ -329,9 +410,63 @@ spec:
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+        - name: process-agent
+          image: "gcr.io/datadoghq/agent:7.57.2"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+              readOnly: true
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -347,7 +482,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -361,22 +496,27 @@ spec:
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
           resources: {}
       volumes:
         - name: auth-token
@@ -395,6 +535,8 @@ spec:
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket
+        - name: logdatadog
+          emptyDir: {}
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs-apm.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "7a7a2481-66c9-4c9b-99de-8b236ac1e05d"
+  install_time: "1728322714"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,13 +204,14 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -200,22 +220,35 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -226,10 +259,12 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
-              value: "false"
+              value: "true"
             - name: DD_LOGS_ENABLED
               value: "true"
             - name: DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL
@@ -242,9 +277,22 @@ spec:
               value: "5555"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: false # Need RW to mount to config path
@@ -284,8 +332,18 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-foreground", "-config=C:/ProgramData/Datadog/datadog.yaml"]
           resources: {}
@@ -295,22 +353,27 @@ spec:
               name: traceport
               protocol: TCP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
             - name: DD_CLUSTER_AGENT_ENABLED
               value: "false"
             - name: DD_LOG_LEVEL
@@ -321,10 +384,28 @@ spec:
               value: "true"
             - name: DD_APM_RECEIVER_PORT
               value: "8126"
+            - name: DD_INSTRUMENTATION_INSTALL_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_time
+            - name: DD_INSTRUMENTATION_INSTALL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_id
+            - name: DD_INSTRUMENTATION_INSTALL_TYPE
+              valueFrom:
+                configMapKeyRef:
+                  name: datadog-kpi-telemetry-configmap
+                  key: install_type
           volumeMounts:
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: true
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: auth-token
               mountPath: C:/ProgramData/Datadog/auth
               readOnly: true
@@ -338,9 +419,63 @@ spec:
             tcpSocket:
               port: 8126
             timeoutSeconds: 5
+        - name: process-agent
+          image: "gcr.io/datadoghq/agent:7.57.2"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+              readOnly: true
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -356,7 +491,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -370,22 +505,27 @@ spec:
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
           resources: {}
       volumes:
         - name: auth-token
@@ -413,6 +553,8 @@ spec:
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket
+        - name: logdatadog
+          emptyDir: {}
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-logs.yaml
+++ b/static/resources/yaml/datadog-agent-windows-logs.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "9e6e6f38-486a-4a68-bc55-3aa343ab507d"
+  install_time: "1728322715"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,13 +204,14 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -200,22 +220,35 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -226,6 +259,8 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
@@ -242,9 +277,22 @@ spec:
               value: "5555"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: false # Need RW to mount to config path
@@ -284,9 +332,73 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+        - name: process-agent
+          image: "gcr.io/datadoghq/agent:7.57.2"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+              readOnly: true
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -302,7 +414,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -316,22 +428,27 @@ spec:
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
           resources: {}
       volumes:
         - name: auth-token
@@ -359,6 +476,8 @@ spec:
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket
+        - name: logdatadog
+          emptyDir: {}
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os

--- a/static/resources/yaml/datadog-agent-windows-vanilla.yaml
+++ b/static/resources/yaml/datadog-agent-windows-vanilla.yaml
@@ -24,6 +24,7 @@ data:
     instances:
       - collectors:
         - secrets
+        - configmaps
         - nodes
         - pods
         - services
@@ -49,6 +50,11 @@ data:
           {}
         annotations_as_tags:
           {}
+  kubernetes_apiserver.yaml: |-
+    init_config:
+    instances:
+      - filtering_enabled: false
+        unbundle_events: false
 ---
 # Source: datadog/templates/install_info-configmap.yaml
 apiVersion: v1
@@ -66,6 +72,18 @@ data:
       tool_version: kubernetes sample manifests
       installer_version: kubernetes sample manifests
 ---
+# Source: datadog/templates/kpi-telemetry-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: datadog-kpi-telemetry-configmap
+  namespace: default
+  labels: {}
+data:
+  install_type: k8s_manual
+  install_id: "8ee4a866-3817-4153-828f-815d5a1c3830"
+  install_time: "1728322715"
+---
 # Source: datadog/templates/kube-state-metrics-core-rbac.yaml
 apiVersion: "rbac.authorization.k8s.io/v1"
 kind: ClusterRole
@@ -77,6 +95,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
       - nodes
       - pods
       - services
@@ -185,13 +204,14 @@ spec:
   template:
     metadata:
       labels:
+        admission.datadoghq.com/enabled: "false"
         app: datadog
       name: datadog
       annotations: {}
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -200,22 +220,35 @@ spec:
               name: dogstatsdport
               protocol: UDP
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
             - name: DD_LOG_LEVEL
               value: "INFO"
             - name: DD_DOGSTATSD_PORT
@@ -226,6 +259,8 @@ spec:
               value: "low"
             - name: DD_LEADER_ELECTION
               value: "true"
+            - name: DD_LEADER_ELECTION_DEFAULT_RESOURCE
+              value: "configmap"
             - name: DD_COLLECT_KUBERNETES_EVENTS
               value: "true"
             - name: DD_APM_ENABLED
@@ -242,9 +277,22 @@ spec:
               value: "5555"
             - name: DD_IGNORE_AUTOCONF
               value: "kubernetes_state"
+            - name: DD_CONTAINER_LIFECYCLE_ENABLED
+              value: "true"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
             - name: DD_EXPVAR_PORT
               value: "6000"
+            - name: DD_COMPLIANCE_CONFIG_ENABLED
+              value: "false"
+            - name: DD_CONTAINER_IMAGE_ENABLED
+              value: "true"
+            - name: DD_KUBELET_CORE_CHECK_ENABLED
+              value: "true"
           volumeMounts:
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
             - name: config
               mountPath: C:/ProgramData/Datadog
               readOnly: false # Need RW to mount to config path
@@ -275,9 +323,73 @@ spec:
             periodSeconds: 15
             successThreshold: 1
             timeoutSeconds: 5
+          startupProbe:
+            failureThreshold: 6
+            httpGet:
+              path: /startup
+              port: 5555
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 5
+        - name: process-agent
+          image: "gcr.io/datadoghq/agent:7.57.2"
+          imagePullPolicy: IfNotPresent
+          command: ["process-agent", "-foreground", "--cfgpath=C:/ProgramData/Datadog/datadog.yaml"]
+          resources: {}
+          env:
+            - name: DD_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "datadog"
+                  key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
+            - name: DD_AUTH_TOKEN_FILE_PATH
+              value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
+            - name: KUBERNETES
+              value: "yes"
+            - name: DD_KUBERNETES_KUBELET_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
+            - name: DD_CLUSTER_AGENT_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED
+              value: "false"
+            - name: DD_PROCESS_CONFIG_CONTAINER_COLLECTION_ENABLED
+              value: "true"
+            - name: DD_PROCESS_AGENT_DISCOVERY_ENABLED
+              value: "true"
+            - name: DD_STRIP_PROCESS_ARGS
+              value: "false"
+            - name: DD_LOG_LEVEL
+              value: "INFO"
+            - name: DD_SYSTEM_PROBE_ENABLED
+              value: "false"
+            - name: DD_ORCHESTRATOR_EXPLORER_ENABLED
+              value: "false"
+          volumeMounts:
+            - name: config
+              mountPath: C:/ProgramData/Datadog
+              readOnly: true
+            - name: logdatadog
+              mountPath: C:/ProgramData/Datadog/logs
+              readOnly: false # Need RW to write logs
+            - name: runtimesocket
+              mountPath: \\.\pipe\docker_engine
+            - name: containerdsocket
+              mountPath: \\.\pipe\containerd-containerd
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -293,7 +405,7 @@ spec:
               readOnly: true
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.45.0"
+          image: "gcr.io/datadoghq/agent:7.57.2"
           imagePullPolicy: IfNotPresent
           command: ["pwsh", "-Command"]
           args:
@@ -307,22 +419,27 @@ spec:
             - name: containerdsocket
               mountPath: \\.\pipe\containerd-containerd
           env:
-            # Needs to be removed when Agent N-2 is built with Golang 1.17
-            - name: GODEBUG
-              value: x509ignoreCN=0
             - name: DD_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: "datadog"
                   key: api-key
+            - name: DD_REMOTE_CONFIGURATION_ENABLED
+              value: "true"
             - name: DD_AUTH_TOKEN_FILE_PATH
               value: C:/ProgramData/Datadog/auth/token
+            - name: DD_LANGUAGE_DETECTION_ENABLED
+              value: "false"
+            - name: DD_LANGUAGE_DETECTION_REPORTING_ENABLED
+              value: "false"
             - name: KUBERNETES
               value: "yes"
             - name: DD_KUBERNETES_KUBELET_HOST
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: DD_OTLP_CONFIG_LOGS_ENABLED
+              value: "false"
           resources: {}
       volumes:
         - name: auth-token
@@ -341,6 +458,8 @@ spec:
         - hostPath:
             path: \\.\pipe\containerd-containerd
           name: containerdsocket
+        - name: logdatadog
+          emptyDir: {}
       tolerations:
         - effect: NoSchedule
           key: node.kubernetes.io/os


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updating the sample manifests with latest Helm configs (`3.73.2`) and Agent version (`7.57.2`). A little outdated with last being June 2023. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->