### PR TITLE
[DOCS-9806] Update SNMP Trap docs

### DIFF
--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -5,6 +5,9 @@ further_reading:
   - link: "https://www.datadoghq.com/blog/diagnose-network-performance-with-snmp-trap-monitoring/"
     tag: "Blog"
     text: "Monitor and diagnose network performance issues with SNMP Traps"
+  - link: "/network_monitoring/devices/troubleshooting"
+    tag: "Documentation"
+    text: "NDM Troubleshooting"
 ---
 
 ## Overview
@@ -54,6 +57,32 @@ Datadog Agent v7.37+ supports listening for SNMP Traps, enabling you to set up [
   {{< img src="network_device_monitoring/snmp/snmp_logs_2.png" alt="Log Explorer showing `source:snmp-traps` with an SNMP Trap log line selected, highlighting the Network Device tag" style="width:90%" >}}
 
 **Note**: Even though SNMP traps are _forwarded as logs_, `logs_enabled` does **not** need to be set to `true`.
+
+### Using the default SNMP Trap port 162
+
+Binding to a port number under 1024 requires elevated permissions To bind to a port number such as the default SNMP Trap port 162, do the following:
+
+1. Grant access to the port using the setcap command:
+
+   ```
+   sudo setcap CAP_NET_BIND_SERVICE=+ep /opt/datadog-agent/bin/agent/agent
+   ```
+
+   **Note**: Re-run this setcap command every time you upgrade the Agent.
+
+2. Verify the setup is correect by running the getcap command:
+
+   ```
+   sudo getcap /opt/datadog-agent/bin/agent/agent
+   ```
+
+   You should see the following output:
+
+   ```
+   /opt/datadog-agent/bin/agent/agent = cap_net_bind_service+ep
+   ```
+
+3. [Restart the Agent][6].
 
 ## Device namespaces
 
@@ -136,11 +165,13 @@ If your MIBs have dependencies, `ddev` fetches them online if they can be found.
 
 If there are errors due to missing dependencies and you have access to the missing MIB files, put the files in a separate folder and use the `--mib-sources <DIR>` parameter so that ddev knows where to find them. Make sure that each filename is the same as the MIB name (for example, `SNMPv2-SMI` and not `snmp_v2_smi.txt`).
 
+## Further Reading
 
-
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /monitors/
 [2]: https://app.datadoghq.com/logs
 [3]: /network_monitoring/devices
 [4]: /developers/integrations/python
 [5]: https://pypi.org/project/pysmi/
+[6]: /agent/configuration/agent-commands/#start-stop-and-restart-the-agent

--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -60,7 +60,7 @@ Datadog Agent v7.37+ supports listening for SNMP Traps, enabling you to set up [
 
 ### Using the default SNMP Trap port 162
 
-Binding to a port number under 1024 requires elevated permissions To bind to a port number such as the default SNMP Trap port 162, do the following:
+Binding to a port number under 1024 requires elevated permissions. To bind to a port number such as the default SNMP Trap port 162, do the following:
 
 1. Grant access to the port using the setcap command:
 
@@ -70,7 +70,7 @@ Binding to a port number under 1024 requires elevated permissions To bind to a p
 
    **Note**: Re-run this setcap command every time you upgrade the Agent.
 
-2. Verify the setup is correect by running the getcap command:
+2. Verify the setup is correct by running the getcap command:
 
    ```
    sudo getcap /opt/datadog-agent/bin/agent/agent

--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -62,7 +62,7 @@ Datadog Agent v7.37+ supports listening for SNMP Traps, enabling you to set up [
 
 Binding to a port number under 1024 requires elevated permissions. To bind to a port number such as the default SNMP Trap port 162, do the following:
 
-1. Grant access to the port using the setcap command:
+1. Grant access to the port using the `setcap` command:
 
    ```
    sudo setcap CAP_NET_BIND_SERVICE=+ep /opt/datadog-agent/bin/agent/agent
@@ -70,7 +70,7 @@ Binding to a port number under 1024 requires elevated permissions. To bind to a 
 
    **Note**: Re-run this setcap command every time you upgrade the Agent.
 
-2. Verify the setup is correct by running the getcap command:
+2. Verify the setup is correct by running the `getcap` command:
 
    ```
    sudo getcap /opt/datadog-agent/bin/agent/agent

--- a/content/en/network_monitoring/devices/troubleshooting.md
+++ b/content/en/network_monitoring/devices/troubleshooting.md
@@ -89,6 +89,10 @@ If either the SNMP status or Agent walk shows an error, it could indicate one of
       ```
    3. Ensure your community string matches.
 
+#### Permission denied
+
+If you see a permission denied error while port binding in agent logs, the port number you've indicated may require elevated permissions. To bind to a port number under 1024, see [Using the default SNMP Trap port 162][8].
+
 #### Incorrect SNMPv2 credentials
 
    **Error**:
@@ -195,3 +199,4 @@ If either the SNMP status or Agent walk shows an error, it could indicate one of
 [5]: /api/latest/network-device-monitoring/#get-the-list-of-interfaces-of-the-device
 [6]: /api/latest/network-device-monitoring/#get-the-list-of-tags-for-a-device
 [7]: /api/latest/network-device-monitoring/#update-the-tags-for-a-device
+[8]: /network_monitoring/devices/snmp_traps/#using-the-default-snmp-trap-port-162

--- a/content/en/network_monitoring/devices/troubleshooting.md
+++ b/content/en/network_monitoring/devices/troubleshooting.md
@@ -65,6 +65,10 @@ The output should look similar to the following:
 
 If either the SNMP status or Agent walk shows an error, it could indicate one of the following issues:
 
+#### Permission denied
+
+If you see a permission denied error while port binding in agent logs, the port number you've indicated may require elevated permissions. To bind to a port number under 1024, see [Using the default SNMP Trap port 162][8].
+
 #### Unreachable or misconfigured device:
 
    **Error**:
@@ -88,10 +92,6 @@ If either the SNMP status or Agent walk shows an error, it could indicate one of
       DROP       all  --  anywhere             10.4.5.6
       ```
    3. Ensure your community string matches.
-
-#### Permission denied
-
-If you see a permission denied error while port binding in agent logs, the port number you've indicated may require elevated permissions. To bind to a port number under 1024, see [Using the default SNMP Trap port 162][8].
 
 #### Incorrect SNMPv2 credentials
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds instructions on how to setup a port number under 1024
- Links to the instructions on the troubleshooting page
- Adds a Further Reading partial that was missing from the SNMP Traps page

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
