### PR TITLE
[DOCS-9450] Remove data retention section on PA

### DIFF
--- a/content/en/product_analytics/user_retention.md
+++ b/content/en/product_analytics/user_retention.md
@@ -73,10 +73,6 @@ Reading the **Dec 04 2023** row of the above graph from left to right:
 - In **Week 0**, 94% of those 144 users completed the return event.
 - In **Week 1**, 92% of the 144 users completed the return event.
 
-## Data retention
-
-Data retention for this feature is limited to 30 days unless your organization is configured to retain data for 90 days. You can file a [support ticket][5] to increase retention to 90 days at no additional cost.
-
 ## Further reading
 {{< partial name="whats-next/whats-next.html" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Per PM request, removes the data retention on the Product Analytics page with the intention of adding it back in later when we have the updated Data Retention page.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
