### PR TITLE
Add an example of `RumResourceAttributesProvider` usage for Kotlin Multiplatform SDK

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/advanced_configuration.md
@@ -57,7 +57,7 @@ fun onUserInteraction() {
 
 ### Enrich resources
 
-When [tracking resources automatically][6], provide a custom `RumResourceAttributesProvider` instance to add custom attributes to each tracked network request/response. For example, if you want to track a network request's headers, create an implementation as following, and pass it in `datadogKtorPlugin` initialization call.
+When [tracking resources automatically][6], provide a custom `RumResourceAttributesProvider` instance to add custom attributes to each tracked network request/response. For example, if you want to track a network request's headers, create an implementation like the following, and pass it in the `datadogKtorPlugin` initialization call.
 
 ```kotlin
 class CustomRumResourceAttributesProvider : RumResourceAttributesProvider {

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/advanced_configuration.md
@@ -55,6 +55,33 @@ fun onUserInteraction() {
 }
 ```
 
+### Enrich resources
+
+When [tracking resources automatically][6], provide a custom `RumResourceAttributesProvider` instance to add custom attributes to each tracked network request/response. For example, if you want to track a network request's headers, create an implementation as following, and pass it in `datadogKtorPlugin` initialization call.
+
+```kotlin
+class CustomRumResourceAttributesProvider : RumResourceAttributesProvider {
+    override fun onRequest(request: HttpRequestSnapshot) =
+        request.headers.names().associateWith { request.headers[it] }.mapKeys { "header.$it" }
+
+    override fun onResponse(response: HttpResponse) = emptyMap<String, Any?>()
+
+    override fun onError(request: HttpRequestSnapshot, throwable: Throwable) = emptyMap<String, Any?>()
+}
+
+val ktorClient = HttpClient {
+    install(
+        datadogKtorPlugin(
+            tracedHosts = mapOf(
+                "example.com" to setOf(TracingHeaderType.DATADOG),
+                "example.eu" to setOf(TracingHeaderType.DATADOG)
+            ),
+            rumResourceAttributesProvider = CustomRumResourceAttributesProvider()
+        )
+    )
+}
+```
+
 ### Custom Resources
 
 In addition to [tracking resources automatically][6], you can also track specific custom resources (such as network requests and third-party provider APIs) with methods (such as `GET` and `POST`) while loading the resource with `RumMonitor#startResource`. Stop tracking with `RumMonitor#stopResource` when it is fully loaded, or `RumMonitor#stopResourceWithError` if an error occurs while loading the resource.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR adds an example of `RumResourceAttributesProvider` usage for Kotlin Multiplatform SDK.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
