### PR TITLE
[DOCS-9753] adding Windows support for Network Path

### DIFF
--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -23,8 +23,7 @@ Setting up Network Path involves configuring your Linux environment to monitor a
 
 ## Prerequisites
 
-- Agent version `7.59` or higher is required.
-- [CNM][1] must be enabled.
+[CNM][1] must be enabled.
 
 **Note**: If your network configuration restricts outbound traffic, follow the setup instructions on the [Agent proxy configuration][2] documentation.
 
@@ -34,6 +33,8 @@ Setting up Network Path involves configuring your Linux environment to monitor a
 
 {{< tabs >}}
 {{% tab "Linux" %}}
+
+Agent `v7.59+` is required.
 
 Manually configure individual paths by specifying the exact endpoint you want to test. This allows you to target specific network routes for monitoring.
 
@@ -134,6 +135,8 @@ Manually configure individual paths by specifying the exact endpoint you want to
 {{% /tab %}}
 {{% tab "Windows" %}}
 
+Agent `v7.61+` is required.
+
 **Note**: Windows only supports TCP traceroutes.
 
 In Windows environments, the Agent uses UDP by default to monitor individual paths. If the protocol is not specified in the configuration, the Agent attempts a UDP traceroute, and any errors are logged. To work around this, ensure the protocol is set to TCP in the following example:
@@ -153,6 +156,8 @@ instances:
 
 {{< tabs >}}
 {{% tab "Linux" %}}
+
+Agent `v7.59+` is required.
 
 **Note**: Network traffic paths is experimental and is not yet stable. Do not deploy network traffic paths widely in a production environment.
 
@@ -200,6 +205,8 @@ Configure network traffic paths to allow the Agent to automatically discover and
 
 {{% /tab %}}
 {{% tab "Windows" %}}
+
+Agent `v7.61+` is required.
 
 For network traffic paths on Windows environments, only detected TCP connections are shown.
 

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -32,6 +32,9 @@ Setting up Network Path involves configuring your Linux environment to monitor a
 
 ### Monitor individual paths
 
+{{< tabs >}}
+{{% tab "Linux" %}}
+
 Manually configure individual paths by specifying the exact endpoint you want to test. This allows you to target specific network routes for monitoring.
 
 1. Enable the `system-probe` traceroute module in `/etc/datadog-agent/system-probe.yaml` by adding the following:
@@ -126,7 +129,30 @@ Manually configure individual paths by specifying the exact endpoint you want to
 
 3. Restart the Agent after making these configuration changes to start seeing network paths.
 
+[4]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+**Note**: Windows only supports TCP traceroutes.
+
+In Windows environments, the Agent uses UDP by default to monitor individual paths. If the protocol is not specified in the configuration, the Agent attempts a UDP traceroute, and any errors are logged. To work around this, ensure the protocol is set to TCP in the following example:
+
+```yaml
+init_config:
+  min_collection_interval: 60 # in seconds, default 60 seconds
+instances:
+  - hostname: api.datadoghq.eu # endpoint hostname or IP
+    protocol: TCP
+    port: 443 # optional port number, default is 80
+```
+{{% /tab %}}
+{{< /tabs >}}
+
 ### Network traffic paths (experimental)
+
+{{< tabs >}}
+{{% tab "Linux" %}}
 
 **Note**: Network traffic paths is experimental and is not yet stable. Do not deploy network traffic paths widely in a production environment.
 
@@ -170,7 +196,15 @@ Configure network traffic paths to allow the Agent to automatically discover and
 
 3. Restart the Agent after making these configuration changes to start seeing network paths.
 
-**Note**: Network path is only supported for Linux environments.
+[3]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L1697
+
+{{% /tab %}}
+{{% tab "Windows" %}}
+
+For network traffic paths on Windows environments, only detected TCP connections are shown.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Further Reading
 
@@ -178,5 +212,5 @@ Configure network traffic paths to allow the Agent to automatically discover and
 
 [1]: /network_monitoring/cloud_network_monitoring/setup/
 [2]: https://docs.datadoghq.com/agent/configuration/proxy/?tab=linux
-[3]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L1645
-[4]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
+
+


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds Windows Support for Network path (Agent v7.61)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
