### PR TITLE
[DOCS-9527] Add Administration Guide to left nav in JA, KO, FR, ES

### DIFF
--- a/config/_default/menus/main.es.yaml
+++ b/config/_default/menus/main.es.yaml
@@ -944,18 +944,44 @@ menu:
     parent: dev_tools
     url: developers/guide/
     weight: 9
+  - name: Administrator's Guide
+    url: administrators_guide/
+    pre: organization
+    parent: essentials_heading
+    identifier: administrators_guide
+    weight: 80000
+  - name: Getting Started
+    url: administrators_guide/getting_started/
+    parent: administrators_guide
+    identifier: administrators_guide_getting_started
+    weight: 1
+  - name: Plan
+    url: administrators_guide/plan/
+    parent: administrators_guide
+    identifier: administrators_guide_plan
+    weight: 2
+  - name: Build
+    url: administrators_guide/build/
+    parent: administrators_guide
+    identifier: administrators_guide_build
+    weight: 3
+  - name: Run
+    url: administrators_guide/run/
+    parent: administrators_guide
+    identifier: administrators_guide_run
+    weight: 4
   - identifier: api
     name: API
     parent: essentials_heading
     pre: api
     url: api/
-    weight: 80000
+    weight: 90000
   - identifier: mobile
     name: Aplicación móvil de Datadog
     parent: essentials_heading
     pre: mobile
     url: mobile/
-    weight: 90000
+    weight: 100000
   - identifier: mobile_enterprise_configuration
     name: Configuración de Enterprise
     parent: mobile
@@ -966,7 +992,7 @@ menu:
     parent: essentials_heading
     pre: coscreen
     url: coscreen/
-    weight: 100000
+    weight: 110000
   - identifier: coscreen_troubleshooting
     name: Solucionar problemas
     parent: coscreen

--- a/config/_default/menus/main.fr.yaml
+++ b/config/_default/menus/main.fr.yaml
@@ -939,18 +939,44 @@ menu:
       parent: dev_tools
       identifier: dev_tools_guides
       weight: 9
+    - name: Administrator's Guide
+      url: administrators_guide/
+      pre: organization
+      parent: essentials_heading
+      identifier: administrators_guide
+      weight: 80000
+    - name: Getting Started
+      url: administrators_guide/getting_started/
+      parent: administrators_guide
+      identifier: administrators_guide_getting_started
+      weight: 1
+    - name: Plan
+      url: administrators_guide/plan/
+      parent: administrators_guide
+      identifier: administrators_guide_plan
+      weight: 2
+    - name: Build
+      url: administrators_guide/build/
+      parent: administrators_guide
+      identifier: administrators_guide_build
+      weight: 3
+    - name: Run
+      url: administrators_guide/run/
+      parent: administrators_guide
+      identifier: administrators_guide_run
+      weight: 4
     - name: API
       url: api/
       pre: api
       identifier: api
       parent: essentials_heading
-      weight: 80000
+      weight: 90000
     - name: Application mobile
       url: mobile/
       pre: mobile
       identifier: mobile
       parent: essentials_heading
-      weight: 90000
+      weight: 100000
     - name: Enterprise Configuration
       url: mobile/enterprise_configuration
       identifier: mobile_enterprise_configuration
@@ -961,7 +987,7 @@ menu:
       pre: coscreen
       identifier: coscreen
       parent: essentials_heading
-      weight: 100000
+      weight: 110000
     - name: Dépannage
       url: coscreen/troubleshooting
       identifier: coscreen_troubleshooting

--- a/config/_default/menus/main.ja.yaml
+++ b/config/_default/menus/main.ja.yaml
@@ -939,18 +939,44 @@ menu:
       parent: dev_tools
       identifier: dev_tools_guides
       weight: 9
+    - name: Administrator's Guide
+      url: administrators_guide/
+      pre: organization
+      parent: essentials_heading
+      identifier: administrators_guide
+      weight: 80000
+    - name: Getting Started
+      url: administrators_guide/getting_started/
+      parent: administrators_guide
+      identifier: administrators_guide_getting_started
+      weight: 1
+    - name: Plan
+      url: administrators_guide/plan/
+      parent: administrators_guide
+      identifier: administrators_guide_plan
+      weight: 2
+    - name: Build
+      url: administrators_guide/build/
+      parent: administrators_guide
+      identifier: administrators_guide_build
+      weight: 3
+    - name: Run
+      url: administrators_guide/run/
+      parent: administrators_guide
+      identifier: administrators_guide_run
+      weight: 4
     - name: API
       url: api/
       pre: api
       identifier: api
       parent: essentials_heading
-      weight: 80000
+      weight: 90000
     - name: モバイルアプリケーション
       url: mobile/
       pre: mobile
       identifier: mobile
       parent: essentials_heading
-      weight: 90000
+      weight: 100000
     - name: Enterprise Configuration
       url: mobile/enterprise_configuration
       identifier: mobile_enterprise_configuration
@@ -961,7 +987,7 @@ menu:
       pre: coscreen
       identifier: coscreen
       parent: essentials_heading
-      weight: 100000
+      weight: 110000
     - name: トラブルシューティング
       url: coscreen/troubleshooting
       identifier: coscreen_troubleshooting

--- a/config/_default/menus/main.ko.yaml
+++ b/config/_default/menus/main.ko.yaml
@@ -939,18 +939,44 @@ menu:
       parent: dev_tools
       identifier: dev_tools_guides
       weight: 9
+    - name: Administrator's Guide
+      url: administrators_guide/
+      pre: organization
+      parent: essentials_heading
+      identifier: administrators_guide
+      weight: 80000
+    - name: Getting Started
+      url: administrators_guide/getting_started/
+      parent: administrators_guide
+      identifier: administrators_guide_getting_started
+      weight: 1
+    - name: Plan
+      url: administrators_guide/plan/
+      parent: administrators_guide
+      identifier: administrators_guide_plan
+      weight: 2
+    - name: Build
+      url: administrators_guide/build/
+      parent: administrators_guide
+      identifier: administrators_guide_build
+      weight: 3
+    - name: Run
+      url: administrators_guide/run/
+      parent: administrators_guide
+      identifier: administrators_guide_run
+      weight: 4
     - name: API
       url: api/
       pre: api
       identifier: api
       parent: essentials_heading
-      weight: 80000
+      weight: 90000
     - name: Datadog Mobile App
       url: mobile/
       pre: mobile
       identifier: mobile
       parent: essentials_heading
-      weight: 90000
+      weight: 100000
     - name: 엔터프라이즈 설정
       url: mobile/enterprise_configuration
       identifier: mobile_enterprise_configuration
@@ -961,7 +987,7 @@ menu:
       pre: coscreen
       identifier: coscreen
       parent: essentials_heading
-      weight: 100000
+      weight: 110000
     - name: 트러블슈팅
       url: coscreen/troubleshooting
       identifier: coscreen_troubleshooting


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
As per [DOCS-9527](https://datadoghq.atlassian.net/browse/DOCS-9527), this PR adds the Administration guide and its child pages to the left nav in Japanese, French, Korean, and Spanish.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
