### PR TITLE
[APM] Update runtime metrics preview notice for Node.js and Ruby libraries

### DIFF
--- a/content/en/tracing/metrics/runtime_metrics/nodejs.md
+++ b/content/en/tracing/metrics/runtime_metrics/nodejs.md
@@ -18,10 +18,6 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 
-<div class="alert alert-warning">
-This feature is in public beta.
-</div>
-
 ## Automatic configuration
 
 Runtime metrics collection can be enabled with one configuration parameter in the tracing client either through the tracer option: `tracer.init({ runtimeMetrics: true })` or through the environment variable: `DD_RUNTIME_METRICS_ENABLED=true`

--- a/content/en/tracing/metrics/runtime_metrics/ruby.md
+++ b/content/en/tracing/metrics/runtime_metrics/ruby.md
@@ -18,10 +18,6 @@ further_reading:
       text: 'Explore your services, resources, and traces'
 ---
 
-<div class="alert alert-warning">
-This feature is in public beta.
-</div>
-
 ## Automatic configuration
 
 Runtime metrics collection uses the [`dogstatsd-ruby`][1] gem to send metrics via DogStatsD to the Agent. To collect runtime metrics, you must add this gem to your Ruby application, and make sure that [DogStatsD is enabled for the Agent][2].


### PR DESCRIPTION
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Remove the public beta notice from Node.js runtime metrics and Ruby runtime metrics. This feature has been used in production for years now, we want to declare our support for it in its current form.

### Merge instructions
<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
[APMAPI-1135]


[APMAPI-1135]: https://datadoghq.atlassian.net/browse/APMAPI-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