### PR TITLE
[MLOB-1616] Add tracer version to auto-instrumentation table

### DIFF
--- a/content/en/llm_observability/setup/auto_instrumentation.md
+++ b/content/en/llm_observability/setup/auto_instrumentation.md
@@ -16,7 +16,7 @@ further_reading:
 Datadog's [LLM Observability Python SDK][16] provides integrations that automatically trace and annotate calls to LLM frameworks and libraries. Without changing your code, you can get out-of-the-box traces and observability for calls that your LLM application makes to the following frameworks:
 
 
-| Framework                               | Supported Versions | `ddtrace` Version |
+| Framework                               | Supported Versions | Tracer Version    |
 |-----------------------------------------|--------------------|-------------------|
 | [OpenAI](#openai)                       | >= 0.26.5          | >= 2.9.0          |
 | [Langchain](#langchain)                 | >= 0.0.192         | >= 2.9.0          |

--- a/content/en/llm_observability/setup/auto_instrumentation.md
+++ b/content/en/llm_observability/setup/auto_instrumentation.md
@@ -16,12 +16,12 @@ further_reading:
 Datadog's [LLM Observability Python SDK][16] provides integrations that automatically trace and annotate calls to LLM frameworks and libraries. Without changing your code, you can get out-of-the-box traces and observability for calls that your LLM application makes to the following frameworks:
 
 
-| Framework                               | Supported Versions |
-|-----------------------------------------|--------------------|
-| [OpenAI](#openai)                       | >= 0.26.5          |
-| [Langchain](#langchain)                 | >= 0.0.192         |
-| [AWS Bedrock](#aws-bedrock)             | >= 1.31.57         |
-| [Anthropic](#anthropic)                 | >= 0.28.0          |
+| Framework                               | Supported Versions | `ddtrace` Version |
+|-----------------------------------------|--------------------|-------------------|
+| [OpenAI](#openai)                       | >= 0.26.5          | >= 2.9.0          |
+| [Langchain](#langchain)                 | >= 0.0.192         | >= 2.9.0          |
+| [AWS Bedrock](#aws-bedrock)             | >= 1.31.57         | >= 2.9.0          |
+| [Anthropic](#anthropic)                 | >= 0.28.0          | >= 2.10.0         |
 
 You can programmatically enable automatic tracing of LLM calls to a supported LLM model like OpenAI or a framework like LangChain by setting `integrations_enabled` to `true` in the `LLMOBs.enable()` function. In addition to capturing latency and errors, the integrations capture the input parameters, input and output messages, and token usage (when available) of each traced call.
 

--- a/content/en/llm_observability/setup/auto_instrumentation.md
+++ b/content/en/llm_observability/setup/auto_instrumentation.md
@@ -20,7 +20,7 @@ Datadog's [LLM Observability Python SDK][16] provides integrations that automati
 |-----------------------------------------|--------------------|-------------------|
 | [OpenAI](#openai)                       | >= 0.26.5          | >= 2.9.0          |
 | [Langchain](#langchain)                 | >= 0.0.192         | >= 2.9.0          |
-| [AWS Bedrock](#aws-bedrock)             | >= 1.31.57         | >= 2.9.0          |
+| [Amazon Bedrock](#amazon-bedrock)             | >= 1.31.57         | >= 2.9.0          |
 | [Anthropic](#anthropic)                 | >= 0.28.0          | >= 2.10.0         |
 
 You can programmatically enable automatic tracing of LLM calls to a supported LLM model like OpenAI or a framework like LangChain by setting `integrations_enabled` to `true` in the `LLMOBs.enable()` function. In addition to capturing latency and errors, the integrations capture the input parameters, input and output messages, and token usage (when available) of each traced call.
@@ -45,7 +45,7 @@ LLMObs.enable(integrations_enabled=False, ...)
 patch(<INTEGRATION_NAME_IN_LOWERCASE>=True)
 {{< /code-block >}}
 
-**Note**: Use `botocore` as the name of the [AWS Bedrock](#aws-bedrock) integration when manually enabling.
+**Note**: Use `botocore` as the name of the [Amazon Bedrock](#amazon-bedrock) integration when manually enabling.
 
 ## OpenAI
 
@@ -82,20 +82,20 @@ The LangChain integration instruments the following methods:
 
 **Note:** The LangChain integration does not yet support tracing streamed calls.
 
-## AWS Bedrock
+## Amazon Bedrock
 
-The AWS Bedrock integration provides automatic tracing for the AWS Bedrock Runtime Python SDK's chat model calls (using [Boto3][5]/[Botocore][6]).
+The Amazon Bedrock integration provides automatic tracing for the Amazon Bedrock Runtime Python SDK's chat model calls (using [Boto3][5]/[Botocore][6]).
 
 ### Traced methods
 
-The AWS Bedrock integration instruments the following methods:
+The Amazon Bedrock integration instruments the following methods:
 
 - [Chat messages][7]:
   - `InvokeModel`
 - [Streamed chat messages][8]:
   -  `InvokeModelWithResponseStream`
 
-**Note:** The AWS Bedrock integration does not yet support tracing embedding calls.
+**Note:** The Amazon Bedrock integration does not yet support tracing embedding calls.
 
 ## Anthropic
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds a tracer (`ddtrace`) version column to our auto-instrumentation table, which is the version the LLMObs auto-instrumentation was introduced to the Python tracer.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
We are not including Gemini in this PR, we'll have another PR that documents our Gemini support, and part of that PR will include the tracer version that introduced the LLMObs integration.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->