### PR TITLE
DOCS-9556: Rename Service Catalog headings

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1880,12 +1880,12 @@ menu:
       parent: service_catalog
       identifier: service_catalog_browse
       weight: 2
-    - name: Manage a Service
+    - name: Manage a Component
       url: service_catalog/manage
       parent: service_catalog
       identifier: service_catalog_investigate
       weight: 3
-    - name: Service Definitions
+    - name: Definitions
       url: service_catalog/service_definitions/
       parent: service_catalog
       identifier: service_catalog_definitions_versions
@@ -1910,7 +1910,7 @@ menu:
       parent: service_catalog_definitions_versions
       identifier: service_catalog_definitions_2-0
       weight: 404
-    - name: Service Scorecards
+    - name: Scorecards
       url: service_catalog/scorecards
       parent: service_catalog
       identifier: service_catalog_scorecards

--- a/content/en/service_catalog/manage.md
+++ b/content/en/service_catalog/manage.md
@@ -1,5 +1,5 @@
 ---
-title: Manage a Service
+title: Manage a Component
 aliases:
   - /tracing/service_catalog/investigating
   - /service_catalog/investigating/

--- a/content/en/service_catalog/scorecards/_index.md
+++ b/content/en/service_catalog/scorecards/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Service Scorecards
+title: Scorecards
 aliases:
   - /tracing/service_catalog/scorecards
 further_reading:
@@ -8,10 +8,10 @@ further_reading:
   text: "Service Catalog"
 - link: /api/latest/service-scorecards/
   tag: "Documentation" 
-  text: "Service Scorecards API" 
+  text: "Scorecards API" 
 - link: "https://www.datadoghq.com/blog/service-scorecards/"
   tag: "Blog"
-  text: "Prioritize and promote service observability best practices with Service Scorecards"
+  text: "Prioritize and promote service observability best practices with Scorecards"
 - link: "https://www.datadoghq.com/blog/datadog-custom-scorecards/"
   tag: "Blog"
   text: "Formalize best practices with custom Scorecards"
@@ -24,23 +24,23 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="false" >}}
-Service Scorecards are in Preview.
+Scorecards are in Preview.
 {{< /callout >}}
 
-{{< img src="/tracing/service_catalog/scorecard-overview.png" alt="Service Scorecards dashboard highlighting Production Readiness out-of-the-box rules" style="width:90%;" >}}
+{{< img src="/tracing/service_catalog/scorecard-overview.png" alt="Scorecards dashboard highlighting Production Readiness out-of-the-box rules" style="width:90%;" >}}
 
 ## Overview
 
-Service Scorecards help you monitor, prioritize, plan, and communicate effectively to take informed actions that improve your service's health and performance. Each scorecard shows the status for Production Readiness, Observability Best Practices, and Documentation & Ownership. All services with defined metadata in the Service Catalog are automatically evaluated against a set of pass-fail criteria.
+Scorecards help you monitor, prioritize, plan, and communicate effectively to take informed actions that improve your service's health and performance. Each scorecard shows the status for Production Readiness, Observability Best Practices, and Documentation & Ownership. All services with defined metadata in the Service Catalog are automatically evaluated against a set of pass-fail criteria.
 
 You can select the rules used to populate the Scorecards, and you can generate reports, which are sent directly to your team's Slack channel, to regularly report on scorecard results.
 
 ## Get started
 
-{{< whatsnext desc="Set up Service Scorecards and explore how they can help your team:" >}}
-    {{< nextlink href="/service_catalog/scorecards/scorecard_configuration/" >}}Configure Service Scorecards{{< /nextlink >}}
+{{< whatsnext desc="Set up Scorecards and explore how they can help your team:" >}}
+    {{< nextlink href="/service_catalog/scorecards/scorecard_configuration/" >}}Configure Scorecards{{< /nextlink >}}
     {{< nextlink href="/service_catalog/scorecards/custom_rules/" >}}Create custom rules{{< /nextlink >}}
