### PR TITLE
Add resourece groups to build_live and adjust mergequeue jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,8 +157,9 @@ before_script:
 # If the branch has a name of <slack-user>/<feature-name> then ci builds a preview site
 build_preview:
   <<: *base_template
-  <<: *preview_rules
-  <<: *if_mergequeue
+  rules:
+    - !reference [.preview_rules ]
+    - !reference [.if_mergequeue ]
   stage: build
   cache:
     - *hugo_cache
@@ -211,8 +212,9 @@ build_preview:
 
 link_checks_preview:
   <<: *base_template
-  <<: *preview_rules
-  <<: *if_mergequeue
+  rules:
+    - !reference [.preview_rules ]
+    - !reference [.if_mergequeue ]
   stage: post-deploy
   cache: {}
   environment: "preview"
@@ -236,8 +238,9 @@ link_checks_preview:
 
 missing_tms_preview:
   <<: *base_template
-  <<: *preview_rules
-  <<: *if_mergequeue
+  rules:
+    - !reference [.preview_rules ]
+    - !reference [.if_mergequeue ]
   stage: post-deploy
   environment: "preview"
   allow_failure: true
@@ -447,8 +450,6 @@ test_live_link_checks:
   variables:
     URL: ${LIVE_DOMAIN}
     GIT_STRATEGY: none
-    RESOURCE_GROUP_ORDER: oldest_first
-    RESOURCE_GROUP_LIMIT: 1
   script:
     - dog --config "$HOME/.dogrc" event post "documentation htmltest ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" --alert_type "info" --tags="${DEFAULT_TAGS}"
     - find ./public -name "*.html" -exec sed -i -e "s#https://docs.datadoghq.com/#/#g" {} +
@@ -462,7 +463,6 @@ test_live_link_checks:
   artifacts:
     paths:
       - ./tmp/.htmltest
-  resource_group: build_live_group
 
 sourcemaps_live:
   <<: *base_template
@@ -479,10 +479,6 @@ sourcemaps_live:
   dependencies:
     - build_live
   allow_failure: true
-  resource_group: build_live_group
-  variables:
-    RESOURCE_GROUP_ORDER: oldest_first
-    RESOURCE_GROUP_LIMIT: 1
 
 evaluate_missing_metrics:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - bootstrap
+  - preview-test-group
   - build
   - post-deploy
   - cleanup
@@ -146,6 +147,38 @@ before_script:
       when: never
     - if: $CI_COMMIT_BRANCH != null # Variable doesnt exists on merge request pipelines or tag pipelines.
       when: on_success
+
+test_resource_groups-1:
+  <<: *base_template
+  stage: preview-test-group
+  script:
+    - echo "Testing resource group 1"
+    - echo "Starting sleep for 3 minutes..."
+    - sleep 180  # Sleep for 180 seconds (3 minutes)
+    - echo "Sleep completed"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "devin.ford/test-resource-groups"'
+      when: always
+  resource_group: build_live_group
+  variables:
+    RESOURCE_GROUP_ORDER: oldest_first
+    RESOURCE_GROUP_LIMIT: 1
+
+test_resource_groups-2:
+  <<: *base_template
+  stage: preview-test-group
+  script:
+    - echo "Testing resource group 2"
+    - echo "Starting sleep for 3 minutes..."
+    - sleep 180  # Sleep for 180 seconds (3 minutes)
+    - echo "Sleep completed"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "devin.ford/test-resource-groups"'
+      when: always
+  resource_group: build_live_group
+  variables:
+    RESOURCE_GROUP_ORDER: oldest_first
+    RESOURCE_GROUP_LIMIT: 1
 
 
 # ================== preview ================== #

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -157,7 +157,7 @@ test_resource_groups-1:
     - sleep 180  # Sleep for 180 seconds (3 minutes) 
     - echo "Sleep completed"
   rules:
-    - if: '$CI_COMMIT_BRANCH == "devin.ford/test-resource-groups"'
+    - if: '$CI_COMMIT_BRANCH =~ /devin\.ford\/test-resource-groups/'
       when: always
   resource_group: build_live_group
   variables:
@@ -173,7 +173,7 @@ test_resource_groups-2:
     - sleep 180  # Sleep for 180 seconds (3 minutes)
     - echo "Sleep completed"
   rules:
-    - if: '$CI_COMMIT_BRANCH == "devin.ford/test-resource-groups"'
+    - if: '$CI_COMMIT_BRANCH =~ /devin\.ford\/test-resource-groups/'
       when: always
   resource_group: build_live_group
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -447,14 +447,14 @@ post_build_failure_status_to_spec_repo:
 
 # Standard master build job
 build_live:
