### PR TITLE
[dbm] add sharded_data_distribution to mongos

### DIFF
--- a/layouts/shortcodes/dbm-mongodb-agent-config-sharded-cluster.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-config-sharded-cluster.md
@@ -57,6 +57,23 @@ instances:
     #
     reported_database_hostname: <DATABASE_HOSTNAME_OVERRIDE>
 
+    ## @param additional_metrics - list of strings - optional
+    ## List of additional metrics to collect. Available options are:
+    ## - metrics.commands: Use of database commands
+    ## - tcmalloc: TCMalloc memory allocator
+    ## - top: Usage statistics for each collection
+    ## - collection: Metrics of the specified collections
+    ## - jumbo_chunks: Count and percentage of jumbo chunks. Ignored on mongod instances.
+    ## - sharded_data_distribution: Distribution of data in sharded collections.
+    #
+    additional_metrics: ["metrics.commands", "tcmalloc", "top", "collection", "jumbo_chunks", "sharded_data_distribution"]
+
+    ## @param collections_indexes_stats - boolean - optional
+    ## Set to true to collect index statistics for the specified collections.
+    ## Requires `collections` to be set.
+    #
+    collections_indexes_stats: true
+
     ## @param database_autodiscovery - mapping - optional
     ## Enable database autodiscovery to automatically collect metrics from all your MongoDB databases.
     #
@@ -113,6 +130,7 @@ instances:
     cluster_name: <MONGO_CLUSTER_NAME>
     reported_database_hostname: <DATABASE_HOSTNAME_OVERRIDE>
     additional_metrics: ["metrics.commands", "tcmalloc", "top", "collection", "jumbo_chunks", "sharded_data_distribution"]
+    collections_indexes_stats: true
     database_autodiscovery:
       enabled: true
   ## Shard1

--- a/layouts/shortcodes/dbm-mongodb-agent-config-sharded-cluster.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-config-sharded-cluster.md
@@ -112,7 +112,7 @@ instances:
     dbm: true
     cluster_name: <MONGO_CLUSTER_NAME>
     reported_database_hostname: <DATABASE_HOSTNAME_OVERRIDE>
-    additional_metrics: ["metrics.commands", "tcmalloc", "top", "collection", "jumbo_chunks"]
+    additional_metrics: ["metrics.commands", "tcmalloc", "top", "collection", "jumbo_chunks", "sharded_data_distribution"]
     database_autodiscovery:
       enabled: true
   ## Shard1


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds `sharded_data_distribution` to mongodb sharded cluster configuration.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->