### PR TITLE
Update Sarama library url in data streams Go example

### DIFF
--- a/content/en/data_streams/go.md
+++ b/content/en/data_streams/go.md
@@ -47,7 +47,7 @@ If a service consumes data from one point and produces to another point, propaga
 
 ```go
 import (
-  ddsarama "gopkg.in/DataDog/dd-trace-go.v1/contrib/Shopify/sarama"
+  ddsarama "gopkg.in/DataDog/dd-trace-go.v1/contrib/IBM/sarama.v1"
 )
 
 ...


### PR DESCRIPTION
- Update sarama library url to non-deprecated library in data streams Go example.

Related to #25833 