### PR TITLE
[dbm] add additional note to the getlog limitation

### DIFF
--- a/layouts/shortcodes/dbm-mongodb-agent-data-collected.en.md
+++ b/layouts/shortcodes/dbm-mongodb-agent-data-collected.en.md
@@ -2,8 +2,10 @@
 
 Database Monitoring for MongoDB captures slow operations from either MongoDB slow query logs or the `system.profile` collection. Slow operations are defined as those taking longer than the `slowms` threshold set in your MongoDB configuration.
 
--   With Database Profiling Enabled: When profiling is enabled at levels 1 or 2, Database Monitoring collects slow operations from the `system.profile` collection.
--   With Database Profiling Disabled: If profiling is disabled, Database Monitoring relies on MongoDB slow query logs to gather slow operations.
+- With Database Profiling Enabled: When profiling is enabled at levels 1 or 2, Database Monitoring collects slow operations from the `system.profile` collection.
+- With Database Profiling Disabled: If profiling is disabled, Database Monitoring relies on MongoDB `getLog` command to gather slow operations from slow query logs.
+
+**Note**: The `getLog` command retrieves the most recent 1024 `mongod` events. In busy databases with a high volume of slow queries or when the slow query collection interval is set to a higher interval (resulting in less frequent collection), some slow queries may not be captured.
 
 ### Operation samples and explain plans
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds additional notes to explain the limitations about MongoDB slow queries collection with `getLog` command. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
