### PR TITLE
APM .NET SDK - remove obsolete instructions and restore lost warnings

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core.md
@@ -181,13 +181,10 @@ For information about the different methods for setting environment variables, s
 
 #### Services not in IIS
 
-<div class="alert alert-info">Starting v2.14.0, you don't need to set <code>CORECLR_PROFILER</code> if you installed the tracer using the MSI.</div>
-
 1. Set the following required environment variables for automatic instrumentation to attach to your application:
 
    ```
    CORECLR_ENABLE_PROFILING=1
-   CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    ```
 2. For standalone applications and Windows services, manually restart the application.
 
@@ -286,9 +283,11 @@ To attach automatic instrumentation to your service, you must set the required e
 
 ### Windows
 
-#### Windows services
+<div class="alert alert-warning">
+  <strong>Note:</strong> The .NET runtime tries to load the .NET library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to be instrumented.</strong>
+</div>
 
-<div class="alert alert-info">Starting v2.14.0, you don't need to set <code>CORECLR_PROFILER</code> if you installed the tracer using the MSI.</div>
+#### Windows services
 
 {{< tabs >}}
 
@@ -298,7 +297,6 @@ In the Registry Editor, create a multi-string value called `Environment` in the 
 
 ```text
 CORECLR_ENABLE_PROFILING=1
-CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
 {{< img src="tracing/setup/dotnet/RegistryEditorCore.png" alt="Using the Registry Editor to create environment variables for a Windows service" >}}
@@ -308,8 +306,7 @@ CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 {{% tab "PowerShell" %}}
 
 ```powershell
-[string[]] $v = @("CORECLR_ENABLE_PROFILING=1", "CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}")
-Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<SERVICE NAME> -Name Environment -Value $v
+Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<SERVICE NAME> -Name Environment -Value 'CORECLR_ENABLE_PROFILING=1'
 ```
 {{% /tab %}}
 
@@ -338,12 +335,10 @@ After installing the MSI, no additional configuration is needed to automatically
 To automatically instrument a console application, set the environment variables from a batch file before starting your application:
 
 ```bat
-rem Set environment variables
+rem Set required environment variables
 SET CORECLR_ENABLE_PROFILING=1
-rem Unless v2.14.0+ and you installed the tracer with the MSI
-SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 
-rem Set additional Datadog environment variables
+rem (Optional) Set additional Datadog environment variables, for example:
 SET DD_LOGS_INJECTION=true
 SET DD_RUNTIME_METRICS_ENABLED=true
 
@@ -358,13 +353,13 @@ dotnet.exe example.dll
 To set the required environment variables from a bash file before starting your application:
 
 ```bash
-# Set environment variables
+# Set required environment variables
 export CORECLR_ENABLE_PROFILING=1
 export CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 export CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
 export DD_DOTNET_TRACER_HOME=/opt/datadog
 
-# Set additional Datadog environment variables
+# (Optional) Set additional Datadog environment variables, for example:
 export DD_LOGS_INJECTION=true
 export DD_RUNTIME_METRICS_ENABLED=true
 
@@ -379,13 +374,13 @@ dotnet example.dll
 To set the required environment variables on a Linux Docker container:
 
   ```docker
-  # Set environment variables
+  # Set required environment variables
   ENV CORECLR_ENABLE_PROFILING=1
   ENV CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
   ENV CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
   ENV DD_DOTNET_TRACER_HOME=/opt/datadog
 
-  # Set additional Datadog environment variables
+  # (Optional) Set additional Datadog environment variables, for example:
   ENV DD_LOGS_INJECTION=true
   ENV DD_RUNTIME_METRICS_ENABLED=true
 
@@ -400,12 +395,13 @@ When using `systemctl` to run .NET applications as a service, you can add the re
 1. Create a file called `environment.env` containing:
 
     ```ini
+    # Set required environment variables
     CORECLR_ENABLE_PROFILING=1
     CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
     CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
     DD_DOTNET_TRACER_HOME=/opt/datadog
 
-    # Set additional Datadog environment variables
+    # (Optional) Set additional Datadog environment variables, for example:
     DD_LOGS_INJECTION=true
     DD_RUNTIME_METRICS_ENABLED=true
     ```
