### PR TITLE
[DOCS-9682] Add connect rum to traces link to otel section

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -690,7 +690,7 @@ menu:
       parent: otel_interoperability
       weight: 705
     - name: Correlate RUM and Traces
-      url: /real_user_monitoring/platform/connect_rum_and_traces/
+      url: /opentelemetry/interoperability/connect_rum_and_traces
       identifier: otel_rum
       parent: otel_interoperability
       weight: 706

--- a/content/en/opentelemetry/interoperability/connect_rum_and_traces.md
+++ b/content/en/opentelemetry/interoperability/connect_rum_and_traces.md
@@ -1,0 +1,6 @@
+---
+title: Connect RUM and Traces
+description: Learn how to integrate Real User Monitoring with APM.
+---
+
+{{< include-markdown "/real_user_monitoring/platform/connect_rum_and_traces/" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Per internal feedback:
- Adds a "Connect RUM to Traces" page to the Otel section with the include-markdown shortcode that links to RUM
- I'm also trying to link directly to the relevant section, but am having trouble

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
