### PR TITLE
add Spanish selector to language dropdown

### DIFF
--- a/assets/scripts/lang-redirects.js
+++ b/assets/scripts/lang-redirects.js
@@ -7,8 +7,8 @@ const ignoredPaths = [];
 
 /* eslint-enable no-unused-vars */
 
-const allowedLanguages = ['en', 'ja', 'fr', 'ko'];
-const redirectLanguages = ['ja', 'fr', 'ko'];
+const allowedLanguages = ['en', 'ja', 'fr', 'ko', 'es'];
+const redirectLanguages = ['ja', 'fr', 'ko', 'es'];
 const enabledSubdomains = [
 	'www',
 	'docs',

--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -21,4 +21,4 @@ ko:
   weight: 4
 es:
   languageName: "Español"
-  weight: -1
+  weight: 5

--- a/layouts/partials/language-region-select.html
+++ b/layouts/partials/language-region-select.html
@@ -9,18 +9,14 @@
       </button>
       <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
         <!--  dropdown-item hrefs are updated asynchronously in async-loading.js -->
-        {{ if ne .Language.Lang "es" }}
-          {{/*  load this without conditional once typesense nightly build runs 11.6.24 */}}
-          <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}" {{ if ne .Language.Lang "en" }} data-lang="{{ .Language.Lang }}"{{end}}>{{ .Language.LanguageName }}</a>
-        {{ end }}
+        <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}" {{ if ne .Language.Lang "en" }} data-lang="{{ .Language.Lang }}"{{end}}>{{ .Language.LanguageName }}</a>
 
         <!-- Manually adding English option to non-English sites -->
         {{ if ne .Sites.First .Site }}
           <a class="dropdown-item" href="{{ replace .Permalink (printf "/%s/" .Language.Lang) "/" }}?lang_pref=en">English</a>
         {{ end }}
 
-        {{ range where .Translations "Language.Lang" "not in" (slice "en" "es") }}
-          {{/* remove "es" from conditional once typesense nightly build runs 11.6.24   */}}
+        {{ range where .Translations "Language.Lang" "!=" "en" }}
           <a class="dropdown-item" href="{{ .Permalink }}?lang_pref={{ .Language.Lang }}" data-lang="{{ .Language.Lang }}">{{ .Language.LanguageName }}</a>
         {{ end }}
       </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

1. adds `Espanol` to the language dropdown. 
1. enable language redirects and `lang_pref` cookie

Motivation: Related to https://github.com/DataDog/documentation/pull/25922
- nightly build for docs ran which was able to index spanish content in typesense. should be able to search for spanish pages.

Preview: https://docs-staging.datadoghq.com/stefon.simmons/es-lang-dropdown/es
- search should show spanish results
- `Espanol` should show in the lang dropdown on non-es pages.
- check that the `lang-pref` cookie is properly set after you select a language from the dropdown

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
