### PR TITLE
[DOCS-9873] Remove web view tracking from Unity docs

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6851,16 +6851,11 @@ menu:
       parent: rum_mobile_unity
       identifier: rum_mobile_unity_mobile_vitals
       weight: 105
-    - name: Web View Tracking
-      url: real_user_monitoring/mobile_and_tv_monitoring/unity/web_view_tracking
-      parent: rum_mobile_unity
-      identifier: rum_mobile_unity_web_view_tracking
-      weight: 106
     - name: Troubleshooting
       url: real_user_monitoring/mobile_and_tv_monitoring/unity/troubleshooting
       parent: rum_mobile_unity
       identifier: rum_mobile_unity_troubleshooting
-      weight: 107
+      weight: 106
     - name: Platform
       identifier: real_user_monitoring_platform
       url: real_user_monitoring/platform

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/_index.md
@@ -28,6 +28,5 @@ To get started with RUM for Unity, create an application and configure the Unity
   {{< nextlink href="/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration">}}<u>Advanced Configuration</u>:Enrich user sessions, manage events and data, track custom global attributes and widgets, review initialization parameters, modify or drop RUM events, and more.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/mobile_and_tv_monitoring/unity/data_collected">}}<u>Data Collected</u>:Review data that the Unity SDK collects.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/mobile_and_tv_monitoring/unity/mobile_vitals">}}<u>Mobile Vitals</u>: View mobile vitals, which help compute insights about your mobile application.{{< /nextlink >}}
-  {{< nextlink href="/real_user_monitoring/mobile_and_tv_monitoring/unity/web_view_tracking">}}<u>Web View Tracking</u>: Monitor web views and eliminate blind spots in your mobile applications.{{< /nextlink >}}
   {{< nextlink href="/real_user_monitoring/mobile_and_tv_monitoring/unity/troubleshooting">}}<u>Troubleshooting</u>: Common troubleshooting Unity SDK issues.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/web_view_tracking.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/web_view_tracking.md
@@ -1,5 +1,0 @@
----
-title: Unity Web View Tracking
----
-
-{{< include-markdown "real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking" >}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/web_view_tracking/_index.md
@@ -6,6 +6,7 @@ aliases:
   - /real_user_monitoring/flutter/web_view_tracking
   - /real_user_monitoring/reactnative/web_view_tracking
   - /real_user_monitoring/kotlin-multiplatform/web_view_tracking
+  - /real_user_monitoring/mobile_and_tv_monitoring/unity/web_view_tracking
 further_reading:
   - link: https://github.com/DataDog/dd-sdk-android
     tag: "Source Code"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Removes the Web View Tracking from Unity docs because it doesn't make sense for this platform

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
