### PR TITLE
[NO-TICKET] Document Ruby profiler setting for reading from opentelemetry context

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -26,7 +26,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][14].
 
-The Datadog Profiler requires Ruby 2.5+ (Ruby 3.1+ or later are recommended). JRuby and TruffleRuby are not supported.
+The Datadog Profiler requires Ruby 2.5+ (Ruby 3.1+ or later is recommended). JRuby and TruffleRuby are not supported.
 
 The following operating systems and architectures are supported:
 - Linux (GNU libc) x86-64, aarch64

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -26,7 +26,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][14].
 
-The Datadog Profiler requires Ruby 2.5+. JRuby and TruffleRuby are not supported.
+The Datadog Profiler requires Ruby 2.5+ (Ruby 3.1+ or later are recommended). JRuby and TruffleRuby are not supported.
 
 The following operating systems and architectures are supported:
 - Linux (GNU libc) x86-64, aarch64
@@ -53,7 +53,7 @@ To begin profiling applications:
 2. Add the `datadog` gem to your `Gemfile` or `gems.rb` file:
 
     ```ruby
-    gem 'datadog', '~> 2.3'
+    gem 'datadog', '~> 2.7'
     ```
 3. Install the gems with `bundle install`.
 
@@ -125,6 +125,7 @@ You can configure the profiler using the following environment variables:
 | `DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
 | `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to `false`. |
 | `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
+| `DD_PROFILING_PREVIEW_OTEL_CONTEXT_ENABLED`   | String  | Set to `only` when using profiling directly with `opentelemetry-sdk`, or `true` for auto-detection of the correct context to read from. Defaults to `false`. |
 | `DD_ENV`                                      | String  | The [environment][10] name, for example: `production`.                                                                                  |
 | `DD_SERVICE`                                  | String  | The [service][10] name, for example, `web-backend`.                                                                                     |
 | `DD_VERSION`                                  | String  | The [version][10] of your service.                                                                                                      |
@@ -139,6 +140,7 @@ Alternatively, you can set profiler parameters in code with these functions, ins
 | `c.profiling.advanced.experimental_heap_enabled`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
 | `c.profiling.advanced.experimental_heap_size_enabled` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to `false`. |
 | `c.profiling.advanced.no_signals_workaround_enabled`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
+| `c.profiling.advanced.preview_otel_context_enabled`   | String  | Set to `only` when using profiling directly with `opentelemetry-sdk`, or `true` for auto-detection of the correct context to read from. Defaults to `false`. |
 | `c.env`                                               | String  | The [environment][10] name, for example: `production`.                                                                                  |
 | `c.service`                                           | String  | The [service][10] name, for example, `web-backend`.                                                                                     |
 | `c.version`                                           | String  | The [version][10] of your service.                                                                                                      |


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR documents the setting introduced in version 2.4.0 of the Datadog Ruby library (https://github.com/DataDog/dd-trace-rb/pull/3984) to have the Ruby profiler directly read from the opentelemetry context.

This allows customers that want to use the opentelemetry Ruby library together with profiling to get the full profiler feature set.

(I've also gone ahead and did some small tweaks to the text: Suggest using the latest version in the config example; Suggest using Ruby 3.1+ in the requirements).

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Ready to go asap :)

### Additional notes
<!-- Anything else we should know when reviewing?-->

N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
