### PR TITLE
fixing redirect due to weighting

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -179,7 +179,7 @@ menu:
       weight: 1802
     - name: Mobile App Tests
       identifier: getting_started_mobile_app
-      url: synthetics/mobile_app_testing/
+      url: getting_started/synthetics/mobile_app_testing
       parent: getting_started_synthetics
       weight: 1803
     - name: Continuous Testing

--- a/content/en/getting_started/synthetics/mobile_app_testing.md
+++ b/content/en/getting_started/synthetics/mobile_app_testing.md
@@ -1,0 +1,19 @@
+---
+title: Getting Started with Mobile App Testing    
+description: "Create intelligent, self-maintaining mobile tests to ensure the most critical parts of your mobile applications are up and running from real devices."
+further_reading:
+- link: "https://www.datadoghq.com/blog/test-creation-best-practices/"
+  tag: "Blog"
+  text: "Best practices for creating end-to-end tests"
+- link: "/synthetics/mobile_app_testing/mobile_app_tests"
+  tag: "Documentation"
+  text: "Learn how to create Synthetic mobile app tests"
+- link: "/synthetics/mobile_app_testing/settings"
+  tag: "Documentation"
+  text: "Learn how to upload your iOS or Android mobile applications"
+- link: "/continuous_testing/"
+  tag: "Documentation"
+  text: "Learn about Continuous Testing & CI/CD"
+--- 
+
+{{< include-markdown "synthetics/mobile_app_testing" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This fixes a bad redirect due to the weighting of Getting Started taking precedence.
Adds a new file under getting_started/synthetics/mobile_app_testing with `include_markdown` shortcode so it will pull in the relevant file . I tested both pages and they work now!

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
