### PR TITLE
Correct the value for header dd-otlp-source in otlp intake doc

### DIFF
--- a/content/en/opentelemetry/otlp_endpoint.md
+++ b/content/en/opentelemetry/otlp_endpoint.md
@@ -53,7 +53,7 @@ export OTEL_EXPORTER_OTLP_TRACES_HEADERS="dd-protocol=otlp,dd-api-key=${DD_API_K
 
 If you are using manual instrumentation with OpenTelemetry SDKs, configure the OTLP HTTP Protobuf exporter programmatically.
 
-<div class="alert alert-info">Based on your <a href="/getting_started/site/">Datadog site</a>, which is {{< region-param key=dd_datacenter code="true" >}}:<br><ul><li>Replace <code>${YOUR_ENDPOINT}</code> with {{< region-param key="otlp_trace_endpoint" code="true" >}}.<li>Replace <code>${YOUR_SITE}</code> with the value you received from Datadog. </div>
+<div class="alert alert-info">Based on your <a href="/getting_started/site/">Datadog site</a>, which is {{< region-param key=dd_datacenter code="true" >}}:<br><ul><li>Replace <code>${YOUR_ENDPOINT}</code> with {{< region-param key="otlp_trace_endpoint" code="true" >}}.<li>Replace <code>${YOUR_SITE}</code> with the organization name you received from Datadog. </div>
 
 {{< tabs >}}
 {{% tab "JavaScript" %}}

--- a/content/en/opentelemetry/otlp_endpoint.md
+++ b/content/en/opentelemetry/otlp_endpoint.md
@@ -53,7 +53,7 @@ export OTEL_EXPORTER_OTLP_TRACES_HEADERS="dd-protocol=otlp,dd-api-key=${DD_API_K
 
 If you are using manual instrumentation with OpenTelemetry SDKs, configure the OTLP HTTP Protobuf exporter programmatically.
 
-<div class="alert alert-info">Based on your <a href="/getting_started/site/">Datadog site</a>, which is {{< region-param key=dd_datacenter code="true" >}}:<br><ul><li>Replace <code>${YOUR_ENDPOINT}</code> with {{< region-param key="otlp_trace_endpoint" code="true" >}}.<li>Replace <code>${YOUR_SITE}</code> with {{< region-param key="dd_site" code="true" >}}. </div>
+<div class="alert alert-info">Based on your <a href="/getting_started/site/">Datadog site</a>, which is {{< region-param key=dd_datacenter code="true" >}}:<br><ul><li>Replace <code>${YOUR_ENDPOINT}</code> with {{< region-param key="otlp_trace_endpoint" code="true" >}}.<li>Replace <code>${YOUR_SITE}</code> with the value you received from Datadog. </div>
 
 {{< tabs >}}
 {{% tab "JavaScript" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The value of `dd-otlp-source` is not meant to be `datadoghq.com` etc. It should be the org name of allowlisted partners.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
