### PR TITLE
profiling: document Go version support explicitly

### DIFF
--- a/content/en/profiler/enabling/go.md
+++ b/content/en/profiler/enabling/go.md
@@ -23,7 +23,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][18].
 
-The Datadog Profiler requires Go 1.19+.
+The Datadog Profiler requires one of the latest two major Go releases. These are the major Go releases [supported by the Go project][24].
 
 For the [Trace to Profiling integration][2] and [Endpoint Profiling][3], use `dd-trace-go` version 1.51.0+.
 
@@ -162,3 +162,4 @@ The [Getting Started with Profiler][17] guide takes a sample service with a perf
 [21]: https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2/profiler#pkg-constants
 [22]:https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2/profiler#WithProfileTypes
 [23]:https://pkg.go.dev/github.com/DataDog/dd-trace-go/v2/profiler#ProfileType
+[24]: https://go.dev/doc/devel/release

--- a/content/en/profiler/enabling/supported_versions.md
+++ b/content/en/profiler/enabling/supported_versions.md
@@ -20,8 +20,8 @@ To use the Datadog Profiler, use at least the minimum versions summarized in the
 
 |                                   |  [Java][1]   |   [Python][2]    |    [Go][3]    |   [Ruby][4]    | [Node.js][5]  |  [.NET][6]  |   [PHP][7]    | [Rust/C/C++][8] |
 |-----------------------------------|:------------:|:----------------:|:-------------:|:--------------:|:-------------:|:-----------------------------------------------------------------------:|:-------------:|:---------------:|
-| <strong>Minimum&nbsp;runtime&nbsp;version</strong> | [JDK&nbsp;8+][17]  | Python&nbsp;2.7+ | Go&nbsp;1.19+ | Ruby&nbsp;2.5+ | Node&nbsp;14+ | .NET&nbsp;Core&nbsp;2.1+, .NET&nbsp;5+, .NET&nbsp;Framework&nbsp;4.6.1+ | PHP&nbsp;7.1+ |                 |
-| <strong>Feature-complete runtime version</strong>       | [JDK&nbsp;11+][17] | Python&nbsp;3.6+ | Go&nbsp;1.21+ | Ruby&nbsp;3.2+ | Node&nbsp;18+ |                              .NET&nbsp;7+                               | PHP&nbsp;8.0+ |                 |
+| <strong>Minimum&nbsp;runtime&nbsp;version</strong> | [JDK&nbsp;8+][17]  | Python&nbsp;2.7+ | [previous major Go release][21] | Ruby&nbsp;2.5+ | Node&nbsp;14+ | .NET&nbsp;Core&nbsp;2.1+, .NET&nbsp;5+, .NET&nbsp;Framework&nbsp;4.6.1+ | PHP&nbsp;7.1+ |                 |
+| <strong>Feature-complete runtime version</strong>       | [JDK&nbsp;11+][17] | Python&nbsp;3.6+ | [latest major Go release][21] | Ruby&nbsp;3.2+ | Node&nbsp;18+ |                              .NET&nbsp;7+                               | PHP&nbsp;8.0+ |                 |
 | <strong>Feature-complete tracing library version</strong>        | [latest][9]  |   [latest][10]   | [latest][11]  |  [latest][12]  | [latest][13]  |                              [latest][14]                               | [latest][15]  |  [latest][16]   |
 
 ## Profile types
@@ -73,3 +73,4 @@ To access additional profiling features, use at least the minimum versions summa
 [18]: /profiler/connect_traces_and_profiles/#identify-code-hotspots-in-slow-traces
 [19]: /profiler/connect_traces_and_profiles/#endpoint-profiling
 [20]: /profiler/connect_traces_and_profiles/#span-execution-timeline-view
+[21]: https://go.dev/doc/devel/release


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Our docs currently say we support, at a minimum, Go 1.19 for the Go
profiler. However, we don't any more, and haven't for a while. Our
policy is now to align our Go version support with the official Go
project policy, which is to support the latest two major releases.
Change the Go profiling docs to reflect that. This should help prevent
the docs from going stale as new versions of Go/our library are
released.

### Merge instructions

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
