### PR TITLE
Add network traffic whitelisting guide for Agentless mode

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4222,146 +4222,151 @@ menu:
       parent: tests_setup
       identifier: tests_setup_junit_xml
       weight: 107
+    - name: Network Traffic
+      url: tests/network/
+      parent: tests
+      identifier: tests_network
+      weight: 2
     - name: Tests in Containers
       url: tests/containers/
       parent: tests
       identifier: tests_containers
-      weight: 2
+      weight: 3
     - name: Search and Manage
       url: tests/search/
       parent: tests
       identifier: tests_search
-      weight: 3
+      weight: 4
     - name: Explorer
       url: tests/explorer/
       parent: tests
       identifier: tests_explorer
-      weight: 4
+      weight: 5
     - name: Search Syntax
       url: tests/explorer/search_syntax
       parent: tests_explorer
       identifier: tests_explorer_search_syntax
-      weight: 401
+      weight: 501
     - name: Search Test Runs
       url: tests/explorer/facets/
       parent: tests_explorer
       identifier: tests_explorer_facets
-      weight: 402
+      weight: 502
     - name: Export
       url: tests/explorer/export/
       parent: tests_explorer
       identifier: tests_explorer_export
-      weight: 403
+      weight: 503
     - name: Saved Views
       url: tests/explorer/saved_views/
       parent: tests_explorer
       identifier: tests_explorer_saved_views
-      weight: 404
+      weight: 504
     - name: Monitors
       url: monitors/types/ci/?tab=tests
       parent: tests
       identifier: tests_monitors
-      weight: 5
+      weight: 6
     - name: Flaky Test Management
       url: tests/flaky_test_management
       parent: tests
       identifier: tests_flaky_test_management
-      weight: 6
+      weight: 7
     - name: Early Flake Detection
       url: tests/flaky_test_management/early_flake_detection
       parent: tests_flaky_test_management
       identifier: tests_early_flake_detection
-      weight: 601
+      weight: 701
     - name: Auto Test Retries
       url: tests/flaky_test_management/auto_test_retries
       parent: tests_flaky_test_management
       identifier: tests_auto_test_retries
-      weight: 602
+      weight: 702
     - name: Test Impact Analysis
       url: tests/test_impact_analysis
       parent: tests
       identifier: test_impact_analysis
-      weight: 7
+      weight: 8
     - name: Setup
       url: tests/test_impact_analysis/setup/
       parent: test_impact_analysis
       identifier: test_impact_analysis_setup
-      weight: 701
+      weight: 81
     - name: .NET
       url: tests/test_impact_analysis/setup/dotnet/
       parent: test_impact_analysis_setup
       identifier: test_impact_analysis_setup_dotnet
-      weight: 101
+      weight: 811
     - name: JavaScript and TypeScript
       url: tests/test_impact_analysis/setup/javascript/
       parent: test_impact_analysis_setup
       identifier: test_impact_analysis_setup_javascript
-      weight: 102
+      weight: 812
     - name: Python
       url: tests/test_impact_analysis/setup/python/
       parent: test_impact_analysis_setup
       identifier: test_impact_analysis_setup_python
-      weight: 103
+      weight: 813
     - name: Swift
       url: tests/test_impact_analysis/setup/swift/
       parent: test_impact_analysis_setup
       identifier: test_impact_analysis_setup_swift
-      weight: 104
+      weight: 814
     - name: Java
       url: tests/test_impact_analysis/setup/java/
       parent: test_impact_analysis_setup
       identifier: test_impact_analysis_setup_java
-      weight: 105
+      weight: 815
     - name: Ruby
       url: tests/test_impact_analysis/setup/ruby/
       parent: test_impact_analysis_setup
       identifier: test_impact_analysis_setup_ruby
-      weight: 106
+      weight: 816
     - name: How It Works
       url: tests/test_impact_analysis/how_it_works/
       parent: test_impact_analysis
       identifier: test_impact_analysis_how_it_works
-      weight: 702
+      weight: 82
     - name: Troubleshooting
       url: tests/test_impact_analysis/troubleshooting/
       parent: test_impact_analysis
       identifier: test_impact_analysis_troubleshooting
-      weight: 703
+      weight: 83
     - name: Developer Workflows
       url: tests/developer_workflows
       parent: tests
       identifier: tests_developer_workflows
