### PR TITLE
Include mobile s8s troubleshooting

### DIFF
--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -141,6 +141,12 @@ Additionally, you might also have to ensure [Datadog Synthetic Monitoring IP ran
 
 Synthetic tests by default do not [renotify][12]. This means that if you add your notification handle such as your email address or Slack handle after a transition is generated (for example: a test going into alert or recovering from a previous alert), a notification is not sent for that transition. A notification is sent for the next transition.
 
+## Mobile tests
+
+### Unable to launch a device recording
+
+If there are security checks during app startup iIn particular if USB debugging is checked), it would be required to upload an .IPA that does not contain these checks. 
+
 ## Private locations
 
 {{< tabs >}}

--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -145,7 +145,7 @@ Synthetic tests by default do not [renotify][12]. This means that if you add you
 
 ### Unable to launch a device recording
 
-If there are security checks during application startup (in particular if USB debugging is checked), we suggest uploading a version of the application that does not contain these checks. 
+If there are security checks during application startup, such as verifying if USB debugging is enabled, Datadog recommends uploading a version of the application that does not contain these checks. 
 
 ## Private locations
 

--- a/content/en/synthetics/troubleshooting/_index.md
+++ b/content/en/synthetics/troubleshooting/_index.md
@@ -145,7 +145,7 @@ Synthetic tests by default do not [renotify][12]. This means that if you add you
 
 ### Unable to launch a device recording
 
-If there are security checks during app startup iIn particular if USB debugging is checked), it would be required to upload an .IPA that does not contain these checks. 
+If there are security checks during application startup (in particular if USB debugging is checked), we suggest uploading a version of the application that does not contain these checks. 
 
 ## Private locations
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Following customer cases, we're updating the documentation to include a mention on how to debug the mobile recorder when encountering errors (due to security checks) 