### PR TITLE
Update _index.md to fix model_name parameter in llm() decorator

### DIFF
--- a/content/en/llm_observability/setup/sdk/_index.md
+++ b/content/en/llm_observability/setup/sdk/_index.md
@@ -405,7 +405,7 @@ The `LLMObs.annotate()` method accepts the following arguments:
 from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs.decorators import embedding, llm, retrieval, workflow
 
-@llm(model="model_name", model_provider="model_provider")
+@llm(model_name="model_name", model_provider="model_provider")
 def llm_call(prompt):
     resp = ... # llm call here
     LLMObs.annotate(


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR fixes the parameter `model=...` to `model_name=...` to align with the actual [parameter name](https://github.com/DataDog/dd-trace-py/blob/105018feb6f3a6c049535c8ff2241229ede2be7d/ddtrace/llmobs/decorators.py#L19) and what is present on the [documentation page already ](https://docs.datadoghq.com/llm_observability/setup/sdk/#arguments).


### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
