### PR TITLE
Add RUM session ID for signup tracking

### DIFF
--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -46,9 +46,9 @@ if (window.DD_RUM) {
             window.DD_RUM.setGlobalContextProperty('branch', branch);
         }
 
-        
-        setRumDeviceId()
-        
+        if (env === 'live') {
+            setRumDeviceId()
+        }
     }
 }
 

--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -46,9 +46,9 @@ if (window.DD_RUM) {
             window.DD_RUM.setGlobalContextProperty('branch', branch);
         }
 
-        if (env === 'live') {
-            setRumDeviceId()
-        }
+        
+        setRumDeviceId()
+        
     }
 }
 

--- a/assets/scripts/components/global-modals.js
+++ b/assets/scripts/components/global-modals.js
@@ -74,6 +74,20 @@ const doOnLoad = () => {
             }
         }
 
+        // Try to append RUM device ID and session ID
+        if(window.DD_RUM) {
+            const rumDeviceId = window.DD_RUM.getUser() ? window.DD_RUM.getUser().device_id : null;
+            if(rumDeviceId) {
+                completeUrl += `${operator}dd-device-id=${rumDeviceId}`;
+                operator = '&';
+            }
+            const rumSessionId = window.DD_RUM.getInternalContext() ? window.DD_RUM.getInternalContext().session_id : null;
+            if(rumSessionId) {
+                completeUrl += `${operator}dd-session-id=${rumSessionId}`;
+                operator = '&';
+            }
+        }
+
         return completeUrl;
     };
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add dd-device-id and dd-session-id to signup URL to improve tracking attribution

https://datadoghq.atlassian.net/browse/WEB-5641

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
https://docs-staging.datadoghq.com/ccole/signup-utm-device-session-id/

1. Click on any free trial CTA
2. Inspect the iframe URL

You should see a new query params appended e.g. `&dd-session-id=XXX&dd-device-id=XXX`

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
