### PR TITLE
fix yarn lock file so local doesnt break for everyone

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6550,7 +6550,7 @@ __metadata:
     tomlify-j0.4: ^3.0.0
     traverse: 0.6.8
     typesense: ^1.8.2
-    typesense-sync: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.2.tgz"
+    typesense-sync: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.4.tgz"
     yaml-lint: ^1.7.0
   languageName: unknown
   linkType: soft
@@ -14776,9 +14776,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typesense-sync@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.2.tgz":
-  version: 1.0.2
-  resolution: "typesense-sync@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.2.tgz"
+"typesense-sync@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.4.tgz":
+  version: 1.0.4
+  resolution: "typesense-sync@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.4.tgz"
   dependencies:
     "@babel/runtime": ^7.25.0
     crypto: ^1.0.1
@@ -14786,7 +14786,7 @@ __metadata:
     typesense: ^1.8.2
     winston: ^3.14.2
     yargs: ^17.7.2
-  checksum: 2dc2af1f9d1e6d8495f6b18c82fd86fbff152db1b4bb1385ce4634f09f677e6e7fbce8cd56506e76bb6e1758cd683268a04d45ae820433d6321b20f0ebdffaee
+  checksum: 82d721c5d98b5e6c53ecc439d257dc506c7b5f8139fd7d7a4999f73ec5bf35ebb70d446a20bc68c81a5ce8696fc3954c957bc818e60a81223cf8ed97c5bafd31
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
bumped `typesense-sync` in previous PR but forgot to yarn install to update lock file.  fixing this so local doesn't break for everyone

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [ ] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->