### PR TITLE
(maint) Pin Vale to a specific version

### DIFF
--- a/.github/workflows/vale_linter.yml
+++ b/.github/workflows/vale_linter.yml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/setup-python@v5.1.0
       with:
         python-version: '3.11'
-    - run: pip install vale
+    - run: pip install vale==3.9.1
 
     - name: Edit StylesPath in Vale config file
       run: sed -i 's/\.\.\/datadog-vale\/styles/datadog-vale\/styles/' .vale.ini

--- a/content/en/agent/basic_agent_usage/amazonlinux.md
+++ b/content/en/agent/basic_agent_usage/amazonlinux.md
@@ -25,7 +25,7 @@ algolia:
 
 ## Overview
 
-This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
+This page quickly outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 

--- a/content/en/agent/basic_agent_usage/amazonlinux.md
+++ b/content/en/agent/basic_agent_usage/amazonlinux.md
@@ -25,7 +25,7 @@ algolia:
 
 ## Overview
 
-This page quickly outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
+This page outlines the basic features of the Datadog Agent for Amazon Linux. If you haven't installed the Agent yet, instructions can be found in the [Datadog Agent Integration][1] documentation.
 
 Packages are available for 64-bit x86 and Arm v8 architectures. For other architectures, use the source install.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

Pinning Vale to a slightly older version to get around a bug. Moving forward, we should probably stick to using a specific version of Vale instead of allowing the action to use the latest version. That way we can test the updates before we use them in CI.

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
