### PR TITLE
Fix links on webview page

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
@@ -133,7 +133,7 @@ Set up the RUM Browser SDK on the web page you want rendered on your mobile appl
 
 #### Kotlin Multiplatform
 
-Add `DatadogWebViewTracking` library to your application by following the guide [here][7].
+Add `DatadogWebViewTracking` library to your application by following the guide [here][5].
 
 ### Instrument your web views
 
@@ -294,7 +294,7 @@ Note that `JavaScriptMode.unrestricted` is required for tracking to work on Andr
 
 ### Access your web views
 
-Your web views appear in the [RUM Explorer][1] with associated `service` and `source` attributes. The `service` attribute indicates the web component the web view is generated from, and the `source` attribute denotes the mobile application's platform, such as Android.
+Your web views appear in the [RUM Explorer][6] with associated `service` and `source` attributes. The `service` attribute indicates the web component the web view is generated from, and the `source` attribute denotes the mobile application's platform, such as Android.
 
 To access your web views:
 
@@ -313,7 +313,7 @@ From here, you can hover over a session event and click **Open View waterfall** 
 
 ## Billing implications
 
-See [RUM & Session Replay Billing][3] for details on how web views in mobile applications impact session recordings and billing.
+See [RUM & Session Replay Billing][7] for details on how web views in mobile applications impact session recordings and billing.
 
 ## Further Reading
 
@@ -321,8 +321,8 @@ See [RUM & Session Replay Billing][3] for details on how web views in mobile app
 
 [1]: /real_user_monitoring/session_replay/mobile/setup_and_configuration
 [2]: /real_user_monitoring/browser/setup/#npm
-[3]: /real_user_monitoring/ios/
+[3]: /real_user_monitoring/mobile_and_tv_monitoring/setup
 [4]: /logs/log_collection/ios
-[5]: https://app.datadoghq.com/rum/explorer
-[6]: /account_management/billing/rum/#how-do-webviews-in-mobile-applications-impact-session-recordings-and-billing
-[7]: /real_user_monitoring/mobile_and_tv_monitoring/setup/kotlin-multiplatform/#add-native-dependencies-for-ios
+[5]: /real_user_monitoring/mobile_and_tv_monitoring/setup/kotlin-multiplatform/#add-native-dependencies-for-ios
+[6]: https://app.datadoghq.com/rum/explorer
+[7]: /account_management/billing/rum/#how-do-webviews-in-mobile-applications-impact-session-recordings-and-billing

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
@@ -319,7 +319,7 @@ See [RUM & Session Replay Billing][7] for details on how web views in mobile app
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /real_user_monitoring/session_replay/mobile/setup_and_configuration
+[1]: /real_user_monitoring/session_replay/mobile/setup_and_configuration/#web-view-instrumentation
 [2]: /real_user_monitoring/browser/setup/#npm
 [3]: /real_user_monitoring/mobile_and_tv_monitoring/setup
 [4]: /logs/log_collection/ios


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
As per [DOCS-9243](https://datadoghq.atlassian.net/browse/DOCS-9243), the links on the mobile RUM webviews page were not lining up correctly and this PR fixes that.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-9243]: https://datadoghq.atlassian.net/browse/DOCS-9243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