### PR TITLE
fix: clarify that APM metrics include tags from DD_TAGS

### DIFF
--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -155,7 +155,7 @@ A JSON array of objects. Each object must have a `"sample_rate"`. The `"name"`,`
   
 `DD_TAGS`
 : **Default**: [] <br>
-A list of default tags to be added to every span, metric and profile. Tags can be separated by commas or spaces, for example: `layer:api,team:intake,key:value` or `layer:api team:intake key:value`.
+A list of default tags to be added to every span, metric, and profile. Tags can be separated by commas or spaces, for example: `layer:api,team:intake,key:value` or `layer:api team:intake key:value`.
 
 ### Agent  
 

--- a/content/en/tracing/trace_collection/library_config/go.md
+++ b/content/en/tracing/trace_collection/library_config/go.md
@@ -155,7 +155,7 @@ A JSON array of objects. Each object must have a `"sample_rate"`. The `"name"`,`
   
 `DD_TAGS`
 : **Default**: [] <br>
-A list of default tags to be added to every span and profile. Tags can be separated by commas or spaces, for example: `layer:api,team:intake,key:value` or `layer:api team:intake key:value`.
+A list of default tags to be added to every span, metric and profile. Tags can be separated by commas or spaces, for example: `layer:api,team:intake,key:value` or `layer:api team:intake key:value`.
 
 ### Agent  
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds that metrics are submitted to the agent from the Go tracer including tags from `DD_TAGS` environment variables.

Source: https://github.com/DataDog/dd-trace-go/pull/3067

### Merge instructions

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```
