### PR TITLE
Include to disable container collection

### DIFF
--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -78,6 +78,7 @@ datadog:
 [...]
   processAgent:
     enabled: false
+    containerCollection: false
 [...]
   env:
     - name: DD_ENABLE_PAYLOADS_EVENTS


### PR DESCRIPTION


### What does this PR do? What is the motivation?
Added a small change to the docs to include to disable container collection.

This is needed to completely disable the process agent so that container collection gets disabled completely. Just setting `datadog.processAgent.enabled` to `false` does not disable container collection on the Live Containers View.


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