-    {{< nextlink href="/service_catalog/scorecards/using_scorecards/" >}}Learn what you can do with Service Scorecards{{< /nextlink >}}
+    {{< nextlink href="/service_catalog/scorecards/using_scorecards/" >}}Learn what you can do with Scorecards{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Further reading

--- a/content/en/service_catalog/scorecards/custom_rules.md
+++ b/content/en/service_catalog/scorecards/custom_rules.md
@@ -8,10 +8,10 @@ further_reading:
   text: "Service Catalog"
 - link: /api/latest/service-scorecards/
   tag: "Documentation" 
-  text: "Service Scorecards API" 
+  text: "Scorecards API" 
 - link: "https://www.datadoghq.com/blog/service-scorecards/"
   tag: "Blog"
-  text: "Prioritize and promote service observability best practices with Service Scorecards"
+  text: "Prioritize and promote service observability best practices with Scorecards"
 - link: "https://www.datadoghq.com/blog/datadog-custom-scorecards/"
   tag: "Blog"
   text: "Formalize best practices with custom Scorecards"
@@ -21,10 +21,10 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="false" >}}
-Service Scorecards are in Preview.
+Scorecards are in Preview.
 {{< /callout >}}
 
-Datadog provides [default rules][1] so you can get started quickly with Service Scorecards, but you can also create custom rules.
+Datadog provides [default rules][1] so you can get started quickly with Scorecards, but you can also create custom rules.
 
 ## Create custom rules
 

--- a/content/en/service_catalog/scorecards/scorecard_configuration.md
+++ b/content/en/service_catalog/scorecards/scorecard_configuration.md
@@ -8,10 +8,10 @@ further_reading:
   text: "Service Catalog"
 - link: /api/latest/service-scorecards/
   tag: "Documentation" 
-  text: "Service Scorecards API" 
+  text: "Scorecards API" 
 - link: "https://www.datadoghq.com/blog/service-scorecards/"
   tag: "Blog"
-  text: "Prioritize and promote service observability best practices with Service Scorecards"
+  text: "Prioritize and promote service observability best practices with Scorecards"
 - link: "https://www.datadoghq.com/blog/datadog-custom-scorecards/"
   tag: "Blog"
   text: "Formalize best practices with custom Scorecards"
@@ -21,7 +21,7 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="false" >}}
-Service Scorecards are in Preview.
+Scorecards are in Preview.
 {{< /callout >}}
 
 Datadog provides the following out-of-the-box scorecards based on a default set of rules: Production Readiness, Observability Best Practices, and Ownership & Documentation. 
@@ -34,7 +34,7 @@ To select which of the out-of-the-box rules are evaluated for each of the defaul
 2. Enable or disable rules to customize how the scores are calculated. 
 3. Click **View your scores** to start tracking your progress toward the selected rules across your defined services.
 
-{{< img src="/tracing/service_catalog/scorecards-setup.png" alt="Service Scorecards setup page" style="width:90%;" >}}
+{{< img src="/tracing/service_catalog/scorecards-setup.png" alt="Scorecards setup page" style="width:90%;" >}}
 
 ## How services are evaluated
 

--- a/content/en/service_catalog/scorecards/using_scorecards.md
+++ b/content/en/service_catalog/scorecards/using_scorecards.md
@@ -8,10 +8,10 @@ further_reading:
   text: "Service Catalog"
 - link: /api/latest/service-scorecards/
   tag: "Documentation" 
-  text: "Service Scorecards API" 
+  text: "Scorecards API" 
 - link: "https://www.datadoghq.com/blog/service-scorecards/"
   tag: "Blog"
-  text: "Prioritize and promote service observability best practices with Service Scorecards"
+  text: "Prioritize and promote service observability best practices with Scorecards"
 - link: "https://www.datadoghq.com/blog/datadog-custom-scorecards/"
   tag: "Blog"
   text: "Formalize best practices with custom Scorecards"
@@ -21,7 +21,7 @@ further_reading:
 ---
 
 {{< callout url="#" btn_hidden="true" header="false" >}}
-Service Scorecards are in Preview.
+Scorecards are in Preview.
 {{< /callout >}}
 
 After configuring your Scorecards, you can view service-level scores, track scores over time, and generate Scorecard reports to automatically update your team with Scorecard information.

--- a/content/en/service_catalog/service_definitions/_index.md
+++ b/content/en/service_catalog/service_definitions/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Service Definitions and Supported Versions
+title: Definitions and Supported Versions
 aliases:
 - /service_catalog/adding_metadata
 - /tracing/service_catalog/service_metadata_structure
