### PR TITLE
[RUM-6587] mention the Host header in RUM proxy guide

### DIFF
--- a/content/en/real_user_monitoring/guide/proxy-rum-data.md
+++ b/content/en/real_user_monitoring/guide/proxy-rum-data.md
@@ -19,8 +19,9 @@ To successfully forward a request to Datadog, your proxy must
 
 1. [Build the Datadog intake URL](#build-the-datadog-intake-url).
 2. Add an `X-Forwarded-For` header containing the request client IP address for accurate geoIP.
-3. Forward the request to the Datadog intake URL using the POST method.
-4. Leave the request body unchanged.
+3. Remove the `Host` header or set it to Datadog intake URL's host (ex: `browser-intake-datadoghq.com`) (your HTTP client will probably add it automatically).
+4. Forward the request to the Datadog intake URL using the POST method.
+5. Leave the request body unchanged.
 
 <div class="alert alert-warning">
 <ul>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Document how to define the Host header when implementing a RUM data proxy. When this header is kept from the customer's proxy request, the request will fail with SSL errors.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->