### PR TITLE
[Documentation repo] Add Architecture Center links to docs pages

### DIFF
--- a/content/en/containers/amazon_ecs/_index.md
+++ b/content/en/containers/amazon_ecs/_index.md
@@ -18,6 +18,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/cloud-cost-management-container-support/"
   tag: "blog"
   text: "Understand your Kubernetes and ECS spend with Datadog Cloud Cost Management"
+- link: "https://www.datadoghq.com/architecture/using-datadog-with-ecs-fargate/"
+  tag: "Architecture Center"
+  text: "Using Datadog with ECS Fargate"
 algolia:
   tags: ['ecs']
 ---

--- a/content/en/integrations/rsyslog.md
+++ b/content/en/integrations/rsyslog.md
@@ -18,6 +18,10 @@ public_title: Datadog-Rsyslog Integration
 supported_os:
     - linux
 integration_id: "rsyslog"
+further_reading:
+- link: "https://www.datadoghq.com/architecture/using-rsyslog-to-send-logs-to-datadog/"
+  tag: "Architecture Center"
+  text: "Using Rsyslog to send logs to Datadog"
 ---
 
 ## Overview
@@ -448,5 +452,8 @@ Configure Rsyslog to gather logs from your host, containers, and services.
 
 Need help? Contact [Datadog support][1].
 
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /help/

--- a/content/en/logs/_index.md
+++ b/content/en/logs/_index.md
@@ -40,6 +40,9 @@ further_reading:
   - link: "https://www.datadoghq.com/blog/monitor-dns-logs-for-network-and-security-datadog/"
     tag: "Blog"
     text: "Monitor DNS logs for network and security analysis"
+  - link: "https://www.datadoghq.com/architecture/a-guide-to-log-management-indexing-strategies-with-datadog/"
+    tag: "Architecture Center"
+    text: "A guide to Log Management Indexing Strategies with Datadog"
 cascade:
     algolia:
         rank: 70

--- a/content/en/network_monitoring/performance/_index.md
+++ b/content/en/network_monitoring/performance/_index.md
@@ -33,6 +33,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/monitor-connection-churn-datadog/"
   tag: "Blog"
   text: "Best practices for monitoring and remediating connection churn"
+- link: "https://www.datadoghq.com/architecture/network-observability-sd-wan-reference-architecture/"
+  tag: "Architecture Center"
+  text: "Network Observability: SD-WAN Reference Architecture"
 algolia:
   tags: ['npm', 'network performance monitoring']
 ---

--- a/content/en/tracing/trace_collection/automatic_instrumentation/_index.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/_index.md
@@ -6,6 +6,9 @@ further_reading:
     - link: "/tracing/glossary/"
       tag: "Documentation"
       text: "APM Terms and Concepts"
+    - link: "https://www.datadoghq.com/architecture/instrument-your-app-using-the-datadog-operator-and-admission-controller/"
+      tag: "Architecture Center"
+      text: "Instrument your app using the Datadog Operator and Admission Controller"
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
See https://datadoghq.atlassian.net/browse/DOCS-9452 - adding Architecture Center links into the docs.

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
