### PR TITLE
Explicitly state compute capacity for multi-org accounts

### DIFF
--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -206,7 +206,7 @@ The following list is an example of log sources that are good candidates for sen
 
 ### Flex Logs for multiple-organization accounts
 
-For each organization in which you want Flex Logs, you must enable a compute size per organization. Compute is one per organization, compute sizes cannot be shared across organizations. Starter and scalable compute cannot be used simultaneously in an organization.
+For each organization in which you want Flex Logs, you must enable a compute size per organization. Only one compute can be used per organization, and compute sizes cannot be shared across organizations. Starter and scalable compute cannot be used simultaneously in an organization.
 
 Datadog generally recommends Flex Logs scalable compute sizes (XS, S, M, and L) for organizations with large log volumes. In a multi-organization setup, there are often many organizations with lower log volumes, so for these organizations, Datadog recommends the Starter compute size for Flex Logs.
 

--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -114,7 +114,7 @@ To disable Flex Logs:
 
 1. Remove Flex Storage from each index where Flex Logs is enabled.
 1. Navigate back to the [Flex Logs Control][5] page.
-1. Click **Disable Flex Logs**.
+1. Click the gear icon and select **Disable Flex Logs**.
 
 ## Upgrade and downgrade Flex Logs compute
 
@@ -206,7 +206,7 @@ The following list is an example of log sources that are good candidates for sen
 
 ### Flex Logs for multiple-organization accounts
 
-For each organization in which you want Flex Logs, you must enable a compute size per organization. Compute sizes cannot be shared across organizations.
+For each organization in which you want Flex Logs, you must enable a compute size per organization. Compute is one per organization, compute sizes cannot be shared across organizations. Starter and scalable compute cannot be used simultaneously in an organization.
 
 Datadog generally recommends Flex Logs scalable compute sizes (XS, S, M, and L) for organizations with large log volumes. In a multi-organization setup, there are often many organizations with lower log volumes, so for these organizations, Datadog recommends the Starter compute size for Flex Logs.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Add statement on capacity of Flex logs compute for multi-org accounts
- Update disable instructions to match UI

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
