### PR TITLE
DOCS-9529 - replace filter on custom kind with dir path

### DIFF
--- a/layouts/shortcodes/integrations.html
+++ b/layouts/shortcodes/integrations.html
@@ -3,7 +3,7 @@
 <!-- From data file -->
 {{ $integration_list := site.Pages }}
 {{ $integration_list := $integration_list | intersect (where $integration_list ".Section" "=" "integrations") }}
-{{ $integration_list := $integration_list | intersect (where $integration_list ".Params.custom_kind" "=" "integration") }}
+{{ $integration_list := $integration_list | intersect (where $integration_list ".File.Dir" "=" "integrations/") }}
 {{ $integration_list := $integration_list | intersect (where $integration_list ".Params.beta" "!=" true) }}
 {{ $integration_list := $integration_list | intersect (where $integration_list ".Params.is_public" "!=" false) }}
 {{ $integration_list := $integration_list | intersect (where $integration_list ".Params.placeholder" "!=" true) }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

We are filtering integrations on `custom_kind` which in some cases is being translated on ja pages and causing them to not appear. This PR updates the filtering to go based off the directory path e.g we want `/integrations/` but not `/integrations/guides` etc.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes

Something like aws rds integration should appear 
https://docs-staging.datadoghq.com/david.jones/int-ja-kinds/ja/integrations/?q=rds
