### PR TITLE
Bumps lambda-datadog Terraform Module Version to 1.5.0 and Datadog Lambda Layers to Latest Supported Versions

### DIFF
--- a/content/en/serverless/aws_lambda/installation/dotnet.md
+++ b/content/en/serverless/aws_lambda/installation/dotnet.md
@@ -200,7 +200,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.3.0"
+  version = "1.5.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -210,8 +210,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 58
-  datadog_dotnet_layer_version = 15
+  datadog_extension_layer_version = 65
+  datadog_dotnet_layer_version = 16
 
   # aws_lambda_function arguments
 }
@@ -236,8 +236,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog .NET Lambda layer to use. Defaults to the latest layer versions.
 
 ```
-  datadog_extension_layer_version = 58
-  datadog_dotnet_layer_version = 15
+  datadog_extension_layer_version = 65
+  datadog_dotnet_layer_version = 16
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/java.md
+++ b/content/en/serverless/aws_lambda/installation/java.md
@@ -273,7 +273,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.3.0"
+  version = "1.5.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -283,7 +283,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 58
+  datadog_extension_layer_version = 65
   datadog_java_layer_version = 15
 
   # aws_lambda_function arguments
@@ -309,7 +309,7 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Java Lambda layer to use. If left blank the latest layer versions will be used.
 
 ```
-  datadog_extension_layer_version = 58
+  datadog_extension_layer_version = 65
   datadog_java_layer_version = 15
 ```
 

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -266,7 +266,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.3.0"
+  version = "1.5.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -276,8 +276,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 58
-  datadog_node_layer_version = 112
+  datadog_extension_layer_version = 65
+  datadog_node_layer_version = 115
 
   # aws_lambda_function arguments
 }
@@ -302,8 +302,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Node.js Lambda layer to use. Defaults to the latest layer versions.
 
 ```
-  datadog_extension_layer_version = 58
-  datadog_node_layer_version = 112
+  datadog_extension_layer_version = 65
+  datadog_node_layer_version = 115
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -257,7 +257,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "1.3.0"
+  version = "1.5.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -267,8 +267,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 58
-  datadog_python_layer_version = 96
+  datadog_extension_layer_version = 65
+  datadog_python_layer_version = 99
 
   # aws_lambda_function arguments
 }
@@ -293,8 +293,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Python Lambda layer to use. If left blank the latest layer versions will be used.
 
 ```
-  datadog_extension_layer_version = 58
-  datadog_python_layer_version = 96
+  datadog_extension_layer_version = 65
+  datadog_python_layer_version = 99
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Bumps the lambda-datadog Terraform module version to 1.5.0 and updates the Datadog Lambda Layers to the latest supported versions.

- https://github.com/DataDog/terraform-aws-lambda-datadog/pull/21
- https://github.com/DataDog/terraform-aws-lambda-datadog/pull/18

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->