### PR TITLE
add operator instructions for OTel receiver configs

### DIFF
--- a/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
@@ -208,8 +208,6 @@ This enables each protocol in the default port (`4317` for OTLP/gRPC and `4318` 
 {{% /tab %}}
 {{% tab "Kubernetes (Operator)" %}}
 
-If you already have the Datadog Agent deployed using the Kubernetes Operator, the agent should be configured to receive OTel traces on port 4317 by default. In the event you are not receiving traces, you can configure the receivers manually. 
-
 1. Follow the [Kubernetes Agent setup][1].
 
 2. Enable the preferred protocol in your Operator's manifest:

--- a/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/interoperability/otlp_ingest_in_the_agent.md
@@ -206,6 +206,37 @@ This enables each protocol in the default port (`4317` for OTLP/gRPC and `4318` 
 
 [1]: /agent/kubernetes/?tab=helm
 {{% /tab %}}
+{{% tab "Kubernetes (Operator)" %}}
+
+If you already have the Datadog Agent deployed using the Kubernetes Operator, the agent should be configured to receive OTel traces on port 4317 by default. In the event you are not receiving traces, you can configure the receivers manually. 
+
+1. Follow the [Kubernetes Agent setup][1].
+
+2. Enable the preferred protocol in your Operator's manifest:
+
+   For gRPC:
+   ```yaml
+   features:
+     otlp:
+       receiver:
+         protocols:
+           grpc:
+             enabled: true
+   ```
+   For HTTP:
+   ```yaml
+   features:
+     otlp:
+       receiver:
+         protocols:
+           http:
+             enabled: true
+   ```
+
+This enables each protocol in the default port (`4317` for OTLP/gRPC and `4318` for OTLP/HTTP).
+
+[1]: /agent/kubernetes/?tab=helm
+{{% /tab %}}
 {{% tab "AWS Lambda" %}}
 
 For detailed instructions on using OpenTelemetry with AWS Lambda and Datadog, including:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Includes Operator specific instructions for Opentelemetry configuration. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
