### PR TITLE
[FIX] hide collapsible element markers on safari and mobile

### DIFF
--- a/assets/styles/components/_collapsible-section.scss
+++ b/assets/styles/components/_collapsible-section.scss
@@ -15,6 +15,11 @@
     transition: background-color 0.3s;
 }
 
+/* hide marker on safari */
+.collapsible-header::-webkit-details-marker {
+  display: none;
+}
+
 .collapsible-header:hover { 
     background-color: #eae2f8;
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fix the duplicated collapsible marker element visible on Safari and Safari + Chrome mobile:
https://docs.datadoghq.com/fr/metrics/overview/

Fixed:
https://docs-staging.datadoghq.com/lisianetu/fix-collapsible-elements/metrics/overview/
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