-  <<: *build_template
+  <<: *build_live_template
   <<: *live_rules
   environment: "live"
   resource_group: build_live_group
 
 # Urgent fix build job
 build_live_urgent:
-  <<: *build_template
+  <<: *build_live_template
   <<: *live_urgent_fix_rules
   environment: "live"
   resource_group: build_live_urgent_group

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,5 @@
 stages:
   - bootstrap
-  - preview-test-group
   - build
   - post-deploy
   - cleanup
@@ -120,8 +119,13 @@ before_script:
 # ==================== rules ==================== #
 .preview_rules: &preview_rules
   rules:
-    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH && $CI_COMMIT_BRANCH =~ $PREVIEW_PATTERN || $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
+    - if: $CI_COMMIT_BRANCH != $CI_DEFAULT_BRANCH && $CI_COMMIT_BRANCH =~ $PREVIEW_PATTERN 
       when: on_success
+
+.if_mergequeue: &if_mergequeue
+  rules:
+    - if: $CI_COMMIT_BRANCH =~ /^mq-working-branch-/
+      when: always
 
 .preview_manual_rules: &preview_manual_rules
   rules:
@@ -148,41 +152,13 @@ before_script:
     - if: $CI_COMMIT_BRANCH != null # Variable doesnt exists on merge request pipelines or tag pipelines.
       when: on_success
 
-test_resource_groups-1:
-  <<: *base_template
-  <<: *preview_rules
-  stage: preview-test-group
-  script:
-    - echo "Testing resource group 1"
-    - echo "Starting sleep for 3 minutes..."
-    - sleep 180  # Sleep for 180 seconds (3 minutes) 
-    - echo "Sleep completed"
-  resource_group: build_live_group
-  variables:
-    RESOURCE_GROUP_ORDER: oldest_first
-    RESOURCE_GROUP_LIMIT: 1
-
-test_resource_groups-2:
-  <<: *base_template
-  <<: *preview_rules
-  stage: preview-test-group
-  script:
-    - echo "Testing resource group 2"
-    - echo "Starting sleep for 3 minutes..."
-    - sleep 180  # Sleep for 180 seconds (3 minutes)
-    - echo "Sleep completed"
-  resource_group: build_live_group
-  variables:
-    RESOURCE_GROUP_ORDER: oldest_first
-    RESOURCE_GROUP_LIMIT: 1
-
-
 
 # ================== preview ================== #
 # If the branch has a name of <slack-user>/<feature-name> then ci builds a preview site
 build_preview:
   <<: *base_template
   <<: *preview_rules
+  <<: *if_mergequeue
   stage: build
   cache:
     - *hugo_cache
@@ -236,6 +212,7 @@ build_preview:
 link_checks_preview:
   <<: *base_template
   <<: *preview_rules
+  <<: *if_mergequeue
   stage: post-deploy
   cache: {}
   environment: "preview"
@@ -260,6 +237,7 @@ link_checks_preview:
 missing_tms_preview:
   <<: *base_template
   <<: *preview_rules
+  <<: *if_mergequeue
   stage: post-deploy
   environment: "preview"
   allow_failure: true
@@ -430,6 +408,8 @@ build_live:
     UNTRACKED_EXTRAS: "data"
     CONFIGURATION_FILE: "./local/bin/py/build/configurations/pull_config.yaml"
     LOCAL: "False"
+    RESOURCE_GROUP_ORDER: oldest_first
+    RESOURCE_GROUP_LIMIT: 1
   script:
     - dog --config "$HOME/.dogrc" event post "documentation deploy ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" --alert_type "info" --tags="${DEFAULT_TAGS}"
     - notify_slack.py "<https://github.com/DataDog/documentation/commit/${CI_COMMIT_SHA}|${CI_COMMIT_SHA:0:8}> sent to gitlab for production deployment. <${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}|details>" --status="#FFD700"
@@ -456,6 +436,7 @@ build_live:
       - ./public/redirects.txt
       - typesense.config.json
     expire_in: 1 week
+  resource_group: build_live_group
 
 test_live_link_checks:
   <<: *base_template
@@ -466,6 +447,8 @@ test_live_link_checks:
   variables:
     URL: ${LIVE_DOMAIN}
     GIT_STRATEGY: none
