### PR TITLE
Bump datadog-lambda-rb layer to version 24

### DIFF
--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -16,7 +16,7 @@
 
 <!-- Ruby Layer -->
 {{- if eq (.Get "layer") "ruby" -}}
-    23
+    24
 {{- end -}}
 
 <!-- Lambda Extension -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Bumps datadog-lambda-rb to layer version 24
https://github.com/DataDog/datadog-lambda-rb/releases/tag/v3.24.0

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
