### PR TITLE
feat(otel-agent): Pin Dockerfile version in BYOC docs

### DIFF
--- a/content/en/opentelemetry/agent/agent_with_custom_components.md
+++ b/content/en/opentelemetry/agent/agent_with_custom_components.md
@@ -48,6 +48,8 @@ The Dockerfile:
 - Creates a virtual environment and installs required Python packages.
 - Builds the OpenTelemetry agent and copies the resulting binary to the final image.
 
+<div class="alert alert-info">The <code>main</code> branch has the most up-to-date version of the <a href="https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent-ot/Dockerfile.agent-otel">Dockerfile</a>. However, it is a development branch that is subject to frequent changes and is less stable than the release tags. For production and other stable use cases, use the tagged versions as listed in this guide.</div>
+
 ## Create an OpenTelemetry Collector Builder manifest
 
 Create and customize an OpenTelemetry Collector Builder (OCB) manifest file, which defines the components to be included in your custom Datadog Agent.

--- a/content/en/opentelemetry/agent/agent_with_custom_components.md
+++ b/content/en/opentelemetry/agent/agent_with_custom_components.md
@@ -37,7 +37,7 @@ Download the Dockerfile template:
    ```
 2. Download the Dockerfile
    ```shell
-   curl -o Dockerfile https://raw.githubusercontent.com/DataDog/datadog-agent/7.61.x/Dockerfiles/agent-ot/Dockerfile.agent-otel
+   curl -o Dockerfile https://raw.githubusercontent.com/DataDog/datadog-agent/refs/tags/7.61.0/Dockerfiles/agent-ot/Dockerfile.agent-otel
    ```
 
 The Dockerfile:
@@ -54,7 +54,7 @@ Create and customize an OpenTelemetry Collector Builder (OCB) manifest file, whi
 
 1. Download the Datadog default manifest:
    ```shell
-   curl -o manifest.yaml https://raw.githubusercontent.com/DataDog/datadog-agent/7.61.x/comp/otelcol/collector-contrib/impl/manifest.yaml
+   curl -o manifest.yaml https://raw.githubusercontent.com/DataDog/datadog-agent/refs/tags/7.61.0/comp/otelcol/collector-contrib/impl/manifest.yaml
    ```
 2. Open the `manifest.yaml` file and add the additional OpenTelemetry components to the corresponding sections (extensions, exporters, processors, receivers, or connectors).
    The highlighted line in this example adds a [metrics transform processor][7]:
@@ -102,7 +102,9 @@ Build your custom Datadog Agent image and push it to a container registry.
 
 1. Build the image with Docker:
    ```shell
-   docker build . -t agent-otel --no-cache
+   docker build . -t agent-otel --no-cache \
+     --build-arg AGENT_VERSION="7.61.0-ot-beta-jmx" \
+     --build-arg AGENT_BRANCH="7.61.x"
    ```
 2. Tag and push the image:
    ```shell

--- a/content/en/opentelemetry/agent/agent_with_custom_components.md
+++ b/content/en/opentelemetry/agent/agent_with_custom_components.md
@@ -37,7 +37,7 @@ Download the Dockerfile template:
    ```
 2. Download the Dockerfile
    ```shell
