### PR TITLE
Fix region conditional on AWS manual role based setup docs

### DIFF
--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -62,14 +62,14 @@ To set up the AWS integration manually, create an IAM policy and IAM role in you
 ### Generate an external ID
 
 1. In the [AWS integration configuration page][1], click **Add AWS Account**, and then select **Manually**.
-{{< site-region region="us,us3,us5,eu,ap1" >}}
 2. Choose which AWS partition your AWS account is scoped to. The partition is either `aws` for commercial regions, `aws-cn` for China*, or `aws-us-gov` for GovCloud. See [Partitions][9] in the AWS documentation for more information.
+{{< site-region region="us,us3,us5,eu,ap1" >}}
 3. Select `Role Delegation` for the access type. Role delegation is only supported for AWS accounts scoped to AWS commercial regions.
 {{< /site-region >}}
 {{< site-region region="gov" >}}
-3. Select `Role Delegation` for the access type. Role delegation is only supported for AWS accounts scoped to AWS commercial or AWS GovCloud regions.
+4. Select `Role Delegation` for the access type. Role delegation is only supported for AWS accounts scoped to AWS commercial or AWS GovCloud regions.
 {{< /site-region >}}
-4. Copy the `AWS External ID`. For more information about the external ID, read the [IAM User Guide][2].
+5. Copy the `AWS External ID`. For more information about the external ID, read the [IAM User Guide][2].
   **Note**: The External ID remains available and is not regenerated for 48 hours, unless explicitly changed by a user or another AWS account is added to Datadog during this period. You can return to the **Add New AWS Account** page within that time period to complete the process of adding an account without the External ID changing.
 
 ### AWS IAM policy for Datadog

--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -67,9 +67,9 @@ To set up the AWS integration manually, create an IAM policy and IAM role in you
 3. Select `Role Delegation` for the access type. Role delegation is only supported for AWS accounts scoped to AWS commercial regions.
 {{< /site-region >}}
 {{< site-region region="gov" >}}
-4. Select `Role Delegation` for the access type. Role delegation is only supported for AWS accounts scoped to AWS commercial or AWS GovCloud regions.
+3. Select `Role Delegation` for the access type. Role delegation is only supported for AWS accounts scoped to AWS commercial or AWS GovCloud regions.
 {{< /site-region >}}
-5. Copy the `AWS External ID`. For more information about the external ID, read the [IAM User Guide][2].
+4. Copy the `AWS External ID`. For more information about the external ID, read the [IAM User Guide][2].
   **Note**: The External ID remains available and is not regenerated for 48 hours, unless explicitly changed by a user or another AWS account is added to Datadog during this period. You can return to the **Add New AWS Account** page within that time period to complete the process of adding an account without the External ID changing.
 
 ### AWS IAM policy for Datadog


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates our manual role based aws integration docs to properly display which partitions are valid based on the user using either a fed or commercial datadog instance.

https://docs-staging.datadoghq.com/saleel/fix-region-conditional-on-aws-manual-setup-docs/integrations/guide/aws-manual-setup/?tab=roledelegation&site=gov (see how step 2 is displayed)

https://docs.datadoghq.com/integrations/guide/aws-manual-setup/?tab=roledelegation#setup (missing in prod)

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
