### PR TITLE
Add Node.js DI documentation page

### DIFF
--- a/content/en/dynamic_instrumentation/enabling/dotnet.md
+++ b/content/en/dynamic_instrumentation/enabling/dotnet.md
@@ -12,7 +12,7 @@ further_reading:
       text: 'Getting Started with Datadog Agent'
 ---
 
-Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version, and go directly to enabling Dynamic Instrumentation in step 4.
+Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version. Then, go directly to enabling Dynamic Instrumentation in step 4.
 
 ## Prerequisites
 
@@ -23,10 +23,7 @@ For a better experience, Datadog recommends enabling [autocomplete and search (i
 1. Install or upgrade your Agent to version [7.45.0][7] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 3. Install or upgrade the .NET tracing libraries to version 2.54.0, by following the relevant instructions for [.NET Framework][2] or [.NET Core][3].
-
-   **Note**: Dynamic Instrumentation is available in the `dd-trace-dotnet` library in versions 2.54.0 and later.
-
-4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your probes and target active clients across these dimensions.
+4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.
 5. After starting your service with Dynamic Instrumentation enabled, you can start using Dynamic Instrumentation on the [APM > Dynamic Instrumentation page][4].
 
 ## Configuration
@@ -43,7 +40,7 @@ Configure Dynamic Instrumentation using the following environment variables:
 
 ## What to do next
 
-See [Dynamic Instrumentation][6] for information about setting snapshot and metric probes and browsing and indexing the data.
+See [Dynamic Instrumentation][6] for information about adding instrumentations and browsing and indexing the data.
 
 ## Further reading
 

--- a/content/en/dynamic_instrumentation/enabling/java.md
+++ b/content/en/dynamic_instrumentation/enabling/java.md
@@ -12,7 +12,7 @@ further_reading:
       text: 'Getting Started with Datadog Agent'
 ---
 
-Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version, and go directly to enabling Dynamic Instrumentation in step 4.
+Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version. Then, go directly to enabling Dynamic Instrumentation in step 4.
 
 ## Requirements
 
@@ -45,7 +45,7 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 
    **Note**: Dynamic Instrumentation is available in the `dd-java-agent.jar` library in versions 1.34.0 and later.
 
-3. Run your service with Dynamic Instrumentation enabled by setting `-Ddd.dynamic.instrumentation.enabled` flag or `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `dd.service`, `dd.env`, and `dd.version` Unified Service Tags so you can filter and group your probes and target active clients across these dimensions.
+3. Run your service with Dynamic Instrumentation enabled by setting `-Ddd.dynamic.instrumentation.enabled` flag or `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `dd.service`, `dd.env`, and `dd.version` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.
    {{< tabs >}}
 {{% tab "Command arguments" %}}
 
@@ -99,7 +99,7 @@ Configure Dynamic Instrumentation using the following environment variables:
 
 ## What to do next
 
-See [Dynamic Instrumentation][6] for information about setting snapshot and metric probes and browsing and indexing the data.
+See [Dynamic Instrumentation][6] for information about adding instrumentations and browsing and indexing the data.
 
 ## Further reading
 

--- a/content/en/dynamic_instrumentation/enabling/nodejs.md
+++ b/content/en/dynamic_instrumentation/enabling/nodejs.md
@@ -1,7 +1,5 @@
 ---
 title: Enable Dynamic Instrumentation for Node.js
-aliases:
-    - /tracing/dynamic_instrumentation/enabling/nodejs/
 private: false
 code_lang: nodejs
 type: multi-code-lang

--- a/content/en/dynamic_instrumentation/enabling/nodejs.md
+++ b/content/en/dynamic_instrumentation/enabling/nodejs.md
@@ -1,9 +1,9 @@
 ---
-title: Enable Dynamic Instrumentation for PHP
+title: Enable Dynamic Instrumentation for Node.js
 aliases:
-    - /tracing/dynamic_instrumentation/enabling/php/
-private: true
-code_lang: php
+    - /tracing/dynamic_instrumentation/enabling/nodejs/
+private: false
+code_lang: nodejs
 type: multi-code-lang
 code_lang_weight: 30
 further_reading:
@@ -12,13 +12,19 @@ further_reading:
       text: 'Getting Started with Datadog Agent'
 ---
 
+{{< beta-callout-private url="https://forms.gle/TODO" >}}
+    Dynamic Instrumentation for Node.js is in limited preview, and is not available to all customers.
+    Request access to join the waiting list.
+    Note that <a href="#limitations">some limitations</a> apply to the preview.
+{{< /beta-callout-private >}}
+
 Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version. Then, go directly to enabling Dynamic Instrumentation in step 4.
 
 ## Installation
 
-1. Install or upgrade your Agent to version [7.45.0][7] or higher.
+1. Install or upgrade your Agent to version [7.45.0][6] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
-3. Install or upgrade the PHP tracing libraries to version 1.4.0, by following the [relevant instructions][2].
+3. Install or upgrade the Node.js tracing library to version 5.32.0 or higher, by following the [relevant instructions][2].
 4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.
 5. After starting your service with Dynamic Instrumentation enabled, you can start using Dynamic Instrumentation on the [APM > Dynamic Instrumentation page][3].
 
@@ -29,14 +35,14 @@ Configure Dynamic Instrumentation using the following environment variables:
 | Environment variable                             | Type          | Description                                                                                                               |
 | ------------------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | `DD_DYNAMIC_INSTRUMENTATION_ENABLED`             | Boolean       | Set to `true` to enable Dynamic Instrumentation.                                                                          |
-| `DD_SERVICE`                                     | String        | The [service][4] name, for example, `web-backend`.                                                                        |
-| `DD_ENV`                                         | String        | The [environment][4] name, for example, `production`.                                                                     |
-| `DD_VERSION`                                     | String        | The [version][4] of your service.                                                                                         |
+| `DD_SERVICE`                                     | String        | The [service][5] name, for example, `web-backend`.                                                                        |
+| `DD_ENV`                                         | String        | The [environment][5] name, for example, `production`.                                                                     |
+| `DD_VERSION`                                     | String        | The [version][5] of your service.                                                                                         |
 | `DD_TAGS`                                        | String        | Tags to apply to produced data. Must be a list of `<key>:<value>` separated by commas such as: `layer:api,team:intake`.   |
 
 ## What to do next
 
-See [Dynamic Instrumentation][5] for information about adding instrumentations and browsing and indexing the data.
+See [Dynamic Instrumentation][4] for information about adding instrumentations and browsing and indexing the data.
 
 ## Limitations
 
@@ -44,21 +50,30 @@ The following limitations apply to the limited preview:
 
 ### Supported features
 
-- [Dynamic Logs][8] attached to a function/method
+- [Dynamic Logs][7] attached to a specific file/line
+- Capturing of variables for Dynamic Logs
+- [PII redaction][8] based on variable/property names
+- [Source code integration][9]
 
 ### Unsupported features
 
-- Dynamic Logs attached to a specific file/line
 - Dynamic Metrics, Spans, and Span Tags
+- Dynamic Logs attached to a function/method
+- Custom template for Dynamic Logs
+- Dynamic Log conditions
+- Source maps (e.g. if using TypeScript, the Dynamic Log needs to be configured against the transpiled JavaScript file)
+- PII redaction based on specific classes or types
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/trace_collection/
-[2]: /tracing/trace_collection/dd_libraries/php/
+[2]: /tracing/trace_collection/dd_libraries/nodejs/
 [3]: https://app.datadoghq.com/dynamic-instrumentation
-[4]: /getting_started/tagging/unified_service_tagging
-[5]: /dynamic_instrumentation/
-[7]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
-[8]: /dynamic_instrumentation/#creating-log-probes
+[4]: /dynamic_instrumentation/
+[5]: /getting_started/tagging/unified_service_tagging
+[6]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
+[7]: /dynamic_instrumentation/#creating-log-probes
+[8]: /dynamic_instrumentation/sensitive-data-scrubbing/#custom-identifier-redaction
+[9]: /integrations/guide/source-code-integration/?tab=nodejs#embed-git-information-in-your-build-artifacts

--- a/content/en/dynamic_instrumentation/enabling/nodejs.md
+++ b/content/en/dynamic_instrumentation/enabling/nodejs.md
@@ -22,7 +22,7 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 
 1. Install or upgrade your Agent to version [7.45.0][6] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
-3. Install or upgrade the Node.js tracing library to version 5.34.0 or higher, by following the [relevant instructions][2].
+3. Install or upgrade the Node.js tracing library to version 5.35.0 or higher, by following the [relevant instructions][2].
 4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.
 5. After starting your service with Dynamic Instrumentation enabled, you can start using Dynamic Instrumentation on the [APM > Dynamic Instrumentation page][3].
 

--- a/content/en/dynamic_instrumentation/enabling/nodejs.md
+++ b/content/en/dynamic_instrumentation/enabling/nodejs.md
@@ -22,7 +22,7 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 
 1. Install or upgrade your Agent to version [7.45.0][6] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
-3. Install or upgrade the Node.js tracing library to version 5.32.0 or higher, by following the [relevant instructions][2].
+3. Install or upgrade the Node.js tracing library to version 5.34.0 or higher, by following the [relevant instructions][2].
 4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.
 5. After starting your service with Dynamic Instrumentation enabled, you can start using Dynamic Instrumentation on the [APM > Dynamic Instrumentation page][3].
 

--- a/content/en/dynamic_instrumentation/enabling/nodejs.md
+++ b/content/en/dynamic_instrumentation/enabling/nodejs.md
@@ -12,7 +12,7 @@ further_reading:
       text: 'Getting Started with Datadog Agent'
 ---
 
-{{< beta-callout-private url="https://forms.gle/TODO" >}}
+{{< beta-callout-private url="https://www.datadoghq.com/product-preview/dynamic-instrumentation-for-nodejs/" >}}
     Dynamic Instrumentation for Node.js is in limited preview, and is not available to all customers.
     Request access to join the waiting list.
     Note that <a href="#limitations">some limitations</a> apply to the preview.

--- a/content/en/dynamic_instrumentation/enabling/php.md
+++ b/content/en/dynamic_instrumentation/enabling/php.md
@@ -38,19 +38,6 @@ Configure Dynamic Instrumentation using the following environment variables:
 
 See [Dynamic Instrumentation][5] for information about adding instrumentations and browsing and indexing the data.
 
-## Limitations
-
-The following limitations apply to the limited preview:
-
-### Supported features
-
-- [Dynamic Logs][8] attached to a function/method
-
-### Unsupported features
-
-- Dynamic Logs attached to a specific file/line
-- Dynamic Metrics, Spans, and Span Tags
-
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -61,4 +48,3 @@ The following limitations apply to the limited preview:
 [4]: /getting_started/tagging/unified_service_tagging
 [5]: /dynamic_instrumentation/
 [7]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
-[8]: /dynamic_instrumentation/#creating-log-probes

--- a/content/en/dynamic_instrumentation/enabling/python.md
+++ b/content/en/dynamic_instrumentation/enabling/python.md
@@ -12,7 +12,7 @@ further_reading:
       text: 'Getting Started with Datadog Agent'
 ---
 
-Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version, and go directly to enabling Dynamic Instrumentation in step 4.
+Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version. Then, go directly to enabling Dynamic Instrumentation in step 4.
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ Recommended, [autocomplete and search (in Preview)][6] is enabled.
 
    **Note**: Dynamic Instrumentation is available in the `ddtrace` library version 2.2.0 and higher.
 
-4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your probes and target active clients across these dimensions.
+4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.
 {{< tabs >}}
 {{% tab "Environment variables" %}}
 
@@ -70,7 +70,7 @@ Configure Dynamic Instrumentation using the following environment variables:
 
 ## What to do next
 
-See [Dynamic Instrumentation][5] for information about setting snapshot and metric probes and browsing and indexing the data.
+See [Dynamic Instrumentation][5] for information about adding instrumentations and browsing and indexing the data.
 
 ## Further reading
 

--- a/content/en/dynamic_instrumentation/enabling/ruby.md
+++ b/content/en/dynamic_instrumentation/enabling/ruby.md
@@ -12,7 +12,7 @@ further_reading:
       text: 'Getting Started with Datadog Agent'
 ---
 
-{{< beta-callout-private url="https://forms.gle/TODO" >}}
+{{< beta-callout-private url="https://www.datadoghq.com/product-preview/dynamic-instrumentation-for-ruby/" >}}
     Dynamic Instrumentation for Ruby is in limited preview, and is not available to all customers.
     Request access to join the waiting list.
     Note that <a href="#limitations">some limitations</a> apply to the preview.

--- a/content/en/dynamic_instrumentation/enabling/ruby.md
+++ b/content/en/dynamic_instrumentation/enabling/ruby.md
@@ -2,7 +2,7 @@
 title: Enable Dynamic Instrumentation for Ruby
 aliases:
     - /tracing/dynamic_instrumentation/enabling/ruby/
-private: true
+private: false
 code_lang: ruby
 type: multi-code-lang
 code_lang_weight: 30
@@ -12,17 +12,22 @@ further_reading:
       text: 'Getting Started with Datadog Agent'
 ---
 
-Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version, and go directly to enabling Dynamic Instrumentation in step 4.
+{{< beta-callout-private url="https://forms.gle/TODO" >}}
+    Dynamic Instrumentation for Ruby is in limited preview, and is not available to all customers.
+    Request access to join the waiting list.
+    Note that <a href="#limitations">some limitations</a> apply to the preview.
+{{< /beta-callout-private >}}
+
+Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version. Then, go directly to enabling Dynamic Instrumentation in step 4.
+
+**Note**: Dynamic Instrumentation is supported only for applications running in `production` environment (`RAILS_ENV`, `RACK_ENV`, etc.).
 
 ## Installation
 
 1. Install or upgrade your Agent to version [7.45.0][7] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 3. Install or upgrade the Ruby tracing library to version 2.9.0 or higher, by following the [relevant instructions][2].
-
-   **Note**: Dynamic Instrumentation is available in the `dd-trace-ruby` library in versions 2.9.0 and later. Only log probes are currently supported.
-
-4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your probes and target active clients across these dimensions.
+4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.
 5. After starting your service with Dynamic Instrumentation enabled, you can start using Dynamic Instrumentation on the [APM > Dynamic Instrumentation page][3].
 
 ## Configuration
@@ -39,7 +44,25 @@ Configure Dynamic Instrumentation using the following environment variables:
 
 ## What to do next
 
-See [Dynamic Instrumentation][5] for information about setting snapshot and metric probes and browsing and indexing the data.
+See [Dynamic Instrumentation][5] for information about adding instrumentations and browsing and indexing the data.
+
+## Limitations
+
+The following limitations apply to the limited preview:
+
+### Supported features
+
+- [Dynamic Logs][8]
+- Capturing of variables for Dynamic Logs attached to a specific file/line
+- [PII redaction][10]
+- [Source code integration][9]
+
+### Unsupported features
+
+- Dynamic Metrics, Spans, and Span Tags
+- Dynamic Log conditions
+- Local variable capture for Dynamic Logs attached to a method
+- Expression evaluation in Dynamic Log templates
 
 ## Further reading
 
@@ -51,3 +74,6 @@ See [Dynamic Instrumentation][5] for information about setting snapshot and metr
 [4]: /getting_started/tagging/unified_service_tagging
 [5]: /dynamic_instrumentation/
 [7]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
+[8]: /dynamic_instrumentation/#creating-log-probes
+[9]: /integrations/guide/source-code-integration/?tab=ruby
+[10]: /dynamic_instrumentation/sensitive-data-scrubbing/#custom-identifier-redaction

--- a/content/en/dynamic_instrumentation/enabling/ruby.md
+++ b/content/en/dynamic_instrumentation/enabling/ruby.md
@@ -63,6 +63,7 @@ The following limitations apply to the limited preview:
 - Dynamic Log conditions
 - Local variable capture for Dynamic Logs attached to a method
 - Expression evaluation in Dynamic Log templates
+- Instrumenting third-party libraries
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

1. Add a Node.js page to the Dynamic Instrumentation (DI) documentation
2. Replicate minor changes to the shared "template" in the other languages
3. Add "Limited Preview" callout with link to waiting list to all languages being in Limited Preview (Node.js and Ruby)
4. Add "Limitations" section to all languages being in Limited Preview (Node.js and Ruby)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
