### PR TITLE
[DOCS-8176] Add info about self-hosted and self-managed Kubernetes clusters

### DIFF
--- a/layouts/shortcodes/observability_pipelines/install_worker/kubernetes.md
+++ b/layouts/shortcodes/observability_pipelines/install_worker/kubernetes.md
@@ -1,4 +1,4 @@
-1. Download the [Helm chart values file][601].
+1. Download the [Helm chart values file][601]. If you are not using a managed service such as Amazon EKS, Google GKE, or Azure AKS, see [Self-hosted and self-managed Kubernetes clusters](#self-hosted-and-self-managed-kubernetes-clusters) before continuing to the next step.
 1. Click **Select API key** to choose the Datadog API key you want to use.
 1. Add the Datadog chart repository to Helm:
     ```shell
@@ -23,9 +23,13 @@
     ```
     --set service.ports[0].protocol=TCP,service.ports[0].port=8088,service.ports[0].targetPort=8282
     ```
-1. Navigate back to the Observability Pipelines installation page and click **Deploy**.
+1. Navigate back to the Observability Pipelines installation page and click **Deploy**.<br><br>
 
 See [Update Existing Pipelines][602] if you want to make changes to your pipeline's configuration.
+
+#### Self-hosted and self-managed Kubernetes clusters
+
+If you are running a self-hosted and self-managed Kubernetes cluster, and have defined zones with node labels using `topology.kubernetes.io/zone`, then you can use the Helm chart values file as is. However, if you are not using the label `topology.kubernetes.io/zone`, you need to update the `topologyKey` in the `values.yaml` file to match the key you are using. Or if you run your Kubernetes install without zones, remove the entire `topology.kubernetes.io/zone` section.
 
 [601]: /resources/yaml/observability_pipelines/v2/setup/values.yaml
 [602]: /observability_pipelines/update_existing_pipelines


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds info about using self-hosted and self-managed Kubernetes clusters.

[DOCS-8176](https://datadoghq.atlassian.net/browse/DOCS-8176)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

[DOCS-8176]: https://datadoghq.atlassian.net/browse/DOCS-8176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