### PR TITLE
Mention converged agent sources API key / site from core agent config

### DIFF
--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -266,7 +266,7 @@ exporters:
       site: ${env:DD_SITE}
 {{< /code-block >}}
 
-Note: If key and / or site are unset, or key is set to a secret, the missing parameters will be sourced from the core agent config. For site, core agent config defaults to `datadoghq.com` (US1). 
+**Note**: If `key` is not specified or set to a secret, or if `site` is not specified, the system uses values from the core Agent configuration. By default, the core Agent sets site to `datadoghq.com` (US1).
 
 ##### Prometheus receiver
 

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -263,10 +263,10 @@ exporters:
   datadog:
     api:
       key: ${env:DD_API_KEY}
-      site: datadoghq.com
+      site: ${env:DD_SITE}
 {{< /code-block >}}
 
-Set `datadog.site` to your [Datadog site][52]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
+Note: If key and / or site are unset, or key is set to a secret, the missing parameters will be sourced from the core agent config. For site, core agent config defaults to `datadoghq.com` (US1). 
 
 ##### Prometheus receiver
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
When site / api key are unset, converged agent will source these params from core agent config.

See converter README: https://github.com/DataDog/datadog-agent/tree/main/comp/otelcol/converter.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
