### PR TITLE
dan.chiniara/add N/A groups explainer to "Verify the presence of data" and "Define the metric"

### DIFF
--- a/content/en/monitors/guide/troubleshooting-monitor-alerts.md
+++ b/content/en/monitors/guide/troubleshooting-monitor-alerts.md
@@ -49,7 +49,7 @@ For most use cases, disable the "Require Full Window" setting unless your specif
 
 ## Verify the presence of data
 
-If your monitor's state or status is not what you expect, confirm the behavior of the underlying data source. For a metric monitor, you can use the [history][2] graph to view the data points being pulled in by the metric query. `N/A` groups are not included in monitors while they are visible in dashboard queries. 
+If your monitor's state or status is not what you expect, confirm the behavior of the underlying data source. For a metric monitor, you can use the [history][2] graph to view the data points being pulled in by the metric query. `N/A` groups are not included in monitors, but are visible in dashboard queries. 
 
 ## Alert conditions
 

--- a/content/en/monitors/guide/troubleshooting-monitor-alerts.md
+++ b/content/en/monitors/guide/troubleshooting-monitor-alerts.md
@@ -49,7 +49,7 @@ For most use cases, disable the "Require Full Window" setting unless your specif
 
 ## Verify the presence of data
 
-If your monitor's state or status is not what you expect, confirm the behavior of the underlying data source. For a metric monitor, you can use the [history][2] graph to view the data points being pulled in by the metric query. 
+If your monitor's state or status is not what you expect, confirm the behavior of the underlying data source. For a metric monitor, you can use the [history][2] graph to view the data points being pulled in by the metric query. `N/A` groups are not included in monitors while they are visible in dashboard queries. 
 
 ## Alert conditions
 

--- a/content/en/monitors/guide/troubleshooting-monitor-alerts.md
+++ b/content/en/monitors/guide/troubleshooting-monitor-alerts.md
@@ -49,7 +49,7 @@ For most use cases, disable the "Require Full Window" setting unless your specif
 
 ## Verify the presence of data
 
-If your monitor's state or status is not what you expect, confirm the behavior of the underlying data source. For a metric monitor, you can use the [history][2] graph to view the data points being pulled in by the metric query. `N/A` groups are not included in monitors, but are visible in dashboard queries. 
+If your monitor's state or status is not what you expect, confirm the behavior of the underlying data source. For a metric monitor, you can use the [history][2] graph to view the data points being pulled in by the metric query. `N/A` groups are not included in monitors but are visible in dashboard queries. 
 
 ## Alert conditions
 

--- a/content/en/monitors/types/metric.md
+++ b/content/en/monitors/types/metric.md
@@ -151,6 +151,7 @@ Any metric reporting to Datadog is available for monitors. Use the editor and th
   - **max/min**: These descriptions of max and min assume that the monitor alerts when the metric goes above the threshold. For monitors that alert when below the threshold, the max and min behavior is reversed.
   - Defining metrics for monitors is similar to defining metrics for graphs. For details on using the `Advanced...` option, see [Advanced graphing][2].
   - There are different behaviors when utilizing `as_count()`. See [as_count() in Monitor Evaluations][3] for details.
+  - `N/A` groups are not included in monitors, so tag keys must have a value. 
 
 ## Set alert conditions
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Mentions that `N/A` groups are not included in monitors. It's currently a feature request. 

https://datadoghq.atlassian.net/browse/FRMNTS-3812


example link 1: [Troubleshooting Monitor Alerts](https://docs-staging.datadoghq.com/dan.chiniara/add-N/A-groups/monitors/guide/troubleshooting-monitor-alerts/#verify-the-presence-of-data)
![image](https://github.com/user-attachments/assets/0412b072-70e7-478b-9b9e-a5f74b9b7f5b)

example link 2: [Metric Monitors](https://docs-staging.datadoghq.com/dan.chiniara/add-N/A-groups/monitors/types/metric/?tab=threshold#define-the-metric)
![image](https://github.com/user-attachments/assets/e22e276a-154d-4320-b7ad-94fb40d06af8)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready for merge