### PR TITLE
Update Usage Attribution to add new Preview metrics

### DIFF
--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -24,8 +24,8 @@ Estimated usage metrics are generally available for the following usage types:
 | Infrastructure Hosts          | `datadog.estimated_usage.hosts`          | Unique hosts seen in the last hour. |
 | Containers                    | `datadog.estimated_usage.containers`     | Unique containers seen in the last hour. |
 | Fargate Tasks                 | `datadog.estimated_usage.fargate_tasks`  | Unique Fargate Tasks seen in the last 5 minutes. |
-| Indexed Custom Metrics        | `datadog.estimated_usage.metrics.custom`, `datadog.estimated_usage.metrics.custom.by_metric` | Unique indexed Custom Metrics seen in the last hour. |
-| Ingested Custom Metrics       | `datadog.estimated_usage.metrics.custom.ingested`, `datadog.estimated_usage.metrics.custom.ingested.by_metric` | Unique ingested Custom Metrics seen in the last hour. |
+| Indexed Custom Metrics        | `datadog.estimated_usage.metrics.custom`, `datadog.estimated_usage.metrics.custom.by_metric`, (Preview) `datadog.estimated_usage.metrics.custom.by_tag` | Unique indexed Custom Metrics seen in the last hour. |
+| Ingested Custom Metrics       | `datadog.estimated_usage.metrics.custom.ingested`, `datadog.estimated_usage.metrics.custom.ingested.by_metric`, (Preview) `datadog.estimated_usage.metrics.custom.ingested.by_tag` | Unique ingested Custom Metrics seen in the last hour. |
 | Logs Ingested Bytes           | `datadog.estimated_usage.logs.ingested_bytes` | Total ingestion of logs in bytes. |
 | Logs Ingested Events          | `datadog.estimated_usage.logs.ingested_events` | Total number of ingested events, including excluded logs. |
 | Logs Drop Count               | `datadog.estimated_usage.logs.drop_count` | Total number of events dropped during ingestion. |

--- a/content/en/account_management/billing/usage_metrics.md
+++ b/content/en/account_management/billing/usage_metrics.md
@@ -24,8 +24,8 @@ Estimated usage metrics are generally available for the following usage types:
 | Infrastructure Hosts          | `datadog.estimated_usage.hosts`          | Unique hosts seen in the last hour. |
 | Containers                    | `datadog.estimated_usage.containers`     | Unique containers seen in the last hour. |
 | Fargate Tasks                 | `datadog.estimated_usage.fargate_tasks`  | Unique Fargate Tasks seen in the last 5 minutes. |
-| Indexed Custom Metrics        | `datadog.estimated_usage.metrics.custom`, `datadog.estimated_usage.metrics.custom.by_metric`, (Preview) `datadog.estimated_usage.metrics.custom.by_tag` | Unique indexed Custom Metrics seen in the last hour. |
-| Ingested Custom Metrics       | `datadog.estimated_usage.metrics.custom.ingested`, `datadog.estimated_usage.metrics.custom.ingested.by_metric`, (Preview) `datadog.estimated_usage.metrics.custom.ingested.by_tag` | Unique ingested Custom Metrics seen in the last hour. |
+| Indexed Custom Metrics        | `datadog.estimated_usage.metrics.custom`, `datadog.estimated_usage.metrics.custom.by_metric`, `datadog.estimated_usage.metrics.custom.by_tag` (in Preview)  | Unique indexed Custom Metrics seen in the last hour. |
+| Ingested Custom Metrics       | `datadog.estimated_usage.metrics.custom.ingested`, `datadog.estimated_usage.metrics.custom.ingested.by_metric`, `datadog.estimated_usage.metrics.custom.ingested.by_tag` (in Preview)  | Unique ingested Custom Metrics seen in the last hour. |
 | Logs Ingested Bytes           | `datadog.estimated_usage.logs.ingested_bytes` | Total ingestion of logs in bytes. |
 | Logs Ingested Events          | `datadog.estimated_usage.logs.ingested_events` | Total number of ingested events, including excluded logs. |
 | Logs Drop Count               | `datadog.estimated_usage.logs.drop_count` | Total number of events dropped during ingestion. |

