### PR TITLE
[DJM K8s documentation] Remove two old host tags

### DIFF
--- a/content/en/data_jobs/kubernetes.md
+++ b/content/en/data_jobs/kubernetes.md
@@ -60,8 +60,6 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
          enabled: true
          mutateUnlabelled: false
      global:
-       tags:
-         - 'data_workload_monitoring_trial:true'
        site: <DATADOG_SITE>
        credentials:
          apiSecret:
@@ -74,9 +72,6 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
        nodeAgent:
          image:
            tag: <DATADOG_AGENT_VERSION>
-         env:
-           - name: DD_DJM_CONFIG_ENABLED
-             value: "true"
    ```
    Replace `<DATADOG_SITE>` with your [Datadog site][5]. Your site is {{< region-param key="dd_site" code="true" >}}. (Ensure the correct SITE is selected on the right).
 
@@ -109,11 +104,6 @@ You can install the Datadog Agent using the [Datadog Operator][3] or [Helm][4].
      apm:
        portEnabled: true
        port: 8126
-     tags:
-       - 'data_workload_monitoring_trial:true'
-     env:
-       - name: DD_DJM_CONFIG_ENABLED
-         value: "true"
 
    agents:
      image:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Remove two old host tags we used to ask customers to add to their `datadog.yaml` . They were used for billing but we are moving to a different billing logic, emitting the metric at spans ingestion.

These host tags are thus no longer requried and are adding confusion in DJM customer support workflow.

Please note that we are not ready yet to merge the PR!

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->