### PR TITLE
Update LP docs to explain that LP monitoring is also enterprise

### DIFF
--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -26,7 +26,7 @@ further_reading:
 
 
 <div class="alert alert-warning">
-Live Processes is included in the Enterprise plan. For all other plans, contact your account representative or <a href="mailto:success@datadoghq.com">success@datadoghq.com</a> to request this feature.
+Live Processes and Live Process Monitoring is included in the Enterprise plan. For all other plans, contact your account representative or <a href="mailto:success@datadoghq.com">success@datadoghq.com</a> to request this feature.
 </div>
 
 ## Introduction

--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -26,7 +26,7 @@ further_reading:
 
 
 <div class="alert alert-warning">
-Live Processes and Live Process Monitoring is included in the Enterprise plan. For all other plans, contact your account representative or <a href="mailto:success@datadoghq.com">success@datadoghq.com</a> to request this feature.
+Live Processes and Live Process Monitoring are included in the Enterprise plan. For all other plans, contact your account representative or <a href="mailto:success@datadoghq.com">success@datadoghq.com</a> to request this feature.
 </div>
 
 ## Introduction

--- a/content/en/monitors/types/process.md
+++ b/content/en/monitors/types/process.md
@@ -19,6 +19,10 @@ further_reading:
   text: "Monitor processes running on AWS Fargate with Datadog"
 ---
 
+<div class="alert alert-warning">
+Live Processes and Live Process Monitoring are included in the Enterprise plan. For all other plans, contact your account representative or <a href="mailto:success@datadoghq.com">success@datadoghq.com</a> to request this feature.
+</div>
+
 ## Overview
 
 Live Process Monitors are based on data collected by the [Process Agent][1]. Create monitors that warn or alert based on the count of any group of processes across hosts or tags.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

A customer was asking if live process monitors are an enterprise-only function. This PR adds Live Process Monitoring to the docs to explain that it is a pro feature as well.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
