### PR TITLE
[Preview] Bump image tag for the Agent with embedded OTel collector

### DIFF
--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -9,7 +9,7 @@ further_reading:
 
 {{< callout url="https://www.datadoghq.com/private-beta/agent-with-embedded-opentelemetry-collector/" btn_hidden="false" header="Join the Preview!">}}
   The Datadog Agent with embedded OpenTelemetry Collector is in Preview. To request access, fill out this form.
-{{< /callout >}} 
+{{< /callout >}}
 
 ## Overview
 
@@ -78,12 +78,12 @@ datadog:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.57.0-v1.0-ot-beta-jmx
+    tag: 7.59.0-v1.1.0-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
    <div class="alert alert-info">This guide uses a Java application example. The <code>-jmx</code> suffix in the image tag enables JMX utilities. For non-Java applications, use <code>7.57.0-v1.0-ot-beta</code> instead.<br> For more details, see <a href="/containers/guide/autodiscovery-with-jmx/?tab=helm">Autodiscovery and JMX integration guide</a>.</div>
-   
+
    By default, the Agent image is pulled from Google Artifact Registry (`gcr.io/datadoghq`). If Artifact Registry is not accessible in your deployment region, [use another registry][53].
 1. Enable the OpenTelemetry Collector and configure the essential ports:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
@@ -144,7 +144,7 @@ Your `datadog-values.yaml` file should look something like this:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.57.0-v1.0-ot-beta-jmx
+    tag: 7.59.0-v1.1.0-ot-beta-jmx
     doNotCheckTag: true
 
 datadog:

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -12,7 +12,7 @@ further_reading:
 
 {{< callout url="https://www.datadoghq.com/private-beta/agent-with-embedded-opentelemetry-collector/" btn_hidden="false" header="Join the Preview!">}}
   The Datadog Agent with embedded OpenTelemetry Collector is in Preview. To request access, fill out this form.
-{{< /callout >}} 
+{{< /callout >}}
 
 If you are already using a standalone OpenTelemetry (OTel) Collector for your OTel-instrumented applications, you can migrate to the Datadog Agent with embedded OpenTelemetry Collector. The embedded OTel Collector allows you to leverage Datadog's enhanced capabilities, including optimized configurations, seamless integrations, and additional features tailored for the Datadog ecosystem.
 
@@ -188,7 +188,7 @@ datadog:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.57.0-v1.0-ot-beta-jmx
+    tag: 7.59.0-v1.1.0-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
@@ -252,7 +252,7 @@ Your `datadog-values.yaml` file should look something like this:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.57.0-v1.0-ot-beta-jmx
+    tag: 7.59.0-v1.1.0-ot-beta-jmx
     doNotCheckTag: true
 
 datadog:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Update the image tag for the `otel-agent` to the latest `7.59.0-v1.1.0-ot-beta-jmx` version.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes

The following docs are private -- the Datadog Agent with embedded OpenTelemetry Collector is in Preview (fka Private Beta).

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
