### PR TITLE
[aws-ints] updating terraform to attach security-audit policy

### DIFF
--- a/content/en/integrations/guide/aws-terraform-setup.md
+++ b/content/en/integrations/guide/aws-terraform-setup.md
@@ -67,6 +67,11 @@ Using [Terraform][1], you can create the Datadog IAM role, policy document, and 
       policy_arn = "${aws_iam_policy.datadog_aws_integration.arn}"
    }
 
+   resource "aws_iam_role_policy_attachment" "datadog_aws_integration_security_audit" {
+      role = "${aws_iam_role.datadog_aws_integration.name}"
+      policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+   }
+
    resource "datadog_integration_aws" "sandbox" {
       account_id  = "<AWS_ACCOUNT_ID>"
       role_name   = "DatadogAWSIntegrationRole"

--- a/content/es/integrations/guide/aws-terraform-setup.md
+++ b/content/es/integrations/guide/aws-terraform-setup.md
@@ -159,7 +159,7 @@ Mediante el uso de [Terraform][1], puedes crear el rol IAM de Datadog, el docume
 [3]: /es/integrations/guide/aws-manual-setup/?tab=accesskeysgovcloudorchinaonly#aws
 {{< /site-region>}}
 
-3. Ejecuta `terraform apply`. Espera hasta 10 minutos para que los datos comiencen a recopilarse y, a continuación, consulta el [dashboard de información general de AWS][5] para ver las métricas enviadas por tus servicios e infraestructura de AWS.
+3. Ejecuta `terraform apply`. Espera hasta 10 minutos para que los datos comiencen a recopilarse y, a continuación, consulta el [dashboard de información general de AWS][5] para ver las métricas enviadas por tus servicios e infraestructura de AWS. 
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/es/integrations/guide/aws-terraform-setup.md
+++ b/content/es/integrations/guide/aws-terraform-setup.md
@@ -66,6 +66,11 @@ Mediante el uso de [Terraform][1], puedes crear el rol IAM de Datadog, el docume
       policy_arn = "${aws_iam_policy.datadog_aws_integration.arn}"
    }
 
+   resource "aws_iam_role_policy_attachment" "datadog_aws_integration_security_audit" {
+      role = "${aws_iam_role.datadog_aws_integration.name}"
+      policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+   }
+
    resource "datadog_integration_aws" "sandbox" {
       account_id  = "<AWS_ACCOUNT_ID>"
       role_name   = "DatadogAWSIntegrationRole"
@@ -154,7 +159,7 @@ Mediante el uso de [Terraform][1], puedes crear el rol IAM de Datadog, el docume
 [3]: /es/integrations/guide/aws-manual-setup/?tab=accesskeysgovcloudorchinaonly#aws
 {{< /site-region>}}
 
-3. Ejecuta `terraform apply`. Espera hasta 10 minutos para que los datos comiencen a recopilarse y, a continuación, consulta el [dashboard de información general de AWS][5] para ver las métricas enviadas por tus servicios e infraestructura de AWS. 
+3. Ejecuta `terraform apply`. Espera hasta 10 minutos para que los datos comiencen a recopilarse y, a continuación, consulta el [dashboard de información general de AWS][5] para ver las métricas enviadas por tus servicios e infraestructura de AWS.
 
 {{< partial name="whats-next/whats-next.html" >}}
 

--- a/content/fr/integrations/guide/aws-terraform-setup.md
+++ b/content/fr/integrations/guide/aws-terraform-setup.md
@@ -67,6 +67,11 @@ L'utilisation de [Terraform][1] vous permet de créer le rôle IAM Datadog, le d
       policy_arn = "${aws_iam_policy.datadog_aws_integration.arn}"
    }
 
+   resource "aws_iam_role_policy_attachment" "datadog_aws_integration_security_audit" {
+      role = "${aws_iam_role.datadog_aws_integration.name}"
+      policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+   }
+
    resource "datadog_integration_aws" "sandbox" {
       account_id  = "<AWS_ACCOUNT_ID>"
       role_name   = "DatadogAWSIntegrationRole"

--- a/content/ja/integrations/guide/aws-terraform-setup.md
+++ b/content/ja/integrations/guide/aws-terraform-setup.md
@@ -66,6 +66,11 @@ title: AWS と Terraform のインテグレーション
       policy_arn = "${aws_iam_policy.datadog_aws_integration.arn}"
    }
 
+   resource "aws_iam_role_policy_attachment" "datadog_aws_integration_security_audit" {
+      role = "${aws_iam_role.datadog_aws_integration.name}"
+      policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+   }
+
    resource "datadog_integration_aws" "sandbox" {
       account_id  = "<AWS_ACCOUNT_ID>"
       role_name   = "DatadogAWSIntegrationRole"

--- a/content/ko/integrations/guide/aws-terraform-setup.md
+++ b/content/ko/integrations/guide/aws-terraform-setup.md
@@ -66,6 +66,11 @@ title: Terraform과 AWS 통합
       policy_arn = "${aws_iam_policy.datadog_aws_integration.arn}"
    }
 
+   resource "aws_iam_role_policy_attachment" "datadog_aws_integration_security_audit" {
+      role = "${aws_iam_role.datadog_aws_integration.name}"
+      policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
+   }
+
    resource "datadog_integration_aws" "sandbox" {
       account_id  = "<AWS_ACCOUNT_ID>"
       role_name   = "DatadogAWSIntegrationRole"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates our suggested terraform code to attach the SecurityAudit policy which is now required by default. Tested this locally and was able to run the updated terraform to attach the policy to our role.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
