### PR TITLE
[MLOB] Update api key documentation for agentless mode

### DIFF
--- a/content/en/llm_observability/setup/sdk/nodejs.md
+++ b/content/en/llm_observability/setup/sdk/nodejs.md
@@ -41,25 +41,25 @@ DD_SITE={{< region-param key="dd_site" code="true" >}} DD_API_KEY=<YOUR_API_KEY>
 DD_LLMOBS_ML_APP=<YOUR_ML_APP_NAME> NODE_OPTIONS="--import dd-trace/initialize.mjs" node <YOUR_APP_ENTRYPOINT>
 ```
 
-`DD_API_KEY`
-: required - _string_
-<br />Your Datadog API key.
-
 `DD_SITE`
-: required - _string_ 
+: required - _string_
 <br />The Datadog site to submit your LLM data. Your site is {{< region-param key="dd_site" code="true" >}}.
 
 `DD_LLMOBS_ENABLED`
-: required - _integer or string_ 
+: required - _integer or string_
 <br />Toggle to enable submitting data to LLM Observability. Should be set to `1` or `true`.
 
 `DD_LLMOBS_ML_APP`
-: required - _string_ 
+: required - _string_
 <br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given root span, see [Tracing multiple applications](#tracing-multiple-applications).
 
 `DD_LLMOBS_AGENTLESS_ENABLED`
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `1` or `true`.
+
+`DD_API_KEY`
+: optional - _string_
+<br />Your Datadog API key. Only required if you are not using the Datadog Agent.
 
 ### In-code setup
 
@@ -123,7 +123,7 @@ To trace a span, use `llmobs.wrap(options, function)` as a function wrapper for 
 
 ### Span Kinds
 
-Span kinds are required, and are specified on the `options` object passed to the `llmobs` tracing functions (`trace`, `wrap`, and `decorate`). See the [Span Kinds documentation][2] for a list of supported span kinds. 
+Span kinds are required, and are specified on the `options` object passed to the `llmobs` tracing functions (`trace`, `wrap`, and `decorate`). See the [Span Kinds documentation][2] for a list of supported span kinds.
 
 **Note:** Spans with an invalid span kind are not submitted to LLM Observability.
 
@@ -379,7 +379,7 @@ getRelevantDocs = llmobs.wrap({ kind: 'retrieval' }, getRelevantDocs)
 The following example demonstrates the second condition, where the last argument is a callback:
 
 #### Example
-  
+
 {{< code-block lang="javascript" >}}
 const express = require('express')
 const app = express()
@@ -426,13 +426,13 @@ processMessage = llmobs.wrap({ kind: 'workflow', sessionId: "<SESSION_ID>" }, pr
 
 ## Annotating a span
 
-The SDK provides the method `llmobs.annotate()` to annotate spans with inputs, outputs, and metadata. 
+The SDK provides the method `llmobs.annotate()` to annotate spans with inputs, outputs, and metadata.
 
 ### Arguments
 
 The `LLMObs.annotate()` method accepts the following arguments:
 
-`span` 
+`span`
 : optional - _Span_ - **default**: the current active span
 <br />The span to annotate. If `span` is not provided (as when using function wrappers), the SDK annotates the current active span.
 
@@ -442,15 +442,15 @@ The `LLMObs.annotate()` method accepts the following arguments:
 
 The `annotationOptions` object can contain the following:
 
-`inputData` 
-: optional - _JSON serializable type or list of objects_ 
+`inputData`
+: optional - _JSON serializable type or list of objects_
 <br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{role: "...", content: "..."}` (for LLM spans).  **Note**: Embedding spans are a special case and require a string or an object (or a list of objects) with this format: `{text: "..."}`.
 
-`outputData` 
-: optional - _JSON serializable type or list of objects_ 
+`outputData`
+: optional - _JSON serializable type or list of objects_
 <br />Either a JSON serializable type (for non-LLM spans) or a list of objects with this format: `{role: "...", content: "..."}` (for LLM spans). **Note**: Retrieval spans are a special case and require a string or an object (or a list of objects) with this format: `{text: "...", name: "...", score: number, id: "..."}`.
 
-`metadata` 
+`metadata`
 : optional - _object_
 <br />An object of JSON serializable key-value pairs that users can add as metadata information relevant to the input or output operation described by the span (`model_temperature`, `max_tokens`, `top_k`, etc.).
 
