### PR TITLE
OPA-2471: de-duplicate the multiple k8s config files

### DIFF
--- a/static/resources/yaml/observability_pipelines/v2/setup/values.yaml
+++ b/static/resources/yaml/observability_pipelines/v2/setup/values.yaml
@@ -1,0 +1,47 @@
+datadog:
+  ## The site parameter is based on the Datadog site you are using.
+  ## For example, the site URL for US1 is "datadoghq.com". See Datadog Site
+  ## for more information: https://docs.datadoghq.com/getting_started/site/
+  site: "datadoghq.com"
+
+## Autoscaling
+##
+autoscaling:
+  enabled: true
+  minReplicas: 2
+  targetCPUUtilizationPercentage: 80
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+
+## HorizontalPodAutoscaler (HPA) requires resource requests to function,
+## so this example configures several default values. Datadog recommends
+## that you change the values to match the actual size of the instances that
+## you are using.
+resources:
+  requests:
+    cpu: 1000m
+    memory: 512Mi
+
+
+## To prevent a single datacenter from causing a complete system failure,
+## the topologySpreadConstraints in this example controls how OP Worker pods
+## are spread across your cluster among availability zones.
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: ScheduleAnyway
+    labelSelector:
+      matchExpressions:
+        - key: app.kubernetes.io/name
+          operator: In
+          values:
+            - observability-pipelines-worker
+
+
+## Load Balancing
+##
+service:
+  enabled: true
+  type: "ClusterIP"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

When installing a worker in obs-pipelines, if you want to deploy to k8s, you need to select a cloud provider to pick the right `values.yaml` file. 3 are available but they are exactly the same. Therefore, I'm making another copy called `values.yaml` temporarily so that we can deploy the current fix. In a later PR, I will remove the 3 other files.

With this PR, the UI will be able to point where a file that, when downloaded, its name is `values.yaml` and we can update the installation script accordingly.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->