### PR TITLE
Update about default config in newer Agent versions

### DIFF
--- a/content/en/tracing/services/inferred_services.md
+++ b/content/en/tracing/services/inferred_services.md
@@ -19,11 +19,12 @@ Explore inferred services in the [Service Catalog][1] by filtering entries by en
 ## Set up inferred services
 
 To see inferred services, you must enable some configurations. 
+Starting from version [7.60.0][1] of the Datadog Agent, these configurations are enabled by default. 
 
 {{< tabs >}}
 {{% tab "Agent v7.55.1+" %}}
 
-For Datadog Agent versions [7.55.1][1] or later, add the following to your `datadog.yaml` configuration file:
+For Datadog Agent versions [7.55.1][2] or later, add the following to your `datadog.yaml` configuration file:
 
 {{< code-block lang="yaml" filename="datadog.yaml" collapsible="true" >}}
 
@@ -42,10 +43,11 @@ DD_APM_PEER_TAGS_AGGREGATION=true
 
 {{< /code-block >}}
 
-If you are using Helm, include these environment variables in your `values.yaml` [file][2].
+If you are using Helm, include these environment variables in your `values.yaml` [file][3].
 
-[1]: https://github.com/DataDog/datadog-agent/releases/tag/7.55.1
-[2]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml
+[1]: https://github.com/DataDog/datadog-agent/releases/tag/7.60.0
+[2]: https://github.com/DataDog/datadog-agent/releases/tag/7.55.1
+[3]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml
 {{% /tab %}}
 {{% tab "Agent v7.50.3 - v7.54.1" %}}
 


### PR DESCRIPTION
Under Set up inferred services, added note to indicate that configurations are enabled by default in v7.60.0 of Agent.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Under Set up inferred services, added note to indicate that configurations are enabled by default in v7.60.0 of Agent.
This was confirmed by the eng team, please see [slack thread](https://dd.slack.com/archives/C04KJSX93BJ/p1736955019784649) 
<img width="995" alt="2025-01-16_16-50-09" src="https://github.com/user-attachments/assets/6a0a7263-be41-4627-a487-a1bf9cddb34f" />


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
