### PR TITLE
Clarify browser session replay privacy default setting

### DIFF
--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -53,7 +53,7 @@ Setting `defaultPrivacyLevel` to `mask` mode masks all HTML text, user input, im
 
 {{< img src="real_user_monitoring/session_replay/mask-mode-fixed.png" alt="Mask mode" style="width:70%;">}}
 
-**Note:** If you do not specify the privacy setting, `mask` is enabled by default when you enable Session Replay.
+**Note:** If the privacy setting is not specified when enabling Session Replay, `mask` is enabled by default.
 **Note**: Masked data is not stored on Datadog servers.
 
 ### Mask user input mode

--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -53,7 +53,7 @@ Setting `defaultPrivacyLevel` to `mask` mode masks all HTML text, user input, im
 
 {{< img src="real_user_monitoring/session_replay/mask-mode-fixed.png" alt="Mask mode" style="width:70%;">}}
 
-**Note:** By default, `mask` is the privacy setting when you enable Session Replay.
+**Note:** If you do not specify the privacy setting, `mask` is enabled by default when you enable Session Replay.
 **Note**: Masked data is not stored on Datadog servers.
 
 ### Mask user input mode
@@ -110,8 +110,6 @@ If you are concerned about the number of visible elements in sensitive fields, e
 In this example replay session, the username in the Datadog navigation is obfuscated.
 
 {{< img src="real_user_monitoring/session_replay/hidden.png" alt="Example of hidden mode obfuscating a username" style="width:60%;">}}
-
-
 
 ### Override the action name
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Clarifies the default privacy setting for browser session replay

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
