### PR TITLE
revised use of traces to include web traces type

### DIFF
--- a/content/en/security/application_security/code_security/setup/_index.md
+++ b/content/en/security/application_security/code_security/setup/_index.md
@@ -23,7 +23,7 @@ further_reading:
 Before setting up Code Security, ensure the following prerequisites are met:
 
 1. **Datadog Agent Installation:** The Datadog Agent is installed and configured for your application's operating system or container, cloud, or virtual environment.
-2. **Datadog APM Configuration:** Datadog APM is configured for your application or service, and traces are being received by Datadog.
+2. **Datadog APM Configuration:** Datadog APM is configured for your application or service, and web traces (`type:web`) are being received by Datadog.
 3. **Supported Tracing Library:** The Datadog Tracing Library used by your application or service supports Code Security capabilities for the language of your application or service. For more details, refer to the [Library Compatibility][1] page.
 
 ## Code Security Enablement Types

--- a/content/en/security/application_security/software_composition_analysis/setup/_index.md
+++ b/content/en/security/application_security/software_composition_analysis/setup/_index.md
@@ -28,7 +28,7 @@ further_reading:
 Before setting up Software Composition Analysis, ensure the following prerequisites are met:
 
 1. **Datadog Agent Installation:** The Datadog Agent is installed and configured for your application's operating system or container, cloud, or virtual environment.
-2. **Datadog APM Configuration:** Datadog APM is configured for your application or service, and traces are being received by Datadog.
+2. **Datadog APM Configuration:** Datadog APM is configured for your application or service, and web traces (`type:web`) are being received by Datadog.
 3. **Supported Tracing Library:** The Datadog Tracing Library used by your application or service supports Software Composition Analysis capabilities for the language of your application or service. For more details, refer to the [Library Compatibility][5] page for each ASM product.
 
 ## Software Composition Analysis enablement types

--- a/content/en/security/application_security/threats/setup/_index.md
+++ b/content/en/security/application_security/threats/setup/_index.md
@@ -7,7 +7,7 @@ disable_toc: false
 
 Before setting up Threat Management, ensure the following prerequisites are met:
 - **Datadog Agent Installation:** The Datadog Agent is installed and configured for your application's operating system or container, cloud, or virtual environment.
-- **Datadog APM Configuration:** Datadog APM is configured for your application or service, and traces are being received by Datadog.
+- **Datadog APM Configuration:** Datadog APM is configured for your application or service, and web traces (`type:web`) are being received by Datadog.
 - **Supported Tracing Library:** The Datadog Tracing Library used by your application or service supports Threat Management capabilities for the language of your application or service. For more details, refer to the [Library Compatibility][1] page.
 
 ## Threat Management Enablement Types

--- a/content/en/security/application_security/threats/threat_management_setup.md
+++ b/content/en/security/application_security/threats/threat_management_setup.md
@@ -8,7 +8,7 @@ disable_toc: false
 Before setting up Threat Management, ensure the following prerequisites are met:
 
 - **Datadog Agent Installation:** The Datadog Agent is installed and configured for your application's operating system or container, cloud, or virtual environment.
-- Datadog APM Configuration: Datadog APM is configured for your application or service, and traces are being received by Datadog.
+- Datadog APM Configuration: Datadog APM is configured for your application or service, and web traces (`type:web`) are being received by Datadog.
 - Supported Tracing Library: The Datadog Tracing Library used by your application or service supports Threat Management capabilities for the language of your application or service. For more details, refer to the Library Compatibility page.
 
 ## Threat Management enablement types overview


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Use of `traces` in ASM prereqs wasn't clear enough. Needed 'web traces'.

### Merge instructions

- [X] Please merge after reviewing

