### PR TITLE
Add PostSync Hook option to change Argo CD duration reported

### DIFF
--- a/content/en/continuous_delivery/deployments/argocd.md
+++ b/content/en/continuous_delivery/deployments/argocd.md
@@ -116,7 +116,7 @@ The [Recommended Setup](#recommended-setup) section below contains recommended a
 The duration reported in deployment events matches the sync duration in Argo CD. However, the sync duration generally represents the time spent by Argo CD to sync the Git repository state and the Kubernetes cluster state.
 This means that what happens after the sync (for example, the time spent by the Kubernetes resources to start up) is not included in the duration.
 
-To change the duration reported to wait until the configured resources have started up and reached a healthy state, you can add a [PostSync Hook][19] to the resources that your Argo CD application monitors.
+To change the duration reported to wait until the configured resources have started up and reached a healthy state, add a new no-op resource monitored by your Argo CD application, with a [PostSync Hook][19] annotation.
 The PostSync Hook will run after all the resources have reached a Healthy state, and the Argo CD sync will wait on the PostSync Hook result to update the application status as Healthy.
 
 Below is represented an example of a PostSync Hook Job that runs a simple `echo` command.

--- a/content/en/continuous_delivery/deployments/argocd.md
+++ b/content/en/continuous_delivery/deployments/argocd.md
@@ -29,7 +29,7 @@ Datadog CD Visibility integrates with Argo CD by using [Argo CD Notifications][2
 
 ## Minimal Setup
 
-The setup below uses the [Webhook notification service][5] of Argo CD in order to send notifications to Datadog.
+The setup below uses the [Webhook notification service][5] of Argo CD to send notifications to Datadog.
 
 First, add your [Datadog API Key][11] in the `argocd-notifications-secret` secret with the `dd-api-key` key. See [the Argo CD guide][2] for information on modifying the `argocd-notifications-secret`.
 

--- a/content/en/continuous_delivery/deployments/argocd.md
+++ b/content/en/continuous_delivery/deployments/argocd.md
@@ -69,10 +69,10 @@ data:
       send: [cd-visibility-template]
 ```
 
-The following fields have been added:
-1. The `cd-visibility-webhook` service added under `data.service.webhook` targets the Datadog intake and configures the correct headers for the request. The `DD-API-KEY` header references the `dd-api-key` entry added previously in the `argocd-notifications-secret`.
-2. The `cd-visibility-template` added under `data.template` defines what to send in the request for the `cd-visibility-webhook` service.
-3. The `cd-visibility-trigger` added under `data.trigger` defines when to send the notification, and it references the `cd-visibility-template`.
+The following resources have been added:
+1. The `cd-visibility-webhook` service targets the Datadog intake and configures the correct headers for the request. The `DD-API-KEY` header references the `dd-api-key` entry added previously in the `argocd-notifications-secret`.
+2. The `cd-visibility-template` defines what to send in the request for the `cd-visibility-webhook` service.
+3. The `cd-visibility-trigger` defines when to send the notification, and it references the `cd-visibility-template`.
 
 <div class="alert alert-warning">
 The call to populate the <code>commit_metadata</code> field is not required. The field is used to enrich the payload with Git information.
@@ -114,7 +114,7 @@ The [Recommended Setup](#recommended-setup) section below contains recommended a
 
 ### Change duration to wait for resources health
 The duration reported in deployment events matches the sync duration in Argo CD. However, the sync duration generally represents the time spent by Argo CD to sync the Git repository state and the Kubernetes cluster state.
-This means that what happens after the sync (for example, the time spent by the Kubernetes resources to start up), is not included in the duration.
+This means that what happens after the sync (for example, the time spent by the Kubernetes resources to start up) is not included in the duration.
 
 To change the duration reported to wait until the configured resources have started up and reached a healthy state, you can add a [PostSync Hook][19] to the resources that your Argo CD application monitors.
 The PostSync Hook will run after all the resources have reached a Healthy state, and the Argo CD sync will wait on the PostSync Hook result to update the application status as Healthy.

--- a/content/en/continuous_delivery/deployments/argocd.md
+++ b/content/en/continuous_delivery/deployments/argocd.md
@@ -220,7 +220,7 @@ metadata:
 
 ## Visualize deployments in Datadog
 
-The [**Deployments**][6] and [**Executions**][7] pages populate with data after a deployment is executed. For more information, see [Search and Manage][9] and [CD Visibility Explorer][10].
+The [**Deployments**][6] and [**Executions**][7] pages populate with data after a deployment has finished. For more information, see [Search and Manage][9] and [CD Visibility Explorer][10].
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Two main things:
1. Improves the current Argo CD documentation by merging the three steps to create the setup into a single one.
2. Add a section to mention how to improve the reported Argo CD duration by taking resources start up into account.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
