### PR TITLE
[DOCS-8947] Add links to architecture docs

### DIFF
--- a/content/en/agent/guide/private-link.md
+++ b/content/en/agent/guide/private-link.md
@@ -7,6 +7,15 @@ further_reading:
     - link: '/integrations/amazon_web_services/#log-collection'
       tag: 'Documentation'
       text: 'Collect logs from your AWS services'
+    - link: "https://www.datadoghq.com/architecture/connect-to-datadog-over-aws-privatelink/"
+      tag: "Architecture Center"
+      text: "Connect to Datadog over AWS PrivateLink"
+    - link: "https://www.datadoghq.com/architecture/connect-to-datadog-over-aws-privatelink-using-aws-transit-gateway/"
+      tag: "Architecture Center"
+      text: "Connect to Datadog over AWS PrivateLink using AWS Transit Gateway"
+    - link: "https://www.datadoghq.com/architecture/connect-to-datadog-over-aws-privatelink-using-aws-vpc-peering/"
+      tag: "Architecture Center"
+      text: "Connect to Datadog over AWS PrivateLink using AWS VPC peering"
 ---
 
 {{% site-region region="us3,us5,eu,gov" %}}

--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -12,6 +12,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/auto-instrument-kubernetes-tracing-with-datadog/"
   tag: "Blog"
   text: "Use library injection to auto-instrument tracing for Kubernetes applications with Datadog APM"
+- link: "https://www.datadoghq.com/architecture/instrument-your-app-using-the-datadog-operator-and-admission-controller/"
+  tag: "Architecture Center"
+  text: "Instrument your app using the Datadog Operator and Admission Controller"
 ---
 
 ## Overview

--- a/content/en/containers/datadog_operator.md
+++ b/content/en/containers/datadog_operator.md
@@ -13,6 +13,9 @@ further_reading:
   - link: 'https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md'
     tag: "Source Code"
     text: 'Datadog Operator: Configuration'
+  - link: https://www.datadoghq.com/architecture/instrument-your-app-using-the-datadog-operator-and-admission-controller/
+    tag: "Architecture Center"
+    text: "Instrument your app using the Datadog Operator and Admission Controller"
 ---
 
 [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enables you to deploy and configure the Datadog Agent in a Kubernetes environment. 

--- a/content/en/logs/log_configuration/_index.md
+++ b/content/en/logs/log_configuration/_index.md
@@ -15,7 +15,10 @@ further_reading:
   text: "Investigate your log processing with the Datadog Log Pipeline Scanner"
 - link: "/logs/guide/"
   tag: "Guide"
-  text: Additional guides about logging with Datadog
+  text: "Additional guides about logging with Datadog"
+- link: "https://www.datadoghq.com/architecture/a-guide-to-log-management-indexing-strategies-with-datadog/"
+  tag: "Architecture Center"
+  text: "A guide to Log Management Indexing Strategies with Datadog"
 ---
 
 ## Overview

--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -19,6 +19,9 @@ further_reading:
     - link: '/synthetics/api_tests'
       tag: 'Documentation'
       text: 'Configure an API Test'
+    - link: "https://www.datadoghq.com/architecture/protect-sensitive-data-with-synthetics-private-location-runners/"
+      tag: "Architecture Center"
+      text: "Protect Sensitive Data with Synthetics Private Location Runners"
     - link: 'https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/synthetics_private_location'
       tag: "External Site"
       text: 'Create and manage Synthetic Private Locations with Terraform'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds links to Architecture docs.

[DOCS-8947](https://datadoghq.atlassian.net/browse/DOCS-8947)

### Merge instructions
<!-- If you want us to merge this PR as soon as we've reviewed, check the box below. If you're waiting for a release or there are other considerations that you want us to be aware of, list them below. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


[DOCS-8947]: https://datadoghq.atlassian.net/browse/DOCS-8947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