### PR TITLE
[APMDT-4564] Span tag vs. Span attribute naming convention

### DIFF
--- a/content/en/tracing/error_tracking/_index.md
+++ b/content/en/tracing/error_tracking/_index.md
@@ -34,9 +34,9 @@ Optionally, to see code snippets in your stack traces, set up the [GitHub integr
 
 To get started with configuring your repository, see the [Source Code Integration documentation][6].
 
-## Use span tags to track error spans
+## Use span attributes to track error spans
 
-The Datadog tracers collect errors through integrations and the manual instrumentation of your backend services' source code. Error spans within a trace are processed by Error Tracking **if the error is located in a service entry span** (the uppermost service span). This span must also contain the `error.stack`, `error.message`, and `error.type` [span tags][1] to be tracked.
+The Datadog tracers collect errors through integrations and the manual instrumentation of your backend services' source code. Error spans within a trace are processed by Error Tracking **if the error is located in a service entry span** (the uppermost service span). This span must also contain the `error.stack`, `error.message`, and `error.type` [span attributes][1] to be tracked.
 
 {{< img src="tracing/error_tracking/flamegraph_with_errors.png" alt="Flame graph with errors" style="width:100%;" >}}
 
@@ -46,7 +46,7 @@ Error Tracking computes a fingerprint for each error span it processes using the
 
 Error Tracking automatically categorizes errors into issues collected from your backend services in the [Error Tracking Explorer][5]. See the [Error Tracking Explorer documentation][3] for a tour of key features.
 
-Issues created from APM include the distribution of impacted spans, the latest most relevant stack trace, span tags, host tags, container tags, and metrics.
+Issues created from APM include the distribution of impacted spans, the latest most relevant stack trace, span attributes, host tags, container tags, and metrics.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

[JIRA ticket
](https://datadoghq.atlassian.net/browse/APMDT-4564)

'Span tag' has been changed to 'span attribute' according to this document: https://docs.google.com/document/d/1hVjAaNxDHRv8X29WtaMdSDnfHbSdSSJ7KaJQzGWCxu8/edit?tab=t.0#heading=h.bm61zafc1pcl

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
