### PR TITLE
[DOCS-9303] Remove bitcode mention from iOS Error Tracking

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -361,12 +361,7 @@ Crash reports are collected in a raw format and mostly contain memory addresses.
 
 Every iOS application produces `.dSYM` files for each application module. These files minimize an application's binary size and enable faster download speed. Each application version contains a set of `.dSYM` files. 
 
-Depending on your setup, you may need to download `.dSYM` files from App Store Connect or find them on your local machine. 
-
-| Bitcode Enabled | Description |
-|---|---|
-| Yes | `.dSYM` files are available after [App Store Connect][7] completes processing your application's build. |
-| No | Xcode exports `.dSYM` files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with dSYM File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** for the Release project configuration. |
+Xcode exports `.dSYM` files to `$DWARF_DSYM_FOLDER_PATH` at the end of your application's build. Ensure that the `DEBUG_INFORMATION_FORMAT` build setting is set to **DWARF with dSYM File**. By default, Xcode projects only set `DEBUG_INFORMATION_FORMAT` to **DWARF with dSYM File** for the Release project configuration.
 
 ### Upload your .dSYM file
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Per user feedback, removed mentions of bitcode from the Error Tracking setup page for iOS because of an Apple update that made it irrelevant.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
