### PR TITLE
Update s8s API error docs to include AUTH errors

### DIFF
--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -198,6 +198,9 @@ A test is considered `FAILED` if it does not satisfy one or more assertions or i
 
 The most common errors include the following:
 
+`AUTHENTICATION_ERROR`
+: As a safety measure, when a test fails due to an authentication error (invalid credentials), Synthetics disables the test retry mechanism until the test is updated with new credentials (and is therefore more likely to succeed). This is done to ensure your failing tests are not run unnecessarily in the interim causing false alerts and inflated usage (billing).
+
 `CONNREFUSED`
 : No connection could be made because the target machine actively refused it.
 

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -199,7 +199,7 @@ A test is considered `FAILED` if it does not satisfy one or more assertions or i
 The most common errors include the following:
 
 `AUTHENTICATION_ERROR`
-: As a safety measure, when a test fails due to an authentication error (invalid credentials), Synthetics disables the test retry mechanism until the test is updated with new credentials (and is therefore more likely to succeed). This is done to ensure your failing tests are not run unnecessarily in the interim causing false alerts and inflated usage (billing).
+: Synthetic Monitoring automatically disables test retries when authentication failures occur. This safety measure remains in effect until you update the test with valid credentials. This prevents unnecessary test executions that would generate false alerts and increase billable usage.
 
 `CONNREFUSED`
 : No connection could be made because the target machine actively refused it.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This change updates our docs so customers have further context on AUTH errors and why the retry mechanism is disabled for these specific errors. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
