### PR TITLE
[NO-TICKET] Add Ruby GVL profiling to documentation

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -122,7 +122,7 @@ You can configure the profiler using the following environment variables:
 | `DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
 | `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to `false`. |
 | `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
-| `DD_PROFILING_PREVIEW_GVL_ENABLED`            | Boolean | Set to `true` to enable Global VM Lock (GVL) profiling. It requires the profiler to be enabled already and Ruby 3.2+. Defaults to `false`. |
+| `DD_PROFILING_PREVIEW_GVL_ENABLED`            | Boolean | Set to `true` to enable Global VM Lock (GVL) profiling. This feature requires Ruby 3.2+, and you must also enable the profiler. Defaults to `false`. |
 | `DD_PROFILING_PREVIEW_OTEL_CONTEXT_ENABLED`   | String  | Set to `only` when using profiling directly with `opentelemetry-sdk`, or `true` for auto-detection of the correct context to read from. Defaults to `false`. |
 | `DD_ENV`                                      | String  | The [environment][10] name, for example: `production`.                                                                                  |
 | `DD_SERVICE`                                  | String  | The [service][10] name, for example, `web-backend`.                                                                                     |
@@ -138,7 +138,7 @@ Alternatively, you can set profiler parameters in code with these functions, ins
 | `c.profiling.advanced.experimental_heap_enabled`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
 | `c.profiling.advanced.experimental_heap_size_enabled` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to `false`. |
 | `c.profiling.advanced.no_signals_workaround_enabled`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
-| `c.profiling.advanced.preview_gvl_enabled`            | Boolean | Set to `true` to enable Global VM Lock (GVL) profiling. It requires the profiler to be enabled already and Ruby 3.2+. Defaults to `false`. |
+| `c.profiling.advanced.preview_gvl_enabled`            | Boolean | Set to `true` to enable Global VM Lock (GVL) profiling. This feature requires Ruby 3.2+, and you must also enable the profiler. Defaults to `false`. |
 | `c.profiling.advanced.preview_otel_context_enabled`   | String  | Set to `only` when using profiling directly with `opentelemetry-sdk`, or `true` for auto-detection of the correct context to read from. Defaults to `false`. |
 | `c.env`                                               | String  | The [environment][10] name, for example: `production`.                                                                                  |
 | `c.service`                                           | String  | The [service][10] name, for example, `web-backend`.                                                                                     |

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -122,6 +122,7 @@ You can configure the profiler using the following environment variables:
 | `DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
 | `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to `false`. |
 | `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
+| `DD_PROFILING_PREVIEW_GVL_ENABLED`            | Boolean | Set to `true` to enable Global VM Lock (GVL) profiling. It requires the profiler to be enabled already and Ruby 3.2+. Defaults to `false`. |
 | `DD_PROFILING_PREVIEW_OTEL_CONTEXT_ENABLED`   | String  | Set to `only` when using profiling directly with `opentelemetry-sdk`, or `true` for auto-detection of the correct context to read from. Defaults to `false`. |
 | `DD_ENV`                                      | String  | The [environment][10] name, for example: `production`.                                                                                  |
 | `DD_SERVICE`                                  | String  | The [service][10] name, for example, `web-backend`.                                                                                     |
@@ -137,6 +138,7 @@ Alternatively, you can set profiler parameters in code with these functions, ins
 | `c.profiling.advanced.experimental_heap_enabled`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
 | `c.profiling.advanced.experimental_heap_size_enabled` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to `false`. |
 | `c.profiling.advanced.no_signals_workaround_enabled`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
+| `c.profiling.advanced.preview_gvl_enabled`            | Boolean | Set to `true` to enable Global VM Lock (GVL) profiling. It requires the profiler to be enabled already and Ruby 3.2+. Defaults to `false`. |
 | `c.profiling.advanced.preview_otel_context_enabled`   | String  | Set to `only` when using profiling directly with `opentelemetry-sdk`, or `true` for auto-detection of the correct context to read from. Defaults to `false`. |
 | `c.env`                                               | String  | The [environment][10] name, for example: `production`.                                                                                  |
 | `c.service`                                           | String  | The [service][10] name, for example, `web-backend`.                                                                                     |

--- a/content/en/profiler/enabling/supported_versions.md
+++ b/content/en/profiler/enabling/supported_versions.md
@@ -21,7 +21,7 @@ To use the Datadog Profiler, use at least the minimum versions summarized in the
 |                                   |  [Java][1]   |   [Python][2]    |    [Go][3]    |   [Ruby][4]    | [Node.js][5]  |  [.NET][6]  |   [PHP][7]    | [Rust/C/C++][8] |
 |-----------------------------------|:------------:|:----------------:|:-------------:|:--------------:|:-------------:|:-----------------------------------------------------------------------:|:-------------:|:---------------:|
 | <strong>Minimum&nbsp;runtime&nbsp;version</strong> | [JDK&nbsp;8+][17]  | Python&nbsp;2.7+ | Go&nbsp;1.19+ | Ruby&nbsp;2.5+ | Node&nbsp;14+ | .NET&nbsp;Core&nbsp;2.1+, .NET&nbsp;5+, .NET&nbsp;Framework&nbsp;4.6.1+ | PHP&nbsp;7.1+ |                 |
