### PR TITLE
Fix the reference links numbering

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -247,14 +247,14 @@ Open the following ports to benefit from all the **Agent** functionalities:
 | Product/Functionality | Port | Protocol | Description |
 | ------  | ---- | ------- | ----------- |
 | Agent<br>APM<br>Containers<br>Live Processes<br>Metrics | 443 | TCP | Most Agent data uses port 443. |
-| [Custom Agent Autoscaling][4] | 8443 | TCP |  |
-| Log collection | 10516 | TCP | Logging over TCP. See [logs endpoints][3] for other connection types. |
-| NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][2].<br>For information on troubleshooting NTP, see [NTP issues][1]. |
+| [Custom Agent Autoscaling][22] | 8443 | TCP |  |
+| Log collection | 10516 | TCP | Logging over TCP. See [logs endpoints][21] for other connection types. |
+| NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][20].<br>For information on troubleshooting NTP, see [NTP issues][19]. |
 
-[1]: /agent/faq/network-time-protocol-ntp-offset-issues/
-[2]: /integrations/ntp/#overview
-[3]: /logs/log_collection/#logging-endpoints
-[4]: /containers/guide/cluster_agent_autoscaling_metrics
+[19]: /agent/faq/network-time-protocol-ntp-offset-issues/
+[20]: /integrations/ntp/#overview
+[21]: /logs/log_collection/#logging-endpoints
+[22]: /containers/guide/cluster_agent_autoscaling_metrics
 
 {{% /site-region %}}
 
@@ -263,13 +263,14 @@ Open the following ports to benefit from all the **Agent** functionalities:
 | Product/Functionality | Port | Protocol | Description |
 | ------  | ---- | ------- | ----------- |
 | Agent<br>APM<br>Containers<br>Live Processes<br>Metrics | 443 | TCP | Most Agent data uses port 443. |
-| [Custom Agent Autoscaling][5] | 8443 | TCP |  |
-| Log collection | 443 | TCP | Logging over TCP. See [logs endpoints][3] for other connection types. |
-| NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][2].<br>For information on troubleshooting NTP, see [NTP issues][1]. |
+| [Custom Agent Autoscaling][22] | 8443 | TCP |  |
+| Log collection | 443 | TCP | Logging over TCP. See [logs endpoints][21] for other connection types. |
+| NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][20].<br>For information on troubleshooting NTP, see [NTP issues][19]. |
 
-[1]: /agent/faq/network-time-protocol-ntp-offset-issues/
-[2]: /integrations/ntp/#overview
-[3]: /logs/log_collection/#logging-endpoints
+[19]: /agent/faq/network-time-protocol-ntp-offset-issues/
+[20]: /integrations/ntp/#overview
+[21]: /logs/log_collection/#logging-endpoints
+[22]: /containers/guide/cluster_agent_autoscaling_metrics
 
 {{% /site-region %}}
 
@@ -278,11 +279,10 @@ Open the following ports to benefit from all the **Agent** functionalities:
 | Product/Functionality | Port | Protocol | Description |
 | ------  | ---- | ------- | ----------- |
 | Agent<br>APM<br>Containers<br>Live Processes<br>Metrics | 443 | TCP | Most Agent data uses port 443. |
-| NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][2].<br>For information on troubleshooting NTP, see [NTP issues][1]. |
+| NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][20].<br>For information on troubleshooting NTP, see [NTP issues][19]. |
 
-[1]: /agent/faq/network-time-protocol-ntp-offset-issues/
-[2]: /integrations/ntp/#overview
-[3]: /logs/log_collection/#logging-endpoints
+[19]: /agent/faq/network-time-protocol-ntp-offset-issues/
+[20]: /integrations/ntp/#overview
 
 {{% /site-region %}}
 
@@ -390,3 +390,7 @@ To avoid running out of storage space, the Agent stores the metrics on disk only
 [16]: /agent/basic_agent_usage/#gui
 [17]: /tracing/
 [18]: /developers/dogstatsd/
+[19]: /agent/faq/network-time-protocol-ntp-offset-issues/
+[20]: /integrations/ntp/#overview
+[21]: /logs/log_collection/#logging-endpoints
+[22]: /containers/guide/cluster_agent_autoscaling_metrics

--- a/content/en/ddsql_editor/reference_tables.md
+++ b/content/en/ddsql_editor/reference_tables.md
@@ -1,0 +1,60 @@
+---
+title: Reference Tables in DDSQL
+further_reading:
+- link: "/integrations/guide/reference-tables/"
+  tag: "Documentation"
+  text: "Add Custom Metadata with Reference Tables"
+---
+
+# Overview
+
+Reference tables are an essential feature within DDSQL, designed to help you organize and simplify your data queries. These tables store predefined sets of information that can be easily referenced within your queries, reducing complexity and enhancing query performance. In addition to querying data, you can join reference tables with other datasets, expanding your analytical capabilities and insights.
+
+## Querying Reference Tables
+
+### DDSQL Editor Capabilities
+
+The DDSQL Editor allows users to query reference tables directly. This guide aims to clarify how you can unlock the full potential of reference tables in your data queries.
+
+### Example Query Syntax
+
+To query a reference table, you can use the following syntax. Assume the reference table is named "test":
+
+```sql
+SELECT * FROM reference_tables.test
+```
+
+This query retrieves all the data from the specified reference table. Modify the query to include specific columns or conditions as needed.
+
+### Joining Data
+
+In addition to querying reference tables, you can also join them with other available datasets. This process allows for richer data analysis and insights. By joining reference tables, you can:
+
+- Combine reference data with live data to enhance your reports and dashboards.
+- Integrate static and dynamic data for comprehensive analytics.
+
+Here's a simple example of joining a reference table with another dataset:
+
+<!-- ```sql
+SELECT a.*, b.*
+FROM reference_tables.test a
+JOIN other_dataset b ON a.key = b.key
+``` -->
+
+## Notes and Best Practices
+
+When using reference tables, consider the following:
+
+- **Keep Tables Updated:** Regularly update reference tables to ensure data accuracy.
+- **Optimize Queries:** Use indexing and other optimization techniques to improve query performance.
+- **Avoid Common Pitfalls:** Ensure your joins and queries are appropriately configured to avoid performance issues.
+
+## Additional Resources
+
+For more detailed information and guidance, refer to our [Reference Tables Documentation](#). You'll find related pages, tutorials, FAQs, and additional resources to deepen your understanding of DDSQL and effectively manage reference tables.
+
+---
+
+
+
+[1]: /integrations/guide/reference-tables/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Numbering caused the APM link to redirect to the Agent NTP troubleshooting page instead of the APM tracing page.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
