### PR TITLE
[WEB-5450] Bring back security rule shortlinks

### DIFF
--- a/layouts/_default/list.redirects.txt
+++ b/layouts/_default/list.redirects.txt
@@ -1,18 +1,23 @@
+{{- $pattern := `^security_monitoring/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$` -}}
 {{- range $p := .Site.Pages -}}
     {{- range .Aliases -}}
         {{- $temp := strings.TrimPrefix "/" . -}}
         {{- $alias := strings.TrimSuffix "/" $temp -}}
-        {{- $target := strings.TrimSuffix "/" $p.RelPermalink -}}
-        {{- printf "%s/ %s\n" $alias $p.RelPermalink -}}
+        {{- if not (findRE $pattern $alias) -}}
+            {{- $target := strings.TrimSuffix "/" $p.RelPermalink -}}
+            {{- printf "%s/ %s\n" $alias $p.RelPermalink -}}
+        {{- end -}}
     {{- end -}}
     {{- with $p.Params.external_redirect -}}
         {{- $redirect_link := . -}}
         {{- $temp := strings.TrimPrefix "/" $p.RelPermalink -}}
         {{- $target := strings.TrimSuffix "/" $temp -}}
-        {{- if not (strings.HasPrefix $redirect_link "https://") -}}
-            {{- printf "%s/ %s\n" $target $redirect_link -}}
-        {{- else -}}
-            {{- printf "%s/ %s %s\n" $target $redirect_link "external" -}}
+        {{- if not (findRE $pattern $target) -}}
+            {{- if not (strings.HasPrefix $redirect_link "https://") -}}
+                {{- printf "%s/ %s\n" $target $redirect_link -}}
+            {{- else -}}
+                {{- printf "%s/ %s %s\n" $target $redirect_link "external" -}}
+            {{- end -}}
         {{- end -}}
     {{- end -}}
 {{- end -}}

--- a/layouts/_default/list.redirects.txt
+++ b/layouts/_default/list.redirects.txt
@@ -1,4 +1,4 @@
-{{- $pattern := `^security_monitoring/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$` -}}
+{{- $pattern := `^security_monitoring/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$|^security/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$` -}}
 {{- range $p := .Site.Pages -}}
     {{- range .Aliases -}}
         {{- $temp := strings.TrimPrefix "/" . -}}

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -148,6 +148,7 @@ def security_rules(content, content_dir):
                 "aliases": [
                     # f"{data.get('defaultRuleId', '').strip()}",
                     f"/security_monitoring/default_rules/{data.get('defaultRuleId', '').strip()}",
+                    f"/security/default_rules/{data.get('defaultRuleId', '').strip()}",
                     f"/security_monitoring/default_rules/{p.stem.lower()}"
                 ],
                 "rule_category": [],

--- a/local/bin/py/build/actions/security_rules.py
+++ b/local/bin/py/build/actions/security_rules.py
@@ -147,7 +147,7 @@ def security_rules(content, content_dir):
                 "default_rule_id": data.get('defaultRuleId', '').strip(),
                 "aliases": [
                     # f"{data.get('defaultRuleId', '').strip()}",
-                    # f"/security_monitoring/default_rules/{data.get('defaultRuleId', '').strip()}",
+                    f"/security_monitoring/default_rules/{data.get('defaultRuleId', '').strip()}",
                     f"/security_monitoring/default_rules/{p.stem.lower()}"
                 ],
                 "rule_category": [],

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds the ability to redirect a security rule based on the rule id
- Updates the redirect meta list to exclude these redirects

https://datadoghq.atlassian.net/browse/WEB-5450

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
https://docs-staging.datadoghq.com/devin.ford/WEB-5450/security/default_rules/9ga-poq-w7v should redirect you to https://docs-staging.datadoghq.com/devin.ford/WEB-5450/security/default_rules/aws-lambda-vpcaccess/
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->