### PR TITLE
[golang]: Update Golang APM Automatic Instrumentation documentation

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
@@ -39,7 +39,8 @@ Before you begin, make sure you've already [installed and configured the Agent][
 
 There are two ways to instrument your Go application:
 
-1. **Manual instrumentation**:
+1. **Semi-Automatic instrumentation**:
+  Use dd-trace-go in conjunction with our integration packages to automatically generate spans about libraries of your choosing. This option:
    - Gives you complete control over which parts of your application are traced.
    - Requires modifying the application's source code.
 2. **Compile-time instrumentation**:
@@ -48,16 +49,12 @@ There are two ways to instrument your Go application:
 
 Refer to the instructions in the section corresponding to your preference below:
 
-{{% collapse-content title="Manual instrumentation" level="p" %}}
-### Activate Go integrations to create spans
+{{% collapse-content title="Semi-Automatic instrumentation" level="p" %}}
 
-Datadog has a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries and frameworks. A list of these packages can be found in the [Compatibility Requirements][1] page. Import these packages into your application and follow the configuration instructions listed alongside each [Integration][1].
+First, import and start the tracer in your code following the [Library Configuration][3] documentation. Refer to the [API documentation][4] for configuration instructions and details about using the API.
 
-### Configuration
+Next, activate Go integrations to generate spans. Datadog has a series of pluggable packages which provide out-of-the-box support for instrumenting a series of libraries and frameworks. A list of these packages can be found in the [Compatibility Requirements][1] page. Import these packages into your application and follow the configuration instructions listed alongside each [Integration][1].
 
-If needed, configure the tracing library to send application performance telemetry data as you require, including setting up Unified Service Tagging. Read [Library Configuration][3] for details.
-
-For configuration instructions and details about using the API, see the Datadog [API documentation][4].
 {{% /collapse-content %}}
 
 {{% collapse-content title="Compile-time instrumentation (Preview)" level="p" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The docs were not explicit enough about what is required to perform "semi automatic instrumentation" for Golang applications with dd-trace-go; I've updated them to be more explicit about the two-step process that is required.

I've also changed the title from "Manual instrumentation" to "Semi-Automatic instrumentation" in an effort to differentiate from "pure" manual instrumentation, which is generating spans manually via the tracing API; by contrast, the mechanism described in this doc benefits from automatic span generation, although code modification is required (unlike other dd-trace libraries' definition of automatic instrumentation).

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
