### PR TITLE
Add missing datadog/connector receiver

### DIFF
--- a/content/en/opentelemetry/collector_exporter/configuration.md
+++ b/content/en/opentelemetry/collector_exporter/configuration.md
@@ -90,7 +90,7 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [hostmetrics, prometheus, otlp]
+      receivers: [hostmetrics, prometheus, otlp, datadog/connector]
       processors: [batch]
       exporters: [datadog/exporter]
     traces:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The `datadog/connector` has to be used as exporter in the `traces` pipeline and as receiver in the `metrics` pipeline.
The doc page was missing the receiver part.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
