### PR TITLE
Modify some sentences in "review debug logs" related to tracer flare  

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -299,7 +299,8 @@ cmake --install .build
 
 ## Review debug logs
 
-When debug mode for your tracer is enabled, tracer-specific log messages report how the tracer was initialized and whether traces were sent to the Agent. **These logs are not sent to the Datadog Agent in the flare and are stored in a separate path depending on your logging configuration**. The following log examples show what might appear in your log file.
+
+When debug mode for your tracer is enabled, tracer-specific log messages report how the tracer was initialized and whether traces were sent to the Agent. Debug logs are stored in a separate path depending on your logging configuration. Debug logs are also sent in the flare, if application-level tracer information is enabled, for  <a href="/tracing/troubleshooting/tracer_debug_logs/#Prerequisites">supported languages</a>. The following log examples show what might appear in your log file.
 
 If there are errors that you don't understand, or if traces are reported as flushed to Datadog but you cannot see them in the Datadog UI, [contact Datadog support][1] and provide the relevant log entries with [a flare][2].
 

--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -300,7 +300,7 @@ cmake --install .build
 ## Review debug logs
 
 
-When debug mode for your tracer is enabled, tracer-specific log messages report how the tracer was initialized and whether traces were sent to the Agent. Debug logs are stored in a separate path depending on your logging configuration. Debug logs are also sent in the flare, if application-level tracer information is enabled, for  <a href="/tracing/troubleshooting/tracer_debug_logs/#Prerequisites">supported languages</a>. The following log examples show what might appear in your log file.
+When debug mode for your tracer is enabled, tracer-specific log messages report how the tracer was initialized and whether traces were sent to the Agent. Debug logs are stored in a separate path depending on your logging configuration. If you enable application-level tracer information, debug logs are also sent in the flare for [supported languages](#prerequisites). The following log examples show what might appear in your log file.
 
 If there are errors that you don't understand, or if traces are reported as flushed to Datadog but you cannot see them in the Datadog UI, [contact Datadog support][1] and provide the relevant log entries with [a flare][2].
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
remove "These logs are not sent to the Datadog Agent in the flare and are stored in a separate path depending on your logging configuration."  that is not true

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
