### PR TITLE
rm trailing space - placeholder translation script - [WEB-5532]

### DIFF
--- a/content/en/llm_observability/configuration/_index.md
+++ b/content/en/llm_observability/configuration/_index.md
@@ -1,4 +1,4 @@
----
+--- 
 title: Configuration
 description: Learn how to configure topics and evaluations for your LLM applications on the Configuration page.
 further_reading: 

--- a/content/en/llm_observability/configuration/_index.md
+++ b/content/en/llm_observability/configuration/_index.md
@@ -1,4 +1,4 @@
---- 
+---
 title: Configuration
 description: Learn how to configure topics and evaluations for your LLM applications on the Configuration page.
 further_reading: 

--- a/local/bin/py/placehold_translations.py
+++ b/local/bin/py/placehold_translations.py
@@ -103,7 +103,7 @@ def create_placeholder_file(template, new_glob, lang_as_dir, files_location):
 
     with open(template) as o_file:
         content = o_file.read()
-        boundary = re.compile(r'^-{3,}$', re.MULTILINE)
+        boundary = re.compile(r'^-{3,}\s*$', re.MULTILINE)
         split = boundary.split(content, 2)
         new_yml = {}
         if len(split) == 3:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
updates the placeholder translation processing by adjusting regex used to split `frontmatter` and `content` to account for 0 or more spaces after `---`.

motivation: https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?selectedIssue=WEB-5532

preview: https://docs-staging.datadoghq.com/stefon.simmons/fix-fm-in-content-translations
  - check that this page https://docs-staging.datadoghq.com/stefon.simmons/fix-fm-in-content-translations/llm_observability/configuration/ looks good on all translated pages (i.e. en, ko, ja, fr)
  - Isnt showing frontmatter in content. rendering further reading links


### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
