### PR TITLE
Add K8 tab to PL Config page

### DIFF
--- a/content/en/synthetics/platform/private_locations/configuration.md
+++ b/content/en/synthetics/platform/private_locations/configuration.md
@@ -28,6 +28,11 @@ docker run --rm datadog/synthetics-private-location-worker --help
 synthetics-pl-worker.exe --help
 ```
 {{% /tab %}}
+{{% tab "Kubernetes" %}}
+
+Check example on [github.com/DataDog/helm-charts/tree/main/charts/synthetics-private-location][6]
+
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Customize your private location
@@ -292,3 +297,4 @@ Command options can also be set using environment variables such as `DATADOG_API
 [3]: https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4282
 [4]: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
 [5]: https://www.iana.org/assignments/iana-ipv6-special-registry/iana-ipv6-special-registry.xhtml
+[6]: https://github.com/DataDog/helm-charts/tree/main/charts/synthetics-private-location


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Kubernetes were not mentioned at all at Private Location Configuaration page, but it is possible to use K8 and customers often ask about this on Technical Support
https://github.com/DataDog/helm-charts/tree/main/charts/synthetics-private-location

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