@@ -421,7 +417,7 @@ When using `systemctl` to run .NET applications as a service, you can add the re
 #### `systemctl` (all services)
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> The .NET runtime tries to load a profiler into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be traced. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to load the profiler.</strong>
+  <strong>Note:</strong> The .NET runtime tries to load the .NET library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to be instrumented.</strong>
 </div>
 
 When using `systemctl` to run .NET applications as a service, you can also set environment variables to be loaded for all services run by `systemctl`.
@@ -429,12 +425,13 @@ When using `systemctl` to run .NET applications as a service, you can also set e
 1. Set the required environment variables by running [`systemctl set-environment`][6]:
 
     ```bash
+    # Set required environment variables
     systemctl set-environment CORECLR_ENABLE_PROFILING=1
     systemctl set-environment CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
     systemctl set-environment CORECLR_PROFILER_PATH=/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
     systemctl set-environment DD_DOTNET_TRACER_HOME=/opt/datadog
 
-    # Set additional Datadog environment variables
+    # (Optional) Set additional Datadog environment variables, for example:
     systemctl set-environment DD_LOGS_INJECTION=true
     systemctl set-environment DD_RUNTIME_METRICS_ENABLED=true
     ```

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -141,13 +141,10 @@ For information about the different methods for setting environment variables, s
 
 #### Services not in IIS
 
-<div class="alert alert-info">Starting v2.14.0, you don't need to set <code>COR_PROFILER</code> if you installed the tracer using the MSI.</div>
-
 1. Set the following required environment variables for automatic instrumentation to attach to your application:
 
    ```
    COR_ENABLE_PROFILING=1
-   COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    ```
 2. For standalone applications and Windows services, manually restart the application.
 
@@ -219,8 +216,6 @@ To attach automatic instrumentation to your service, set the required environmen
 
 ### Windows
 
-<div class="alert alert-info">Starting v2.14.0, you don't need to set <code>COR_PROFILER</code> if you installed the tracer using the MSI.</div>
-
 #### Windows services
 
 {{< tabs >}}
@@ -231,7 +226,6 @@ In the Registry Editor, create a multi-string value called `Environment` in the 
 
 ```text
 COR_ENABLE_PROFILING=1
-COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 ```
 
 {{< img src="tracing/setup/dotnet/RegistryEditorFramework.png" alt="Using the Registry Editor to create environment variables for a Windows service" >}}
@@ -241,8 +235,7 @@ COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 {{% tab "PowerShell" %}}
 
 ```powershell
-[string[]] $v = @("COR_ENABLE_PROFILING=1", "COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}")
-Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<SERVICE NAME> -Name Environment -Value $v
+Set-ItemProperty HKLM:SYSTEM\CurrentControlSet\Services\<SERVICE NAME> -Name Environment -Value 'COR_ENABLE_PROFILING=1'
 ```
 {{% /tab %}}
 
