### PR TITLE
Add Critical Path at ingestion time docs

### DIFF
--- a/content/en/continuous_integration/explorer/_index.md
+++ b/content/en/continuous_integration/explorer/_index.md
@@ -50,6 +50,7 @@ The **CI** panel on the left lists default facets you can use to search for your
 | Wait time | The total time spent waiting for manual approval within a CI execution. |
 | Is Deployment | Indicates whether a job within the pipeline initiated a deployment. |
 | Contains Deployment | Indicates whether the pipeline includes any jobs that trigger a deployment. |
+| On Critical Path | Indicates whether the job is on the critical path of the CI pipeline execution. |
 
 For more information about common facets that you can use as part of your search query in the CI Visibility Explorer, see [Pipeline Execution Facets][3]. 
 

--- a/content/en/continuous_integration/pipelines/_index.md
+++ b/content/en/continuous_integration/pipelines/_index.md
@@ -144,6 +144,7 @@ If your CI provider is not supported, you can try setting up Pipeline Visibility
 |  | Jenkins | GitLab | CircleCI | Buildkite | GitHub Actions | Azure Pipelines | Codefresh | TeamCity | AWS CodePipeline | Other CI Providers |
 |---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | {{< ci-details title="Pipeline trace visualization" >}}Visualization of pipeline executions with associated tracing.{{< /ci-details >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |
+| {{< ci-details title="Filter CI Jobs on the critical path" >}}Identification of CI jobs that are on the critical path of the pipeline.{{< /ci-details >}} | | {{< X >}} | | | | | | | | |
 | {{< ci-details title="Running pipelines" >}}Identification of pipelines executions that are running with associated tracing.{{< /ci-details >}} | | {{< X >}} | | | {{< X >}} | | | | {{< X >}} |
 | {{< ci-details title="Partial retries" >}}Identification of partial retries (for example, when only a subset of jobs were retried).{{< /ci-details >}} |  | {{< X >}} |  | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} | {{< X >}} |  {{< X >}} |
 | {{< ci-details title="Step spans" >}}Step level spans are available for more granular visibility.{{< /ci-details >}} | {{< X >}} (_But are presented as job spans_) |  |  |  | {{< X >}} |  | {{< X >}} |  |  |  {{< X >}} |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR adds a new section in the supported features for CI Visibility related to the Critical Path at ingestion time for CI Jobs coming from GitLab.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