@@ -647,7 +647,7 @@ function processMessage () {
 The Node.js LLM Observability SDK offers an `llmobs.decorate` function which serves as a function decorator for TypeScript applications. This functions tracing behavior is the same as `llmobs.wrap`.
 
 #### Example
-  
+
 {{< code-block lang="javascript" >}}
 // index.ts
 import tracer from 'dd-trace';

--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -43,25 +43,25 @@ DD_SITE=<YOUR_DATADOG_SITE> DD_API_KEY=<YOUR_API_KEY> DD_LLMOBS_ENABLED=1 \
 DD_LLMOBS_ML_APP=<YOUR_ML_APP_NAME> ddtrace-run <YOUR_APP_STARTUP_COMMAND>
 {{< /code-block >}}
 
-`DD_API_KEY`
-: required - _string_
-<br />Your Datadog API key.
-
 `DD_SITE`
-: required - _string_ 
+: required - _string_
 <br />The Datadog site to submit your LLM data. Your site is {{< region-param key="dd_site" code="true" >}}.
 
 `DD_LLMOBS_ENABLED`
-: required - _integer or string_ 
+: required - _integer or string_
 <br />Toggle to enable submitting data to LLM Observability. Should be set to `1` or `true`.
 
 `DD_LLMOBS_ML_APP`
-: required - _string_ 
+: required - _string_
 <br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given root span, see [Tracing multiple applications](#tracing-multiple-applications).
 
 `DD_LLMOBS_AGENTLESS_ENABLED`
 : optional - _integer or string_ - **default**: `false`
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `1` or `true`.
+
+`DD_API_KEY`
+: optional - _string_
+<br />Your Datadog API key. Only required if you are not using the Datadog Agent.
 
 ### In-code setup
 
@@ -82,7 +82,7 @@ LLMObs.enable(
 <br />The name of your LLM application, service, or project, under which all traces and spans are grouped. This helps distinguish between different applications or experiments. See [Application naming guidelines](#application-naming-guidelines) for allowed characters and other constraints. To override this value for a given trace, see [Tracing multiple applications](#tracing-multiple-applications). If not provided, this defaults to the value of `DD_LLMOBS_ML_APP`.
 
 `integrations_enabled` - **default**: `true`
-: optional - _boolean_ 
+: optional - _boolean_
 <br />A flag to enable automatically tracing LLM calls for Datadog's supported [LLM integrations][13]. If not provided, all supported LLM integrations are enabled by default. To avoid using the LLM integrations, set this value to `false`.
 
 `agentless_enabled`
@@ -90,12 +90,12 @@ LLMObs.enable(
 <br />Only required if you are not using the Datadog Agent, in which case this should be set to `True`. This configures the `ddtrace` library to not send any data that requires the Datadog Agent. If not provided, this defaults to the value of `DD_LLMOBS_AGENTLESS_ENABLED`.
 
 `site`
-: optional - _string_ 
+: optional - _string_
 <br />The Datadog site to submit your LLM data. Your site is {{< region-param key="dd_site" code="true" >}}. If not provided, this defaults to the value of `DD_SITE`.
 
 `api_key`
-: optional - _string_ 
-<br />Your Datadog API key. If not provided, this defaults to the value of `DD_API_KEY`.
+: optional - _string_
+<br />Your Datadog API key. Only required if you are not using the Datadog Agent. If not provided, this defaults to the value of `DD_API_KEY`.
 
 `env`
 : optional - _string_
@@ -107,7 +107,7 @@ LLMObs.enable(
 
 ### AWS Lambda setup
 
-Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers. 
+Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers.
 
 **Note**: Using the `Datadog-Python` and `Datadog-Extension` layers automatically turns on all LLM Observability integrations, and force flushes spans at the end of the Lambda function.
 
@@ -192,7 +192,7 @@ from ddtrace.llmobs.decorators import workflow
 @workflow
 def process_message():
     ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Agent span
@@ -221,7 +221,7 @@ from ddtrace.llmobs.decorators import agent
 @agent
 def react_agent():
     ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Tool span
@@ -250,7 +250,7 @@ from ddtrace.llmobs.decorators import tool
 @tool
 def call_weather_api():
     ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Task span
@@ -279,7 +279,7 @@ from ddtrace.llmobs.decorators import task
 @task
 def sanitize_input():
     ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Embedding span
@@ -317,7 +317,7 @@ from ddtrace.llmobs.decorators import embedding
 @embedding(model_name="text-embedding-3", model_provider="openai")
 def perform_embedding():
     ... # user application logic
-    return 
+    return
 {{< /code-block >}}
 
 ### Retrieval span
@@ -354,7 +354,7 @@ def get_relevant_docs(question):
             {"id": doc.id, "score": doc.score, "text": doc.text, "name": doc.name} for doc in context_documents
         ]
     )
-    return 
+    return
 {{< /code-block >}}
 
 ## Tracking user sessions
@@ -370,7 +370,7 @@ def process_user_message():
         ...
         tags = {"user_handle": "poodle@dog.com", "user_id": "1234", "user_name": "poodle"}
     )
-    return 
+    return
 {{< /code-block >}}
 
 ### Session Tracking Tags
@@ -384,25 +384,25 @@ def process_user_message():
 
 ## Annotating a span
 
-The SDK provides the method `LLMObs.annotate()` to annotate spans with inputs, outputs, and metadata. 
+The SDK provides the method `LLMObs.annotate()` to annotate spans with inputs, outputs, and metadata.
 
 ### Arguments
 
 The `LLMObs.annotate()` method accepts the following arguments:
 
-`span` 
+`span`
 : optional - _Span_ - **default**: the current active span
 <br />The span to annotate. If `span` is not provided (as when using function decorators), the SDK annotates the current active span.
 
-`input_data` 
-: optional - _JSON serializable type or list of dictionaries_ 
+`input_data`
+: optional - _JSON serializable type or list of dictionaries_
 <br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{"role": "...", "content": "..."}` (for LLM spans).  **Note**: Embedding spans are a special case and require a string or a dictionary (or a list of dictionaries) with this format: `{"text": "..."}`.
 
-`output_data` 
-: optional - _JSON serializable type or list of dictionaries_ 
+`output_data`
+: optional - _JSON serializable type or list of dictionaries_
 <br />Either a JSON serializable type (for non-LLM spans) or a list of dictionaries with this format: `{"role": "...", "content": "..."}` (for LLM spans). **Note**: Retrieval spans are a special case and require a string or a dictionary (or a list of dictionaries) with this format: `{"text": "...", "name": "...", "score": float, "id": "..."}`.
 
-`metadata` 
+`metadata`
 : optional - _dictionary_
 <br />A dictionary of JSON serializable key-value pairs that users can add as metadata information relevant to the input or output operation described by the span (`model_temperature`, `max_tokens`, `top_k`, etc.).
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR updates the LLM Observability SDK setup documentation, specifically related to `DD_API_KEY`. It is still marked as a required field/configuration but currently it is only required if the user is in agentless mode (i.e. without the Datadog agent).

This PR also makes minor whitespace removal in the SDK setup files.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