@@ -8,10 +8,10 @@ aliases:
 further_reading:
 - link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/service_definition_yaml"
   tag: "External Site"
-  text: "Create and manage service definitions with Terraform"
+  text: "Create and manage definitions with Terraform"
 - link: "/api/latest/service-definition/"
   tag: "API"
-  text: "Learn about the Service Definition API"
+  text: "Learn about the Definition API"
 - link: "/integrations/github"
   tag: "Documentation"
   text: "Learn about the GitHub Integration"
@@ -22,11 +22,11 @@ further_reading:
 
 ## Metadata structure and supported versions
 
-Service Catalog uses service definition schemas to store and display relevant metadata about your services. The schemas have built-in validation rules to ensure that only valid values are accepted. You can view warnings in the **Definition** tab on the Service Catalog side panel for any selected services. 
+Service Catalog uses definition schemas to store and display relevant metadata about your services. The schemas have built-in validation rules to ensure that only valid values are accepted. You can view warnings in the **Definition** tab on the Service Catalog side panel for any selected services. 
 
 ## Supported versions
 
-Datadog supports four versions of the service definition schema:
+Datadog supports four versions of the definition schema:
 
 - [v3.0 (in Preview)][1]: Latest version with expanded data model, multi-ownership support, manual dependency declaration, and enhanced features for complex infrastructure.
 - [v2.2][2]: Supports user annotations for custom metadata and CI pipeline associations to link services with their build processes.
@@ -64,7 +64,7 @@ For detailed information about each version, including full schemas and example 
 
 ### Add metadata with automation
 
-#### Store and edit service definitions in GitHub
+#### Store and edit definitions in GitHub
 
 Configure the [GitHub integration][6] to directly link from where you view the service's definition in the Service Catalog to where it's stored and editable in GitHub. Datadog scans for the `service.datadog.yaml` file at the root of each repository with read permissions.
 
@@ -72,17 +72,17 @@ To install the GitHub integration:
 1. Navigate to the [integration tile][7].
 2. Click **Link GitHub Account** in the **Repo Configuration** tab.
 
-When the GitHub integration is set up for your service definitions, an **Edit in GitHub** button appears in the service's **Definition** tab and links you to GitHub to commit changes.
+When the GitHub integration is set up for your definitions, an **Edit in GitHub** button appears in the service's **Definition** tab and links you to GitHub to commit changes.
 
 {{< img src="tracing/service_catalog/svc_cat_contextual_link.png" alt="An Edit in GitHub button appears in the Definition tab of a service in the Service Catalog" style="width:90%;" >}}
 
 After you update the YAML files for your repositories, your changes propagate to the Service Catalog. You can register multiple services in one YAML file by creating multiple YAML documents. Separate each document with three dashes (`---`).
 
-To prevent accidental overwriting, create and modify your service definition files with either the GitHub integration or the [Service Definition API endpoints][11]. Updating the same service using both the GitHub and the API may result in unintended overwriting.  
+To prevent accidental overwriting, create and modify your definition files with either the GitHub integration or the [Definition API endpoints][11]. Updating the same service using both the GitHub and the API may result in unintended overwriting.  
 
-#### Automate service definition updates with Terraform
+#### Automate definition updates with Terraform
 
-The Service Catalog provides a service definition as a [Terraform resource][8]. Creating and managing services in the Service Catalog through automated pipelines requires [Datadog Provider][9] v3.16.0 or later.
+The Service Catalog provides a definition as a [Terraform resource][8]. Creating and managing services in the Service Catalog through automated pipelines requires [Datadog Provider][9] v3.16.0 or later.
 
 #### Open-source metadata provider
 
@@ -111,11 +111,11 @@ extensions:
 
 ## IDE Plugins
 
-Datadog provides a [JSON Schema][13] for service definitions so that when you are editing a service definition in a [supporting IDE][14], features such as autocomplete and validation are provided.
+Datadog provides a [JSON Schema][13] for definitions so that when you are editing a definition in a [supporting IDE][14], features such as autocomplete and validation are provided.
 
 {{< img src="tracing/service_catalog/ide_plugin.png" alt="VSCode recognizing problem to fix" style="width:100%;" >}}
 