@@ -271,12 +264,10 @@ After installing the MSI, no additional configuration is needed to automatically
 To automatically instrument a console application, set the environment variables from a batch file before starting your application:
 
 ```bat
-rem Set environment variables
+rem Set required environment variables
 SET COR_ENABLE_PROFILING=1
-rem Unless v2.14.0+ and you installed the tracer with the MSI
-SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
 
-rem Set additional Datadog environment variables
+rem Optionally, set additional Datadog environment variables, for example:
 SET DD_LOGS_INJECTION=true
 SET DD_RUNTIME_METRICS_ENABLED=true
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -139,7 +139,11 @@ For information about the different methods for setting environment variables, s
    </div>
 
 
-#### Services not in IIS
+#### Services outside IIS
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> The .NET runtime tries to load the .NET library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to be instrumented.</strong>
+</div>
 
 1. Set the following required environment variables for automatic instrumentation to attach to your application:
 
@@ -155,10 +159,9 @@ For information about the different methods for setting environment variables, s
 Follow the instructions in the package readme, also available in [`dd-trace-dotnet` repository][1].
 Docker examples are also available in the [repository][2].
 
-
-
 [1]: https://github.com/DataDog/dd-trace-dotnet/blob/master/docs/Datadog.Trace.Bundle/README.md
 [2]: https://github.com/DataDog/dd-trace-dotnet/tree/master/tracer/samples/NugetDeployment
+
 {{% /tab %}}
 
 {{< /tabs >}}
@@ -196,6 +199,7 @@ To use custom instrumentation in your .NET application:
 3. In your application code, access the global tracer through the `Datadog.Trace.Tracer.Instance` property to create new spans.
 
 [1]: https://www.nuget.org/packages/Datadog.Trace
+
 {{% /tab %}}
 
 {{% tab "NuGet" %}}
@@ -214,7 +218,9 @@ For more information on adding spans and tags for custom instrumentation, see th
 
 To attach automatic instrumentation to your service, set the required environment variables before starting the application. See [Enable the tracer for your service](#enable-the-tracer-for-your-service) section to identify which environment variables to set based on your .NET Tracer installation method and follow the examples below to correctly set the environment variables based on the environment of your instrumented service.
 
-### Windows
+<div class="alert alert-warning">
+  <strong>Note:</strong> The .NET runtime tries to load the .NET library into <em>any</em> .NET process that is started with these environment variables set. You should limit instrumentation to only the applications that need to be instrumented. <strong>Don't set these environment variables globally as this causes <em>all</em> .NET processes on the host to be instrumented.</strong>
+</div>
 
 #### Windows services
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-framework.md
@@ -273,7 +273,7 @@ To automatically instrument a console application, set the environment variables
 rem Set required environment variables
 SET COR_ENABLE_PROFILING=1
 
-rem Optionally, set additional Datadog environment variables, for example:
+rem (Optionally) Set additional Datadog environment variables, for example:
 SET DD_LOGS_INJECTION=true
 SET DD_RUNTIME_METRICS_ENABLED=true
 

--- a/content/en/tracing/trace_collection/library_config/dotnet-core.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-core.md
@@ -277,7 +277,6 @@ The following configuration variables are available **only** when using automati
 : **TracerSettings property**: `TraceEnabled`<br>
 Enables or disables all instrumentation. Valid values are: `true` or `false`.<br>
 **Default**: `true`
-**Note**: Setting the environment variable to `false` completely disables the client library, and it cannot be enabled through other configuration methods. If it is set to `false` through another configuration method (not an environment variable), the client library is still loaded, but traces will not be generated.
 
 `DD_TRACE_EXPAND_ROUTE_TEMPLATES_ENABLED`
 : Expands all route parameters in the application for ASP.NET/ASP.NET Core (except ID parameters)<br>

--- a/content/en/tracing/trace_collection/library_config/dotnet-framework.md
+++ b/content/en/tracing/trace_collection/library_config/dotnet-framework.md
@@ -294,7 +294,6 @@ The following configuration variables are available **only** when using automati
 : **TracerSettings property**: `TraceEnabled`<br>
 Enables or disables all instrumentation. Valid values are: `true` or `false`.<br>
 **Default**: `true`
-**Note**: Setting the environment variable to `false` completely disables the client library, and it cannot be enabled through other configuration methods. If it is set to `false` through another configuration method (not an environment variable), the client library is still loaded, but traces will not be generated.
 
 `DD_TRACE_EXPAND_ROUTE_TEMPLATES_ENABLED`
 : Expands all route parameters in the application for ASP.NET/ASP.NET Core (except ID parameters)<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Remove the v2.14.0 instructions since `dd-trace-dotnet` [v2.14.0 was released more than two years ago](https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.14.0).
  - remove the notes regarding "Starting v2.14.0, you don't need to set `CORECLR_PROFILER`..."
  - remove `CORECLR_PROFILER` from the snippets
- Remove configuration note about `DD_TRACE_ENABLED` since it is not longer correct since v3.
- Restore warnings about adding the env vars _globally_. (common mistake by users)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
