### PR TITLE
[WEB-5466] Exclude translation PRs and add concurrency to avoid rate limiting in github actions

### DIFF
--- a/.github/workflows/check_cache_values.yml
+++ b/.github/workflows/check_cache_values.yml
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   check-cache-values:
+    if: github.ref != 'refs/heads/guacbot/translation-pipeline' 
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/codeowner_review_status.yml
+++ b/.github/workflows/codeowner_review_status.yml
@@ -6,6 +6,11 @@ on:
 
 permissions: {}
 
+# Stop the current running job if a new push is made to the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   check-code-owners-approval:
     runs-on: ubuntu-latest

--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   static-analysis:
+    if: github.ref != 'refs/heads/guacbot/translation-pipeline'
     runs-on: ubuntu-latest
     name: Datadog Static Analyzer
     steps:

--- a/.github/workflows/gif_check.yml
+++ b/.github/workflows/gif_check.yml
@@ -5,8 +5,14 @@ on:
     paths:
     - 'static/images/**/*'
 
+# Stop the current running job if a new push is made to the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   look-for-gifs:
+    if: github.ref != 'refs/heads/guacbot/translation-pipeline'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -10,7 +10,7 @@ jobs:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
     - name: Set documentation preview
-      if: github.event.pull_request.head.repo.fork == false
+      if: github.event.pull_request.head.repo.fork == false && github.ref != 'refs/heads/guacbot/translation-pipeline'
       uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/merge_label_check.yml
+++ b/.github/workflows/merge_label_check.yml
@@ -12,8 +12,14 @@ permissions:
   contents: read
   pull-requests: read
 
+# Stop the current running job if a new push is made to the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   new-check-for-merge-label:
+    if: github.ref != 'refs/heads/guacbot/translation-pipeline'
     runs-on: ubuntu-latest
     name: "Merge is not allowed when 'Do Not Merge' label is present"
     steps:

--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -8,6 +8,11 @@ permissions:
   contents: read
   pull-requests: write
 
+# Stop the current running job if a new push is made to the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   preview-link:
     if: contains(github.head_ref, '/')

--- a/.github/workflows/synthetics.yml
+++ b/.github/workflows/synthetics.yml
@@ -1,5 +1,10 @@
 name: Preview Synthetics
-on: [pull_request]
+on: 
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - master
+  workflow_dispatch: # allows manual trigger
 
 # Stop the current running job if a new push is made to the PR
 concurrency:
@@ -11,6 +16,7 @@ permissions:
 
 jobs:
   synthetic_testing:
+    if: github.ref != 'refs/heads/guacbot/translation-pipeline'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/vale_linter.yml
+++ b/.github/workflows/vale_linter.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# Stop the current running job if a new push is made to the PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   vale:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate_filenames.yml
+++ b/.github/workflows/validate_filenames.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   run_static_asset_validation:
+    if: github.ref != 'refs/heads/guacbot/translation-pipeline'
     runs-on: ubuntu-latest
     steps:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds a concurrency check to most workflows to allow a new workflow to cancel a previously running one
- Ignores translations branches for most workflows
- Adds a manual dispatch for synthetics if docs wanted to run it against a translations PR

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->
https://datadoghq.atlassian.net/browse/WEB-5466
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->