### PR TITLE
Add Agent-only column to CSM setup table

### DIFF
--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -73,7 +73,7 @@ For broader coverage and additional functionalities, deploy the Datadog Agent to
     <td>{{< X >}}</td>
   </tr>
   <tr>
-    <td style="padding-left: 20px;">Host benchmarks</td>
+    <td style="padding-left: 20px;"><a href="/security/default_rules/?search=host+benchmarks">Host benchmarks</a></td>
     <td></td>
     <td>{{< X >}}</td>
     <td>{{< X >}}</td>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We got an internal request to clarify which features in CSM are available if you use an Agent-only setup. Cyril asked for a new column in an existing table to break down the available features, and while I was in there, I replaced the text "yes"es with our X shortcode.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
