### PR TITLE
[SFTY-1061] Remove Safety Center beta callout

### DIFF
--- a/content/en/account_management/safety_center.md
+++ b/content/en/account_management/safety_center.md
@@ -1,6 +1,5 @@
 ---
 title: Safety Center
-is_beta: true
 further_reading:
     - link: "/account_management/api-app-keys/"
       tag: "Documentation"
@@ -12,10 +11,6 @@ further_reading:
       tag: "Documentation"
       text: "OAuth Apps"
 ---
-
-{{< callout url="#" header="false" btn_hidden="true" >}}
-  Datadog Safety Center is in public beta.
-{{< /callout >}}
 
 ## Overview
 Datadog's Safety Center in **Organization Settings** is a centralized location for security alerts and best practices. [Administrators][1] of an organization can open this page to review recommendations and take action on high priority security warnings and alerts.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Safety Center is going GA, so we need to remove the beta callout from the documentation.

https://datadoghq.atlassian.net/browse/SFTY-1061

### Merge instructions

- [x] Please merge after reviewing

### Additional notes

N/A