### PR TITLE
Add notes about disabling GKE for SBOM collection

### DIFF
--- a/content/en/infrastructure/containers/container_images.md
+++ b/content/en/infrastructure/containers/container_images.md
@@ -103,7 +103,9 @@ container_image:
 
 The following instructions turn on [Software Bill of Materials][5] (SBOM) collection for CSM Vulnerabilities. SBOM collection enables automatic detection of container image vulnerabilities. Vulnerabilities are evaluated and scanned against your containers every hour. Vulnerability management for container images is included in [CSM Pro and Enterprise plans][10].
 
-**Note**: The CSM Vulnerabilities feature is not available for AWS Fargate or Windows environments.
+**Notes**:
+- The CSM Vulnerabilities feature is not available for AWS Fargate or Windows environments.
+- SBOM collection is not compatible with the image streaming feature in Google Kubernetes Engine (GKE). To disable it, see the [Disable Image streaming][11] section of the GKE docs.
 
 {{< tabs >}}
 {{% tab "Kubernetes (Operator)" %}}
@@ -230,3 +232,4 @@ Tag and enrich your container images with arbitrary tags by using [extract label
 [8]: /security/cloud_security_management/vulnerabilities
 [9]: https://app.datadoghq.com/container-images/image-trends
 [10]: https://www.datadoghq.com/pricing/?product=cloud-security-management#products
+[11]: https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#disable

--- a/content/en/security/cloud_security_management/setup/agent/kubernetes.md
+++ b/content/en/security/cloud_security_management/setup/agent/kubernetes.md
@@ -17,6 +17,8 @@ Use the following instructions to enable Misconfigurations, Threat Detection, an
 
 - Latest Datadog Agent version. For installation instructions, see [Getting Started with the Agent][5] or install the Agent from the [Datadog UI][6].
 
+**Note**: SBOM collection is not compatible with the image streaming feature in Google Kubernetes Engine (GKE). To disable it, see the [Disable Image streaming][7] section of the GKE docs.
+
 ## Installation
 
 {{< tabs >}}
@@ -149,3 +151,4 @@ Add the following settings to the `env` section of `security-agent` and `system-
 [4]: /security/cloud_security_management/setup#supported-deployment-types-and-features
 [5]: /getting_started/agent
 [6]: https://app.datadoghq.com/account/settings/agent/latest
+[7]: https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#disable

--- a/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
+++ b/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
@@ -56,7 +56,7 @@ Datadog doesn't support image streaming with Google Kubernetes Engine (GKE). If 
 The resulting error appears as:
 
 ```sh
-unable to mount containerd image, err: unable to scan image named: gke.gcr.io/{image-name}, image is not unpacked
+unable to mount containerd image, err: unable to scan image named: {image-name}, image is not unpacked
 ```
 
 The workaround for this issue is to disable image streaming in GKE. For more information, see the [Disable Image streaming][5] section of the GKE docs.

--- a/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
+++ b/content/en/security/cloud_security_management/troubleshooting/vulnerabilities.md
@@ -49,6 +49,18 @@ The workaround for this issue is to set the configuration option:
 - For Helm: set `datadog.sbom.containerImage.uncompressedLayersSupport: true` in your `values.yaml` file.
 - For Datadog Operator: set `features.sbom.containerImage.uncompressedLayersSupport` to `true` in your DatadogAgent CRD.
 
+### GKE image streaming
+
+Datadog doesn't support image streaming with Google Kubernetes Engine (GKE). If you have that option enabled in GKE, your Agent can't generate container SBOMs.
+
+The resulting error appears as:
+
+```sh
+unable to mount containerd image, err: unable to scan image named: gke.gcr.io/{image-name}, image is not unpacked
+```
+
+The workaround for this issue is to disable image streaming in GKE. For more information, see the [Disable Image streaming][5] section of the GKE docs.
+
 ## Disable CSM Vulnerabilities
 
 In the `datadog-values.yaml` file for the Agent, set the following configuration settings to `false`:
@@ -81,3 +93,4 @@ datadog:
 [2]: /security/cloud_security_management/setup/csm_enterprise?tab=aws#configure-the-agent-for-vulnerabilities
 [3]: https://app.datadoghq.com/security/configuration/csm/setup
 [4]: https://app.datadoghq.com/metric/summary
+[5]: https://cloud.google.com/kubernetes-engine/docs/how-to/image-streaming#disable


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
See [Slack thread](https://dd.slack.com/archives/C04G2K21B08/p1736963127234069) - a customer was having issues getting their Agent to generate a customer SBOM, and we linked it to the image streaming feature in GKE. I've added some notes to tell users to disable the image streaming feature so they can enable SBOM collection in CSM Vulnerabilities.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
