### PR TITLE
[DOCS-9671] Undo translation of RUM code snippets to Spanish

### DIFF
--- a/content/es/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
+++ b/content/es/real_user_monitoring/mobile_and_tv_monitoring/setup/android.md
@@ -36,19 +36,19 @@ Declara [dd-sdk-android-rum][1] y el [complemento Gradle][12] como dependencia e
 
 ```groovy
 buildscript {
-    dependencias {
+    dependencies {
         classpath("com.datadoghq:dd-sdk-android-gradle-plugin:x.x.x")
     }
 }
-complementos {
+plugins {
     id("com.datadoghq.dd-sdk-android-gradle-plugin")
     //(...)
 }
 android {
     //(...)
 }
-dependencias {
-    implementación "com.datadoghq:dd-sdk-android-rum:x.x.x" 
+dependencies {
+    implementation "com.datadoghq:dd-sdk-android-rum:x.x.x" 
     //(...)
 }
 
@@ -77,29 +77,29 @@ Consulta [`trackingConsent`][6] para añadir el cumplimiento del Reglamento gene
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-clase SampleApplication : Application() {
-    sustituir fun onCreate() {
+class SampleApplication : Application() {
+    override fun onCreate() {
         super.onCreate()
-        configuración de valor = Configuration.Builder(
+        val configuration = Configuration.Builder(
             clientToken = <CLIENT_TOKEN>,
-            variable de entorno = <ENV_NAME>,
-            variante = <APP_VARIANT_NAME>
+            env = <ENV_NAME>,
+            variant = <APP_VARIANT_NAME>
         ).build()
-        Datadog.initialize(this, configuración, trackingConsent)
+        Datadog.initialize(this, configuration, trackingConsent)
     }
 }
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-```Java
-clase pública SampleApplication extiende Application {
+```java
+public class SampleApplication extends Application {
     @Override
-    anulación pública onCreate() {
+    public void onCreate() {
         super.onCreate();
-        Configuración configuración =
-                nuevo Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
+        Configuration configuration =
+                new Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
                         .build();
-        Datadog.initialize(this, configuración, trackingConsent);
+        Datadog.initialize(this, configuration, trackingConsent);
     }
 }
 ```
@@ -111,32 +111,32 @@ clase pública SampleApplication extiende Application {
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-clase SampleApplication : Application() {
-    sustituir fun onCreate() {
+class SampleApplication : Application() {
+    override fun onCreate() {
         super.onCreate()
-        configuración de valor = Configuration.Builder(
+        val configuration = Configuration.Builder(
                 clientToken = <CLIENT_TOKEN>,
-                variable de entorno = <ENV_NAME>,
-                variante = <APP_VARIANT_NAME>
+                env = <ENV_NAME>,
+                variant = <APP_VARIANT_NAME>
             )
             .useSite(DatadogSite.EU1)
             .build()
-        Datadog.initialize(this, configuración, trackingConsent)
+        Datadog.initialize(this, configuration, trackingConsent)
     }
 }
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-```Java
-clase públcia SampleApplication extends Application {
+```java
+public class SampleApplication extends Application {
     @Override
-    anulación pública onCreate() {
+    public void onCreate() {
         super.onCreate();
-        Configuración configuración =
-                nuevo Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
+        Configuration configuration =
+                new Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
                         .useSite(DatadogSite.EU1)
                         .build();
-        Datadog.initialize(this, configuración, trackingConsent);
+        Datadog.initialize(this, configuration, trackingConsent);
     }
 }
 ```
@@ -148,32 +148,32 @@ clase públcia SampleApplication extends Application {
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-clase SampleApplication : Applicación() {
-    sustituir fun onCreate() {
+class SampleApplication : Application() {
+    override fun onCreate() {
         super.onCreate()
-        configuración de valor = Configuration.Builder(
+        val configuration = Configuration.Builder(
                 clientToken = <CLIENT_TOKEN>,
-                variable de entorno = <ENV_NAME>,
-                variante = <APP_VARIANT_NAME>
+                env = <ENV_NAME>,
+                variant = <APP_VARIANT_NAME>
             )
             .useSite(DatadogSite.US3)
             .build()
-        Datadog.initialize(this, configuración, trackingConsent)
+        Datadog.initialize(this, configuration, trackingConsent)
     }
 }
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-```Java
-clase pública SampleApplication extends Application {
+```java
+public class SampleApplication extends Application {
     @Override
-    anulación pública onCreate() {
+    public void onCreate() {
         super.onCreate();
-        Configuración configuración =
-                nuevo Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
+        Configuration configuration =
+                new Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
                         .useSite(DatadogSite.US3)
                         .build();
-        Datadog.initialize(this, configuración, trackingConsent);
+        Datadog.initialize(this, configuration, trackingConsent);
     }
 }
 ```
@@ -185,32 +185,32 @@ clase pública SampleApplication extends Application {
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-clase SampleApplication : Application() {
-    sustituir fun onCreate() {
+class SampleApplication : Application() {
+    override fun onCreate() {
         super.onCreate()
-        configuración de valor = Configuration.Builder(
+        val configuration = Configuration.Builder(
                 clientToken = <CLIENT_TOKEN>,
-                variable de entorno = <ENV_NAME>,
-                variante = <APP_VARIANT_NAME>
+                env = <ENV_NAME>,
+                variant = <APP_VARIANT_NAME>
             )
             .useSite(DatadogSite.US5)
             .build()
-        Datadog.initialize(this, configuración, trackingConsent)
+        Datadog.initialize(this, configuration, trackingConsent)
     }
 }
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-```Java
-clase pública SampleApplication extends Application {
+```java
+public class SampleApplication extends Application {
     @Override
-    anulación pública onCreate() {
+    public void onCreate() {
         super.onCreate();
-        Configuración configuración =
-                nuevo Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
+        Configuration configuration =
+                new Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
                         .useSite(DatadogSite.US5)
                         .build();
-        Datadog.initialize(this, configuración, trackingConsent);
+        Datadog.initialize(this, configuration, trackingConsent);
     }
 }
 ```
@@ -222,32 +222,32 @@ clase pública SampleApplication extends Application {
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-clase SampleApplication : Application() {
-    sustituir fun onCreate() {
+class SampleApplication : Application() {
+    override fun onCreate() {
         super.onCreate()
-        configuración de valor = Configuration.Builder(
+        val configuration = Configuration.Builder(
                 clientToken = <CLIENT_TOKEN>,
-                variable de entorno = <ENV_NAME>,
-                variante = <APP_VARIANT_NAME>
+                env = <ENV_NAME>,
+                variant = <APP_VARIANT_NAME>
             )
             .useSite(DatadogSite.US1_FED)
             .build()
-        Datadog.initialize(this, configuraciión, trackingConsent)
+        Datadog.initialize(this, configuration, trackingConsent)
     }
 }
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-```Java
-clase pública SampleApplication extiende Aplicación {
+```java
+public class SampleApplication extends Application {
     @Override
-    anulación pública onCreate() {
+    public void onCreate() {
         super.onCreate();
-        Configuración configuración =
-                nuevo Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
+        Configuration configuration =
+                new Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
                         .useSite(DatadogSite.US1_FED)
                         .build();
-        Datadog.initialize(this, configuración, trackingConsent);
+        Datadog.initialize(this, configuration, trackingConsent);
     }
 }
 ```
@@ -259,32 +259,32 @@ clase pública SampleApplication extiende Aplicación {
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-clase SampleApplication : Aplicación() {
-    sustituir fun onCreate() {
+class SampleApplication : Application() {
+    override fun onCreate() {
         super.onCreate()
-        configuración de valor = Configuration.Builder(
+        val configuration = Configuration.Builder(
                 clientToken = <CLIENT_TOKEN>,
-                variable de entorno = <ENV_NAME>,
-                variante = <APP_VARIANT_NAME>
+                env = <ENV_NAME>,
+                variant = <APP_VARIANT_NAME>
             )
             .useSite(DatadogSite.AP1)
             .build()
-        Datadog.initialize(this, configuración, trackingConsent)
+        Datadog.initialize(this, configuration, trackingConsent)
     }
 }
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-```Java
-clase pública SampleApplication extiende Aplicación {
+```java
+public class SampleApplication extends Application {
     @Override
-    anulación pública onCreate() {
+    public void onCreate() {
         super.onCreate();
-        Configuración configuración =
-                nuevo Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
+        Configuration configuration =
+                new Configuration.Builder(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>)
                         .useSite(DatadogSite.AP1)
                         .build();
-        Datadog.initialize(this, configuración, trackingConsent);
+        Datadog.initialize(this, configuration, trackingConsent);
     }
 }
 ```
@@ -302,7 +302,7 @@ Para controlar los datos que tu aplicación envía a Datadog RUM, puedes especif
 
 ```kotlin
 val rumConfig = RumConfiguration.Builder(applicationId)
-        // Aquí el 75 % de las sesiones de RUM se envía a Datadog
+        // Here 75% of the RUM sessions are sent to Datadog
         .setSessionSampleRate(75.0f)
         .build()
 Rum.enable(rumConfig)
@@ -323,8 +323,8 @@ Rum.enable(rumConfig)
 {{% /tab %}}
 
 {{% tab "Java" %}}
-```Java
-    RumConfiguration rumConfig = nuevo RumConfiguration.Builder(applicationId)
+```java
+    RumConfiguration rumConfig = new RumConfiguration.Builder(applicationId)
       .trackInteractions()
       .trackLongTasks(durationThreshold)
       .useViewTrackingStrategy(strategy)
@@ -365,9 +365,9 @@ val okHttpClient = OkHttpClient.Builder()
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-```Java
-final Map<String, Configurar<TracingHeaderType>> tracedHostsWithHeaderType = nuevo HashMap<>();
-final Configurar<TracingHeaderType> datadogAndW3HeadersTypes = nuevo HashSet<>(Arrays.asList(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT));
+```java
+final Map<String, Set<TracingHeaderType>> tracedHostsWithHeaderType = new HashMap<>();
+final Set<TracingHeaderType> datadogAndW3HeadersTypes = new HashSet<>(Arrays.asList(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT));
 tracedHostsWithHeaderType.put("example.com", datadogAndW3HeadersTypes);
 tracedHostsWithHeaderType.put("example.eu", datadogAndW3HeadersTypes);
 OkHttpClient okHttpClient = new OkHttpClient.Builder()
@@ -413,9 +413,9 @@ Añade el siguiente fragmento durante configuración de RUM:
 Puedes el uso de la instancia `Closeable` de monitor mediante la utilización del método `useMonitored`, se informará de cualquier error ocurrido a Datadog y cerrar el recurso después.
 
 ```kotlin
-valor cerrable: Cerrable = ...
+val closeable: Closeable = ...
 closeable.useMonitored {
-    // Tu código aquí
+    // Your code here
 }
 
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Undoes Spanish translations for code snippets on the Android Setup page, as they would not work

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it recieves the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
