### PR TITLE
Change Android SDK `DatadogInterceptor` and `TracingInterceptor` creation snippets from constructor to builder

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/android/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/android/advanced_configuration.md
@@ -126,7 +126,7 @@ Note the action type should be one of the following: "custom", "click", "tap", "
 
 ### Enrich resources
 
-When [tracking resources automatically][6], provide a custom `RumResourceAttributesProvider` instance to add custom attributes to each tracked network request. For example, if you want to track a network request's headers, create an implementation as follows, and pass it in the constructor of the `DatadogInterceptor`.
+When [tracking resources automatically][6], provide a custom `RumResourceAttributesProvider` instance to add custom attributes to each tracked network request. For example, if you want to track a network request's headers, create an implementation as follows, and pass it in the builder of the `DatadogInterceptor`.
 
 {{< tabs >}}
 {{% tab "Kotlin" %}}
@@ -509,16 +509,18 @@ To get timing information in resources (such as third-party providers, network r
 {{< tabs >}}
 {{% tab "Kotlin" %}}
    ```kotlin
+       val tracedHosts = listOf("example.com")
        val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(DatadogInterceptor())
+        .addInterceptor(DatadogInterceptor.Builder(tracedHosts).build())
         .eventListenerFactory(DatadogEventListener.Factory())
         .build()
    ```
 {{% /tab %}}
 {{% tab "Java" %}}
    ```java
+       List<String> tracedHosts = Arrays.asList("example.com");
        OkHttpClient okHttpClient = new OkHttpClient.Builder()
-        .addInterceptor(new DatadogInterceptor())
+        .addInterceptor(new DatadogInterceptor.Builder(tracedHosts).build())
         .eventListenerFactory(new DatadogEventListener.Factory())
         .build();
    ```

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/android/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/android/setup.md
@@ -398,7 +398,7 @@ val tracedHostsWithHeaderType = mapOf(
     "example.com" to setOf(
         TracingHeaderType.DATADOG,
         TracingHeaderType.TRACECONTEXT),
-    "example.eu" to  setOf(
+    "example.eu" to setOf(
         TracingHeaderType.DATADOG,
         TracingHeaderType.TRACECONTEXT))
 val okHttpClient = OkHttpClient.Builder()
@@ -408,8 +408,8 @@ val okHttpClient = OkHttpClient.Builder()
 {{% /tab %}}
 {{% tab "Java" %}}
 ```java
-final Map<String, Set<TracingHeaderType>> tracedHostsWithHeaderType = new HashMap<>();
-final Set<TracingHeaderType> datadogAndW3HeadersTypes = new HashSet<>(Arrays.asList(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT));
+Map<String, Set<TracingHeaderType>> tracedHostsWithHeaderType = new HashMap<>();
+Set<TracingHeaderType> datadogAndW3HeadersTypes = new HashSet<>(Arrays.asList(TracingHeaderType.DATADOG, TracingHeaderType.TRACECONTEXT));
 tracedHostsWithHeaderType.put("example.com", datadogAndW3HeadersTypes);
 tracedHostsWithHeaderType.put("example.eu", datadogAndW3HeadersTypes);
 OkHttpClient okHttpClient = new OkHttpClient.Builder()

--- a/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
+++ b/content/en/real_user_monitoring/platform/connect_rum_and_traces.md
@@ -153,8 +153,8 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
     val tracedHosts = listOf("example.com", "example.eu")
 
     val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(DatadogInterceptor(tracedHosts))
-        .addNetworkInterceptor(TracingInterceptor(tracedHosts))
+        .addInterceptor(DatadogInterceptor.Builder(tracedHosts).build())
+        .addNetworkInterceptor(TracingInterceptor.Builder(tracedHosts).build())
         .eventListenerFactory(DatadogEventListener.Factory())
         .build()
     ```
@@ -164,8 +164,14 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
 3.  _(Optional)_ Configure the `traceSampler` parameter to keep a defined percentage of the backend traces. If not set, 20% of the traces coming from application requests are sent to Datadog. To keep 100% of backend traces:
 
 ```kotlin
+    val tracedHosts = listOf("example.com")
+
     val okHttpClient = OkHttpClient.Builder()
-       .addInterceptor(DatadogInterceptor(traceSampler = RateBasedSampler(100f)))
+       .addInterceptor(
+           DatadogInterceptor.Builder(tracedHosts)
+               .setTraceSampler(RateBasedSampler(100f))
+               .build()
+       )
        .build()
 ```
 
@@ -461,8 +467,8 @@ The default injection style is `tracecontext`, `Datadog`.
                           "example.eu" to setOf(TracingHeaderType.DATADOG))
 
     val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(DatadogInterceptor(tracedHosts))
-        .addNetworkInterceptor(TracingInterceptor(tracedHosts))
+        .addInterceptor(DatadogInterceptor.Builder(tracedHosts).build())
+        .addNetworkInterceptor(TracingInterceptor.Builder(tracedHosts).build())
         .eventListenerFactory(DatadogEventListener.Factory())
         .build()
     ```

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/android.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/android.md
@@ -688,19 +688,24 @@ If you want to trace your OkHttp requests, you can add the provided [Interceptor
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
+val tracedHosts = listOf("example.com", "example.eu")
 val okHttpClient = OkHttpClient.Builder() 
         .addInterceptor(
-            DatadogInterceptor(listOf("example.com", "example.eu"), traceSampler = RateBasedSampler(20f))
+            DatadogInterceptor.Builder(tracedHosts)
+                .setTraceSampler(RateBasedSampler(20f))
+                .build()
         )
         .build()
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
 ```java
-final List<String> tracedHosts = Arrays.asList("example.com", "example.eu");
-final OkHttpClient okHttpClient = new OkHttpClient.Builder()
+List<String> tracedHosts = Arrays.asList("example.com", "example.eu");
+OkHttpClient okHttpClient = new OkHttpClient.Builder()
         .addInterceptor(
-                new DatadogInterceptor(/** SDK instance name or null **/, tracedHosts, null, null, new RateBasedSampler(20f))
+            new DatadogInterceptor.Builder(tracedHosts)
+                    .setTraceSampler(new RateBasedSampler(20f))
+                    .build()
         )
         .build();
 ```
@@ -718,20 +723,32 @@ The interceptor tracks requests at the application level. You can also add a `Tr
 ```kotlin
 val tracedHosts = listOf("example.com", "example.eu") 
 val okHttpClient =  OkHttpClient.Builder()
-        .addInterceptor(DatadogInterceptor(tracedHosts, traceSampler = RateBasedSampler(20f)))
-        .addNetworkInterceptor(TracingInterceptor(tracedHosts, traceSampler = RateBasedSampler(20f)))
+        .addInterceptor(
+            DatadogInterceptor.Builder(tracedHosts)
+                .setTraceSampler(RateBasedSampler(20f))
+                .build()
+        )
+        .addNetworkInterceptor(
+            TracingInterceptor.Builder(tracedHosts)
+                .setTraceSampler(RateBasedSampler(100f))
+                .build()
+        )
         .build()
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
 ```java
-final List<String> tracedHosts = Arrays.asList("example.com", "example.eu");
-final OkHttpClient okHttpClient = new OkHttpClient.Builder()
+List<String> tracedHosts = Arrays.asList("example.com", "example.eu");
+OkHttpClient okHttpClient = new OkHttpClient.Builder()
         .addInterceptor(
-                new DatadogInterceptor(/** SDK instance name or null **/, tracedHosts, null, null, new RateBasedSampler(20f))
+            new DatadogInterceptor.Builder(tracedHosts)
+                    .setTraceSampler(new RateBasedSampler(20f))
+                    .build()
         )
         .addNetworkInterceptor(
-                new TracingInterceptor(/** SDK instance name or null **/, tracedHosts, null, new RateBasedSampler(20f))
+            new TracingInterceptor.Builder(tracedHosts)
+                    .setTraceSampler(new RateBasedSampler(20f))
+                    .build()
         )
         .build();
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Constructors for these classes are deprecated and builders should be used instead.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
