### PR TITLE
feat: mq only preview build and synthetic testing

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,7 +149,7 @@ before_script:
       when: on_success
 # ================== templates ================== #
 .base_template: &base_template
-  image: registry.ddbuild.io/ci/websites/webops-site-build:v42145832-00d7fc2f
+  image: registry.ddbuild.io/ci/websites/webops-site-build:v48290164-5b75a7bd
   tags:
     - "arch:amd64"
   rules:
@@ -164,7 +164,6 @@ before_script:
 build_preview:
   <<: *base_template
   rules:
-    - !reference [.preview_rules, rules ]
     - !reference [.if_mergequeue, rules ]
   stage: build
   cache:
@@ -214,6 +213,64 @@ build_preview:
       if [ -s $PREVIEW_ERROR_LOG ] && [ $CI_JOB_STATUS != 'success' ]; then
         echo "Error Detected: $(cat $PREVIEW_ERROR_LOG)";
       fi # Output the error to the console
+  interruptible: true
+
+# Only build the site for merge queue, we don't need to deploy or artifact since this is a follow up check to ensure the site builds correctly
+build_preview_mergequeue:
+  <<: *base_template
+  rules:
+    - !reference [.preview_rules, rules ]
+    - !reference [.if_mergequeue, rules ]
+  stage: build
+  cache:
+    - *hugo_cache
+    - *yarn_cache_pull_push
+    - *pip_cache
+  environment: "preview"
+  variables:
+    URL: ${PREVIEW_DOMAIN}
+    CONFIG: ${PREVIEW_CONFIG}
+    CONFIGURATION_FILE: "./local/bin/py/build/configurations/pull_config_preview.yaml"
+    LOCAL: "False"
+  script:
+    - dog --config "$HOME/.dogrc" event post "documentation build ${CI_COMMIT_REF_NAME} started" "${CI_PROJECT_URL}/pipelines/${CI_PIPELINE_ID}" --alert_type "info" --tags="${DEFAULT_TAGS}"
+    - touch Makefile.config
+    - make dependencies
+    - make config
+    - ./node_modules/.bin/jest --testPathPattern=assets/scripts/tests/
+    - yarn run prebuild
+    - make update_websites_sources_module
+    - build_site
+    - ci_pass_step "${CI_PROJECT_NAME}-${CI_JOB_NAME}" # run at completion of job, if job fails at any point prior this won't run
+  artifacts:
+    when: always
+    paths:
+      - ${ARTIFACT_RESOURCE}
+      - ./integrations_data
+      - .github/
+      - .vale.ini
+      - .htmltest.yml
+      - ./logs
+      - $PREVIEW_ERROR_LOG
+      - ./latest-cached.tar.gz
+      - typesense.config.json
+  interruptible: true
+
+synthetic_tests_mergequeue:
+  <<: *base_template
+  rules:
+    - !reference [.preview_rules, rules ]
+    - !reference [.if_mergequeue, rules ]
+  stage: post-deploy
+  environment: "preview"
+  variables:
+    URL: ${PREVIEW_DOMAIN}
+  allow_failure: false
+  cache: {}
+  dependencies:
+    - build_preview
+  script:
+    - run_preview_synthetic_tests "./datadog-ci.preview.json"
   interruptible: true
 
 link_checks_preview:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Updates to the latest webops image (will stop duplicate outputs in ci)
- Creates a merge queue only preview build where we don't deploy to cut down on time since we're not visually checking these builds
### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
