### PR TITLE
Add warning to Serverless Nodejs installation instructions

### DIFF
--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -380,7 +380,7 @@ module "lambda-datadog" {
 <div class="alert alert-warning">Do not install the Datadog Lambda Library as a layer <i>and</i> as a JavaScript package. If using the Datadog Lambda Layer (recommended), do not include <code>datadog-lambda-js</code> in your <code>package.json</code>, or install it as a dev dependency and run <code>npm install --production</code> before deploying.</div>
 
 ## Minimize Cold Start Duration (Beta)
-Starting with version 63 of [the Datadog Extension][7], you can set the environment variable `DD_EXTENSION_VERSION` to `next` to use an optimized version of the Datadog Extension that reduces instrumentation overhead by up to 70%. To leave feedback or report a bug, please add an [issue on Github][8] and tag your issue with `version/next`.
+Starting with version 63 of [the Datadog Extension][7], you can set the environment variable `DD_EXTENSION_VERSION` to `next` to use an optimized version of the Datadog Extension that reduces instrumentation overhead by up to 70%. To leave feedback or report a bug, add an [issue on GitHub][8] and tag your issue with `version/next`.
 
 ## What's next?
 

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -377,8 +377,10 @@ module "lambda-datadog" {
 {{% /tab %}}
 {{< /tabs >}}
 
+<div class="alert alert-warning">Do not install the Datadog Lambda Library as a layer _and_ as a JavaScript package. If you're using the Datadog Lambda Layer (recommended), do not include `datadog-lambda-js` in your `package.json`, or install it as a dev dependency and run `npm install --production` before deploying.</div>
+
 ## Minimize Cold Start Duration (Beta)
-Starting with version 63 of [the Datadog Extension][7], you can set the environment variable `DD_EXTENSION_VERSION` to `next` to use an optimized version of the Datadog Extension that reduces instrumentation overhead by up to 70%. To leave feedback or report a bug, please add an [issue on Github][8] and tag your issue with `version/next`. 
+Starting with version 63 of [the Datadog Extension][7], you can set the environment variable `DD_EXTENSION_VERSION` to `next` to use an optimized version of the Datadog Extension that reduces instrumentation overhead by up to 70%. To leave feedback or report a bug, please add an [issue on Github][8] and tag your issue with `version/next`.
 
 ## What's next?
 

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -377,7 +377,7 @@ module "lambda-datadog" {
 {{% /tab %}}
 {{< /tabs >}}
 
-<div class="alert alert-warning">Do not install the Datadog Lambda Library as a layer <i>and</i> as a JavaScript package. If you're using the Datadog Lambda Layer (recommended), do not include <code>datadog-lambda-js</code> in your <code>package.json</code>, or install it as a dev dependency and run <code>npm install --production</code> before deploying.</div>
+<div class="alert alert-warning">Do not install the Datadog Lambda Library as a layer <i>and</i> as a JavaScript package. If using the Datadog Lambda Layer (recommended), do not include <code>datadog-lambda-js</code> in your <code>package.json</code>, or install it as a dev dependency and run <code>npm install --production</code> before deploying.</div>
 
 ## Minimize Cold Start Duration (Beta)
 Starting with version 63 of [the Datadog Extension][7], you can set the environment variable `DD_EXTENSION_VERSION` to `next` to use an optimized version of the Datadog Extension that reduces instrumentation overhead by up to 70%. To leave feedback or report a bug, please add an [issue on Github][8] and tag your issue with `version/next`.

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -377,7 +377,7 @@ module "lambda-datadog" {
 {{% /tab %}}
 {{< /tabs >}}
 
-<div class="alert alert-warning">Do not install the Datadog Lambda Library as a layer _and_ as a JavaScript package. If you're using the Datadog Lambda Layer (recommended), do not include `datadog-lambda-js` in your `package.json`, or install it as a dev dependency and run `npm install --production` before deploying.</div>
+<div class="alert alert-warning">Do not install the Datadog Lambda Library as a layer <i>and</i> as a JavaScript package. If you're using the Datadog Lambda Layer (recommended), do not include <code>datadog-lambda-js</code> in your <code>package.json</code>, or install it as a dev dependency and run <code>npm install --production</code> before deploying.</div>
 
 ## Minimize Cold Start Duration (Beta)
 Starting with version 63 of [the Datadog Extension][7], you can set the environment variable `DD_EXTENSION_VERSION` to `next` to use an optimized version of the Datadog Extension that reduces instrumentation overhead by up to 70%. To leave feedback or report a bug, please add an [issue on Github][8] and tag your issue with `version/next`.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR adds a disclaimer to in the Serverless Nodejs installation instructions to make it clear to customers not to have `datadog-lambda-js` installed in both the `node_modules` and as a lambda layer. 

This is already mentioned under the `Custom` tab, but the vast majority of people reading this page will only be following the `Datadog CLI`, `Serverless Framework`, or `AWS SAM` tabs where it is not explicitly stated to only install the Lambda library in one place.

It's common for users to install the Lambda layers as instructed by the documentation, but then then see import errors in their code, causing them to run `npm install datadog-lambda-js`. Now they will have the Lambda library installed in two places, which will (1) increase package size and cold start duration, and (2) break custom metrics.

We've had several customers open support tickets recently about broken metrics caused by this issue, so this PR aims to avoid this problem in the future.

<img width="825" alt="Screenshot 2024-10-24 at 4 46 47 PM" src="https://github.com/user-attachments/assets/d12c8525-4199-4f54-a06c-f27ebfd89260">

https://docs-staging.datadoghq.com/nicholas.hulston/add-serverless-node-disclaimer/serverless/aws_lambda/installation/nodejs/?tab=datadogcli

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->