### PR TITLE
update docs removing the exception to console errors

### DIFF
--- a/content/en/error_tracking/troubleshooting.md
+++ b/content/en/error_tracking/troubleshooting.md
@@ -2,7 +2,7 @@
 title: Error Tracking Troubleshooting
 ---
 
-If you experience unexpected behavior with Error Tracking, the troubleshooting steps below can help you resolve the issue quickly. If you continue to have trouble, reach out to [Datadog support][1]. 
+If you experience unexpected behavior with Error Tracking, the troubleshooting steps below can help you resolve the issue quickly. If you continue to have trouble, reach out to [Datadog support][1].
 
 Datadog recommends regularly updating to the latest version of the Datadog tracing libraries, mobile SDKs, and web SDKs, as each release contains improvements and fixes.
 
@@ -10,7 +10,7 @@ Datadog recommends regularly updating to the latest version of the Datadog traci
 
 ### Logs
 
-Make sure the error message has the [required attributes][2], and Error Tracking for Logs is [activated][7]. 
+Make sure the error message has the [required attributes][2], and Error Tracking for Logs is [activated][7].
 
 This [example query][3] searches for logs meeting the criteria for inclusion in Error Tracking.
 
@@ -47,9 +47,9 @@ if (span != null && (span instanceof MutableSpan)) {
 {{% tab "Python" %}}
 
 ```python
-context = tracer.get_call_context() 
-root_span = context.get_current_root_span() 
-root_span.set_tag('<TAG>', '<VALUE>') 
+context = tracer.get_call_context()
+root_span = context.get_current_root_span()
+root_span.set_tag('<TAG>', '<VALUE>')
 ```
 
 {{% /tab %}}
@@ -66,7 +66,7 @@ current_root_span.set_tag('<TAG>', '<VALUE>') unless current_root_span.nil?
 
 ### RUM
 
-Error Tracking only processes errors that are sent with the source set to `custom`, `source` or `report`, and contain a stack trace. Errors sent with any other source (such as `console`) or sent from browser extensions are not processed by Error Tracking.
+Error Tracking only processes errors that are sent with the source set to `custom`, `source`, `report`, `network` or `console`, and contain a stack trace.
 
 This [example query][6] shows RUM errors that meet the criteria for inclusion in Error Tracking.
 

--- a/content/en/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/en/real_user_monitoring/browser/collecting_browser_errors.md
@@ -57,7 +57,7 @@ addError(
 );
 {{< /code-block >}}
 
-**Note**: [Error Tracking][4] processes errors that are sent with the source set to `custom`, `source` or `report`, and contain a stack trace. Errors sent with any other source (such as `console`) or sent from browser extensions are not processed by Error Tracking.
+**Note**: [Error Tracking][4] processes errors that are sent with the source set to `custom`, `source`, `report`, `network` or `console`, and contain a stack trace
 
 {{< tabs >}}
 {{% tab "NPM" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Now that we're fingerprinting console errors we should remove this text from our docs

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
