### PR TITLE
Bump otel-agent version to 7.61 

### DIFF
--- a/content/en/opentelemetry/agent/agent_with_custom_components.md
+++ b/content/en/opentelemetry/agent/agent_with_custom_components.md
@@ -42,7 +42,7 @@ Download the Dockerfile template:
 
 The Dockerfile:
 
-- Creates a [multi-stage build][6] with Ubuntu 24.04 and `datadog/agent:7.59.0-v1.1.0-ot-beta-jmx`.
+- Creates a [multi-stage build][6] with Ubuntu 24.04 and `datadog/agent:7.61.0-ot-beta-jmx`.
 - Installs Go, Python, and necessary dependencies.
 - Downloads and unpacks the Datadog Agent source code.
 - Creates a virtual environment and installs required Python packages.
@@ -54,7 +54,7 @@ Create and customize an OpenTelemetry Collector Builder (OCB) manifest file, whi
 
 1. Download the Datadog default manifest:
    ```shell
-   curl -o manifest.yaml https://raw.githubusercontent.com/DataDog/datadog-agent/7.59.x/comp/otelcol/collector-contrib/impl/manifest.yaml
+   curl -o manifest.yaml https://raw.githubusercontent.com/DataDog/datadog-agent/7.61.x/comp/otelcol/collector-contrib/impl/manifest.yaml
    ```
 2. Open the `manifest.yaml` file and add the additional OpenTelemetry components to the corresponding sections (extensions, exporters, processors, receivers, or connectors).
    The highlighted line in this example adds a [metrics transform processor][7]:
@@ -65,7 +65,7 @@ dist:
   description: Datadog OpenTelemetry Collector
   version: 0.104.0
   output_path: ./comp/otelcol/collector-contrib/impl
-  otelcol_version: 0.104.0
+  otelcol_version: 0.114.0
 
 extensions:
 # You will see a list of extensions already included by Datadog
@@ -77,18 +77,18 @@ exporters:
 
 processors:
 # adding metrics transform processor to modify metrics
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.104.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.114.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.104.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.104.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.104.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.104.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.104.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.104.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.104.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.104.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.104.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.114.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.114.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.114.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.114.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.114.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.114.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.114.0
 
 connectors:
 # You will see a list of connectors already included by Datadog

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -71,8 +71,10 @@ datadog:
   site: datadoghq.com
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
+  logLevel: info
    {{< /code-block >}}
    Set `datadog.site` to your [Datadog site][52]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
+   <div class="alert alert-danger">The log level <code>datadog.logLevel</code> parameter value should be set in lower case. Valid log levels are: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, <code>critical</code>, <code>off</code>.</div>
 1. Switch the Datadog Agent Docker repository to use development builds:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
@@ -82,7 +84,7 @@ agents:
     doNotCheckTag: true
 ...
    {{< /code-block >}}
-   <div class="alert alert-info">This guide uses a Java application example. The <code>-jmx</code> suffix in the image tag enables JMX utilities. For non-Java applications, use <code>7.57.0-v1.0-ot-beta</code> instead.<br> For more details, see <a href="/containers/guide/autodiscovery-with-jmx/?tab=helm">Autodiscovery and JMX integration guide</a>.</div>
+   <div class="alert alert-info">This guide uses a Java application example. The <code>-jmx</code> suffix in the image tag enables JMX utilities. For non-Java applications, use <code>7.61.0-ot-beta</code> instead.<br> For more details, see <a href="/containers/guide/autodiscovery-with-jmx/?tab=helm">Autodiscovery and JMX integration guide</a>.</div>
 
    By default, the Agent image is pulled from Google Artifact Registry (`gcr.io/datadoghq`). If Artifact Registry is not accessible in your deployment region, [use another registry][53].
 1. Enable the OpenTelemetry Collector and configure the essential ports:
@@ -151,6 +153,7 @@ datadog:
   site: datadoghq.com
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
+  logLevel: info
 
   otelCollector:
     enabled: true

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -78,7 +78,7 @@ datadog:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.59.0-v1.1.0-ot-beta-jmx
+    tag: 7.61.0-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
@@ -144,7 +144,7 @@ Your `datadog-values.yaml` file should look something like this:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.59.0-v1.1.0-ot-beta-jmx
+    tag: 7.61.0-ot-beta-jmx
     doNotCheckTag: true
 
 datadog:

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -74,8 +74,8 @@ datadog:
   logLevel: info
    {{< /code-block >}}
    Set `datadog.site` to your [Datadog site][52]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