-| <strong>Feature-complete runtime version</strong>       | [JDK&nbsp;11+][17] | Python&nbsp;3.6+ | Go&nbsp;1.21+ | Ruby&nbsp;3.1+ | Node&nbsp;18+ |                              .NET&nbsp;7+                               | PHP&nbsp;8.0+ |                 |
+| <strong>Feature-complete runtime version</strong>       | [JDK&nbsp;11+][17] | Python&nbsp;3.6+ | Go&nbsp;1.21+ | Ruby&nbsp;3.2+ | Node&nbsp;18+ |                              .NET&nbsp;7+                               | PHP&nbsp;8.0+ |                 |
 | <strong>Feature-complete tracing library version</strong>        | [latest][9]  |   [latest][10]   | [latest][11]  |  [latest][12]  | [latest][13]  |                              [latest][14]                               | [latest][15]  |  [latest][16]   |
 
 ## Profile types
@@ -47,7 +47,7 @@ To access additional profiling features, use at least the minimum versions summa
 |-----------------------------------|:-------:|:-------:|:------------:|:------:|:---------:|:-------:|:------:|:----------:|
 | {{< ci-details title="Trace to Profiling integration" >}}Find specific lines of code related to performance issues. <a href="/profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces">Learn more</a>{{< /ci-details >}}   | [JDK&nbsp;8+][17] | tracer&nbsp;2.12.0,<br>2.11.4, 2.10.7 | tracer&nbsp;1.51.0 | tracer&nbsp;1.21.1 | tracer&nbsp;5.11.0,<br>4.35.0, 3.56.0 | tracer&nbsp;2.30.0 | tracer&nbsp;2.30.0 |      |
 | {{< ci-details title="Endpoint Profiling" >}}Identify endpoints that are bottlenecks or responsible for heavy resource consumption. <a href="/profiler/connect_traces_and_profiles/#endpoint-profiling">Learn more</a>{{< /ci-details >}}   | [JDK&nbsp;8+][17] | tracer&nbsp;0.54.0 | tracer&nbsp;1.37.0 | tracer&nbsp;0.52.0 | tracer&nbsp;5.0.0,<br>4.24.0, 3.45.0 | tracer&nbsp;2.15.0 | tracer&nbsp;0.79.0 |      |
-| {{< ci-details title="Timeline View" >}}Surface time-based patterns and work distribution over the period of a span. <a href="/profiler/connect_traces_and_profiles/#span-execution-timeline-view">Learn more</a>{{< /ci-details >}}   | [JDK&nbsp;8+][17] | tracer&nbsp;2.12.0,<br>2.11.4, 2.10.7 | tracer&nbsp;1.51.0 | tracer&nbsp;1.21.1 | tracer&nbsp;5.11.0,<br>4.35.0, 3.56.0 | tracer&nbsp;2.30.0 | tracer&nbsp;0.89.0 |      |
+| {{< ci-details title="Timeline View" >}}Surface time-based patterns and work distribution over the period of a span. <a href="/profiler/connect_traces_and_profiles/#span-execution-timeline-view">Learn more</a>{{< /ci-details >}}   | [JDK&nbsp;8+][17] | tracer&nbsp;2.12.0,<br>2.11.4, 2.10.7 | tracer&nbsp;1.51.0 | tracer&nbsp;1.21.1<br>(2.4.0 for GVL profiling) | tracer&nbsp;5.11.0,<br>4.35.0, 3.56.0 | tracer&nbsp;2.30.0 | tracer&nbsp;0.89.0 |      |
 
 ## Further reading
 

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -168,6 +168,10 @@ Heap Live Size (alpha, v2.3.0+)
 : The amount of heap memory allocated by each method that has not yet been garbage collected. This is useful for investigating the overall memory usage of your service and identifying potential memory leaks.<br />
 _Requires: Ruby 3.1+_ and [manual enablement][2]
 
+GVL profiling (in Timeline) (preview, v2.4.0+)
+: Records time when threads are prevented from working by other "noisy neighbor" threads, including background threads. This is useful for investigating latency spikes in the application when using the timeline visualization.<br />
+_Requires: Ruby 3.2+_ and [manual enablement][2]
+
 [1]: /profiler/enabling/ruby/#requirements
 [2]: /profiler/enabling/ruby/#configuration
 {{< /programming-lang >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR adds the Ruby GVL profiling feature to the documentation. This feature was introduced in https://github.com/DataDog/dd-trace-rb/pull/3929 and mentioned in the 2.4.0 release notes https://github.com/DataDog/dd-trace-rb/releases/tag/v2.4.0 but we had not yet updated the docs to mention it.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it recieves the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

N/A

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
