### PR TITLE
Update Java's disabled by default integrations

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -118,16 +118,22 @@ Also, frameworks like Spring Boot (version 3) inherently work because they usual
 
 The following instrumentations are disabled by default and can be enabled with the following settings:
 
-| Instrumentation     | To Enable 									                                                                                                              |
-|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| JAX-WS                       | `-Ddd.integration.jax-ws.enabled=true`                                                                                                    |
-| Mulesoft                     | `-Ddd.integration.mule.enabled=true`, `-Ddd.integration.grizzly-client.enabled=true`, `-Ddd.integration.grizzly-filterchain.enabled=true` |
-| Grizzly                      | `-Ddd.integration.grizzly-client.enabled=true`                                                                                            |
-| Grizzly-HTTP                 | `-Ddd.integration.grizzly-filterchain.enabled=true`                                                                                       |
-| Ning                         | `-Ddd.integration.ning.enabled=true`                                                                                                      |
-| Spark Java                   | `-Ddd.integration.sparkjava.enabled=true`                                                                                                 |
-| Hazelcast (client side only) | `-Ddd.integration.hazelcast.enabled=true` </br> `-Ddd.integration.hazelcast_legacy.enabled=true`                                          |
-| TIBCO BusinessWorks          | `-Ddd.integration.tibco.enabled=true`                                                                                                     |
+| Instrumentation              | To Enable 									                                                                                                                                 |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| Grizzly                      | `-Ddd.integration.grizzly-client.enabled=true`                                                                                                      |
+| Grizzly-HTTP                 | `-Ddd.integration.grizzly-filterchain.enabled=true`                                                                                                 |
+| Hazelcast (client side only) | `-Ddd.integration.hazelcast.enabled=true` </br> `-Ddd.integration.hazelcast_legacy.enabled=true`                                                    |
+| Ignite                       | `-Ddd.integration.ignite.enabled=true`                                                                                                              |
+| JAX-WS                       | `-Ddd.integration.jax-ws.enabled=true`                                                                                                              |
+| JDBC Datasource              | `-Ddd.integration.jdbc-datasource.enabled=true`                                                                                                     |
+| Kotlin Coroutines            | `-Ddd.integration.kotlin_coroutine.experimental.enabled=true`                                                                                       |
+| Mulesoft                     | `-Ddd.integration.mule.enabled=true` <br/> `-Ddd.integration.grizzly-client.enabled=true` <br/> `-Ddd.integration.grizzly-filterchain.enabled=true` |
+| Netty Promise                | `-Ddd.integration.netty-promise.enabled=true`                                                                                                       |
+| Ning                         | `-Ddd.integration.ning.enabled=true`                                                                                                                |
+| Spark Java                   | `-Ddd.integration.sparkjava.enabled=true`                                                                                                           |
+| TIBCO BusinessWorks          | `-Ddd.integration.tibco.enabled=true`                                                                                                               |
+| URL Connection               | `-Ddd.integration.urlconnection.enabled=true` </br> `-Ddd.integration.httpurlconnection.enabled=true`                                               |
+| ZIO                          | `-Ddd.integration.zio.experimental.enabled=true`                                                                                                    |
 
 
 **Note**: JAX-WS integration instruments endpoints annotated with @WebService (JAX-WS 1.x) and @WebServiceProvider (JAX-WS 2.x).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The disabled by default integration list was inaccurate - this makes it complete.

This was populated using this [Github search](https://github.com/search?q=repo%3ADataDog%2Fdd-trace-java+++%40Override+++public+boolean+defaultEnabled%28%29+%7B+++++return+false%3B+++%7D&type=code&p=2)

Note that this does not include [Servlet](https://github.com/DataDog/dd-trace-java/blob/master/dd-java-agent/instrumentation/servlet/src/main/java/datadog/trace/instrumentation/servlet/http/HttpServletInstrumentation.java) since I was suspicious about it actually being disabled

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
