### PR TITLE
remove object id

### DIFF
--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -11,7 +11,7 @@
             {{ with $page.File }}
               {{ $rel_path = (print .Lang "/" .Path) }}
             {{ end }}
-            {{ $object_id := md5 $rel_path }}
+            {{ $id := md5 $rel_path }}
             {{ $title := $page.Params.integration_title | default $page.Title }}
             {{ $content := $page.Plain | htmlUnescape | safeHTML | truncate 10000 }}
             {{ $tags := $page.Params.algolia.tags }}
@@ -39,8 +39,7 @@
             {{- if eq $headingCount 0 -}}
                 {{- /* Full page record */ -}}
                 {{- $record := (
-                    dict "objectID" $object_id
-                    "id" $object_id
+                    dict "id" $id
                     "title" $title
                     "section_header" ""
                     "content" $content

--- a/layouts/partials/algolia/glossary.json
+++ b/layouts/partials/algolia/glossary.json
@@ -3,13 +3,12 @@
 {{- with $headless := $hugo_context.Site.GetPage "/glossary/terms" -}}
     {{- range $headless.Resources.ByType "page" -}}
         {{- $page := . -}}
-        {{- $object_id := (print $glossaryPage.File.UniqueID "_" $headless.File.Lang "_" ($page.Params.Title | anchorize)) -}}
+        {{- $id := (print $glossaryPage.File.UniqueID "_" $headless.File.Lang "_" ($page.Params.Title | anchorize)) -}}
         {{- $relpermalink := print $glossaryPage.RelPermalink "#" ($page.Params.Title | anchorize) -}}
         {{- $content := .Plain -}}
         {{
             $hugo_context.Scratch.Add "algoliaindex" (
-                dict "objectID" $object_id
-                "id" $object_id
+                dict "id" $id
                 "title" "Glossary"
                 "section_header" $page.Params.Title
                 "content" $content

--- a/layouts/partials/algolia/page-sections.json
+++ b/layouts/partials/algolia/page-sections.json
@@ -46,10 +46,9 @@
               {{- if gt (len $c) 2 -}}
                   {{- $full_url := print $page.Permalink "#" ($section_header | anchorize) -}}
                   {{- $relpermalink := print $page.RelPermalink "#" ($section_header | anchorize) -}}
-                  {{- $object_id := (print $page.File.UniqueID "_" $page.File.Lang "_" ($section_header | anchorize) "_" $i "_" $order) -}}
+                  {{- $id := (print $page.File.UniqueID "_" $page.File.Lang "_" ($section_header | anchorize) "_" $i "_" $order) -}}
                   {{- $hugo_context.Scratch.Add "algoliaindex" (
-                      dict "objectID" $object_id
-                      "id" $object_id
+                      dict "id" $id
                       "title" $title
                       "section_header" $section_header
                       "content" $c

--- a/layouts/partials/algolia/standard-attributes.json
+++ b/layouts/partials/algolia/standard-attributes.json
@@ -2,12 +2,11 @@
 {{- $page := $hugo_context.Site.GetPage "/standard-attributes/" -}}
 
 {{- range $attr := $page.Params.attributes -}}
-  {{- $object_id := (print $page.File.UniqueID "_" $page.File.Lang "_" ($attr.name | anchorize)) -}}
+  {{- $id := (print $page.File.UniqueID "_" $page.File.Lang "_" ($attr.name | anchorize)) -}}
   {{- $relpermalink := print $page.RelPermalink "?search=" $attr.name -}}
   {{
     $hugo_context.Scratch.Add "algoliaindex" (
-        dict "objectID" $object_id
-        "id" $object_id
+        dict "id" $id
         "title" "Default Standard Attributes"
         "section_header" $attr.name
         "content" (print $attr.name " " $attr.description)


### PR DESCRIPTION
### What does this PR do? What is the motivation?
removes `object_id` from generated search json.   we already have an id field, `object_id` was leftover from algolia


### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
