### PR TITLE
date update graphing guides

### DIFF
--- a/content/en/dashboards/guide/_index.md
+++ b/content/en/dashboards/guide/_index.md
@@ -23,7 +23,7 @@ cascade:
     {{< nextlink href="dashboards/guide/context-links" >}}Context Links{{< /nextlink >}}
     {{< nextlink href="dashboards/guide/unit-override" >}}Unit override{{< /nextlink >}}
     {{< nextlink href="dashboards/guide/how-to-use-terraform-to-restrict-dashboards" >}}Using Terraform to restrict the editing of a dashboard{{< /nextlink >}}
-    {{< nextlink href="dashboards/guide/is-read-only-deprecation" >}}Dashboards API: Migrate from is_read_only by November 30, 2024{{< /nextlink >}}
+    {{< nextlink href="dashboards/guide/is-read-only-deprecation" >}}Dashboards API: Migrate from is_read_only by December 13, 2024{{< /nextlink >}}
     {{< nextlink href="dashboards/guide/embeddable-graphs-with-template-variables" >}}Embeddable graphs with template variables{{< /nextlink >}}
     {{< nextlink href="dashboards/guide/unable-to-iframe" >}}Why am I unable to iFrame certain HTTPS URLs?{{< /nextlink >}}
     {{< nextlink href="dashboards/guide/powerpacks-best-practices" >}}Powerpacks best practices{{< /nextlink >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates the deadline set in the title of the `Dashboards API: Migrate from is_read_only` guide in the Graphing Guides list (from `November 30, 2024` to `December 13, 2024`).

<img width="740" alt="image" src="https://github.com/user-attachments/assets/c938471e-465c-4c77-9f66-c8ba48ea9edf" />
<img width="752" alt="image" src="https://github.com/user-attachments/assets/34fca1cb-6d75-402c-8f57-25f5d08fd5c1" />


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
