### PR TITLE
Adding table for supported versions & removing note

### DIFF
--- a/content/en/database_monitoring/setup_postgres/_index.md
+++ b/content/en/database_monitoring/setup_postgres/_index.md
@@ -14,7 +14,7 @@ disable_sidebar: true
 | Postgres 13  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        |           | {{< X >}} |
 | Postgres 14  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        | {{< X >}} | {{< X >}} |
 | Postgres 15  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        | {{< X >}} | {{< X >}} |
-| Postgres 16  | {{< X >}}   | {{< X >}}  | {{< X >}}     |                  |           |           |
+| Postgres 16  | {{< X >}}   | {{< X >}}  | {{< X >}}     |                  |           | {{< X >}} |
 
 ### Setup instructions by hosting type
 

--- a/content/en/database_monitoring/setup_postgres/_index.md
+++ b/content/en/database_monitoring/setup_postgres/_index.md
@@ -3,6 +3,18 @@ title: Setting up Postgres
 description: Setting up Database Monitoring on a Postgres database
 disable_sidebar: true
 ---
+### Postgres versions supported
+
+| Version       | Self-hosted | Amazon RDS | Amazon Aurora | Google Cloud SQL | Google AlloyDB | Azure |
+|--------------|-------------|------------|---------------|------------------|---------|--------|
+| Postgres 9.6 | {{< X >}}   | {{< X >}}  | {{< X >}}     |                  |           | {{< X >}} |
+| Postgres 10  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        |           | {{< X >}} |
+| Postgres 11  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        |           | {{< X >}} |
+| Postgres 12  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        |           | {{< X >}} |
+| Postgres 13  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        |           | {{< X >}} |
+| Postgres 14  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        | {{< X >}} | {{< X >}} |
+| Postgres 15  | {{< X >}}   | {{< X >}}  | {{< X >}}     | {{< X >}}        | {{< X >}} | {{< X >}} |
+| Postgres 16  | {{< X >}}   | {{< X >}}  | {{< X >}}     |                  |           |           |
 
 ### Setup instructions by hosting type
 
@@ -11,5 +23,3 @@ To learn how to set up Database Monitoring on a Postgres database, select your h
 {{< partial name="dbm/dbm-setup-postgres" >}}
 
 <br>
-
-Note: Postgres versions 9.6-16 are supported for each hosting type, with the exception of Google Cloud SQL, which supports versions 9.6-15.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds a table for supported versions for Postgres, similar to the table on setting up MySQL: https://docs.datadoghq.com/database_monitoring/setup_mysql/#mysql-versions-supported

Table was removed previously but adding AlloyDB re-enforces that it should be there as we do not support every version for each hosting type anymore. [[Github PR](https://github.com/DataDog/documentation/pull/24910)]

Also removes the note below the icons, as it is not accurate, we’ve added support for Alloy DB since this comment.
Google Cloud also does not support 9.6 as per [this](https://docs.datadoghq.com/database_monitoring/setup_postgres/gcsql?tab=host#:~:text=Supported%20PostgreSQL%20versions)


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->