### PR TITLE
[IDE] Add the opt-out of telemetry section in the JetBrains and Visual Studio plugin documentation

### DIFF
--- a/content/en/developers/ide_plugins/idea/_index.md
+++ b/content/en/developers/ide_plugins/idea/_index.md
@@ -206,6 +206,11 @@ Once the configuration file is created, the static analyzer runs automatically i
 
 You can give feedback in the [discussion forum][1], or send an e-mail to [team-ide-integration@datadoghq.com][11].
 
+## Data and Telemetry
+Datadog anonymously collects information about your usage of this IDE, including how you interact with it, whether errors occurred while using it, and what caused those errors, in accordance with the [Datadog Privacy Policy](https://www.datadoghq.com/legal/privacy/) and [Datadog's EULA](https://www.datadoghq.com/legal/eula/).
+
+If you don't wish to send this data to Datadog, you can opt out at any time in the settings: `Settings > Tools > Datadog > Data Sharing` and disable the `Send usage statistics` option.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/developers/ide_plugins/idea/_index.md
+++ b/content/en/developers/ide_plugins/idea/_index.md
@@ -207,7 +207,7 @@ Once the configuration file is created, the static analyzer runs automatically i
 You can give feedback in the [discussion forum][1], or send an e-mail to [team-ide-integration@datadoghq.com][11].
 
 ## Data and Telemetry
-Datadog anonymously collects information about your usage of this IDE, including how you interact with it, whether errors occurred while using it, and what caused those errors, in accordance with the [Datadog Privacy Policy](https://www.datadoghq.com/legal/privacy/) and [Datadog's EULA](https://www.datadoghq.com/legal/eula/).
+Datadog anonymously collects information about your usage of this IDE, including how you interact with it, whether errors occurred while using it, and what caused those errors, in accordance with the [Datadog Privacy Policy][16] and [Datadog's EULA][17].
 
 If you don't wish to send this data to Datadog, you can opt out at any time in the settings: `Settings > Tools > Datadog > Data Sharing` and disable the `Send usage statistics` option.
 
@@ -235,3 +235,5 @@ If you don't wish to send this data to Datadog, you can opt out at any time in t
 [13]: /static_analysis/?tab=githubactions
 [14]: /static_analysis/rules/#python-rules
 [15]: /logs/explorer/analytics/patterns/
+[16]: https://www.datadoghq.com/legal/privacy/
+[17]: https://www.datadoghq.com/legal/eula/

--- a/content/en/developers/ide_plugins/visual_studio/_index.md
+++ b/content/en/developers/ide_plugins/visual_studio/_index.md
@@ -90,7 +90,7 @@ Report a bug, request a new feature, or ask for help on the [Discussion Forum][1
 ## Data and Telemetry
 Datadog anonymously collects information about your usage of this IDE, including how you interact with it, whether errors occurred while using it, and what caused those errors, in accordance with the [Datadog Privacy Policy](https://www.datadoghq.com/legal/privacy/) and [Datadog's EULA](https://www.datadoghq.com/legal/eula/).
 
-If you don't wish to send this data to Datadog, you can opt out at any time in the settings: `Settings > Tools > Datadog > Data Sharing` and disable the `Send usage statistics` option.
+If you don't wish to send this data to Datadog, you can opt out at any time in the settings: `Options > Datadog > General > Data Sharing` and disable the `Send usage statistics` option.
 
 ## Further Reading
 

--- a/content/en/developers/ide_plugins/visual_studio/_index.md
+++ b/content/en/developers/ide_plugins/visual_studio/_index.md
@@ -87,6 +87,11 @@ When you start editing a source file supported by Static Analysis, the extension
 
 Report a bug, request a new feature, or ask for help on the [Discussion Forum][15] and [Issue Tracker][16] on GitHub. You can also email `team-ide-integration@datadoghq.com`.
 
+## Data and Telemetry
+Datadog anonymously collects information about your usage of this IDE, including how you interact with it, whether errors occurred while using it, and what caused those errors, in accordance with the [Datadog Privacy Policy](https://www.datadoghq.com/legal/privacy/) and [Datadog's EULA](https://www.datadoghq.com/legal/eula/).
+
+If you don't wish to send this data to Datadog, you can opt out at any time in the settings: `Settings > Tools > Datadog > Data Sharing` and disable the `Send usage statistics` option.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/developers/ide_plugins/visual_studio/_index.md
+++ b/content/en/developers/ide_plugins/visual_studio/_index.md
@@ -88,7 +88,7 @@ When you start editing a source file supported by Static Analysis, the extension
 Report a bug, request a new feature, or ask for help on the [Discussion Forum][15] and [Issue Tracker][16] on GitHub. You can also email `team-ide-integration@datadoghq.com`.
 
 ## Data and Telemetry
-Datadog anonymously collects information about your usage of this IDE, including how you interact with it, whether errors occurred while using it, and what caused those errors, in accordance with the [Datadog Privacy Policy](https://www.datadoghq.com/legal/privacy/) and [Datadog's EULA](https://www.datadoghq.com/legal/eula/).
+Datadog anonymously collects information about your usage of this IDE, including how you interact with it, whether errors occurred while using it, and what caused those errors, in accordance with the [Datadog Privacy Policy][21] and [Datadog's EULA][22].
 
 If you don't wish to send this data to Datadog, you can opt out at any time in the settings: `Options > Datadog > General > Data Sharing` and disable the `Send usage statistics` option.
 
@@ -113,3 +113,5 @@ If you don't wish to send this data to Datadog, you can opt out at any time in t
 [18]: /logs/explorer/
 [19]: /code_analysis/static_analysis/
 [20]: /code_analysis/static_analysis_rules/
+[21]: https://www.datadoghq.com/legal/privacy/
+[22]: https://www.datadoghq.com/legal/eula/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add the opt-out of telemetry section in the JetBrains and Visual Studio plugin documentation

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->