### PR TITLE
appsec/java: explicit we don't support grpc request blocking

### DIFF
--- a/content/en/security/application_security/threats/setup/compatibility/java.md
+++ b/content/en/security/application_security/threats/setup/compatibility/java.md
@@ -68,6 +68,7 @@ Datadog does not officially support any early-access versions of Java.
 | ----------------------- | ---------- | --------------- | ---------------------------------------------- | ---------------------------------------------- |
 | Grizzly                 | 2.0+       |  {{< X >}} |  {{< X >}} |  {{< X >}} |
 | Glassfish               |            |  {{< X >}} |  {{< X >}} |  {{< X >}} |
+| gRPC                    | 1.5+       |  {{< X >}} |  Not supported |  {{< X >}} |
 | Java Servlet | 2.3+, 3.0+ |   {{< X >}} |  {{< X >}} |  {{< X >}} |
 | Jetty                   | 7.0-9.x, 10.x    |  {{< X >}} |  {{< X >}} |  {{< X >}} |
 | Spring Boot             | 1.5        |  {{< X >}} |  {{< X >}} |  {{< X >}} |
@@ -75,7 +76,6 @@ Datadog does not officially support any early-access versions of Java.
 | Spring WebFlux          | 5.0+       |            |            |  {{< X >}} |
 | Tomcat                  | 5.5+       |   {{< X >}} |  {{< X >}} |  {{< X >}} |
 | Vert.x                  | 3.4-3.9.x  |   {{< X >}} |  {{< X >}} |  {{< X >}} |
-| gRPC                   | TBD  |   {{< X >}} |  Not supported |  {{< X >}} |
 
 **Note**: Many application servers are Servlet compatible and are automatically covered by that instrumentation, such as Websphere, Weblogic, and JBoss. Also, frameworks like Spring Boot (version 3) inherently work because they usually use a supported embedded application server, such as Tomcat, Jetty, or Netty.
 

--- a/content/en/security/application_security/threats/setup/compatibility/java.md
+++ b/content/en/security/application_security/threats/setup/compatibility/java.md
@@ -68,7 +68,7 @@ Datadog does not officially support any early-access versions of Java.
 | ----------------------- | ---------- | --------------- | ---------------------------------------------- | ---------------------------------------------- |
 | Grizzly                 | 2.0+       |  {{< X >}} |  {{< X >}} |  {{< X >}} |
 | Glassfish               |            |  {{< X >}} |  {{< X >}} |  {{< X >}} |
-| gRPC                    | 1.5+       |  {{< X >}} |  Not supported |  {{< X >}} |
+| gRPC                    | 1.5+       |  {{< X >}} | {{< tooltip text="N/A" tooltip="Blocking not yet available for gRPC" >}} |  {{< X >}} |
 | Java Servlet | 2.3+, 3.0+ |   {{< X >}} |  {{< X >}} |  {{< X >}} |
 | Jetty                   | 7.0-9.x, 10.x    |  {{< X >}} |  {{< X >}} |  {{< X >}} |
 | Spring Boot             | 1.5        |  {{< X >}} |  {{< X >}} |  {{< X >}} |

--- a/content/en/security/application_security/threats/setup/compatibility/java.md
+++ b/content/en/security/application_security/threats/setup/compatibility/java.md
@@ -75,6 +75,7 @@ Datadog does not officially support any early-access versions of Java.
 | Spring WebFlux          | 5.0+       |            |            |  {{< X >}} |
 | Tomcat                  | 5.5+       |   {{< X >}} |  {{< X >}} |  {{< X >}} |
 | Vert.x                  | 3.4-3.9.x  |   {{< X >}} |  {{< X >}} |  {{< X >}} |
+| gRPC                   | TBD  |   {{< X >}} |  Not supported |  {{< X >}} |
 
 **Note**: Many application servers are Servlet compatible and are automatically covered by that instrumentation, such as Websphere, Weblogic, and JBoss. Also, frameworks like Spring Boot (version 3) inherently work because they usually use a supported embedded application server, such as Tomcat, Jetty, or Netty.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds gRPC as a supported framework to the java security matrix:

![image](https://github.com/user-attachments/assets/a854f806-fa14-4811-92cf-f9880e27ed8a)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
