### PR TITLE
[web-5767] removes rbac script from local docs build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ source-dd-source:
 
 # All the requirements for a full build
 dependencies: clean source-dd-source
-	make hugpython all-examples data/permissions.json update_pre_build node_modules placeholders
+	make hugpython all-examples update_pre_build node_modules placeholders
 
 integrations_data/extracted/vector:
 	$(call source_repo,vector,https://github.com/vectordotdev/vector.git,master,true,website/)

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,7 @@ EXAMPLES_DIR = $(shell pwd)/examples/content/en/api
 EXAMPLES_REPOS := datadog-api-client-go datadog-api-client-java datadog-api-client-python datadog-api-client-ruby datadog-api-client-typescript datadog-api-client-rust
 
 # Set defaults when no makefile.config or missing entries
-# Use DATADOG_API_KEY if set, otherwise try DD_API_KEY and lastly fall back to false
 GITHUB_TOKEN ?= ""
-DD_API_KEY ?= false
-DD_APP_KEY ?= false
-DATADOG_API_KEY ?= $(DD_API_KEY)
-DATADOG_APP_KEY ?= $(DD_APP_KEY)
 FULL_BUILD ?= false
 CONFIGURATION_FILE ?= "./local/bin/py/build/configurations/pull_config_preview.yaml"
 
@@ -106,11 +101,6 @@ source-dd-source:
 # All the requirements for a full build
 dependencies: clean source-dd-source
 	make hugpython all-examples data/permissions.json update_pre_build node_modules placeholders
-
-# builds permissions json from rbac
-# Always run if PULL_RBAC_PERMISSIONS or we are running in gitlab e.g CI_COMMIT_REF_NAME exists
-data/permissions.json: hugpython
-	@. hugpython/bin/activate && ./local/bin/py/build/pull_rbac.py "$(DATADOG_API_KEY)" "$(DATADOG_APP_KEY)"
 
 integrations_data/extracted/vector:
 	$(call source_repo,vector,https://github.com/vectordotdev/vector.git,master,true,website/)

--- a/Makefile.config.example
+++ b/Makefile.config.example
@@ -2,8 +2,6 @@
 # Create a new file called Makefile.config using this file as a template for your local config
 
 GITHUB_TOKEN := ${github_personal_token}
-DATADOG_API_KEY := false
-DATADOG_APP_KEY := false
 FULL_BUILD := false
 CONFIGURATION_FILE := "./local/bin/py/build/configurations/pull_config_preview.yaml"
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 require (
 	github.com/DataDog/websites-modules v1.4.202 // indirect
-	github.com/DataDog/websites-sources v0.0.0-20241125134453-6f4fe0220a22 // indirect
+	github.com/DataDog/websites-sources v0.0.0-20250107113720-055628b87cb7 // indirect
 )
 
 // replace github.com/DataDog/websites-modules => /Users/matt.fitzsimmons/source/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
 github.com/DataDog/websites-modules v1.4.202 h1:utVIiSFtR0IrA0cEnxupCo4sYISRMWxpPAFs/16t5FY=
 github.com/DataDog/websites-modules v1.4.202/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
-github.com/DataDog/websites-sources v0.0.0-20241125134453-6f4fe0220a22 h1:4mxdsEkowAJuPndJUWb14oibV+KYKMu37hMvX0DD3rk=
-github.com/DataDog/websites-sources v0.0.0-20241125134453-6f4fe0220a22/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=
+github.com/DataDog/websites-sources v0.0.0-20250107113720-055628b87cb7 h1:3MeRlEkGXsPT/Xq/fE5lMR/+M4thO1TlTPrOQQtFp5w=
+github.com/DataDog/websites-sources v0.0.0-20250107113720-055628b87cb7/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=


### PR DESCRIPTION
### What does this PR do? What is the motivation?
- removes rbac script from makefile
- removes api and app key variable instantiation from makefile (no longer necessary since rbac api call is not happening in docs build anymore)

### Merge instructions

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/web-5767-rbac-migration/account_management/rbac/permissions
green build https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/757247813

RBAC permissions page should be mirroring what's in prod.  Otherwise should be no local build issues from removing the api and app key definitions locally (RBAC api call was the only relevant use of them locally)
