### PR TITLE
[CWS] fix manual default policy deployment

### DIFF
--- a/content/en/security/threats/workload_security_rules/custom_rules.md
+++ b/content/en/security/threats/workload_security_rules/custom_rules.md
@@ -122,7 +122,7 @@ Next, use the following instructions to upload the policy file to each host.
 {{< tabs >}}
 {{% tab "Host" %}}
 
-Copy the `default.policy` file to the target host in the `{$DD_AGENT}/runtime-security.d` folder. The file must have `read` and `write` access for the `dd-agent` user on the host. This may require use of a utility such as SCP or FTP.
+Copy the `default.policy` file to the target host in the `/etc/datadog-agent/runtime-security.d` folder. The file must have `read` and `write` access for the `root` user on the host. This may require use of a utility such as SCP or FTP.
 
 To apply the changes, restart the [Datadog Agent][1].
 
@@ -137,8 +137,7 @@ To apply the changes, restart the [Datadog Agent][1].
 
     ```yaml
     securityAgent:
-      compliance:
-        # [...]
+      # [...]
       runtime:
         # datadog.securityAgent.runtime.enabled
         # Set to true to enable Security Runtime Module
@@ -147,17 +146,12 @@ To apply the changes, restart the [Datadog Agent][1].
           # datadog.securityAgent.runtime.policies.configMap
           # Place custom policies here
           configMap: jdefaultpol
-      syscallMonitor:
-        # datadog.securityAgent.runtime.syscallMonitor.enabled
-        # Set to true to enable Syscall monitoring.
-        enabled: false
+      # [...]
     ```
 
 3. Upgrade the Helm chart with `helm upgrade <RELEASENAME> -f values.yaml --set datadog.apiKey=<APIKEY> datadog/datadog`.
 
     **Note:** If you need to make further changes to `default.policy`, you can either use `kubectl edit cm jdefaultpol` or replace the configMap with  `kubectl create configmap jdefaultpol --from-file default.policy -o yaml --dry-run=client | kubectl replace -f -`.
-
-4. Restart the [Datadog Agent][1].
 
 [1]: /agent/configuration/agent-commands/?tab=agentv6v7#restart-the-agent
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR fixes the instruction to deploy manually the CWS default policy.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
