### PR TITLE
ci(workflows): use official GitHub action for token generation

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -24,10 +24,10 @@ jobs:
     steps:
       - name: Get GitHub App token
         id: get_token
-        uses: tibdex/github-app-token@v1.3.0
+        uses: actions/create-github-app-token@v1
         with:
-          app_id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
           repository: DataDog/datadog-api-spec
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v1.0.0


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Changes use of action `tibdex/github-app-token` to official GitHub one in workflows
