### PR TITLE
[STAL-3162] Add Kotlin rulesets

### DIFF
--- a/content/en/code_analysis/static_analysis_rules/_index.md
+++ b/content/en/code_analysis/static_analysis_rules/_index.md
@@ -92,13 +92,13 @@ rulesets:
     description: |
       This plugin exports a `recommended` configuration that enforces React good practices.
   kotlin-best-practices:
-    title: "Rules to enforce Kotlin best practices."
+    title: "Follow best practices for writing Kotlin code"
     description: |
-
+      Rules to enforce Kotlin best practices.
   kotlin-code-style:
-    title: "Rules to check code style for Kotlin"
+    title: "Enforce Kotlin code style"
     description: |
-
+      Rules to enforce Kotlin code style.
   php-best-practices:
     title: "Follow best practices for writing PHP code"
     description: |


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This adds the new kotlin rule sets to the main documentation for the static analysis rules documentation
### Merge instructions

```
/merge
```
