### PR TITLE
Update php-datadogstatsd to the latest minor version

### DIFF
--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -303,7 +303,7 @@ The Java DataDog StatsD Client is distributed with maven central, and can be [do
 Add the following to your `composer.json`:
 
 ```text
-"datadog/php-datadogstatsd": "1.4.*"
+"datadog/php-datadogstatsd": "1.6.*"
 ```
 
 **Note**: The first version shipped in Composer is _0.0.3_


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The "[Install the DogStatsD client](https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent&code-lang=php#install-the-dogstatsd-client)" section refers to an old version of the `datadog/php-datadogstatsd` client library.

I updated the snippet to use the latest minor version (1.6.*) of the library.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
