### PR TITLE
enables typesense live syncing job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -339,21 +339,21 @@ algolia_sync_live:
       CI_PIPELINE_SOURCE=$CI_PIPELINE_SOURCE
       yarn run algolia:sync
 
-#typesense_sync_live:
-#  <<: *base_template
-#  <<: *live_rules
-#  stage: post-deploy
-#  environment: "live"
-#  allow_failure: true
-#  interruptible: true
-#  timeout: 2h
-#  dependencies:
-#    - build_live
-#  script:
-#    - >
-#      TYPESENSE_ADMIN_API_KEY=$(get_secret 'typesense_prod_admin_api_key')
-#      TYPESENSE_HOST=$(get_secret 'typesense_prod_host')
-#      yarn run typesense:sync
+typesense_sync_live:
+ <<: *base_template
+ <<: *live_rules
+ stage: post-deploy
+ environment: "live"
+ allow_failure: true
+ interruptible: true
+ timeout: 2h
+ dependencies:
+   - build_live
+ script:
+   - >
+     TYPESENSE_ADMIN_API_KEY=$(get_secret 'typesense_prod_admin_api_key')
+     TYPESENSE_HOST=$(get_secret 'typesense_prod_host')
+     yarn run typesense:sync
 
 sourcemaps_preview:
   <<: *base_template

--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -149,6 +149,11 @@ outputFormats:
     isPlainText: true
     mediaType: "application/json"
     notAlternative: true
+  Search:
+    baseName: "search"
+    isPlainText: true
+    mediaType: "application/json"
+    notAlternative: true
   Redirects:
     baseName: "redirects"
     isPlainText: true

--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -6,6 +6,7 @@ en:
       - HTML
       - RSS
       - Algolia
+      - Search
       - Redirects
     page:
       - HTML

--- a/content/en/metrics/custom_metrics/historical_metrics.md
+++ b/content/en/metrics/custom_metrics/historical_metrics.md
@@ -1,5 +1,5 @@
 ---
-title: Historical Metrics Ingestion
+title: Historical Metrics Ingestion - Brian's Typesense Update Test
 further_reading:
 - link: "https://www.datadoghq.com/blog/historical-metrics/"
   tag: "Blog"

--- a/content/en/metrics/custom_metrics/historical_metrics.md
+++ b/content/en/metrics/custom_metrics/historical_metrics.md
@@ -1,5 +1,5 @@
 ---
-title: Historical Metrics Ingestion - Brian's Typesense Update Test
+title: Historical Metrics Ingestion
 further_reading:
 - link: "https://www.datadoghq.com/blog/historical-metrics/"
   tag: "Blog"

