### PR TITLE
[SDCI-880] Add K8s explanation for infra correlation for Gitlab

### DIFF
--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -255,17 +255,19 @@ Datadog infrastructure correlation is possible using different methods:
 
 {{< tabs >}}
 {{% tab "Non autoscaling executors" %}}
-The GitLab runner must have a tag of the form `host:<hostname>`. Tags can be added while [registering a new runner][6]. As a result, this method is only available when the runner is directly running the job.
+The GitLab runner must have a tag of the form `host:<hostname>`. Tags can be added while [registering a new runner][1]. As a result, this method is only available when the runner is directly running the job.
 
 This excludes executors that are autoscaling the infrastructure in order to run the job (such as the Kubernetes, Docker Autoscaler, or Instance executors) as it is not possible to add tags dynamically for those runners.
 
 For existing runners:
 
-GitLab >= 15.8: Add tags through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
+- GitLab >= 15.8: Add tags through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
 
-GitLab < 15.8: Add tags by updating the runner's `config.toml`. Or add tags through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
+- GitLab < 15.8: Add tags by updating the runner's `config.toml`. Or add tags through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
 
 After these steps, CI Visibility adds the hostname to each job. To see the metrics, click on a job span in the trace view. In the drawer, a new tab named **Infrastructure** appears which contains the host metrics.
+
+[1]: https://docs.gitlab.com/runner/register/
 {{% /tab %}}
 
 {{% tab "Docker Autoscaler" %}}
@@ -376,7 +378,7 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 {{% /tab %}}
 {{< /tabs >}}
 
-Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in [Log Management][28]. Logs for GitLab jobs can be identified by the `datadog.product:cipipeline` and `source:gitlab` tags.
+Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in [Log Management][6]. Logs for GitLab jobs can be identified by the `datadog.product:cipipeline` and `source:gitlab` tags.
 
 For more information about processing job logs collected from the GitLab integration, see the [Processors documentation][17].
 
@@ -411,7 +413,7 @@ The **CI Pipeline List** page shows data for only the default branch of each rep
 [3]: https://docs.gitlab.com/ee/user/project/integrations/webhooks.html
 [4]: https://app.datadoghq.com/ci/pipelines
 [5]: https://app.datadoghq.com/ci/pipeline-executions
-[6]: https://docs.gitlab.com/runner/register/
+[6]: /logs/guide/best-practices-for-log-management/
 [7]: https://docs.gitlab.com/ee/administration/job_artifacts.html#using-object-storage
 [8]: https://docs.gitlab.com/ee/administration/feature_flags.html
 [9]: /logs/
@@ -433,4 +435,3 @@ The **CI Pipeline List** page shows data for only the default branch of each rep
 [25]: /glossary/#custom-span
 [26]: /continuous_integration/explorer
 [27]: /continuous_integration/search/#search-for-pipelines
-[28]: /logs/guide/best-practices-for-log-management/

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -278,9 +278,13 @@ After these steps, CI Visibility adds the hostname to each job. To see the metri
 
 CI Visibility also supports Infrastructure metrics for "Instance" and "Docker Autoscaler" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][18].
 
+#### Kubernetes executor
+
+CI Visibility supports Infrastructure metrics for the Kubernetes executor. For this, it is necessary to have the Datadog Agent monitoring the Kubernetes Gitlab infrastructure. See [Install the Datadog Agent on Kubernetes][30]
+
 #### Other executors
 
-CI Visibility does not support Infrastructure metrics for other executors such as the Kubernetes executor.
+CI Visibility does not support Infrastructure metrics for other executors.
 
 ### View error messages for pipeline failures
 
@@ -425,3 +429,4 @@ The **CI Pipeline List** page shows data for only the default branch of each rep
 [27]: /continuous_integration/explorer
 [28]: /continuous_integration/search/#search-for-pipelines
 [29]: /logs/guide/best-practices-for-log-management/
+[30]: /containers/kubernetes/installation/?tab=datadogoperator

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -20,7 +20,7 @@ further_reading:
 
 ## Overview
 
-[GitLab][18] is a DevOps platform that automates the software development lifecycle with integrated CI/CD features, enabling you to deploy applications fast and securely.
+[GitLab][18] is a DevOps platform that automates the software development lifecycle with integrated CI/CD features, enabling automated, continuous deployment of applications with built-in security controls.
 
 Set up tracing in GitLab to collect data on your pipeline executions, analyze performance bottlenecks, troubleshoot operational issues, and optimize your deployment workflows.
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -255,7 +255,7 @@ Datadog infrastructure correlation is possible using different methods:
 
 {{< tabs >}}
 {{% tab "Non autoscaling executors" %}}
