### PR TITLE
[DOCS-9787] Update link to Error Tracking

### DIFF
--- a/content/en/logs/error_tracking/_index.md
+++ b/content/en/logs/error_tracking/_index.md
@@ -23,7 +23,7 @@ further_reading:
 
 {{% error-tracking-description %}}
 
-Take a tour of key Error Tracking features in the [Error Tracking Explorer][3] documentation. To view the Error Tracking Explorer for Logs in Datadog, navigate to [**Logs** > **Error Tracking**][1].
+Take a tour of key Error Tracking features in the [Error Tracking Explorer][3] documentation. To view the Error Tracking Explorer for Logs in Datadog, navigate to [**Error Tracking**][1].
 
 ## Setup
 
@@ -38,6 +38,6 @@ Error Tracking for Logs processes properly configured error logs with stack trac
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/logs/error-tracking
+[1]: https://app.datadoghq.com/error-tracking
 [2]: /logs/log_collection
 [3]: /error_tracking/explorer


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Per internal feedback, this updates the link to Error Tracking on the Logs setup page because Error Tracking is now its own product.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
