### PR TITLE
adding redirect to ASM Threats

### DIFF
--- a/content/en/security/application_security/threats/setup/threat_detection/_index.md
+++ b/content/en/security/application_security/threats/setup/threat_detection/_index.md
@@ -3,6 +3,7 @@ title: Enabling ASM Threat Detection using Datadog Tracing Libraries
 type: multi-code-lang
 aliases:
 - /security/application_security/enabling/tracing_libraries/threat_detection/
+- /security/application_security/threats/threat_detection/
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"


### PR DESCRIPTION
Eng Mgr asked for a redirect for a URL in a support request. A lot of files in this section have been moved, so if this URL has been around awhile a redirect should probably be added to the correct target topic.

Tested redirect locally. Worked fine.

Merge readiness:
- [X] Ready for merge

