### PR TITLE
Update minimum Ruby tracer version for dynamic instrumentation to 2.9.0

### DIFF
--- a/content/en/dynamic_instrumentation/enabling/ruby.md
+++ b/content/en/dynamic_instrumentation/enabling/ruby.md
@@ -18,9 +18,9 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 
 1. Install or upgrade your Agent to version [7.45.0][7] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
-3. Install or upgrade the Ruby tracing library to version 2.8.0 or higher, by following the [relevant instructions][2].
+3. Install or upgrade the Ruby tracing library to version 2.9.0 or higher, by following the [relevant instructions][2].
 
-   **Note**: Dynamic Instrumentation is available in the `dd-trace-ruby` library in versions 2.8.0 and later. Only log probes are currently supported.
+   **Note**: Dynamic Instrumentation is available in the `dd-trace-ruby` library in versions 2.9.0 and later. Only log probes are currently supported.
 
 4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your probes and target active clients across these dimensions.
 5. After starting your service with Dynamic Instrumentation enabled, you can start using Dynamic Instrumentation on the [APM > Dynamic Instrumentation page][3].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Update minimum Ruby tracer version for dynamic instrumentation to 2.9.0 since there have been several issues fixed in 2.9.0.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
