### PR TITLE
[CONTP-377] add docs for kubernetes resources labels/annotations as tags

### DIFF
--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -103,7 +103,349 @@ com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
 ```
 
 ## Tag extraction
+
+### Kubernetes resources labels as tags
+
+Starting with Agent v7.58+, the Agent can be configured to collect labels for any kubernetes resource and use them as tags to attach to all metrics, traces. and logs associated with the kubernetes resource.
+
+This configuration option is more generic and should be preferred over:
+- podLabelsAsTags
+- nodeLabelsAsTags
+- namespaceLabelsAsTags
+
+{{< tabs >}}
+
+{{% tab "Datadog Operator" %}}
+
+Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
+
+If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+
+
+To extract a given node label `<NODE_LABEL>` and a given deployment label `<DEPLOYMENT_LABEL>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    kubernetesResourcesLabelsAsTags:
+      nodes:
+        <NODE_LABEL>: <NODE_TAG_KEY>
+      deployments.apps:
+        <DEPLOYMENT_LABEL>: <DEPLOYMENT_TAG_KEY>
+```
+
+For example, you could set up:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    kubernetesResourcesLabelsAsTags:
+      nodes:
+       kubernetes.io/arch: arch
+      deployments.apps:
+        foo: bar
+      pods:
+        baz: qux
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all resource labels as tags to your metrics. In this example, the tags' names for statefulsets are prefixed by `<PREFIX>_`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    kubernetesResourcesLabelsAsTags:
+      statefulsets.apps:
+        "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+
+Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
+
+If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+
+To extract a given node label `<NODE_LABEL>` and a given deployment label `<DEPLOYMENT_LABEL>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Helm datadog-values.yaml file:
+
+
+```yaml
+datadog:
+  kubernetesResourcesLabelsAsTags:
+    nodes:
+      <NODE_LABEL>: <NODE_TAG_KEY>
+    deployments.apps:
+      <DEPLOYMENT_LABEL>: <DEPLOYMENT_TAG_KEY>
+```
+
+For example, you could set up:
+
+```yaml
+datadog:
+  kubernetesResourcesLabelsAsTags:
+    nodes:
+      kubernetes.io/arch: arch
+    deployments.apps:
+      foo: bar
+    pods:
+      baz: qux
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all resource labels as tags to your metrics. In this example, the tags' names for statefulsets are prefixed by `<PREFIX>_`:
+
+```yaml
+datadog:
+  kubernetesResourcesLabelsAsTags:
+    statefulsets.apps:
+      "*": <PREFIX>_%%label%%
+```
+{{% /tab %}}
+
+{{% tab "Manual (DaemonSet)" %}}
+
+Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
+
+If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+
+To extract a given node label `<NODE_LABEL>` and a given deployment label `<DEPLOYMENT_LABEL>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
+
+```bash
+ DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS='{"nodes":{"<NODE_LABEL>": "<NODE_TAG_KEY>"},"deployments.apps":{"<DEPLOYMENT_LABEL>": "<DEPLOYMENT_TAG_KEY>"}}'
+```
+
+For example, you could set up:
+
+```bash
+DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS='{"nodes":{"kubernetes.io/arch": "arch"},"deployments.apps":{"foo":"bar"},"pods":{"baz":"qux"}}'
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all resource labels as tags to your metrics. In this example, the tags' names for statefulsets are prefixed by `<PREFIX>_`:
+
+```bash
+DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS='{"statefulsets.apps":{"*": "<PREFIX>_%%label%%"}}'
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+**Notes**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
+
+<div class="alert alert-info">
+
+This configuration option is merged with other configurations set in <a href="/containers/kubernetes/tag/#pod-labels-as-tags">podLabelsAsTags</a>, <a href="/containers/kubernetes/tag/#namespace-labels-as-tags">namespaceLabelsAsTags</a> and <a href="/containers/kubernetes/tag/#node-labels-as-tags">nodeLabelsAsTags</a>. In case of conflict, <a href="/containers/kubernetes/tag/#kubernetes-resources-labels-as-tags">`kubernetesResourcesLabelsAsTags`</a> take precedence while merging the configurations.
+
+For example, if you have the following configurations:
+
+```yaml
+datadog:
+  kubernetesResourcesLabelsAsTags:
+    pods:
+      foo: bar
+      baz: qux
+
+  podLabelsAsTags:
+    foo: quux
+    bar: quuz
+```
+
+The following mapping will be used to extract tags from pod labels:
+
+```yaml
+foo: bar
+baz: qux
+bar: quuz
+```
+
+</div>
+
+{{< /tabs >}}
+
+
+### Kubernetes resources annotations as tags
+
+Starting with Agent v7.58+, the Agent can be configured to collect annotations for any kubernetes resource and use them as tags to attach to all metrics, traces. and logs associated with the kubernetes resource.
+
+This configuration option is more generic and should be preferred over:
+- podAnnotationsAsTags
+- nodeAnnotationsAsTags
+- namespaceAnnotationsAsTags
+
+{{< tabs >}}
+
+{{% tab "Datadog Operator" %}}
+
+Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
+
+If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+
+
+To extract a given node annotation `<NODE_ANNOTATION>` and a given deployment annotation `<DEPLOYMENT_ANNOTATION>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    kubernetesResourcesAnnotationsAsTags:
+      nodes:
+        <NODE_ANNOTATION>: <NODE_TAG_KEY>
+      deployments.apps:
+        <DEPLOYMENT_ANNOTATION>: <DEPLOYMENT_TAG_KEY>
+```
+
+For example, you could set up:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    kubernetesResourcesAnnotationsAsTags:
+      nodes:
+       kubernetes.io/arch: arch
+      deployments.apps:
+        foo: bar
+      pods:
+        baz: qux
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all resource annotations as tags to your metrics. In this example, the tags' names for statefulsets are prefixed by `<PREFIX>_`:
+
+```yaml
+apiVersion: datadoghq.com/v2alpha1
+kind: DatadogAgent
+metadata:
+  name: datadog
+spec:
+  global:
+    kubernetesResourcesAnnotationsAsTags:
+      statefulsets.apps:
+        "*": <PREFIX>_%%annotation%%
+```
+{{% /tab %}}
+
+{{% tab "Helm" %}}
+
+Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
+
+If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+
+To extract a given node annotation `<NODE_ANNOTATION>` and a given deployment annotation `<DEPLOYMENT_ANNOTATION>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Helm datadog-values.yaml file:
+
+
+```yaml
+datadog:
+  kubernetesResourcesAnnotationsAsTags:
+    nodes:
+      <NODE_ANNOTATION>: <NODE_TAG_KEY>
+    deployments.apps:
+      <DEPLOYMENT_ANNOTATION>: <DEPLOYMENT_TAG_KEY>
+```
+
+For example, you could set up:
+
+```yaml
+datadog:
+  kubernetesResourcesAnnotationsAsTags:
+    nodes:
+      kubernetes.io/arch: arch
+    deployments.apps:
+      foo: bar
+    pods:
+      baz: qux
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all resource annotations as tags to your metrics. In this example, the tags' names for statefulsets are prefixed by `<PREFIX>_`:
+
+```yaml
+datadog:
+  kubernetesResourcesAnnotationsAsTags:
+    statefulsets.apps:
+      "*": <PREFIX>_%%annotation%%
+```
+{{% /tab %}}
+
+{{% tab "Manual (DaemonSet)" %}}
+
+Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
+
+If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+
+To extract a given node annotation `<NODE_ANNOTATION>` and a given deployment annotation `<DEPLOYMENT_ANNOTATION>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
+
+```bash
+ DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS='{"nodes":{"<NODE_ANNOTATION>": "<NODE_TAG_KEY>"},"deployments.apps":{"<DEPLOYMENT_ANNOTATION>": "<DEPLOYMENT_TAG_KEY>"}}'
+```
+
+For example, you could set up:
+
+```bash
+DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS='{"nodes":{"kubernetes.io/arch": "arch"},"deployments.apps":{"foo":"bar"},"pods":{"baz":"qux"}}'
+```
+
+For Agent v7.24.0+, use the following environment variable configuration to add all resource annotations as tags to your metrics. In this example, the tags' names for statefulsets are prefixed by `<PREFIX>_`:
+
+```bash
+DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS='{"statefulsets.apps":{"*": "<PREFIX>_%%annotation%%"}}'
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+**Notes**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
+
+<div class="alert alert-info">
+
+This configuration option is merged with other configurations set in <a href="/containers/kubernetes/tag/#pod-annotations-as-tags">podAnnotationsAsTags</a>, <a href="/containers/kubernetes/tag/#namespace-annotations-as-tags">namespaceAnnotationsAsTags</a> and <a href="/containers/kubernetes/tag/#node-annotations-as-tags">nodeAnnotationsAsTags</a>. In case of conflict, <a href="/containers/kubernetes/tag/#kubernetes-resources-annotations-as-tags">`kubernetesResourcesAnnotationsAsTags`</a> take precedence while merging the configurations.
+
+For example, if you have the following configurations:
+
+```yaml
+datadog:
+  kubernetesResourcesAnnotationsAsTags:
+    pods:
+      foo: bar
+      baz: qux
+
+  podAnnotationsAsTags:
+    foo: quux
+    bar: quuz
+```
+
+The following mapping will be used to extract tags from pod annotations:
+
+```yaml
+foo: bar
+baz: qux
+bar: quuz
+```
+
+</div>
+
+{{< /tabs >}}
+
+
+
 ### Node labels as tags
