### PR TITLE
fix missing links in SCA setup

### DIFF
--- a/content/en/security/application_security/software_composition_analysis/setup/_index.md
+++ b/content/en/security/application_security/software_composition_analysis/setup/_index.md
@@ -44,9 +44,9 @@ Before setting up Software Composition Analysis, ensure the following prerequisi
 
 ### Settings page
 
-Alternatively, you can enable Software Composition Analysis through the [Settings] page.
+Alternatively, you can enable Software Composition Analysis through the [Settings][3] page.
 
-1. Navigate to the [Settings] page and select **Get Started in Software Composition Analysis (SCA)**.
+1. Navigate to the [Settings][3] page and select **Get Started** in **Software Composition Analysis (SCA)**.
 2. For static analysis in source code, select **Select Repositories**.
 3. Select **Add Github Account** and follow the [instructions][4] to create a new GitHub Application.
 4. Once the GitHub account is set up, select **Select Repositories** and enable **Software Composition Analysis (SCA)**.


### PR DESCRIPTION
two instances of "Settings" do not include links to the UI even though the reference link is the topic MD.

Adding the link references in this commit.

### Merge instructions

Merge readiness:
- [X] Ready for merge
