### PR TITLE
Clarify port 9443 in the Rancher troubleshooting

### DIFF
--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -360,7 +360,7 @@ For more information, see [Adding firewall rules for specific use cases][15] in 
 
 #### Rancher
 
-If you are using Rancher with an EKS cluster or a private GKE cluster, additional configuration is required. For more information, see [Rancher Webhook - Common Issues][16] in the Rancher documentation.
+If you are using Rancher with an EKS cluster or a private GKE cluster, additional configuration is required. For more information, see [Rancher Webhook - Common Issues][16] in the Rancher documentation. As our Admission Controller's webhook functions very similar to the Rancher webhook, just on port `8000` instead of Rancher's `9443`.
 
 ##### Rancher and EKS
 To use Rancher in an EKS cluster, deploy the Cluster Agent pod with the following configuration:
@@ -393,7 +393,7 @@ clusterAgent:
 You must also add a security group inbound rule, as described in the [Amazon EKS](#amazon-elastic-kubernetes-service-eks) section on this page.
 
 ##### Rancher and GKE
-To use Rancher in a private GKE cluster, edit your firewall rules to allow inbound access over TCP on port `8000` and port `9443`. See the [GKE](#google-kubernetes-engine-gke) section on this page.
+To use Rancher in a private GKE cluster, edit your firewall rules to allow inbound access over TCP on port `8000`. See the [GKE](#google-kubernetes-engine-gke) section on this page.
 
 ## Further Reading
 

--- a/content/en/containers/troubleshooting/admission-controller.md
+++ b/content/en/containers/troubleshooting/admission-controller.md
@@ -360,7 +360,9 @@ For more information, see [Adding firewall rules for specific use cases][15] in 
 
 #### Rancher
 
-If you are using Rancher with an EKS cluster or a private GKE cluster, additional configuration is required. For more information, see [Rancher Webhook - Common Issues][16] in the Rancher documentation. As our Admission Controller's webhook functions very similar to the Rancher webhook, just on port `8000` instead of Rancher's `9443`.
+If you are using Rancher with an EKS cluster or a private GKE cluster, additional configuration is required. For more information, see [Rancher Webhook - Common Issues][16] in the Rancher documentation.
+
+**Note**: Since Datadog's Admission Controller's webhook operates similarly to the Rancher webhook, Datadog needs access to port `8000` instead of Rancher's `9443`.
 
 ##### Rancher and EKS
 To use Rancher in an EKS cluster, deploy the Cluster Agent pod with the following configuration:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Minor change to the Rancher section of the troubleshooting documentation. Clarifying that we need access to port 8000, similar to how Rancher needs access through port 9443. The Datadog Cluster Agent/Admission Controller itself does not need port 9443 access. 

From customer request.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