+
+<div class="alert alert-info">
+
+If you are on agent version 7.58.0+, you are advised to use <a href="/containers/kubernetes/tag/#kubernetes-resources-labels-as-tags">Kubernetes resources labels as tags</a> to node configure labels as tags.
+
+</div>
 
 Starting with Agent v6.0+, the Agent can collect labels for a given node and use them as tags to attach to all metrics, traces, and logs emitted associated with this `host` in Datadog:
 
@@ -198,6 +540,12 @@ DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 
 ### Pod labels as tags
 
+<div class="alert alert-info">
+
+If you are on agent version 7.58.0+, you are advised to use <a href="/containers/kubernetes/tag/#kubernetes-resources-labels-as-tags">Kubernetes resources labels as tags</a> to configure pod labels as tags.
+
+</div>
+
 Starting with Agent v6.0+, the Agent can collect labels for a given pod and use them as tags to attach to all metrics, traces, and logs emitted by this pod:
 
 {{< tabs >}}
@@ -291,6 +639,12 @@ DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 
 ### Pod annotations as tags
 
+<div class="alert alert-info">
+
+If you are on agent version 7.58.0+, you are advised to use <a href="/containers/kubernetes/tag/#kubernetes-resources-labels-as-tags">Kubernetes resources labels as tags</a> to configure pod annotations as tags.
+
+</div>
+
 Starting with Agent v6.0+, the Agent can collect annotations for a given pod and use them as tags to attach to all metrics, traces, and logs emitted by this pod:
 
 {{< tabs >}}
