### PR TITLE
ci(workflows): fix use of create-github-app-token

### DIFF
--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repositories: DataDog/datadog-api-spec
+          repositories: datadog-api-spec
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v1.0.0
         with:

--- a/.github/workflows/approved_status.yml
+++ b/.github/workflows/approved_status.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           app-id: ${{ secrets.PIPELINE_GITHUB_APP_ID }}
           private-key: ${{ secrets.PIPELINE_GITHUB_APP_PRIVATE_KEY }}
-          repository: DataDog/datadog-api-spec
+          repositories: DataDog/datadog-api-spec
       - name: Post PR review status check
         uses: DataDog/github-actions/post-review-status@v1.0.0
         with:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Fixes use of `create-github-app-token` action with correct field name