### PR TITLE
Fix broken pidMode link in ECS Fargate

### DIFF
--- a/content/en/developers/dogstatsd/unix_socket.md
+++ b/content/en/developers/dogstatsd/unix_socket.md
@@ -265,7 +265,7 @@ When running inside a container, DogStatsD needs to run in the host's PID namesp
     },
     ```
 
-2. Add the [`PidMode` parameter][10] in the task definition and set it to `task` as follows:
+2. Add the [PidMode parameter][10] in the task definition and set it to `task` as follows:
 
     ```json
     "pidMode": "task"


### PR DESCRIPTION
There was a broken link under the ECS Fargate tab, fixing this.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