-The [JSON schema for Datadog service definitions][15] is registered with the open source [Schema Store][14].
+The [JSON schema for Datadog definitions][15] is registered with the open source [Schema Store][14].
 
 ## Further reading
 

--- a/content/en/service_catalog/service_definitions/v2-0.md
+++ b/content/en/service_catalog/service_definitions/v2-0.md
@@ -1,12 +1,12 @@
 ---
-title: Service Definition Schema v2.0
+title: Definition Schema v2.0
 further_reading:
 - link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/service_definition_yaml"
   tag: "External Site"
-  text: "Create and manage service definitions with Terraform"
+  text: "Create and manage definitions with Terraform"
 - link: "/api/latest/service-definition/"
   tag: "API"
-  text: "Learn about the Service Definition API"
+  text: "Learn about the Definition API"
 - link: "/integrations/github"
   tag: "Documentation"
   text: "Learn about the GitHub Integration"
@@ -17,7 +17,7 @@ further_reading:
 
 ## Overview
 
-Schema v2 is the earliest supported version of the Service Definition schema. It provides basic metadata structure for services and some experimental features.
+Schema v2 is the earliest supported version of the Definition schema. It provides basic metadata structure for services and some experimental features.
 
 ## Key features
 

--- a/content/en/service_catalog/service_definitions/v2-1.md
+++ b/content/en/service_catalog/service_definitions/v2-1.md
@@ -1,12 +1,12 @@
 ---
-title: Service Definition Schema v2.1
+title: Definition Schema v2.1
 further_reading:
 - link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/service_definition_yaml"
   tag: "External Site"
-  text: "Create and manage service definitions with Terraform"
+  text: "Create and manage definitions with Terraform"
 - link: "/api/latest/service-definition/"
   tag: "API"
-  text: "Learn about the Service Definition API"
+  text: "Learn about the Definition API"
 - link: "/integrations/github"
   tag: "Documentation"
   text: "Learn about the GitHub Integration"

--- a/content/en/service_catalog/service_definitions/v2-2.md
+++ b/content/en/service_catalog/service_definitions/v2-2.md
@@ -1,12 +1,12 @@
 ---
-title: Service Definition Schema v2.2
+title: Definition Schema v2.2
 further_reading:
 - link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/service_definition_yaml"
   tag: "External Site"
-  text: "Create and manage service definitions with Terraform"
+  text: "Create and manage definitions with Terraform"
 - link: "/api/latest/service-definition/"
   tag: "API"
-  text: "Learn about the Service Definition API"
+  text: "Learn about the Definition API"
 - link: "/integrations/github"
   tag: "Documentation"
   text: "Learn about the GitHub Integration"

--- a/content/en/service_catalog/service_definitions/v3-0.md
+++ b/content/en/service_catalog/service_definitions/v3-0.md
@@ -1,12 +1,12 @@
 ---
-title: Service Definition Schema v3.0 (in Preview)
+title: Definition Schema v3.0 (in Preview)
 further_reading:
 - link: "https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/service_definition_yaml"
   tag: "External Site"
-  text: "Create and manage service definitions with Terraform"
+  text: "Create and manage definitions with Terraform"
 - link: "/api/latest/service-definition/"
   tag: "API"
-  text: "Learn about the Service Definition API"
+  text: "Learn about the Definition API"
 - link: "/integrations/github"
   tag: "Documentation"
   text: "Learn about the GitHub Integration"
@@ -20,7 +20,7 @@ further_reading:
 
 ## Overview
 
-Schema v3.0 is the latest version of the Service Definition schema and is in Preview. It introduces several new features and enhancements to provide more flexibility and detailed service definitions.
+Schema v3.0 is the latest version of the Definition schema and is in Preview. It introduces several new features and enhancements to provide more flexibility and detailed definitions.
 
 {{< callout url="https://forms.gle/L5zXVkKr5bAzbdMD9" d_target="#signupModal" btn_hidden="false" header="Opt in to the Preview for metadata schema v3.0!" >}}
 {{< /callout >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Renames Service Catalog headings. Requested by PM.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
