### PR TITLE
[CIVIS] Better explain billing exclusions for CI Visiblity

### DIFF
--- a/content/en/account_management/billing/ci_visibility.md
+++ b/content/en/account_management/billing/ci_visibility.md
@@ -23,7 +23,7 @@ This guide provides a non-exhaustive list of billing considerations for [CI Visi
 
 A committer is an active Git contributor, identified by their Git author email address. For billing purposes, a committer is included if they make at least three commits in a given month.
 
-## Charges for bot or no-reply committers with GitHub.com email addresses
+## Charges for bot or actions in the GitHub UI
 
 Datadog does not charge for bot or actions made in the GitHub UI. These types of committers are excluded from billing calculations.
 

--- a/content/en/account_management/billing/ci_visibility.md
+++ b/content/en/account_management/billing/ci_visibility.md
@@ -25,7 +25,7 @@ A committer is an active Git contributor, identified by their Git author email a
 
 ## Charges for bot or actions in the GitHub UI
 
-Datadog does not charge for bot or actions made in the GitHub UI. These types of committers are excluded from billing calculations.
+Datadog does not charge for bot or commits resulting from actions made in the GitHub UI. These types of commits are excluded from billing calculations.
 
 ## Excluding commits from specific people
 

--- a/content/en/account_management/billing/ci_visibility.md
+++ b/content/en/account_management/billing/ci_visibility.md
@@ -23,7 +23,7 @@ This guide provides a non-exhaustive list of billing considerations for [CI Visi
 
 A committer is an active Git contributor, identified by their Git author email address. For billing purposes, a committer is included if they make at least three commits in a given month.
 
-## Charges for bot or actions in the GitHub UI
+## Charges for commits made by bots or actions performed in the GitHub UI
 
 Datadog does not charge for bot or commits resulting from actions made in the GitHub UI. These types of commits are excluded from billing calculations.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The documentation page is not clear about what CI Visibility excludes from billing: commits from bots and made from the GitHub UI are not billed, however if the noreply email is set as the author and committer of the user, the commit gets billed. This PR fixes that.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
