### PR TITLE
Move Log Collection out of OTel Integrations

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -614,6 +614,11 @@ menu:
       identifier: otel_batch_memory
       parent: otel_collector_configuration
       weight: 3023
+    - name: Log Collection
+      url: /opentelemetry/collector_exporter/log_collection/
+      identifier: otel_log_collection
+      parent: otel_collector_configuration
+      weight: 3024
     - name: Integrations
       url: opentelemetry/integrations/
       identifier: otel_integrations

--- a/content/en/opentelemetry/collector_exporter/log_collection.md
+++ b/content/en/opentelemetry/collector_exporter/log_collection.md
@@ -2,6 +2,7 @@
 title: Log Collection
 aliases:
 - /opentelemetry/collector_exporter/log_collection/
+- /opentelemetry/integrations/log_collection/
 further_reading:
 - link: "/opentelemetry/collector_exporter/"
   tag: "Documentation"

--- a/content/en/opentelemetry/integrations/_index.md
+++ b/content/en/opentelemetry/integrations/_index.md
@@ -38,12 +38,6 @@ Gain insights into your containerized environments and host systems:
 - [Docker Metrics][4]
 - [Host Metrics][5]
 
-### Logs
-
-Collect and manage logs from configured file paths:
-
-- [Log Collection][7]
-
 ### Vendor technologies
 
 Extend your observability to popular vendor technologies:
@@ -60,5 +54,4 @@ Extend your observability to popular vendor technologies:
 [4]: /opentelemetry/integrations/docker_metrics/
 [5]: /opentelemetry/integrations/host_metrics/
 [6]: /opentelemetry/integrations/kafka_metrics/
-[7]: /opentelemetry/integrations/log_collection/
 [8]: /opentelemetry/integrations/collector_health_metrics/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
* Move Log Collection out of Integrations and under Collector Config.
* Remove mention on Integrations page.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
