### PR TITLE
suppress glossary warnings on non-en pgs

### DIFF
--- a/layouts/glossary/list.html
+++ b/layouts/glossary/list.html
@@ -4,7 +4,8 @@
     {{ $headless_term_pages := $headless.Resources.ByType "page" }}
     {{ $letters := slice }}
     {{ $products := slice }}
-
+    {{ $lang := .Site.Language.Lang }}
+    
     <div 
     class="glossary-main" 
     x-data="{
@@ -83,7 +84,7 @@
                             {{ if $valid_core_product }}
                                 {{ $products = union $products (slice $valid_core_product.name) }}
                                 {{ $valid_core_products_array = $valid_core_products_array | append . }}
-                            {{ else }}
+                            {{else if (eq $lang "en") }}
                                 {{ warnf "Ignoring invalid core_product tag %q" . }}
                                 {{ warnf "in %q" $dot.File.Path }}
                             {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

suppresses `/glossary` pg warnings on non-en pgs by only showing warnings if building english pages.

motivation: example: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/699672034#L533
```
WARN  Ignoring invalid core_product tag “신서틱(Synthetic) 모니터링”
WARN  Ignoring invalid core_product tag “보안”
WARN  Ignoring invalid core_product tag “인프라스트럭처 모니터링”
```
preview: 
- docs: https://docs-staging.datadoghq.com/stefon.simmons/suppress-glossary-warnings/glossary/
   -  should be no visual change
- build: https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/699694989
   - should not see any build warnings for invalid core_product tag

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
