### PR TITLE
Update azure_app_services_linux.md

### DIFF
--- a/content/en/serverless/azure_app_services/azure_app_services_linux.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_linux.md
@@ -59,7 +59,7 @@ Set these values in the `DD_START_APP` environment variable. Examples below are 
 Go to **General settings** and add the following to the **Startup Command** field:
 
 ```
-curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.10.9/datadog_wrapper | bash
+curl -s https://raw.githubusercontent.com/DataDog/datadog-aas-linux/v1.10.11/datadog_wrapper | bash
 ```
 
 {{< img src="serverless/azure_app_service/startup-command-1.jpeg" alt="Azure App Service Configuration: the Stack settings, under the Configuration section of Settings in the Azure UI. Underneath the stack, major version, and minor version fields is a 'Startup Command' field that is populated by the above curl command." style="width:100%;" >}}


### PR DESCRIPTION
For a few days a client have been struggling to add telemetry to an Azure App (linux) Service. The relevant docs are here:

https://docs.datadoghq.com/serverless/azure_app_services/azure_app_services_linux/?tab=nodenetphppython#set-general-settings

* The docs ask the user to deploy v1.10.9 of datadog-aas-linux.
* That version contains a nasty couple of bugs which basically cause mayhem (largely because the hostname is forced to be “none”)
* This has been fixed in v1.10.11 (which works excellently)
* The README for the project in Github correctly points the user to v1.10.11, but the main docs (linked above) still point to v.1.10.9

They lost more than a few engineer hours to this over the course of this week. The good news is that with v1.10.11 it all works well.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
