### PR TITLE
fix ref numbers

### DIFF
--- a/content/en/cloud_cost_management/datadog_costs/_index.md
+++ b/content/en/cloud_cost_management/datadog_costs/_index.md
@@ -78,8 +78,7 @@ You can use out-of-the-box tags to break down and allocate your Datadog cost dat
 [4]: https://app.datadoghq.com/billing/usage
 [5]: /account_management/plan_and_usage/cost_details/#cost-summary-sub-organization
 [6]: /account_management/rbac/
-[7]: /account_management/rbac/permissions
-[8]: /account_management/plan_and_usage/cost_details/
-[9]: /account_management/billing/usage_attribution/
-[10]: /account_management/plan_and_usage/cost_details/#cost-summary
-[11]: /account_management/plan_and_usage/cost_details/#cost-chargebacks
+[7]: /account_management/plan_and_usage/cost_details/
+[8]: /account_management/billing/usage_attribution/
+[9]: /account_management/plan_and_usage/cost_details/#cost-summary
+[10]: /account_management/plan_and_usage/cost_details/#cost-chargebacks


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Looks like reference numbers were [bumped by 1 in this PR](https://github.com/DataDog/documentation/pull/26818/files#diff-2a0d38184a546c7c1afd64fd42c146decfcd014c92da5d521852a4c18becef2aL77) causing doc links to lead to the wrong page. A recent CCM customer support issue would have been solved by correct links here.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
