### PR TITLE
proxy configuration: update recommended fqdn to metrics.agent.{site}

### DIFF
--- a/content/en/agent/configuration/proxy.md
+++ b/content/en/agent/configuration/proxy.md
@@ -398,9 +398,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-api
     mode http
@@ -681,9 +681,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
 
 backend datadog-api
     mode http
@@ -931,7 +931,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }
@@ -1051,7 +1051,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }

--- a/content/en/agent/guide/agent-5-proxy.md
+++ b/content/en/agent/guide/agent-5-proxy.md
@@ -313,9 +313,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-api
     mode http
@@ -596,9 +596,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
 
 backend datadog-api
     mode http
@@ -824,7 +824,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }
@@ -943,7 +943,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }

--- a/content/es/agent/configuration/proxy.md
+++ b/content/es/agent/configuration/proxy.md
@@ -425,9 +425,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-api
     mode http
@@ -692,9 +692,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # The following configuration is for HAProxy 1.8 and newer
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
 
 backend datadog-api
     mode http
@@ -978,7 +978,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }
@@ -1092,7 +1092,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }

--- a/content/fr/agent/configuration/proxy.md
+++ b/content/fr/agent/configuration/proxy.md
@@ -425,9 +425,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # La configuration suivante est valable pour HAProxy 1.8 et versions ultérieures
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <CHEMIN_VERS_CERTIFICATS> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <CHEMIN_VERS_CERTIFICATS> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Décommenter la configuration suivante pour les anciennes versions de HAProxy
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <CHEMIN_VERS_CERTIFICATS>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <CHEMIN_VERS_CERTIFICATS>
 
 backend datadog-api
     mode http
@@ -692,9 +692,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # La configuration suivante est valable pour HAProxy 1.8 et versions ultérieures
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <CHEMIN_VERS_CRT_CERTIFICATS_DATADOG> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <CHEMIN_VERS_CRT_CERTIFICATS_DATADOG> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Décommenter la configuration suivante pour les anciennes versions de HAProxy
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <CHEMIN_VERS_CRT_CERTIFICATS_DATADOG>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <CHEMIN_VERS_CRT_CERTIFICATS_DATADOG>
 
 backend datadog-api
     mode http
@@ -978,7 +978,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }
@@ -1092,7 +1092,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }

--- a/content/ko/agent/configuration/proxy.md
+++ b/content/ko/agent/configuration/proxy.md
@@ -425,9 +425,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # 다음 설정은 HAProxy 1.8 이상용
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # 이전 HAProxy 버전에서는 다음 구성의 주석을 해제
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
 
 backend datadog-api
     mode http
@@ -692,9 +692,9 @@ backend datadog-metrics
     balance roundrobin
     mode http
     # 다음 구성은 HAProxy 1.8 이상용
-    server-template mothership 5 haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
+    server-template mothership 5 metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
     # 이전 HAProxy 버전에서는 다음 구성의 주석을 해제
-    # server mothership haproxy-app.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
+    # server mothership metrics.agent.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
 
 backend datadog-api
     mode http
@@ -978,7 +978,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }
@@ -1092,7 +1092,7 @@ http {
         }
         location / {
             proxy_ssl_verify on;
-            proxy_pass https://haproxy-app.agent.{{< region-param key="dd_site" >}}:443/;
+            proxy_pass https://metrics.agent.{{< region-param key="dd_site" >}}:443/;
         }
     }
 }


### PR DESCRIPTION
the haproxy-app.agent.datadoghq.com is pointing to `metrics.agent.datadoghq.com.`

see:
```
dig haproxy-app.agent.datadoghq.com

; <<>> DiG 9.10.6 <<>> haproxy-app.agent.datadoghq.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 44042
;; flags: qr rd ra; QUERY: 1, ANSWER: 10, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;haproxy-app.agent.datadoghq.com. IN    A

;; ANSWER SECTION:
haproxy-app.agent.datadoghq.com. 300 IN CNAME   metrics.agent.datadoghq.com.
```

All proxy should send there metrics to the fqnd with metrics.agent.{site} in order to properly go throw private link.

see also: https://docs.datadoghq.com/agent/guide/private-link/?tab=connectfromsameregion#setup

