### PR TITLE
[CWS-3524] pull CWS documentation from release branch (and not main)

### DIFF
--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -568,10 +568,9 @@
             file_name: 'agent_config.yaml'
             output_content: false
         - action: pull-and-push-folder
-          branch: main
+          branch: 7.59.x
           globs:
           - 'docs/cloud-workload-security/agent_expressions.md'
-          - 'docs/cloud-workload-security/backend.md'
           - 'docs/cloud-workload-security/backend_linux.md'
           - 'docs/cloud-workload-security/backend_windows.md'
           - 'docs/cloud-workload-security/linux_expressions.md'

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: true
+    cache_enabled: false
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -1,6 +1,6 @@
 ---
 - config:
-    cache_enabled: false
+    cache_enabled: true
 
 - data:
     - org_name: jenkinsci

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -570,10 +570,9 @@
             file_name: 'agent_config.yaml'
             output_content: false
         - action: pull-and-push-folder
-          branch: main
+          branch: 7.59.x
           globs:
           - 'docs/cloud-workload-security/agent_expressions.md'
-          - 'docs/cloud-workload-security/backend.md'
           - 'docs/cloud-workload-security/backend_linux.md'
           - 'docs/cloud-workload-security/backend_windows.md'
           - 'docs/cloud-workload-security/linux_expressions.md'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR, in addition to removing a file that is no longer needed, changes the pull config to only pull the CWS documentation from the release branch of the agent and not from main. This will allow us to make sure new features are not available in the documentation before they are available to users through the agent.

The downside of this is that PR will be required for every release to update the release branch.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
