### PR TITLE
(Agent) Unindex guides from older Agent versions

### DIFF
--- a/content/en/agent/guide/agent-5-architecture.md
+++ b/content/en/agent/guide/agent-5-architecture.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 5 architecture
 disable_toc: false
+private: true
 ---
 
 This page covers Agent 5 architecture. To find out about architecture for the latest version of the Agent, see [Agent Architecture][1].

--- a/content/en/agent/guide/agent-5-autodiscovery.md
+++ b/content/en/agent/guide/agent-5-autodiscovery.md
@@ -3,6 +3,7 @@ title: Autodiscovery with Agent v5
 private: true
 aliases:
   - /agent/faq/agent-5-autodiscovery
+private: true
 ---
 
 <div class="alert alert-info">

--- a/content/en/agent/guide/agent-5-check-status.md
+++ b/content/en/agent/guide/agent-5-check-status.md
@@ -1,6 +1,7 @@
 ---
 title: Troubleshoot an Agent Check on Agent 5
 disable_toc: false
+private: true
 ---
 
 This page covers troubleshooting an Agent Check on Agent 5. For information on the latest version of the Agent, see [Troubleshoot an Agent Check][4].

--- a/content/en/agent/guide/agent-5-commands.md
+++ b/content/en/agent/guide/agent-5-commands.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 5 Commands
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/agent/guide/agent-5-configuration-files.md
+++ b/content/en/agent/guide/agent-5-configuration-files.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 5 Configuration Files
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/agent/guide/agent-5-debug-mode.md
+++ b/content/en/agent/guide/agent-5-debug-mode.md
@@ -1,5 +1,6 @@
 ---
 title: Agent 5 Debug Mode
+private: true
 ---
 
 ## Overview

--- a/content/en/agent/guide/agent-5-flare.md
+++ b/content/en/agent/guide/agent-5-flare.md
@@ -3,6 +3,7 @@ title: Send an Agent 5 flare
 disable_toc: false
 aliases:
 - agent/guide/windows-flare-agent-5
+private: true
 ---
 
 This page covers the ports used by Agent 5. For information on the latest version of the Agent, see [Send a Flare][1].

--- a/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
+++ b/content/en/agent/guide/agent-5-kubernetes-basic-agent-usage.md
@@ -3,6 +3,7 @@ title: Kubernetes Basic Agent Usage in Agent v5
 private: true
 aliases:
   - /agent/faq/agent-5-kubernetes-basic-agent-usage
+private: true
 ---
 
 {{< img src="integrations/kubernetes/k8sdashboard.png" alt="Kubernetes Dashboard" >}}

--- a/content/en/agent/guide/agent-5-log-files.md
+++ b/content/en/agent/guide/agent-5-log-files.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 5 Log Files
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/agent/guide/agent-5-permissions-issues.md
+++ b/content/en/agent/guide/agent-5-permissions-issues.md
@@ -1,5 +1,6 @@
 ---
 title: Agent 5 Permission Issues
+private: true
 ---
 
 The Agent needs a specific set of permissions in order to collect your data on your host, find the most common permission issues below and how to solve them.

--- a/content/en/agent/guide/agent-5-ports.md
+++ b/content/en/agent/guide/agent-5-ports.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 5 ports
 disable_toc: false
+private: true
 ---
 
 This page covers the ports used by Agent 5. For information on the latest version of the Agent, see [Network Traffic][1].

--- a/content/en/agent/guide/agent-5-proxy.md
+++ b/content/en/agent/guide/agent-5-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 5 proxy configuration
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/agent/guide/agent-6-commands.md
+++ b/content/en/agent/guide/agent-6-commands.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 6 Commands
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/agent/guide/agent-6-configuration-files.md
+++ b/content/en/agent/guide/agent-6-configuration-files.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 6 Configuration Files
 disable_toc: false
+private: true
 ---
 
 ## Agent main configuration file

--- a/content/en/agent/guide/agent-6-log-files.md
+++ b/content/en/agent/guide/agent-6-log-files.md
@@ -1,6 +1,7 @@
 ---
 title: Agent 6 Log Files
 disable_toc: false
+private: true
 ---
 
 ## Overview

--- a/content/en/agent/guide/install-agent-5.md
+++ b/content/en/agent/guide/install-agent-5.md
@@ -4,6 +4,7 @@ further_reading:
 - link: "/agent/basic_agent_usage/"
   tag: "Documentation"
   text: "Basic Agent Usage"
+private: true  
 ---
 
 This guide covers installing Agent 5. Datadog recommends installing or upgrading to Agent 7 for the latest features. For information on installing the latest version of the Agent, follow the [Agent 7 Installation Instructions][1]. For information on upgrading to Agent 7 from an earlier version, see [Upgrade to Datadog Agent v7][2].

--- a/content/en/agent/guide/install-agent-6.md
+++ b/content/en/agent/guide/install-agent-6.md
@@ -4,6 +4,7 @@ further_reading:
 - link: "/agent/basic_agent_usage/"
   tag: "Documentation"
   text: "Basic Agent Usage"
+private: true  
 ---
 
 This guide covers installing Agent 6. Datadog recommends installing or upgrading to Agent 7 for the latest features. For information on installing the latest version of the Agent, follow the [latest Agent Installation Instructions][1]. For information on upgrading to Agent 7 from an earlier version, see [Upgrade to Datadog Agent v7][2].

--- a/content/en/agent/guide/upgrade_to_agent_6.md
+++ b/content/en/agent/guide/upgrade_to_agent_6.md
@@ -4,6 +4,7 @@ aliases:
   - /agent/faq/upgrade-to-agent-v6
   - /agent/versions/upgrade_to_agent_v6/
   - /agent/guide/upgrade-to-agent-v6
+private: true
 ---
 
 <div class="alert alert-info">


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Google is taking users to guides for older versions of the Agent.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
