### PR TITLE
Update synthetics-windows-pl version

### DIFF
--- a/data/synthetics_worker_versions.json
+++ b/data/synthetics_worker_versions.json
@@ -1,6 +1,6 @@
 [
     {
         "client": "synthetics-windows-pl",
-        "version": "1.52.0"
+        "version": "1.53.0"
     }
 ]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
A customer in the ticket below pointed out that the windows installer link in the docs still points to version 1.52, when the recommended now is version 1.53. 
[Zendesk ticket](https://datadog.zendesk.com/agent/tickets/1904732)
https://docs.datadoghq.com/getting_started/synthetics/private_location/

I confirmed that in the form to create a new PL in Datadog UI, we suggest 1.5.3
<img width="837" alt="2024-10-25_13-15-50" src="https://github.com/user-attachments/assets/4f1be020-c900-4678-8852-58f38399e930">

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

- [x] Please merge after reviewing

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->