-The GitLab runner must have a tag of the form `host:<hostname>`. Tags can be added while [registering a new runner][1]. As a result, this method is only available when the runner is directly running the job.
+The GitLab runner must have a tag in the form `host:<hostname>`. Tags can be added while [registering a new runner][1]. As a result, this method is only available when the runner is directly running the job.
 
 This excludes executors that are autoscaling the infrastructure in order to run the job (such as the Kubernetes, Docker Autoscaler, or Instance executors) as it is not possible to add tags dynamically for those runners.
 
@@ -283,7 +283,7 @@ CI Visibility supports Infrastructure metrics for "Instance" executors. For more
 {{% /tab %}}
 
 {{% tab "Kubernetes" %}}
-CI Visibility supports Infrastructure metrics for the Kubernetes executor. For this, it is necessary to have the Datadog Agent monitoring the Kubernetes Gitlab infrastructure. See [Install the Datadog Agent on Kubernetes][1] to install the Datadog agent in a Kubernetes cluster.
+CI Visibility supports Infrastructure metrics for the Kubernetes executor. For this, it is necessary to have the Datadog Agent monitoring the Kubernetes Gitlab infrastructure. See [Install the Datadog Agent on Kubernetes][1] to install the Datadog Agent in a Kubernetes cluster.
 
 [1]: /containers/kubernetes/installation/?tab=datadogoperator
 {{% /tab %}}

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -292,16 +292,6 @@ CI Visibility does not support Infrastructure metrics for other executors.
 
 {{< /tabs >}}
 
-
-#### Instance and Docker Autoscaler executors
-
-CI Visibility also supports Infrastructure metrics for "Instance" and "Docker Autoscaler" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][18].
-
-#### Kubernetes executor
-
-
-
-
 ### View error messages for pipeline failures
 
 Error messages are supported for GitLab versions 15.2.0 and above.

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -261,16 +261,10 @@ This excludes executors that are autoscaling the infrastructure in order to run 
 
 For existing runners:
 
-{{< tabs >}}
-{{% tab "GitLab &gt;&equals; 15.8" %}}
-Add tags through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
-{{% /tab %}}
+GitLab >= 15.8: Add tags through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
 
-{{% tab "GitLab &lt; 15.8" %}}
-Add tags by updating the runner's `config.toml`. Or add tags
-through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
-{{% /tab %}}
-{{< /tabs >}}
+GitLab < 15.8: Add tags by updating the runner's `config.toml`. Or add tags through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
+
 After these steps, CI Visibility adds the hostname to each job. To see the metrics, click on a job span in the trace view. In the drawer, a new tab named **Infrastructure** appears which contains the host metrics.
 {{% /tab %}}
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -253,8 +253,8 @@ If you are using self-hosted GitLab runners, you can correlate jobs with the inf
 
 Datadog infrastructure correlation is possible using different methods:
 
-#### Tagging runners with hostname
-
+{{< tabs >}}
+{{% tab "Non autoscaling executors" %}}
 The GitLab runner must have a tag of the form `host:<hostname>`. Tags can be added while [registering a new runner][6]. As a result, this method is only available when the runner is directly running the job.
 
 This excludes executors that are autoscaling the infrastructure in order to run the job (such as the Kubernetes, Docker Autoscaler, or Instance executors) as it is not possible to add tags dynamically for those runners.
@@ -271,8 +271,27 @@ Add tags by updating the runner's `config.toml`. Or add tags
 through the UI by going to **Settings > CI/CD > Runners** and editing the appropriate runner.
 {{% /tab %}}
 {{< /tabs >}}
-
 After these steps, CI Visibility adds the hostname to each job. To see the metrics, click on a job span in the trace view. In the drawer, a new tab named **Infrastructure** appears which contains the host metrics.
+{{% /tab %}}
+
+{{% tab "Docker Autoscaler" %}}
+CI Visibility supports Infrastructure metrics for "Docker Autoscaler" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][18].
+{{% /tab %}}
+
+{{% tab "Instance" %}}
+CI Visibility supports Infrastructure metrics for "Instance" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][18].
+{{% /tab %}}
+
+{{% tab "Kubernetes" %}}
+CI Visibility supports Infrastructure metrics for the Kubernetes executor. For this, it is necessary to have the Datadog Agent monitoring the Kubernetes Gitlab infrastructure. See [Install the Datadog Agent on Kubernetes][30] to install the Datadog agent in a Kubernetes cluster.
+{{% /tab %}}
+
+{{% tab "Other executors" %}}
+CI Visibility does not support Infrastructure metrics for other executors.
+{{% /tab %}}
+
+{{< /tabs >}}
+
 
 #### Instance and Docker Autoscaler executors
 
