### PR TITLE
Explicit 7.58.0+ as minimum mongo version

### DIFF
--- a/layouts/shortcodes/dbm-mongodb-before-you-begin.en.md
+++ b/layouts/shortcodes/dbm-mongodb-before-you-begin.en.md
@@ -1,5 +1,5 @@
 Supported Agent versions
-: 7.58.0
+: 7.58.0+
 
 Performance impact
 : The default Agent configuration for Database Monitoring is conservative, but you can adjust settings such as the collection interval and operation sampling rate to better suit your needs. For most workloads, the Agent represents less than one percent of query execution time on the database and less than one percent of CPU. <br/><br/>


### PR DESCRIPTION
https://dd.slack.com/archives/C027TGQFUMR/p1730924543747039

A customer was confused that it was only 7.58.0 and not versions above as well

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
