### PR TITLE
[SDCI-801] Add troubleshooting for custom commands and fix Buildkite terminology

### DIFF
--- a/content/en/continuous_integration/pipelines/_index.md
+++ b/content/en/continuous_integration/pipelines/_index.md
@@ -89,11 +89,10 @@ While the concept of a CI pipeline may vary depending on your provider, see how 
 {{% /tab %}}
 {{% tab "Buildkite" %}}
 
-| Datadog                    | Buildkite |
-|----------------------------|-----------|
-| Pipeline                   | Pipeline  |
-| Job                        | Job       |
-| _Not available in Datadog_ | Step      |
+| Datadog                    | Buildkite                       |
+|----------------------------|---------------------------------|
+| Pipeline                   | Build (execution of a pipeline) |
+| Job                        | Job (execution of a step)       |
 
 {{% /tab %}}
 {{% tab "TeamCity" %}}

--- a/content/en/continuous_integration/pipelines/custom_commands.md
+++ b/content/en/continuous_integration/pipelines/custom_commands.md
@@ -137,6 +137,12 @@ the `DD_GITHUB_JOB_NAME` environment variable needs to be exposed, pointing to t
         - run: datadog-ci trace ...
     ```
 
+## Troubleshooting
+
+### Payload too large
+The size limit is approximately `4MB`. The most common cause for this error are extremely large tags.
+The `--dry-run` option can be used to see the traced command contents before sending it to Datadog.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Includes 2 small changes:
- Adds a troubleshooting section in the `custom_commands` page.
- Fixes the terminology mapping from Datadog <-> Buildkite. 
 
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
