### PR TITLE
[DOCS-8979] Add OP info to dual ship doc

### DIFF
--- a/content/en/agent/configuration/dual-shipping.md
+++ b/content/en/agent/configuration/dual-shipping.md
@@ -218,7 +218,7 @@ DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"https://<VERSION>-app.agent.datadog
 
 ## Logs
 
-Use the Agent for dual shipping if you want to send logs to multiple Datadog organizations. Use [Observability Pipelines][2] if you want to send logs to Datadog and external destinations.
+Use the Agent if you want to dual ship logs to multiple Datadog organizations. Use [Observability Pipelines][2] if you want to send logs to Datadog and external destinations.
 
 TCP requires Agent version >= 6.6.<br/>
 HTTPS requires Agent version >= 6.13.

--- a/content/en/agent/configuration/dual-shipping.md
+++ b/content/en/agent/configuration/dual-shipping.md
@@ -19,9 +19,9 @@ Dual shipping can impact billing if you are sending data to multiple Datadog org
 
 This document provides examples of Agent configurations for dual shipping different types of data (for example, APM, logs, Cluster Agent metrics, and so on) to multiple Datadog organizations.
 
-**Note**: If you want to dual ship logs or split log traffic across different logging vendors, cloud storages, or SIEM providers, see [Observability Pipelines][2].
+**Note**: Use [Observability Pipelines][1] if you want to dual ship logs or split log traffic across different logging vendors, cloud storages, or SIEM providers.
 
-For a full list of network traffic destinations, see [Network Traffic][1].
+For a full list of network traffic destinations, see [Network Traffic][2].
 
 ## Metrics and service checks
 
@@ -527,5 +527,5 @@ To avoid exposing your API key(s) in clear text inside the `ConfigMap`, you can 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent/configuration/network/
-[2]: /observability_pipelines/
+[1]: /observability_pipelines/
+[2]: /agent/configuration/network/

--- a/content/en/agent/configuration/dual-shipping.md
+++ b/content/en/agent/configuration/dual-shipping.md
@@ -6,6 +6,9 @@ further_reading:
 - link: "/agent/configuration/network/"
   tag: "Guide"
   text: "Network Traffic"
+- link: "/observability_pipelines/"
+  tag: "documentation"
+  text: "Send logs to external destinations with Observability Pipelines"
 ---
 
 <div class="alert alert-danger">
@@ -212,6 +215,8 @@ DD_EVP_PROXY_CONFIG_ADDITIONAL_ENDPOINTS='{\"https://<VERSION>-app.agent.datadog
 ```
 
 ## Logs
+
+Use the Agent for dual shipping if you want to send logs to multiple Datadog organizations. Use [Observability Pipelines][2] if you want to send logs to Datadog and external destinations.
 
 TCP requires Agent version >= 6.6.<br/>
 HTTPS requires Agent version >= 6.13.
@@ -521,3 +526,4 @@ To avoid exposing your API key(s) in clear text inside the `ConfigMap`, you can 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /agent/configuration/network/
+[2]: /observability_pipelines/

--- a/content/en/agent/configuration/dual-shipping.md
+++ b/content/en/agent/configuration/dual-shipping.md
@@ -17,7 +17,9 @@ Dual shipping can impact billing if you are sending data to multiple Datadog org
 
 ## Overview
 
-If you wish to send data to more than one destination, such as a second Datadog organization, you can configure the Agent to send data to additional endpoints. To set up the Agent to send different kinds of data to multiple endpoints or API keys, use the configurations below.
+This document provides examples of Agent configurations for dual shipping different types of data (for example, APM, logs, Cluster Agent metrics, and so on) to multiple Datadog organizations.
+
+**Note**: If you want to dual ship logs or split log traffic across different logging vendors, cloud storages, or SIEM providers, see [Observability Pipelines][2].
 
 For a full list of network traffic destinations, see [Network Traffic][1].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Adds info about using OP for dual shipping.

[DOCS-8979](https://datadoghq.atlassian.net/browse/DOCS-8979)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8979]: https://datadoghq.atlassian.net/browse/DOCS-8979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