### PR TITLE
Updating Windows command line instruction

### DIFF
--- a/content/en/synthetics/platform/private_locations/configuration.md
+++ b/content/en/synthetics/platform/private_locations/configuration.md
@@ -25,7 +25,7 @@ docker run --rm datadog/synthetics-private-location-worker --help
 {{% /tab %}}
 {{% tab "Windows" %}}
 ```
-synthetics-private-location.exe --help
+synthetics-pl-worker.exe --help
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -42,7 +42,7 @@ docker run --rm -v $PWD/<MY_WORKER_CONFIG_FILE_NAME>.json:/etc/datadog/synthetic
 {{% /tab %}}
 {{% tab "Windows" %}}
 ```cmd
-synthetics-private-location.exe --config=<PathToYourConfiguration> --logFormat=json
+synthetics-pl-worker.exe --config=<PathToYourConfiguration> --logFormat=json
 ```
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
Updating Windows command line instruction to correctly point to the .exe for the config file.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updating Windows command line instruction to correctly point to the .exe for the config file.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

