### PR TITLE
revise Agent info in Prerequisites

### DIFF
--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -15,7 +15,7 @@ Use the following instructions to enable Misconfigurations, Threat Detection, an
 
 ## Prerequisites
 
-- Datadog Agent version `7.46` or later.
+- Latest Datadog Agent version. For installation instructions, see [Getting Started with the Agent][5] or install the Agent from the [Datadog UI][6].
 
 ## Installation
 
@@ -147,3 +147,5 @@ Add the following settings to the `env` section of `security-agent` and `system-
 [2]: /security/threats
 [3]: /security/cloud_security_management/vulnerabilities
 [4]: /security/cloud_security_management/setup#supported-deployment-types-and-features
+[5]: /getting_started/agent
+[6]: https://app.datadoghq.com/account/settings/agent/latest


### PR DESCRIPTION
DOCS-9687.

Prerequisites was "Datadog Agent version 7.46 or later." but we are updating it to advise the user to use the latest version with links to docs and UI.

### Merge instructions

Merge readiness:
- [X] Ready for merge
