### PR TITLE
Update otel_collector_datadog_exporter.md

### DIFF
--- a/content/en/opentelemetry/collector_exporter/otel_collector_datadog_exporter.md
+++ b/content/en/opentelemetry/collector_exporter/otel_collector_datadog_exporter.md
@@ -102,9 +102,9 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [hostmetrics, prometheus, otlp]
+      receivers: [hostmetrics, prometheus, otlp, datadog/connector]
       processors: [batch]
-      exporters: [datadog]
+      exporters: [datadog/exporter]
     traces:
       receivers: [otlp]
       processors: [batch]
@@ -112,7 +112,7 @@ service:
     logs:
       receivers: [otlp, filelog]
       processors: [batch]
-      exporters: [datadog]
+      exporters: [datadog/exporter]
 ```
 
 The above configuration enables the receiving of OTLP data from OpenTelemetry instrumentation libraries over HTTP and gRPC, and sets up a [batch processor][5], which is mandatory for any non-development environment. Note that you may get `413 - Request Entity Too Large` errors if you batch too much telemetry data in the batch processor.


### PR DESCRIPTION
modifying example otelcol config so that the exporters are all set as `datadog/exporter`, and adding `datadog/connector` to metrics pipeline

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing