### PR TITLE
[WEB-5663] Update RUM configuration privacy level

### DIFF
--- a/assets/scripts/components/dd-browser-logs-rum.js
+++ b/assets/scripts/components/dd-browser-logs-rum.js
@@ -32,10 +32,12 @@ if (window.DD_RUM) {
             service: 'docs',
             version: CI_COMMIT_SHORT_SHA,
             trackUserInteractions: true,
-            trackFrustrations: true,
-            enableExperimentalFeatures: ["clickmap"],
+            enableExperimentalFeatures: ['zero_lcp_telemetry'],
             sessionSampleRate: 100,
             sessionReplaySampleRate: 50,
+            trackResources: true,
+            trackLongTasks: true,
+            defaultPrivacyLevel: 'mask-user-input',
             allowedTracingUrls: [window.location.origin],
             internalAnalyticsSubdomain: IA_SUBDOMAIN
         });


### PR DESCRIPTION
### What does this PR do? What is the motivation?

https://datadoghq.atlassian.net/browse/WEB-5663

Updates browser RUM configuration for site:
- add `defaultPrivacyLevel` set to `mask-user-input` to match other DD websites
- update config based on being version 5+
  - update `enableExperimentalFeatures` to be `zero_lcp_telemetry` to match corpsite (remove no longer applicable `clickmap`
  - remove `trackFrustrations`, which is now handled by `trackUserInteractions`
  - add `trackResources` and `trackLongTasks` (match corpsite) 

Preview: https://docs-staging.datadoghq.com/davidweid/update-browser-rum/

Example:
- [Now has text visible](https://dd-corpsite.datadoghq.com/rum/replay/sessions/a4ae13b4-b35e-47fa-b080-1fccd8035a54?applicationId=3493b4e7-ab12-4852-8836-ba96af7bc745&seed=5d9ca422-baf2-4e56-86fd-2f4aebd47bdb&ts=1733854148363) vs [didn't have text visible](https://dd-corpsite.datadoghq.com/rum/replay/sessions/a4ae13b4-b35e-47fa-b080-1fccd8035a54?applicationId=3493b4e7-ab12-4852-8836-ba96af7bc745&seed=5d9ca422-baf2-4e56-86fd-2f4aebd47bdb&ts=1733854148363)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
