### PR TITLE
Make SFN->Lambda trace linking doc collapsable

### DIFF
--- a/content/en/serverless/step_functions/installation.md
+++ b/content/en/serverless/step_functions/installation.md
@@ -139,16 +139,19 @@ For developers using [Serverless Framework][4] to deploy serverless applications
 <div class="alert alert-warning"> If you are using a different instrumentation method such as Serverless Framework or datadog-ci, enabling autosubscription may create duplicated logs. Choose one configuration method to avoid this behavior.</div>
 
 4. Set up tags. Open your AWS console and go to your Step Functions state machine. Open the *Tags* section and add `env:<ENV_NAME>`, `service:<SERVICE_NAME>`, and `version:<VERSION>` tags. The `env` tag is required to see traces in Datadog, and it defaults to `dev`. The `service` tag defaults to the state machine's name. The `version` tag defaults to `1.0`.
-5. For Node.js and Python runtimes, you can link your Step Function traces to Lambda traces. On the Lambda Task, set the `Parameters` key with the following: 
+5. Link your Step Function traces to downstream Lambda traces<!-- or nested Step Function traces-->:
 
-   ```json
-   "Parameters": {
-     "Payload.$": "States.JsonMerge($$, $, false)",
-     ...
-   }
-   ```
+{{% collapse-content title="Link Step Function traces to downstream Lambda traces" level="h4" %}}
+For Node.js and Python runtimes, you can link your Step Function traces to Lambda traces. On the Lambda Task, set the `Parameters` key with the following: 
 
-   The `JsonMerge` [intrinsic function][6] merges the [Step Functions context object][7] (`$$`) with the original Lambda's input payload (`$`). Fields of the original payload overwrite the Step Functions context object if their keys are the same.
+```json
+"Parameters": {
+  "Payload.$": "States.JsonMerge($$, $, false)",
+  ...
+}
+```
+
+The `JsonMerge` [intrinsic function][1] merges the [Step Functions context object][2] (`$$`) with the original Lambda's input payload (`$`). Fields of the original payload overwrite the Step Functions context object if their keys are the same.
 
 **Example**:
 
@@ -185,13 +188,21 @@ Alternatively, if you have business logic defined in the payload, you could also
 
 If you have not yet instrumented your Lambda functions to send traces, you can [follow the steps to add the Lambda layer for your preferred runtime][3].
 
+[1]: https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html#asl-intrsc-func-json-manipulate
+[2]: https://docs.aws.amazon.com/step-functions/latest/dg/input-output-contextobject.html
+[3]: /logs/guide/forwarder/?tab=cloudformation#installation
+{{% /collapse-content %}} 
+
+<!--
+{{% collapse-content title="Link Step Function traces to nested Step Function traces" level="h4" %}}
+TODO
+{{% /collapse-content %}} 
+-->
+
 [1]: /logs/guide/forwarder/
 [2]: /logs/guide/forwarder/?tab=cloudformation#upgrade-to-a-new-version
-[3]: /logs/guide/forwarder/?tab=cloudformation#installation
 [4]: /getting_started/integrations/aws/
 [5]: https://app.datadoghq.com/integrations/aws
-[6]: https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html#asl-intrsc-func-json-manipulate
-[7]: https://docs.aws.amazon.com/step-functions/latest/dg/input-output-contextobject.html
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
On this page: https://docs.datadoghq.com/serverless/step_functions/installation/?tab=custom, make this part collapsable:
<img width="776" alt="image" src="https://github.com/user-attachments/assets/44ef74bd-07cd-4002-9fe2-9bf56af0fb8a">

This part is for Step Function -> Lambda trace linking. In a later PR, I'll add a section for Step Function -> Step Function trace linking. I want to make both sections collapsable to avoid making the page too long and scaring our developers.

This PR addresses comments on @cswatt  PR https://github.com/DataDog/documentation/pull/25517. Because she won't be back until Oct 21, I'm creating this new PR.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->