### PR TITLE
Update postgresql to postgres for  Datadog Operator & Helm

### DIFF
--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -548,7 +548,7 @@ spec:
     nodeAgent:
       extraConfd:
         configDataMap:
-          postgresql.yaml: |-
+          postgres.yaml: |-
             ad_identifiers:
               - postgres
             init_config:
@@ -558,7 +558,7 @@ spec:
                 username: "datadog"
                 password: "%%env_PG_PASSWORD%%"
 ```
-As a result, the Agent contains a `postgresql.yaml` file with the above configuration in the `conf.d` directory.
+As a result, the Agent contains a `postgres.yaml` file with the above configuration in the `conf.d` directory.
 
 {{% /tab %}}
 {{% tab "Helm" %}}
@@ -568,7 +568,7 @@ In `datadog-values.yaml`:
 ```yaml
 datadog:
   confd:
-    postgresql.yaml: |-
+    postgres.yaml: |-
       ad_identifiers:
         - postgres
       init_config:
@@ -578,7 +578,7 @@ datadog:
           username: "datadog"
           password: "%%env_PG_PASSWORD%%"
 ```
-As a result, the Agent contains a `postgresql.yaml` file with the above configuration in the `conf.d` directory.
+As a result, the Agent contains a `postgres.yaml` file with the above configuration in the `conf.d` directory.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Ticket: https://datadog.zendesk.com/agent/tickets/1886059
Customer followed our doc, but the agent returned "python module not found " error. When the customer used "postgres", it worked.

Our official integration here is postgres: https://github.com/DataDog/integrations-core/tree/master/postgres.
This is shown in the Annotations tab: 

<img width="406" alt="2024-10-23_15-02-39" src="https://github.com/user-attachments/assets/6d1c92d2-2ea6-4c98-b128-ccf35af028da">

However the Operator & Helm tab currently show postgresql:

<img width="803" alt="2024-10-23_15-03-56" src="https://github.com/user-attachments/assets/d7a7b9f1-788a-4eea-8e39-895013ae38db">

Using postgresql is throwing the error "no python module found"

### Merge instructions

<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->