### PR TITLE
[.NET SSI] Don't recommend using `-musl` images for SSI

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm/_index.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm/_index.md
@@ -365,7 +365,7 @@ Replace `<CONTAINER IMAGE TAG>` with the desired library version. Available vers
 - [Java][31]
 - [Node.js][32]
 - [Python][33]
-- [.NET][34] (For .NET applications using a musl-based Linux distribution like Alpine, specify a tag with the `-musl` suffix, such as `v2.29.0-musl`.)
+- [.NET][34]
 - [Ruby][35]
 
 <div class="alert alert-warning">Exercise caution when using the <code>latest</code> tag, as major library releases may introduce breaking changes.</div>


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes the recommendation about using `-musl` tags for .NET SSI tags - this isn't required with the latest versions of the .NET SSI images.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it recieves the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
