### PR TITLE
Clarify the Ruby OpenTelemetry configuration block difference

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/ruby/otel.md
@@ -66,6 +66,8 @@ The following OpenTelemetry features implemented in the Datadog library as noted
 
     - [Add additional Datadog configuration settings][6]
     - [Activate or reconfigure Datadog instrumentation][7]
+   
+   OpenTelemetry configuration can be changed separately, using the [`OpenTelemetry::SDK.configure` block][15].
 
 Datadog combines these OpenTelemetry spans with other Datadog APM spans into a single trace of your application. It supports [integration instrumentation][7] and [OpenTelemetry Automatic instrumentation][8] also.
 
@@ -125,9 +127,10 @@ Read the [OpenTelemetry][14] specification for more information.
 [5]: https://opentelemetry.io/docs/instrumentation/ruby/manual/
 [6]: /tracing/trace_collection/dd_libraries/ruby/#additional-configuration
 [7]: /tracing/trace_collection/dd_libraries/ruby#integration-instrumentation
-[8]: https://opentelemetry.io/docs/instrumentation/ruby/automatic/
+[8]: https://opentelemetry.io/docs/languages/ruby/libraries/
 [9]: /tracing/trace_collection/trace_context_propagation/
 [10]: /tracing/trace_collection/dd_libraries/ruby/#custom-logging
 [12]: /opentelemetry/guide/otel_api_tracing_interoperability/
 [13]: https://opentelemetry.io/docs/specs/otel/trace/api/#add-events
 [14]: https://opentelemetry.io/docs/specs/otel/trace/api/#record-exception
+[15]: https://opentelemetry.io/docs/languages/ruby/getting-started/#instrumentation


### PR DESCRIPTION
Clarify that there are two separate configuration blocks: one for Ruby Datadog configuration; and the other for OpenTelemetry configuration. This has come up as a source of confusion where it can be understood that both Datadog and OpenTelemetry configurations go inside the Datadog configuration block.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
