### PR TITLE
Add shutdown hook to java lambda custom metrics examples.

### DIFF
--- a/content/en/serverless/aws_lambda/metrics.md
+++ b/content/en/serverless/aws_lambda/metrics.md
@@ -226,6 +226,22 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
         response.setStatusCode(200);
         return response;
     }
+
+    static {
+        // ensure all metrics are flushed before shutdown
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("[runtime] shutdownHook triggered");
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    System.out.println("[runtime] sleep interrupted");
+                }
+                System.out.println("[runtime] exiting");
+            }
+        });
+    }
 }
 ```
 

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -142,6 +142,22 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
         response.setStatusCode(200);
         return response;
     }
+
+    static {
+        // ensure all metrics are flushed before shutdown
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("[runtime] shutdownHook triggered");
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    System.out.println("[runtime] sleep interrupted");
+                }
+                System.out.println("[runtime] exiting");
+            }
+        });
+    }
 }
 ```
 

--- a/content/es/serverless/aws_lambda/metrics.md
+++ b/content/es/serverless/aws_lambda/metrics.md
@@ -185,6 +185,22 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
         response.setStatusCode(200);
         return response;
     }
+
+    static {
+        // asegúrese de que todas las métricas se vacíen antes del cierre
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("[runtime] shutdownHook activado");
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    System.out.println("[runtime] sleep interrumpido");
+                }
+                System.out.println("[runtime] saliendo");
+            }
+        });
+    }
 }
 ```
 

--- a/content/es/serverless/custom_metrics/_index.md
+++ b/content/es/serverless/custom_metrics/_index.md
@@ -142,6 +142,22 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
         response.setStatusCode(200);
         return response;
     }
+
+    static {
+        // asegúrese de que todas las métricas se vacíen antes del cierre
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("[runtime] shutdownHook activado");
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    System.out.println("[runtime] sleep interrumpido");
+                }
+                System.out.println("[runtime] saliendo");
+            }
+        });
+    }
 }
 ```
 

--- a/content/ja/serverless/custom_metrics/_index.md
+++ b/content/ja/serverless/custom_metrics/_index.md
@@ -142,6 +142,22 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
         response.setStatusCode(200);
         return response;
     }
+
+    static {
+        // シャットダウン前にすべてのメトリクスがフラッシュされるようにする
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("[runtime] shutdownHook triggered");
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    System.out.println("[runtime] sleep interrupted");
+                }
+                System.out.println("[runtime] exiting");
+            }
+        });
+    }
 }
 ```
 

--- a/content/ko/serverless/aws_lambda/metrics.md
+++ b/content/ko/serverless/aws_lambda/metrics.md
@@ -186,6 +186,22 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
         response.setStatusCode(200);
         return response;
     }
+
+    static {
+        // 종료 전에 모든 측정항목이 플러시되었는지 확인하세요
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("[runtime] shutdownHook triggered");
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    System.out.println("[runtime] sleep interrupted");
+                }
+                System.out.println("[runtime] exiting");
+            }
+        });
+    }
 }
 ```
 

--- a/content/ko/serverless/custom_metrics/_index.md
+++ b/content/ko/serverless/custom_metrics/_index.md
@@ -142,6 +142,22 @@ public class Handler implements RequestHandler<APIGatewayV2ProxyRequestEvent, AP
         response.setStatusCode(200);
         return response;
     }
+
+    static {
+        // 종료 전에 모든 측정항목이 플러시되었는지 확인하세요
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                System.out.println("[runtime] shutdownHook triggered");
+                try {
+                    Thread.sleep(300);
+                } catch (InterruptedException e) {
+                    System.out.println("[runtime] sleep interrupted");
+                }
+                System.out.println("[runtime] exiting");
+            }
+        });
+    }
 }
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds an example shutdown hook to AWS Lambda java custom metrics examples. This code is required so that all metrics are flushed before shutdown.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
