### PR TITLE
Adjust feature flags collection docs

### DIFF
--- a/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
+++ b/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
@@ -29,11 +29,9 @@ Feature flag tracking is available in the RUM Browser SDK. To start, set up [RUM
 <details>
   <summary>Before <code>v5.17.0</code></summary>
 
-If you are using a version anterior to 5.17.0, initialize the RUM SDK and configure the `enableExperimentalFeatures` initialization parameter with ` ["feature_flags"]` to start collecting feature flag data.
+If you are using a version previous to 5.17.0, initialize the RUM SDK and configure the `enableExperimentalFeatures` initialization parameter with `["feature_flags"]` to start collecting feature flag data.
 
-{{< tabs >}}
-{{% tab "NPM" %}}
-
+{{% collapse-content title="NPM" level="h4" %}}
 ```javascript
   import { datadogRum } from '@datadog/browser-rum';
 
@@ -44,10 +42,9 @@ If you are using a version anterior to 5.17.0, initialize the RUM SDK and config
     ...
 });
 ```
+{{% /collapse-content %}} 
 
-{{% /tab %}}
-{{% tab "CDN async" %}}
-
+{{% collapse-content title="CDN async" level="h4" %}}
 ```javascript
 window.DD_RUM.onReady(function() {
     window.DD_RUM.init({
@@ -57,10 +54,9 @@ window.DD_RUM.onReady(function() {
     })
 })
 ```
+{{% /collapse-content %}} 
 
-{{% /tab %}}
-{{% tab "CDN sync" %}}
-
+{{% collapse-content title="CDN sync" level="h4" %}}
 ```javascript
 window.DD_RUM &&
     window.DD_RUM.init({
@@ -69,9 +65,7 @@ window.DD_RUM &&
       ...
     })
 ```
-
-{{% /tab %}}
-{{< /tabs >}}
+{{% /collapse-content %}}
 
 </details>
 <br/>

--- a/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
+++ b/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
@@ -26,10 +26,13 @@ By enriching your RUM data with feature flag data, you can be confident that you
 
 Feature flag tracking is available in the RUM Browser SDK. To start, set up [RUM browser monitoring][1]. You need the Browser RUM SDK version >= 4.25.0.
 
-To start collecting feature flag data, initialize the RUM SDK and configure the `enableExperimentalFeatures` initialization parameter with ` ["feature_flags"]`.
+<details>
+  <summary>Before <code>v5.17.0</code></summary>
 
-<details open>
-  <summary>npm</summary>
+If you are using a version anterior to 5.17.0, initialize the RUM SDK and configure the `enableExperimentalFeatures` initialization parameter with ` ["feature_flags"]` to start collecting feature flag data.
+
+{{< tabs >}}
+{{% tab "NPM" %}}
 
 ```javascript
   import { datadogRum } from '@datadog/browser-rum';
@@ -42,10 +45,8 @@ To start collecting feature flag data, initialize the RUM SDK and configure the 
 });
 ```
 
-</details>
-
-<details>
-  <summary>CDN async</summary>
+{{% /tab %}}
+{{% tab "CDN async" %}}
 
 ```javascript
 window.DD_RUM.onReady(function() {
@@ -56,10 +57,9 @@ window.DD_RUM.onReady(function() {
     })
 })
 ```
-</details>
 
-<details>
-  <summary>CDN sync</summary>
+{{% /tab %}}
+{{% tab "CDN sync" %}}
 
 ```javascript
 window.DD_RUM &&
@@ -69,6 +69,10 @@ window.DD_RUM &&
       ...
     })
 ```
+
+{{% /tab %}}
+{{< /tabs >}}
+
 </details>
 <br/>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The feature flags collection does not require to add the `enableExperimentalFeatures` init param for a while now. We should not tell customers to use `enableExperimentalFeatures` as they are meant to be internal only (in general). 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->