### PR TITLE
Use render image hook so images from upstream integration readmes point to correct dir in S3

### DIFF
--- a/layouts/integrations/_markup/render-image.html
+++ b/layouts/integrations/_markup/render-image.html
@@ -1,3 +1,4 @@
-{{- $url := .Destination | safeURL -}}
-{{- $alt := .PlainText | default "" -}}
-{{< img src="(print $url)" alt="(print $alt)" popup="true" >}}
+<img src="https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" .Destination }}"
+  {{- with .PlainText }} alt="{{ . }}"{{ end -}}
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+>

--- a/layouts/integrations/_markup/render-image.html
+++ b/layouts/integrations/_markup/render-image.html
@@ -1,0 +1,3 @@
+{{- $url := .Destination | safeURL -}}
+{{- $alt := .PlainText | default "" -}}
+{{< img src="(print $url)" alt="(print $alt)" popup="true" >}}

--- a/layouts/integrations/_markup/render-image.html
+++ b/layouts/integrations/_markup/render-image.html
@@ -8,13 +8,15 @@
 {{- $app_id := .Page.Params.integration_id | default .Page.Params.name -}}
 {{- $img := replaceRE `(./)?images/` "" .Destination -}}
 {{- $url := split $img "/" -}}
+{{- $app_listings_bucket := cond (eq (hugo.Environment) "live") "dd-app-listings" "dd-app-listings-staging" -}}
+
 {{- if eq (index $url 0) "integrations" -}}
 <img src="{{ (print site.Params.img_url "images/" (.Destination | safeURL)) }}"
   {{- with .PlainText }} alt="{{ . }}"{{ end -}}
   {{- with .Title }} title="{{ . }}"{{ end -}}
 >
 {{- else -}}
-<img src="https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ $img }}"
+<img src="https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ $img }}"
   {{- with .PlainText }} alt="{{ . }}"{{ end -}}
   {{- with .Title }} title="{{ . }}"{{ end -}}
 >

--- a/layouts/integrations/_markup/render-image.html
+++ b/layouts/integrations/_markup/render-image.html
@@ -1,4 +1,21 @@
-<img src="https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" .Destination }}"
+{{-
+/*
+   Inline Images on Integrations Pages
+   This loads images that start with integrations/ from docs
+   Anything else attempts to load from dd-app-listings bucket
+*/
+-}}
+{{- $app_id := .Page.Params.integration_id | default .Page.Params.name -}}
+{{- $img := replaceRE `(./)?images/` "" .Destination -}}
+{{- $url := split $img "/" -}}
+{{- if eq (index $url 0) "integrations" -}}
+<img src="{{ (print site.Params.img_url "images/" (.Destination | safeURL)) }}"
   {{- with .PlainText }} alt="{{ . }}"{{ end -}}
   {{- with .Title }} title="{{ . }}"{{ end -}}
 >
+{{- else -}}
+<img src="https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ $img }}"
+  {{- with .PlainText }} alt="{{ . }}"{{ end -}}
+  {{- with .Title }} title="{{ . }}"{{ end -}}
+>
+{{- end -}}

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -115,7 +115,7 @@
         contents:
 
         - action: integrations
-          branch: main
+          branch: moreauowen/fix-docs-images
           globs:
           - "*/metadata.csv"
           - "*/manifest.json"

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -115,7 +115,7 @@
         contents:
 
         - action: integrations
-          branch: moreauowen/fix-docs-images
+          branch: main
           globs:
           - "*/metadata.csv"
           - "*/manifest.json"


### PR DESCRIPTION
### What does this PR do? What is the motivation?
overwrite image src under the `integrations` dir to point to proper location in s3 so app and docs are pulling from the same source of truth.   this happens if images are inlined in the integration readmes and dont use the docs hugo img shortcode.  See incident-33967 for more

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
https://docs-staging.datadoghq.com/david.jones/irender/integrations/
