### PR TITLE
fix integration carousel bugs

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,7 +3,7 @@
   data-env="{{.Site.Params.environment}}" data-commit-ref="{{ .Site.Params.branch }}" style="opacity:0"
   class="{{ if or $.Site.Params.announcement_banner.link $.Site.Params.announcement_banner.desktop_message }}banner announcement{{ end }}">
 
-<head>  
+<head>
   {{ partialCached "header-scripts.html" . }}
 
   <meta charset="utf-8">
@@ -80,7 +80,9 @@
 
 
   <!--- integrations carousel modal --->
-  {{ if and (in .Params.custom_kind "integration") (.Params.tile) (.Params.tile.media | len) }}
+  {{ $dir := "" }}
+  {{ with .File }}{{ $dir = .Dir }}{{ end }}
+  {{ if and (eq $dir "integrations/") (.Params.tile) (.Params.tile.media | len) }}
   {{ partial "integrations-carousel/integrations-carousel-modal.html" . }}
   {{ end }}
 </body>

--- a/layouts/integrations/single.html
+++ b/layouts/integrations/single.html
@@ -11,8 +11,9 @@
     </div>
 
     {{ partial "integration-labels/integration-labels.html" . }}
-    
-    {{ if and (in .Params.custom_kind "integration") ($media | len) }}
+    {{ $dir := "" }}
+    {{ with .File }}{{ $dir = .Dir }}{{ end }}
+    {{ if and (eq $dir "integrations/") ($media | len) }}
         {{ partial "integrations-carousel/integrations-carousel.html" (dict "context" . "media" $media) }}
     {{ end }}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Helps with custom_kind translations causing carousel to not appear.
https://datadoghq.atlassian.net/browse/DOCS-9768

Similar changes to https://github.com/DataDog/documentation/pull/26387

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes

https://docs.datadoghq.com/ja/integrations/mongodb_atlas/

vs

https://docs-staging.datadoghq.com/david.jones/custom-kind-carousel/ja/integrations/mongodb_atlas/

Also test random integrations images at top still appear https://docs-staging.datadoghq.com/david.jones/custom-kind-carousel/integrations/
