### PR TITLE
Show DD_APM_IGNORE_RESOURCES example with comma separated list.

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -192,6 +192,8 @@ The **ignore resources** option allows resources to be excluded if the global ro
 
 You can specify resources to ignore either in the Agent configuration file, `datadog.yaml`, or with the `DD_APM_IGNORE_RESOURCES` environment variable. See examples below.
 
+Using `datadog.yaml`:
+
 {{< code-block lang="yaml" filename="datadog.yaml" >}}
 apm_config:
 ## @param ignore_resources - list of strings - optional
@@ -201,7 +203,14 @@ apm_config:
   ignore_resources: ["(GET|POST) /healthcheck","API::NotesController#index"]
 {{< /code-block >}}
 
+Using `DD_APM_IGNORE_RESOURCES`:
+
+```shell
+DD_APM_IGNORE_RESOURCES=(GET|POST) /healthcheck,API::NotesController#index
+```
+
 **Notes**:
+- When using the environment variable format (`DD_APM_IGNORE_RESOURCES`), values must be provided as a comma-separated list of strings.
 - The regex syntax that the Trace Agent accepts is evaluated by Go's [regexp][6].
 - Depending on your deployment strategy, you may have to adjust the regex by escaping special characters.
 - If you use dedicated containers with Kubernetes, make sure that the environment variable for the ignore resource option is being applied to the **trace-agent** container.

--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -206,7 +206,7 @@ apm_config:
 Using `DD_APM_IGNORE_RESOURCES`:
 
 ```shell
-DD_APM_IGNORE_RESOURCES=(GET|POST) /healthcheck,API::NotesController#index
+DD_APM_IGNORE_RESOURCES="(GET|POST) /healthcheck,API::NotesController#index"
 ```
 
 **Notes**:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Docs are unclear how to format `DD_APM_IGNORE_RESOURCES` with multiple values.
- Added a "Using `DD_APM_IGNORE_RESOURCES`" example.
- Added a note clarifying that the variable takes a comma-separate list of strings.

Template:
https://github.com/DataDog/datadog-agent/blob/aa3b2b0448f8555c4ed54cba4e1f730ab3d09fcd/pkg/config/config_template.yaml#L1289

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
