### PR TITLE
Update tutorial-enable-java-admission-controller.md

### DIFF
--- a/content/en/tracing/guide/tutorial-enable-java-admission-controller.md
+++ b/content/en/tracing/guide/tutorial-enable-java-admission-controller.md
@@ -221,7 +221,7 @@ kubectl describe pod springfront{{< /code-block >}}
     /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-qvmtk (ro)
     ```
 
-9. Verify that the Datadog tracing library is injected into the pod by checking the pod logs. For example::
+9. Verify that the Datadog tracing library is injected into the pod by checking the pod logs. For example:
    {{< code-block lang="shell" >}}
 kubectl logs -f springfront-797b78d6db-jqjdl{{< /code-block >}}
 

--- a/content/en/tracing/guide/tutorial-enable-java-admission-controller.md
+++ b/content/en/tracing/guide/tutorial-enable-java-admission-controller.md
@@ -125,10 +125,12 @@ labels:
 4. Configure the Datadog Admission Controller to inject a Java tracing library to the app container by adding the following annotation to the pod:
    {{< code-block lang="yaml" >}}
 annotations:
-  admission.datadoghq.com/java-lib.version: "latest"{{< /code-block >}}
+  admission.datadoghq.com/java-lib.version: "<CONTAINER IMAGE TAG>"{{< /code-block >}}
 
-    This annotation specifies the latest version of the Java tracing library. You can also reference a specific version of the library, such as `"v1.5.0"`.
-
+    Replace `<CONTAINER IMAGE TAG>` with the desired library version. Available versions are listed in the [Java source repository][14]
+   
+    <div class="alert alert-warning">Exercise caution when using the <code>latest</code> tag, as major library releases may introduce breaking changes.</div>
+    
     The final pod definition should look like the excerpt below. See also the full [YAML file][10] in the sample repo. The instructions you added to instrument the app are highlighted:
 
     {{< highlight yaml "hl_lines=6-8 24-28" >}}
@@ -159,14 +161,14 @@ annotations:
             tags.datadoghq.com/service: "springfront"
             tags.datadoghq.com/version: "12"
         annotations:
-            admission.datadoghq.com/java-lib.version: "latest"
+            admission.datadoghq.com/java-lib.version: "<CONTAINER IMAGE TAG>"
     {{< /highlight >}}
 
-5. Run the sample app with the following command:
+6. Run the sample app with the following command:
    {{< code-block lang="shell" >}}
 kubectl apply -f depl-with-lib-inj.yaml{{< /code-block >}}
 
-6. Run the following command to show that the app and Agent are running:
+7. Run the following command to show that the app and Agent are running:
    {{< code-block lang="shell" >}}
 kubectl get pods{{< /code-block >}}
 
@@ -181,7 +183,7 @@ kubectl get pods{{< /code-block >}}
     springfront-797b78d6db-mppbg                        1/1     Running   0          27m
     ```
 
-7. Run the following command to see details of the pod:
+8. Run the following command to see details of the pod:
    {{< code-block lang="shell" >}}
 kubectl describe pod springfront{{< /code-block >}}
 
@@ -219,7 +221,7 @@ kubectl describe pod springfront{{< /code-block >}}
     /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-qvmtk (ro)
     ```
 
-8. Verify that the Datadog tracing library is injected into the pod by checking the pod logs. For example::
+9. Verify that the Datadog tracing library is injected into the pod by checking the pod logs. For example::
    {{< code-block lang="shell" >}}
 kubectl logs -f springfront-797b78d6db-jqjdl{{< /code-block >}}
 
@@ -273,3 +275,4 @@ If you're not receiving traces as expected, set up debug mode for the Java trace
 [11]: https://app.datadoghq.com/services
 [12]: /tracing/trace_collection/admission_controller
 [13]: /tracing/troubleshooting/tracer_debug_logs/#enable-debug-mode
+[14]: https://github.com/DataDog/dd-trace-java/releases


### PR DESCRIPTION
Changing the example to use <CONTAINER IMAGE TAG> in the annotations rather than "latest". 

Added note about using caution when using the latest the "latest" tag

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

To change the examples so they no longer use the "latest" tag when specifying to a library version. Similar to what is seen here: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm/?tab=kubernetespreview#specifying-at-the-service-level 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it recieves the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
