### PR TITLE
Add Node.js Supported Versions to Serverless Span Auto Linking Docs

### DIFF
--- a/content/en/serverless/aws_lambda/distributed_tracing.md
+++ b/content/en/serverless/aws_lambda/distributed_tracing.md
@@ -121,7 +121,9 @@ If you are viewing the request that originated before the change event and the l
 
 If you are viewing the request that originated before the change event and the linked trace is ingested, you can see the linked span as a `Forward` link. 
 
-This functionality is available for Python instrumented AWS Lambda functions on layer version 101 and above and python applications instrumented with [`dd-trace-py`][31] on version 2.16 and above.
+This functionality is available for:
+- Python AWS Lambda functions instrumented with layer version 101 and above, and Python applications instrumented with [`dd-trace-py`][31] on version 2.16 and above.
+- Node.js AWS Lambda functions instrumented with layer version 118 and above, and Node.js applications instrumented with [`dd-trace-js`][32] on versions 4.53.0 and above or versions 5.29.0 and above.
 
 ### DyanmoDB Change Stream Auto-linking
 
@@ -396,3 +398,4 @@ If you are already tracing your serverless application with X-Ray and want to co
 [29]: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
 [30]: https://docs.datadoghq.com/tracing/trace_explorer/trace_view/?tab=spanlinksbeta
 [31]: https://github.com/DataDog/dd-trace-py/
+[32]: https://github.com/DataDog/dd-trace-js/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We just added support for Span Auto Linking on Node.js. This updates the documentation to list the supported Node.js versions.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
