### PR TITLE
Adds crossorigin attribute to resources

### DIFF
--- a/layouts/partials/css.html
+++ b/layouts/partials/css.html
@@ -12,4 +12,4 @@
     {{ end }}
 {{- end -}}
 
-<link rel="stylesheet" integrity="{{ $outputStyles.Data.Integrity }}" href="{{- $outputStyles.Permalink -}}">
+<link rel="stylesheet" integrity="{{ $outputStyles.Data.Integrity }}" href="{{- $outputStyles.Permalink -}}" crossorigin="anonymous">

--- a/layouts/partials/header-scripts.html
+++ b/layouts/partials/header-scripts.html
@@ -55,7 +55,7 @@ hugo defaults to environment development with hugo server
 {{ if $isProd }}
   {{ $dd_libs_js = $dd_libs_js | fingerprint "sha512" }}
 {{ end }}
-<script type="text/javascript" src="{{ $dd_libs_js.Permalink }}" {{ if $isProd }} integrity="{{ $dd_libs_js.Data.Integrity }}" {{ end }}></script>
+<script type="text/javascript" src="{{ $dd_libs_js.Permalink }}" {{ if $isProd }} integrity="{{ $dd_libs_js.Data.Integrity }}" {{ end }} crossorigin="anonymous"></script>
 
 
 {{ $opts := dict "targetPath" "static/dd-browser-logs-rum.js" "defines" $defines "sourceMap" $sourcemap "minify" $isProd }}
@@ -69,7 +69,7 @@ hugo defaults to environment development with hugo server
   {{ if $isProd }}
     {{ $js = $js | fingerprint "sha512" }}
   {{ end }}
-  <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+  <script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }} crossorigin="anonymous"></script>
 {{ end }}
 
 {{ $opts := dict "targetPath" "static/lang-redirects.js" "defines" $defines "sourceMap" $sourcemap "minify" $isProd }}
@@ -77,11 +77,11 @@ hugo defaults to environment development with hugo server
 {{ if $isProd }}
   {{ $js = $js | fingerprint "sha512" }}
 {{ end }}
-<script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+<script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }} crossorigin="anonymous"></script>
 
 {{ $opts := dict "targetPath" "static/region-redirects.js" "defines" $defines "sourceMap" $sourcemap "minify" $isProd }}
 {{ $js := resources.Get "scripts/region-redirects.js" | js.Build $opts }}
 {{ if $isProd }}
   {{ $js = $js | fingerprint "sha512" }}
 {{ end }}
-<script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }}></script>
+<script type="text/javascript" src="{{ $js.Permalink }}" {{ if $isProd }} integrity="{{ $js.Data.Integrity }}" {{ end }} crossorigin="anonymous"></script>


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds crossorigin attribute to resources enabling CDN-hosted artifacts to be rendered by the browser out of context. This is helpful in cases where we need to verify rendered page content separate from domain config

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [X] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
Chore: No visible changes, nothing to test in preview
