### PR TITLE
Remove Preview Mentions from Inferred Service Docs

### DIFF
--- a/content/en/tracing/guide/inferred-service-opt-in.md
+++ b/content/en/tracing/guide/inferred-service-opt-in.md
@@ -1,8 +1,6 @@
 ---
 title: Inferred Service dependencies
-
 disable_toc: false
-private: true
 further_reading:
 - link: "/tracing/services/"
   tag: "Documentation"
@@ -18,10 +16,6 @@ further_reading:
   text: "Service Overrides"
 ---
 
-{{< callout url="https://docs.google.com/forms/d/1imGm-4SfOPjwAr6fwgMgQe88mp4Y-n_zV0K3DcNW4UA/edit" d_target="#signupModal" btn_hidden="true" btn_hidden="false" header="Request access to the Preview!" >}}
-Inferred service dependencies are in Preview. To request access, complete the form.
-{{< /callout >}}
-
 ## Overview
 
 Datadog can automatically discover the dependencies for an instrumented service, such as a database, a queue, or a third-party API, even if that dependency hasn't been instrumented yet. By analyzing outbound requests from your instrumented services, Datadog infers the presence of these dependencies and collects associated performance metrics.
@@ -31,8 +25,6 @@ With the new inferred entities experience, you can filter [Service Catalog][3] e
 To determine the names and types of the inferred service dependencies, Datadog uses standard span attributes and maps them to `peer.*` attributes. For the full list of `peer.*` attributes, see [Inferred service dependencies nomenclature](#inferred-service-dependencies-nomemclature). Inferred external APIs use the default naming scheme `net.peer.name`. For example, `api.stripe.com`, `api.twilio.com`, `us6.api.mailchimp.com`. Inferred databases use the default naming scheme `db.instance`.
 
 If you're using the Go, Java, Node.js, PHP, .NET, or Ruby tracer, you can customize the default names for inferred entities.
-
-**Note:** If you configure monitors, dashboards, or notebooks for a given inferred service during the Preview, you may need to update them if the naming scheme changes. Read more about migration steps in the [opt-in instructions](#opt-in).
 
 ### Service page Dependency map
 

--- a/content/en/tracing/guide/service_overrides.md
+++ b/content/en/tracing/guide/service_overrides.md
@@ -1,16 +1,11 @@
 ---
 title: Service Overrides
 disable_toc: false
-private: true
 further_reading:
 - link: "/tracing/guide/inferred-service-opt-in"
   tag: "Documentation"
   text: "Opting-in to the new service representation"
 ---
-
-{{< callout url="https://docs.google.com/forms/d/1imGm-4SfOPjwAr6fwgMgQe88mp4Y-n_zV0K3DcNW4UA/edit" d_target="#signupModal" btn_hidden="false" header="Request access to the Preview!" >}}
-Inferred service dependencies are in Preview. To request access, complete the form. For opt-in instructions, see the <a href="/tracing/guide/inferred-service-opt-in/">Inferred Service dependencies guide</a>.
-{{< /callout >}}
 
 ## Overview
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Remove mention of Preview from Inferred Service opt-in and Service Overrides.
- Make these docs public (remove private).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
