### PR TITLE
Add "aggregation" to public Notifications doc

### DIFF
--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -118,12 +118,6 @@ The options are:
 
 **Note**: Depending on the integration, some content may not be displayed by default.
 
-### Metadata
-
-Add metadata (Priority, Tags, Datadog Team) to your monitor. Monitor Priority allows you to set the importance of your monitor through P-level (P1 to P5). Monitor tag--which are different from metric tags--are used in the UI to group and search for monitors. If tag policies are configured, the required tags and tag values need to be added. To learn more, see [Tag Policies][10]. Datadog Teams allows you to set a layer of ownership to this monitor and view all the monitors linked to your team. To learn more, see [Datadog Teams][11].
-
-{{< img src="monitors/notifications/notifications_metadata.png" alt="View of policy tag configuration. Underneath 'Policy tags' are three example tags, cost_center, product_id, and env, next to a 'Select value' dropdown." style="width:100%;" >}}
-
 ### Renotify
 
 Enable monitor renotification (optional) to remind your team that a problem is not solved.
@@ -150,6 +144,20 @@ If you use the `{{#is_renotify}}` block, the original notification message is al
 2. Send the escalation message to a subset of groups.
 
 Learn how to configure your monitors for those use cases in the [example section][12].
+
+### Metadata
+
+Add metadata (Priority, Tags, Datadog Team) to your monitor. Monitor Priority allows you to set the importance of your monitor through P-level (P1 to P5). Monitor tag--which are different from metric tags--are used in the UI to group and search for monitors. If tag policies are configured, the required tags and tag values need to be added. To learn more, see [Tag Policies][10]. Datadog Teams allows you to set a layer of ownership to this monitor and view all the monitors linked to your team. To learn more, see [Datadog Teams][11].
+
+{{< img src="monitors/notifications/notifications_metadata.png" alt="View of policy tag configuration. Underneath 'Policy tags' are three example tags, cost_center, product_id, and env, next to a 'Select value' dropdown." style="width:100%;" >}}
+
+### Aggregation
+
+If the monitor's query is grouped by one or more dimensions, you can remove one or more of them from the notification grouping, or choose to notify as a Simple Alert.
+
+{{< img src="monitors/notifications/notifications_aggregation.png" alt="View of aggregation configuration set to multi-alert." style="width:100%;" >}}
+
+More information on this feature can be found on [Configure Monitors][18]
 
 
 ## Audit notifications
@@ -206,3 +214,4 @@ Message variables auto-populate with a randomly selected group based on the scop
 [15]: /monitors/configuration/
 [16]: /monitors/guide/recovery-thresholds/
 [17]: /service_management/workflows/trigger/#add-a-monitor-trigger-to-your-workflow
+[18]: /monitors/configuration/#set-alert-aggregation


### PR DESCRIPTION
Reordered existing sections to match the monitor-edit page

Added "Aggregation" section

Referenced the #set-alert-aggregation section of the Configure Monitors page

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Briefly describes the notification-aggregation section of the monitor-edit page, so that all notification options are mentioned

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
