### PR TITLE
Remove "Preview" label from Log Subqueries docs

### DIFF
--- a/content/en/logs/explorer/advanced_search.md
+++ b/content/en/logs/explorer/advanced_search.md
@@ -20,8 +20,6 @@ When you need to further refine the results of a log search, use [subqueries](#f
 
 ## Filter logs with subqueries
 
-<div class="alert alert-warning">Filtering logs with subqueries is in Preview.</div>
-
 Use subqueries when you want to filter the results of a query based on the results of a secondary query. See [subquery examples](#subquery-examples) for two example scenarios.
 
 To add a subquery filter:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
