### PR TITLE
Add handling SIGTERM to go tracer example (APMSP-1534)

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -47,14 +47,14 @@ func main() {
     // Make sure this line stays in your main function.
     defer tracer.Stop()
 
-  	// If you expect your application to be shutdown via SIGTERM (e.g. a container in k8s)
-  	// You likely want to listen for that signal and explicitly stop the tracer to ensure no data is lost
-  	sigChan := make(chan os.Signal, 1)
-  	signal.Notify(sigChan, syscall.SIGTERM)
-  	go func() {
-  		<-sigChan
-  		tracer.Stop()
-  	}()
+    // If you expect your application to be shutdown via SIGTERM (e.g. a container in k8s)
+    // You likely want to listen for that signal and explicitly stop the tracer to ensure no data is lost
+    sigChan := make(chan os.Signal, 1)
+    signal.Notify(sigChan, syscall.SIGTERM)
+    go func() {
+        <-sigChan
+        tracer.Stop()
+    }()
 }
 ```
 

--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -46,6 +46,15 @@ func main() {
     // When the tracer is stopped, it will flush everything it has to the Datadog Agent before quitting.
     // Make sure this line stays in your main function.
     defer tracer.Stop()
+
+  	// If you expect your application to be shutdown via SIGTERM (e.g. a container in k8s)
+  	// You likely want to listen for that signal and explicitly stop the tracer to ensure no data is lost
+  	sigChan := make(chan os.Signal, 1)
+  	signal.Notify(sigChan, syscall.SIGTERM)
+  	go func() {
+  		<-sigChan
+  		tracer.Stop()
+  	}()
 }
 ```
 

--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -47,8 +47,8 @@ func main() {
     // Make sure this line stays in your main function.
     defer tracer.Stop()
 
-    // If you expect your application to be shutdown via SIGTERM (e.g. a container in k8s)
-    // You likely want to listen for that signal and explicitly stop the tracer to ensure no data is lost
+    // If you expect your application to be shut down by SIGTERM (for example, a container in Kubernetes),
+    // you might want to listen for that signal and explicitly stop the tracer to ensure no data is lost
     sigChan := make(chan os.Signal, 1)
     signal.Notify(sigChan, syscall.SIGTERM)
     go func() {


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
To prevent losing data in case of a SIGTERM it's useful to explicitly stop the tracer so it flushes any outstanding data before the program exits.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
