### PR TITLE
[dbm] clarify mongodb atlas setup with using dig to resolve SRV

### DIFF
--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -67,7 +67,7 @@ To monitor your MongoDB Atlas Cluster, you must install and configure the Datado
 
 Applications usually connect to MongoDB Atlas using an SRV connection string, but the Datadog Agent must connect directly to the individual MongoDB instance being monitored. If the Agent connects to different MongoDB instance while it is running (as in the case of failover, load balancing, and so on), the Agent calculates the difference in statistics between two hosts, producing inaccurate metrics.
 
-To get the individual MongoDB instance hostname and port, you can use network utility command line tools like `dig` command in Linux or `nslookup` command in Windows to resolve the SRV connection string.
+To get the individual MongoDB instance hostname and port, you can use network utility command line tools like `dig` in Linux or `nslookup` in Windows to resolve the SRV connection string.
 
 {{< tabs >}}
 {{% tab "Replica Set" %}}
@@ -76,7 +76,7 @@ To get the individual MongoDB instance hostname and port, you can use network ut
 
 For a non-sharded (replica set) cluster with the SRV connection string `mongodb+srv://XXXXX.XXX.mongodb.net/`:
 
-Use the `dig` command in Linux to resolve the SRV connection string:
+Use `dig` in Linux to resolve the SRV connection string:
 
 {{< code-block lang="shell" >}}
 dig +short SRV _mongodb._tcp.XXXXX.XXX.mongodb.net
@@ -90,7 +90,7 @@ The output should be similar to:
 0 0 27017 XXXXX-00-02.4zh9o.mongodb.net.
 {{< /code-block >}}
 
-Use the `nslookup` command in Windows to resolve the SRV connection string:
+Use `nslookup` in Windows to resolve the SRV connection string:
 
 {{< code-block lang="shell" >}}
 nslookup -type=SRV _mongodb._tcp.XXXXX.XXX.mongodb.net
@@ -118,7 +118,7 @@ You can use the `<HOST>:<PORT>` retrieved from the SRV connection string to conf
 
 For a sharded cluster with the SRV connection string `mongodb+srv://XXXXX.XXX.mongodb.net/`:
 
-Use the `dig` command in Linux to resolve the SRV connection string:
+Use `dig` in Linux to resolve the SRV connection string:
 
 {{< code-block lang="shell" >}}
 dig +short SRV _mongodb._tcp.XXXXX.XXX.mongodb.net
@@ -132,7 +132,7 @@ The output should be similar to:
 0 0 27016 XXXXX-00-02.4zh9o.mongodb.net.
 {{< /code-block >}}
 
-Use the `nslookup` command in Windows to resolve the SRV connection string:
+Use `nslookup` in Windows to resolve the SRV connection string:
 
 {{< code-block lang="shell" >}}
 nslookup -type=SRV _mongodb._tcp.XXXXX.XXX.mongodb.net

--- a/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
+++ b/content/en/database_monitoring/setup_mongodb/mongodbatlas.md
@@ -67,7 +67,7 @@ To monitor your MongoDB Atlas Cluster, you must install and configure the Datado
 
 Applications usually connect to MongoDB Atlas using an SRV connection string, but the Datadog Agent must connect directly to the individual MongoDB instance being monitored. If the Agent connects to different MongoDB instance while it is running (as in the case of failover, load balancing, and so on), the Agent calculates the difference in statistics between two hosts, producing inaccurate metrics.
 
-To get the individual MongoDB instance hostname and port, you can use the `dig` command to resolve the SRV connection string:
+To get the individual MongoDB instance hostname and port, you can use network utility command line tools like `dig` command in Linux or `nslookup` command in Windows to resolve the SRV connection string.
 
 {{< tabs >}}
 {{% tab "Replica Set" %}}
@@ -76,8 +76,10 @@ To get the individual MongoDB instance hostname and port, you can use the `dig` 
 
 For a non-sharded (replica set) cluster with the SRV connection string `mongodb+srv://XXXXX.XXX.mongodb.net/`:
 
+Use the `dig` command in Linux to resolve the SRV connection string:
+
 {{< code-block lang="shell" >}}
