### PR TITLE
[dbm] explicitly grant read access to config database

### DIFF
--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -39,7 +39,7 @@ The Datadog Agent requires read-only access to the MongoDB Atlas Cluster to coll
 4. Add the following permissions to the custom role:
    - `read` on the `admin` database
    - `read` on the `local` database
-   - `read` on the `config` database
+   - `read` on the `config` database (Sharded Cluster only)
    - `clusterMonitor` on the `admin` database
    - `read` on the user created databases you want to monitor, or `readAnyDatabase` to monitor all databases
 5. Click **Add Custom Role**.

--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -39,8 +39,9 @@ The Datadog Agent requires read-only access to the MongoDB Atlas Cluster to coll
 4. Add the following permissions to the custom role:
    - `read` on the `admin` database
    - `read` on the `local` database
+   - `read` on the `config` database
    - `clusterMonitor` on the `admin` database
-   - `read` on the databases you want to monitor, or `readAnyDatabase` to monitor all databases
+   - `read` on the user created databases you want to monitor, or `readAnyDatabase` to monitor all databases
 5. Click **Add Custom Role**.
 
 #### Create a monitoring user with the custom monitoring role


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Explicitly read access to `config` database for MongoDB Atlas. This is because the built-in `readAnyDatabase` role from MongoDB Atlas does not provide read access to `config` database. 

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->