### PR TITLE
[CI Visibility] Add CI provider name to custom pipeline example

### DIFF
--- a/content/en/continuous_integration/pipelines/custom.md
+++ b/content/en/continuous_integration/pipelines/custom.md
@@ -69,6 +69,7 @@ To send pipeline events programmatically to Datadog, ensure that your [`DD_API_K
    {
      "data": {
        "attributes": {
+         "provider_name": "my-ci-provider",
          "resource": {
            "level": "pipeline",
            "unique_id": "b3262537-a573-44eb-b777-4c0f37912b05",

--- a/content/en/continuous_integration/pipelines/custom.md
+++ b/content/en/continuous_integration/pipelines/custom.md
@@ -69,7 +69,7 @@ To send pipeline events programmatically to Datadog, ensure that your [`DD_API_K
    {
      "data": {
        "attributes": {
-         "provider_name": "my-ci-provider",
+         "provider_name": "<YOUR_CI_PROVIDER>",
          "resource": {
            "level": "pipeline",
            "unique_id": "b3262537-a573-44eb-b777-4c0f37912b05",


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
We added a new field called `provider_name` which will allow customers to specify the provider name. Up until now we always used `custom`. There will be another PR for the API spec

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
