### PR TITLE
Add handling for missing media value

### DIFF
--- a/layouts/integrations/single.html
+++ b/layouts/integrations/single.html
@@ -10,12 +10,12 @@
         </div>
     </div>
 
-    {{ partial "integration-labels/integration-labels.html" . }}
+
     
     {{ $integrationTitle := .Params.integration_title | default .Title }}
     {{ with $media }}
       {{ if and (in .Params.custom_kind "integration") (gt (len $media) 0) }}
-        <!-- Your code here -->
+        {{ partial "integration-labels/integration-labels.html" . }}
       {{ else }}
         {{ warnf "%s is missing the $media value" $integrationTitle }}
       {{ end }}

--- a/layouts/integrations/single.html
+++ b/layouts/integrations/single.html
@@ -10,12 +10,12 @@
         </div>
     </div>
 
-
+    {{ partial "integration-labels/integration-labels.html" . }}
     
     {{ $integrationTitle := .Params.integration_title | default .Title }}
     {{ with $media }}
       {{ if and (in .Params.custom_kind "integration") (gt (len $media) 0) }}
-        {{ partial "integration-labels/integration-labels.html" . }}
+        {{ partial "integrations-carousel/integrations-carousel.html" (dict "context" . "media" $media) }}
       {{ else }}
         {{ warnf "%s is missing the $media value" $integrationTitle }}
       {{ end }}

--- a/layouts/integrations/single.html
+++ b/layouts/integrations/single.html
@@ -12,8 +12,15 @@
 
     {{ partial "integration-labels/integration-labels.html" . }}
     
-    {{ if and (in .Params.custom_kind "integration") ($media | len) }}
-        {{ partial "integrations-carousel/integrations-carousel.html" (dict "context" . "media" $media) }}
+    {{ $integrationTitle := .Params.integration_title | default .Title }}
+    {{ with $media }}
+      {{ if and (in .Params.custom_kind "integration") (gt (len $media) 0) }}
+        <!-- Your code here -->
+      {{ else }}
+        {{ warnf "%s is missing the $media value" $integrationTitle }}
+      {{ end }}
+    {{ else }}
+      {{ warnf "%s is missing the $media value" $integrationTitle }}
     {{ end }}
 
     {{ .Content }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds a check and output for building integration pages with missing `media` key
### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->