### PR TITLE
Mention PHP for exception replay and dynamic instrumentation

### DIFF
--- a/content/en/dynamic_instrumentation/_index.md
+++ b/content/en/dynamic_instrumentation/_index.md
@@ -46,6 +46,7 @@ Dynamic Instrumentation requires the following:
 - For Java applications, tracing library [`dd-trace-java`][3] 1.34.0 or higher.
 - For Python applications, tracing library [`dd-trace-py`][4] 2.2.0 or higher.
 - For .NET applications, tracing library [`dd-trace-dotnet`][5] 2.54.0 or higher.
+- For PHP applications, tracing library [`dd-trace-php`][18] 1.4.0 or higher.
 - [Unified Service Tagging][6] tags `service`, `env`, and `version` are applied to your deployment.
 - Recommended, [autocomplete and search (open beta)][17] is enabled.
 - Recommended, [Source Code Integration][7] is set up for your service.
@@ -77,7 +78,7 @@ For more detailed instructions, select your runtime below:
 ### Limitations
 
 - Dynamic Instrumentation is not yet compatible with Azure App Services or serverless environments.
-- Support is limited to applications built with Python, Java, and .NET.
+- Support is limited to applications built with Python, Java, .NET and PHP.
 
 ## Explore Dynamic Instrumentation
 
@@ -223,3 +224,4 @@ You can use a *span tag probe* as an alternative to [using Custom Instrumentatio
 [15]: /dynamic_instrumentation/expression-language
 [16]: https://app.datadoghq.com/dynamic-instrumentation/setup
 [17]: /dynamic_instrumentation/symdb/
+[18]: https://github.com/DataDog/dd-trace-php

--- a/content/en/dynamic_instrumentation/enabling/php.md
+++ b/content/en/dynamic_instrumentation/enabling/php.md
@@ -21,7 +21,7 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 3. Install or upgrade the PHP tracing libraries to version 1.4.0, by following the [relevant instructions][2].
 
-   **Note**: Dynamic Instrumentation is available in the `dd-trace-php` library in versions 1.4.0 and later. Currently only function and method probes are supported.
+   **Note**: Dynamic Instrumentation is available in the `dd-trace-php` library in versions 1.4.0 and later. Only function and method probes are supported.
 
 4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your probes and target active clients across these dimensions.
 5. After starting your service with Dynamic Instrumentation enabled, you can start using Dynamic Instrumentation on the [APM > Dynamic Instrumentation page][3].

--- a/content/en/dynamic_instrumentation/enabling/php.md
+++ b/content/en/dynamic_instrumentation/enabling/php.md
@@ -1,0 +1,55 @@
+---
+title: Enable Dynamic Instrumentation for PHP
+aliases:
+    - /tracing/dynamic_instrumentation/enabling/php/
+is_beta: true
+private: false
+code_lang: php
+type: multi-code-lang
+code_lang_weight: 30
+further_reading:
+    - link: 'agent'
+      tag: 'Documentation'
+      text: 'Getting Started with Datadog Agent'
+---
+
+Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version, and go directly to enabling Dynamic Instrumentation in step 4.
+
+## Installation
+
+1. Install or upgrade your Agent to version [7.45.0][7] or higher.
+2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
+3. Install or upgrade the PHP tracing libraries to version 1.4.0, by following the [relevant instructions][2].
+
+   **Note**: Dynamic Instrumentation is available in the `dd-trace-php` library in versions 1.4.0 and later. Currently only function and method probes are supported.
+
+4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your probes and target active clients across these dimensions.
+5. After starting your service with Dynamic Instrumentation enabled, you can start using Dynamic Instrumentation on the [APM > Dynamic Instrumentation page][3].
+
+## Configuration
+
+Configure Dynamic Instrumentation using the following environment variables:
+
+| Environment variable                             | Type          | Description                                                                                                               |
+| ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `DD_DYNAMIC_INSTRUMENTATION_ENABLED`             | Boolean       | Set to `true` to enable Dynamic Instrumentation.                                                                          |
+| `DD_SERVICE`                                     | String        | The [service][4] name, for example, `web-backend`.                                                                        |
+| `DD_ENV`                                         | String        | The [environment][4] name, for example: `production`.                                                                     |
+| `DD_VERSION`                                     | String        | The [version][4] of your service.                                                                                         |
+| `DD_TAGS`                                        | String        | Tags to apply to produced data. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
+
+## What to do next
+
+See [Dynamic Instrumentation][5] for information about setting snapshot and metric probes and browsing and indexing the data.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/trace_collection/
+[2]: /tracing/trace_collection/dd_libraries/php/
+[3]: https://app.datadoghq.com/dynamic-instrumentation
+[4]: /getting_started/tagging/unified_service_tagging
+[5]: /dynamic_instrumentation/
+[7]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
+[8]: /dynamic_instrumentation/symdb/

--- a/content/en/error_tracking/backend/exception_replay.md
+++ b/content/en/error_tracking/backend/exception_replay.md
@@ -29,13 +29,14 @@ Exception Replay in APM Error Tracking automatically captures production variabl
 
 ## Requirements
 Supported languages
-: Python, Java, .NET
+: Python, Java, .NET, PHP
 
 - Your Datadog Agent must be configured for APM.
 - Your application must be instrumented with:
   - `ddtrace` for Python
   - `dd-trace-java` for Java
   - `dd-trace-dotnet` for .NET
+  - `dd-trace-php` for PHP
 
 Exception Replay is only available in APM Error Tracking. Error Tracking for Logs and RUM is not supported.
 
@@ -47,6 +48,8 @@ Exception Replay is only available in APM Error Tracking. Error Tracking for Log
    * `dd-trace-java` version `1.35.0` or higher.
    * `dd-trace-dotnet` version `2.53.0` or higher.
 4. Set the `DD_EXCEPTION_DEBUGGING_ENABLED` environment variable to `true` to run your service with Error Tracking Exception Replay enabled.
+
+For `dd-trace-php` version `1.4.0` or higher, set the `DD_EXCEPTION_REPLAY_ENABLED` environment variable to `true`.
 
 ### Redacting sensitive data
 

--- a/layouts/partials/dynamic_instrumentation/dynamic-instrumentation-languages.html
+++ b/layouts/partials/dynamic_instrumentation/dynamic-instrumentation-languages.html
@@ -30,6 +30,13 @@
           </div>
         </a>
       </div>
+      <div class="col">
+        <a class="card h-100" href="/dynamic_instrumentation/enabling/php">
+          <div class="card-body text-center py-2 px-1">
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "Dotnet" "width" "400") }}
+          </div>
+        </a>
+      </div>
     </div>
     </br>
     </div>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
With PHP 1.4 DI and exception replay are now supported.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->