@@ -280,11 +299,8 @@ CI Visibility also supports Infrastructure metrics for "Instance" and "Docker Au
 
 #### Kubernetes executor
 
-CI Visibility supports Infrastructure metrics for the Kubernetes executor. For this, it is necessary to have the Datadog Agent monitoring the Kubernetes Gitlab infrastructure. See [Install the Datadog Agent on Kubernetes][30]
 
-#### Other executors
 
-CI Visibility does not support Infrastructure metrics for other executors.
 
 ### View error messages for pipeline failures
 

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -20,7 +20,7 @@ further_reading:
 
 ## Overview
 
-[GitLab][19] is a DevOps platform that automates the software development lifecycle with integrated CI/CD features, enabling you to deploy applications fast and securely.
+[GitLab][18] is a DevOps platform that automates the software development lifecycle with integrated CI/CD features, enabling you to deploy applications fast and securely.
 
 Set up tracing in GitLab to collect data on your pipeline executions, analyze performance bottlenecks, troubleshoot operational issues, and optimize your deployment workflows.
 
@@ -28,19 +28,19 @@ Set up tracing in GitLab to collect data on your pipeline executions, analyze pe
 
 | Pipeline Visibility | Platform | Definition |
 |---|---|---|
-| [Running pipelines][25] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines show with status "Running" on Datadog. |
-| [Partial retries][20] | Partial pipelines | View partially retried pipeline executions. |
-| [Manual steps][21] | Manual steps | View manually triggered pipelines. |
-| [Queue time][22] | Queue time | View the amount of time pipeline jobs sit in the queue before processing. |
+| [Running pipelines][24] | Running pipelines | View pipeline executions that are running. Queued or waiting pipelines show with status "Running" on Datadog. |
+| [Partial retries][19] | Partial pipelines | View partially retried pipeline executions. |
+| [Manual steps][20] | Manual steps | View manually triggered pipelines. |
+| [Queue time][21] | Queue time | View the amount of time pipeline jobs sit in the queue before processing. |
 | Logs correlation | Logs correlation | Correlate pipeline spans to logs and enable [job log collection][12]. |
 | Infrastructure metric correlation | Infrastructure metric correlation | Correlate jobs to [infrastructure host metrics][14] for self-hosted GitLab runners. |
 | Custom pre-defined tags | Custom pre-defined tags | Set [custom tags][10] to all generated pipeline, stages, and job spans. |
 | [Custom tags][15] [and measures at runtime][16] | Custom tags and measures at runtime | Configure [custom tags and measures][13] at runtime. |
 | Parameters | Parameters | Set custom `env` or `service` parameters when a pipeline is triggered. |
 | [Pipeline failure reasons][11] | Pipeline failure reasons | Identify pipeline failure reasons from [error messages][15]. |
-| [Approval wait time][23] | Approval wait time  | View the amount of time jobs and pipelines wait for manual approvals. |
-| [Execution time][24] | Execution time  | View the amount of time pipelines have been running jobs. Gitlab refers to this metric as `duration`. Duration in Gitlab and execution time may show different values. Gitlab does not take into consideration jobs that failed due to certain kinds of failures (such as runner system failures). |
-| [Custom spans][26] | Custom spans | Configure custom spans for your pipelines. |
+| [Approval wait time][22] | Approval wait time  | View the amount of time jobs and pipelines wait for manual approvals. |
+| [Execution time][23] | Execution time  | View the amount of time pipelines have been running jobs. Gitlab refers to this metric as `duration`. Duration in Gitlab and execution time may show different values. Gitlab does not take into consideration jobs that failed due to certain kinds of failures (such as runner system failures). |
+| [Custom spans][25] | Custom spans | Configure custom spans for your pipelines. |
 
 The following GitLab versions are supported:
 
@@ -269,15 +269,21 @@ After these steps, CI Visibility adds the hostname to each job. To see the metri
 {{% /tab %}}
 
 {{% tab "Docker Autoscaler" %}}
-CI Visibility supports Infrastructure metrics for "Docker Autoscaler" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][18].
+CI Visibility supports Infrastructure metrics for "Docker Autoscaler" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][1].
+
+[1]: /continuous_integration/guides/infrastructure_metrics_with_gitlab
 {{% /tab %}}
 
 {{% tab "Instance" %}}
-CI Visibility supports Infrastructure metrics for "Instance" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][18].
+CI Visibility supports Infrastructure metrics for "Instance" executors. For more information, see the [Correlate Infrastructure Metrics with GitLab Jobs guide][1].
+
+[1]: /continuous_integration/guides/infrastructure_metrics_with_gitlab
 {{% /tab %}}
 
 {{% tab "Kubernetes" %}}
