### PR TITLE
Document Agent Telemetry enablement by default (with Agent 7.59)

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -88,6 +88,53 @@ If you have a requirement to avoid storing secrets in plaintext in the Agent's c
 
 For more information, see the [Secrets Management][18] documentation.
 
+## Telemetry collection
+
+Datadog may collect environmental, performance, and feature usage information about the Datadog Agent. This may include diagnostic logs and crash dumps of the Datadog Agent with obfuscated stack traces to support and further improve the Datadog Agent.
+
+You can also disable this telemetry collection by updating the below setting in the Agent Configuration File.
+{{< tabs >}}
+{{% tab "datadog.yaml" %}}
+
+```yaml
+agent_telemetry:
+  enabled: false
+```
+
+**Telemetry content:**
+
+`Metadata`
+- MachineID
+- MachineName
+- OS
+- OS version
+- Agent version
+
+`Metrics`
+- checks.execution_time
+- pymem.inuse, pymem.alloc
+- api_server.request_duration_seconds
+- logs.decoded, logs.processed
+- logs.sender_latency, logs.bytes_missed
+- logs.sent, logs.dropped
+- logs.bytes_sent, logs.encoded_bytes_sent
+- dogstatsd.udp_packets
+- dogstatsd.uds_packets
+- transactions.input_count, transactions.requeued
+- transactions.retries
+- point.sent, point.dropped
+- oracle.activity_samples_count, oracle.activity_latency
+- oracle.statement_metrics, oracle.statement_plan_errors
+- postgres.collect_relations_autodiscovery_ms
+- postgres.collect_stat_autodiscovery_ms
+- postgres.get_new_pg_stat_activity_ms
+- postgres.get_new_pg_stat_activity_count
+- postgres.get_active_connections_ms
+- postgres.get_active_connections_count
+- postgres.collect_activity_snapshot_ms
+- postgres.collect_statement_samples_ms
+- postgres.collect_statement_samples_count
+
 ### Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -100,6 +100,8 @@ You can also disable this telemetry collection by updating the below setting in 
 agent_telemetry:
   enabled: false
 ```
+{{% /tab %}}
+{{< /tabs >}}
 
 **Telemetry content:**
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
It needs to be merged just before Agent 7.59 is released (plan for 10/31/2024)
- [ ] Please merge after reviewing

### Additional notes
It may go through a few iteration based on PM and Legal review

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->