### PR TITLE
[Q4 Docs Hackathon] Add Tooltip Entries to VSCode Snippets

### DIFF
--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -286,5 +286,12 @@
 				"{{% /collapse-content %}}"
 			],
 			"description": "Collapse and expand content"
-	}	
+	},
+	"Tooltip": {
+			"prefix": ";;tooltip",
+			"body": [
+				"{{< tooltip ${1|text,glossary|}}=\"${2:term}\" ${3|tooltip=\"Additional information here\",case=\"title\"|} >}}"
+			],
+			"description": "Add interactive, informative tooltips to terms or phrases with support for custom content and glossary terms. Options: text/tooltip for custom content, glossary/case for glossary terms (case options: title, lower, upper, sentence)"
+	}
 }

--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -281,17 +281,24 @@
 	"Collapse": {
 			"prefix": ";;collapse",
 			"body": [
-				"{{% collapse-content title=\"Datadog Operator\" level=\"h4\" %}}",
+				"{{% collapse-content title=\"${1:title}\" level=\"${2|h1,h2,h3,h4,h5,p|}\" %}}",
 				"...",
 				"{{% /collapse-content %}}"
 			],
 			"description": "Collapse and expand content"
 	},
-	"Tooltip": {
-			"prefix": ";;tooltip",
+	"Tooltip (Custom)": {
+			"prefix": ";;tooltip-custom",
 			"body": [
-				"{{< tooltip ${1|text,glossary|}}=\"${2:term}\" ${3|tooltip=\"Additional information here\",case=\"title\"|} >}}"
+				"{{< tooltip text=\"${1:term}\" tooltip=\"${2:Additional information here}\" case=${3|title,lower,upper,sentence|} >}}"
 			],
-			"description": "Add interactive, informative tooltips to terms or phrases with support for custom content and glossary terms. Options: text/tooltip for custom content, glossary/case for glossary terms (case options: title, lower, upper, sentence)"
+			"description": "Add interactive tooltips to terms or phrases. `text` is the term or phrase to be highlighted; `tooltip` is displayed on hover."
+	},
+	"Tooltip (Glossary)": {
+			"prefix": ";;tooltip-glossary",
+			"body": [
+				"{{< tooltip glossary=\"${2:term}\" case=${4|title,lower,upper,sentence|} >}}"
+			],
+			"description": "Add interactive tooltips to terms or phrases. `glossary` must match the filename of a glossary entry."
 	}
 }

--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -281,8 +281,8 @@
 	"Collapse": {
 			"prefix": ";;collapse",
 			"body": [
-				"{{% collapse-content title=\"${1:title}\" level=\"${2|h4,h1,h2,h3,h5,p|}\" %}}",
-				"${3:...}",
+				"{{% collapse-content title=\"${1:title}\" level=\"${2|h4,h1,h2,h3,h5,p|}\" expanded=\"${3|false,true|}\" %}}",
+				"${4:...}",
 				"{{% /collapse-content %}}"
 			],
 			"description": "Collapse and expand content"

--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -281,8 +281,8 @@
 	"Collapse": {
 			"prefix": ";;collapse",
 			"body": [
-				"{{% collapse-content title=\"${1:title}\" level=\"${2|h1,h2,h3,h4,h5,p|}\" %}}",
-				"...",
+				"{{% collapse-content title=\"${1:title}\" level=\"${2|h4,h1,h2,h3,h5,p|}\" %}}",
+				"${3:...}",
 				"{{% /collapse-content %}}"
 			],
 			"description": "Collapse and expand content"
@@ -290,14 +290,14 @@
 	"Tooltip (Custom)": {
 			"prefix": ";;tooltip-custom",
 			"body": [
-				"{{< tooltip text=\"${1:term}\" tooltip=\"${2:Additional information here}\" case=${3|title,lower,upper,sentence|} >}}"
+				"{{< tooltip text=\"${1:term}\" tooltip=\"${2:Additional information here}\" case=\"${3|title,lower,upper,sentence|}\" >}}"
 			],
 			"description": "Add interactive tooltips to terms or phrases. `text` is the term or phrase to be highlighted; `tooltip` is displayed on hover."
 	},
 	"Tooltip (Glossary)": {
 			"prefix": ";;tooltip-glossary",
 			"body": [
-				"{{< tooltip glossary=\"${2:term}\" case=${4|title,lower,upper,sentence|} >}}"
+				"{{< tooltip glossary=\"${2:term}\" case=\"${4|title,lower,upper,sentence|}\" >}}"
 			],
 			"description": "Add interactive tooltips to terms or phrases. `glossary` must match the filename of a glossary entry."
 	}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Tooltips missing from our snippets.
- Added choices to collapse-content entry.
- Added new expanded option to collapse-content.

To test this, you would have to pull down the branch locally and try to add the snippets to a markdown file with `;;tooltip...`.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
