### PR TITLE
DD_TRACE_AGENT_URL in Go Library Config

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -80,7 +80,11 @@ Enable web framework and library instrumentation. When false, the application co
 
 `DD_TRACE_AGENT_PORT`
 : **Default**: `8126` <br>
-Overrides the default trace Agent port for Datadog trace submission. If the [Agent configuration][13] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then the library configuration `DD_DOGSTATSD_PORT` must match it.
+Overrides the default trace Agent port for Datadog trace submission. Ignored if `DD_TRACE_AGENT_URL` is set. If the [Agent configuration][13] sets `receiver_port` or `DD_APM_RECEIVER_PORT` to something other than the default `8126`, then the library configuration `DD_DOGSTATSD_PORT` must match it.
+
+`DD_TRACE_AGENT_URL`
+: **Default**: `null` <br>
+Override the Agent URL used for trace submission. Supports `http://`, `https://`, and `unix://` protocols. Takes precedence over `DD_AGENT_HOST` and `DD_TRACE_AGENT_PORT` if set.
 
 `DD_TRACE_SAMPLE_RATE`
 : **Default**: `nil`<br>
@@ -157,7 +161,7 @@ A list of default tags to be added to every span and profile. Tags can be separa
 
 `DD_AGENT_HOST`
 : **Default**: `localhost` <br>
-Override the default trace Agent host address for trace submission.
+Override the default trace Agent host address for trace submission. Ignored if `DD_TRACE_AGENT_URL` is set.
 
 `DD_DOGSTATSD_PORT`
 : **Default**: `8125` <br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Missing `DD_TRACE_AGENT_URL`, noted in https://github.com/DataDog/documentation/issues/26299.
- Added new entry for this option under Traces.
- Also added note to `DD_TRACE_AGENT_PORT` and `DD_AGENT_HOST` indicating priority.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
