### PR TITLE
[Network Path ] Tag Network Traffic as experimental, update minimum version

### DIFF
--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -1,6 +1,6 @@
 ---
 title: Setup
-description: Setting up Network Path 
+description: Setting up Network Path
 is_beta: true
 further_reading:
 - link: "/network_monitoring/network_path/list_view"
@@ -15,7 +15,7 @@ further_reading:
 <div class="alert alert-warning">Network Path for Datadog Network Performance Monitoring is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-<div class="alert alert-info">Network Path for Datadog Network Performance Monitoring is in Preview. Reach out to your Datadog representative to sign up, and then use the following instructions to configure the Datadog Agent to gather network path data.</div> 
+<div class="alert alert-info">Network Path for Datadog Network Performance Monitoring is in Preview. Reach out to your Datadog representative to sign up, and then use the following instructions to configure the Datadog Agent to gather network path data.</div>
 
 ## Overview
 
@@ -23,54 +23,12 @@ Setting up Network Path involves configuring your Linux environment to monitor a
 
 ## Prerequisites
 
-- Agent version `7.55` or higher is required.
+- Agent version `7.59` or higher is required.
 - [NPM][1] must be enabled.
 
 **Note**: If your network configuration restricts outbound traffic, follow the setup instructions on the [Agent proxy configuration][2] documentation.
 
 ## Setup
-
-### Network traffic paths
-
-Configure network traffic paths to allow the Agent to automatically discover and monitor network paths based on actual network traffic, without requiring you to specify endpoints manually.
-
-<div class="alert alert-warning"> Enabling Network Path to automatically detect paths can generate a significant number of logs, particularly when monitoring network paths across a large number of hosts. </div> 
-
-1. Enable the `system-probe` traceroute module in `/etc/datadog-agent/system-probe.yaml` by adding the following:
-
-   ```
-   traceroute:
-     enabled: true
-   ```
-
-2. Enable `network_path` to monitor NPM connections by creating or editing the `/etc/datadog-agent/datadog.yaml` file: 
-
-    ```yaml
-    network_path:
-      connections_monitoring:
-        enabled: true
-      collector:
-        # workers: <NUMER OF WORKERS> # default 4
-    ```
- 
-    For full configuration details, reference the [example config][3], or use the following:
-
-    ```yaml
-    network_path:
-      connections_monitoring:
-        ## @param enabled - bool - required - default:false
-        ## Enable network path collection
-        #
-        enabled: true
-      collector:
-        ## @param workers - int - optional - default:4
-        ## Number of workers that can collect paths in parallel
-        ## Recommendation: leave at default
-        #
-        # workers: <NUMER OF WORKERS> # default 4
-    ```
-
-3. Restart the Agent after making these configuration changes to start seeing network paths.
 
 ### Monitor individual paths
 
@@ -83,7 +41,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
      enabled: true
    ```
 
-2. Enable `network_path` to monitor new destinations from this Agent by creating or editing the `/etc/datadog-agent/conf.d/network_path.d/conf.yaml` file: 
+2. Enable `network_path` to monitor new destinations from this Agent by creating or editing the `/etc/datadog-agent/conf.d/network_path.d/conf.yaml` file:
 
    ```yaml
    init_config:
@@ -91,7 +49,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
    instances:
      # configure the endpoints you want to monitor, one check instance per endpoint
      # warning: Do not set the port when using UDP. Setting the port when using UDP can cause traceroute calls to fail and falsely report an unreachable destination.
-   
+
      - hostname: api.datadoghq.eu # endpoint hostname or IP
        protocol: TCP
        port: 443
@@ -100,7 +58,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
          - "tag_key2:tag_value2"
      ## optional configs:
      # max_ttl: 30 # max traderoute TTL, default is 30
-     # timeout: 10 # timeout in seconds of traceroute calls, default is 10s
+     # timeout: 1000 # timeout in milliseconds per hop, default is 1s
 
      # more endpoints
      - hostname: 1.1.1.1 # endpoint hostname or IP
@@ -109,7 +67,7 @@ Manually configure individual paths by specifying the exact endpoint you want to
          - "tag_key:tag_value"
          - "tag_key2:tag_value2"
     ```
- 
+
    For full configuration details, reference the [example config][4], or use the following:
 
    ```yaml
@@ -124,26 +82,26 @@ Manually configure individual paths by specifying the exact endpoint you want to
      ## Traceroute will be run against this endpoint with a sequence of different TTL.
      #
      - hostname: <HOSTNAME_OR_IP>
-  
-     ## @param port - uint16 - optional - default:<RANDOM PORT>
+
+     ## @param port - integer - optional - default:<RANDOM PORT>
      ## The port of the destination endpoint.
      ## For UDP, we do not recommend setting the port since it can make probes less reliable.
      ## By default, the port is random.
      #
      # port: <PORT>
 
-     ## @param max_ttl - uint8 - optional - default:30
+     ## @param max_ttl - integer - optional - default:30
      ## The maximum traceroute TTL used during path collection.
      #
      # max_ttl: 30
-  
-     ## @param timeout - uint32 - optional - default:3000
-     ## The timeout of traceroute network calls.
-     ## The timeout is in millisecond.
+
+     ## @param timeout - integer - optional - default:1000
+     ## Specifies how much time in milliseconds the traceroute should
+     ## wait for a response from each hop before timing out.
      #
-     # timeout: 3000
-  
-     ## @param min_collection_interval - int - optional - default:60
+     # timeout: 1000
+
+     ## @param min_collection_interval - integer - optional - default:60
      ## Interval between each traceroute runs for each destination.
      # min_collection_interval: <interval_in_seconds>
      ## @param source_service - string - optional
@@ -168,7 +126,51 @@ Manually configure individual paths by specifying the exact endpoint you want to
 
 3. Restart the Agent after making these configuration changes to start seeing network paths.
 
-**Note**: Network path is only supported for Linux environments. 
+### Network traffic paths (experimental)
+
+**Note**: Network traffic paths is currently experimental and is not yet considered stable. We do not recommend deploying network traffic paths widely in a production environment.
+
+Configure network traffic paths to allow the Agent to automatically discover and monitor network paths based on actual network traffic, without requiring you to specify endpoints manually.
+
+<div class="alert alert-warning"> Enabling Network Path to automatically detect paths can generate a significant number of logs, particularly when monitoring network paths across a large number of hosts. </div>
+
+1. Enable the `system-probe` traceroute module in `/etc/datadog-agent/system-probe.yaml` by adding the following:
+
+   ```
+   traceroute:
+     enabled: true
+   ```
+
+2. Enable `network_path` to monitor NPM connections by creating or editing the `/etc/datadog-agent/datadog.yaml` file:
+
+    ```yaml
+    network_path:
+      connections_monitoring:
+        enabled: true
+      # collector:
+        # workers: <NUMER OF WORKERS> # default 4
+    ```
+
+    For full configuration details, reference the [example config][3], or use the following:
+
+    ```yaml
+    network_path:
+      connections_monitoring:
+        ## @param enabled - bool - required - default:false
+        ## Enable network path collection
+        #
+        enabled: true
+      collector:
+        ## @param workers - int - optional - default:4
+        ## Number of workers that can collect paths in parallel
+        ## Recommendation: leave at default
+        #
+        # workers: <NUMER OF WORKERS> # default 4
+    ```
+
+3. Restart the Agent after making these configuration changes to start seeing network paths.
+
+**Note**: Network path is only supported for Linux environments.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates the setup documentation for Network Path to reflect the experimental status of network traffic paths, bumps the minimum version, and makes small fixes to default configurations.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
