### PR TITLE
[SYNTH-16307] move windows-pl to prod bucket

### DIFF
--- a/content/en/getting_started/synthetics/private_location.md
+++ b/content/en/getting_started/synthetics/private_location.md
@@ -112,5 +112,5 @@ Use your new private location just like a managed location in your Synthetic tes
 [10]: https://podman.io/
 [11]: https://app.vagrantup.com/ubuntu/boxes/jammy64
 [12]: /synthetics/private_locations?tab=windows#install-your-private-location
-[13]: https://dd-public-oss-mirror.s3.amazonaws.com/synthetics-windows-pl/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
+[13]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 [14]: https://www.datadoghq.com/legal/eula/

--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -93,7 +93,7 @@ You must install .NET version 4.7.2 or later on your computer before using the M
 
 {{< /site-region >}}
 
-[101]: https://dd-public-oss-mirror.s3.amazonaws.com/synthetics-windows-pl/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
+[101]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 [102]: https://www.datadoghq.com/legal/eula/
 
 {{% /tab %}}
@@ -548,7 +548,7 @@ Once the process is complete, click **Finish** on the installation completion pa
 
 <div class="alert alert-warning">If you entered your JSON configuration, the Windows Service starts running using that configuration. If you did not enter your configuration, run <code>C:\\Program Files\Datadog-Synthetics\Synthetics\synthetics-pl-worker.exe --config=< PathToYourConfiguration ></code> from a command prompt or use the <code>start menu</code> shortcut to start the Synthetics Private Location Worker.</div>
 
-[101]: https://dd-public-oss-mirror.s3.amazonaws.com/synthetics-windows-pl/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
+[101]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 [102]: https://app.datadoghq.com/synthetics/settings/private-locations
 
 {{% /tab %}}
@@ -580,7 +580,7 @@ Additional parameters can be added:
 | LOGGING_MAXDAYS | Number of days to keep file logs on the system before deleting them. Can be any number when running an unattended installation. | 7 | `--logFileMaxDays` | Integer |
 | WORKERCONFIG_FILEPATH | This should be changed to the path to your Synthetics Private Location Worker JSON configuration file. Wrap this path in quotes if your path contains spaces. | <None> | `--config` | String |
 
-[101]: https://dd-public-oss-mirror.s3.amazonaws.com/synthetics-windows-pl/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
+[101]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/es/synthetics/platform/private_locations/_index.md
+++ b/content/es/synthetics/platform/private_locations/_index.md
@@ -90,7 +90,7 @@ Antes de utilizar el instalador MSI, debes instalar .NET versión 4.7.2 o poster
 
 {{< /site-region >}}
 
-[101]: https://dd-public-oss-mirror.s3.amazonaws.com/synthetics-windows-pl/datadog-synthetics-worker-1.49.0.amd64.msi
+[101]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 [102]: https://www.datadoghq.com/legal/eula/
 
 {{% /tab %}}
@@ -545,7 +545,7 @@ Una vez completado el proceso, haz clic en **Finish** (Finalizar) en la página 
 
 <div class="alert alert-warning">Si introdujiste tu configuración JSON, el servicio de Windows comienza a ejecutarse utilizando esa configuración. Si no introdujiste tu configuración JSON, ejecuta <code>C:\\Program Files\Datadog-Synthetics\Synthetics\synthetics-pl-worker.exe --config=< PathToYourConfiguration ></code> desde un símbolo del sistema o utilice el acceso directo del <code>menú de inicio para iniciar el worker de localización privada Synthetics.</div>
 
-[101]: https://dd-public-oss-mirror.s3.amazonaws.com/synthetics-windows-pl/datadog-synthetics-worker-1.49.0.amd64.msi
+[101]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 [102]: https://app.datadoghq.com/synthetics/settings/private-locations
 
 {{% /tab %}}
@@ -577,7 +577,7 @@ Se pueden añadir parámetros adicionales:
 | LOGGING_MAXDAYS | Número de días para conservar logs de archivo en el sistema antes de eliminarlos. Puede ser cualquier número cuando se ejecuta una instalación desatendida. | 7 | `--logFileMaxDays` | Entero |
 | WORKERCONFIG_FILEPATH | Debe cambiarse por la ruta a tu archivo de configuración JSON del worker de localización privada Synthetics. Escriba esta ruta entre comillas, si la ruta contiene espacios. | <None> | `--config` | Cadena |
 
