### PR TITLE
Add a note on CI runs not triggering s8s monitors

### DIFF
--- a/content/en/continuous_testing/troubleshooting.md
+++ b/content/en/continuous_testing/troubleshooting.md
@@ -45,7 +45,7 @@ Check whether you are using API endpoints to trigger your CI/CD test runs. In or
 
 The first thing to check is which failure mode flags you are passing in your [global configuration file][3]. For CI runs that contain multiple tests, some tests are queued based on the parallelization setting defined on the [Continuous Testing Settings page][9]. You may need to adapt both your configuration and parallelization based on your organizational needs.
 
-## Synthetics Monitors
+## Synthetics monitors
 
 The CI doesn't trigger Synthetics monitors and do not factor into monitor evaluation at all, however failing runs will make the CI red. 
 

--- a/content/en/continuous_testing/troubleshooting.md
+++ b/content/en/continuous_testing/troubleshooting.md
@@ -47,7 +47,7 @@ The first thing to check is which failure mode flags you are passing in your [gl
 
 ## Synthetics monitors
 
-The CI doesn't trigger Synthetics monitors and do not factor into monitor evaluation at all, however failing runs will make the CI red. 
+The CI does not trigger Synthetics monitors or incorporate them into monitor evaluations; however, failing runs will result in the CI showing a red status.
 
 ## Further reading
  

--- a/content/en/continuous_testing/troubleshooting.md
+++ b/content/en/continuous_testing/troubleshooting.md
@@ -45,6 +45,10 @@ Check whether you are using API endpoints to trigger your CI/CD test runs. In or
 
 The first thing to check is which failure mode flags you are passing in your [global configuration file][3]. For CI runs that contain multiple tests, some tests are queued based on the parallelization setting defined on the [Continuous Testing Settings page][9]. You may need to adapt both your configuration and parallelization based on your organizational needs.
 
+## Synthetics Monitors
+
+The CI doesn't trigger Synthetics monitors and do not factor into monitor evaluation at all, however failing runs will make the CI red. 
+
 ## Further reading
  
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Making this docs change so that users are aware that CI failed runs don't factor into a synthetics test's monitor evaluation.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
