### PR TITLE
fix test impact analysis activation instructions - still referred to Intelligent Test Runner

### DIFF
--- a/layouts/shortcodes/ci-itr-activation-instructions.en.md
+++ b/layouts/shortcodes/ci-itr-activation-instructions.en.md
@@ -1,4 +1,4 @@
-### Activate Intelligent Test Runner for the test service
+### Activate Test Impact Analysis for the test service
 
 You, or a user in your organization with the **Intelligent Test Runner Activation** (`intelligent_test_runner_activation_write`) permission, must activate Test Impact Analysis on the [Test Service Settings][101] page.
 

--- a/layouts/shortcodes/ci-itr-activation-instructions.fr.md
+++ b/layouts/shortcodes/ci-itr-activation-instructions.fr.md
@@ -1,7 +1,7 @@
-### Activer la fonctionnalité Intelligent Test Runner pour le service de test
+### Activer la fonctionnalité Test Impact Analysis pour le service de test
 
-Pour activer la fonctionnalité Intelligent Test Runner, accédez à la page [Test Service Settings][101]. Vous devez disposer de l'autorisation d'**activation d'Intelligent Test Runner** (`intelligent_test_runner_activation_write`).
+Pour activer la fonctionnalité Test Impact Analysis, accédez à la page [Test Service Settings][101]. Vous devez disposer de l'autorisation d'**activation d'Intelligent Test Runner** (`intelligent_test_runner_activation_write`).
 
-<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Fonctionnalité Intelligent Test Runner activée dans les paramètres du service de test à la section CI de Datadog."></picture></a></figure></div>
+<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Fonctionnalité Test Impact Analysis activée dans les paramètres du service de test à la section CI de Datadog."></picture></a></figure></div>
 
 [101]: https://app.datadoghq.com/ci/settings/test-service

--- a/layouts/shortcodes/ci-itr-activation-instructions.ja.md
+++ b/layouts/shortcodes/ci-itr-activation-instructions.ja.md
@@ -1,7 +1,7 @@
-### テストサービスの Intelligent Test Runner を有効にする
+### テストサービスの Test Impact Analysis を有効にする
 
-あなた、またはあなたの組織で **Intelligent Test Runner Activation** (`intelligent_test_runner_activation_write`) 権限を持つユーザーが、[テストサービス設定][101]ページで Intelligent Test Runner を有効にする必要があります。
+あなた、またはあなたの組織で **Intelligent Test Runner Activation** (`intelligent_test_runner_activation_write`) 権限を持つユーザーが、[テストサービス設定][101]ページで Test Impact Analysis を有効にする必要があります。
 
-<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Intelligent test runner enabled in test service settings in the CI section of Datadog."></picture></a></figure></div>
+<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Test Impact Analysis enabled in test service settings in the CI section of Datadog."></picture></a></figure></div>
 
 [101]: https://app.datadoghq.com/ci/settings/test-service

--- a/layouts/shortcodes/ci-itr-activation-instructions.ko.md
+++ b/layouts/shortcodes/ci-itr-activation-instructions.ko.md
@@ -1,7 +1,7 @@
-### 테스트 서비스를 위한 Intelligent Test Runner 활성화
+### 테스트 서비스를 위한 Test Impact Analysis 활성화
 
 **Intelligent Test Runner Activation** (`intelligent_test_runner_activation_write`) 권한이 있는 조직의 사용자는 [Test Service Settings][101] 페이지에서 Intelligent Test Runner를 활성화해야 합니다.
 
-<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Intelligent test runner enabled in test service settings in the CI section of Datadog."></picture></a></figure></div>
+<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Test Impact Analysis enabled in test service settings in the CI section of Datadog."></picture></a></figure></div>
 
 [101]: https://app.datadoghq.com/ci/settings/test-service


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Test impact analysis docs still mentioned Intelligent Test Runner in a couple of places.

### Merge instructions
- [x] Please merge after reviewing
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
