### PR TITLE
Update font-size for definition lists to match main body text

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -608,6 +608,7 @@ h5 {
     
     ul,
     ol,
+    dl,
     p {
         &:lang(ja) {
             font-size: 14px;
@@ -923,6 +924,7 @@ table,
 
 dl {
     border: 1px solid $ddgray;
+    font-size: 18px;
 
     a {
         border-bottom: 1px solid;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- update font-size for definition lists in main body content to match the font size of `p`, `ol`, and `ul` in main body content

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes

https://docs-staging.datadoghq.com/carlos/update-def-lists-fontsize/api_catalog/#key-terminology
