### PR TITLE
update docs regarding network source

### DIFF
--- a/content/en/error_tracking/frontend/browser.md
+++ b/content/en/error_tracking/frontend/browser.md
@@ -17,7 +17,7 @@ further_reading:
 
 ## Overview
 
-[Error Tracking][4] processes errors collected from the browser by the Browser SDK. Whenever a [source][1], [custom][2], or [report][3] error containing a stack trace is collected, Error Tracking processes and groups it under an issue, or group of similar errors. 
+[Error Tracking][4] processes errors collected from the browser by the Browser SDK. Whenever a [source][1], [custom][2], [report][3], or [console][3] error containing a stack trace is collected, Error Tracking processes and groups it under an issue, or group of similar errors.
 
 ## Setup
 
@@ -29,9 +29,9 @@ If you have not set up the Browser SDK yet, follow the [in-app setup instruction
 
 ## Link errors with your source code
 
-In addition to sending source maps, the [Datadog CLI][10] reports Git information such as the commit hash, repository URL, and a list of tracked file paths in the code repository. 
+In addition to sending source maps, the [Datadog CLI][10] reports Git information such as the commit hash, repository URL, and a list of tracked file paths in the code repository.
 
-Error Tracking can use this information to correlate errors with your source code, allowing you to pivot from any stack trace frame to the related line of code in [GitHub][11], [GitLab][12] and [Bitbucket][13]. 
+Error Tracking can use this information to correlate errors with your source code, allowing you to pivot from any stack trace frame to the related line of code in [GitHub][11], [GitLab][12] and [Bitbucket][13].
 
 <div class="alert alert-info">Linking from stack frames to source code is supported in the <a href="https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command">Datadog CLI</a> version <code>0.12.0</code> version and later.</div>
 

--- a/content/en/error_tracking/troubleshooting.md
+++ b/content/en/error_tracking/troubleshooting.md
@@ -66,7 +66,7 @@ current_root_span.set_tag('<TAG>', '<VALUE>') unless current_root_span.nil?
 
 ### RUM
 
-Error Tracking only processes errors that are sent with the source set to `custom`, `source`, `report`, `network` or `console`, and contain a stack trace.
+Error Tracking only processes errors that are sent with the source set to `custom`, `source`, `report`, or `console`, and contain a stack trace. Errors sent with any other source (such as `network`) or sent from browser extensions are not processed by Error Tracking.
 
 This [example query][6] shows RUM errors that meet the criteria for inclusion in Error Tracking.
 

--- a/content/en/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/en/real_user_monitoring/browser/collecting_browser_errors.md
@@ -57,7 +57,7 @@ addError(
 );
 {{< /code-block >}}
 
-**Note**: [Error Tracking][4] processes errors that are sent with the source set to `custom`, `source`, `report`, `network` or `console`, and contain a stack trace
+**Note**: [Error Tracking][4] processes errors that are sent with the source set to `custom`, `source`, `report`, `network` or `console`, and contain a stack trace. Errors sent with any other source (such as `network`) or sent from browser extensions are not processed by Error Tracking.
 
 {{< tabs >}}
 {{% tab "NPM" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

There was a mixup and network errors should've never be taken into account by error tracking. Updating the docs to reflect the fix.

### Merge instructions

Can be merged anytime

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
