### PR TITLE
Linux kernel versions supported by the eBPF-less solution

### DIFF
--- a/content/en/security/threats/supported_linux_distributions.md
+++ b/content/en/security/threats/supported_linux_distributions.md
@@ -19,7 +19,9 @@ Cloud Security Management Threats supports the following Linux distributions:
 **Notes:**
 
 - Custom kernel builds are not supported.
+- The [CSM Threats eBPF-less solution for eBPF disabled environments][2] uses a ptrace-based Datadog Agent. The ptrace-based Datadog Agent supports Linux kernel versions 3.4.43 to 4.9.85.
 - For compatibility with a custom Kubernetes network plugin like Cilium or Calico, see the [Troubleshooting Cloud Security Management Threats][1].
 - Data collection is done using eBPF, so Datadog requires, at minimum, platforms that have underlying Linux kernel versions of 4.14.0+ or have eBPF features backported (for example, Centos/RHEL 7 with kernel 3.10 has eBPF features backported, so it is supported).
 
 [1]: /security/cloud_security_management/troubleshooting/threats
+[2]: /security/cloud_security_management/guide/ebpf-free-agent

--- a/content/en/security/threats/supported_linux_distributions.md
+++ b/content/en/security/threats/supported_linux_distributions.md
@@ -19,7 +19,7 @@ Cloud Security Management Threats supports the following Linux distributions:
 **Notes:**
 
 - Custom kernel builds are not supported.
-- The [CSM Threats eBPF-less solution for eBPF disabled environments][2] uses a ptrace-based Datadog Agent. The ptrace-based Datadog Agent supports Linux kernel versions 3.4.43 to 4.9.85.
+- The [CSM Threats eBPF-less solution for eBPF disabled environments][2] uses a ptrace-based Datadog Agent. The ptrace-based Datadog Agent supports Linux kernel versions from 3.4.43 to 4.9.85.
 - For compatibility with a custom Kubernetes network plugin like Cilium or Calico, see the [Troubleshooting Cloud Security Management Threats][1].
 - Data collection is done using eBPF, so Datadog requires, at minimum, platforms that have underlying Linux kernel versions of 4.14.0+ or have eBPF features backported (for example, Centos/RHEL 7 with kernel 3.10 has eBPF features backported, so it is supported).
 


### PR DESCRIPTION
DOCS-9375

List the Linux kernel versions supported by the eBPF-less solution (ptrace-based Datadog Agent).