--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -1,0 +1,74 @@
+{{- if (or (eq hugo.Environment "live") (in (slice "typesense_sync_preview:manual" "algolia_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
+    {{ $.Scratch.Add "algoliaindex" slice }}
+    {{ $section := $.Site.GetPage "section" .Section }}
+    {{ $hugo_context := . }}
+    {{ $apiPagesWithoutTypeAPI := slice "api/latest/" "api/latest/rate-limits/" "api/latest/scopes/" }}
+
+    {{ range (where (where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api") ".RelPermalink" "not in" $apiPagesWithoutTypeAPI) }}
+        {{ $page := . }}
+        {{ if and ($page.IsDescendant $section) (ne $page.Params.private true) (not (in $page.RelPermalink "/faq")) (not $page.Draft) (not (isset .Params "external_redirect")) }}
+            {{ $rel_path := "" }}
+            {{ with $page.File }}
+              {{ $rel_path = (print .Lang "/" .Path) }}
+            {{ end }}
+            {{ $object_id := md5 $rel_path }}
+            {{ $title := $page.Params.integration_title | default $page.Title }}
+            {{ $content := $page.Plain | htmlUnescape | safeHTML | truncate 10000 }}
+            {{ $tags := $page.Params.algolia.tags }}
+            {{ $rank := $page.Params.algolia.rank | default 70 }}
+            {{ $category := $page.Params.algolia.category | default "Documentation" }}
+            {{ $subcategory := $page.Params.algolia.subcategory }}
+
+            {{- /* Fallback to page's ancestor if subcategory isnt set in Params. */ -}}
+            {{ if not $subcategory }}
+                {{ if eq (lower $page.FirstSection.Title) ("service_managements") }}
+                    {{ $subcategory = $page.CurrentSection.Title }}
+                {{ else }}
+                    {{ $subcategory = $page.FirstSection.Title }}
+                {{ end }}
+            {{ end }}
+
+            {{- /* remove "is not supported" alert content which appears at the beginning of some markdown files */ -}}
+            {{- $content = replaceRE `(\w|\s)*\s(is not supported for your selected Datadog site \(\))(.|\s)` "" $content 1 -}}
+
+            {{- /* record for each individual section (split by h2 header) */ -}}
+            {{- partial "algolia/page-sections.json" (dict "context" $hugo_context "page" $page "title" $title "category" $category "subcategory" $subcategory "rank" $rank) -}}
+
+            {{/* This page has no h2 headings lets do a full page record, so we don't miss the page */}}
+            {{- $headingCount := (len .Fragments.HeadingsMap) | default 0 -}}
+            {{- if eq $headingCount 0 -}}
+                {{- /* Full page record */ -}}
+                {{- $record := (
+                    dict "objectID" $object_id
+                    "id" $object_id
+                    "title" $title
+                    "section_header" ""
+                    "content" $content
+                    "type" $page.Type
+                    "relpermalink" $page.RelPermalink
+                    "distinct_base_url" $page.RelPermalink
+                    "full_url" $page.Permalink
+                    "language" $page.Language.Lang
+                    "category" $category
+                    "subcategory" $subcategory
+                    "rank" $rank
+                    "order" -1
+                    "tags" (slice)
+                ) -}}
+
+                {{- if $tags -}}
+                    {{- $tags_dict := (dict "tags" $tags) -}}
+                    {{- $record = merge $record $tags_dict -}}
+                {{- end -}}
+
+                {{- $.Scratch.Add "algoliaindex" $record -}}
+            {{- end -}}
+        {{ end }}
+    {{ end }}
+
+    {{- /* api pages are controlled by layout and not markdown, so we need to index them separately */ -}}
+    {{ partial "algolia/api-pages-full-index.json" (dict "context" $hugo_context) }}
+
+    {{- /* Outputs final JSON object, copied to public/ folder. */ -}}
+    {{- $.Scratch.Get "algoliaindex" | jsonify -}}
+{{- end -}}

--- a/layouts/partials/algolia/api-pages-full-index.json
+++ b/layouts/partials/algolia/api-pages-full-index.json
@@ -34,21 +34,23 @@
         {{ range $endpoint_path, $endpoint_data := $api_v1_data.paths }}
             {{ range $endpoint_data }}
                 {{ $tags := slice }}
-                {{ with $endpoint_data.tags }}{{ $tags = . }}{{ end }}
+                {{ if isset . "tags" }}
+                  {{ $tags = .tags }}
+                {{ end }}
 
                 {{ if in $tags $title }}
 
-                    {{ 
+                    {{
                         $params := (dict
-                            "context" $hugo_context 
-                            "page" $page 
-                            "title" $title 
-                            "lang" $lang 
-                            "api_version" "v1" 
-                            "endpoint_data" . 
+                            "context" $hugo_context
+                            "page" $page
+                            "title" $title
+                            "lang" $lang
+                            "api_version" "v1"
+                            "endpoint_data" .
                             "api_v1_translate_actions" $api_v1_translate_actions
                             "api_v2_translate_actions" $api_v2_translate_actions
-                        ) 
+                        )
                     }}
 
                     {{ partial "algolia/api-page-index.json" $params }}
@@ -60,21 +62,23 @@
         {{ range $endpoint_path, $endpoint_data := $api_v2_data.paths }}
             {{ range $endpoint_data }}
                 {{ $tags := slice }}
-                {{ with $endpoint_data.tags }}{{ $tags = . }}{{ end }}
+                {{ if isset . "tags" }}
+                  {{ $tags = .tags }}
+                {{ end }}
 
                 {{ if in $tags $title }}
 
-                    {{ 
-                        $params := (dict 
-                            "context" $hugo_context 
-                            "page" $page 
-                            "title" $title 
-                            "lang" $lang 
-                            "api_version" "v2" 
-                            "endpoint_data" . 
+                    {{
+                        $params := (dict
+                            "context" $hugo_context
+                            "page" $page
+                            "title" $title
+                            "lang" $lang
+                            "api_version" "v2"
+                            "endpoint_data" .
                             "api_v1_translate_actions" $api_v1_translate_actions
                             "api_v2_translate_actions" $api_v2_translate_actions
-                        ) 
+                        )
                     }}
 
                     {{ partial "algolia/api-page-index.json" $params }}

--- a/local/bin/js/typesense_sync.cjs
+++ b/local/bin/js/typesense_sync.cjs
@@ -11,10 +11,9 @@ const index = async () => {
     const promises = []
 
     for (const collection of config.collections) {
-        const collectionFile = "./public/algolia.json";
         console.log(`Indexing collection ${collection.name}`)
-        promises.push(await typesenseSync(collection.name, collectionFile))
+        promises.push(typesenseSync(collection.name, collection.file_path))
     }
 
-    return Promise.all(promises)
+    return await Promise.all(promises)
 }

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "tomlify-j0.4": "^3.0.0",
         "traverse": "0.6.8",
         "typesense": "^1.8.2",
-        "typesense-sync": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.2.tgz",
+        "typesense-sync": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.4.tgz",
         "yaml-lint": "^1.7.0"
     },
     "devDependencies": {

--- a/typesense.config.json
+++ b/typesense.config.json
@@ -1,7 +1,7 @@
 {
     "collections": [
         {
-            "name": "docs_main_v1",
+            "name": "docs_alias",
             "file_path": "./public/search.json",
             "synonyms": [
                 {

--- a/typesense.config.json
+++ b/typesense.config.json
@@ -1,7 +1,7 @@
 {
     "collections": [
         {
-            "name": "docs_alias",
+            "name": "docs_main_v1",
             "file_path": "./public/search.json",
             "synonyms": [
                 {

--- a/typesense.config.json
+++ b/typesense.config.json
@@ -2,7 +2,7 @@
     "collections": [
         {
             "name": "docs_main_v1",
-            "short_name": "docs",
+            "file_path": "./public/search.json",
             "synonyms": [
                 {
                     "id": "agent",
@@ -57,15 +57,18 @@
                   {
                       "name": "docs_alias_view",
                       "search_parameters": {
-                          "sort_by": "rank:desc,order:asc,_text_match:desc",
-                          "query_by": "tags,title,section_header,content"
+                          "query_by": "tags,title,content,section_header",
+                          "group_by": "distinct_base_url",
+                          "group_limit": 1
                       }
                   },
                   {
                       "name": "docs_alias_api_view",
                       "search_parameters": {
                           "sort_by": "rank:asc,_text_match:desc",
-                          "query_by": "tags,title,section_header,content"
+                          "query_by": "tags,content,title,section_header",
+                          "group_by": "distinct_base_url",
+                          "group_limit": 1
                       }
                   }
               ]


### PR DESCRIPTION
### What does this PR do? What is the motivation?
- enables the typesense indexing job in live, so we can run typesense and algolia in parallel as we prepare to switch over.
- adds a `search.json` output for typesense specifically so no current Algolia processes are changed.

### Merge instructions
- [x] Please merge after websites reviews

### Additional notes
- `typesense_sync` job ran successfully in preview: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/680879329
- live typesense job is uncommented in gitlab config
- Current Algolia jobs are not affected by these changes