### PR TITLE
danielarodriguez/amisnotesforagentless scanning

### DIFF
--- a/content/en/security/cloud_security_management/agentless_scanning/_index.md
+++ b/content/en/security/cloud_security_management/agentless_scanning/_index.md
@@ -27,7 +27,8 @@ further_reading:
 ## Overview
 
 Agentless Scanning provides visibility into vulnerabilities that exist within your AWS hosts, running containers, Lambda functions, and Amazon Machine Images (AMIs) without requiring you to install the Datadog Agent. Datadog recommends enabling Agentless Scanning as a first step to gain complete visibility into your cloud resources, and then installing the Datadog Agent on your core assets over time for deeper security and observability context.
-**Note**: For Amazon Machine Images (AMIs), we currently only scan those associated with running instances. At this time, we are unable to scan private AMIs stored in an external AWS account.
+
+<div class="alert alert-warning"><strong>Note</strong>: For Amazon Machine Images (AMIs), Agentless Scanning scans only those images associated with running instances. It does not scan private AMIs stored in external AWS accounts.</div>
 
 ## Availability
 

--- a/content/en/security/cloud_security_management/agentless_scanning/_index.md
+++ b/content/en/security/cloud_security_management/agentless_scanning/_index.md
@@ -27,6 +27,7 @@ further_reading:
 ## Overview
 
 Agentless Scanning provides visibility into vulnerabilities that exist within your AWS hosts, running containers, Lambda functions, and Amazon Machine Images (AMIs) without requiring you to install the Datadog Agent. Datadog recommends enabling Agentless Scanning as a first step to gain complete visibility into your cloud resources, and then installing the Datadog Agent on your core assets over time for deeper security and observability context.
+**Note**: For Amazon Machine Images (AMIs), we currently only scan those associated with running instances. At this time, we are unable to scan private AMIs stored in an external AWS account.
 
 ## Availability
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updating the documentation to prevent confusions in customer such as the ones generated in this ticket: https://datadog.zendesk.com/agent/tickets/1938531 where customer commented:
"This is true, there are no instances currently running based on ami-035fe275b037a0c0d. I launched instance from that AMI for collecting vulnerabilities inside the host for the reference and terminated instance after a while.

I didn’t understood from the documentation how this feature worked. There is mentioning about scanning of AMIs in agentless scanning overview https://docs.datadoghq.com/security/cloud_security_management/agentless_scanning/ (https://docs.datadoghq.com/security/cloud_security_management/agentless_scanning/) , but I don’t see mention that this would only apply to running instances."

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it recieves the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
