### PR TITLE
(DOCS-9263) Add log archives note

### DIFF
--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -53,7 +53,7 @@ To set up the AWS integration manually, create an IAM policy and IAM role in you
 
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">
-  To set up <strong>Log Archives</strong> with an AWS Integration using Role Delegation, contact <a href="https://docs.datadoghq.com/help/">Datadog Support</a>.
+  To set up <strong>Log Archives</strong> with an AWS integration using Role Delegation, contact <a href="https://docs.datadoghq.com/help/">Datadog Support</a>.
 </div>
 {{< /site-region >}}
 

--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -51,6 +51,12 @@ Use this guide to manually set up the Datadog [AWS Integration][1].
 
 To set up the AWS integration manually, create an IAM policy and IAM role in your AWS account, and configure the role with an AWS External ID generated in your Datadog account. This allows Datadog's AWS account to query AWS APIs on your behalf, and pull data into your Datadog account. The sections below detail the steps for creating each of these components, and then completing the setup in your Datadog account.
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">
+  To set up <strong>Log Archives</strong> with an AWS Integration using Role Delegation, contact <a href="https://docs.datadoghq.com/help/">Datadog Support</a>.
+</div>
+{{< /site-region >}}
+
 ## Setup
 
 ### Generate an external ID

--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -53,7 +53,7 @@ To set up the AWS integration manually, create an IAM policy and IAM role in you
 
 {{< site-region region="gov" >}}
 <div class="alert alert-warning">
-  To set up <strong>Log Archives</strong> with an AWS integration using Role Delegation, contact <a href="https://docs.datadoghq.com/help/">Datadog Support</a>.
+  <em>Setting up S3 Log Archives using Role Delegation is currently in limited availability. Contact <a href="https://docs.datadoghq.com/help/">Datadog Support</a> to request this feature in your Datadog for Government account</em>.
 </div>
 {{< /site-region >}}
 

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -44,18 +44,15 @@ See how to [archive your logs with Observability Pipelines][4] if you want to ro
 {{< tabs >}}
 {{% tab "AWS S3" %}}
 
-1. If not already configured, set up the [AWS integration][1] for the AWS account that holds your S3 bucket.
+{{< site-region region="gov" >}}
+<div class="alert alert-warning"><em>Setting up S3 Archives using Role Delegation is currently in limited availability. Contact <a href="https://docs.datadoghq.com/help/">Datadog Support</a> to request this feature in your Datadog for Government account</em>.</div>
+{{< /site-region >}}
+
+If not already configured, set up the [AWS integration][1] for the AWS account that holds your S3 bucket.
    * In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
    * Specifically for AWS China accounts, use access keys as an alternative to role delegation.
 
-{{< site-region region="gov" >}}
-2. To set up Log Archives with an AWS integration using **Role Delegation**, contact [Datadog Support][101].
-
-[101]: /help/
-{{< /site-region >}}
-
 [1]: /integrations/amazon_web_services/?tab=automaticcloudformation#setup
-
 {{% /tab %}}
 {{% tab "Azure Storage" %}}
 

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -44,16 +44,18 @@ See how to [archive your logs with Observability Pipelines][4] if you want to ro
 {{< tabs >}}
 {{% tab "AWS S3" %}}
 
+1. If not already configured, set up the [AWS integration][1] for the AWS account that holds your S3 bucket.
+   * In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
+   * Specifically for AWS China accounts, use access keys as an alternative to role delegation.
+
 {{< site-region region="gov" >}}
-<div class="alert alert-warning">AWS Role Delegation is not supported on the Datadog for Government site. Access keys must be used.</div>
+2. To set up Log Archives with an AWS integration using **Role Delegation**, contact [Datadog Support][101].
+
+[101]: /help/
 {{< /site-region >}}
 
-If not already configured, set up the [AWS integration][1] for the AWS account that holds your S3 bucket.
-
-* In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
-* Specifically for AWS GovCloud or China accounts, use access keys as an alternative to role delegation.
-
 [1]: /integrations/amazon_web_services/?tab=automaticcloudformation#setup
+
 {{% /tab %}}
 {{% tab "Azure Storage" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- Add information about setting up log archives with the AWS integration using role delegation for US1-FED users
- Remove outdated warnings about role delegation not being supported for US1-FED users

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->