### PR TITLE
Update README.md with link to finding Slack username 

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,4 @@ Within 10 minutes of merging to master, it deploys automatically.
 [18]: /CONTRIBUTING.md
 [19]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 [20]: https://datadoghq.atlassian.net/wiki/spaces/docs4docs/pages/3960766866/Build+setup+guide
-[21]: https://slack.com/help/articles/221769328-Locate-your-Slack-URL-or-ID
+[21]: https://www.highviewapps.com/kb/how-do-i-find-my-slack-username/


### PR DESCRIPTION
the previous link went to page on finding the Profile ID, which is not the Slack username needed.

Merge readiness:
- [X] Ready for merge

