### PR TITLE
Move synthetics permissions info to reuse shortcode

### DIFF
--- a/content/en/synthetics/api_tests/dns_tests.md
+++ b/content/en/synthetics/api_tests/dns_tests.md
@@ -139,30 +139,7 @@ If you are using the [custom role feature][11], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][12] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -179,4 +156,3 @@ To do so:
 [9]: /synthetics/settings/#global-variables
 [10]: /account_management/rbac/
 [11]: /account_management/rbac#custom-roles
-[12]: /account_management/rbac/granular_access

--- a/content/en/synthetics/api_tests/grpc_tests.md
+++ b/content/en/synthetics/api_tests/grpc_tests.md
@@ -212,31 +212,7 @@ If you are using the [custom role feature][13], add your user to any custom role
 
 ## Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][14] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
-
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -256,4 +232,3 @@ To do so:
 [11]: /synthetics/api_tests/errors/#ssl-errors
 [12]: /account_management/rbac/
 [13]: /account_management/rbac#custom-roles
-[14]: /account_management/rbac/granular_access

--- a/content/en/synthetics/api_tests/http_tests.md
+++ b/content/en/synthetics/api_tests/http_tests.md
@@ -247,30 +247,7 @@ If you are using the [custom role feature][14], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][18] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -293,4 +270,3 @@ To do so:
 [15]: /account_management/rbac/#create-a-custom-role
 [16]: /synthetics/api_tests/errors/#http-errors
 [17]: /api_catalog
-[18]: /account_management/rbac/granular_access

--- a/content/en/synthetics/api_tests/icmp_tests.md
+++ b/content/en/synthetics/api_tests/icmp_tests.md
@@ -121,30 +121,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][11] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -160,4 +137,3 @@ To do so:
 [8]: /synthetics/settings/#global-variables
 [9]: /account_management/rbac/
 [10]: /account_management/rbac#custom-roles
-[11]: /account_management/rbac/granular_access

--- a/content/en/synthetics/api_tests/ssl_tests.md
+++ b/content/en/synthetics/api_tests/ssl_tests.md
@@ -152,30 +152,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][13] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -193,4 +170,3 @@ To do so:
 [10]: /synthetics/api_tests/errors/#ssl-errors
 [11]: /account_management/rbac/
 [12]: /account_management/rbac#custom-roles
-[13]: /account_management/rbac/granular_access

--- a/content/en/synthetics/api_tests/tcp_tests.md
+++ b/content/en/synthetics/api_tests/tcp_tests.md
@@ -131,30 +131,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][11] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -170,4 +147,3 @@ To do so:
 [8]: /synthetics/settings/#global-variables
 [9]: /account_management/rbac/
 [10]: /account_management/rbac#custom-roles
-[11]: /account_management/rbac/granular_access

--- a/content/en/synthetics/api_tests/udp_tests.md
+++ b/content/en/synthetics/api_tests/udp_tests.md
@@ -129,30 +129,7 @@ If you are using the [custom role feature][10], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][11] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -168,4 +145,3 @@ To do so:
 [8]: /synthetics/guide/synthetic-test-monitors
 [9]: /account_management/rbac/
 [10]: /account_management/rbac#custom-roles
-[11]: /account_management/rbac/granular_access

--- a/content/en/synthetics/api_tests/websocket_tests.md
+++ b/content/en/synthetics/api_tests/websocket_tests.md
@@ -156,30 +156,7 @@ If you are using the [custom role feature][11], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][12] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -196,4 +173,3 @@ To do so:
 [9]: /synthetics/api_tests/errors/#ssl-errors
 [10]: /account_management/rbac/
 [11]: /account_management/rbac#custom-roles
-[12]: /account_management/rbac/granular_access

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -221,30 +221,7 @@ If you are using the [custom role feature][15], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][18] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  | View recording | Edit recording |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- | -------------- | -------------- |
-| No access    |                         |                         |                   |           |                |                |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |                |                |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} | {{< X >}}      | {{< X >}}      |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 

--- a/content/en/synthetics/mobile_app_testing/_index.md
+++ b/content/en/synthetics/mobile_app_testing/_index.md
@@ -173,30 +173,7 @@ If you are using the [custom role feature][9], add your user to any custom role 
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][10] to limit who has access to your test based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/settings/grace_2.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View test configuration | Edit test configuration | View test results | Run test  |
-| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
-| No access    |                         |                         |                   |           |
-| Viewer       | {{< X >}}               |                         | {{< X >}}         |           |
-| Editor       | {{< X >}}               | {{< X >}}               | {{< X >}}         | {{< X >}} |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further reading
 
@@ -211,7 +188,6 @@ To do so:
 [7]: /synthetics/guide/synthetic-test-monitors/
 [8]: /account_management/rbac/?tab=datadogapplication#datadog-default-roles
 [9]: /account_management/rbac/?tab=datadogapplication#custom-roles
