### PR TITLE
Fix mixed links in merge-step-functions-lambda.md

### DIFF
--- a/content/en/serverless/step_functions/merge-step-functions-lambda.md
+++ b/content/en/serverless/step_functions/merge-step-functions-lambda.md
@@ -182,5 +182,5 @@ To link your Step Function traces to nested Step Function traces, configure your
 
 This capability is not supported.
 
-[1]: /serverless/installation/#installation-instructions
-[2]: /serverless/step_functions/installation
+[1]: /serverless/step_functions/installation
+[2]: /serverless/installation/#installation-instructions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The 2 href links in the introduction of [this page](https://docs.datadoghq.com/serverless/step_functions/merge-step-functions-lambda/) are inverted.

This PR fixes the issue.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
