### PR TITLE
Remove "-ccm" from Elastic Cloud integration link

### DIFF
--- a/content/en/cloud_cost_management/saas_costs.md
+++ b/content/en/cloud_cost_management/saas_costs.md
@@ -173,7 +173,7 @@ Your Elastic Cloud cost data for the past 15 months can be accessed in Cloud Cos
 
 {{< img src="cloud_cost/saas_costs/elasticcloud_setup.png" alt="Integrate with Elastic Cloud to collect cost data." style="width:100%" >}}
 
-[101]: https://app.datadoghq.com/integrations/elastic-cloud-ccm
+[101]: https://app.datadoghq.com/integrations/elastic-cloud
 [102]: https://cloud.elastic.co/account/keys
 
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
As it stands now, the Elastic Cloud integration link leads to: "app.datadoghq.com/integrations/elastic-cloud-ccm". This link does not resolve to the integration tile "Elastic Cloud". Additionally, following this link shows an error in the integration page showing - "Integration not found". I suggest we remove the "-ccm" part of the hyper link so that it just leads to "app.datadoghq.com/integrations/elastic-cloud" which will take users to the correct place outlined in the documentation.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