+    RESOURCE_GROUP_ORDER: oldest_first
+    RESOURCE_GROUP_LIMIT: 1
   script:
     - dog --config "$HOME/.dogrc" event post "documentation htmltest ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" --alert_type "info" --tags="${DEFAULT_TAGS}"
     - find ./public -name "*.html" -exec sed -i -e "s#https://docs.datadoghq.com/#/#g" {} +
@@ -479,6 +462,7 @@ test_live_link_checks:
   artifacts:
     paths:
       - ./tmp/.htmltest
+  resource_group: build_live_group
 
 sourcemaps_live:
   <<: *base_template
@@ -495,6 +479,10 @@ sourcemaps_live:
   dependencies:
     - build_live
   allow_failure: true
+  resource_group: build_live_group
+  variables:
+    RESOURCE_GROUP_ORDER: oldest_first
+    RESOURCE_GROUP_LIMIT: 1
 
 evaluate_missing_metrics:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -154,10 +154,10 @@ test_resource_groups-1:
   script:
     - echo "Testing resource group 1"
     - echo "Starting sleep for 3 minutes..."
-    - sleep 180  # Sleep for 180 seconds (3 minutes)
+    - sleep 180  # Sleep for 180 seconds (3 minutes) 
     - echo "Sleep completed"
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "devin.ford/test-resource-groups"'
+    - if: '$CI_COMMIT_BRANCH == "devin.ford/test-resource-groups"'
       when: always
   resource_group: build_live_group
   variables:
@@ -173,7 +173,7 @@ test_resource_groups-2:
     - sleep 180  # Sleep for 180 seconds (3 minutes)
     - echo "Sleep completed"
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "devin.ford/test-resource-groups"'
+    - if: '$CI_COMMIT_BRANCH == "devin.ford/test-resource-groups"'
       when: always
   resource_group: build_live_group
   variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -177,6 +177,7 @@ test_resource_groups-2:
     RESOURCE_GROUP_LIMIT: 1
 
 
+
 # ================== preview ================== #
 # If the branch has a name of <slack-user>/<feature-name> then ci builds a preview site
 build_preview:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,8 +158,8 @@ before_script:
 build_preview:
   <<: *base_template
   rules:
-    - !reference [.preview_rules ]
-    - !reference [.if_mergequeue ]
+    - !reference [.preview_rules, rules ]
+    - !reference [.if_mergequeue, rules ]
   stage: build
   cache:
     - *hugo_cache
@@ -213,8 +213,8 @@ build_preview:
 link_checks_preview:
   <<: *base_template
   rules:
-    - !reference [.preview_rules ]
-    - !reference [.if_mergequeue ]
+    - !reference [.preview_rules, rules ]
+    - !reference [.if_mergequeue, rules ]
   stage: post-deploy
   cache: {}
   environment: "preview"
@@ -239,8 +239,8 @@ link_checks_preview:
 missing_tms_preview:
   <<: *base_template
   rules:
-    - !reference [.preview_rules ]
-    - !reference [.if_mergequeue ]
+    - !reference [.preview_rules, rules ]
+    - !reference [.if_mergequeue, rules ]
   stage: post-deploy
   environment: "preview"
   allow_failure: true

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -53,6 +53,7 @@ variables:
   PREVIEW_PATTERN: '/.+?\/[a-zA-Z0-9_-]+/'
   PREVIEW_ERROR_LOG: "/go/src/github.com/DataDog/documentation/preview_error.log"
   PIP_CACHE_DIR: "${CI_PROJECT_DIR}/.pipcache/"
+  URGENT_FIX: "false" # set to true if the branch is an urgent fix to skip the build_live queue
 
 
 # ================== copy scripts =============== #
@@ -134,7 +135,12 @@ before_script:
 
 .live_rules: &live_rules
   rules:
-    - if: $CI_COMMIT_REF_NAME == "master"
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $URGENT_FIX == "false"
+      when: on_success
+
+.live_urgent_fix_rules: &live_urgent_fix_rules
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH && $URGENT_FIX == "true"
       when: on_success
 
 .live_schedule_rules: &live_schedule_rules
@@ -395,9 +401,8 @@ post_build_failure_status_to_spec_repo:
   allow_failure: true
 
 # ================== live ================== #
-build_live:
+.build_live_template: &build_live_template
   <<: *base_template
-  <<: *live_rules
   stage: build
   cache:
     - *hugo_cache
@@ -439,7 +444,20 @@ build_live:
       - ./public/redirects.txt
       - typesense.config.json
     expire_in: 1 week
