### PR TITLE
[DJM-585] Add logs env var in code snippet - EMR

### DIFF
--- a/content/en/data_jobs/emr.md
+++ b/content/en/data_jobs/emr.md
@@ -105,6 +105,9 @@ When you create a new EMR cluster in the [Amazon EMR console][4], add a bootstra
    SECRET_NAME=datadog/dd_api_key
    export DD_API_KEY=$(aws secretsmanager get-secret-value --secret-id $SECRET_NAME | jq -r .SecretString | jq -r '.["dd_api_key"]')
 
+   # Optional: turn on to send spark driver and worker logs to Datadog
+   export DD_EMR_LOGS_ENABLED=true
+
    # Download and run the latest init script
    curl -L https://install.datadoghq.com/scripts/install-emr.sh > djm-install-script; bash djm-install-script || true
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
In the code snippet that customers copy paste as EMR cluster init action, add the env var to turn on logs collection. Flag it as optional.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness: Not ready yet
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
