### PR TITLE
[CWS] remove usage of logs in the fargate setup docs and replace with agent events

### DIFF
--- a/content/en/security/guide/aws_fargate_config_guide.md
+++ b/content/en/security/guide/aws_fargate_config_guide.md
@@ -335,7 +335,7 @@ spec:
 
 ### Verify that the Agent is sending events to CSM
 
-When you enable CSM on AWS Fargate ECS or EKS, the Agent sends a log to Datadog to confirm that the default ruleset has been successfully deployed. To view the log, navigate to the [Logs][9] page in Datadog and search for `@agent.rule_id:ruleset_loaded`.
+When you enable CSM on AWS Fargate ECS or EKS, the Agent sends an agent event to Datadog to confirm that the default ruleset has been successfully deployed. To view the agent event, navigate to the [Agent Events][9] page in Datadog and search for `@agent.rule_id:ruleset_loaded`.
 
 <div class="alert alert-info">You can also verify the Agent is sending events to CSM by manually triggering an AWS Fargate security signal.</div>
 
@@ -418,7 +418,7 @@ For step-by-step instructions, see [AWS Configuration Guide for Cloud SIEM][17].
 [6]: /integrations/eks_fargate/?tab=manual#aws-eks-fargate-rbac
 [7]: /resources/json/datadog-agent-cws-ecs-fargate.json
 [8]: /integrations/faq/integration-setup-ecs-fargate/?tab=rediswebui
-[9]: https://app.datadoghq.com/logs
+[9]: https://app.datadoghq.com/security/agent-events
 [10]: /security/application_security/threats/setup/threat_detection/java/?tab=awsfargate
 [11]: /security/application_security/threats/setup/threat_detection/java/?tab=amazonecs
 [12]: /security/application_security/threats/setup/threat_detection/dotnet?tab=awsfargate


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

By default, the CWS/CSM threats agent does not send events to logs anymore but to a specific track called agent events with a separate explorer and UI page. This PR fixes the documentation to not mention logs anymore, but directly the agent events (and related links).


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
