### PR TITLE
Add space to fix code formatting in `error_tracking.md`

### DIFF
--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -137,7 +137,7 @@ Error Tracking monitors use [Issue States][2] to ensure that your alerts stay fo
 
 As a result, Datadog does not recommend using `issue.age` and `issue.regression.age`. However, If state-based monitor behavior is not suitable for you, these filters can still be used if manually specified.
 
-**Note**: If you plan to use `issue.age` and `issue.regression.age` in your monitor, this filter key is not consistent across products. For example, it could be`@issue.age` or `issue.age`.
+**Note**: If you plan to use `issue.age` and `issue.regression.age` in your monitor, this filter key is not consistent across products. For example, it could be `@issue.age` or `issue.age`.
 
 ### New Issue monitors are generating too much noise
 New Issue monitors trigger alerts on issues marked **For Review** that meet your alerting criteria. If issues are not properly triaged (marked as **Reviewed**, **Ignored**, or **Resolved**), a New Issue monitor may trigger more than once for the same issue if the issue fluctuates between OK and ALERT states.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This adds a space after `be` to fix a tiny formatting issue in `error_tracking.md` that was creating a `mailto` link where it shouldn't be.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

A bit difficult to replicate the formatting issue here in GitHub description, so best seen -> https://docs.datadoghq.com/error_tracking/monitors/?tab=highimpact#new-issue-monitors-do-not-take-into-account-issue-age at the bottom of the paragraph.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->