### PR TITLE
Update Statuspage integration docs to explicitly list required permissions

### DIFF
--- a/content/en/service_management/incident_management/guides/statuspage.md
+++ b/content/en/service_management/incident_management/guides/statuspage.md
@@ -35,8 +35,10 @@ Install the integration through the [Statuspage Integration tile][1]. For more i
 
 ## Add a Statuspage incident
 
+You must have a role with Incidents Write and Integrations Read permissions in order to add a Statuspage incident.
+
 1. In the [Incidents page][4], open an existing incident.
-1. At the top of the incident page, click **Add a Statuspage incident**.
+1. At the top of the incident page, click **Add a Statuspage incident**. 
 1. Enter all the required fields, which include Select a Statuspage, Incident name, and Incident status. You can also specify which Statuspage components are affected. 
 
 {{< img src="service_management/incidents/guide/statuspage/add_update_statuspage_form.png" alt="Form to add or update a Statuspage incident, including required fields for Select a Statuspage, Incident name, and Incident status" style="width:70%;" >}}

--- a/content/en/service_management/incident_management/guides/statuspage.md
+++ b/content/en/service_management/incident_management/guides/statuspage.md
@@ -35,7 +35,7 @@ Install the integration through the [Statuspage Integration tile][1]. For more i
 
 ## Add a Statuspage incident
 
-You must have a role with Incidents Write and Integrations Read permissions in order to add a Statuspage incident.
+You must have a role with Incidents Write and Integrations Read permissions to add a Statuspage incident.
 
 1. In the [Incidents page][4], open an existing incident.
 1. At the top of the incident page, click **Add a Statuspage incident**.

--- a/content/en/service_management/incident_management/guides/statuspage.md
+++ b/content/en/service_management/incident_management/guides/statuspage.md
@@ -38,7 +38,7 @@ Install the integration through the [Statuspage Integration tile][1]. For more i
 You must have a role with Incidents Write and Integrations Read permissions in order to add a Statuspage incident.
 
 1. In the [Incidents page][4], open an existing incident.
-1. At the top of the incident page, click **Add a Statuspage incident**. 
+1. At the top of the incident page, click **Add a Statuspage incident**.
 1. Enter all the required fields, which include Select a Statuspage, Incident name, and Incident status. You can also specify which Statuspage components are affected. 
 
 {{< img src="service_management/incidents/guide/statuspage/add_update_statuspage_form.png" alt="Form to add or update a Statuspage incident, including required fields for Select a Statuspage, Incident name, and Incident status" style="width:70%;" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The Incident App team received a customer support inquiry about the Statuspage integration not displaying on an incident for some of the users in an org. After closer inspection, it was was discovered that those users did not have the Integrations Read permission. This isn't explicitly mentioned in the public docs, so adding it (along with Incidents Write) to make onboarding easier for orgs that decide to use this integration.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