@@ -383,6 +737,12 @@ DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS='{"*":"<PREFIX>_%%annotation%%"}'
 **Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
 ### Namespace labels as tags
+
+<div class="alert alert-info">
+
+If you are on agent version 7.58.0+, you are advised to use <a href="/containers/kubernetes/tag/#kubernetes-resources-labels-as-tags">Kubernetes resources labels as tags</a> to configure namespace labels as tags.
+
+</div>
 
 Starting with Agent 7.55.0+, the Agent can collect labels for a given namespace and use them as tags to attach to all metrics, traces, and logs emitted by all pods in this namespace:
 

--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -106,9 +106,9 @@ com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
 
 ### Kubernetes resources labels as tags
 
-Starting with Agent v7.58+, the Agent can be configured to collect labels for any kubernetes resource and use them as tags to attach to all metrics, traces. and logs associated with the kubernetes resource.
+Starting with Agent v7.58+, the Agent can be configured to collect labels for any Kubernetes resource and use them as tags to attach to all metrics, traces, and logs associated with that resource.
 
-This configuration option is more generic and should be preferred over:
+This configuration option is more generic and should be preferred over the following options:
 - podLabelsAsTags
 - nodeLabelsAsTags
 - namespaceLabelsAsTags
@@ -119,7 +119,7 @@ This configuration option is more generic and should be preferred over:
 
 Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
 
-If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+If a specific resource is in the empty API group (for example, `pods` and `nodes`), it can be specified using `resourceType`.
 
 
 To extract a given node label `<NODE_LABEL>` and a given deployment label `<DEPLOYMENT_LABEL>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
@@ -138,7 +138,7 @@ spec:
         <DEPLOYMENT_LABEL>: <DEPLOYMENT_TAG_KEY>
 ```
 
-For example, you could set up:
+For example:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -175,9 +175,9 @@ spec:
 
 Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
 
-If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+If a specific resource is in the empty API group (for example, `pods` and `nodes`), it can be specified using `resourceType`.
 