-   curl -o Dockerfile https://raw.githubusercontent.com/DataDog/datadog-agent/main/Dockerfiles/agent-ot/Dockerfile.agent-otel
+   curl -o Dockerfile https://raw.githubusercontent.com/DataDog/datadog-agent/7.61.x/Dockerfiles/agent-ot/Dockerfile.agent-otel
    ```
 
 The Dockerfile:
@@ -63,7 +63,7 @@ dist:
   module: github.com/DataDog/comp/otelcol/collector-contrib
   name: otelcol-contrib
   description: Datadog OpenTelemetry Collector
-  version: 0.104.0
+  version: 0.114.0
   output_path: ./comp/otelcol/collector-contrib/impl
   otelcol_version: 0.114.0
 
@@ -80,8 +80,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.114.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.104.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.104.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.114.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.114.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.114.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.114.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.114.0
@@ -212,7 +212,7 @@ This section discusses some common issues you might encounter while building and
 #0 88.24 # github.com/opencontainers/runc/libcontainer/cgroups/ebpf
 #0 88.24 /go/pkg/mod/github.com/opencontainers/runc@v1.1.12/libcontainer/cgroups/ebpf/ebpf_linux.go:190:3: unknown field Replace in struct literal of type link.RawAttachProgramOptions
 #0 89.14 # github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver
-#0 89.14 /go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.104.0/internal/k8sapiserver/k8sapiserver.go:47:68: undefined: record.EventRecorderLogger
+#0 89.14 /go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.114.0/internal/k8sapiserver/k8sapiserver.go:47:68: undefined: record.EventRecorderLogger
 ------
 ```
 

--- a/content/en/opentelemetry/agent/agent_with_custom_components.md
+++ b/content/en/opentelemetry/agent/agent_with_custom_components.md
@@ -37,12 +37,12 @@ Download the Dockerfile template:
    ```
 2. Download the Dockerfile
    ```shell
-   curl -o Dockerfile https://raw.githubusercontent.com/DataDog/datadog-agent/refs/tags/7.61.0/Dockerfiles/agent-ot/Dockerfile.agent-otel
+   curl -o Dockerfile https://raw.githubusercontent.com/DataDog/datadog-agent/refs/tags/7.62.2/Dockerfiles/agent-ot/Dockerfile.agent-otel
    ```
 
 The Dockerfile:
 
-- Creates a [multi-stage build][6] with Ubuntu 24.04 and `datadog/agent:7.61.0-ot-beta-jmx`.
+- Creates a [multi-stage build][6] with Ubuntu 24.04 and `datadog/agent:7.62.2-ot-beta-jmx`.
 - Installs Go, Python, and necessary dependencies.
 - Downloads and unpacks the Datadog Agent source code.
 - Creates a virtual environment and installs required Python packages.
@@ -56,7 +56,7 @@ Create and customize an OpenTelemetry Collector Builder (OCB) manifest file, whi
 
 1. Download the Datadog default manifest:
    ```shell
-   curl -o manifest.yaml https://raw.githubusercontent.com/DataDog/datadog-agent/refs/tags/7.61.0/comp/otelcol/collector-contrib/impl/manifest.yaml
+   curl -o manifest.yaml https://raw.githubusercontent.com/DataDog/datadog-agent/refs/tags/7.62.2/comp/otelcol/collector-contrib/impl/manifest.yaml
    ```
 2. Open the `manifest.yaml` file and add the additional OpenTelemetry components to the corresponding sections (extensions, exporters, processors, receivers, or connectors).
    The highlighted line in this example adds a [metrics transform processor][7]:
@@ -65,9 +65,9 @@ dist:
   module: github.com/DataDog/comp/otelcol/collector-contrib
   name: otelcol-contrib
   description: Datadog OpenTelemetry Collector
-  version: 0.114.0
+  version: 0.115.0
   output_path: ./comp/otelcol/collector-contrib/impl
-  otelcol_version: 0.114.0
+  otelcol_version: 0.115.0
 
 extensions:
 # You will see a list of extensions already included by Datadog
@@ -79,18 +79,18 @@ exporters:
 
 processors:
 # adding metrics transform processor to modify metrics
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.114.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.115.0
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.114.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.114.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.114.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.114.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.114.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.114.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.114.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.114.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.114.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.115.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.115.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.115.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/fluentforwardreceiver v0.115.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.115.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.115.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.115.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/receivercreator v0.115.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.115.0
 
 connectors:
 # You will see a list of connectors already included by Datadog
@@ -105,8 +105,8 @@ Build your custom Datadog Agent image and push it to a container registry.
 1. Build the image with Docker:
    ```shell
    docker build . -t agent-otel --no-cache \
