### PR TITLE
🐛 remove browser/setup/_index.html to solve redirection loop

### DIFF
--- a/content/en/real_user_monitoring/browser/setup/_index.md
+++ b/content/en/real_user_monitoring/browser/setup/_index.md
@@ -1,8 +1,0 @@
----
-title: RUM Browser Monitoring Setup
-type: multi-code-lang
-aliases:
-  - /real_user_monitoring/browser/setup/client/
----
-
-{{< include-markdown "/real_user_monitoring/browser/setup/client/" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->


* `content/en/real_user_monitoring/browser/setup/_index.md` contains an alias to `/real_user_monitoring/browser/setup/client/`
* `content/en/real_user_monitoring/browser/setup/client.md` contains an alias to `/real_user_monitoring/browser/setup`

This causes a redirection loop because pages are redirecting to each other. This makes the page inaccessible.

Removing the `_index.md` file fixes the issue. Those pages are working correctly:
* https://docs-staging.datadoghq.com/benoit/remove-browser-rum-setup-redirection/real_user_monitoring/browser/setup/ is redirecting to `...setup/client`
* https://docs-staging.datadoghq.com/benoit/remove-browser-rum-setup-redirection/real_user_monitoring/browser/setup/client is displayed correctly.



### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
