### PR TITLE
Fix japanese conversion error on send-aws-services-logs-with-the-datadog-kines…

### DIFF
--- a/content/ja/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/ja/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -141,7 +141,7 @@ AWS CLI で設定する例としては、[Kinesis データストリームを使
 
 ### 検証
 
-[CloudWatch][1] のロググループの詳細ページの **Subscription filters** 田部井をチェックして、新しい Kinesis ストリームまたは Amazon Data Firehose ストリームがロググループをサブスクライブしているかを確認します。
+[CloudWatch][1] のロググループの詳細ページの **Subscription filters** タブをチェックして、新しい Kinesis ストリームまたは Amazon Data Firehose ストリームがロググループをサブスクライブしているかを確認します。
 
 ### Datadog でログを確認する
 


### PR DESCRIPTION
…is-firehose-destination.md

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Fix japanese  conversion error on send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
  - before: 「田部井」
  - after: 「タブ」

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
