### PR TITLE
Add note about percentile aggregations

### DIFF
--- a/content/en/dashboards/widgets/query_value.md
+++ b/content/en/dashboards/widgets/query_value.md
@@ -59,7 +59,7 @@ This widget can be used with the **[Dashboards API][5]**. See the following tabl
 {{< dashboards-widgets-api >}}
 
 ### Troubleshooting
- - If your query is using a percentile value to aggregate underlying data points, you may find that the value returned on the widget remains the same across different time ranges. This behavior can be expected with a large sample size of underlying data points ([reference][7]). Changes in values like this can typically be more easily found across narrower time ranges.
+ - If your query is using a percentile value to aggregate underlying data points, you may find that the value returned on the widget remains the same across different time ranges. This behavior can be expected with a large sample size of underlying data points. Changes in values like this can typically be more easily found across narrower time ranges. For more information on this concept, see the [Law of large numbers][7].
 
 ## Further Reading
 

--- a/content/en/dashboards/widgets/query_value.md
+++ b/content/en/dashboards/widgets/query_value.md
@@ -26,7 +26,7 @@ The widget can display the latest value reported, or an aggregate computed from 
     * Metric: See the [Querying documentation][1] to configure a metric query.
     * Indexed Spans: See the [Trace search documentation][2] to configure an Indexed Span query.
     * Log Events: See the [Log search documentation][3] to configure a log event query.
-2. Reduce the query values to a single value, calculated as the `avg`, `min`, `sum`, `max`, or `last` value of all data points in the specified timeframe.
+2. Reduce the query values to a single value, calculated as the `avg`, `min`, `sum`, `max`, or `last` value of all data points in the specified timeframe. Percentile values like `p75` or `p90` can also be used where supported.
 3. Choose the units and the formatting. Autoformat scales the dashboard for you based on the units.
 4. Optionally, configure a conditional format depending on the value displayed. See [Visual Formatting Rules](#visual-formatting-rules) for more examples.
 5. Optionally, overlay a timeseries background:
@@ -58,6 +58,9 @@ This widget can be used with the **[Dashboards API][5]**. See the following tabl
 
 {{< dashboards-widgets-api >}}
 
+### Troubleshooting
+ - If your query is using a percentile value to aggregate underlying data points, you may find that the value returned on the widget remains the same across different time ranges. This behavior can be expected with a large sample size of underlying data points ([reference][7]). Changes in values like this can typically be more easily found across narrower time ranges.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -68,3 +71,4 @@ This widget can be used with the **[Dashboards API][5]**. See the following tabl
 [4]: /dashboards/guide/context-links/
 [5]: /api/latest/dashboards/
 [6]: /dashboards/graphing_json/widget_json/
+[7]: https://en.wikipedia.org/wiki/Law_of_large_numbers


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Querying for percentile aggregations can be done in query value widgets for some product areas and distribution metrics where percentiles are enabled. Looking to add that note and a troubleshooting point about it.

Motivation for adding some content here is from a [support ticket](https://datadog.zendesk.com/agent/tickets/1869162) and related [technical escalation](https://datadoghq.atlassian.net/browse/WEBPS-5734) that led a customer to beleive that there was a problem with their rum data or with our platform, when in reality they were just experiencing expected behavior due to how the statistics worked out in the particular scenario.

### Merge instructions

- [ x ] Please merge after reviewing

### Additional notes
Happy to receive feedback or reword anything.