### PR TITLE
Small fix to improve page search-ability for Graal NI profiling

### DIFF
--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -129,9 +129,9 @@ java \
 {{% /tab %}}
 {{< /tabs >}}
 
-{{% collapse-content title="(Optional) Build and run native-image" level="h4" %}}
+{{% collapse-content title="(Optional) Build and run Graal native-image" level="h4" %}}
 
-Follow the [Tracer Setup Instructions][14] to build your native image with the Datadog Java Profiler.
+Follow the [Tracer Setup Instructions][14] to build your Graal native image with the Datadog Java Profiler.
 
 When the service binary is built, you can use environment variables to enable and configure the Datadog Java Profiler:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
After some discussion with customers and @r1viollet + @jbachorik, we've decided to add the full name of the tool to the profiling page (which links to the tracer page's instructions on using Graal NI) to aid with search discovery for profiling customers .

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->