### PR TITLE
Fix 'pagerduty' typo in import_entries_backstage.md

### DIFF
--- a/content/en/service_catalog/customize/import_entries_backstage.md
+++ b/content/en/service_catalog/customize/import_entries_backstage.md
@@ -35,7 +35,7 @@ Upon import, the following occurs:
 - `spec.owner` gets mapped to `team`
 - `metadata.links` gets mapped to `links`
   - The annotation `github.com/project-slug` maps to a link with `type=repo` and `url=https://www.github.com/${github.com/project-slug}`
-  - The annotations `pagertduty.com/service-id` and `pagertduty.com/account` are combined and map to `integration.pagerduty`
+  - The annotations `pagerduty.com/service-id` and `pagerduty.com/account` are combined and map to `integration.pagerduty`
 - `metadata.description` gets mapped to `description`
 - `spec.system` gets mapped to `application`
 - `spec.dependsOn` gets mapped to `dependsOn`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

I shouted at computers for a solid hour after copy/pasting the pagerduty annotation names from these docs to my backstage yaml failed to appease the Datadog service catalog import gods. Hopefully less computers will be verbally abused as a result of this contribution.