-   <div class="alert alert-danger">The log level <code>datadog.logLevel</code> parameter value should be set in lower case. Valid log levels are: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, <code>critical</code>, <code>off</code>.</div>
-1. Switch the Datadog Agent image tag to use builds with embedded OpenTelemetry collector:
+   <div class="alert alert-warning">The log level <code>datadog.logLevel</code> parameter value should be set in lower case. Valid log levels are: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, <code>critical</code>, <code>off</code>.</div>
+1. Switch the Datadog Agent image tag to use builds with embedded OpenTelemetry Collector:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
   image:

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -75,7 +75,7 @@ datadog:
    {{< /code-block >}}
    Set `datadog.site` to your [Datadog site][52]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
    <div class="alert alert-danger">The log level <code>datadog.logLevel</code> parameter value should be set in lower case. Valid log levels are: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, <code>critical</code>, <code>off</code>.</div>
-1. Switch the Datadog Agent Docker repository to use development builds:
+1. Switch the Datadog Agent image tag to use builds with embedded OpenTelemetry collector:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
   image:

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -183,8 +183,10 @@ datadog:
   site: datadoghq.com
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
+  logLevel: info
    {{< /code-block >}}
    Set `datadog.site` to your [Datadog site][10]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
+   <div class="alert alert-danger">The log level <code>datadog.logLevel</code> parameter value should be set in lower case. Valid log levels are: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, <code>critical</code>, <code>off</code>.</div>
 1. Switch the Datadog Agent Docker repository to use development builds:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
@@ -261,6 +263,7 @@ datadog:
   site: datadoghq.com
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
+  logLevel: info
 
   otelCollector:
     enabled: true

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -186,7 +186,7 @@ datadog:
   logLevel: info
    {{< /code-block >}}
    Set `datadog.site` to your [Datadog site][10]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
-   <div class="alert alert-danger">The log level <code>datadog.logLevel</code> parameter value should be set in lower case. Valid log levels are: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, <code>critical</code>, <code>off</code>.</div>
+   <div class="alert alert-warning">The log level <code>datadog.logLevel</code> parameter value should be set in lower case. Valid log levels are: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, <code>critical</code>, <code>off</code>.</div>
 1. Switch the Datadog Agent image tag to use builds with embedded OpenTelemetry collector:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -188,7 +188,7 @@ datadog:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.59.0-v1.1.0-ot-beta-jmx
+    tag: 7.61.0-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
@@ -252,7 +252,7 @@ Your `datadog-values.yaml` file should look something like this:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.59.0-v1.1.0-ot-beta-jmx
+    tag: 7.61.0-ot-beta-jmx
     doNotCheckTag: true
 
 datadog:

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -180,9 +180,11 @@ Use a YAML file to specify the Helm chart parameters for the [Datadog Agent char
 1. Configure the Datadog API and application key secrets:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 datadog:
+  site: datadoghq.com
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
    {{< /code-block >}}
+   Set `datadog.site` to your [Datadog site][10]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
 1. Switch the Datadog Agent Docker repository to use development builds:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
@@ -256,6 +258,7 @@ agents:
     doNotCheckTag: true
 
 datadog:
+  site: datadoghq.com
   apiKeyExistingSecret: datadog-secret
   appKeyExistingSecret: datadog-secret
 
@@ -393,3 +396,4 @@ After you've confirmed that all data is being collected correctly in Datadog, yo
 [7]: /opentelemetry/agent/install_agent_with_collector#configure-the-datadog-agent
 [8]: https://app.datadoghq.com/organization-settings/api-keys/
 [9]: https://app.datadoghq.com/organization-settings/application-keys
+[10]: /getting_started/site/

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -187,7 +187,7 @@ datadog:
    {{< /code-block >}}
    Set `datadog.site` to your [Datadog site][10]. Otherwise, it defaults to `datadoghq.com`, the US1 site.
    <div class="alert alert-danger">The log level <code>datadog.logLevel</code> parameter value should be set in lower case. Valid log levels are: <code>trace</code>, <code>debug</code>, <code>info</code>, <code>warn</code>, <code>error</code>, <code>critical</code>, <code>off</code>.</div>
-1. Switch the Datadog Agent Docker repository to use development builds:
+1. Switch the Datadog Agent image tag to use builds with embedded OpenTelemetry collector:
    {{< code-block lang="yaml" filename="datadog-values.yaml" collapsible="true" >}}
 agents:
   image:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

- Bump `otel-agent` version to the latest stable `7.61.0`
- Add missing `datadog.site` param to the migration guide
- Add temporary fix for log level issue by explicitly setting `datadog.logLevel` param to a lowercase value, eg. `info`, `debug`, etc.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
