### PR TITLE
Remove "beta" label from Span Links

### DIFF
--- a/content/es/tracing/trace_explorer/trace_view.md
+++ b/content/es/tracing/trace_explorer/trace_view.md
@@ -176,9 +176,7 @@ Ve [Hotspots de código][1] para identificar las líneas de código relacionadas
 [1]: /es/profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
 
 {{% /tab %}}
-{{% tab "Span Links (Beta)" %}}
-
-<div class="alert alert-info">La compatibilidad con enlaces de tramo está en fase beta.</div>
+{{% tab "Span Links" %}}
 
 [Los enlaces de tramo][4] correlacionan uno o más tramos juntos que están causalmente relacionados, pero no tienen una relación típica principal-secundario.
 
@@ -191,7 +189,7 @@ Haz clic en un tramo en la gráfica de llamas para mostrar tramos conectados con
 Para saber más sobre los enlaces de tramo y cómo añadirlos con instrumentación personalizada, lee [Enlaces de tramo][4].
 
 [1]: /es/tracing/trace_pipeline/trace_retention/
-[2]: /es/tracing/trace_collection/custom_instrumentation/php#adding-span-links-beta
+[2]: /es/tracing/trace_collection/custom_instrumentation/php#adding-span-links
 [3]: /es/tracing/trace_collection/otel_instrumentation/java#requirements-and-limitations
 [4]: /es/tracing/trace_collection/span_links/
 


### PR DESCRIPTION
Span Links is not in beta anymore on the UI. We should remove any mention to the feature in beta from the documentation.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
