### PR TITLE
Update the callout of Data Jobs Monitoring for Apache Airflow

### DIFF
--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -14,8 +14,8 @@ further_reading:
       text: 'Data Jobs Monitoring'
 ---
 
-{{< callout url="https://www.datadoghq.com/private-beta/monitoring-for-data-and-data-pipelines/" d_target="#signupModal" btn_hidden="false" header="Request access to the Preview!" >}}
-Data Jobs Monitoring for Apache Airflow is in Preview. To request access, complete the form.
+{{< callout url="#" btn_hidden="true" header="Try the Preview!" >}}
+Data Jobs Monitoring for Apache Airflow is in Preview. To try it, follow the setup instructions below.
 {{< /callout >}}
 
 [Data Jobs Monitoring][1] provides visibility into the performance and reliability of workflows run by Apache Airflow DAGs.

--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -15,7 +15,7 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="Data Jobs Monitoring for Apache Airflow is in Preview" >}}
-Data Jobs Monitoring for Apache Airflow is in Preview. To try it, follow the setup instructions below.
+To try the preview for Airflow monitoring, follow the setup instructions below.
 {{< /callout >}}
 
 [Data Jobs Monitoring][1] provides visibility into the performance and reliability of workflows run by Apache Airflow DAGs.

--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -14,7 +14,7 @@ further_reading:
       text: 'Data Jobs Monitoring'
 ---
 
-{{< callout url="#" btn_hidden="true" header="Try the Preview!" >}}
+{{< callout url="#" btn_hidden="true" header="Data Jobs Monitoring for Apache Airflow is in Preview" >}}
 Data Jobs Monitoring for Apache Airflow is in Preview. To try it, follow the setup instructions below.
 {{< /callout >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? 
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This doc update removes the requirement for a preview signup, allowing users to try the Data Jobs Monitoring preview directly.

### What is the motivation?
Remove onboarding frictions.
