### PR TITLE
Update manual_instrumentation.md

### DIFF
--- a/content/en/data_streams/manual_instrumentation.md
+++ b/content/en/data_streams/manual_instrumentation.md
@@ -23,7 +23,7 @@ Data Streams Monitoring (DSM) propagates context through message headers. Use ma
 
 2. On services sending or consuming messages, declare the supported types. For example:
 {{< code-block lang="text" >}}
-kinesis, kafka, rabbitmq, sqs, sns
+kinesis, kafka, rabbitmq, sqs, sns, servicebus
 {{< /code-block >}}
 
 3. Call the Data Streams Monitoring checkpoints when messages are produced and when they are consumed, as shown in the example code below:


### PR DESCRIPTION
Making it clear what servicebus should be named

### What does this PR do? What is the motivation?
This PR let's our users know that they should name their Azure Service bus `servicebus` when instrumenting DSM manually. 

<img width="582" alt="image" src="https://github.com/user-attachments/assets/514301d5-daa4-470e-ad64-4d99ac8c052e" />

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```


