### PR TITLE
Small follow up changes to CONTAINER_NAME/CONTAINER_IMAGE adjustment

### DIFF
--- a/content/en/containers/docker/integrations.md
+++ b/content/en/containers/docker/integrations.md
@@ -230,7 +230,7 @@ Supply placeholder values as follows:
 : The name of your Datadog integration, such as `etcd` or `redisdb`.
 
 `<CONTAINER_IMAGE>`
-: An identifier to match against the container image (`.spec.containers[i].image`). <br/><br/>
+: An identifier to match against the container image. <br/><br/>
 For example: if you supply `redis` as a container identifier, your Autodiscovery template is applied to all containers with image names that match `redis`. If you have one container running `foo/redis:latest` and `bar/redis:v2`, your Autodiscovery template is applied to both containers.<br/><br/>
 The `ad_identifiers` parameter takes a list, so you can supply multiple container identifiers. You can also use custom identifiers. See [Custom Autodiscovery Identifiers][7].
 

--- a/content/en/containers/guide/autodiscovery-with-jmx.md
+++ b/content/en/containers/guide/autodiscovery-with-jmx.md
@@ -220,7 +220,7 @@ This configuration file should include `ad_identifiers`:
 
 ```yaml
 ad_identifiers:
-  - "<SHORT_IMAGE>"
+  - <CONTAINER_IMAGE>
 
 init_config:
   is_jmx: true
@@ -232,7 +232,7 @@ instances:
     port: "<JMX_PORT>"
 ```
 
-Replace `<SHORT_IMAGE>` with the short image name of your desired container. For example, the container image `gcr.io/CompanyName/my-app:latest` has a short image name of `my-app`. As the Datadog Agent discovers that container, it sets up the JMX configuration as described in this file.
+Replace `<CONTAINER_IMAGE>` with the short image name of your desired container. For example, the container image `gcr.io/CompanyName/my-app:latest` has a short image name of `my-app`. As the Datadog Agent discovers that container, it sets up the JMX configuration as described in this file.
 
 You can alternatively reference and specify [custom identifiers to your containers][4] if you do not want to base this on the short image name.
 
@@ -261,7 +261,7 @@ spec:
         configDataMap:
           <INTEGRATION_NAME>.yaml: |-
             ad_identifiers:
-              - "<SHORT_IMAGE>"
+              - <CONTAINER_IMAGE>
 
             init_config:
               is_jmx: true
@@ -281,7 +281,7 @@ datadog:
   confd:
     <INTEGRATION_NAME>.yaml: |
       ad_identifiers:
-        - "<SHORT_IMAGE>"
+        - <CONTAINER_IMAGE>
 
       init_config:
         is_jmx: true

--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -328,8 +328,7 @@ Supply placeholder values as follows:
 : The name of your Datadog integration, such as `etcd` or `redisdb`.
 
 `<CONTAINER_NAME>`
-: An identifier to match against the names (`spec.containers[0].name`, **not** `spec.containers[0].image`) of the containers that correspond to your integration. <br/><br/>
-The `ad_identifiers` parameter takes a list, so you can supply multiple container identifiers. You can also use custom identifiers. See [Custom Autodiscovery Identifiers][21].
+: An identifier to match against the names (`spec.containers[i].name`, **not** `spec.containers[i].image`) of the containers that correspond to your integration.
 
 `<CONTAINER_IMAGE>`
 : An identifier to match against the container image (`.spec.containers[i].image`). <br/><br/>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
A few small follow up changes to:

- https://github.com/DataDog/documentation/pull/25980

In brief:
- Removed the `spec.containers[i].image` from Docker as that is Kubernetes specific
- I had previously put had `<SHORT_IMAGE>` in the JMX Docs instead of `<CONTAINER_IDENTIFIER>` so fixed that
- `ad_identifiers` is specific to the file setup, so took it out of the `<CONTAINER_NAME>` section for AD annotations

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
