### PR TITLE
Update is_match and is_exact_match description

### DIFF
--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -31,9 +31,9 @@ The following conditional variables are available:
 |----------------------------|--------------------------------------------------------------------|
 | `{{#is_alert}}`            | The monitor alerts                                                 |
 | `{{^is_alert}}`            | The monitor does not alert                                         |
-| `{{#is_match}}`            | The context matches the provided substring. If a numeric value is used it will be converted to a string.|
+| `{{#is_match}}`            | The context matches the provided substring. If a numeric value is used, it is converted to a string.|
 | `{{^is_match}}`            | The context does not match the provided substring                  |
-| `{{#is_exact_match}}`      | The context exactly matches the provided string.<br> If a number is used, the numeric value will be considered, regardless of its type. This means that as long as two numbers have the same value, they will be considered equal by the function|
+| `{{#is_exact_match}}`      | The context exactly matches the provided string.<br> If a number is used, the numeric value is considered, regardless of its type. This means that as long as two numbers have the same value, they are considered equal by the function. |
 | `{{^is_exact_match}}`      | The context does not exactly match the provided string             |
 | `{{#is_no_data}}`          | The monitor is triggered for missing data                          |
 | `{{^is_no_data}}`          | The monitor is not triggered for missing data                      |

--- a/content/en/monitors/notify/variables.md
+++ b/content/en/monitors/notify/variables.md
@@ -31,9 +31,9 @@ The following conditional variables are available:
 |----------------------------|--------------------------------------------------------------------|
 | `{{#is_alert}}`            | The monitor alerts                                                 |
 | `{{^is_alert}}`            | The monitor does not alert                                         |
-| `{{#is_match}}`            | The context matches the provided substring                         |
+| `{{#is_match}}`            | The context matches the provided substring. If a numeric value is used it will be converted to a string.|
 | `{{^is_match}}`            | The context does not match the provided substring                  |
-| `{{#is_exact_match}}`      | The context exactly matches the provided string                    |
+| `{{#is_exact_match}}`      | The context exactly matches the provided string.<br> If a number is used, the numeric value will be considered, regardless of its type. This means that as long as two numbers have the same value, they will be considered equal by the function|
 | `{{^is_exact_match}}`      | The context does not exactly match the provided string             |
 | `{{#is_no_data}}`          | The monitor is triggered for missing data                          |
 | `{{^is_no_data}}`          | The monitor is not triggered for missing data                      |
@@ -181,7 +181,7 @@ The `is_exact_match` conditional variable also supports [`{{value}}` template va
 {{/is_exact_match}}
 ```
 
-To notify your dev team if the value that breached the threshold of your monitor is 5, use the following:
+To notify your dev team if the value that breached the threshold of your monitor is 5 (or 5.0), use the following:
 
 ```text
 {{#is_exact_match "value" "5"}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The is_exact_match considers only the numeric values when used with numbers. Added a description that clarifies this scenario.