### PR TITLE
Add caveat for APM trace metrics with datadogconnector

### DIFF
--- a/content/en/opentelemetry/integrations/trace_metrics.md
+++ b/content/en/opentelemetry/integrations/trace_metrics.md
@@ -58,6 +58,10 @@ See [Trace Metrics][2].
 
 For a full working example configuration with the Datadog exporter, see [`trace-metrics.yaml`][3].
 
+## Known issues
+
+Datadog Connector does not currently support [Datadog Agent host tags](https://docs.datadoghq.com/tracing/metrics/metrics_namespace/) on APM Trace Metrics calculated by the Datadog Connector. Second primary tag can be set via a workaround; contact support for more details.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
add datadog connector host tags caveat

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
after https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36329, it was requested to add a note about `datadogconnector` and supported tags on APM Stats payloads.

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions
will update once team approves of language.
<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
