### PR TITLE
Remove `AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID`

### DIFF
--- a/content/en/serverless/step_functions/merge-step-functions-lambda.md
+++ b/content/en/serverless/step_functions/merge-step-functions-lambda.md
@@ -124,7 +124,6 @@ To link your Step Function traces to nested Step Function traces, configure your
     "StateMachineArn": "${stateMachineArn}",
     "Input": {
       "StatePayload": "Hello from Step Functions!",
-      "AWS_STEP_FUNCTIONS_STARTED_BY_EXECUTION_ID.$": "$$.Execution.Id",
       "CONTEXT": {
         "Execution.$": "$$.Execution",
         "State.$": "$$.State",


### PR DESCRIPTION
This field is never used. Removing it to avoid confusing customers.

### Merge instructions
Please merge it after review. Thanks!