### PR TITLE
Remove OTel/DD Metrics page links and search

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -733,10 +733,6 @@ menu:
       url: /opentelemetry/guide/otel_demo_to_datadog/
       parent: otel_guides
       weight: 1004
-    - name: Combining OTel and Datadog Metrics
-      url: opentelemetry/guide/combining_otel_and_datadog_metrics/
-      parent: otel_guides
-      weight: 1005
     - name: Developers
       url: developers/
       pre: dev-code

--- a/content/en/opentelemetry/guide/_index.md
+++ b/content/en/opentelemetry/guide/_index.md
@@ -10,7 +10,6 @@ private: true
 {{< nextlink href="/opentelemetry/guide/migration/" >}}Migrate to OpenTelemetry Collector version 0.95.0+{{< /nextlink >}}
 {{< nextlink href="/opentelemetry/guide/otlp_delta_temporality/" >}}Producing Delta Temporality Metrics{{< /nextlink >}}
 {{< nextlink href="/opentelemetry/guide/otel_demo_to_datadog/" >}}Sending Data from OpenTelemetry Demo to Datadog{{< /nextlink >}}
-{{< nextlink href="/opentelemetry/guide/combining_otel_and_datadog_metrics/" >}}Combining OpenTelemetry Datadog Integration Metrics{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Read more on the blog

--- a/content/en/opentelemetry/guide/combining_otel_and_datadog_metrics.md
+++ b/content/en/opentelemetry/guide/combining_otel_and_datadog_metrics.md
@@ -1,5 +1,6 @@
 ---
 title: Combining OpenTelemetry and Datadog Metrics
+private: true
 further_reading:
     - link: '/metrics/'
       tag: 'Documentation'


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Please see https://datadoghq.atlassian.net/browse/DOCS-9592 - we got a request to make this page only accessible if customers have the direct link. Changes I made:
- Removed sidebar link
- Removed link from OTel guides page
- Added parameter to hide page from search

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
