### PR TITLE
Add documentation for GCS unsupported storage classes

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -273,6 +273,18 @@ If you wish to rehydrate from archives in another access tier, you must first mo
 
 [1]: /logs/archives/rehydrating/
 {{% /tab %}}
+{{% tab "Google Cloud Storage" %}}
+
+[Rehydration][1] only supports the following storage classes:
+
+- Standard
+- Nearline
+- Coldline
+
+If you wish to rehydrate from archives in another storage class, you must first move them to one of the supported classes above.
+
+[1]: /logs/archives/rehydrating/
+{{% /tab %}}
 {{< /tabs >}}
 
 #### Server side encryption (SSE)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
- For GCS (Google Cloud Storage) Logs Rehydrations we only support rehydrating from the following storage Classes (Standard, Coldline and Nearline)
- We should document this in the public docs.

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
