### PR TITLE
Extend Dashboards is_read_only deprecation date

### DIFF
--- a/content/en/dashboards/guide/is-read-only-deprecation.md
+++ b/content/en/dashboards/guide/is-read-only-deprecation.md
@@ -1,5 +1,5 @@
 ---
-title: "Dashboards API: Migrate from is_read_only by November 30, 2024"
+title: "Dashboards API: Migrate from is_read_only by December 13, 2024"
 further_reading:
 - link: "/dashboards/guide/how-to-use-terraform-to-restrict-dashboard-edit/"
   tag: "Guide"
@@ -11,11 +11,11 @@ further_reading:
 
 ## Overview
 
-On **November 30, 2024**, Datadog is removing support for the `is_read_only` attribute in the Dashboards API's. For customers who manage Dashboards with the API directly, Datadog recommends that you transition to [`restricted_roles`](#migrate-to-restricted_roles) or [Restriction Policies](#restriction-policies). 
+On **December 13, 2024**, Datadog is removing support for the `is_read_only` attribute in the Dashboards API's. For customers who manage Dashboards with the API directly, Datadog recommends that you transition to [`restricted_roles`](#migrate-to-restricted_roles) or [Restriction Policies](#restriction-policies). 
 
-## Actions to take before November 30, 2024
+## Actions to take before December 13, 2024
 
-Before November 30, 2024, migrate off of `is_read_only` to `restricted_roles` or consider participating in the beta for Restriction Policies.
+Before December 13, 2024, migrate off of `is_read_only` to `restricted_roles` or consider participating in the beta for Restriction Policies.
 
 ### Migrate to `restricted_roles`
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We're extending the shutdown date for this API attribute to Friday, December 13th. 

### Merge instructions
I'd like to merge this on Friday, November 15th to align with the comms that'll be sent out to customers. 

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
