### PR TITLE
Fix Agentless resources filtering tag

### DIFF
--- a/layouts/shortcodes/csm-agentless-exclude-resources.en.md
+++ b/layouts/shortcodes/csm-agentless-exclude-resources.en.md
@@ -1,3 +1,3 @@
-To exclude AWS hosts, containers, and Lambda functions from scans, apply the tag `CompanyAgentlessScanner:false` to each resource. For detailed instructions on adding this tag, refer to the [AWS documentation][105].
+To exclude AWS hosts, containers, and Lambda functions from scans, apply the tag `DatadogAgentlessScanner:false` to each resource. For detailed instructions on adding this tag, refer to the [AWS documentation][105].
 
 [105]: https://docs.aws.amazon.com/tag-editor/latest/userguide/tagging.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Fix the tag to exclude resources from being scanned by the Agentless scanning.
The tag was correct prior to #24801 

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
