### PR TITLE
fix horizontalpodautoscalers acronym in Orchestrator Explorer documentation

### DIFF
--- a/content/en/infrastructure/containers/orchestrator_explorer.md
+++ b/content/en/infrastructure/containers/orchestrator_explorer.md
@@ -232,7 +232,7 @@ Additionally, resources contain a `kube_<api_kind>:<metadata.name>` tag. For exa
 >
 > - Pods use `pod_name` instead.
 > - *VPAs: `verticalpodautoscaler`*.
-> - *VPHs: `horizontalpodautoscaler`*.
+> - *HPAs: `horizontalpodautoscaler`*.
 > - *Persistent Volume Claims: `persistentvolumeclaim`*.
 
 Based on the labels attached to the resource, the following tags will also be extracted:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Found typo while reading doc

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
