### PR TITLE
Update Kubernetes configuration to collected logs only

### DIFF
--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -31,7 +31,7 @@ To disable payloads, you must be running Agent v6.4+. This disables metric data 
 {{% /tab %}}
 {{% tab "Docker" %}}
 
-If you are using the Docker containerized Agent, set the `DD_ENABLE_PAYLOADS_EVENTS`, `DD_ENABLE_PAYLOADS_SERIES`, `DD_ENABLE_PAYLOADS_SERVICE_CHECKS`, and `DD_ENABLE_PAYLOADS_SKETCHES` environment variables to `false` in addition to your Agent configuration:
+If you're using the Docker containerized Agent, make sure to set the following environment variables in addition to your Agent configuration:
 
 ```shell
 docker run -d --name datadog-agent \
@@ -55,21 +55,26 @@ docker run -d --name datadog-agent \
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-If you are deploying the Agent in Kubernetes, set the `DD_ENABLE_PAYLOADS_EVENTS`, `DD_ENABLE_PAYLOADS_SERIES`, `DD_ENABLE_PAYLOADS_SERVICE_CHECKS`, and `DD_ENABLE_PAYLOADS_SKETCHES` environment variables to `false` in addition to your Agent configuration.
+If you're deploying the Agent in Kubernetes, make the following changes in your Helm chart in addition to your Agent configuration:
 
 ```yaml
  ## Send logs only
- datadog:
- [...]
-   env:
-      - name: DD_ENABLE_PAYLOADS_EVENTS
-        value: "false"
-      - name: DD_ENABLE_PAYLOADS_SERIES
-        value: "false"
-      - name: DD_ENABLE_PAYLOADS_SERVICE_CHECKS
-        value: "false"
-      - name: DD_ENABLE_PAYLOADS_SKETCHES
-        value: "false"
+clusterAgent:
+  enabled: false
+datadog:
+[...]
+  processAgent:
+    enabled: false
+[...]
+  env:
+    - name: DD_ENABLE_PAYLOADS_EVENTS
+      value: "false"
+    - name: DD_ENABLE_PAYLOADS_SERIES
+      value: "false"
+    - name: DD_ENABLE_PAYLOADS_SERVICE_CHECKS
+      value: "false"
+    - name: DD_ENABLE_PAYLOADS_SKETCHES
+      value: "false"
 ```
 
 {{% /tab %}}

--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -38,7 +38,13 @@ To disable payloads, you must be running Agent v6.4+. This disables metric data 
 {{% /tab %}}
 {{% tab "Docker" %}}
 
-If you're using the Docker containerized Agent, make sure to set the following environment variables in addition to your Agent configuration:
+If you're using the Docker containerized Agent, set the following environment variables to `false`:
+- `DD_ENABLE_PAYLOADS_EVENTS`
+- `DD_ENABLE_PAYLOADS_SERIES`
+- `DD_ENABLE_PAYLOADS_SERVICE_CHECKS`
+- `DD_ENABLE_PAYLOADS_SKETCHES`
+
+Here's an example of how you can include these settings in your Docker run command:
 
 ```shell
 docker run -d --name datadog-agent \

--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -2,6 +2,13 @@
 title: Use the Datadog Agent for Log Collection Only
 aliases:
   - /logs/faq/how-to-set-up-only-logs
+further_reading:
+- link: "/containers/docker/log/?tab=containerinstallation"
+  tag: "Documentation"
+  text: "Docker Log Collection"
+- link: "/containers/kubernetes/log/"
+  tag: "Documentation"
+  text: "Kubenetes Log Collection"
 ---
 
 <div class="alert alert-danger">Infrastructure Monitoring is a prerequisite to using APM. If you are an APM customer, do not turn off metric collection or you might lose critical telemetry and metric collection information.</div>
@@ -79,3 +86,7 @@ datadog:
 
 {{% /tab %}}
 {{< /tabs >}}
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Update the Helm chart configuration to collect logs only in Kubernetes
- [DOCS-9388](https://datadoghq.atlassian.net/browse/DOCS-9388)

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


[DOCS-9388]: https://datadoghq.atlassian.net/browse/DOCS-9388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