### PR TITLE
Update agent_metrics_submission.md

### DIFF
--- a/content/en/metrics/custom_metrics/agent_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/agent_metrics_submission.md
@@ -42,8 +42,6 @@ self.monotonic_count(name, value, tags=None, hostname=None, device_name=None)
 
 This function submits the number of events that occurred during the check interval. It can be called multiple times during a check's execution, each sample being added to the value that is sent.
 
-**Note**: Metrics submitted with this function are stored with a `COUNT` metric type in Datadog. Each value in the stored timeseries is a delta of the metric's value between samples (not time-normalized).
-
 Function template:
 
 ```python

--- a/content/en/metrics/custom_metrics/agent_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/agent_metrics_submission.md
@@ -42,6 +42,8 @@ self.monotonic_count(name, value, tags=None, hostname=None, device_name=None)
 
 This function submits the number of events that occurred during the check interval. It can be called multiple times during a check's execution, each sample being added to the value that is sent.
 
+**Note**: Metrics submitted with this function are stored with a `COUNT` metric type in Datadog.
+
 Function template:
 
 ```python


### PR DESCRIPTION
I don't think this statement is true. I think the note is meant for monotonic_count rather than the count. The count just submits the raw submission and not the delta. 

explanation here makes more sense:
https://docs.datadoghq.com/metrics/types/?tab=count#example

Also tested with custom agent check:

```
class MyClass(AgentCheck):
    def check(self, instance):
        self.count(
            "example_metric.count",
            2,
            tags=["env:dev","metric_submission_type:count"],
        )
        self.count(
            "example_metric.count",
            5,
            tags=["env:dev","metric_submission_type:count"],
        )
```

it consistently submits 7 (2 +5)        