### PR TITLE
Fix invalid argument in KMP example

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/setup.md
@@ -373,7 +373,7 @@ val ktorClient = HttpClient {
                 "example.com" to setOf(TracingHeaderType.DATADOG),
                 "example.eu" to setOf(TracingHeaderType.DATADOG)
             ),
-            traceSamplingRate = 100f
+            traceSampleRate = 100f
         )
     )
 }


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Currently, our documentation advises the use of `traceSamplingRate` to set the sampling rate in [this document](https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/setup/?tab=rum#initialize-the-rum-ktor-plugin-to-track-network-events-made-with-ktor). Looking at the repo, this argument is actually called `traceSampleRate`. This PR fixes the argument name.

You can see the correct argument name being used [here](https://github.com/DataDog/dd-sdk-kotlin-multiplatform/blob/233abeb3c38780c75c67e633f466edb8e0554076/integrations/ktor/src/commonMain/kotlin/com/datadog/kmp/ktor/DatadogKtorPlugin.kt#L35), and the fact that traceSamplingRate is not present in the repository [here](https://github.com/search?q=repo%3ADataDog%2Fdd-sdk-kotlin-multiplatform%20traceSamplingRate&type=code).
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->