### PR TITLE
Move fluent bit log collection to logs guide

### DIFF
--- a/content/en/logs/guide/_index.md
+++ b/content/en/logs/guide/_index.md
@@ -32,8 +32,9 @@ cascade:
     {{< nextlink href="/logs/guide/apigee" >}}Collect Apigee Logs{{< /nextlink >}}
     {{< nextlink href="/logs/guide/azure-logging-guide/" >}}Send Azure Logs to Datadog{{< /nextlink >}}
     {{< nextlink href="/logs/guide/azure-native-logging-guide/" >}}Send Azure Logs with the Datadog Resource{{< /nextlink >}}
+    {{< nextlink href="/logs/guide/fluentbit" >}}Send Fluent Bit Logs{{< /nextlink >}}
     {{< nextlink href="/integrations/google_cloud_platform/#log-collection" >}}Collect Google Cloud logs with the Datadog Dataflow template{{< /nextlink >}}
-    {{< nextlink href="/logs/guide/collect-google-cloud-logs-with-push/" >}}Collect Google Cloud logs with a Pub/Sub Push subscription{{< /nextlink >}}    
+    {{< nextlink href="/logs/guide/collect-google-cloud-logs-with-push/" >}}Collect Google Cloud logs with a Pub/Sub Push subscription{{< /nextlink >}}
     {{< nextlink href="logs/guide/collect-heroku-logs" >}}Collect Heroku Logs{{< /nextlink >}}
     {{< nextlink href="logs/guide/log-collection-troubleshooting-guide" >}}Log Collection Troubleshooting Guide{{< /nextlink >}}
     {{< nextlink href="logs/guide/docker-logs-collection-troubleshooting-guide" >}}Docker Log Collection Troubleshooting Guide{{< /nextlink >}}

--- a/content/en/logs/guide/fluentbit.md
+++ b/content/en/logs/guide/fluentbit.md
@@ -1,28 +1,18 @@
 ---
-title: Fluent Bit
+title: Send Fluent Bit Logs to Datadog
 name: fluentbit
-custom_kind: integration
 description: 'Configure Fluent Bit to collect, parse, and forward log data from several sources.'
-short_description: 'Collect, parse, and forward log data from several sources.'
-categories:
-    - log collection
-doc_link: /integrations/fluentbit/
-dependencies:
-    ['https://github.com/DataDog/documentation/blob/master/content/en/integrations/fluentbit.md']
-has_logo: true
-integration_title: Fluent Bit
-is_public: true
-public_title: Datadog-Fluent Bit Integration
 further_reading:
     - link: 'https://www.datadoghq.com/blog/fluentbit-integration-announcement/'
       tag: 'Blog'
       text: 'Centralize your logs with Datadog and Fluent Bit'
-integration_id: "fluentbit"
 ---
 
 ## Overview
 
 Configure Fluent Bit to collect, parse, and forward log data from several different sources to Datadog for monitoring. Fluent Bit has a small memory footprint (~450 KB), so you can use it to collect logs in environments with limited resources, such as containerized services and embedded Linux systems. [Datadog's Fluent Bit output plugin][1] supports Fluent Bit v1.3.0+.
+
+To configure the Fluent Bit Agent check, see [Fluent Bit (Agent)][13]
 
 ## Setup
 
@@ -87,3 +77,5 @@ Need help? Contact [Datadog support][11].
 [10]: /getting_started/tagging/
 [11]: /help/
 [12]: /logs/log_configuration/pipelines/?tab=host#preprocessing
+[13]: /integrations/fluentbit/
+

--- a/content/en/logs/guide/fluentbit.md
+++ b/content/en/logs/guide/fluentbit.md
@@ -12,7 +12,7 @@ further_reading:
 
 Configure Fluent Bit to collect, parse, and forward log data from several different sources to Datadog for monitoring. Fluent Bit has a small memory footprint (~450 KB), so you can use it to collect logs in environments with limited resources, such as containerized services and embedded Linux systems. [Datadog's Fluent Bit output plugin][1] supports Fluent Bit v1.3.0+.
 
-To configure the Fluent Bit Agent check, see [Fluent Bit (Agent)][13]
+To configure the Fluent Bit Agent check, see [Fluent Bit (Agent)][13].
 
 ## Setup
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- The integration docs should pull from the the integration-extras repo, but the log collection docs was overriding that automation.
- [DOCS-9143](https://datadoghq.atlassian.net/browse/DOCS-9143)
- Integration-extras documentation: https://github.com/DataDog/integrations-extras/pull/2576

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


[DOCS-9143]: https://datadoghq.atlassian.net/browse/DOCS-9143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