### PR TITLE
[error tracking] Remove outdated track selector on monitors

### DIFF
--- a/content/en/monitors/types/error_tracking.md
+++ b/content/en/monitors/types/error_tracking.md
@@ -48,7 +48,7 @@ There are two types of alerting conditions you can configure your Error Tracking
 {{% tab "High Impact" %}}
 High Impact monitors alert on issues that are **For Review** or **Reviewed** and that meet your alerting conditions. Read more about [Issue States][1].
 
-1. Select **RUM**, **APM**, or **Logs** and build a search query using the same logic as the [Error Tracking Explorer search][2] for the issues' error occurrences.
+1. Build a search query using the same logic as the [Error Tracking Explorer search][2] for the issues' error occurrences.
 2. Choose the metric you want to monitor. There are three suggested filter options to access the most frequently used facets:
 
     - **Error Occurrences**: Triggers when the error count is `above` or `above or equal to`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Remove mention to outdated track selector on Error Tracking monitors.
It doesn't exist anymore.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing