### PR TITLE
[ACCESSINT-95] Add allow_self_lockout to documentation

### DIFF
--- a/data/api/v2/full_spec.yaml
+++ b/data/api/v2/full_spec.yaml
@@ -40608,7 +40608,7 @@ paths:
       operationId: UpdateRestrictionPolicy
       parameters:
       - $ref: '#/components/parameters/ResourceID'
-      - description: Allow admins (users with user_access_manage_role) to remove their own access from a resource if set to `true`. Admin self lockout is unallowed by default.
+      - description: Allows admins (users with the user_access_manage permission) to remove their own access from the resource if set to `true`. By default, this is set to `false`, preventing admins from locking themselves out.
         in: query
         name: allow_self_lockout
         required: false

--- a/data/api/v2/full_spec.yaml
+++ b/data/api/v2/full_spec.yaml
@@ -40608,6 +40608,12 @@ paths:
       operationId: UpdateRestrictionPolicy
       parameters:
       - $ref: '#/components/parameters/ResourceID'
+      - description: Allow admins (users with user_access_manage_role) to remove their own access from a resource if set to `true`. Admin self lockout is unallowed by default.
+        in: query
+        name: allow_self_lockout
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR updates UpdateRestrictionPolicy documentation to include the `allow_self_lockout` query parameter.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
