### PR TITLE
DOCS-9032 Ruby version support for API Sec

### DIFF
--- a/content/en/security/application_security/threats/setup/compatibility/_index.md
+++ b/content/en/security/application_security/threats/setup/compatibility/_index.md
@@ -15,7 +15,7 @@ The following ASM capabilities are supported relative to each language's tracing
 | ASM capability                         | Java    | .NET     | Node.js                                          | Python        | Go              | Ruby          | PHP           |
 |----------------------------------------|---------|----------|--------------------------------------------------|---------------|-----------------|---------------|---------------|
 | Threat Detection                       | 1.8.0   | 2.23.0   | 4.0.0                                            | 1.9.0         | 1.47.0          | 1.9.0         | 0.84.0        |
-| API Security                           | 1.31.0  | 2.42.0   | 4.30.0 for Node.js 16+, or 5.6.0 for Node.js 18+ | 2.6.0         | 1.59.0          | 1.15.0        | 0.98.0        |
+| API Security                           | 1.31.0  | 2.42.0   | 4.30.0 for Node.js 16+, or 5.6.0 for Node.js 18+ | 2.6.0         | 1.59.0          | 2.4.0        | 0.98.0        |
 | Threat Protection                      | 1.9.0   | 2.26.0   | 4.0.0                                            | 1.10.0        | v1.50.0         | 1.11.0        | 0.86.0        |
 | Customize response to blocked requests | 1.11.0  | 2.27.0   | 4.1.0                                            | 1.19.0        | v1.53.0         | 1.15.0        | 0.86.0        |
 | Automatic user activity event tracking | 1.38.0  | support pending   | support pending                                            | 2.11.0        | support pending   | support pending        | support pending        |

--- a/content/en/security/application_security/threats/setup/compatibility/ruby.md
+++ b/content/en/security/application_security/threats/setup/compatibility/ruby.md
@@ -17,7 +17,7 @@ The following application security capabilities are supported in the Ruby librar
 | Software Composition Analysis (SCA) | 1.11.0 |
 | Code Security        | not supported |
 | Automatic user activity event tracking | 1.14.0 |
-| API Security | not supported |
+| API Security | 2.4.0 |
 
 The minimum tracer version to get all supported application security capabilities for Ruby is 1.15.0.
 


### PR DESCRIPTION
updated Ruby version support for API Sec to 2.4.0

### What does this PR do? What is the motivation?

Updates version number

### Merge instructions

Merge after reviews.