### PR TITLE
[CLOUDS-5524] Update Azure Integration manual app registration instructions

### DIFF
--- a/content/en/integrations/guide/azure-manual-setup.md
+++ b/content/en/integrations/guide/azure-manual-setup.md
@@ -188,11 +188,10 @@ A form to create a new app registration is displayed:
 #### Creating the app registration
 
 1. Under **Azure Active Directory**, navigate to **App Registrations** and click **New registration**.
-2. Enter the following and click the **Create** button. The name and sign-on URL are not used but are required for the setup process.
+2. Enter the following and click the **Create** button.
 
     - Name: `Datadog Auth`
-    - Supported Account Types: `Accounts in this organizational directory only (Datadog)`
-    - Redirect URI: {{< region-param key="dd_full_site" code="true" >}}
+    - Supported Account Types: `Accounts in this organizational directory only`
 
 {{< img src="integrations/guide/azure_manual_setup/Azure_create_ad.png" alt="Azure create app" popup="true" style="width:80%;" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

1. Removes the reference to redirect URIs. They are no longer required for creating app registrations and are not needed.
2. Removes "Datadog" from "Accounts in this organizational directory only". This is a quote from the app registration creation page in the Azure portal (see screenshot below). It only says "Datadog" because I was into the Datadog directory. For customers, it will use the name of their Azure directory. Having "Datadog" here can be confusing.
<img width="832" alt="Screenshot 2024-12-20 at 5 00 07 PM" src="https://github.com/user-attachments/assets/6cedbea3-25a3-4e27-9176-4aa984fa4295" />


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