-     --build-arg AGENT_VERSION="7.61.0-ot-beta-jmx" \
-     --build-arg AGENT_BRANCH="7.61.x"
+     --build-arg AGENT_VERSION="7.62.2-ot-beta-jmx" \
+     --build-arg AGENT_BRANCH="7.62.x"
    ```
 2. Tag and push the image:
    ```shell
@@ -216,7 +216,7 @@ This section discusses some common issues you might encounter while building and
 #0 88.24 # github.com/opencontainers/runc/libcontainer/cgroups/ebpf
 #0 88.24 /go/pkg/mod/github.com/opencontainers/runc@v1.1.12/libcontainer/cgroups/ebpf/ebpf_linux.go:190:3: unknown field Replace in struct literal of type link.RawAttachProgramOptions
 #0 89.14 # github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/k8sapiserver
-#0 89.14 /go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.114.0/internal/k8sapiserver/k8sapiserver.go:47:68: undefined: record.EventRecorderLogger
+#0 89.14 /go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver@v0.115.0/internal/k8sapiserver/k8sapiserver.go:47:68: undefined: record.EventRecorderLogger
 ------
 ```
 

--- a/content/en/opentelemetry/agent/install_agent_with_collector.md
+++ b/content/en/opentelemetry/agent/install_agent_with_collector.md
@@ -80,11 +80,11 @@ datadog:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.61.0-ot-beta-jmx
+    tag: 7.62.2-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
-   <div class="alert alert-info">This guide uses a Java application example. The <code>-jmx</code> suffix in the image tag enables JMX utilities. For non-Java applications, use <code>7.61.0-ot-beta</code> instead.<br> For more details, see <a href="/containers/guide/autodiscovery-with-jmx/?tab=helm">Autodiscovery and JMX integration guide</a>.</div>
+   <div class="alert alert-info">This guide uses a Java application example. The <code>-jmx</code> suffix in the image tag enables JMX utilities. For non-Java applications, use <code>7.62.2-ot-beta</code> instead.<br> For more details, see <a href="/containers/guide/autodiscovery-with-jmx/?tab=helm">Autodiscovery and JMX integration guide</a>.</div>
 
    By default, the Agent image is pulled from Google Artifact Registry (`gcr.io/datadoghq`). If Artifact Registry is not accessible in your deployment region, [use another registry][53].
 1. Enable the OpenTelemetry Collector and configure the essential ports:
@@ -146,7 +146,7 @@ Your `datadog-values.yaml` file should look something like this:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.61.0-ot-beta-jmx
+    tag: 7.62.2-ot-beta-jmx
     doNotCheckTag: true
 
 datadog:

--- a/content/en/opentelemetry/agent/migration.md
+++ b/content/en/opentelemetry/agent/migration.md
@@ -192,7 +192,7 @@ datadog:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.61.0-ot-beta-jmx
+    tag: 7.62.2-ot-beta-jmx
     doNotCheckTag: true
 ...
    {{< /code-block >}}
@@ -256,7 +256,7 @@ Your `datadog-values.yaml` file should look something like this:
 agents:
   image:
     repository: gcr.io/datadoghq/agent
-    tag: 7.61.0-ot-beta-jmx
+    tag: 7.62.2-ot-beta-jmx
     doNotCheckTag: true
 
 datadog:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Pin Dockerfile version to the latest stable release (`7.61`) instead of `main`
- Bump components version to v0.114.0 in OCB manifest file
- Switch to tagged versions of Dockerfile and OCB manifest instead of using branch (`7.61.x`)
- Update `docker build ...` command to set build args to use agent version `7.61.0` (the default build arg agent version in the `7.61.x` branch [is still set to `7.57`](https://github.com/DataDog/datadog-agent/blob/7.61.0/Dockerfiles/agent-ot/Dockerfile.agent-otel#L1-L2))


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
