### PR TITLE
Update Download Step new MB limit

### DIFF
--- a/content/en/synthetics/guide/testing-file-upload-and-download.md
+++ b/content/en/synthetics/guide/testing-file-upload-and-download.md
@@ -31,7 +31,7 @@ Datadog's browser tests and the `Test a downloaded file` assertion allow you to 
 
 To setup a browser test with this assertion:
 
-1. **Record the step that generates the file download** in your browser test. The example below shows how to record a click on a button that triggers the download of a `.docx` file. The file size must be below 100Mb.
+1. **Record the step that generates the file download** in your browser test. The example below shows how to record a click on a button that triggers the download of a `.docx` file. The file size must be below 250Mb.
 
     {{< img src="synthetics/guide/testing-a-downloaded-file/recording_step.mp4" alt="Recording steps" video="true">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR changes the older limit we used to have for Download steps. 
Previously it was 100mb but now it is at 250mb

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->