### PR TITLE
Updating Windows command line instruction

### DIFF
--- a/content/en/synthetics/platform/private_locations/configuration.md
+++ b/content/en/synthetics/platform/private_locations/configuration.md
@@ -25,7 +25,7 @@ docker run --rm datadog/synthetics-private-location-worker --help
 {{% /tab %}}
 {{% tab "Windows" %}}
 ```
-synthetics-private-location.exe --help
+synthetics-pl-worker.exe --help
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -42,7 +42,7 @@ docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetic
 {{% /tab %}}
 {{% tab "Windows" %}}
 ```cmd
-synthetics-private-location.exe --config=<PathToYourConfiguration> --logFormat=json
+synthetics-pl-worker.exe --config=<PathToYourConfiguration> --logFormat=json
 ```
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Updating windows command line invocation to correctly point users to the appropriate .exe for running against user-defined config file.