-[10]: /account_management/rbac/granular_access
 [11]: /mobile_app_testing/mobile_app_tests/steps/
 [12]: https://app.datadoghq.com/synthetics/mobile/create
 [13]: /continuous_testing/cicd_integrations/configuration?tab=npm#test-files

--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -876,30 +876,7 @@ If you are using the [custom role feature][21], add your user to a custom role t
 
 ## Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][24] to limit who has access to your private location based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/private_locations/grace.png" alt="Set permissions for your private location" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View PL instructions | View PL metrics | Use PL in test | Edit PL configuration  |
-| ------------ | ---------------------| --------------- | -------------- | ---------------------- |
-| No access    |                      |                 |                |                        |
-| Viewer       | {{< X >}}            | {{< X >}}       | {{< X >}}      |                        |
-| Editor       | {{< X >}}            | {{< X >}}       | {{< X >}}      | {{< X >}}              |
-
-<div class="alert alert-info"><strong>Note</strong>: You will be able to see results from Private Location even if you don't have Viewer access to that Private Location.</div>
+{{% synthetics_grace_permissions %}}
 
 ## Further Reading
 
@@ -925,4 +902,3 @@ To do so:
 [21]: /account_management/rbac#custom-roles
 [22]: https://app.datadoghq.com/synthetics/settings/private-locations
 [23]: /continuous_testing/cicd_integrations/configuration
-[24]: /account_management/rbac/granular_access

--- a/content/en/synthetics/platform/settings/_index.md
+++ b/content/en/synthetics/platform/settings/_index.md
@@ -278,28 +278,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 
 ### Restrict access
 
-{{< img src="synthetics/settings/grace_1.png" alt="Set permissions for your test" style="width:70%;" >}}
-
-Use [granular access control][22] to limit who has access to your global variable based on roles, teams, or individual users.
-
-To do so:
-
-1. Open the permissions section of the form
-2. Click on `edit access`
-
-{{< img src="synthetics/gv_grace.png" alt="Set permissions for your global variable" style="width:70%;" >}}
-
-3. Click on `restrict access`
-4. Select teams, roles, or users
-5. Click `add`
-6. Select the level of access you want to associate with each of them
-7. Click on done
-
-| Access level | View GV value | View GV metadata | Use GV in test | Edit GV value/metadata  |
-| ------------ | --------------| ---------------- | -------------- | ----------------------- |
-| No access    |               |                  |                |                         |
-| Viewer       | {{< X >}}     | {{< X >}}        | {{< X >}}      |                         |
-| Editor       | {{< X >}}     | {{< X >}}        | {{< X >}}      | {{< X >}}               |
+{{% synthetics_grace_permissions %}}
 
 ## Integration settings
 
@@ -348,4 +327,3 @@ For more information, see [Explore RUM & Session Replay][14].
 [19]: /synthetics/mobile_app_testing/#use-global-variables
 [20]: https://app.datadoghq.com/synthetics/settings/default
 [21]: https://app.datadoghq.com/monitors/settings/policies
-[22]: /account_management/rbac/granular_access

--- a/layouts/shortcodes/synthetics_grace_permissions.md
+++ b/layouts/shortcodes/synthetics_grace_permissions.md
@@ -1,0 +1,27 @@
+Use [granular access control][12] to limit who has access to your test based on roles, teams, or individual users:
+
+1. Open the permissions section of the form.
+2. Click **Edit Access**.
+<figure class="text-center">
+<img src="{{ .Site.Params.img_url}}images/synthetics/settings/grace_2.png" alt="Set permissions for your test from Private Locations configuration form" width="80%">
+</figure>
+
+3. Click **Restrict Access**.
+4. Select teams, roles, or users.
+<figure class="text-center">
+<img src="{{ .Site.Params.img_url}}images/synthetics/settings/grace_1.png" alt="Set permissions for your test from Private Locations configuration form" width="80%">
+</figure>
+
+5. Click **Add**.
+6. Select the level of access you want to associate with each of them.
+7. Click **Done**.
+
+<div class="alert alert-info"><strong>Note</strong>: You can view results from a Private Location even without Viewer access to that Private Location.</div>
+
+| Access level | View test configuration | Edit test configuration | View test results | Run test  |
+| ------------ | ----------------------- | ----------------------- | ------------------| --------- |
+| No access    |                         |                         |                   |           |
+| Viewer       | Yes                     |                         | Yes               |           |
+| Editor       | Yes                     | Yes                     | Yes               | Yes       |
+
+[12]: /account_management/rbac/granular_access


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Editorial review for permissions content from https://github.com/DataDog/documentation/pull/26847
- Move synthetics permissions content to reuse shortcode

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
