### PR TITLE
Add support for secret manager

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -41,7 +41,7 @@ Datadog recommends using a Kinesis Data Stream as input when using the Datadog d
    b. Set the destination as `Datadog`.  
    c. Provide a name for the delivery stream.  
    d. In the **Destination settings**, choose the `Datadog logs` HTTP endpoint URL that corresponds to your [Datadog site][5].  
-   e. Paste your API key into the **API key** field. You can get or create an API key from the [Datadog API Keys page][3]. If you prefer to use Secret Manager authentication, add in your Datadog API key in the full JSON format in the value field like follows: `{"api_key":"<YOUR_API_KEY>"}`.
+   e. Paste your API key into the **API key** field. You can get or create an API key from the [Datadog API Keys page][3]. If you prefer to use Secrets Manager authentication, add in your Datadog API key in the full JSON format in the value field like follows: `{"api_key":"<YOUR_API_KEY>"}`.
    f. Optionally, configure the **Retry duration**, the buffer settings, or add **Parameters**, which are attached as tags to your logs.  
    **Note**: Datadog recommends setting the **Buffer size** to `2 MiB` if the logs are single line messages.  
    g. In the **Backup settings**, select an S3 backup bucket to receive any failed events that exceed the retry duration.  

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -42,6 +42,7 @@ Datadog recommends using a Kinesis Data Stream as input when using the Datadog d
    c. Provide a name for the delivery stream.  
    d. In the **Destination settings**, choose the `Datadog logs` HTTP endpoint URL that corresponds to your [Datadog site][5].  
    e. Paste your API key into the **API key** field. You can get or create an API key from the [Datadog API Keys page][3]. If you prefer to use Secrets Manager authentication, add in your Datadog API key in the full JSON format in the value field like follows: `{"api_key":"<YOUR_API_KEY>"}`.
+   
    f. Optionally, configure the **Retry duration**, the buffer settings, or add **Parameters**, which are attached as tags to your logs.  
    **Note**: Datadog recommends setting the **Buffer size** to `2 MiB` if the logs are single line messages.  
    g. In the **Backup settings**, select an S3 backup bucket to receive any failed events that exceed the retry duration.  

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -41,7 +41,7 @@ Datadog recommends using a Kinesis Data Stream as input when using the Datadog d
    b. Set the destination as `Datadog`.  
    c. Provide a name for the delivery stream.  
    d. In the **Destination settings**, choose the `Datadog logs` HTTP endpoint URL that corresponds to your [Datadog site][5].  
-   e. Paste your API key into the **API key** field. You can get or create an API key from the [Datadog API Keys page][3].  
+   e. Paste your API key into the **API key** field. You can get or create an API key from the [Datadog API Keys page][3]. If you prefer to use Secret Manager authentication, add in your Datadog API key in the full JSON format in the value field like follows: `{"api_key":"<YOUR_API_KEY>"}`.
    f. Optionally, configure the **Retry duration**, the buffer settings, or add **Parameters**, which are attached as tags to your logs.  
    **Note**: Datadog recommends setting the **Buffer size** to `2 MiB` if the logs are single line messages.  
    g. In the **Backup settings**, select an S3 backup bucket to receive any failed events that exceed the retry duration.  

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -42,7 +42,6 @@ Datadog recommends using a Kinesis Data Stream as input when using the Datadog d
    c. Provide a name for the delivery stream.  
    d. In the **Destination settings**, choose the `Datadog logs` HTTP endpoint URL that corresponds to your [Datadog site][5].  
    e. Paste your API key into the **API key** field. You can get or create an API key from the [Datadog API Keys page][3]. If you prefer to use Secrets Manager authentication, add in your Datadog API key in the full JSON format in the value field like follows: `{"api_key":"<YOUR_API_KEY>"}`.
-   
    f. Optionally, configure the **Retry duration**, the buffer settings, or add **Parameters**, which are attached as tags to your logs.  
    **Note**: Datadog recommends setting the **Buffer size** to `2 MiB` if the logs are single line messages.  
    g. In the **Backup settings**, select an S3 backup bucket to receive any failed events that exceed the retry duration.  

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -41,7 +41,7 @@ Datadog recommends using a Kinesis Data Stream as input when using the Datadog d
    b. Set the destination as `Datadog`.  
    c. Provide a name for the delivery stream.  
    d. In the **Destination settings**, choose the `Datadog logs` HTTP endpoint URL that corresponds to your [Datadog site][5].  
-   e. Paste your API key into the **API key** field. You can get or create an API key from the [Datadog API Keys page][3]. If you prefer to use Secrets Manager authentication, add in your Datadog API key in the full JSON format in the value field like follows: `{"api_key":"<YOUR_API_KEY>"}`.
+   e. Paste your API key into the **API key** field. You can get or create an API key from the [Datadog API Keys page][3]. If you prefer to use Secrets Manager authentication, add in your Datadog API key in the full JSON format in the value field as follows: `{"api_key":"<YOUR_API_KEY>"}`.
    
    f. Optionally, configure the **Retry duration**, the buffer settings, or add **Parameters**, which are attached as tags to your logs.  
    **Note**: Datadog recommends setting the **Buffer size** to `2 MiB` if the logs are single line messages.  


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Add instructions on how to authenticate with Secrets Manger.

AWS released support of Amazon Data Firehose with AWS Secrets Manager. 
https://aws.amazon.com/about-aws/whats-new/2024/06/amazon-data-firehose-integration-secrets-manager/

Some customers don't know how to do this. See the slack channel.
https://dd.slack.com/archives/CMD6QSA3D/p1731635858928549

AWS doc on how to do this. I have verified it in our sandbox.
https://docs.aws.amazon.com/firehose/latest/dev/secrets-manager-whats-secret.html

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
