### PR TITLE
Rename Azure Active Directory to Microsoft Entra ID, Part 1

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6538,9 +6538,9 @@ menu:
       identifier: account_management_saml_auth0
       parent: account_management_saml
       weight: 403
-    - name: Azure
-      url: account_management/saml/azure/
-      identifier: account_management_saml_azure
+    - name: Entra ID
+      url: account_management/saml/entra/
+      identifier: account_management_saml_entra
       parent: account_management_saml
       weight: 404
     - name: Google

--- a/content/en/account_management/saml/entra.md
+++ b/content/en/account_management/saml/entra.md
@@ -20,13 +20,13 @@ Follow the [Microsoft Entra single sign-on (SSO) integration with Datadog][1] tu
 
 1. Go to the [Datadog SAML page][3].
 
-2. Choose and upload the **SAML XML Metadata** file downloaded from Azure.
+2. Choose and upload the **SAML XML Metadata** file downloaded from Microsoft.
 
 3. You should see the messages **SAML is ready** and **Valid IdP metadata installed**:
 
     {{< img src="account_management/saml/SAML_Configuration___Datadog11.png" alt="SAML_Configuration___Datadog11" style="width:70%;">}}
 
-4. Click **Enable** to start using Azure AD single sign-on with SAML:
+4. Click **Enable** to start using Entra ID single sign-on with SAML:
 
     {{< img src="account_management/saml/SAML_Configuration___Datadog12.png" alt="SAML_Configuration___Datadog12" style="width:70%;">}}
 
@@ -38,7 +38,7 @@ If you are using SSO with a Datadog button or link, a sign-on URL is required:
 
     {{< img src="account_management/saml/SAML_Configuration___Datadog13.png" alt="SAML_Configuration___Datadog13" style="width:70%;">}}
 
-2. In Azure, navigate to the SSO Configuration section of your Azure Application, check **Show advanced URL settings**, and add your single sign-on URL.
+2. In Microsoft Entra ID, navigate to the SSO Configuration section of your application, check **Show advanced URL settings**, and add your single sign-on URL.
 
 ## Further Reading
 

--- a/content/en/account_management/saml/entra.md
+++ b/content/en/account_management/saml/entra.md
@@ -1,6 +1,7 @@
 ---
-title: Azure Active Directory SAML IdP
+title: Microsoft Entra ID SAML IdP
 aliases:
+  - /account_management/saml/azure/
   - /account_management/faq/how-do-i-configure-azure-ad-as-a-saml-idp/
 further_reading:
 - link: "/account_management/saml/"
@@ -13,7 +14,7 @@ further_reading:
 
 ## Setup
 
-Follow the [Azure Active Directory single sign-on (SSO) integration with Datadog][1] tutorial to configure Azure AD as a SAML identity provider (IdP). **Note**: An Azure AD subscription is required. If you don't have a subscription, sign up for a [free account][2].
+Follow the [Microsoft Entra single sign-on (SSO) integration with Datadog][1] tutorial to configure Entra ID as a SAML identity provider (IdP). **Note**: An Entra ID subscription is required. If you don't have a subscription, sign up for a [free account][2].
 
 ### Datadog
 
@@ -43,6 +44,6 @@ If you are using SSO with a Datadog button or link, a sign-on URL is required:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.microsoft.com/en-us/azure/active-directory/saas-apps/datadog-tutorial
+[1]: https://learn.microsoft.com/en-us/entra/identity/saas-apps/datadog-tutorial
 [2]: https://azure.microsoft.com/free/
 [3]: https://app.datadoghq.com/saml/saml_setup


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
First PR in a series of changes to rename Azure Active Directory to Microsoft Entra ID.

This PR has the following changes:
- Renames the filename of the Azure Active Directory doc for SAML setup from `azure.md` to `entra.md`
- Updates text in the Azure Active Directory doc for SAML setup to say "Microsoft Entra ID"
- Updates a few outdated links
- Creates an alias from `account_management/saml/azure/` to `account_management/saml/entra/`

A follow-on PR will update existing links in the documentation repo from `azure` to `entra`.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->