### PR TITLE
Update available metric tags

### DIFF
--- a/content/en/tracing/guide/ddsketch_trace_metrics.md
+++ b/content/en/tracing/guide/ddsketch_trace_metrics.md
@@ -21,7 +21,7 @@ Trace metrics are collected automatically for your services and resources and ar
   - *Prerequisite:* This metric exists for any APM service .
   - *Description:* Represents latency distributions for all services, resources and versions across different environments and second primary tags.
   - *Metric type:* [DISTRIBUTION][2]
-  - *Tags:* `env`, `service`, `version`, `resource`, and [the second primary tag][3].
+  - *Tags:* `env`, `service`,`version`, `resource`, `resource_name`, `http.status_code`, `synthetics`, and [the second primary tag][3].
 
 The APM Service and Resource pages use this metric type automatically. You can use these metrics to power your dashboards and monitors.
 


### PR DESCRIPTION
Update tags to match the tags we mark as available here: https://docs.datadoghq.com/tracing/metrics/metrics_namespace/#latency-distribution

I confirmed in the metric explorer that they are available:

<img width="896" alt="image" src="https://github.com/user-attachments/assets/3290b13c-2b45-4a58-a10e-020d0e0f44b1">


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