-CI Visibility supports Infrastructure metrics for the Kubernetes executor. For this, it is necessary to have the Datadog Agent monitoring the Kubernetes Gitlab infrastructure. See [Install the Datadog Agent on Kubernetes][30] to install the Datadog agent in a Kubernetes cluster.
+CI Visibility supports Infrastructure metrics for the Kubernetes executor. For this, it is necessary to have the Datadog Agent monitoring the Kubernetes Gitlab infrastructure. See [Install the Datadog Agent on Kubernetes][1] to install the Datadog agent in a Kubernetes cluster.
+
+[1]: /containers/kubernetes/installation/?tab=datadogoperator
 {{% /tab %}}
 
 {{% tab "Other executors" %}}
@@ -370,13 +376,13 @@ The <a href="https://docs.gitlab.com/ee/administration/object_storage.html#amazo
 {{% /tab %}}
 {{< /tabs >}}
 
-Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in [Log Management][29]. Logs for GitLab jobs can be identified by the `datadog.product:cipipeline` and `source:gitlab` tags.
+Logs are billed separately from CI Visibility. Log retention, exclusion, and indexes are configured in [Log Management][28]. Logs for GitLab jobs can be identified by the `datadog.product:cipipeline` and `source:gitlab` tags.
 
 For more information about processing job logs collected from the GitLab integration, see the [Processors documentation][17].
 
 ## View partial and downstream pipelines
 
-You can use the following filters to customize your search query in the [CI Visibility Explorer][27].
+You can use the following filters to customize your search query in the [CI Visibility Explorer][26].
 
 {{< img src="ci/partial_retries_search_tags.png" alt="The Pipeline executions page with Partial Pipeline:retry entered in the search query" style="width:100%;">}}
 
@@ -394,7 +400,7 @@ You can also apply these filters using the facet panel on the left hand side of 
 
 Once the integration is successfully configured, the [**CI Pipeline List**][4] and [**Executions**][5] pages populate with data after the pipelines finish.
 
-The **CI Pipeline List** page shows data for only the default branch of each repository. For more information, see [Search and Manage CI Pipelines][28].
+The **CI Pipeline List** page shows data for only the default branch of each repository. For more information, see [Search and Manage CI Pipelines][27].
 
 ## Further reading
 
@@ -417,16 +423,14 @@ The **CI Pipeline List** page shows data for only the default branch of each rep
 [15]: /continuous_integration/pipelines/gitlab/?tab=gitlabcom#view-error-messages-for-pipeline-failures
 [16]: /account_management/teams/
 [17]: /logs/log_configuration/processors/
-[18]: /continuous_integration/guides/infrastructure_metrics_with_gitlab
-[19]: https://about.gitlab.com/
-[20]: /glossary/#partial-retry
-[21]: /glossary/#manual-step
-[22]: /glossary/#queue-time
-[23]: /glossary/#approval-wait-time
-[24]: /glossary/#pipeline-execution-time
-[25]: /glossary/#running-pipeline
-[26]: /glossary/#custom-span
-[27]: /continuous_integration/explorer
-[28]: /continuous_integration/search/#search-for-pipelines
-[29]: /logs/guide/best-practices-for-log-management/
-[30]: /containers/kubernetes/installation/?tab=datadogoperator
+[18]: https://about.gitlab.com/
+[19]: /glossary/#partial-retry
+[20]: /glossary/#manual-step
+[21]: /glossary/#queue-time
+[22]: /glossary/#approval-wait-time
+[23]: /glossary/#pipeline-execution-time
+[24]: /glossary/#running-pipeline
+[25]: /glossary/#custom-span
+[26]: /continuous_integration/explorer
+[27]: /continuous_integration/search/#search-for-pipelines
+[28]: /logs/guide/best-practices-for-log-management/

--- a/content/en/continuous_integration/pipelines/gitlab.md
+++ b/content/en/continuous_integration/pipelines/gitlab.md
@@ -20,7 +20,7 @@ further_reading:
 
 ## Overview
 
-[GitLab][19] is a DevOps platform that automates the software development lifecycle with integrated CI/CD features, enabling you to deploy applications quickly and securely.
+[GitLab][19] is a DevOps platform that automates the software development lifecycle with integrated CI/CD features, enabling you to deploy applications fast and securely.
 
 Set up tracing in GitLab to collect data on your pipeline executions, analyze performance bottlenecks, troubleshoot operational issues, and optimize your deployment workflows.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR updates the documentation to reflect the new GA feature of Gitlab K8s infra correlation for job spans.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
