### PR TITLE
:memo: Adds explanation on restricted variable behavior

### DIFF
--- a/content/en/synthetics/platform/settings/_index.md
+++ b/content/en/synthetics/platform/settings/_index.md
@@ -280,7 +280,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 
 Access restriction is available for customers using [custom roles][11] on their accounts. If you are using the [custom role feature][12], add your user to any custom role that includes `synthetics_global_variable_read` and `synthetics_global_variable_write` permissions. 
 
-You can restrict access to a global variable based on the roles in your organization. When creating a global variable, choose which roles (in addition to your user) can read and write your global variable in **Permissions settings**. 
+You can restrict access to a global variable based on the roles in your organization. When creating a global variable, choose which roles (in addition to your user) can read and write your global variable in **Permissions settings**. Restricting a variable prevents other users to add it in a test and use it, but they will still be able to see the variable name if it was added in a test by an authorized user. 
 
 {{< img src="synthetics/settings/restrict_access_1.png" alt="Restrict access to a global variable" style="width:100%;" >}}
 

--- a/content/en/synthetics/platform/settings/_index.md
+++ b/content/en/synthetics/platform/settings/_index.md
@@ -280,7 +280,7 @@ If you are using the [custom role feature][12], add your user to any custom role
 
 Access restriction is available for customers using [custom roles][11] on their accounts. If you are using the [custom role feature][12], add your user to any custom role that includes `synthetics_global_variable_read` and `synthetics_global_variable_write` permissions. 
 
-You can restrict access to a global variable based on the roles in your organization. When creating a global variable, choose which roles (in addition to your user) can read and write your global variable in **Permissions settings**. Restricting a variable prevents other users to add it in a test and use it, but they will still be able to see the variable name if it was added in a test by an authorized user. 
+You can restrict access to a global variable based on the roles in your organization. When creating a global variable, choose which roles (in addition to your user) can read and write your global variable in **Permissions settings**. Restricting a variable prevents other users from adding it to a test and using it, but they are still able to see the variable name if it was added to a test by an authorized user. 
 
 {{< img src="synthetics/settings/restrict_access_1.png" alt="Restrict access to a global variable" style="width:100%;" >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Remediation for [VULN-7734](https://datadoghq.atlassian.net/browse/VULN-7734)

Synthetics global variable have their own restriction controls, but the behavior on the test results and test recorder changes depending if the variable was already being used or not.

Recorder behavior:
Removing access to a global variable already used in a test will **still** display it in the variables list and steps. Changing this behavior could lead to confusion on steps missing critical info to be properly displayed. The variable value remain unnacessible. 

Results behavior:
Removing access to a global variable already used in a test will **still** display it in the test results and screenshots in case the value is being used as plain text. Removing access to the test and result in question can lead to users being locked out of tests after a permission change. We already identified [100+ orgs](https://app.datadoghq.com/dashboard/6ch-jvv-hrr/track-tests-with-forbidden-gvs?fromUser=false&refresh_mode=sliding&from_ts=1733059009392&to_ts=1735651009392&live=true) that could be impacted by this change.

### Merge instructions

Merge readiness:
- [X] Ready for merge




[VULN-7734]: https://datadoghq.atlassian.net/browse/VULN-7734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