-      weight: 8
+      weight: 9
     - name: Code Coverage
       url: tests/code_coverage
       parent: tests
       identifier: tests_code_coverage
-      weight: 9
+      weight: 10
     - name: Instrument Browser Tests with RUM
       url: tests/browser_tests
       parent: tests
       identifier: tests_browser_tests
-      weight: 10
+      weight: 11
     - name: Instrument Swift Tests with RUM
       url: tests/swift_tests
       parent: tests
       identifier: tests_swift_tests
-      weight: 11
+      weight: 12
     - name: Correlate Logs and Tests
       url: tests/correlate_logs_and_tests
       parent: tests
       identifier: tests_correlate_logs_and_tests
-      weight: 12
+      weight: 13
     - name: Guides
       url: tests/guides/
       parent: tests
       identifier: tests_guides
-      weight: 13
+      weight: 14
     - name: Troubleshooting
       url: tests/troubleshooting/
       parent: tests
       identifier: tests_troubleshooting
-      weight: 14
+      weight: 15
     - name: Code Analysis
       url: code_analysis/
       pre: ci

--- a/content/en/tests/network.md
+++ b/content/en/tests/network.md
@@ -1,0 +1,72 @@
+---
+title: Network Traffic
+further_reading:
+  - link: "/tests/setup/"
+    tag: "Documentation"
+    text: "Set up Test Optimization for your language"
+  - link: "/tests/containers/"
+    tag: "Documentation"
+    text: "Forwarding Environment Variables for Tests in Containers"
+  - link: "/tests/troubleshooting/"
+    tag: "Documentation"
+    text: "Troubleshooting Test Optimization"
+---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">
+The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.
+</div>
+{{< /site-region >}}
+
+<div class="alert alert-warning">
+Traffic is always initiated by the tracers to Datadog. No sessions are ever initiated from Datadog back to the tracers.
+</div>
+
+## Destinations
+
+The network endpoints accessed by the tracers are dependent on the Datadog site.
+To see destinations based on your [Datadog site][1], click the `DATADOG SITE` selector on the right.
+
+Ensure the following HTTP endpoints are accessible from the host where your tests are executed:
+
+- `api.`{{< region-param key="dd_site" code="true" >}}
+- `citestcycle-intake.`{{< region-param key="dd_site" code="true" >}}
+- `citestcov-intake.`{{< region-param key="dd_site" code="true" >}}
+- `http-intake.logs.`{{< region-param key="dd_site" code="true" >}}
+- `instrumentation-telemetry-intake.`{{< region-param key="dd_site" code="true" >}}
+- `webhook-intake.`{{< region-param key="dd_site" code="true" >}}
+
+### Static IP addresses
+
+Some of these domains are **CNAME** records pointing to a set of static IP addresses. These addresses can be found at `https://ip-ranges.`{{< region-param key="dd_site" code="true" >}}.
+
+The information is structured as JSON following this schema:
+
+{{< code-block lang="text" disable_copy="true" >}}
+{
+  "version": 1,                          // <-- incremented every time this information is changed
+  "modified": "YYYY-MM-DD-HH-MM-SS",     // <-- timestamp of the last modification
+  "<SECTION-NAME>": {                    // <-- the section for a specific service
+      "prefixes_ipv4": [                 // <-- list of IPv4 CIDR blocks
+        "a.b.c.d/x",
+        ...
+      ],
+      "prefixes_ipv6": [                 // <-- list of IPv6 CIDR blocks
+        ...
+      ]
+  },
+  ...
+}
+{{< /code-block >}}
+
+Each section has a dedicated endpoint, for example `https://ip-ranges.{{< region-param key="dd_site" >}}/api.json`.
+
+### Inclusion
+
+Add all of the `ip-ranges` to your inclusion list. While only a subset are active at any given moment, there are variations over time within the entire set due to regular network operation and maintenance.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /getting_started/site/

--- a/content/en/tests/setup/_index.md
+++ b/content/en/tests/setup/_index.md
@@ -5,10 +5,24 @@ aliases:
 - /continuous_integration/tests/setup/
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">
+The selected Datadog site ({{< region-param key="dd_site_name" >}}) is not supported.
+</div>
+{{< /site-region >}}
+
 For information about configuration options for [Test Optimization][1], choose your language:
 
 {{< partial name="continuous_integration/ci-tests-setup.html" >}}
 
 <br>
 
