### PR TITLE
Change `ADO.NET` to more specific namespaces

### DIFF
--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -73,7 +73,7 @@ APM tracer integrations support a *Propagation Mode*, which controls the amount 
 
 \* [CommandType.StoredProcedure][25] not supported
 
-\*\* Full mode SQL Server/Java:
+\*\* Full mode SQL Server for Java/.NET:
 - The instrumentation executes a `SET context_info` command when the client issues a query, which makes an additional round-trip to the database.
 - If your applications uses `context_info` to instrument the application, it is overwritten by the APM tracer.
 - Prerequisites:

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -61,7 +61,8 @@ APM tracer integrations support a *Propagation Mode*, which controls the amount 
 |                                          | [Npgsql][16] *         | {{< X >}} |           |                     |                     |
 |                                          | [MySql.Data][17] *     |           | {{< X >}} |                     |                     |
 |                                          | [MySqlConnector][18] * |           | {{< X >}} |                     |                     |
-|                                          | [ADO.NET][24] *        |           |           | {{< X >}} **       |                     |
+|                                          | [System.Data.SqlClient][24] * |    |           | {{< X >}} **        |                     |
+|                                          | [Microsoft.Data.SqlClient][32] * | |           | {{< X >}} **        |                     |
 | **PHP**  [dd-trace-php][19] >= 0.86.0    |                        |           |           |                     |                     |
 |                                          | [pdo][20]              | {{< X >}} | {{< X >}} |                     |                     |
 |                                          | [MySQLi][21]           |           | {{< X >}} |                     |                     |
@@ -448,7 +449,7 @@ View historical performance of similar queries to those executed in your trace, 
 [21]: https://www.php.net/manual/en/book.mysqli.php
 [22]: https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/
 [23]: https://github.com/DataDog/dd-trace-java
-[24]: https://learn.microsoft.com/en-us/dotnet/framework/data/adonet/ado-net-overview
+[24]: https://learn.microsoft.com/sql/connect/ado-net/microsoft-ado-net-sql-server
 [25]: https://learn.microsoft.com/en-us/dotnet/api/system.data.sqlclient.sqlcommand.commandtype?view=dotnet-plat-ext-7.0#remarks:~:text=[…]%20should%20set
 [26]: https://app.datadoghq.com/services
 [27]: https://pypi.org/project/asyncpg/
@@ -456,3 +457,4 @@ View historical performance of similar queries to those executed in your trace, 
 [29]: https://pypi.org/project/mysql-connector-python/
 [30]: https://pypi.org/project/mysqlclient/
 [31]: https://github.com/PyMySQL/PyMySQL
+[32]: https://learn.microsoft.com/sql/connect/ado-net/introduction-microsoft-data-sqlclient-namespace?view=sql-server-ver16

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -74,12 +74,12 @@ APM tracer integrations support a *Propagation Mode*, which controls the amount 
 \* [CommandType.StoredProcedure][25] not supported
 
 \*\* Full mode SQL Server for Java/.NET:
-- The instrumentation executes a `SET context_info` command when the client issues a query, which makes an additional round-trip to the database.
-- If your applications uses `context_info` to instrument the application, it is overwritten by the APM tracer.
-- Prerequisites:
-  - Agent version 7.55.0 or greater
-  - Java tracer version 1.39.0 or greater
-  - .NET tracer version 3.3 or greater
+  - The instrumentation executes a `SET context_info` command when the client issues a query, which makes an additional round-trip to the database.
+  - If your applications uses `context_info` to instrument the application, it is overwritten by the APM tracer.
+  - Prerequisites:
+    - Agent version 7.55.0 or greater
+    - Java tracer version 1.39.0 or greater
+    - .NET tracer version 3.3 or greater
 
 ## Setup
 For the best user experience, ensure the following environment variables are set in your application:

--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -457,4 +457,4 @@ View historical performance of similar queries to those executed in your trace, 
 [29]: https://pypi.org/project/mysql-connector-python/
 [30]: https://pypi.org/project/mysqlclient/
 [31]: https://github.com/PyMySQL/PyMySQL
-[32]: https://learn.microsoft.com/sql/connect/ado-net/introduction-microsoft-data-sqlclient-namespace?view=sql-server-ver16
+[32]: https://learn.microsoft.com/sql/connect/ado-net/introduction-microsoft-data-sqlclient-namespace


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Breaks up `ADO.NET` into `System.Data.SqlClient` and `Microsoft.Data.SqlClient`
We don't fully support `ADO.NET` for DBM, but we _do_ support it via these two namespaces.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
