### PR TITLE
SDCD-437: Updating pagerduty service mapping logic in dora setup page

### DIFF
--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -101,7 +101,7 @@ The matching algorithm works in the following steps:
    - If a single Datadog service matches, the incident metrics and events are emitted with the service and team.
    - If multiple Datadog services match, the incident metrics and events are emitted with the team.
 
-For more information about setting the PagerDuty service URL for a Datadog service, see [Use Integrations with Service Catalog][103].
+   For more information about setting the PagerDuty service URL for a Datadog service, see [Use Integrations with Service Catalog][103].
 
 3. If the PagerDuty service name of the incident matches a service name in the Service Catalog, the incident metrics and events are emitted with the service and team.
 4. If the PagerDuty team name of the incident matches a team name in the Service Catalog, the incident metrics and events are emitted with the team.

--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -87,12 +87,12 @@ The severity of the incident in the DORA Metrics product is based on the [incide
 
 ### Mapping PagerDuty services to Datadog services
 
-When an incident event is received for a specific [PagerDuty service][101], Datadog attempts to retrieve the related Datadog service and team from any relevant [Datadog monitors][108] and from the [Service Catalog][102].
+When an incident event is received for a specific [PagerDuty service][101], Datadog attempts to retrieve the related Datadog service and team from any triggering [Datadog monitors][107] and from the [Service Catalog][102].
 
 The matching algorithm works in the following steps:
 
-1. If the PagerDuty incident event was [triggered from a monitor][107]:
-   - If the monitor is in [Multi Alert mode][109], the incident metrics and events are emmitted with the `env`, `service`, and `team` from the alerted group.
+1. If the PagerDuty incident event was [triggered from a Datadog monitor][107]:
+   - If the monitor is in [Multi Alert mode][109], the incident metrics and events are emitted with the `env`, `service`, and `team` from the alerted group.
    - If the monitor has [tags][110] for `env`, `service`, or `team`:
      - `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with the environment.
      - `service`: If the monitor has one or more `service` tags, the incident metrics and events are emitted with the provided services.
@@ -115,7 +115,6 @@ The matching algorithm works in the following steps:
 [105]: https://app.datadoghq.com/organization-settings/api-keys
 [106]: https://support.pagerduty.com/main/docs/incident-priority
 [107]: /integrations/pagerduty/#troubleshooting
-[108]: /monitors/
 [109]: /monitors/configuration/#multi-alert
 [110]: /monitors/manage/#monitor-tags
 

--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -94,9 +94,9 @@ The matching algorithm works in the following steps:
 1. If the PagerDuty incident event was [triggered from a monitor][107]:
    - If the monitor is in [Multi Alert mode][109], the incident metrics and events are emmitted with the `env`, `service`, and `team` from the alerted group.
    - If the monitor has [tags][110] for `env`, `service`, or `team`:
-    - `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with the environment.
-    - `service`: If the monitor has one or more `service` tags, the incident metrics and events are emitted with the provided services.
-    - `team`: If the monitor has a single `team` tag, the incident metrics and events are emitted with the team.
+     - `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with the environment.
+     - `service`: If the monitor has one or more `service` tags, the incident metrics and events are emitted with the provided services.
+     - `team`: If the monitor has a single `team` tag, the incident metrics and events are emitted with the team.
 2. If the service URL of the incident matches the PagerDuty service URL for any services in the Service Catalog:
    - If a single Datadog service matches, the incident metrics and events are emitted with the service and team.
    - If multiple Datadog services match, the incident metrics and events are emitted with the team.

--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -94,9 +94,9 @@ The matching algorithm works in the following steps:
 1. If the PagerDuty incident event was [triggered from a monitor][107]:
    - If the monitor is in [Multi Alert mode][109], the incident metrics and events are emmitted with the `env`, `service`, and `team` from the alerted group.
    - If the monitor has [tags][110] for `env`, `service`, or `team`:
-    `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with that environment.
-    `service`: If the monitor has one or more `service` tags, the incident metrics and events are emitted with the provided services.
-    `team`: If the monitor has a single `team` tag, the incident metrics and events are emitted with that team.
+    - `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with that environment.
+    - `service`: If the monitor has one or more `service` tags, the incident metrics and events are emitted with the provided services.
+    - `team`: If the monitor has a single `team` tag, the incident metrics and events are emitted with that team.
 2. If the service URL of the incident matches the PagerDuty service URL for any services in the Service Catalog:
    - If a single Datadog service matches, the incident metrics and events are emitted with the service and team.
    - If multiple Datadog services match, the incident metrics and events are emitted with the team.

--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -87,20 +87,26 @@ The severity of the incident in the DORA Metrics product is based on the [incide
 
 ### Mapping PagerDuty services to Datadog services
 
-When an incident event is received for a specific [PagerDuty service][101], Datadog attempts to retrieve the related Datadog service and team from the [Service Catalog][102].
+When an incident event is received for a specific [PagerDuty service][101], Datadog attempts to retrieve the related Datadog service and team from any relevant [Datadog monitors][108] and from the [Service Catalog][102].
 
-The matching algorithm works in the following scenarios:
+The matching algorithm works in the following steps:
 
-1. If the incident service URL matches with the PagerDuty service URL configured for one or more services in the Service Catalog:
-   
-   - If the incident service URL matches a single Datadog service, the incident metrics and events are emitted with the Datadog service name and team retrieved from the Service Catalog.
-   - If the incident service URL matches multiple Datadog services, the incident metrics and events are emitted with the Datadog team name.
-   
-   For more information about setting the PagerDuty service URL for a Datadog service, see [Use Integrations with Service Catalog][103].
+1. If the PagerDuty incident event was [triggered from a monitor][107]:
+   - If the monitor is in [Multi Alert mode][109], the incident metrics and events are emmitted with the `env`, `service`, and `team` from the alerted group.
+   - If the monitor has [tags][110] for `env`, `service`, or `team`:
+    `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with that environment.
+    `service`: If the monitor has one or more `service` tags, the incident metrics and events are emitted with the provided services.
+    `team`: If the monitor has a single `team` tag, the incident metrics and events are emitted with that team.
+2. If the service URL of the incident matches the PagerDuty service URL for any services in the Service Catalog:
+   - If a single Datadog service matches, the incident metrics and events are emitted with the service and team.
+   - If multiple Datadog services match, the incident metrics and events are emitted with the team.
 
-2. If the PagerDuty service name of the incident matches a Datadog service name in the Service Catalog, the incident metrics and events are emitted with the Datadog service name and team retrieved from the Service Catalog.
-3. If the PagerDuty team name of the incident matches a Datadog team name in the Service Catalog, the incident metrics and events are emitted with the corresponding Datadog team name.
-4. If the PagerDuty service name of the incident matches a Datadog team name in the Service Catalog, the incident metrics and events are emitted with the Datadog team name.
+For more information about setting the PagerDuty service URL for a Datadog service, see [Use Integrations with Service Catalog][103].
+
+3. If the PagerDuty service name of the incident matches a service name in the Service Catalog, the incident metrics and events are emitted with that service and team.
+4. If the PagerDuty team name of the incident matches a team name in the Service Catalog, the incident metrics and events are emitted with that team.
+5. If the PagerDuty service name of the incident matches a team name in the Service Catalog, the incident metrics and events are emitted with the team.
+6. If there have been no matches up to this point, the incident metrics and events are emitted with the PagerDuty service and PagerDuty team provided in the incident.
 
 [101]: https://support.pagerduty.com/docs/services-and-integrations
 [102]: /service_catalog/
@@ -108,6 +114,10 @@ The matching algorithm works in the following scenarios:
 [104]: /integrations/pagerduty/
 [105]: https://app.datadoghq.com/organization-settings/api-keys
 [106]: https://support.pagerduty.com/main/docs/incident-priority
+[107]: /integrations/pagerduty/#troubleshooting
+[108]: /monitors/
+[109]: /monitors/configuration/#multi-alert
+[110]: /monitors/manage/#monitor-tags
 
 {{% /tab %}}
 {{% tab "API" %}}

--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -94,17 +94,17 @@ The matching algorithm works in the following steps:
 1. If the PagerDuty incident event was [triggered from a monitor][107]:
    - If the monitor is in [Multi Alert mode][109], the incident metrics and events are emmitted with the `env`, `service`, and `team` from the alerted group.
    - If the monitor has [tags][110] for `env`, `service`, or `team`:
-    - `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with that environment.
+    - `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with the environment.
     - `service`: If the monitor has one or more `service` tags, the incident metrics and events are emitted with the provided services.
-    - `team`: If the monitor has a single `team` tag, the incident metrics and events are emitted with that team.
+    - `team`: If the monitor has a single `team` tag, the incident metrics and events are emitted with the team.
 2. If the service URL of the incident matches the PagerDuty service URL for any services in the Service Catalog:
    - If a single Datadog service matches, the incident metrics and events are emitted with the service and team.
    - If multiple Datadog services match, the incident metrics and events are emitted with the team.
 
 For more information about setting the PagerDuty service URL for a Datadog service, see [Use Integrations with Service Catalog][103].
 
-3. If the PagerDuty service name of the incident matches a service name in the Service Catalog, the incident metrics and events are emitted with that service and team.
-4. If the PagerDuty team name of the incident matches a team name in the Service Catalog, the incident metrics and events are emitted with that team.
+3. If the PagerDuty service name of the incident matches a service name in the Service Catalog, the incident metrics and events are emitted with the service and team.
+4. If the PagerDuty team name of the incident matches a team name in the Service Catalog, the incident metrics and events are emitted with the team.
 5. If the PagerDuty service name of the incident matches a team name in the Service Catalog, the incident metrics and events are emitted with the team.
 6. If there have been no matches up to this point, the incident metrics and events are emitted with the PagerDuty service and PagerDuty team provided in the incident.
 

--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -97,6 +97,7 @@ The matching algorithm works in the following steps:
      - `env`: If the monitor has a single `env` tag, the incident metrics and events are emitted with the environment.
      - `service`: If the monitor has one or more `service` tags, the incident metrics and events are emitted with the provided services.
      - `team`: If the monitor has a single `team` tag, the incident metrics and events are emitted with the team.
+     
 2. If the service URL of the incident matches the PagerDuty service URL for any services in the Service Catalog:
    - If a single Datadog service matches, the incident metrics and events are emitted with the service and team.
    - If multiple Datadog services match, the incident metrics and events are emitted with the team.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We are in the processes of changing the mapping rules for DORA failures when we get PagerDuty alerts. This PR provides details into those new mapping rules and modifies the rules that were already written for clarity.

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] We are waiting for the customer-wide release of this before it is merged. I can update whomever reviews this PR when that happens and we are ready for merging.
### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->