### PR TITLE
Add warning about closing spans in APM Go SDK Docs

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/go/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/dd-api.md
@@ -109,8 +109,8 @@ err := someOperation()
 span.Finish(tracer.WithError(err))
 ```
 
-Note: Closing a span that was not started in your code will lead to undefined behaviour.
-Please refer to your specific dd-trace-go [integration][10] documentation to do that.
+Note: Closing a span that was not started in your code can lead to missing data.
+Please follow your specific dd-trace-go [integration documentation][10] to do that.
 
 ## Adding spans
 

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/dd-api.md
@@ -109,6 +109,9 @@ err := someOperation()
 span.Finish(tracer.WithError(err))
 ```
 
+Note: Closing a span that was not started in your code will lead to undefined behaviour.
+Please refer to your specific dd-trace-go [integration][10] documentation to do that.
+
 ## Adding spans
 
 If you aren't using supported library instrumentation (see [Library compatibility][3]), you may want to to manually instrument your code.
@@ -223,4 +226,5 @@ Traces can be excluded based on their resource name, to remove synthetic traffic
 [6]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer#StartSpanFromContext
 [7]: /tracing/glossary/#trace
 [9]: /tracing/security
+[10]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1
 [11]: /tracing/trace_collection/trace_context_propagation/

--- a/content/en/tracing/trace_collection/custom_instrumentation/go/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/go/dd-api.md
@@ -109,8 +109,8 @@ err := someOperation()
 span.Finish(tracer.WithError(err))
 ```
 
-Note: Closing a span that was not started in your code can lead to missing data.
-Please follow your specific dd-trace-go [integration documentation][10] to do that.
+**Note**: Closing a span that was not started in your code can lead to missing data.
+Please follow your specific `dd-trace-go` [integration documentation][10] to do that.
 
 ## Adding spans
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR adds a warning about closing spans that were not created by the customer but by a SDK integration. We now consider it noteworthy because it created an issue where ASM was being disabled backend side because the data that where supposed to be sent via those spans weren't because it was closed of by the user code.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->