### PR TITLE
feat(admission): add instruction to remove Datadog Admission Controllers

### DIFF
--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -15,6 +15,9 @@ further_reading:
 - link: "https://www.datadoghq.com/architecture/instrument-your-app-using-the-datadog-operator-and-admission-controller/"
   tag: "Architecture Center"
   text: "Instrument your app using the Datadog Operator and Admission Controller"
+- link: "/containers/guide/cluster_agent_disable_admission_controller"
+  tag: "Documentation"
+  text: "Disable the Datadog Admission Controller with the Cluster Agent"
 ---
 
 ## Overview

--- a/content/en/containers/guide/_index.md
+++ b/content/en/containers/guide/_index.md
@@ -31,6 +31,7 @@ disable_toc: true
 {{< whatsnext desc="Cluster Agent guides:" >}}
     {{< nextlink href="/containers/guide/cluster_agent_autoscaling_metrics" >}}Autoscaling with custom and external metrics in the Cluster Agent{{< /nextlink >}}
     {{< nextlink href="/containers/guide/clustercheckrunners" >}}Cluster Check Runners{{< /nextlink >}}
+    {{< nextlink href="/containers/guide/cluster_agent_disable_admission_controller" >}}Disable the Datadog Admission Controller with the Cluster Agent{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Operator guides:" >}}

--- a/content/en/containers/guide/cluster_agent_disable_admission_controller.md
+++ b/content/en/containers/guide/cluster_agent_disable_admission_controller.md
@@ -1,0 +1,84 @@
+---
+title: Disable the Datadog Admission Controller with the Cluster Agent
+further_reading:
+- link: "https://www.datadoghq.com/blog/datadog-cluster-agent/"
+  tag: "Blog"
+  text: "Introducing the Datadog Cluster Agent"
+- link: "/containers/cluster_agent/admission_controller/"
+  tag: "Documentation"
+  text: "Datadog Admission Controller"
+- link: "/agent/cluster_agent/troubleshooting/"
+  tag: "Documentation"
+  text: "Troubleshooting the Datadog Cluster Agent"
+---
+
+## Overview
+
+The Datadog Cluster Agent manages the Datadog Admission Controller by creating, updating, and deleting Admission Controllers as needed.
+To disable the Admission Controller or remove the Cluster Agent, you must first disable the Admission Controller features in the Cluster Agent configuration and redeploy the Cluster Agent.
+Once the Admission Controllers are removed, the Cluster Agent can be safely removed if necessary.
+
+## Requirements
+
+1. DataDog Cluster Agent v7.63+
+
+## Steps
+
+{{< tabs >}}
+{{% tab "Datadog Operator" %}}
+To disable the Admission Controllers with your Cluster Agent managed by the Datadog Operator:
+* Set `features.admissionController.enabled` to `true` in your `DatadogAgent` configuration.
+* Set `features.admissionController.validation.enabled` to `false` in your `DatadogAgent` configuration.
+* Set `features.admissionController.mutation.enabled` to `false` in your `DatadogAgent` configuration.
+
+```yaml
+  apiVersion: datadoghq.com/v2alpha1
+  kind: DatadogAgent
+  metadata:
+    name: datadog
+  spec:
+    features:
+      admissionController:
+        enabled: true
+        validation:
+          enabled: false
+        mutation:
+          enabled: false
+```
+
+Note that the `features.admissionController.enabled` parameter is set to `true` to allow the Cluster Agent to manage the Kubernetes Admission Controllers.
+
+After redeploying the Cluster Agent with the updated configuration, the Admission Controllers are removed.
+{{% /tab %}}
+{{% tab "Helm" %}}
+To disable the Admission Controllers with your Cluster Agent managed by the Datadog Helm Chart:
+* Set `clusterAgent.admissionController.enabled` to `true`.
+* Set `clusterAgent.admissionController.validation.enabled` to `false`.
+* Set `clusterAgent.admissionController.mutation.enabled` to `false`.
+
+```yaml
+clusterAgent:
+  enabled: true
+  admissionController:
+    enabled: true
+    validation:
+      enabled: false
+    mutation:
+      enabled: false
+```
+{{% /tab %}}
+{{% /tabs %}}
+
+You can confirm the Admission Controllers are removed by checking `ValidatingWebhookConfiguration` and `MutatingWebhookConfiguration` resources in your cluster.
+
+```shell
+kubectl get validatingwebhookconfigurations.admissionregistration.k8s.io
+```
+
+```shell
+kubectl get mutatingwebhookconfigurations.admissionregistration.k8s.io
+```
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/containers/guide/cluster_agent_disable_admission_controller.md
+++ b/content/en/containers/guide/cluster_agent_disable_admission_controller.md
@@ -18,18 +18,18 @@ The Datadog Cluster Agent manages the Datadog Admission Controller by creating, 
 To disable the Admission Controller or remove the Cluster Agent, you must first disable the Admission Controller features in the Cluster Agent configuration and redeploy the Cluster Agent.
 Once the Admission Controllers are removed, the Cluster Agent can be safely removed if necessary.
 
-## Requirements
+## Prerequisites
 
-1. DataDog Cluster Agent v7.63+
+Datadog Cluster Agent v7.63+
 
 ## Steps
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
 To disable the Admission Controllers with your Cluster Agent managed by the Datadog Operator:
-* Set `features.admissionController.enabled` to `true` in your `DatadogAgent` configuration.
-* Set `features.admissionController.validation.enabled` to `false` in your `DatadogAgent` configuration.
-* Set `features.admissionController.mutation.enabled` to `false` in your `DatadogAgent` configuration.
+1. Set `features.admissionController.enabled` to `true` in your `DatadogAgent` configuration.
+2. Set `features.admissionController.validation.enabled` to `false` in your `DatadogAgent` configuration.
+3. Set `features.admissionController.mutation.enabled` to `false` in your `DatadogAgent` configuration.
 
 ```yaml
   apiVersion: datadoghq.com/v2alpha1
@@ -46,15 +46,15 @@ To disable the Admission Controllers with your Cluster Agent managed by the Data
           enabled: false
 ```
 
-Note that the `features.admissionController.enabled` parameter is set to `true` to allow the Cluster Agent to manage the Kubernetes Admission Controllers.
+**Note**: The the `features.admissionController.enabled` parameter is set to `true` to allow the Cluster Agent to manage the Kubernetes Admission Controllers.
 
 After redeploying the Cluster Agent with the updated configuration, the Admission Controllers are removed.
 {{% /tab %}}
 {{% tab "Helm" %}}
 To disable the Admission Controllers with your Cluster Agent managed by the Datadog Helm Chart:
-* Set `clusterAgent.admissionController.enabled` to `true`.
-* Set `clusterAgent.admissionController.validation.enabled` to `false`.
-* Set `clusterAgent.admissionController.mutation.enabled` to `false`.
+1. Set `clusterAgent.admissionController.enabled` to `true`.
+2. Set `clusterAgent.admissionController.validation.enabled` to `false`.
+3. Set `clusterAgent.admissionController.mutation.enabled` to `false`.
 
 ```yaml
 clusterAgent:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds a Container Guide on how to properly disable the Cluster Agent Admission Controllers.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
