### PR TITLE
DJM for Airflow on Astronomer

### DIFF
--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -123,8 +123,8 @@ For Astronomer customers using Astro, <a href=https://www.astronomer.io/docs/lea
 ## Requirements
 
 * [Astro Runtime 12.1.0][1] or later is required.
-* [apache-airflow-providers-openlineage][2] 1.11.0 or later is required.
-* [openlineage-python][8] 1.23.0 or later is required.
+* [apache-airflow-providers-openlineage 1.11.0][2] or later is required.
+* [openlineage-python 1.23.0][8] or later is required.
 
 ## Setup
 

--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -113,6 +113,65 @@ To get started, follow the instructions below.
 [6]: https://docs.aws.amazon.com/mwaa/latest/userguide/mwaa-create-role.html
 
 {{% /tab %}}
+
+{{% tab "Astronomer" %}}
+
+<div class="alert alert-warning">
+For Astronomer customers using Astro, the following setup may affect the lineage feature offered by Astro. see <a href=https://www.astronomer.io/docs/learn/airflow-openlineage#lineage-on-astro>this</a> for context.
+</div>
+
+## Requirements
+
+* [Apache Airflow 2.8.0][1] or later is required.
+* [apache-airflow-providers-openlineage][2] 1.11.0 or later is required.
+
+## Setup
+
+Data Jobs Monitoring is supported for Apache Airflow deployment with [apache-airflow-providers-openlineage][2] installed.
+
+To get started, follow the instructions below.
+
+1. Airflow provider `openlineage` is already installed with [Astro Runtimes][3]. Ensure your [Astro Runtime][3] comes with the package version greater or equal to `1.11.0` for `apache-airflow-providers-openlineage`.
+   
+   Alternatively, add the following to your `requirements.txt` file inside your [Astro project][4] to customize the package versions.
+
+   ```text
+   apache-airflow-providers-openlineage>=1.11.0
+   openlineage-python>=1.23.0
+   ```
+
+2. Configure `openlineage` provider. The simplest option is to set the following environment variables [using the Astro UI][5]:
+   
+   ```shell
+   OPENLINEAGE__TRANSPORT__TYPE=composite
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__TYPE=http
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__URL=<DD_DATA_OBSERVABILITY_INTAKE>
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__AUTH__TYPE=api_key
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__AUTH__API_KEY=<DD_API_KEY>
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__COMPRESSION=gzip
+   ```
+
+   **Important:**
+   * replace `<DD_DATA_OBSERVABILITY_INTAKE>` fully with `https://data-obs-intake.`{{< region-param key="dd_site" code="true" >}}.
+   * replace `<DD_API_KEY>` fully with your valid [Datadog API key][7].
+
+   **Optionally:**
+   * set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow instance to allow jobs from different Airflow instances logically separated.
+   * set `OPENLINEAGE_CLIENT_LOGGING` to `DEBUG` for OpenLineage client and its child modules to log at `DEBUG` logging level. This can be useful in troubleshooting during the configuration of `openlineage` provider. 
+
+   See [Astronomer official guide][5] for managing environment variables for a Deployment, and check official documentation [configuration-openlineage][6] for other supported configurations of `openlineage` provider.
+
+3. Trigger a update to your Deployment and wait for it to finish.
+
+[1]: https://github.com/apache/airflow/releases/tag/2.8.0
+[2]: https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html
+[3]: https://www.astronomer.io/docs/astro/runtime-provider-reference
+[4]: https://www.astronomer.io/docs/astro/cli/develop-project
+[5]: https://www.astronomer.io/docs/astro/manage-env-vars#using-the-astro-ui
+[6]: https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/configurations-ref.html#configuration-openlineage
+[7]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ## Validation

--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -51,7 +51,7 @@ To get started, follow the instructions below.
    * Replace `<DD_API_KEY>` with your valid [Datadog API key][4].
    
    **Optional:**
-   * Set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow deployment to allow jobs from different Airflow deployments logically separated.
+   * Set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow deployment. This allows Datadog to logically separate this deployment's jobs from those of other Airflow deployments.
    * Set `OPENLINEAGE_CLIENT_LOGGING` to `DEBUG` for OpenLineage client and its child modules. This can be useful in troubleshooting during the configuration of `openlineage` provider. 
 
    Check official documentation [configuration-openlineage][3] for other supported configurations of the `openlineage` provider.
@@ -95,7 +95,7 @@ To get started, follow the instructions below.
    * Replace `<DD_API_KEY>` fully with your valid [Datadog API key][5].
 
    **Optional:**
-   * Set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow deployment to allow jobs from different Airflow deployments logically separated.
+   * Set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow deployment. This allows Datadog to logically separate this deployment's jobs from those of other Airflow deployments.
    * Set `OPENLINEAGE_CLIENT_LOGGING` to `DEBUG` for OpenLineage client and its child modules. This can be useful in troubleshooting during the configuration of `openlineage` provider. 
 
    Check official documentation [configuration-openlineage][4] for other supported configurations of `openlineage` provider.
@@ -117,7 +117,7 @@ To get started, follow the instructions below.
 {{% tab "Astronomer" %}}
 
 <div class="alert alert-warning">