--- a/content/en/metrics/guide/custom_metrics_governance.md
+++ b/content/en/metrics/guide/custom_metrics_governance.md
@@ -190,7 +190,12 @@ After you've received an alert, use the Metrics Volume Management page to inspec
     {{< nextlink href="/monitors/types/change-alert/" >}}Alert when the volume changes beyond a certain percent.{{< /nextlink >}}
     {{< nextlink href="/monitors/types/anomaly/" >}}Alert on anomalous changes in usage.{{< /nextlink >}}
     {{< nextlink href="/monitors/types/forecasts/" >}}Forecast future metrics growth and alert on any unexpected overall deviation.{{< /nextlink >}}
+
 {{< /whatsnext >}}
+
+{{< callout url="#" btn_hidden="true" header="Join the Preview!">}}
+  Real-time [estimated Custom Metric usage metrics][16] can now be prepopulated with the tags you set in the [Usage Attribution][17] page. To enable this feature, reach out to Customer Success. 
+{{< /callout >}}  
 
 ## Summary of best practices
 
@@ -218,3 +223,5 @@ After you've received an alert, use the Metrics Volume Management page to inspec
 [13]: https://app.datadoghq.com/metric/volume?bulk_manage_tags=true&facet.query_activity=-queried&sort=volume_total
 [14]: https://docs.datadoghq.com/metrics/metrics-without-limits/#configuration-of-tags
 [15]: /metrics/summary/#metrics-related-assets
+[16]: account_management/billing/usage_metrics/
+[17]: account_management/billing/usage_attribution/

--- a/content/en/metrics/guide/custom_metrics_governance.md
+++ b/content/en/metrics/guide/custom_metrics_governance.md
@@ -194,8 +194,8 @@ After you've received an alert, use the Metrics Volume Management page to inspec
 {{< /whatsnext >}}
 
 {{< callout url="#" btn_hidden="true" header="Join the Preview!">}}
-  Real-time [estimated Custom Metric usage metrics][16] can now be prepopulated with the tags you set in the [Usage Attribution][17] to monitor custom metric volume fluctuations. To enable this feature, reach out to Customer Success. 
-{{< /callout >}}  
+  Real-time <a href="/account_management/billing/usage_metrics/">estimated Custom Metric usage metrics</a> can now be prepopulated with the tags you set in the <a href="/account_management/billing/usage_attribution/">Usage Attribution</a> to monitor custom metric volume fluctuations. To enable this feature, reach out to Customer Success. 
+{{< /callout >}}
 
 ## Summary of best practices
 
@@ -223,5 +223,3 @@ After you've received an alert, use the Metrics Volume Management page to inspec
 [13]: https://app.datadoghq.com/metric/volume?bulk_manage_tags=true&facet.query_activity=-queried&sort=volume_total
 [14]: https://docs.datadoghq.com/metrics/metrics-without-limits/#configuration-of-tags
 [15]: /metrics/summary/#metrics-related-assets
-[16]: account_management/billing/usage_metrics/
-[17]: account_management/billing/usage_attribution/

--- a/content/en/metrics/guide/custom_metrics_governance.md
+++ b/content/en/metrics/guide/custom_metrics_governance.md
@@ -194,7 +194,7 @@ After you've received an alert, use the Metrics Volume Management page to inspec
 {{< /whatsnext >}}
 
 {{< callout url="#" btn_hidden="true" header="Join the Preview!">}}
-  Real-time [estimated Custom Metric usage metrics][16] can now be prepopulated with the tags you set in the [Usage Attribution][17] page. To enable this feature, reach out to Customer Success. 
+  Real-time [estimated Custom Metric usage metrics][16] can now be prepopulated with the tags you set in the [Usage Attribution][17] to monitor custom metric volume fluctuations. To enable this feature, reach out to Customer Success. 
 {{< /callout >}}  
 
 ## Summary of best practices


### PR DESCRIPTION
Adding `datadog.estimated_usage.metrics.custom.by_tag` and `datadog.estimated_usage.metrics.custom.ingested.by_tag` as per new Preview feature.