### PR TITLE
Add Send PR Approval Status to ignore list

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -10,3 +10,5 @@ wait_for_check_timeout_in_minutes: 120 # 2 hours (default)
 gitlab_jobs_retry_enable: true
 gitlab_fail_fast: true
 team: webops-platform
+checks_to_ignore:
+  - "Send PR Approval Status"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds the `Send PR Approval Status` job to the ignore list for merge queue. I believe the skipped jobs are causing the queue to stall
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->