### PR TITLE
docs: fix kubernetes config file name

### DIFF
--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -254,7 +254,7 @@ Complete the following steps to install the [Datadog Cluster Agent][1] on your K
     ```yaml
     clusterAgent:
       confd:
-        postgres.yaml: |-
+        mysql.yaml: |-
           cluster_check: true
           init_config:
           instances:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
the helm yaml config should be mysql.yaml instead of postgres.yaml for the setup_mysql doc

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
