### PR TITLE
doc: add a note about available contextual variables for line probes

### DIFF
--- a/content/en/dynamic_instrumentation/expression-language.md
+++ b/content/en/dynamic_instrumentation/expression-language.md
@@ -33,10 +33,9 @@ The following sections summarize the variables and operations that the Dynamic I
 |-------------|----------------------------------------------------------------------------|
 | `@return`   | Provides access to the return value                                        |
 | `@duration` | Provides access to the call execution duration                             |
-| `@it`       | Provides access to the current value in collection iterating operations    |
 | `@exception`| Provides access to the current uncaught exception                          |
 
-**Note**: When you **instrument a specific line number**, only `@it` is available as a contextual variable. To access the full set of contextual variables (`@return`, `@duration`, `@it`, and `@exception`), **instrument the entire method** rather than a single line.
+**Note**: These variables are **only available** when instrumenting an **entire method**, and **not** for individual lines of code.
 
 ## String operations
 
@@ -51,6 +50,8 @@ The following sections summarize the variables and operations that the Dynamic I
 | `matches(value_src, string_literal)` | Checks whether the string matches the regular expression provided as a string literal. | `matches("Hello", "^H.*o$")` -> `True` |
 
 ## Collection operations
+
+When working with collections (lists, maps, etc.), a variable `@it` is available which provides access to the current value in a collection during iteration.
 
 The following examples use a variable named `myCollection` defined as `[1,2,3]`:
 

--- a/content/en/dynamic_instrumentation/expression-language.md
+++ b/content/en/dynamic_instrumentation/expression-language.md
@@ -36,6 +36,7 @@ The following sections summarize the variables and operations that the Dynamic I
 | `@it`       | Provides access to the current value in collection iterating operations    |
 | `@exception`| Provides access to the current uncaught exception                          |
 
+**Note**: When you **instrument a specific line number**, only `@it` is available as a contextual variable. To access the full set of contextual variables (`@return`, `@duration`, `@it`, and `@exception`), **instrument the entire method** rather than a single line.
 
 ## String operations
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This pull request includes updates to the documentation for the Dynamic Instrumentation Expression Language. The changes clarify the availability of certain variables and provide additional information on collection operations.

Documentation updates:

* [`content/en/dynamic_instrumentation/expression-language.md`](diffhunk://#diff-da2f021d6516ed91d9d4cdf85a6edae072affa4e6de289ab5b45ec342b4d8ac5L36-R38): Added a note specifying that certain variables (`@return`, `@duration`, `@exception`) are only available when instrumenting an entire method, not for individual lines of code.
* [`content/en/dynamic_instrumentation/expression-language.md`](diffhunk://#diff-da2f021d6516ed91d9d4cdf85a6edae072affa4e6de289ab5b45ec342b4d8ac5R54-R55): Added information about the `@it` variable, which provides access to the current value in a collection during iteration, under the collection operations section.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
