### PR TITLE
Update datadog_operator.md: Add `site` to the sample YAML

### DIFF
--- a/content/en/getting_started/containers/datadog_operator.md
+++ b/content/en/getting_started/containers/datadog_operator.md
@@ -33,7 +33,7 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
   ```
   Replace `<DATADOG_API_KEY>` with your [Datadog API key][5].
   
-  **Note**: add an application key for autoscaling using the external metrics server by adding `--from-literal app-key=<DATADOG_APP_KEY>`
+  **Note**: Add an application key for autoscaling using the external metrics server by adding `--from-literal app-key=<DATADOG_APP_KEY>`
 
 3. Create a `datadog-agent.yaml` file with the spec of your `DatadogAgent` deployment configuration. The following sample configuration enables metrics, logs, and APM:
   ```yaml
@@ -54,7 +54,7 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
       logCollection:
         enabled: true
   ```
-  **Note**: Make sure to set `site` to the datadog site you are using - for instance, **datadoghq.eu**. 
+  **Note**: Make sure to set `site` to the Datadog site you are using (for instance, `datadoghq.eu`). 
   
   For all configuration options, see the [Operator configuration spec][6].
 

--- a/content/en/getting_started/containers/datadog_operator.md
+++ b/content/en/getting_started/containers/datadog_operator.md
@@ -32,8 +32,8 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
   kubectl create secret generic datadog-secret --from-literal api-key=<DATADOG_API_KEY>
   ```
   Replace `<DATADOG_API_KEY>` with your [Datadog API key][5].
-
-  **Note**: add the application key for autoscaling using the external metrics server.
+  
+  **Note**: add an application key for autoscaling using the external metrics server by adding `--from-literal app-key=<DATADOG_APP_KEY>`
 
 3. Create a `datadog-agent.yaml` file with the spec of your `DatadogAgent` deployment configuration. The following sample configuration enables metrics, logs, and APM:
   ```yaml
@@ -43,6 +43,7 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
     name: datadog
   spec:
     global:
+      site: datadoghq.com
       credentials:
         apiSecret:
           secretName: datadog-secret
@@ -53,6 +54,8 @@ The [Datadog Operator][1] is an open source [Kubernetes Operator][2] that enable
       logCollection:
         enabled: true
   ```
+  **Note**: Make sure to set `site` to the datadog site you are using - for instance, **datadoghq.eu**. 
+  
   For all configuration options, see the [Operator configuration spec][6].
 
 4. Deploy the Datadog Agent:


### PR DESCRIPTION
Adds `site` to the example YAML for the operator setup and clarify app key config

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
There is no mention of the `global.site` field in the example YAML. Without going through the linked CRD field spec, users who are not using the default site datadoghq.com will struggle to get the agent running. The error messages received lead down a "bad credentials" rabbit hole which does not make it immediately obvious that the site might be wrong, so I think it is a good idea to point out this needs to be set, here, on the getting started pages. 

I've also expanded on adding the app key as again, I think this is something most people will need, and it is better to be explicit about this. 

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
