### PR TITLE
logs.processed and logs.sent metrics will not be emitted

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -147,10 +147,8 @@ DD_AGENT_TELEMETRY_ENABLED=false
 | pymem.alloc                                 | Total number of bytes allocated by the Python interpreter since the start of the Agent            |
 | api_server.request_duration_seconds         | CLI commands execution performance (if executed)                                                  |
 | logs.decoded                                | Total number of decoded logs                                                                      |
-| logs.processed                              | Total number of processed logs                                                                    |
 | logs.sender_latency                         | HTTP sender latency in milliseconds                                                               |
 | logs.bytes_missed                           | Total number of bytes lost before they could be consumed by the Agent, such as after log rotation |
-| logs.sent                                   | Total number of sent logs                                                                         |
 | logs.dropped                                | Total number of logs dropped                                                                      |
 | logs.bytes_sent                             | Total number of bytes send before encoding, if any                                                |
 | logs.encoded_bytes_sent                     | Total number of sent bytes after encoding, if any                                                 |


### PR DESCRIPTION
Reflecting https://github.com/DataDog/datadog-agent/pull/33644 change (Agent 7.64 release)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
