### PR TITLE
Add missing ios view referrer on view mapper

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration.md
@@ -793,7 +793,7 @@ Depending on the event's type, only some specific properties can be modified:
 |                  | `RUMResourceEvent.view.url`          | URL of the view linked to this resource. |
 | RUMViewEvent     | `RUMViewEvent.view.name`             | Name of the view.                        |
 |                  | `RUMViewEvent.view.url`              | URL of the view.                         |
-|                  | `RUMViewEvent.view.referrer`         | URL that linked to the initial view of the page.|                         |
+|                  | `RUMViewEvent.view.referrer`         | URL that linked to the initial view of the page.|
 
 ## Retrieve the RUM session ID
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration.md
@@ -793,6 +793,7 @@ Depending on the event's type, only some specific properties can be modified:
 |                  | `RUMResourceEvent.view.url`          | URL of the view linked to this resource. |
 | RUMViewEvent     | `RUMViewEvent.view.name`             | Name of the view.                        |
 |                  | `RUMViewEvent.view.url`              | URL of the view.                         |
+|                  | `RUMViewEvent.view.referrer`         | URL that linked to the initial view of the page.|                         |
 
 ## Retrieve the RUM session ID
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds `view.referrer` to iOS list of attributes changed through event mappers

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
