### PR TITLE
[error-tracking] Remove entry span fingerprinting limitation

### DIFF
--- a/content/en/error_tracking/troubleshooting.md
+++ b/content/en/error_tracking/troubleshooting.md
@@ -43,6 +43,6 @@ Spans associated with the error need to be retained with a custom retention filt
 [1]: /help/
 [2]: /logs/error_tracking/backend/?tab=serilog#attributes-for-error-tracking
 [3]: https://app.datadoghq.com/logs?query=status%3A%28emergency%20OR%20alert%20OR%20critical%20OR%20error%29%20AND%20%28%40error.stack%3A%2A%20OR%20%40error.kind%3A%2A%29%20
-[5]: https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20%40error.stack%3A%2A%20AND%20%40error.message%3A%2A%20AND%20error.type%3A%2A%20AND%20%40_top_level%3A1%20
+[5]: https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20%40error.stack%3A%2A%20AND%20%40error.message%3A%2A%20AND%20error.type%3A%2A%20
 [6]: https://app.datadoghq.com/rum/sessions?query=%40type%3Aerror%20%40error.stack%3A%2A
 [7]: https://app.datadoghq.com/error-tracking/settings

--- a/content/en/error_tracking/troubleshooting.md
+++ b/content/en/error_tracking/troubleshooting.md
@@ -6,7 +6,7 @@ If you experience unexpected behavior with Error Tracking, the troubleshooting s
 
 Datadog recommends regularly updating to the latest version of the Datadog tracing libraries, mobile SDKs, and web SDKs, as each release contains improvements and fixes.
 
-##  Errors are not found in Error Tracking
+## Errors are not found in Error Tracking
 
 ### Logs
 
@@ -17,52 +17,14 @@ This [example query][3] searches for logs meeting the criteria for inclusion in 
 ### APM
 
 To be processed by Error Tracking, a span must have these attributes:
+
 - `error.type`
 - `error.message`
 - `error.stack`
 
 **Note**: The stack must have at least two lines and one *meaningful* frame (a frame with a function name and a filename in most languages).
 
-Only errors from service entry spans (the uppermost service spans) are processed by Error Tracking. Error Tracking primarily captures unhandled exceptions, and this behavior is in place to avoid capturing errors handled internally by the service.
-
 This [example query][5] searches for spans meeting the criteria for inclusion in Error Tracking.
-
-#### Workarounds for bubbling up child span errors to service entry span
-
-Some tracers provide a way to access the root span and bubble up the error from child to root.
-
-{{< tabs >}}
-{{% tab "Java" %}}
-
-```java
-final Span span = GlobalTracer.get().activeSpan();
-if (span != null && (span instanceof MutableSpan)) {
-    MutableSpan localRootSpan = ((MutableSpan) span).getLocalRootSpan();
-    // do stuff with root span
-    localRootSpan.setTag("<TAG>", "<VALUE>");
-}
-```
-
-{{% /tab %}}
-{{% tab "Python" %}}
-
-```python
-context = tracer.get_call_context()
-root_span = context.get_current_root_span()
-root_span.set_tag('<TAG>', '<VALUE>')
-```
-
-{{% /tab %}}
-{{% tab "Ruby" %}}
-
-```ruby
-current_root_span = Datadog.tracer.active_root_span
-current_root_span.set_tag('<TAG>', '<VALUE>') unless current_root_span.nil?
-```
-
-{{% /tab %}}
-
-{{< /tabs >}}
 
 ### RUM
 
@@ -81,8 +43,6 @@ Spans associated with the error need to be retained with a custom retention filt
 [1]: /help/
 [2]: /logs/error_tracking/backend/?tab=serilog#attributes-for-error-tracking
 [3]: https://app.datadoghq.com/logs?query=status%3A%28emergency%20OR%20alert%20OR%20critical%20OR%20error%29%20AND%20%28%40error.stack%3A%2A%20OR%20%40error.kind%3A%2A%29%20
-[4]: /tracing/error_tracking/#use-span-tags-to-track-error-spans
 [5]: https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20%40error.stack%3A%2A%20AND%20%40error.message%3A%2A%20AND%20error.type%3A%2A%20AND%20%40_top_level%3A1%20
 [6]: https://app.datadoghq.com/rum/sessions?query=%40type%3Aerror%20%40error.stack%3A%2A
 [7]: https://app.datadoghq.com/error-tracking/settings
-[8]: /tracing/trace_collection/custom_instrumentation/java/dd-api/#set-tags--errors-on-a-root-span-from-a-child-span

--- a/content/en/tracing/error_tracking/_index.md
+++ b/content/en/tracing/error_tracking/_index.md
@@ -36,7 +36,7 @@ To get started with configuring your repository, see the [Source Code Integratio
 
 ## Use span attributes to track error spans
 
-The Datadog tracers collect errors through integrations and the manual instrumentation of your backend services' source code.  Error spans within a trace are processed by Error Tracking if they are service top-level errors, whether or not they are located in service entry spans. This span must also contain the `error.stack`, `error.message`, and `error.type` [span attributes][1] to be tracked.
+The Datadog tracers collect errors through integrations and the manual instrumentation of your backend services' source code. Error Tracking processes error spans within a trace if they occur at the service level, regardless of whether they are located in service entry spans. This span must also contain the `error.stack`, `error.message`, and `error.type` [span attributes][1] to be tracked.
 
 {{< img src="tracing/error_tracking/flamegraph_with_errors.png" alt="Flame graph with errors" style="width:100%;" >}}
 

--- a/content/en/tracing/error_tracking/_index.md
+++ b/content/en/tracing/error_tracking/_index.md
@@ -36,7 +36,7 @@ To get started with configuring your repository, see the [Source Code Integratio
 
 ## Use span attributes to track error spans
 
-The Datadog tracers collect errors through integrations and the manual instrumentation of your backend services' source code. Error spans within a trace are processed by Error Tracking **if the error is located in a service entry span** (the uppermost service span). This span must also contain the `error.stack`, `error.message`, and `error.type` [span attributes][1] to be tracked.
+The Datadog tracers collect errors through integrations and the manual instrumentation of your backend services' source code.  Error spans within a trace are processed by Error Tracking if they are service top-level errors, whether or not they are located in service entry spans. This span must also contain the `error.stack`, `error.message`, and `error.type` [span attributes][1] to be tracked.
 
 {{< img src="tracing/error_tracking/flamegraph_with_errors.png" alt="Flame graph with errors" style="width:100%;" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR removes all references to entry span fingerprinting limitations.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
