### PR TITLE
update pa11y image ref

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -548,6 +548,7 @@ run_pa11y:manual:
       when: never
     - if: $CI_COMMIT_TAG == null
       when: manual
+  timeout: 2h
 
 tag_successful_live_pipeline:
   <<: *base_template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -515,7 +515,7 @@ link_checks:on-schedule:
 
 # template for what runs in pa11y to avoid duplication
 .pa11y_live_template: &pa11y_live_template
-  image: registry.ddbuild.io/ci/websites/pa11y-preview:v48715921-28822659
+  image: registry.ddbuild.io/ci/websites/pa11y:v48852638-b2768bdb
   tags: ["arch:amd64"]
   stage: post-deploy
   cache: []

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -515,7 +515,7 @@ link_checks:on-schedule:
 
 # template for what runs in pa11y to avoid duplication
 .pa11y_live_template: &pa11y_live_template
-  image: registry.ddbuild.io/ci/websites/pa11y:v33259941-f0dfbc91
+  image: registry.ddbuild.io/ci/websites/pa11y-preview:v48715921-28822659
   tags: ["arch:amd64"]
   stage: post-deploy
   cache: []


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
uses update pa11y image. [more info here](https://github.com/DataDog/websites-images/pull/241)

motivation: https://datadoghq.atlassian.net/browse/WEB-5575
preview: 
1. docs: https://docs-staging.datadoghq.com/stefon.simmons/update-pa11y-image/
   - no visual change

1. build (`run_pa11y` manual execution): 
   - run_pa11y should succeed  
   - https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/705652810

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
