### PR TITLE
fix failing typesense sync live job 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -350,6 +350,7 @@ typesense_sync_live:
  dependencies:
    - build_live
  script:
+   - yarn add typesense-sync@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/typesense-sync-v1.0.4.tgz
    - >
      TYPESENSE_ADMIN_API_KEY=$(get_secret 'typesense_prod_admin_api_key')
      TYPESENSE_HOST=$(get_secret 'typesense_prod_host')


### PR DESCRIPTION
### What does this PR do? What is the motivation?
`typesense-sync` live job is failing because the package needs to be installed in the runner.   it works in preview because we are building the site on demand in the preview job.

see example of failing build: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/683461882

### Merge instructions
- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->