### PR TITLE
Add details for GKE Autopilot compute class + cleanup

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -294,9 +294,9 @@ providers:
 {{% /tab %}}
 {{< /tabs >}}
 
-### Spot pods and compute Classes
+### Spot pods and compute classes
 
-Using [Spot Pods][10] in GKE Autopilot clusters introduces [Taints][9] to the corresponding Spot GKE nodes. When using Spot Pods, additional configuration is required to provide the Agent DaemonSet with a matching Toleration.
+Using [Spot Pods][10] in GKE Autopilot clusters introduces [taints][9] to the corresponding Spot GKE nodes. When using Spot Pods, additional configuration is required to provide the Agent DaemonSet with a matching toleration.
 
 {{< tabs >}}
 {{% tab "Helm" %}}
@@ -313,7 +313,7 @@ agents:
 {{% /tab %}}
 {{< /tabs >}}
 
-Similarly when using [GKE Autopilot Compute classes][11] to run workloads that have specific hardware requirements, take note of the [Taints][9] that GKE Autopilot is applying to these specific nodes and add matching Tolerations to the Agent DaemonSet. You can match the Tolerations on your corresponding pods. For example for the `Scale-Out` compute class use a Toleration like:
+Similarly when using [GKE Autopilot Compute classes][11] to run workloads that have specific hardware requirements, take note of the [taints][9] that GKE Autopilot is applying to these specific nodes and add matching tolerations to the Agent DaemonSet. You can match the tolerations on your corresponding pods. For example for the `Scale-Out` compute class use a toleration like:
 
 {{< tabs >}}
 {{% tab "Helm" %}}

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -243,6 +243,8 @@ GKE Autopilot requires some configuration, shown below.
 
 Datadog recommends that you specify resource limits for the Agent container. Autopilot sets a relatively low default limit (50m CPU, 100Mi memory) that may lead the Agent container to quickly OOMKill depending on your environment. If applicable, also specify resource limits for the Trace Agent and Process Agent containers. Additionally, you may wish to create a priority class for the Agent to ensure it is scheduled.
 
+**Note**: Network Performance Monitoring is not supported for GKE Autopilot.
+
 {{< tabs >}}
 {{% tab "Helm" %}}
 
@@ -292,30 +294,11 @@ providers:
 {{% /tab %}}
 {{< /tabs >}}
 
-### Spot pods and instances
+### Spot pods and compute Classes
 
-Using Spot Pods in GKE Autopilot clusters introduces taints to these GKE nodes. To use Spot Pods, additional configuration is required to provide the Datadog Agent with tolerations.
+Using [Spot Pods][10] in GKE Autopilot clusters introduces [Taints][9] to the corresponding Spot GKE nodes. When using Spot Pods, additional configuration is required to provide the Agent DaemonSet with a matching Toleration.
 
 {{< tabs >}}
-{{% tab "Datadog Operator" %}}
-```yaml
-apiVersion: datadoghq.com/v2alpha1
-kind: DatadogAgent
-metadata:
-  name: datadog
-spec:
-  global:
-    credentials:
-      apiKey: <DATADOG_API_KEY>
-  override:
-    nodeAgent:
-      tolerations:
-        - effect: NoSchedule
-          key: cloud.google.com/gke-spot
-          operator: Equal
-          value: "true"
-```
-{{% /tab %}}
 {{% tab "Helm" %}}
 ```yaml
 agents:
@@ -330,7 +313,22 @@ agents:
 {{% /tab %}}
 {{< /tabs >}}
 
-**Note**: Network Performance Monitoring is not supported for GKE Autopilot.
+Similarly when using [GKE Autopilot Compute classes][11] to run workloads that have specific hardware requirements, take note of the [Taints][9] that GKE Autopilot is applying to these specific nodes and add matching Tolerations to the Agent DaemonSet. You can match the Tolerations on your corresponding pods. For example for the `Scale-Out` compute class use a Toleration like:
+
+{{< tabs >}}
+{{% tab "Helm" %}}
+```yaml
+agents:
+  #(...)
+  # agents.tolerations -- Allow the DaemonSet to schedule on tainted nodes (requires Kubernetes >= 1.6)
+  tolerations:
+  - effect: NoSchedule
+    key: cloud.google.com/compute-class
+    operator: Equal
+    value: Scale-Out
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Red Hat OpenShift {#Openshift}
 
@@ -611,3 +609,6 @@ agents:
 [6]: /agent/guide/operator-eks-addon
 [7]: /containers/kubernetes/apm/?tab=tcp
 [8]: /tracing/guide/setting_up_apm_with_kubernetes_service
+[9]: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
+[10]: https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-spot-pods
+[11]: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-compute-classes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
GKE Autopilot supports compute classes for dedicated hardware, and like their GKE Spot Pods, sort of silently manages these with Tainted nodes. Autopilot will automatically add Tolerations to the workloads you specify, however, you need to do this manually to the Agent. 

https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-compute-classes

Additionally does some minor cleanup and removes the Operator steps for Spot Pods, since the Operator does not support Autopilot anyway. 

From customer requests.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->