### PR TITLE
Updates the language on the serverless init cloud run page to push customers to use the sidecar

### DIFF
--- a/content/en/serverless/guide/gcr_serverless_init.md
+++ b/content/en/serverless/guide/gcr_serverless_init.md
@@ -10,7 +10,7 @@ further_reading:
 
 ## Overview
 
-<div class="alert alert-info">Note, if you are running multiple containers per Google Cloud Run application the recommended approach is to use the Datadog sidecar: <a href="/serverless/google_cloud_run">Instrument Google Cloud Run</a>.</div>
+<div class="alert alert-info">If you are running multiple containers per Google Cloud Run application, Datadog recommends using the Datadog sidecar: <a href="/serverless/google_cloud_run">Instrument Google Cloud Run</a>.</div>
 
 Google Cloud Run is a fully managed serverless platform for deploying and scaling container-based applications. Datadog provides monitoring and log collection for Cloud Run through the [Google Cloud integration][1]. Datadog also provides a solution for instrumenting your Cloud Run applications with a purpose-built Agent to enable tracing, custom metrics, and direct log collection.
 

--- a/content/en/serverless/guide/gcr_serverless_init.md
+++ b/content/en/serverless/guide/gcr_serverless_init.md
@@ -10,7 +10,7 @@ further_reading:
 
 ## Overview
 
-<div class="alert alert-info">To instrument your Google Cloud Run applications with a sidecar, see <a href="/serverless/google_cloud_run">Instrument Google Cloud Run</a>.</div>
+<div class="alert alert-info">Note, if you are running multiple containers per Google Cloud Run application the recommended approach is to use the Datadog sidecar: <a href="/serverless/google_cloud_run">Instrument Google Cloud Run</a>.</div>
 
 Google Cloud Run is a fully managed serverless platform for deploying and scaling container-based applications. Datadog provides monitoring and log collection for Cloud Run through the [Google Cloud integration][1]. Datadog also provides a solution for instrumenting your Cloud Run applications with a purpose-built Agent to enable tracing, custom metrics, and direct log collection.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
We've seen issues with port conflicts when using serverless init, specifically when a customer is running multiple container instances per app. The recommended approach in this case is to utilize the sidecar, plus we want to push customers away from serverless init

### Merge instructions

Merge readiness:
- [X] Ready for merge


### Additional notes
