### PR TITLE
Update datadog_forwarder_node.md to use CDK Construct v2

### DIFF
--- a/content/en/serverless/guide/datadog_forwarder_node.md
+++ b/content/en/serverless/guide/datadog_forwarder_node.md
@@ -157,10 +157,10 @@ Run the following Yarn or NPM command in your CDK project to install the Datadog
 
 ```sh
 #Yarn
-yarn add --dev datadog-cdk-constructs
+yarn add --dev datadog-cdk-constructs-v2
 
 #NPM
-npm install datadog-cdk-constructs --save-dev
+npm install datadog-cdk-constructs-v2 --save-dev
 ```
 
 ### Instrument
@@ -169,12 +169,12 @@ To instrument the function, import the `datadog-cdk-construct` module in your AW
 
 ```typescript
 import * as cdk from "@aws-cdk/core";
-import { Datadog } from "datadog-cdk-constructs";
+import { DatadogLambda } from "datadog-cdk-constructs-v2";
 
 class CdkStack extends cdk.Stack {
   constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
-    const datadog = new Datadog(this, "Datadog", {
+    const datadogLambda = new DatadogLambda(this, "DatadogLambda", {
       nodeLayerVersion: {{< latest-lambda-layer-version layer="node" >}},
       forwarderArn: "<FORWARDER_ARN>",
       service: "<SERVICE>",  // Optional
@@ -195,7 +195,7 @@ If your Lambda function is configured to use code signing, you must add Datadog'
 More information and additional parameters can be found in the [Datadog CDK NPM page][1].
 
 
-[1]: https://www.npmjs.com/package/datadog-cdk-constructs
+[1]: https://www.npmjs.com/package/datadog-cdk-constructs-v2
 [2]: https://docs.datadoghq.com/serverless/forwarder/
 [3]: https://docs.aws.amazon.com/lambda/latest/dg/configuration-codesigning.html#config-codesigning-config-update
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
1. Replace the package `datadog-cdk-constructs` with `datadog-cdk-constructs-v2`. `datadog-cdk-constructs` is for AWS CDK v1, [which has reached its end of support on 2023/06/01](https://aws.amazon.com/blogs/devops/cdk-v1-end-of-support/). We have also removed `datadog-cdk-constructs` v1 from our codebase in 2024.
2. Replace `Datadog` class with `DatadogLambda`, which is the recommended API to instrument a Lambda function using Datadog CDK Construct.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
