### PR TITLE
removed chrome hack

### DIFF
--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -1,5 +1,5 @@
 import { getQueryParameterByName } from '../helpers/browser';
-import { getCookieByName, chromeHashFix } from '../helpers/helpers';
+import { getCookieByName } from '../helpers/helpers';
 import regionConfig from '../config/regions.config';
 
 const initCodeTabs = () => {
@@ -105,13 +105,11 @@ const initCodeTabs = () => {
                 }
             }else{
                 activateCodeTab(firstTab)
-                chromeHashFix();
             }
         } else {
             if (codeTabsList.length > 0) {
                 activateCodeTab(firstTab)
             }
-            chromeHashFix();
         }
     }
 

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -1,5 +1,5 @@
 import configDocs from './config/config-docs';
-import { updateMainContentAnchors, gtag, chromeHashFix } from './helpers/helpers';
+import { updateMainContentAnchors, gtag } from './helpers/helpers';
 import { bodyClassContains } from './helpers/helpers';
 import { DOMReady } from './helpers/documentReady';
 import { initializeIntegrations } from './components/integrations';
@@ -122,8 +122,6 @@ const doOnLoad = () => {
 
     if (document.querySelector('.code-tabs')) {
         initCodeTabs();
-    } else {
-        chromeHashFix();
     }
 };
 

--- a/assets/scripts/helpers/helpers.js
+++ b/assets/scripts/helpers/helpers.js
@@ -52,17 +52,6 @@ const getCookieByName = (name) => {
     return value;
 };
 
-const chromeHashFix = () => {
-    const isChrome = /Chrome/.test(navigator.userAgent);
-    if (window.location.hash && isChrome) {
-        setTimeout(function () {
-            const hash = window.location.hash;
-            window.location.hash = '';
-            window.location.hash = hash;
-        }, 300);
-    }
-}
-
 const bodyClassContains = (string) => document.body.classList.contains(string);
 
-export { updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, bodyClassContains, chromeHashFix };
+export { updateMainContentAnchors, reloadWistiaVidScripts, gtag, getCookieByName, bodyClassContains };


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This removes the Chrome hash scrolling hack. This is being moved to GTM to increase the predictability and reliability of when it runs.

This addresses this ticket: https://datadoghq.atlassian.net/browse/WEB-5511

When this goes live, worst case scenario is that it will behave the same as it is now until we deploy the GTM change. Extensive testing has been done in preview with the GTM change, but it's impossible to test broadly until it goes live.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

/merge

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
