### PR TITLE
fix: remove leftover occurrences of dd:ignore (plus misc. tweaks)

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
@@ -21,9 +21,6 @@ further_reading:
 - link: https://github.com/DataDog/orchestrion
   tag: "Source Code"
   text: "Orchestrion source code"
-- link: https://datadoghq.dev/orchestrion
-  tag: "External Site"
-  text: "Orchestrion documentation"
 - link: "/tracing/glossary/"
   tag: "Documentation"
   text: "Explore your services, resources and traces"

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
@@ -83,7 +83,8 @@ To install and set up Orchestrion:
    Refer to the output of `orchestrion pin -help` for more information about available customization options.
 1. Commit changes to your version control system (unless you are integrating `orchestrion` directly in your CI/CD pipeline):
    ```sh
-   git commit -m "chore: enable orchestrion" go.mod go.sum orchestrion.tool.go
+   git add go.mod go.sum orchestrion.tool.go
+   git commit -m "chore: enable orchestrion"
    ```
 
    Now you can manage your dependency on `orchestrion` like any other dependency using the `go.mod` file.

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
@@ -129,7 +129,7 @@ Applications instrumented by `orchestrion` support Unified Service Tagging (UST)
 
 For more information, refer to the [Unified Service Tagging documentation][14].
 
-#### Tracer Configuration
+#### Tracer configuration
 
 Refer to [Library Configuration][16] documentation for all configuration instructions.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
@@ -199,19 +199,19 @@ import "database/sql"
 // Caller-side instrumentation normally happens within this function...
 func normal() {
   // The following assignment will NOT be modified to add any caller-side
-  // instrumentation as it is opted out by the dd:ignore directive:
+  // instrumentation as it is opted out by the orchestrion:ignore directive:
   //orchestrion:ignore
   db, err := sql.Open("driver-name", "database=example")
   // ...
 }
 
 // Caller-side instrumentation will NOT happen in the following function
-// as it is annotated with dd:ignore.
+// as it is annotated with orchestrion:ignore.
 //orchestrion:ignore
 func excluded() {
   // The following assignment will NOT be modified to add any caller-side
-  // instrumentation as the surrounding context is excluded by a dd:ignore
-  // directive:
+  // instrumentation as the surrounding context is excluded by an
+  // orchestrion:ignore directive:
   db, err := sql.Open("driver-name", "database=example")
   // ...
 }

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
@@ -131,7 +131,7 @@ For more information, refer to the [Unified Service Tagging documentation][14].
 
 #### Tracer configuration
 
-Refer to [Library Configuration][16] documentation for all configuration instructions.
+Refer to [Library Configuration][16] for configuration instructions.
 
 #### Create custom trace spans
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/go.md
@@ -128,6 +128,10 @@ Applications instrumented by `orchestrion` support Unified Service Tagging (UST)
 
 For more information, refer to the [Unified Service Tagging documentation][14].
 
+#### Tracer Configuration
+
+Refer to [Library Configuration][16] documentation for all configuration instructions.
+
 #### Create custom trace spans
 
 Custom trace spans can be automatically created for any function annotated with the `//dd:span` directive comment:
@@ -239,6 +243,8 @@ To troubleshoot builds that `orchestrion` manages, see [Troubleshooting Go Compi
 [13]: /tracing/troubleshooting/go_compile_time/
 [14]: /getting_started/tagging/unified_service_tagging/
 [15]: /security/application_security/threats/exploit-prevention/
+[16]: /tracing/trace_collection/library_config/go/#traces
+
 
 {{% /tab %}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Removes the last occurrences of `dd:ignore` that were left behind, when the current form is `orchestrion:ignore`. 

