### PR TITLE
Fix failing no_translate job

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -683,7 +683,7 @@ run_notranslate_tag:schedule:
     - build_live
   timeout: 4h
   script:
-    - python3 -m venv ./venv && source ./venv/bin/activate && pip install transifex-python
+    - python3 -m venv ./venv && source ./venv/bin/activate && pip install six transifex-python
     - export transifex_api_key="$(get_secret 'transifex_api_key')"
     - source ./venv/bin/activate && python3 ./local/bin/py/add_notranslate_tag.py
   rules:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The no translate job is failing on missing six module, resolve by installing manually for now

### Merge instructions

<!-- If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. -->

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
