### PR TITLE
[MLOB] reflect python openai/langchain tracing support versions

### DIFF
--- a/content/en/llm_observability/setup/auto_instrumentation.md
+++ b/content/en/llm_observability/setup/auto_instrumentation.md
@@ -23,8 +23,8 @@ Datadog's [LLM Observability Python SDK][16] provides integrations that automati
 
 | Framework                                  | Supported Versions | Tracer Version    |
 |--------------------------------------------|--------------------|-------------------|
-| [OpenAI](#openai), [Azure OpenAI](#openai) | >= 1.0.0           | >= 2.9.0          |
-| [Langchain](#langchain)                    | >= 0.0.192         | >= 2.9.0          |
+| [OpenAI](#openai), [Azure OpenAI](#openai) | >= 1.0.0           | >= 3.0.0          |
+| [Langchain](#langchain)                    | >= 0.1.0           | >= 3.0.0          |
 | [Amazon Bedrock](#amazon-bedrock)          | >= 1.31.57         | >= 2.9.0          |
 | [Anthropic](#anthropic)                    | >= 0.28.0          | >= 2.10.0         |
 | [Google Gemini](#google-gemini)            | >= 0.7.2           | >= 2.14.0         |

--- a/content/en/llm_observability/setup/auto_instrumentation.md
+++ b/content/en/llm_observability/setup/auto_instrumentation.md
@@ -23,7 +23,7 @@ Datadog's [LLM Observability Python SDK][16] provides integrations that automati
 
 | Framework                                  | Supported Versions | Tracer Version    |
 |--------------------------------------------|--------------------|-------------------|
-| [OpenAI](#openai), [Azure OpenAI](#openai) | >= 0.26.5          | >= 2.9.0          |
+| [OpenAI](#openai), [Azure OpenAI](#openai) | >= 1.0.0           | >= 2.9.0          |
 | [Langchain](#langchain)                    | >= 0.0.192         | >= 2.9.0          |
 | [Amazon Bedrock](#amazon-bedrock)          | >= 1.31.57         | >= 2.9.0          |
 | [Anthropic](#anthropic)                    | >= 0.28.0          | >= 2.10.0         |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates the LLM Observability Python auto-instrumentation page to accurately depict which versions of OpenAI/LangChain we have tracing support for (we dropped v0, v0.1 support in ddtrace>=3.0 respectively)
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
