### PR TITLE
Use GCR in the Otel Agent examples

### DIFF
--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -83,6 +83,7 @@ agents:
 ...
    {{< /code-block >}}
    <div class="alert alert-info">This guide uses a Java application example. The <code>-jmx</code> suffix in the image tag enables JMX utilities. For non-Java applications, use <code>7.57.0-v1.0-ot-beta</code> instead.<br> For more details, see <a href="/containers/guide/autodiscovery-with-jmx/?tab=helm">Autodiscovery and JMX integration guide</a>.</div>
+   
    By default, the Agent image is pulled from Google Artifact Registry (`gcr.io/datadoghq`). If Artifact Registry is not accessible in your deployment region, [use another registry][53].
 1. Enable the OpenTelemetry Collector and configure the essential ports:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -83,7 +83,7 @@ agents:
 ...
    {{< /code-block >}}
    <div class="alert alert-info">This guide uses a Java application example. The <code>-jmx</code> suffix in the image tag enables JMX utilities. For non-Java applications, use <code>7.57.0-v1.0-ot-beta</code> instead.<br> For more details, see <a href="/containers/guide/autodiscovery-with-jmx/?tab=helm">Autodiscovery and JMX integration guide</a>.</div>
-   By default, the Agent image is pulled from Google Artifact Registry (<code>gcr.io/datadoghq</code>). If Artifact Registry is not accessible in your deployment region, <a href="/containers/guide/changing_container_registry/">use another registry</a>.
+   By default, the Agent image is pulled from Google Artifact Registry (`gcr.io/datadoghq`). If Artifact Registry is not accessible in your deployment region, [use another registry][53].
 1. Enable the OpenTelemetry Collector and configure the essential ports:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 datadog:
@@ -598,3 +598,4 @@ By default, the Datadog Agent with embedded Collector ships with the following C
 [50]: https://docs.docker.com/engine/install/
 [51]: https://github.com/DataDog/datadog-agent/blob/main/comp/otelcol/collector-contrib/impl/manifest.yaml#L7
 [52]: /getting_started/site/
+[53]: /containers/guide/changing_container_registry/

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -77,12 +77,13 @@ datadog:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
   image:
-    repository: datadog/agent
+    repository: gcr.io/datadoghq/agent
     tag: 7.57.0-v1.0-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
    <div class="alert alert-info">This guide uses a Java application example. The <code>-jmx</code> suffix in the image tag enables JMX utilities. For non-Java applications, use <code>7.57.0-v1.0-ot-beta</code> instead.<br> For more details, see <a href="/containers/guide/autodiscovery-with-jmx/?tab=helm">Autodiscovery and JMX integration guide</a>.</div>
+   By default, the Agent image is pulled from Google Artifact Registry (<code>gcr.io/datadoghq</code>). If Artifact Registry is not accessible in your deployment region, <a href="/containers/guide/changing_container_registry/">use another registry</a>.
 1. Enable the OpenTelemetry Collector and configure the essential ports:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 datadog:
@@ -141,7 +142,7 @@ Your `datadog-values.yaml` file should look something like this:
 {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="false" >}}
 agents:
   image:
-    repository: datadog/agent
+    repository: gcr.io/datadoghq/agent
     tag: 7.57.0-v1.0-ot-beta-jmx
     doNotCheckTag: true
 

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -187,7 +187,7 @@ datadog:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
   image:
-    repository: datadog/agent
+    repository: gcr.io/datadoghq/agent
     tag: 7.57.0-v1.0-ot-beta-jmx
     doNotCheckTag: true
 ...
@@ -251,7 +251,7 @@ Your `datadog-values.yaml` file should look something like this:
 {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="false" >}}
 agents:
   image:
-    repository: datadog/agent
+    repository: gcr.io/datadoghq/agent
     tag: 7.57.0-v1.0-ot-beta-jmx
     doNotCheckTag: true
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The GCR is a default container registry used in Datadog's Helm charts. Updating `otel-agent` docs for the consistency.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->