### PR TITLE
Have Metrics Explorer page point to Quick Graphs page

### DIFF
--- a/content/en/metrics/explorer.md
+++ b/content/en/metrics/explorer.md
@@ -57,7 +57,9 @@ Export your graph to a dashboard or notebook with the buttons at the top right. 
 
 ### Quick Graphs
 
-With [Quick Graphs][7], you get even more options to visualize your data, such as Timeseries, Top List, Query value, and Geomap without needing to create a [Dashboard][4] or [Notebook][2].
+With Quick Graphs, you have more options to visualize your data, without needing to create a [Dashboard][4] or [Notebook][2]. These graphs are useful for understanding and troubleshooting issues without creating permanent dashboards or complex visualization setups.
+
+For more information, see the [Quick Graphs][7] documentation.
 
 ## Further reading
 

--- a/content/en/metrics/explorer.md
+++ b/content/en/metrics/explorer.md
@@ -10,6 +10,9 @@ further_reading:
   - link: "/metrics/distributions/"
     tag: "Documentation"
     text: "Metrics Distributions"
+  - link: "/dashboards/guide/quick-graphs/"
+    tag: "Documentation"
+    text: "Quick Graphs"
     
 ---
 
@@ -52,6 +55,10 @@ You can optionally add functions to your query using the function button. Not al
 
 Export your graph to a dashboard or notebook with the buttons at the top right. You can also use **Split Graph in Notebook** to view the data split into individual graphs by things like region, service, or environment.
 
+### Quick Graphs
+
+With [Quick Graphs][7], you get even more options to visualize your data, such as Timeseries, Top List, Query value, and Geomap without needing to create a [Dashboard][4] or [Notebook][2].
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -61,6 +68,5 @@ Export your graph to a dashboard or notebook with the buttons at the top right. 
 [3]: /dashboards/#screenboards
 [4]: /dashboards/#get-started
 [5]: /metrics/introduction/#space-aggregation
-[6]: https://docs.datadoghq.com/dashboards/querying/#advanced-graphing
-
-
+[6]: /dashboards/querying/#advanced-graphing
+[7]: /dashboards/guide/quick-graphs/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
A prime use case of Quick Graphs is to provide alternate visualizations for metrics that are not present in Metrics Explorer. This change documents Quick Graphs in the same place as Metrics Explorer to improve discoverability.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
