### PR TITLE
[Shared Dash] Replace "domain" with "base url"

### DIFF
--- a/content/en/dashboards/sharing/shared_dashboards.md
+++ b/content/en/dashboards/sharing/shared_dashboards.md
@@ -88,13 +88,13 @@ By default, public dashboards are accessible for one year before they expire and
 
 ## Embedded shared dashboards
 
-You can add embedded shared dashboards to a website with an iframe. These embedded shared dashboards are only accessible by the configured website domains. To share an embedded dashboard:
+You can add embedded shared dashboards to a website with an iframe. Embedded shared dashboards can only be accessed through the allowlisted website base URLs. To share an embedded dashboard:
 
 1. Click **Share** in the upper-right corner of the dashboard.
 2. Select **Share Dashboard**.
 3. Select the **Embed** option in the **Select a Share Type** step.
 4. Configure the desired time, variable, and color options in the **Configure Dashboard** step.
-5. Add the website domains that you want to allowlist as embeddable domains.
+5. Add the website base URLs that you want to allowlist.
 6. Click **Share Dashboard** to create the share URL.
 
 ## Configuration Options


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR updates the documentation on Embedded Shared Dashboards to be more accurate by replacing "domain" with "base URL"

Embedded shared dashboards is a newly launched feature that allows you to allowlist websites that you can embed a dashboard in. We've had some confused customers because they were not sure what exactly to put in the allowlist. The docs currently say the allowlist is a "domain" allowlist (ex: `google.com`), but it is actually implemented as a base URL allowlist: (ex: `https://google.com`).

Example:
If your website URL is "https://datadoghq.atlassian.net/wiki/spaces/x", you should put "https://datadoghq.atlassian.net" in the allowlist.

### Merge instructions

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```