### PR TITLE
Fix broken endpoint param

### DIFF
--- a/content/en/opentelemetry/otlp_logs.md
+++ b/content/en/opentelemetry/otlp_logs.md
@@ -37,7 +37,7 @@ If you are using [OpenTelemetry automatic instrumentation][3], set the following
 
 ```shell
 export OTEL_EXPORTER_OTLP_LOGS_PROTOCOL="http/protobuf"
-export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="{{< region-param key="otlp_logs_endpoint" >}}"
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="${YOUR_ENDPOINT}" // Replace this with the correct endpoint
 export OTEL_EXPORTER_OTLP_LOGS_HEADERS="dd-protocol=otlp,dd-api-key=${DD_API_KEY}"
 ```
 
@@ -91,7 +91,7 @@ Configure your `config.yaml` like this:
 ```yaml
 exporters:
   otlphttp:
-    logs_endpoint: {{< region-param key="otlp_logs_endpoint" >}}
+    logs_endpoint: ${YOUR_ENDPOINT} // Replace this with the correct endpoint
     headers:
       dd-protocol: "otlp"
       dd-api-key: ${env:DD_API_KEY}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adding `site-region` around the content broke our dynamic endpoint placeholders inside code blocks.
- This PR swaps out the dynamic value to be a placeholder, ${YOUR_ENDPOINT}.
- This should be replaced with the endpoint listed in the Configuration alert.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
