### PR TITLE
Add instructions for viewing usage pills

### DIFF
--- a/content/en/account_management/plan_and_usage/usage_details.md
+++ b/content/en/account_management/plan_and_usage/usage_details.md
@@ -90,11 +90,11 @@ Time selection contains options to view usage graphs at daily, weekly, monthly o
 
 <div class="alert alert-warning">This feature is in beta. To request access and confirm your organization meets the feature criteria, contact your account representative or <a href="https://docs.datadoghq.com/help/">Customer Support</a>.</div>
 
-To display the committed and allotted pills, ensure the `See included usage` toggle is on:
-1. On the Total Usage card where you want to see committed and allotted usage data, click the eye (`See included usage`) icon.
-1. The icon changes to an eye with a slash through it. Committed and allotted pills populate on the card.
-
 Purple on-demand pills highlight the portion of billable usage that is on-demand usage. Blue committed and allotted pills highlight the portion of your usage that is covered by commitments and <a href="https://www.datadoghq.com/pricing/allotments/">allotments</a> from parent products. The dashed `Committed` line shows commitments per product, without any allotments (such as Custom Metrics or Containers).
+
+To display the committed and allotted pills on a card, ensure the **See included usage** toggle is on:
+1. On the total usage card where you want to see committed and allotted usage data, click the eye (**See included usage**) icon.
+1. The icon changes to an eye with a slash through it. Committed and allotted pills populate on the card.
 
 {{< img src="account_management/billing/UsageTilesWithPillsUsageTrendsWithCommittedLine.png" alt="Billable on-demand pills and committed usage lines on trends graphs." style="width:100%; align:left" >}}
 

--- a/content/en/account_management/plan_and_usage/usage_details.md
+++ b/content/en/account_management/plan_and_usage/usage_details.md
@@ -90,6 +90,10 @@ Time selection contains options to view usage graphs at daily, weekly, monthly o
 
 <div class="alert alert-warning">This feature is in beta. To request access and confirm your organization meets the feature criteria, contact your account representative or <a href="https://docs.datadoghq.com/help/">Customer Support</a>.</div>
 
+To display the committed and allotted pills, ensure the `See included usage` toggle is on:
+1. On the Total Usage card where you want to see committed and allotted usage data, click the eye (`See included usage`) icon.
+1. The icon changes to an eye with a slash through it. Committed and allotted pills populate on the card.
+
 Purple on-demand pills highlight the portion of billable usage that is on-demand usage. Blue committed and allotted pills highlight the portion of your usage that is covered by commitments and <a href="https://www.datadoghq.com/pricing/allotments/">allotments</a> from parent products. The dashed `Committed` line shows commitments per product, without any allotments (such as Custom Metrics or Containers).
 
 {{< img src="account_management/billing/UsageTilesWithPillsUsageTrendsWithCommittedLine.png" alt="Billable on-demand pills and committed usage lines on trends graphs." style="width:100%; align:left" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add instructions for enabling allotted and committed pills in total usage cards.
Requested by a support engineer on https://datadoghq.atlassian.net/browse/DOCS-9571

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
