### PR TITLE
Move note about default Session Replay privacy setting higher

### DIFF
--- a/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
+++ b/content/en/real_user_monitoring/session_replay/browser/privacy_options.md
@@ -26,6 +26,8 @@ By enabling Session Replay, you can automatically mask sensitive elements from b
 
 To enable your privacy settings, set `defaultPrivacyLevel` to `mask`, `mask-user-input`, or `allow` in your JavaScript configuration.
 
+**Note:** If the privacy setting is not specified when enabling Session Replay, `mask` is enabled by default.
+
 ```javascript
 import { datadogRum } from '@datadog/browser-rum';
 
@@ -53,7 +55,6 @@ Setting `defaultPrivacyLevel` to `mask` mode masks all HTML text, user input, im
 
 {{< img src="real_user_monitoring/session_replay/mask-mode-fixed.png" alt="Mask mode" style="width:70%;">}}
 
-**Note:** If the privacy setting is not specified when enabling Session Replay, `mask` is enabled by default.
 **Note**: Masked data is not stored on Datadog servers.
 
 ### Mask user input mode


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This is a tiny PR that moves the note higher to the more relevant section.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
