### PR TITLE
Add Limited Availability Label to YAML Extensions

### DIFF
--- a/content/en/service_catalog/service_definitions/_index.md
+++ b/content/en/service_catalog/service_definitions/_index.md
@@ -88,7 +88,7 @@ The Service Catalog provides a definition as a [Terraform resource][8]. Creating
 
 As an alternative to the GitHub integration and Terraform, you can use an open-sourced GitHub Action solution named [Datadog Service Catalog Metadata Provider][10].
 
-## Build custom extensions 
+## Build custom extensions (in Limited Availability)
 
 The `extensions` field is supported in all versions including v2.0. You can incorporate this custom field into deployment processes to standardize and codify best practices.
 

--- a/content/en/service_catalog/service_definitions/_index.md
+++ b/content/en/service_catalog/service_definitions/_index.md
@@ -88,7 +88,9 @@ The Service Catalog provides a definition as a [Terraform resource][8]. Creating
 
 As an alternative to the GitHub integration and Terraform, you can use an open-sourced GitHub Action solution named [Datadog Service Catalog Metadata Provider][10].
 
-## Build custom extensions (in Limited Availability)
+## Build custom extensions
+
+<div class="alert alert-info">Custom extensions are in Limited Availability.</div>
 
 The `extensions` field is supported in all versions including v2.0. You can incorporate this custom field into deployment processes to standardize and codify best practices.
 


### PR DESCRIPTION
Adding Limited Availability Label to YAML extensions until giving pending commercialization discussions.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adding Limited Availability Label to YAML extensions until giving pending commercialization discussions.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
