### PR TITLE
document allocated_spend_type for data transfer

### DIFF
--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -147,7 +147,7 @@ Next, Datadog examines the daily [workload resources][104] running on that node.
 
 [Network Performance Monitoring][105] must be enabled on all AWS hosts to allow accurate data transfer cost allocation. If some hosts do not have Network Performance Monitoring enabled, the data transfer costs for these hosts is not allocated and may appear as an `n/a` bucket depending on filter and group-by conditions.
 
-Datadog supports data transfer cost allocation only through the [standard 6 workload resources][104]. If you use [custom workload resources][106] their data transfer costs may only be allocated down to the cluster level and not the node/namespace level.
+Datadog supports data transfer cost allocation using [standard 6 workload resources][104] only. For [custom workload resources][106], data transfer costs can be allocated down to the cluster level only, and not the node/namespace level.
 
 [101]: /containers/kubernetes/tag/?tab=containerizedagent#node-labels-as-tags
 [102]: /containers/kubernetes/tag/?tab=containerizedagent#pod-labels-as-tags

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -141,6 +141,10 @@ ECS tasks that run on Fargate are already fully allocated [in the CUR][103]. CCM
 
 For Kubernetes data transfer allocation, a Kubernetes node is joined with its associated data transfer costs from the [CUR][103]. The node's cluster name and all node tags are added to the entire data transfer cost for the node. This allows you to associate cluster-level dimensions with the cost of the data transfer, without considering the pods scheduled to the node.
 
+Next, Datadog looks at all of the [workload resources][104] running on that node for the day. The cost of the node is allocated to the workload level based on the resources it has used and the length of time it ran. This calculated cost is enriched with all of the workload resource's tags.
+
+**Note**: Only _tags_ from pods and nodes are added to cost metrics. To include labels, enable labels as tags for [nodes][101] and [pods][102].
+
 [Network Performance Monitoring][105] must be enabled on all AWS hosts to allow accurate data transfer cost allocation. If some hosts do not have Network Performance Monitoring enabled, the data transfer costs for these hosts is not allocated and may appear as an `n/a` bucket depending on filter and group-by conditions.
 
 Datadog supports data transfer cost allocation only through the [standard 6 workload resources][104]. If you use custom workload resources their data transfer costs may only be allocated down to the cluster level and not the node/namespace level.
@@ -234,6 +238,15 @@ The cost of an EBS volume has three components: IOPS, throughput, and storage. E
 **Note**: Persistent volume allocation is only supported in Kubernetes clusters, and is only available for pods that are part of a Kubernetes StatefulSet.
 
 [101]: https://app.datadoghq.com/integrations/amazon-web-services
+
+### Data transfer
+
+Costs are allocated into the following spend types:
+
+| Spend type | Description    |
+| -----------| -----------    |
+| Usage | Cost of data transfer that is monitored by Network Performance Monitoring and allocated. |
+| Not monitored | Cost of data transfer not monitored by Network Performance Monitoring. This cost is not allocated. |
 
 {{% /tab %}}
 {{% tab "Azure" %}}

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -141,7 +141,7 @@ ECS tasks that run on Fargate are already fully allocated [in the CUR][103]. CCM
 
 For Kubernetes data transfer allocation, a Kubernetes node is joined with its associated data transfer costs from the [CUR][103]. The node's cluster name and all node tags are added to the entire data transfer cost for the node. This allows you to associate cluster-level dimensions with the cost of the data transfer, without considering the pods scheduled to the node.
 
-Next, Datadog looks at all of the [workload resources][104] running on that node for the day. The cost of the node is allocated to the workload level based on the volume of network traffic used. This calculated cost is enriched with all of the workload resource's tags.
+Next, Datadog examines the daily [workload resources][104] running on that node. The node cost is allocated to the workload level according to network traffic volume usage. This calculated cost is enriched with all of the workload resource's tags.
 
 **Note**: Only _tags_ from pods and nodes are added to cost metrics. To include labels, enable labels as tags for [nodes][101] and [pods][102].
 

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -141,7 +141,7 @@ ECS tasks that run on Fargate are already fully allocated [in the CUR][103]. CCM
 
 For Kubernetes data transfer allocation, a Kubernetes node is joined with its associated data transfer costs from the [CUR][103]. The node's cluster name and all node tags are added to the entire data transfer cost for the node. This allows you to associate cluster-level dimensions with the cost of the data transfer, without considering the pods scheduled to the node.
 
-Next, Datadog looks at all of the [workload resources][104] running on that node for the day. The cost of the node is allocated to the workload level based on the resources it has used and the length of time it ran. This calculated cost is enriched with all of the workload resource's tags.
+Next, Datadog looks at all of the [workload resources][104] running on that node for the day. The cost of the node is allocated to the workload level based on the volume of network traffic used. This calculated cost is enriched with all of the workload resource's tags.
 
 **Note**: Only _tags_ from pods and nodes are added to cost metrics. To include labels, enable labels as tags for [nodes][101] and [pods][102].
 

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -147,13 +147,14 @@ Next, Datadog looks at all of the [workload resources][104] running on that node
 
 [Network Performance Monitoring][105] must be enabled on all AWS hosts to allow accurate data transfer cost allocation. If some hosts do not have Network Performance Monitoring enabled, the data transfer costs for these hosts is not allocated and may appear as an `n/a` bucket depending on filter and group-by conditions.
 
-Datadog supports data transfer cost allocation only through the [standard 6 workload resources][104]. If you use custom workload resources their data transfer costs may only be allocated down to the cluster level and not the node/namespace level.
+Datadog supports data transfer cost allocation only through the [standard 6 workload resources][104]. If you use [custom workload resources][106] their data transfer costs may only be allocated down to the cluster level and not the node/namespace level.
 
 [101]: /containers/kubernetes/tag/?tab=containerizedagent#node-labels-as-tags
 [102]: /containers/kubernetes/tag/?tab=containerizedagent#pod-labels-as-tags
 [103]: https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html
 [104]: https://kubernetes.io/docs/concepts/workloads/
 [105]: /network_monitoring/performance/setup
+[106]: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
 
 {{% /tab %}}
 {{% tab "Azure" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Document `allocated_spend_type` for data transfer. Also, clarify allocation strategy for data transfer.


<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
