### PR TITLE
Clarify correct import for Android SDK

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/android.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/android.md
@@ -307,12 +307,16 @@ dependencies {
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
+import io.opentracing.util.GlobalTracer
+
 val tracer = AndroidTracer.Builder().build()
 GlobalTracer.registerIfAbsent(tracer)
 ```
 {{% /tab %}} 
 {{% tab "Java" %}}
 ```java
+import io.opentracing.util.GlobalTracer;
+
 AndroidTracer tracer = new AndroidTracer.Builder().build();
 GlobalTracer.registerIfAbsent(tracer);
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Several issues have been opened by customers who are using `com.datadog.trace.api.GlobalTracer` instead of `io.opentracing.util.GlobalTracer`.
- Add explicit import statement to the code example in question.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
