### PR TITLE
Update beta flag to preview for DORA metrics

### DIFF
--- a/content/en/dora_metrics/_index.md
+++ b/content/en/dora_metrics/_index.md
@@ -29,7 +29,7 @@ further_reading:
 <div class="alert alert-warning">DORA Metrics is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-warning">DORA Metrics is in public beta.</div>
+<div class="alert alert-warning">DORA Metrics is in Preview.</div>
 
 ## Overview
 

--- a/content/en/dora_metrics/data_collected/_index.md
+++ b/content/en/dora_metrics/data_collected/_index.md
@@ -19,7 +19,7 @@ further_reading:
 <div class="alert alert-warning">DORA Metrics is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-warning">DORA Metrics is in public beta.</div>
+<div class="alert alert-warning">DORA Metrics is in Preview.</div>
 
 ## Overview
 

--- a/content/en/dora_metrics/setup/_index.md
+++ b/content/en/dora_metrics/setup/_index.md
@@ -12,7 +12,7 @@ further_reading:
 <div class="alert alert-warning">DORA Metrics is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-warning">DORA Metrics is in public beta.</div>
+<div class="alert alert-warning">DORA Metrics is in Preview.</div>
 
 ## Overview
 

--- a/content/en/dora_metrics/setup/deployments.md
+++ b/content/en/dora_metrics/setup/deployments.md
@@ -26,7 +26,7 @@ further_reading:
 <div class="alert alert-warning">DORA Metrics is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-warning">DORA Metrics is in public beta.</div>
+<div class="alert alert-warning">DORA Metrics is in Preview.</div>
 
 ## Overview
 

--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -30,7 +30,7 @@ further_reading:
 <div class="alert alert-warning">DORA Metrics is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-<div class="alert alert-warning">DORA Metrics is in public beta.</div>
+<div class="alert alert-warning">DORA Metrics is in Preview.</div>
 
 ## Overview
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates the public beta banner to say "Preview" for DORA Metrics according to the [Product Lifecycle Google Sheet](https://docs.google.com/spreadsheets/d/1a9w--iUbysCeyNDI4Hjy8H4FrOPMokpzRJYKz4zGyGo/edit?gid=0#gid=0).

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->