-[101]: https://dd-public-oss-mirror.s3.amazonaws.com/synthetics-windows-pl/datadog-synthetics-worker-1.49.0.amd64.msi
+[101]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/ja/getting_started/synthetics/private_location.md
+++ b/content/ja/getting_started/synthetics/private_location.md
@@ -112,5 +112,5 @@ title: プライベートロケーションの概要
 [10]: https://podman.io/
 [11]: https://app.vagrantup.com/ubuntu/boxes/jammy64
 [12]: /ja/synthetics/private_locations?tab=windows#install-your-private-location
-[13]: https://dd-public-oss-mirror.s3.amazonaws.com/synthetics-windows-pl/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
+[13]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 [14]: https://www.datadoghq.com/legal/eula/

--- a/local/bin/py/version_getter.py
+++ b/local/bin/py/version_getter.py
@@ -8,72 +8,53 @@ import defusedxml.ElementTree as ET
 import semver
 
 
-def get_highest_version(versions):
-    highest_version = '0.0.0'
-    for version in versions:
-        if semver.compare(version, highest_version) > 0:
-            highest_version = version
-    return highest_version
-
 def get_data():
-    url = "https://dd-public-oss-mirror.s3.amazonaws.com/"
+    url = "https://ddsynthetics-windows.s3.amazonaws.com/installers.json"
     response = requests.get(url)
     if response.status_code != 200:
-        print(response.text)
-        raise Exception("Failed to retrieve data from the public oss mirror")
-    return response.text
+        raise Exception("Failed to list ddsynthetics-windows bucket")
+    return response
 
-def get_keys(data):
-    keys = []
-    xml_data = ET.iterparse(StringIO(data))
-    for _, element in xml_data:
-        _, _, element.tag = element.tag.rpartition("}") # strip namespace
-    root = xml_data.root
-    for elem in root.iter():
-        if elem.tag == 'Key':
-            for product in PRODUCTS:
-                if elem.text.startswith(product) and not re.search(r'alpha|beta', elem.text):
-                    keys.append(elem.text)
-    return keys
 
-def get_versions(keys):
-    '''Get the highest version for each product tag'''
-    product_version = {}
-    product_version_array = []
-    all_versions = []
+def get_version(data):
+    '''Get the latest version'''
+    data = data.json()
+    latest_info = data.get("synthetics-private-location", {}).get("latest", {}).get("x86_64", {}).get("url", "")
+    if latest_info:
+        # Extract version number from the URL
+        match = re.search(r"datadog-synthetics-worker-(\d+\.\d+\.\d+)\.amd64\.msi", latest_info)
+        if match:
+            version=match.group(1)
+        else:
+            raise Exception("Failed to extract latest version")
+    else:
+        raise Exception("Failed to find latest release")
     
-    for product in PRODUCTS:
-        for key in keys:
-            pattern = r"\d{1,4}.\d{1,4}.\d{1,4}"
-            try:
-                version = re.search(pattern, key).group()
-                product_version_array.append(version)
-            except:
-                continue
-        highest_version = get_highest_version(product_version_array)
-        product_version["client"] = product
-        product_version["version"] = highest_version
-        all_versions.append(product_version)
-    return all_versions    
+    return version    
 
 '''
-Gets the latest version tag from the public oss mirror
-Currently only supports synthetics-windows-pl
+Gets the latest version tag from
+https://ddsynthetics-windows.s3.amazonaws.com/installers.json
 '''
 if __name__ == "__main__":
     github_output = os.getenv('GITHUB_OUTPUT')
-    PRODUCTS = ["synthetics-windows-pl"]
     data = get_data()
-    keys = get_keys(data)
+    latest_version = get_version(data)
+
     try:
         current_versions = json.load(open('data/synthetics_worker_versions.json'))
     except:
         current_versions = {}
-    final_versions = get_versions(keys)
-    
-    if current_versions != final_versions:
-        print("New version detected!")
-        print(final_versions)
+
+    current_version = current_versions[0].get('version')
+    print("Current version: ", current_version)
+
+    if current_version != latest_version:
+        print("New version detected: ", latest_version)
+        final_versions = [{
+            "client": "synthetics-windows-pl",
+            "version": latest_version
+        }]
         with open('data/synthetics_worker_versions.json', 'w') as f:
             f.write(json.dumps(final_versions, indent=4, sort_keys=True))
         with open(github_output, 'a', encoding='utf-8') as f:

--- a/local/bin/py/version_getter.py
+++ b/local/bin/py/version_getter.py
@@ -2,11 +2,7 @@
 import re
 import os
 import json
-from io import StringIO
 import requests
-import defusedxml.ElementTree as ET
-import semver
-
 
 def get_data():
     url = "https://ddsynthetics-windows.s3.amazonaws.com/installers.json"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Windows PL moved from `staging` bucket to `prod`.

As the new bucket has no permission to list the content, the bump script uses `installers.json` file to identify the latest version.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
