### PR TITLE
Datadog OTLP Logs Intake Endpoint: Hide Config Content for Unsupported Sites

### DIFF
--- a/content/en/opentelemetry/otlp_logs.md
+++ b/content/en/opentelemetry/otlp_logs.md
@@ -1,6 +1,5 @@
 ---
 title: Datadog OTLP Logs Intake Endpoint
-private: true
 further_reading:
   - link: "https://opentelemetry.io/docs/concepts/sdk-configuration/general-sdk-configuration/"
     tag: "External Site"
@@ -22,6 +21,9 @@ further_reading:
 Datadog's OpenTelemetry Protocol (OTLP) logs intake API endpoint allows you to send logs directly to Datadog. With this feature, you don't need to run the [Datadog Agent][2] or [OpenTelemetry Collector + Datadog Exporter][1].
 
 Choose this option for a straightforward setup to send logs directly to Datadog without using the Datadog Agent or OpenTelemetry Collector.
+
+{{< site-region region="us,us3,us5,eu" >}}
+
 
 ## Configuration
 
@@ -113,6 +115,8 @@ If you receive a `403 Forbidden` error when sending logs to the Datadog OTLP log
 
 - The endpoint URL is incorrect for your organization.  
    **Solution**: Use the correct endpoint URL for your organization. Your site is {{< region-param key=dd_datacenter code="true" >}}, so you need to use the {{< region-param key="otlp_logs_endpoint" code="true" >}} endpoint.
+   
+{{< /site-region >}}
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Content is undefined for AP1 and Gov endpoints.
- This is because the site unsupported.
- To fix this, I'm wrapping all of the config content to prevent it from displaying at all for unsupported sites.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