-To extract a given node label `<NODE_LABEL>` and a given deployment label `<DEPLOYMENT_LABEL>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Helm datadog-values.yaml file:
+To extract a given node label `<NODE_LABEL>` and a given deployment label `<DEPLOYMENT_LABEL>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Helm `datadog-values.yaml` file:
 
 
 ```yaml
@@ -216,7 +216,7 @@ datadog:
 
 Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
 
-If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+If a specific resource is in the empty API group (for example `pods` and `nodes`), it can be specified using `resourceType`.
 
 To extract a given node label `<NODE_LABEL>` and a given deployment label `<DEPLOYMENT_LABEL>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
@@ -258,7 +258,7 @@ datadog:
     bar: quuz
 ```
 
-The following mapping will be used to extract tags from pod labels:
+The following mapping is used to extract tags from pod labels:
 
 ```yaml
 foo: bar
@@ -273,9 +273,9 @@ bar: quuz
 
 ### Kubernetes resources annotations as tags
 
-Starting with Agent v7.58+, the Agent can be configured to collect annotations for any kubernetes resource and use them as tags to attach to all metrics, traces. and logs associated with the kubernetes resource.
+Starting with Agent v7.58+, the Agent can be configured to collect annotations for any Kubernetes resource and use them as tags to attach to all metrics, traces. and logs associated with that resource.
 
-This configuration option is more generic and should be preferred over:
+This configuration option is more generic and should be preferred over the following options:
 - podAnnotationsAsTags
 - nodeAnnotationsAsTags
 - namespaceAnnotationsAsTags
@@ -286,7 +286,7 @@ This configuration option is more generic and should be preferred over:
 
 Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
 
-If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+If a specific resource is in the empty API group (for example, `pods` and `nodes`), it can be specified using `resourceType`.
 
 
 To extract a given node annotation `<NODE_ANNOTATION>` and a given deployment annotation `<DEPLOYMENT_ANNOTATION>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Operator's `DatadogAgent` configuration in `datadog-agent.yaml`:
@@ -305,7 +305,7 @@ spec:
         <DEPLOYMENT_ANNOTATION>: <DEPLOYMENT_TAG_KEY>
 ```
 
-For example, you could set up:
+For example:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -342,7 +342,7 @@ spec:
 
 Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
 
-If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+If a specific resource is in the empty API group (for example `pods` and `nodes`), it can be specified using `resourceType`.
 
 To extract a given node annotation `<NODE_ANNOTATION>` and a given deployment annotation `<DEPLOYMENT_ANNOTATION>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following configuration to your Helm datadog-values.yaml file:
 
@@ -356,7 +356,7 @@ datadog:
       <DEPLOYMENT_ANNOTATION>: <DEPLOYMENT_TAG_KEY>
 ```
 
-For example, you could set up:
+For example:
 
 ```yaml
 datadog:
@@ -383,7 +383,7 @@ datadog:
 
 Each resource type should be specified in the format `resourceType.apiGroup`, where `resourceType` is the plural name of the resource.
 
-If a specific resource is in the empty api group (for example `pods` and `nodes`), it can be specified using `resourceType`.
+If a specific resource is in the empty api group (for example, `pods` and `nodes`), it can be specified using `resourceType`.
 
 To extract a given node annotation `<NODE_ANNOTATION>` and a given deployment annotation `<DEPLOYMENT_ANNOTATION>` and transform them as tag keys `<NODE_TAG_KEY>` and `<DEPLOYMENT_TAG_KEY>` within Datadog, add the following environment variable to the Datadog Agent:
 
@@ -425,7 +425,7 @@ datadog:
     bar: quuz
 ```
 
-The following mapping will be used to extract tags from pod annotations:
+The following mapping is used to extract tags from pod annotations:
 
 ```yaml
 foo: bar

--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -268,7 +268,6 @@ bar: quuz
 
 </div>
 
-{{< /tabs >}}
 
 
 ### Kubernetes resources annotations as tags

--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -435,8 +435,6 @@ bar: quuz
 
 </div>
 
-{{< /tabs >}}
-
 
 
 ### Node labels as tags


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates the kubernetes tag documentation page to include kubernetes resource labels and annotations as tags.

This is a new feature that was introduced in 7.58.0. ([feature PR](https://github.com/DataDog/datadog-agent/pull/27369))
 
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Should be merged when:
- The operator v1.10.0 is released

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->