### PR TITLE
[DOCS-9193] updating RH Open shift v4.x instructions

### DIFF
--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -362,11 +362,10 @@ oc exec -it <datadog cluster agent pod> -n <datadog ns> -- agent clusterchecks
 
 ### Etcd
 
-Certificates are needed to communicate with the Etcd service, which can be found in the secret `kube-etcd-client-certs` in the `openshift-monitoring` namespace. To give the Datadog Agent access to these certificates, first copy them into the same namespace the Datadog Agent is running in:
+Certificates are needed to communicate with the Etcd service, which can be found in the secret `etcd-metric-client` in the `openshift-etcd-operator` namespace. To give the Datadog Agent access to these certificates, first copy them into the same namespace the Datadog Agent is running in:
 
 ```shell
-oc get secret kube-etcd-client-certs -n openshift-monitoring -o yaml | sed 's/namespace: openshift-monitoring/namespace: <datadog agent namespace>/'  | oc create -f -
-
+oc get secret etcd-metric-client -n openshift-etcd-operator -o yaml | sed 's/namespace: openshift-etcd-operator/namespace: <datadog agent namespace>/'  | oc create -f -
 ```
 
 These certificates should be mounted on the Cluster Check Runner pods by adding the volumes and volumeMounts as below.
@@ -396,7 +395,7 @@ spec:
       volumes:
         - name: etcd-certs
           secret:
-            secretName: kube-etcd-client-certs
+            secretName: etcd-metric-client
         - name: disable-etcd-autoconf
           emptyDir: {}
 {{< /code-block >}}
@@ -410,7 +409,7 @@ clusterChecksRunner:
   volumes:
     - name: etcd-certs
       secret:
-        secretName: kube-etcd-client-certs
+        secretName: etcd-metric-client
     - name: disable-etcd-autoconf
       emptyDir: {}
   volumeMounts:
@@ -419,6 +418,7 @@ clusterChecksRunner:
       readOnly: true
     - name: disable-etcd-autoconf
       mountPath: /etc/datadog-agent/conf.d/etcd.d
+      
 {{< /code-block >}}
 
 {{% /tab %}}

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -359,8 +359,89 @@ The last annotation `ad.datadoghq.com/endpoints.resolve` is needed because the s
 oc exec -it <datadog cluster agent pod> -n <datadog ns> -- agent clusterchecks
 
 ```
-
 ### Etcd
+
+{{% collapse-content title="Etcd Openshift 4.0 - 4.13" level="h4" %}}
+Certificates are needed to communicate with the Etcd service, which can be found in the secret `kube-etcd-client-certs` in the `openshift-monitoring` namespace. To give the Datadog Agent access to these certificates, first copy them into the same namespace the Datadog Agent is running in:
+
+```shell
+oc get secret kube-etcd-client-certs -n openshift-monitoring -o yaml | sed 's/namespace: openshift-monitoring/namespace: <datadog agent namespace>/'  | oc create -f -
+
+```
+
+These certificates should be mounted on the Cluster Check Runner pods by adding the volumes and volumeMounts as below.
+
+**Note**: Mounts are also included to disable the Etcd check autoconfiguration file packaged with the agent.
+
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+
+{{< code-block lang="yaml" filename="datadog-agent.yaml" >}}
+kind: DatadogAgent
+apiVersion: datadoghq.com/v2alpha1
+metadata:
+  name: datadog
+spec:
+  override:
+    clusterChecksRunner:
+      containers:
+        agent:
+          volumeMounts:
+            - name: etcd-certs
+              readOnly: true
+              mountPath: /etc/etcd-certs
+            - name: disable-etcd-autoconf
+              mountPath: /etc/datadog-agent/conf.d/etcd.d
+      volumes:
+        - name: etcd-certs
+          secret:
+            secretName: kube-etcd-client-certs
+        - name: disable-etcd-autoconf
+          emptyDir: {}
+{{< /code-block >}}
+
+{{% /tab %}}
+{{% tab "Helm" %}}
+
+{{< code-block lang="yaml" filename="datadog-values.yaml" >}}
+...
+clusterChecksRunner:
+  volumes:
+    - name: etcd-certs
+      secret:
+        secretName: kube-etcd-client-certs
+    - name: disable-etcd-autoconf
+      emptyDir: {}
+  volumeMounts:
+    - name: etcd-certs
+      mountPath: /host/etc/etcd
+      readOnly: true
+    - name: disable-etcd-autoconf
+      mountPath: /etc/datadog-agent/conf.d/etcd.d
+{{< /code-block >}}
+
+{{% /tab %}}
+
+{{< /tabs >}}
+
+Then, annotate the service running in front of Etcd:
+
+```shell
+oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.check_names=["etcd"]'
+oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.init_configs=[{}]'
+oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.instances=[{"prometheus_url": "https://%%host%%:%%port%%/metrics", "tls_ca_cert": "/etc/etcd-certs/etcd-client-ca.crt", "tls_cert": "/etc/etcd-certs/etcd-client.crt",
+      "tls_private_key": "/etc/etcd-certs/etcd-client.key"}]'
+oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.resolve=ip'
+
+```
+
+The Datadog Cluster Agent schedules the checks as endpoint checks and dispatches them to Cluster Check Runners.
+
+{{% /collapse-content %}} 
+
+
+{{% collapse-content title="Etcd Openshift 4.14 and higher" level="h4" %}}
 
 Certificates are needed to communicate with the Etcd service, which can be found in the secret `etcd-metric-client` in the `openshift-etcd-operator` namespace. To give the Datadog Agent access to these certificates, first copy them into the same namespace the Datadog Agent is running in:
 
@@ -425,7 +506,6 @@ clusterChecksRunner:
 
 {{< /tabs >}}
 
-
 Then, annotate the service running in front of Etcd:
 
 ```shell
@@ -434,10 +514,11 @@ oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.init_conf
 oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.instances=[{"prometheus_url": "https://%%host%%:%%port%%/metrics", "tls_ca_cert": "/etc/etcd-certs/etcd-client-ca.crt", "tls_cert": "/etc/etcd-certs/etcd-client.crt",
       "tls_private_key": "/etc/etcd-certs/etcd-client.key"}]'
 oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.resolve=ip'
-
 ```
 
 The Datadog Cluster Agent schedules the checks as endpoint checks and dispatches them to Cluster Check Runners.
+
+{{% /collapse-content %}} 
 
 
 ### Controller Manager


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

In RHOCP 4.14, the `kube-etcd-client-cert` secret has been relocated from the `openshift-monitoring` namespace to the `openshift-etcd-operator` namespace, and it is named as the `etcd-metric-client` secret. Updating the OpenShift4 `etcd` instructions to reflect this

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->


- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->