### PR TITLE
Remove self-redirect for Kotlin Multiplatform

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/data_collected.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/data_collected.md
@@ -4,7 +4,7 @@ description: Learn about the data collected by Kotlin Multiplatform Monitoring.
 aliases:
 - /real_user_monitoring/kotlin-multiplatform/data_collected/
 - /real_user_monitoring/kotlin_multiplatform/data_collected/
-- /real_user_monitoring/mobile_and_tv_monitoring/kotlin-multiplatform/data_collected/
+- /real_user_monitoring/mobile_and_tv_monitoring/data_collected/kotlin-multiplatform/
 further_reading:
 - link: https://github.com/DataDog/dd-sdk-kotlin-multiplatform
   tag: "Source Code"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Noticed this page had a circular redirect so this PR corrects it.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
