### PR TITLE
[Profiling .NET] Update the .NET profiling doc to support Single Step APM Instrumentation

### DIFF
--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -93,7 +93,7 @@ You can install the Datadog .NET Profiler machine-wide so that any services on t
 1. With [Single Step APM Instrumentation][1], there is nothing else to install. Go to [Enabling the Profiler](#enabling-the-profiler) to see how to activate the profiler for an application.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> If APM was already manually installed, it is required to uninstall it by removing the following environment variables: CORECLR_ENABLE_PROFILING, CORECLR_PROFILER, CORECLR_PROFILER_PATH, and the value that points to Datadog.Linux.ApiWrapper.x64.so in LD_PRELOAD. If they are in your dockerfile, remove them.
+  <strong>Note:</strong> If APM was already manually installed, you must uninstall it by removing the following environment variables: <code>CORECLR_ENABLE_PROFILING</code>, <code>CORECLR_PROFILER</code>, <code>CORECLR_PROFILER_PATH</code>, and the value that points to <code>Datadog.Linux.ApiWrapper.x64.so</code> in <code>LD_PRELOAD</code>. For example, if you are setting these environment variables in your dockerfile for a service, you should remove them to avoid conflicts with Single Step Instrumentation.
   If these environment variables are still set, the corresponding old installed version vill be silently used instead of the one installed with Single Step Instrumentation.
 </div>
 
@@ -184,17 +184,17 @@ To install the .NET Profiler per-webapp:
    DD_VERSION=1.2.3
    ```
 
-Here are the supported values for `DD_PROFILING_ENABLED`environment variable:
+   Here are the supported values for `DD_PROFILING_ENABLED`environment variable:
 
-| Value                         | Description                                                                                                           |
-| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `1` or `true`                 | Activate the profiler.                                                                                                |
-| `Auto`                        | Activate the profiler if and only if (1) a trace has been created and (2) the application lasts more than 30 seconds. |
-| `0` or `false`                | Disable the profiler.                                                                                                 |
+   | Value                         | Description                                                                                                           |
+   | ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+   | `1` or `true`                 | Activate the profiler.                                                                                                |
+   | `Auto`                        | Activate the profiler if and only if (1) a trace has been created and (2) the application lasts more than 30 seconds. |
+   | `0` or `false`                | Disable the profiler.                                                                                                 |
 
-<div class="alert alert-info">
-  <strong>Note</strong>: The Auto value is aimed to avoid short lived processes without any trace. This is in preview and this setting will soon be integrated into the Single Step Instrumentation workflow.
-</div>
+   <div class="alert alert-info">
+     <strong>Note</strong>: The Auto value is aimed to avoid short lived processes without any trace. This is in preview and this setting will soon be integrated into the Single Step Instrumentation workflow.
+   </div>
 
 [1]: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm
 {{% /tab %}}

--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -70,9 +70,13 @@ The following profiling features are available in the following minimum versions
 
 Continuous Profiler is not supported for AWS Lambda.
 
+<div class="alert alert-warning">
+  <strong>Note:</strong> Unlike APM, Continuous Profiler is not activated by default when the APM package gets installed. This is why you need to explicitly [enable it](#enabling-the-profiler) for the applications you want to profile.
+</div>
+
 ## Installation
 
-Ensure Datadog Agent v6+ is installed and running. Datadog recommends using [Datadog Agent v7+][1]. The profiler ships together with the tracing library (beginning with v2.8.0), so if you are already using [APM to collect traces][5] for your application, you can skip installing the library and go directly to [Enabling the profiler](#enabling-the-profiler).
+Ensure Datadog Agent v6+ is installed and running. Datadog recommends using [Datadog Agent v7+][1]. The profiler ships together with the tracing library (beginning with v2.8.0), so if you are already using [APM to collect traces][5] for your application, you can skip installing the library and go directly to [Enabling the Profiler](#enabling-the-profiler).
 
 Otherwise, install the profiler using the following steps, depending on your operating system.
 
@@ -81,9 +85,21 @@ Otherwise, install the profiler using the following steps, depending on your ope
 </div>
 
 
-You can install the Datadog .NET Profiler machine-wide so that all services on the machine can be instrumented, or you can install it on a per-application basis to allow developers to manage the instrumentation through the application's dependencies. To see machine-wide installation instructions, click the **Windows** or **Linux** tab. To see per-application installation instructions, click the **NuGet** tab.
+You can install the Datadog .NET Profiler machine-wide so that any services on the machine can be instrumented, or you can install it on a per-application basis to allow developers to manage the instrumentation through the application's dependencies. To see machine-wide installation instructions, click the **Windows** or **Linux** tab. To see per-application installation instructions, click the **NuGet** tab.
 
 {{< tabs >}}
+
+{{% tab "Linux with Single Step APM Instrumentation" %}}
+1. With [Single Step APM Instrumentation][1], there is nothing else to install. Go to [Enabling the Profiler](#enabling-the-profiler) to see how to activate the profiler for an application.
+
+<div class="alert alert-warning">
+  <strong>Note:</strong> If APM was already manually installed, it is required to uninstall it by removing the following environment variables: `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH`, and the value that points to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD`.
+  If these environment variables are still set, the corresponding old installed version vill be silently used instead of the one installed with Single Step Instrumentation.
+</div>
+
+
+[1]: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm
+{{% /tab %}}
 
 {{% tab "Linux" %}}
 To install the .NET Profiler machine-wide:
@@ -151,11 +167,36 @@ To install the .NET Profiler per-webapp:
 
 ## Enabling the Profiler
 
-<div class="alert alert-info">
+<div class="alert alert-warning">
   <strong>Note</strong>: Datadog does not recommend enabling the profiler at machine-level or for all IIS applications. If you do have enabled it machine-wide, read the <a href="/profiler/profiler_troubleshooting/?code-lang=dotnet#avoid-enabling-the-profiler-machine-wide">Troubleshooting documentation</a> for information about reducing the overhead that is associated with enabling the profiler for all system applications.
 </div>
 
 {{< tabs >}}
+
+{{% tab "Linux with Single Step APM Instrumentation" %}}
+
+2. With [Single Step APM Instrumentation][1], only `DD_PROFILING_ENABLED` must be set to activate the profiler for an application.
+   ```
+   DD_PROFILING_ENABLED=1
+   DD_ENV=production
+   DD_VERSION=1.2.3
+   ```
+
+Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
+
+| Value                         | Description                                                                                                           |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `1` or `true`                 | Activate the profiler.                                                                                                |
+| `Auto`                        | Activate the profiler if and only if (1) a trace has been created and (2) the application lasts more than 30 seconds. |
+| `0` or `false`                | Disable the profiler.                                                                                                 |
+
+<div class="alert alert-info">
+  <strong>Note</strong>: The `Auto` value is aimed to avoid short lived processes without any trace. This is in preview and this setting will soon be integrated into the Single Step Instrumentation workflow.
+</div>
+
+[1]: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm
+{{% /tab %}}
+
 {{% tab "Linux" %}}
 3. Set the following required environment variables for automatic instrumentation to attach to your application:
 

--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -71,7 +71,7 @@ The following profiling features are available in the following minimum versions
 Continuous Profiler is not supported for AWS Lambda.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> Unlike APM, Continuous Profiler is not activated by default when the APM package gets installed. This is why you need to explicitly [enable it](#enabling-the-profiler) for the applications you want to profile.
+  <strong>Note:</strong> Unlike APM, Continuous Profiler is not activated by default when the APM package gets installed. This is why you need to explicitly enable it for the applications you want to profile.
 </div>
 
 ## Installation
@@ -93,7 +93,7 @@ You can install the Datadog .NET Profiler machine-wide so that any services on t
 1. With [Single Step APM Instrumentation][1], there is nothing else to install. Go to [Enabling the Profiler](#enabling-the-profiler) to see how to activate the profiler for an application.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> If APM was already manually installed, it is required to uninstall it by removing the following environment variables: `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH`, and the value that points to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD`.
+  <strong>Note:</strong> If APM was already manually installed, it is required to uninstall it by removing the following environment variables: CORECLR_ENABLE_PROFILING, CORECLR_PROFILER, CORECLR_PROFILER_PATH, and the value that points to Datadog.Linux.ApiWrapper.x64.so in LD_PRELOAD.
   If these environment variables are still set, the corresponding old installed version vill be silently used instead of the one installed with Single Step Instrumentation.
 </div>
 
@@ -178,11 +178,13 @@ To install the .NET Profiler per-webapp:
 2. With [Single Step APM Instrumentation][1], only `DD_PROFILING_ENABLED` must be set to activate the profiler for an application.
    ```
    DD_PROFILING_ENABLED=1
+
+   # other optional environment variables
    DD_ENV=production
    DD_VERSION=1.2.3
    ```
 
-Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
+Here are the supported values for `DD_PROFILING_ENABLED`environment variable:
 
 | Value                         | Description                                                                                                           |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------- |
@@ -191,7 +193,7 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
 | `0` or `false`                | Disable the profiler.                                                                                                 |
 
 <div class="alert alert-info">
-  <strong>Note</strong>: The `Auto` value is aimed to avoid short lived processes without any trace. This is in preview and this setting will soon be integrated into the Single Step Instrumentation workflow.
+  <strong>Note</strong>: The Auto value is aimed to avoid short lived processes without any trace. This is in preview and this setting will soon be integrated into the Single Step Instrumentation workflow.
 </div>
 
 [1]: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm
@@ -207,6 +209,8 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
    DD_DOTNET_TRACER_HOME=/opt/datadog
    LD_PRELOAD=/opt/datadog/continuousprofiler/Datadog.Linux.ApiWrapper.x64.so
    DD_PROFILING_ENABLED=1
+
+   # other optional environment variables
    DD_ENV=production
    DD_VERSION=1.2.3
    ```
@@ -234,6 +238,8 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
    CORECLR_ENABLE_PROFILING=1
    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    DD_PROFILING_ENABLED=1
+
+   # other optional environment variables
    DD_ENV=production
    DD_VERSION=1.2.3
    ```
@@ -245,6 +251,8 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
    COR_ENABLE_PROFILING=1
    COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    DD_PROFILING_ENABLED=1
+
+   # other optional environment variables
    DD_ENV=production
    DD_VERSION=1.2.3
    ```
@@ -283,6 +291,8 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
    CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    DD_PROFILING_ENABLED=1
    DD_SERVICE=MyService
+
+   # other optional environment variables
    DD_ENV=production
    DD_VERSION=1.2.3
    ```
@@ -294,6 +304,8 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
    COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    DD_PROFILING_ENABLED=1
    DD_SERVICE=MyService
+
+   # other optional environment variables
    DD_ENV=production
    DD_VERSION=1.2.3
    ```
@@ -344,6 +356,8 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
    SET CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    SET DD_PROFILING_ENABLED=1
    SET DD_SERVICE=MyService
+
+   REM other optional environment variables
    SET DD_ENV=production
    SET DD_VERSION=1.2.3
 
@@ -356,6 +370,8 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
    SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
    SET DD_PROFILING_ENABLED=1
    SET DD_SERVICE=MyService
+
+   REM other optional environment variables
    SET DD_ENV=production
    SET DD_VERSION=1.2.3
 
@@ -378,6 +394,8 @@ Here are the supported values for `DD_PROFILING__ENABLED`environment variable:
    DD_PROFILING_ENABLED=1
    LD_PRELOAD=<System-dependent path>
    DD_SERVICE=MyService
+
+   # other optional environment variables
    DD_ENV=production
    DD_VERSION=1.2.3
    DD_DOTNET_TRACER_HOME=<APP_DIRECTORY>/datadog

--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -71,7 +71,7 @@ The following profiling features are available in the following minimum versions
 Continuous Profiler is not supported for AWS Lambda.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> Unlike APM, Continuous Profiler is not activated by default when the APM package gets installed. This is why you need to explicitly enable it for the applications you want to profile.
+  <strong>Note:</strong> Unlike APM, Continuous Profiler is not activated by default when the APM package is installed. You must explicitly enable it for the applications you want to profile.
 </div>
 
 ## Installation

--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -93,7 +93,12 @@ You can install the Datadog .NET Profiler machine-wide so that any services on t
 1. With [Single Step APM Instrumentation][1], there is nothing else to install. Go to [Enabling the Profiler](#enabling-the-profiler) to see how to activate the profiler for an application.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> If APM was already manually installed, you must uninstall it by removing the following environment variables: <code>CORECLR_ENABLE_PROFILING</code>, <code>CORECLR_PROFILER</code>, <code>CORECLR_PROFILER_PATH</code>, and the value that points to <code>Datadog.Linux.ApiWrapper.x64.so</code> in <code>LD_PRELOAD</code>. For example, if you are setting these environment variables in your dockerfile for a service, you should remove them to avoid conflicts with Single Step Instrumentation.
+  <strong>Note:</strong> If APM was already manually installed, you must uninstall it by removing the following environment variables:<br /> 
+  - <code>CORECLR_ENABLE_PROFILING</code><br />
+  - <code>CORECLR_PROFILER</code><br />
+  - <code>CORECLR_PROFILER_PATH</code><br />
+  - The value that points to <code>Datadog.Linux.ApiWrapper.x64.so</code> in <code>LD_PRELOAD</code><br /><br /> 
+  For example, if you are setting these environment variables in your dockerfile for a service, you should remove them to avoid conflicts with Single Step Instrumentation.
   If these environment variables are still set, the corresponding old installed version vill be silently used instead of the one installed with Single Step Instrumentation.
 </div>
 

--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -93,7 +93,7 @@ You can install the Datadog .NET Profiler machine-wide so that any services on t
 1. With [Single Step APM Instrumentation][1], there is nothing else to install. Go to [Enabling the Profiler](#enabling-the-profiler) to see how to activate the profiler for an application.
 
 <div class="alert alert-warning">
-  <strong>Note:</strong> If APM was already manually installed, it is required to uninstall it by removing the following environment variables: CORECLR_ENABLE_PROFILING, CORECLR_PROFILER, CORECLR_PROFILER_PATH, and the value that points to Datadog.Linux.ApiWrapper.x64.so in LD_PRELOAD.
+  <strong>Note:</strong> If APM was already manually installed, it is required to uninstall it by removing the following environment variables: CORECLR_ENABLE_PROFILING, CORECLR_PROFILER, CORECLR_PROFILER_PATH, and the value that points to Datadog.Linux.ApiWrapper.x64.so in LD_PRELOAD. If they are in your dockerfile, remove them.
   If these environment variables are still set, the corresponding old installed version vill be silently used instead of the one installed with Single Step Instrumentation.
 </div>
 

--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -99,7 +99,7 @@ You can install the Datadog .NET Profiler machine-wide so that any services on t
   - <code>CORECLR_PROFILER_PATH</code><br />
   - The value that points to <code>Datadog.Linux.ApiWrapper.x64.so</code> in <code>LD_PRELOAD</code><br /><br /> 
   For example, if you are setting these environment variables in your dockerfile for a service, you should remove them to avoid conflicts with Single Step Instrumentation.
-  If these environment variables are still set, the corresponding old installed version vill be silently used instead of the one installed with Single Step Instrumentation.
+  If these environment variables are still set, the corresponding previously installed version is silently used instead of the one installed with Single Step Instrumentation.
 </div>
 
 

--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -193,7 +193,7 @@ To install the .NET Profiler per-webapp:
    | `0` or `false`                | Disable the profiler.                                                                                                 |
 
    <div class="alert alert-info">
-     <strong>Note</strong>: The Auto value is aimed to avoid short lived processes without any trace. This is in preview and this setting will soon be integrated into the Single Step Instrumentation workflow.
+     <strong>Note</strong>: The Auto value is aimed to avoid short lived processes without any trace. This feature is in Preview.
    </div>
 
 [1]: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/single-step-apm

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -120,7 +120,7 @@ If it is set to another value or not set at all, the profiler is disabled.
 
 4. Check the result of profiles export:
 
-   1. If debug logs were not enabled in step 2.2, set the `DD_TRACE_DEBUG` environment variable to `true` for the application and restart it.
+   1. If debug logs were not enabled in step 2.b, set the `DD_TRACE_DEBUG` environment variable to `true` for the application and restart it.
 
    2. Open the `DD-DotNet-Profiler-Native-<Application Name>-<pid>` log file in the `/var/log/datadog` folder.
 

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -94,7 +94,7 @@ If it is set to another value or not set at all, the profiler is disabled.
 
 2. Check that the profiler has been loaded from the loader log:
 
-   1. Open the `dotnet-native-loader-dotnet-<pid>` log file in the `/var/log/datadog` folder.
+   1. Open the `dotnet-native-loader-dotnet-<PID>` log file in the `/var/log/datadog` folder.
 
    2. Look for `CorProfiler::Initialize: Continuous Profiler initialized successfully.` near the end. If that message is not present, enable debug logs by setting the `DD_TRACE_DEBUG` environment variable for the application.
 

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -181,7 +181,7 @@ The default profiler log directory is `%ProgramData%\Datadog .NET Tracer\logs\`.
       [...] GetFunction: DllCanUnloadNow
       ```
 
-3. Check that the value of `DD_PROFILING_ENABLED` is set to `1`; if it is not set or with another value, the profiler is disabled.
+3. Check that the value of `DD_PROFILING_ENABLED` is set to `1`; if it is not set, or set with another value, the profiler is disabled.
 
 4. Check the result of profiles export:
 

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -80,7 +80,9 @@ If you've configured the profiler and don't see profiles in the profile search p
    
    If these variables have been set, remove them from your scripts or Dockerfile. Otherwise, a previous manually-installed version of the profiler is used.
 
-6. Check that the value of `DD_PROFILING_ENABLED` is set to `1` or `Auto`. For the latter, the profiler will generate profiles if and only if (1) a trace was created and (2) the application ran for more than 30 seconds.
+6. Check that the value of `DD_PROFILING_ENABLED` is set to `1` or `Auto`. If set to `Auto`, the profiler generates profiles only if both of the following conditions are met:
+   - A trace was created
+   - The application ran for more than 30 seconds
 If it is set to another value or not set at all, the profiler is disabled.
 
 [1]: /profiler/enabling/dotnet/?tab=linux#configuration

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -15,7 +15,7 @@ If you've configured the profiler and don't see profiles in the profile search p
 
 {{< tabs >}}
 
-{{% tab "Linux" %}}
+{{% tab "Linux with Single Step APM Instrumentation" %}}
 
 1. Check that the Agent is installed and running.
 
@@ -72,6 +72,73 @@ If you've configured the profiler and don't see profiles in the profile search p
 
    Note that the following message could appear, but it does not impact Datadog profiling: `Profiler signal handler has been replaced. Restoring it.` This indicates only that the Datadog signal handler is reinstalled when it was overwritten.
 
+5. Check that the following environment variables `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH` are not set, and that the value pointing to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD` is not set. If this is the case, remove them or an old manually version is still set.
+
+6. Check that the value of `DD_PROFILING_ENABLED` is set to `1` or `Auto`. For the latter, the profiler will generate profiles if and only if (1) a trace was creating and (2) the application ran for more than 30 seconds.
+If it is set to `0`, the profiler is disabled.
+
+[1]: /profiler/enabling/dotnet/?tab=linux#configuration
+
+{{% /tab %}}
+{{% tab "Linux" %}}
+
+1. Check that the Agent is installed and running.
+
+2. Check that the profiler has been loaded from the loader log:
+
+   1. Open the `dotnet-native-loader-dotnet-<pid>` log file in the `/var/log/datadog` folder.
+
+   2. Look for `CorProfiler::Initialize: Continuous Profiler initialized successfully.` near the end. If that message is not present, enable debug logs by setting the `DD_TRACE_DEBUG` environment variable for the application.
+
+   3. Restart the application.
+
+   4. Open the `dotnet-native-loader-dotnet-<pid>` log file in the `/var/log/datadog` folder.
+
+   5. Look for the `#Profiler` entry.
+
+   6. Check the following lines to ensure that the profiler library has been loaded:
+      ```
+      [...] #Profiler
+      [...] PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x64;.\Datadog.Profiler.Native.dll
+      [...] PROFILER;{BD1A650D-AC5D-4896-B64F-D6FA25D6B26A};win-x86;.\Datadog.Profiler.Native.dll
+      [...] DynamicDispatcherImpl::LoadConfiguration: [PROFILER] Loading: .\Datadog.Profiler.Native.dll [AbsolutePath=/opt/datadog/linux-x64/./Datadog.Tracer.Native.so]
+      [...] [PROFILER] Creating a new DynamicInstance object
+      [...] Load: /opt/datadog/linux-x64/./Datadog.Tracer.Native.so
+      [...] GetFunction: DllGetClassObject
+      [...] GetFunction: DllCanUnloadNow
+      ```
+
+3. Check that the value of `DD_PROFILING_ENABLED` is set to `1`; if it is not set or with another value, the profiler is disabled.
+
+4. Check the result of profiles export:
+
+   1. If debug logs were not enabled in step 2.2, set the `DD_TRACE_DEBUG` environment variable to `true` for the application and restart it.
+
+   2. Open the `DD-DotNet-Profiler-Native-<Application Name>-<pid>` log file in the `/var/log/datadog` folder.
+
+   3. Look for `libddprof error: Failed to send profile.` entries: this message means it can't contact the agent. Ensure the `DD_TRACE_AGENT_URL` is set to the correct Agent URL. See [Enabling the .NET Profiler-Configuration][1] for more information.
+
+   4. If the `Failed to send profile` message is not present, look for `The profile was sent. Success?` entries.
+
+      The following message means the profile has been sent successfully:
+      ```
+      true, Http code: 200
+      ```
+
+   5. Check the other HTTP codes for possible errors such as 403 for invalid API key.
+
+5. For missing CPU or Wall time profiles only, check that the Datadog signal handler for stack walk has not been replaced:
+
+   1. Open the `DD-DotNet-Profiler-Native-<Application Name>-<pid>` log file in the `/var/log/datadog` folder.
+
+   2. Look for these two messages:
+      - `Profiler signal handler was replaced again. It will not be restored: the profiler is disabled.`
+      - `Fail to restore profiler signal handler.`
+
+   3. If one of these messages is present, it means that the application code or a third party code is repeatedly reinstalling its own signal handler over the Datadog signal handler. To avoid any further conflict, the CPU and Wall time profilers are disabled.
+
+   Note that the following message could appear, but it does not impact Datadog profiling: `Profiler signal handler has been replaced. Restoring it.` This indicates only that the Datadog signal handler is reinstalled when it was overwritten.
+
 [1]: /profiler/enabling/dotnet/?tab=linux#configuration
 
 {{% /tab %}}
@@ -106,7 +173,9 @@ The default profiler log directory is `%ProgramData%\Datadog .NET Tracer\logs\`.
       [...] GetFunction: DllCanUnloadNow
       ```
 
-3. Check the result of profiles export:
+3. Check that the value of `DD_PROFILING_ENABLED` is set to `1`; if it is not set or with another value, the profiler is disabled.
+
+4. Check the result of profiles export:
 
    1. If debug logs were not enabled in step 2.2, set the `DD_TRACE_DEBUG` environment variable to `true` for the application and restart it.
 

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -72,7 +72,7 @@ If you've configured the profiler and don't see profiles in the profile search p
 
    Note that the following message could appear, but it does not impact Datadog profiling: `Profiler signal handler has been replaced. Restoring it.` This indicates only that the Datadog signal handler is reinstalled when it was overwritten.
 
-5. Check that the following environment variables `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH` are not set, and that the value pointing to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD` is not set. If this is the case, remove them or an old manually installed version of the profiler will still be used.
+5. Check that the following environment variables `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH` are not set, and that the value pointing to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD` is not set. If this is the case, remove them from scripts or from the docker file where they are set. Otherwise, an old manually installed version of the profiler will still be used.
 
 6. Check that the value of `DD_PROFILING_ENABLED` is set to `1` or `Auto`. For the latter, the profiler will generate profiles if and only if (1) a trace was created and (2) the application ran for more than 30 seconds.
 If it is set to another value or not set at all, the profiler is disabled.

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -72,10 +72,10 @@ If you've configured the profiler and don't see profiles in the profile search p
 
    Note that the following message could appear, but it does not impact Datadog profiling: `Profiler signal handler has been replaced. Restoring it.` This indicates only that the Datadog signal handler is reinstalled when it was overwritten.
 
-5. Check that the following environment variables `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH` are not set, and that the value pointing to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD` is not set. If this is the case, remove them or an old manually version is still set.
+5. Check that the following environment variables `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH` are not set, and that the value pointing to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD` is not set. If this is the case, remove them or an old manually installed version of the profiler will still be used.
 
-6. Check that the value of `DD_PROFILING_ENABLED` is set to `1` or `Auto`. For the latter, the profiler will generate profiles if and only if (1) a trace was creating and (2) the application ran for more than 30 seconds.
-If it is set to `0`, the profiler is disabled.
+6. Check that the value of `DD_PROFILING_ENABLED` is set to `1` or `Auto`. For the latter, the profiler will generate profiles if and only if (1) a trace was created and (2) the application ran for more than 30 seconds.
+If it is set to another value or not set at all, the profiler is disabled.
 
 [1]: /profiler/enabling/dotnet/?tab=linux#configuration
 

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -185,7 +185,7 @@ The default profiler log directory is `%ProgramData%\Datadog .NET Tracer\logs\`.
 
 4. Check the result of profiles export:
 
-   1. If debug logs were not enabled in step 2.2, set the `DD_TRACE_DEBUG` environment variable to `true` for the application and restart it.
+   1. If debug logs were not enabled in step 2.b, set the `DD_TRACE_DEBUG` environment variable to `true` for the application and restart it.
 
    2. Open the `DD-DotNet-Profiler-Native-<Application Name>-<pid>` log file from the default log folder.
 

--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -72,7 +72,13 @@ If you've configured the profiler and don't see profiles in the profile search p
 
    Note that the following message could appear, but it does not impact Datadog profiling: `Profiler signal handler has been replaced. Restoring it.` This indicates only that the Datadog signal handler is reinstalled when it was overwritten.
 
-5. Check that the following environment variables `CORECLR_ENABLE_PROFILING`, `CORECLR_PROFILER`, `CORECLR_PROFILER_PATH` are not set, and that the value pointing to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD` is not set. If this is the case, remove them from scripts or from the docker file where they are set. Otherwise, an old manually installed version of the profiler will still be used.
+5. Confirm that the following environment variables are not set:
+   - `CORECLR_ENABLE_PROFILING`
+   - `CORECLR_PROFILER`
+   - `CORECLR_PROFILER_PATH`
+   - The value pointing to `Datadog.Linux.ApiWrapper.x64.so` in `LD_PRELOAD`
+   
+   If these variables have been set, remove them from your scripts or Dockerfile. Otherwise, a previous manually-installed version of the profiler is used.
 
 6. Check that the value of `DD_PROFILING_ENABLED` is set to `1` or `Auto`. For the latter, the profiler will generate profiles if and only if (1) a trace was created and (2) the application ran for more than 30 seconds.
 If it is set to another value or not set at all, the profiler is disabled.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
We faced customer cases where the profiling documentation could be misleading when APM is deployed with Single Step Instrumentation. So, the enabling and troubleshooting parts of the .NET profiling documentation are updated to be more explicit.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
