### PR TITLE
Add return type to workspace sql reference

### DIFF
--- a/content/en/logs/workspaces/sql_reference.md
+++ b/content/en/logs/workspaces/sql_reference.md
@@ -46,39 +46,101 @@ FROM products {{< /code-block >}} |
 
 The following SQL functions are supported:
 
-| Function    | Description                                                                            |  Example                                                                                                  |
-|-------------|----------------------------------------------------------------------------------------|----------------|
-| `MIN`       | Returns the smallest value in a set of data.                         | {{< code-block lang="sql" >}}SELECT MIN(response_time) AS min_response_time 
+| Function               | Return Type                     | Description                                                             |
+|------------------------|---------------------------------|-------------------------------------------------------------------------|
+| `min(variable v)`      | typeof v                      | Returns the smallest value in a set of data.                              |
+| `max(variable v)`      | typeof v                      | Returns the maximum value across all input values.                        |
+| `count(any a)`         | numeric                       | Returns the number of input values that are not null.                     |
+| `sum(numeric n)`       | numeric                       | Returns the summation across all input values.                            |
+| `avg(numeric n)`       | numeric                       | Returns the average value (arithmetic mean) across all input values.      |
+| `ceil(numeric n)`      | numeric                       | Returns the value rounded up to the nearest integer.                      |
+| `floor(numeric n)`     | numeric                       | Returns the value rounded down to the nearest integer.                    |
+| `round(numeric n)`     | numeric                       | Returns the value rounded to the nearest integer.                         |
+| `lower(string s)`      | string                        | Returns the string as lowercase.                                          |
+| `upper(string s)`      | string                        | Returns the string as uppercase.                                          |
+| `abs(numeric n)`       | numeric                       | Returns the absolute value.                                               |
+| `coalesce(args a)`     | typeof first non-null a OR null | Returns the first non-null value or null if all are null.               |
+
+
+
+{{% collapse-content title="Examples" level="h3" %}}
+
+### `MIN`
+{{< code-block lang="sql" >}}
+SELECT MIN(response_time) AS min_response_time 
 FROM logs 
-WHERE status_code = 200 {{< /code-block >}} |
-| `MAX`       | Returns the maximum value across all input values.                   | {{< code-block lang="sql" >}}SELECT MAX(response_time) AS max_response_time 
+WHERE status_code = 200 
+{{< /code-block >}} 
+
+### `MAX`
+{{< code-block lang="sql" >}}
+SELECT MAX(response_time) AS max_response_time 
 FROM logs 
-WHERE status_code = 200 {{< /code-block >}} |
-| `COUNT`     | Returns the number of input values that are not null.                      | {{< code-block lang="sql" >}}SELECT COUNT(request_id) AS total_requests 
+WHERE status_code = 200 
+{{< /code-block >}} 
+
+### `COUNT`      
+{{< code-block lang="sql" >}}SELECT COUNT(request_id) AS total_requests 
 FROM logs 
-WHERE status_code = 200 {{< /code-block >}} |
-| `SUM`       | Returns the summation across all input values.                       | {{< code-block lang="sql" >}}SELECT SUM(bytes_transferred) AS total_bytes 
+WHERE status_code = 200 {{< /code-block >}} 
+
+### `SUM`        
+{{< code-block lang="sql" >}}SELECT SUM(bytes_transferred) AS total_bytes 
 FROM logs 
-GROUP BY service_name {{< /code-block >}} |
-| `AVG`       | Returns the average value (arithmetic mean) across all input values. | {{< code-block lang="sql" >}}SELECT AVG(response_time) 
+GROUP BY service_name 
+{{< /code-block >}} 
+
+### `AVG`        
+{{< code-block lang="sql" >}}SELECT AVG(response_time) 
 AS avg_response_time 
 FROM logs 
 WHERE status_code = 200 
-GROUP BY service_name {{< /code-block >}} |
-| `CEIL`/`CEILING(numerical column)` | Returns the value rounded up to the nearest integer.            | {{< code-block lang="sql" >}} SELECT CEIL(price) AS rounded_price 
-FROM products {{< /code-block >}} |
-| `FLOOR`     | Returns the value rounded down to the nearest integer.               | {{< code-block lang="sql" >}}SELECT FLOOR(price) AS floored_price 
-FROM products {{< /code-block >}} |
-| `ROUND`     | Returns the value rounded to the nearest integer.                    | {{< code-block lang="sql" >}}SELECT ROUND(price) AS rounded_price 
-FROM products {{< /code-block >}} |
-| `LOWER`     | Returns the string as lower case.                                       | {{< code-block lang="sql" >}}SELECT LOWER(customer_name) AS lowercase_name 
-FROM customers {{< /code-block >}} |
-| `UPPER`     | Returns the string as uppercase.                                        | {{< code-block lang="sql" >}}SELECT UPPER(customer_name) AS uppercase_name 
-FROM customers {{< /code-block >}} |
-| `ABS`       | Returns the absolute value.                                          | {{< code-block lang="sql" >}}SELECT ABS(balance) AS absolute_balance 
-FROM accounts {{< /code-block >}} |
-| `COALESCE`  | Returns the first non-null value.                                    | {{< code-block lang="sql" >}}SELECT COALESCE(phone_number, email) AS contact_info 
-FROM users {{< /code-block >}} |
+GROUP BY service_name 
+{{< /code-block >}} 
+
+### `CEIL`
+{{< code-block lang="sql" >}} 
+SELECT CEIL(price) AS rounded_price 
+FROM products 
+{{< /code-block >}}
+
+### `FLOOR`      
+{{< code-block lang="sql" >}}
+SELECT FLOOR(price) AS floored_price 
+FROM products 
+{{< /code-block >}} 
+
+### `ROUND`      
+{{< code-block lang="sql" >}}
+SELECT ROUND(price) AS rounded_price 
+FROM products 
+{{< /code-block >}} 
+
+### `LOWER`   
+{{< code-block lang="sql" >}}
+SELECT LOWER(customer_name) AS lowercase_name 
+FROM customers 
+{{< /code-block >}} 
+
+### `UPPER`  
+{{< code-block lang="sql" >}}
+SELECT UPPER(customer_name) AS uppercase_name 
+FROM customers 
+{{< /code-block >}} 
+
+### `ABS`        
+{{< code-block lang="sql" >}}
+SELECT ABS(balance) AS absolute_balance 
+FROM accounts 
+{{< /code-block >}} 
+
+### `COALESCE`  
+{{< code-block lang="sql" >}}
+ SELECT COALESCE(phone_number, email) AS contact_info 
+FROM users 
+{{< /code-block >}} 
+
+{{% /collapse-content %}} 
 
 
 ## Further reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Add a return type column
- Move the examples out to a collapse content

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