-dig +short SRV \_mongodb.\_tcp.XXXXX.XXX.mongodb.net
+dig +short SRV _mongodb._tcp.XXXXX.XXX.mongodb.net
 {{< /code-block >}}
 
 The output should be similar to:
@@ -88,13 +90,27 @@ The output should be similar to:
 0 0 27017 XXXXX-00-02.4zh9o.mongodb.net.
 {{< /code-block >}}
 
-In this example, the individual MongoDB instances from the replica set are:
+Use the `nslookup` command in Windows to resolve the SRV connection string:
+
+{{< code-block lang="shell" >}}
+nslookup -type=SRV _mongodb._tcp.XXXXX.XXX.mongodb.net
+{{< /code-block >}}
+
+The output should be similar to:
+
+{{< code-block lang="shell" >}}
+_mongodb._tcp.XXXXX.XXX.mongodb.net service = 0 0 27017 XXXXX-00-00.4zh9o.mongodb.net.
+_mongodb._tcp.XXXXX.XXX.mongodb.net service = 0 0 27017 XXXXX-00-01.4zh9o.mongodb.net.
+_mongodb._tcp.XXXXX.XXX.mongodb.net service = 0 0 27017 XXXXX-00-02.4zh9o.mongodb.net.
+{{< /code-block >}}
+
+In this example, the individual MongoDB instances `<HOST>:<PORT>` from the replica set are:
 
 -   `XXXXX-00-00.4zh9o.mongodb.net:27017`
 -   `XXXXX-00-01.4zh9o.mongodb.net:27017`
 -   `XXXXX-00-02.4zh9o.mongodb.net:27017`
 
-You can use one of these hostnames to configure the Agent.
+You can use the `<HOST>:<PORT>` retrieved from the SRV connection string to configure the Agent.
 {{% /tab %}}
 {{% tab "Sharded Cluster" %}}
 
@@ -102,8 +118,10 @@ You can use one of these hostnames to configure the Agent.
 
 For a sharded cluster with the SRV connection string `mongodb+srv://XXXXX.XXX.mongodb.net/`:
 
+Use the `dig` command in Linux to resolve the SRV connection string:
+
 {{< code-block lang="shell" >}}
-dig +short SRV \_mongodb.\_tcp.XXXXX.XXX.mongodb.net
+dig +short SRV _mongodb._tcp.XXXXX.XXX.mongodb.net
 {{< /code-block >}}
 
 The output should be similar to:
@@ -114,13 +132,27 @@ The output should be similar to:
 0 0 27016 XXXXX-00-02.4zh9o.mongodb.net.
 {{< /code-block >}}
 
+Use the `nslookup` command in Windows to resolve the SRV connection string:
+
+{{< code-block lang="shell" >}}
+nslookup -type=SRV _mongodb._tcp.XXXXX.XXX.mongodb.net
+{{< /code-block >}}
+
+The output should be similar to:
+
+{{< code-block lang="shell" >}}
+_mongodb._tcp.XXXXX.XXX.mongodb.net service = 0 0 27016 XXXXX-00-00.4zh9o.mongodb.net.
+_mongodb._tcp.XXXXX.XXX.mongodb.net service = 0 0 27016 XXXXX-00-01.4zh9o.mongodb.net.
+_mongodb._tcp.XXXXX.XXX.mongodb.net service = 0 0 27016 XXXXX-00-02.4zh9o.mongodb.net.
+{{< /code-block >}}
+
 In this example, the individual `mongos` routers are:
 
 -   `XXXXX-00-00.4zh9o.mongodb.net:27016`
 -   `XXXXX-00-01.4zh9o.mongodb.net:27016`
 -   `XXXXX-00-02.4zh9o.mongodb.net:27016`.
 
-You can use one of these hostnames to configure the Agent.
+You can use the `<HOST>:<PORT>` retrieved from the SRV connection string to configure the Agent.
 
 ##### Shard members
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds additional clarifications to the MongoDB Atlas setup docs where customer needs to use network utility command tools like `dig` or `nslookup` to resolve the SRV connection string.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
