### PR TITLE
[SDCI] update instructions to disable CI Visibility for GitHub Actions

### DIFF
--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -1,5 +1,5 @@
 ---
-title: Set up Tracing on GitHub Actions Workflows
+title: Set up CI Visibility on GitHub Actions Workflows
 aliases:
   - /continuous_integration/setup_pipelines/github
 further_reading:
@@ -25,7 +25,7 @@ further_reading:
 
 [GitHub Actions][1] is an automation tool that allows you to build, test, and deploy your code in GitHub. Create workflows that automate every step of your development process, streamlining software updates and enhancing code quality with CI/CD features integrated into your repositories.
 
-Set up tracing in GitHub Actions to track the execution of your workflows, identify performance bottlenecks, troubleshoot operational issues, and optimize your deployment processes.
+Set up CI Visibility in GitHub Actions to track the execution of your workflows, identify performance bottlenecks, troubleshoot operational issues, and optimize your deployment processes.
 
 ### Compatibility
 
@@ -61,7 +61,7 @@ The [GitHub Actions][1] integration uses a private [GitHub App][11] to collect w
 6. Give the app a name, for example, `Datadog CI Visibility`.
 7. Click **Install GitHub App** and follow the instructions on GitHub.
 
-### Configure tracing for GitHub Actions
+### Configure CI Visibility for GitHub Actions
 
 After the GitHub App is created and installed, enable CI Visibility on the accounts and/or repositories you want visibility into.
 
@@ -72,7 +72,7 @@ After the GitHub App is created and installed, enable CI Visibility on the accou
 
 Pipelines appear immediately after enabling CI Visibility for any account or repository.
 
-### Disable GitHub Actions tracing
+### Disable CI Visiblity for GitHub Actions
 
 To disable the CI Visibility GitHub Actions integration:
 

--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -77,7 +77,7 @@ Pipelines appear immediately after enabling CI Visibility for any account or rep
 To disable the CI Visibility GitHub Actions integration:
 
 1. Go to the [CI GitHub Settings][14] page.
-2. Choose the GitHub account that you want to disable CI Visibility for, and click on **Edit**.
+2. Choose the GitHub account that you want to disable CI Visibility for, and click **Account Enabled**.
 3. Untoggle **Enable CI Visibility**, or choose which repository you want to disable it for individually.
 
 ### Collect job logs

--- a/content/en/continuous_integration/pipelines/github.md
+++ b/content/en/continuous_integration/pipelines/github.md
@@ -74,12 +74,11 @@ Pipelines appear immediately after enabling CI Visibility for any account or rep
 
 ### Disable GitHub Actions tracing
 
-To disable the CI Visibility GitHub Actions integration, make sure the GitHub app is no longer subscribed to the
-workflow job and workflow run events. To remove the events:
+To disable the CI Visibility GitHub Actions integration:
 
-1. Go to the [GitHub Apps][14] page.
-2. Click **Edit > Permission & events** on the relevant Datadog GitHub App (if you have multiple apps, you have to repeat the process for each).
-3. Scroll to the **Subscribe to events** section, and make sure that **Workflow job** and **Workflow run** are not selected.
+1. Go to the [CI GitHub Settings][14] page.
+2. Choose the GitHub account that you want to disable CI Visibility for, and click on **Edit**.
+3. Untoggle **Enable CI Visibility**, or choose which repository you want to disable it for individually.
 
 ### Collect job logs
 
@@ -125,7 +124,7 @@ The **CI Pipeline List** page shows data for only the default branch of each rep
 [11]: https://docs.github.com/developers/apps/getting-started-with-apps/about-apps
 [12]: https://app.datadoghq.com/integrations/github/
 [13]: https://app.datadoghq.com/ci/setup/pipeline?provider=github
-[14]: https://github.com/settings/apps
+[14]: https://app.datadoghq.com/ci/settings/provider
 [15]: /logs/
 [16]: /logs/guide/best-practices-for-log-management/
 [17]: https://app.datadoghq.com/ci/pipelines


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We currently give instructions in order to disable CI Visibility that are difficult for people to perform, because most of the time, they are not an administrator of their GitHub organization. There is a way to disable CI Visibility for GitHub Actions directly in the Datadog UI, and this PR documents that.

### Merge instructions

No concerns.

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
