### PR TITLE
Add ebs storage setup link to ccm docs

### DIFF
--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -44,6 +44,7 @@ The following table presents the list of collected features and the minimal Agen
 1. For Kubernetes support, install the [**Datadog Agent**][102] in a Kubernetes environment and ensure that you enable the [**Orchestrator Explorer**][103] in your Agent configuration.
 1. For AWS ECS support, set up [**Datadog Container Monitoring**][104] in ECS tasks.
 1. Optionally, enable [AWS Split Cost Allocation][105] for usage-based ECS allocation.
+1. To enable storage cost allocation, set up [EBS Monitoring][108].
 1. To enable GPU container cost allocation, install the [Datadog DCGM integration][106].
 1. To enable Data transfer cost allocation, set up [Network Performance Monitoring][107]. **Note**: additional charges apply
 
@@ -54,6 +55,7 @@ The following table presents the list of collected features and the minimal Agen
 [105]: https://docs.aws.amazon.com/cur/latest/userguide/enabling-split-cost-allocation-data.html
 [106]: /integrations/dcgm/?tab=kubernetes#installation
 [107]: /network_monitoring/performance/setup
+[108]: /integrations/amazon_ebs/#setup
 
 {{% /tab %}}
 {{% tab "Azure" %}}

--- a/content/en/cloud_cost_management/container_cost_allocation.md
+++ b/content/en/cloud_cost_management/container_cost_allocation.md
@@ -44,7 +44,7 @@ The following table presents the list of collected features and the minimal Agen
 1. For Kubernetes support, install the [**Datadog Agent**][102] in a Kubernetes environment and ensure that you enable the [**Orchestrator Explorer**][103] in your Agent configuration.
 1. For AWS ECS support, set up [**Datadog Container Monitoring**][104] in ECS tasks.
 1. Optionally, enable [AWS Split Cost Allocation][105] for usage-based ECS allocation.
-1. To enable storage cost allocation, set up [EBS Monitoring][108].
+1. To enable storage cost allocation, set up [EBS metric collection][108].
 1. To enable GPU container cost allocation, install the [Datadog DCGM integration][106].
 1. To enable Data transfer cost allocation, set up [Network Performance Monitoring][107]. **Note**: additional charges apply
 
@@ -55,7 +55,7 @@ The following table presents the list of collected features and the minimal Agen
 [105]: https://docs.aws.amazon.com/cur/latest/userguide/enabling-split-cost-allocation-data.html
 [106]: /integrations/dcgm/?tab=kubernetes#installation
 [107]: /network_monitoring/performance/setup
-[108]: /integrations/amazon_ebs/#setup
+[108]: /integrations/amazon_ebs/#metric-collection
 
 {{% /tab %}}
 {{% tab "Azure" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


I am not sure why this is not linked already. We need this set up for customers to get the full ebs storage allocation on ccm. Without the metrics from the integration, ebs allocation wont show idle cost. As far as I am aware this is not documented and so we really should add it.