+
+# Standard master build job
+build_live:
+  <<: *build_template
+  <<: *live_rules
+  environment: "live"
   resource_group: build_live_group
+
+# Urgent fix build job
+build_live_urgent:
+  <<: *build_template
+  <<: *live_urgent_fix_rules
+  environment: "live"
+  resource_group: build_live_urgent_group
 
 test_live_link_checks:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,15 +150,13 @@ before_script:
 
 test_resource_groups-1:
   <<: *base_template
+  <<: *preview_rules
   stage: preview-test-group
   script:
     - echo "Testing resource group 1"
     - echo "Starting sleep for 3 minutes..."
     - sleep 180  # Sleep for 180 seconds (3 minutes) 
     - echo "Sleep completed"
-  rules:
-    - if: '$CI_COMMIT_BRANCH =~ /devin\.ford\/test-resource-groups/'
-      when: always
   resource_group: build_live_group
   variables:
     RESOURCE_GROUP_ORDER: oldest_first
@@ -166,15 +164,13 @@ test_resource_groups-1:
 
 test_resource_groups-2:
   <<: *base_template
+  <<: *preview_rules
   stage: preview-test-group
   script:
     - echo "Testing resource group 2"
     - echo "Starting sleep for 3 minutes..."
     - sleep 180  # Sleep for 180 seconds (3 minutes)
     - echo "Sleep completed"
-  rules:
-    - if: '$CI_COMMIT_BRANCH =~ /devin\.ford\/test-resource-groups/'
-      when: always
   resource_group: build_live_group
   variables:
     RESOURCE_GROUP_ORDER: oldest_first


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Adds a resource group to `build_live` with variables to set a first in first out order
- Updates rules so mergequeue only has to run a few jobs since the checks will have been validated prior to approval

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

This PR will introduce a queue system for the `build_live` job as a follow up to `incident #31242`. The build live job is set to allow 1 job to run at a time, so as merges to `master` occur, they will join the queue if a job is already running to prevent any deployment sync issues as we experienced during the incident. This will also not prevent updates from going out in a timely fashion unlike canceling the previously running job. This will allow the build and deploy to complete prior to moving onto the next merge to master, but won't delay in a scenario where 4 PRs are merged 10 minutes apart canceling previously running builds which has resulted in over an hour for the site updates to go live, but will prevent deployments getting out of sync when a runner lags behind.

The other part of this pull request is to sure up the merge queue so that we can start to utilize it. The merge queue will build a preview site, and run the link check and missing tms jobs in order to consider it a success. Since pull requests are approved once all of those checks pass, resetting the metadata redirect info and source map in order to merge was redundant. The merge queue serves as a way to allow multiple builds to be verified and avoid and downstream conflicts that might have been unforeseen when 2 or more pull requests are merged. Usage of the merge queue is fairly straight forward and in most cases once all approvals and checks have passed and been made, `/merge` in a comment will add the PR to the queue and merge as long as the jobs all pass in CI. 

This should speed things up a bit and fix some painpoints around dual codeowners since the merge queue will not run if all required approvals are not on the pull request. This will also allow internal contributors to merge pull requests once approvals and checks have passed (this can be disabled if needed and pinpointed to a certain team or teams). A confluence document from the webops team will also be created outlining these things, how to leverage it, and what changes have been made around deployments as well.

For more detailed information on how the merge queue works, and how to use it please see the [confluence](https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue). 

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

### Resource group related testing/info

Initial push to a test job created to validate the functionality of resource groups: https://gitlab.ddbuild.io/DataDog/documentation/-/pipelines/46294992

Second pipeline, not the queue time at the top:
https://gitlab.ddbuild.io/DataDog/documentation/-/pipelines/46295052

Screenshot of second pipeline with notification that it was waiting for the resource:
![image](https://github.com/user-attachments/assets/15e4976a-7801-4159-bc56-ec53980fdcc7)

### Mergequeue related testing/info
Test PR 1: https://github.com/DataDog/documentation/pull/25657
Test PR 2: https://github.com/DataDog/documentation/pull/25656

You'll see the queue notifies me that it is watiing for approvals/checks before merging (this was also a config issue with the repo at first that I had the devflow team help out with to fix)

Gitlab runners for mq (this ran all jobs prior to the adjustment in this PR):
https://gitlab.ddbuild.io/DataDog/documentation/-/pipelines/46281801
https://gitlab.ddbuild.io/DataDog/documentation/-/pipelines/46281780