### PR TITLE
Revert "Add documentation for GCS unsupported storage classes"

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -273,18 +273,6 @@ If you wish to rehydrate from archives in another access tier, you must first mo
 
 [1]: /logs/archives/rehydrating/
 {{% /tab %}}
-{{% tab "Google Cloud Storage" %}}
-
-[Rehydration][1] only supports the following storage classes:
-
-- Standard
-- Nearline
-- Coldline
-
-If you wish to rehydrate from archives in another storage class, you must first move them to one of the supported classes above.
-
-[1]: /logs/archives/rehydrating/
-{{% /tab %}}
 {{< /tabs >}}
 
 #### Server side encryption (SSE)


### PR DESCRIPTION
Reverts DataDog/documentation#26897

The PR making the content of the documentation true has been reverted (see https://github.com/DataDog/logs-backend/pull/90915), we should also clean up the documentation