### PR TITLE
Make code block collapsible parameter work correctly

### DIFF
--- a/layouts/shortcodes/code-block.html
+++ b/layouts/shortcodes/code-block.html
@@ -15,7 +15,7 @@
 {{ with $filename }}
 <p class="code-filename my-0">{{ . }}</p>
 {{ end }}
-{{ if $collapsible }}
+{{ if eq $collapsible "true" }}
 <div class="js-code-block-visibility-toggle">
 <div class="chevron chevron-down d-none"></div>
 <div class="chevron chevron-up"></div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- We noticed that code blocks are still collapsible, even when `collapsible="false"`
- (They only were not collapsible when `collapsible` wasn't set)
- It seems like this is because `{{ if $collapsible }}` evaluated to `true`, regardless of what we set.
- Updated the line to `{{ if eq $collapsible "true" }}` which seems to fix things.

**Verifying**

- [Example where collapsible="false"](https://docs-staging.datadoghq.com/brett.blue/collapsible-fix/integrations/guide/azure-programmatic-management/?tab=windows#terraform)
- [Example where collapsible="true"](https://docs-staging.datadoghq.com/brett.blue/collapsible-fix/account_management/org_settings/cross_org_visibility_api/#payload)
- [Example where collapsible is not set](https://docs-staging.datadoghq.com/brett.blue/collapsible-fix/getting_started/opentelemetry/#instrumenting-the-application)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
