### PR TITLE
Update 128-bit trace id instructions

### DIFF
--- a/content/en/tracing/guide/send_traces_to_agent_by_api.md
+++ b/content/en/tracing/guide/send_traces_to_agent_by_api.md
@@ -58,7 +58,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource` and so on
 | `service`    | string  | The service you are tracing. The service name must not be longer than 100 characters. |
 | `span_id`    | int64   | The span integer (64-bit unsigned) ID. |
 | `start`      | int64   | The start time of the request in nanoseconds from the UNIX epoch. |
-| `trace_id`   | int64 or int128   | The unique integer (64-bit unsigned or 128-bit unsigned) ID of the trace containing this span. |
+| `trace_id`   | int64   | The lower 64-bits of the unique integer ID of the trace containing this span. Set any upper 64-bits by setting the tag `_dd.p.tid` in hex-encoded lowercase. |
 | `type`       | enum    | The type of request. Allowed enum values: `web`, `db`, `cache`, `custom` |
 
 

--- a/content/en/tracing/guide/send_traces_to_agent_by_api.md
+++ b/content/en/tracing/guide/send_traces_to_agent_by_api.md
@@ -58,7 +58,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource` and so on
 | `service`    | string  | The service you are tracing. The service name must not be longer than 100 characters. |
 | `span_id`    | int64   | The span integer (64-bit unsigned) ID. |
 | `start`      | int64   | The start time of the request in nanoseconds from the UNIX epoch. |
-| `trace_id`   | int64   | The lower 64-bits of the unique integer ID of the trace containing this span. Set any upper 64-bits by setting the tag `_dd.p.tid` in hex-encoded lowercase in `meta`. |
+| `trace_id`   | int64   | The lower 64-bits of the unique integer ID of the trace containing this span. For a 128-bit trace ID set the upper 64-bits on the tag `_dd.p.tid` in hex-encoded lowercase in `meta`. |
 | `type`       | enum    | The type of request. Allowed enum values: `web`, `db`, `cache`, `custom` |
 
 

--- a/content/en/tracing/guide/send_traces_to_agent_by_api.md
+++ b/content/en/tracing/guide/send_traces_to_agent_by_api.md
@@ -58,7 +58,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource` and so on
 | `service`    | string  | The service you are tracing. The service name must not be longer than 100 characters. |
 | `span_id`    | int64   | The span integer (64-bit unsigned) ID. |
 | `start`      | int64   | The start time of the request in nanoseconds from the UNIX epoch. |
-| `trace_id`   | int64   | The lower 64-bits of the unique integer ID of the trace containing this span. For a 128-bit trace ID set the upper 64-bits on the tag `_dd.p.tid` in hex-encoded lowercase in `meta`. |
+| `trace_id`   | int64   | The lower 64 bits of the unique integer ID for the trace containing this span. For a 128-bit trace ID, set the upper 64 bits using the `_dd.p.tid` tag in hex-encoded lowercase format in the `meta` field. |
 | `type`       | enum    | The type of request. Allowed enum values: `web`, `db`, `cache`, `custom` |
 
 

--- a/content/en/tracing/guide/send_traces_to_agent_by_api.md
+++ b/content/en/tracing/guide/send_traces_to_agent_by_api.md
@@ -58,7 +58,7 @@ and each span is a dictionary with a `trace_id`, `span_id`, `resource` and so on
 | `service`    | string  | The service you are tracing. The service name must not be longer than 100 characters. |
 | `span_id`    | int64   | The span integer (64-bit unsigned) ID. |
 | `start`      | int64   | The start time of the request in nanoseconds from the UNIX epoch. |
-| `trace_id`   | int64   | The lower 64-bits of the unique integer ID of the trace containing this span. Set any upper 64-bits by setting the tag `_dd.p.tid` in hex-encoded lowercase. |
+| `trace_id`   | int64   | The lower 64-bits of the unique integer ID of the trace containing this span. Set any upper 64-bits by setting the tag `_dd.p.tid` in hex-encoded lowercase in `meta`. |
 | `type`       | enum    | The type of request. Allowed enum values: `web`, `db`, `cache`, `custom` |
 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Update the documentation here to indicate that 128-bit trace IDs must be split across the trace ID field and the tag `_dd.p.tid`

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->