-For Astronomer customers using Astro, <a href=https://www.astronomer.io/docs/learn/airflow-openlineage#lineage-on-astro>Astro offers lineage features that rely on the Airflow OpenLineage provider</a>. This product depends on the same provider and uses the <a href=https://openlineage.io/docs/client/python#composite>Composite</a> transport to add additional transport without affecting the existing one.
+For Astronomer customers using Astro, <a href=https://www.astronomer.io/docs/learn/airflow-openlineage#lineage-on-astro>Astro offers lineage features that rely on the Airflow OpenLineage provider</a>. Data Jobs Monitoring depends on the same OpenLineage provider and uses the <a href=https://openlineage.io/docs/client/python#composite>Composite</a> transport to add additional transport.
 </div>
 
 ## Requirements
@@ -150,7 +150,7 @@ For Astronomer customers using Astro, <a href=https://www.astronomer.io/docs/lea
    * replace `<DD_API_KEY>` with your valid [Datadog API key][7].
 
    **Optional:**
-   * Set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow deployment to allow jobs from different Airflow deployments logically separated.
+   * Set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow deployment. This allows Datadog to logically separate this deployment's jobs from those of other Airflow deployments.
    * Set `OPENLINEAGE_CLIENT_LOGGING` to `DEBUG` for the OpenLineage client and its child modules to log at a `DEBUG` logging level. This can be useful for troubleshooting during the configuration of an OpenLineage provider. 
 
    See the [Astronomer official guide][5] for managing environment variables for a deployment. See Apache Airflow's [OpenLineage Configuration Reference][6] for other supported configurations of the OpenLineage provider.

--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -117,13 +117,14 @@ To get started, follow the instructions below.
 {{% tab "Astronomer" %}}
 
 <div class="alert alert-warning">
-For Astronomer customers using Astro, the following setup may affect the lineage feature offered by Astro. see <a href=https://www.astronomer.io/docs/learn/airflow-openlineage#lineage-on-astro>this</a> for context.
+For Astronomer customers using Astro, <a href=https://www.astronomer.io/docs/learn/airflow-openlineage#lineage-on-astro>Astro offers lineage features that rely on the Airflow OpenLineage provider</a>. This product depends on the same provider and uses the <a href=https://openlineage.io/docs/client/python#composite>Composite</a> transport to add additional transport without affecting the existing one.
 </div>
 
 ## Requirements
 
-* [Apache Airflow 2.8.0][1] or later is required.
+* [Astro Runtime 12.1.0][1] or later is required.
 * [apache-airflow-providers-openlineage][2] 1.11.0 or later is required.
+* [openlineage-python][8] 1.23.0 or later is required.
 
 ## Setup
 
@@ -131,9 +132,7 @@ Data Jobs Monitoring is supported for Apache Airflow deployment with [apache-air
 
 To get started, follow the instructions below.
 
-1. Airflow provider `openlineage` is already installed with [Astro Runtimes][3]. Ensure your [Astro Runtime][3] comes with the package version greater or equal to `1.11.0` for `apache-airflow-providers-openlineage`.
-   
-   Alternatively, add the following to your `requirements.txt` file inside your [Astro project][4] to customize the package versions.
+1. Install provider `openlineage` with [openlineage-python][8] `1.23.0` or later. [Astro Runtime 12.1.0][9] or later already comes with the package version greater or equal to `1.11.0` for `apache-airflow-providers-openlineage`, add the following to your `requirements.txt` file inside your [Astro project][4] to install [openlineage-python][8] `1.23.0` or later.
 
    ```text
    apache-airflow-providers-openlineage>=1.11.0
@@ -144,32 +143,33 @@ To get started, follow the instructions below.
    
    ```shell
    OPENLINEAGE__TRANSPORT__TYPE=composite
-   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__TYPE=http
-   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__URL=<DD_DATA_OBSERVABILITY_INTAKE>
-   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__AUTH__TYPE=api_key
-   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__AUTH__API_KEY=<DD_API_KEY>
-   OPENLINEAGE__TRANSPORT__TRANSPORTS__DD_OBS_INTAKE__COMPRESSION=gzip
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DATADOG__TYPE=http
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DATADOG__URL=<DD_DATA_OBSERVABILITY_INTAKE>
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DATADOG__AUTH__TYPE=api_key
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DATADOG__AUTH__API_KEY=<DD_API_KEY>
+   OPENLINEAGE__TRANSPORT__TRANSPORTS__DATADOG__COMPRESSION=gzip
    ```
 
-   **Important:**
    * replace `<DD_DATA_OBSERVABILITY_INTAKE>` fully with `https://data-obs-intake.`{{< region-param key="dd_site" code="true" >}}.
    * replace `<DD_API_KEY>` fully with your valid [Datadog API key][7].
 
-   **Optionally:**
-   * set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow instance to allow jobs from different Airflow instances logically separated.
+   **Optional:**
+   * Set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow deployment to allow jobs from different Airflow deployments logically separated.
    * set `OPENLINEAGE_CLIENT_LOGGING` to `DEBUG` for OpenLineage client and its child modules to log at `DEBUG` logging level. This can be useful in troubleshooting during the configuration of `openlineage` provider. 
 
    See [Astronomer official guide][5] for managing environment variables for a Deployment, and check official documentation [configuration-openlineage][6] for other supported configurations of `openlineage` provider.
 
 3. Trigger a update to your Deployment and wait for it to finish.
 
-[1]: https://github.com/apache/airflow/releases/tag/2.8.0
+[1]: https://www.astronomer.io/docs/astro/runtime-release-notes#astro-runtime-1210
 [2]: https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html
 [3]: https://www.astronomer.io/docs/astro/runtime-provider-reference
 [4]: https://www.astronomer.io/docs/astro/cli/develop-project
 [5]: https://www.astronomer.io/docs/astro/manage-env-vars#using-the-astro-ui
 [6]: https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/configurations-ref.html#configuration-openlineage
 [7]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
+[8]: https://github.com/OpenLineage/OpenLineage/releases/tag/1.23.0
+[9]: https://www.astronomer.io/docs/astro/runtime-provider-reference#astro-runtime-1210
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -122,24 +122,20 @@ For Astronomer customers using Astro, <a href=https://www.astronomer.io/docs/lea
 
 ## Requirements
 
-* [Astro Runtime 12.1.0][1] or later is required.
-* [apache-airflow-providers-openlineage 1.11.0][2] or later is required.
-* [openlineage-python 1.23.0][8] or later is required.
+* [Astro Runtime 12.1.0+][1]
+* [`apache-airflow-providers-openlineage` 1.11.0+][2]
+* [`openlineage-python` 1.23.0+][8]
 
 ## Setup
 
-Data Jobs Monitoring is supported for Apache Airflow deployment with [apache-airflow-providers-openlineage][2] installed.
-
-To get started, follow the instructions below.
-
-1. Install provider `openlineage` with [openlineage-python][8] `1.23.0` or later. [Astro Runtime 12.1.0][9] or later already comes with the package version greater or equal to `1.11.0` for `apache-airflow-providers-openlineage`, add the following to your `requirements.txt` file inside your [Astro project][4] to install [openlineage-python][8] `1.23.0` or later.
+1. Install the OpenLineage provider (`apache-airflow-providers-openlineage`) 1.11.0+ and [`openlineage-python`][8] 1.23.0+. Add the following to your `requirements.txt` file inside your [Astro project][4]:
 
    ```text
    apache-airflow-providers-openlineage>=1.11.0
    openlineage-python>=1.23.0
    ```
 
-2. Configure `openlineage` provider. The simplest option is to set the following environment variables [using the Astro UI][5]:
+2. Configure the OpenLineage provider. You can do this by setting the following environment variables [using the Astro UI][5]:
    
    ```shell
    OPENLINEAGE__TRANSPORT__TYPE=composite
@@ -150,16 +146,16 @@ To get started, follow the instructions below.
    OPENLINEAGE__TRANSPORT__TRANSPORTS__DATADOG__COMPRESSION=gzip
    ```
 
-   * replace `<DD_DATA_OBSERVABILITY_INTAKE>` fully with `https://data-obs-intake.`{{< region-param key="dd_site" code="true" >}}.
-   * replace `<DD_API_KEY>` fully with your valid [Datadog API key][7].
+   * replace `<DD_DATA_OBSERVABILITY_INTAKE>` with `https://data-obs-intake.`{{< region-param key="dd_site" code="true" >}}.
+   * replace `<DD_API_KEY>` with your valid [Datadog API key][7].
 
    **Optional:**
    * Set `AIRFLOW__OPENLINEAGE__NAMESPACE` with a unique name for your Airflow deployment to allow jobs from different Airflow deployments logically separated.
-   * set `OPENLINEAGE_CLIENT_LOGGING` to `DEBUG` for OpenLineage client and its child modules to log at `DEBUG` logging level. This can be useful in troubleshooting during the configuration of `openlineage` provider. 
+   * Set `OPENLINEAGE_CLIENT_LOGGING` to `DEBUG` for the OpenLineage client and its child modules to log at a `DEBUG` logging level. This can be useful for troubleshooting during the configuration of an OpenLineage provider. 
 
-   See [Astronomer official guide][5] for managing environment variables for a Deployment, and check official documentation [configuration-openlineage][6] for other supported configurations of `openlineage` provider.
+   See the [Astronomer official guide][5] for managing environment variables for a deployment. See Apache Airflow's [OpenLineage Configuration Reference][6] for other supported configurations of the OpenLineage provider.
 
-3. Trigger a update to your Deployment and wait for it to finish.
+3. Trigger a update to your deployment and wait for it to finish.
 
 [1]: https://www.astronomer.io/docs/astro/runtime-release-notes#astro-runtime-1210
 [2]: https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/index.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add setup guide for Data Jobs Monitoring for Airflow running on Astronomer.

For customers running Airflow with Astronomer, this setup guide would provide them the necessary guidance for unblocking them to try the preview of Data Jobs Monitoring for Airflow running on Astronomer. And it allows us gather direct feedbacks from customer as we continue to evolve the product.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->