### PR TITLE
docs: remove reference to beta in FIPS documentation

### DIFF
--- a/content/en/agent/configuration/agent-fips-proxy.md
+++ b/content/en/agent/configuration/agent-fips-proxy.md
@@ -32,14 +32,12 @@ The Datadog Agent FIPS Proxy's compliance is based on its use of the FIPS 140-2 
 
 **It is your responsibility to ensure operating environment compliance with the security policy and wider FIPS guidance.**
 
-Supported platforms (64-bit x86):
+Supported platforms:
 
 |||
 | ---  | ----------- |
-| Bare metal and VMs | RHEL >= 7<br>Debian >= 8<br>Ubuntu >= 14.04<br>SUSE >= 12 (beta)|
+| Bare metal and VMs | RHEL >= 7<br>Debian >= 8<br>Ubuntu >= 14.04<br>SUSE >= 12|
 | Cloud and container| Amazon ECS<br>AWS EKS (Helm)|
-
-**Note**: arm64 architecture is available in beta
 
 Supported products (Agent 7.45+):
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Remove references to beta in the FIPS documentation

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->