### PR TITLE
Add PHP to resource_based_sampling and adaptive_sampling guide

### DIFF
--- a/content/en/tracing/guide/adaptive_sampling.md
+++ b/content/en/tracing/guide/adaptive_sampling.md
@@ -51,7 +51,7 @@ The following table lists minimum tracing library versions required for Adaptive
 | Node.js     | [v5.16.0][12]            |
 | .NET        | [v2.54.0][13]            |
 | C++/Proxies | [v0.2.2][14]             |
-| PHP         |  Not available           |
+| PHP         | [v1.4.0][17]             |
 
 ## View sampling rates by resource
 
@@ -112,3 +112,4 @@ The configuration should take effect in 5-6 minutes, the time it takes for Datad
 [14]: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.2.2
 [15]: /tracing/guide/resource_based_sampling/
 [16]: /tracing/trace_pipeline/ingestion_controls
+[17]: https://github.com/DataDog/dd-trace-php/releases/tag/1.4.0

--- a/content/en/tracing/guide/resource_based_sampling.md
+++ b/content/en/tracing/guide/resource_based_sampling.md
@@ -37,7 +37,7 @@ Go        | [v1.64.0][6]
 Python    | [v.2.9.0][10]
 Ruby      | [v2.0.0][11]
 Node.js   | [v5.16.0][12]
-PHP       | _Coming soon_
+PHP       | [v1.4.0][15]
 .NET      | [v.2.53.2][13]
 C++       | [v0.2.2][14]
 
@@ -85,3 +85,4 @@ From the **Service Ingestion Summary**, resources for which the sampling rate ar
 [12]: https://github.com/DataDog/dd-trace-js/releases/tag/v5.16.0
 [13]: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.53.2
 [14]: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.2.2
+[15]: https://github.com/DataDog/dd-trace-php/releases/tag/1.4.0


### PR DESCRIPTION
It's available since 1.4.0.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->