### PR TITLE
fix header overlap (api/) - [WEB-5393]

### DIFF
--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -72,15 +72,15 @@ $ddpurple: #632ca6;
         min-height: 500px;
 
         @include media-breakpoint-up(md) {
-            height: 600px;
+            min-height: 600px;
         }
 
         @include media-breakpoint-up(lg) {
-            height: 600px;
+            min-height: 600px;
         }
 
         @include media-breakpoint-up(xl) {
-            height: 600px;
+            min-height: 600px;
         }
     }
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

update api docs styles to fix overlapping headers.
   - wrapper for accordion should should expand and shrink when interacted with
 
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-5393
preview: https://docs-staging.datadoghq.com/stefon.simmons/fix-api-docs-heading-overlap/api/latest/synthetics/#create-a-browser-test
   - change viewport width. headers should not overlap other elements on the page. 
   - expand and collapse the accordion. headers move with the expanding element

- [x] Please merge after Corp review

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->