### PR TITLE
[Bugfix] Defer tooltip script loading until after HTML is parsed

### DIFF
--- a/layouts/partials/footer-scripts.html
+++ b/layouts/partials/footer-scripts.html
@@ -61,4 +61,4 @@ hugo defaults to environment development with hugo server
 {{- if $isProd -}}
   {{- $tooltipJs = $tooltipJs | fingerprint "sha512" -}}
 {{- end -}}
-<script type="text/javascript" src="{{ $tooltipJs.Permalink }}" {{ if $isProd }} integrity="{{ $tooltipJs.Data.Integrity }}" {{ end }}></script>
+<script defer type="text/javascript" src="{{ $tooltipJs.Permalink }}" {{ if $isProd }} integrity="{{ $tooltipJs.Data.Integrity }}" {{ end }}></script>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- The tooltip functionality wasn't initializing on first page load in Chrome.
- After refreshing the page, it works as expected.
- This only started happening recently in Chrome.
- Added `defer` to script initialization in footer-scripts.html to make sure the HTML is parsed before the script runs.

### Test instructions
1. Go to a page using a tooltip.
2. Make sure it displays on hover immediately.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