+If you run your tests in an environment with network restrictions,
+check the [Agent Network Traffic][2] or [Agentless Network Traffic][3] guide for information on how to configure whitelisting.
+
+If you run your tests in a container, check the [Tests in Containers][4] guide for additional setup steps.
+
 [1]: /continuous_integration/tests
+[2]: /agent/configuration/network/
+[3]: /tests/network/
+[4]: /tests/containers/

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -25,7 +25,7 @@ further_reading:
       text: "Correlate logs and test traces"
     - link: "/tests/troubleshooting/"
       tag: "Documentation"
-      text: "Troubleshooting CI Visibility"
+      text: "Troubleshooting Test Optimization"
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/tests/test_impact_analysis/setup/ruby.md
+++ b/content/en/tests/test_impact_analysis/setup/ruby.md
@@ -11,7 +11,7 @@ further_reading:
       text: "Explore Test Results and Performance"
     - link: "/tests/troubleshooting/"
       tag: "Documentation"
-      text: "Troubleshooting CI Visibility"
+      text: "Troubleshooting Test Optimization"
 ---
 
 ## Compatibility

--- a/content/en/tests/troubleshooting/_index.md
+++ b/content/en/tests/troubleshooting/_index.md
@@ -18,8 +18,9 @@ This page provides information to help you troubleshot issues with Test Optimiza
 
 1. Go to the [**Tests**][3] page for the language you're instrumenting and check that the testing framework you are using is supported in the **Compatibility** section.
 2. Check if you see any test results in the [**Test Runs**][4] section. If you do see results there, but not in the [**Tests**][5] section, Git information is missing. See [Data appears in Test Runs but not Tests](#data-appears-in-test-runs-but-not-tests) to troubleshoot it.
-3. If you are reporting the data through the Datadog Agent, make sure it is running on the host where tests are run (accessible at `localhost:8126`), or if accessible on another hostname or port, make sure you run your tests with the appropriate Agent hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_TRACE_AGENT_PORT` environment variables. You can activate [debug mode][6] in the tracer to check if it's able to connect to the Agent.
-4. If you still don't see any results, [contact Support][2] for troubleshooting help.
+3. If you are reporting the data through the Datadog Agent, make sure there is [network connectivity][15] from the host where your tests are running to the host and port where the Agent is running. Make sure you run your tests with the appropriate Agent hostname set in the `DD_AGENT_HOST` and the appropriate port in `DD_TRACE_AGENT_PORT` environment variables. You can activate [debug mode][6] in the tracer to check if it's able to connect to the Agent.
+4. If you are reporting the data directly to Datadog ("Agentless mode"), make sure there is [network connectivity][16] from the host where your tests are running to Datadog's hosts. You can activate [debug mode][6] in the tracer to check if it's able to connect to Datadog.
+5. If you still don't see any results, [contact Support][2] for troubleshooting help.
 
 ## You are uploading JUnit test reports with `datadog-ci` but some or all tests are missing
 If you are uploading JUnit test report files with `datadog-ci` CLI and you do not see the tests, it is likely the tests are being discarded because the report is considered incorrect.
@@ -170,3 +171,5 @@ The best way to fix this is to make sure that the test parameters are the same b
 [12]: /tests/test_impact_analysis/
 [13]: /tests/#parameterized-test-configurations
 [14]: /tests/#supported-features
+[15]: /agent/configuration/network/
+[16]: /tests/network/

--- a/layouts/partials/continuous_integration/ci-tests-setup.html
+++ b/layouts/partials/continuous_integration/ci-tests-setup.html
@@ -51,13 +51,6 @@
           </div>
         </a>
       </div>
-      <div class="col">
-        <a class="card h-100" href="/tests/containers/">
-          <div class="card-body text-center py-2 px-1">
-            {{ partial "img.html" (dict "root" $dot "src" "integrations_logos/container.svg" "class" "img-fluid" "alt" "tests in containers" "width" "150") }}
-          </div>
-        </a>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds a page with the guidelines on how to configure network whitelisting for using Test Visibility in Agentless mode.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
