### PR TITLE
[test optimization] Add test session name `DD_TEST_SESSION_NAME` instructions

### DIFF
--- a/content/en/tests/setup/dotnet.md
+++ b/content/en/tests/setup/dotnet.md
@@ -86,7 +86,7 @@ To instrument your test suite, prefix your test command with `dd-trace ci run`, 
 By using <a href="https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test">dotnet test</a>:
 
 {{< code-block lang="shell" >}}
-dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
+dd-trace ci run --dd-service=my-dotnet-app -- dotnet test
 {{< /code-block >}}
 
 {{% /tab %}}
@@ -96,7 +96,7 @@ dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- dotnet test
 By using <a href="https://docs.microsoft.com/en-us/visualstudio/test/vstest-console-options">VSTest.Console.exe</a>:
 
 {{< code-block lang="shell" >}}
-dd-trace ci run --dd-service=my-dotnet-app --dd-env=ci -- VSTest.Console.exe {test_assembly}.dll
+dd-trace ci run --dd-service=my-dotnet-app -- VSTest.Console.exe {test_assembly}.dll
 {{< /code-block >}}
 
 {{% /tab %}}
@@ -160,6 +160,12 @@ The following list shows the default values for key configuration settings:
 : Datadog Agent URL for trace collection in the form `http://hostname:port`.<br/>
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
+
+`test_session.name` (only available as environment variable right now)
+: Use it to identify a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
+**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
+**Default**: (CI job name + test command)<br/>
+**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
 
 For more information about `service` and `env` reserved tags, see [Unified Service Tagging][6]. All other [Datadog Tracer configuration][7] options can also be used.
 
@@ -360,6 +366,34 @@ await module.CloseAsync();
 {{< /code-block >}}
 
 Always call `module.Close()` or `module.CloseAsync()` at the end so that all the test data is flushed to Datadog.
+
+## Best Practices
+
+### Test session name `DD_TEST_SESSION_NAME`
+
+Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+
+- `unit-tests`
+- `integration-tests`
+- `smoke-tests`
+- `flaky-tests`
+- `ui-tests`
+- `backend-tests`
+
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+
+- CI job name
+- Command used to run the tests (such as `yarn test`)
+
+The test session name should be unique within a repository to help you distinguish different groups of tests.
+
+#### When to use `DD_TEST_SESSION_NAME`
+
+If your tests are run with commands that include a dynamic string, such as:
+
+- `DD_TEST_SESSION_NAME=integration-tests dotnet test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+
+The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
 
 ## Further reading
 

--- a/content/en/tests/setup/dotnet.md
+++ b/content/en/tests/setup/dotnet.md
@@ -371,7 +371,7 @@ Always call `module.Close()` or `module.CloseAsync()` at the end so that all the
 
 ### Test session name `DD_TEST_SESSION_NAME`
 
-Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+Use `DD_TEST_SESSION_NAME` to define the name of the test session and the related group of tests (for example,`test_session.name`). Examples of values for this tag would be:
 
 - `unit-tests`
 - `integration-tests`
@@ -393,7 +393,7 @@ If your tests are run with commands that include a dynamic string, such as:
 
 - `DD_TEST_SESSION_NAME=integration-tests dotnet test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
+Then the default value for the test session name constantly changes. Datadog recommends using `DD_TEST_SESSION_NAME` in this case.
 
 ## Further reading
 

--- a/content/en/tests/setup/dotnet.md
+++ b/content/en/tests/setup/dotnet.md
@@ -161,8 +161,8 @@ The following list shows the default values for key configuration settings:
 **Environment variable**: `DD_TRACE_AGENT_URL`<br/>
 **Default**: `http://localhost:8126`
 
-`test_session.name` (only available as environment variable right now)
-: Use it to identify a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
+`test_session.name` (only available as an environment variable)
+: Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
 **Environment variable**: `DD_TEST_SESSION_NAME`<br/>
 **Default**: (CI job name + test command)<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
@@ -367,7 +367,7 @@ await module.CloseAsync();
 
 Always call `module.Close()` or `module.CloseAsync()` at the end so that all the test data is flushed to Datadog.
 
-## Best Practices
+## Best practices
 
 ### Test session name `DD_TEST_SESSION_NAME`
 
@@ -380,12 +380,12 @@ Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
 
 - CI job name
 - Command used to run the tests (such as `yarn test`)
 
-The test session name should be unique within a repository to help you distinguish different groups of tests.
+The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 
 #### When to use `DD_TEST_SESSION_NAME`
 

--- a/content/en/tests/setup/dotnet.md
+++ b/content/en/tests/setup/dotnet.md
@@ -371,7 +371,7 @@ Always call `module.Close()` or `module.CloseAsync()` at the end so that all the
 
 ### Test session name `DD_TEST_SESSION_NAME`
 
-Use `DD_TEST_SESSION_NAME` to define the name of the test session and the related group of tests (for example,`test_session.name`). Examples of values for this tag would be:
+Use `DD_TEST_SESSION_NAME` to define the name of the test session and the related group of tests. Examples of values for this tag would be:
 
 - `unit-tests`
 - `integration-tests`

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -123,6 +123,9 @@ Set the following environment variables to configure the tracer:
 `MAVEN_OPTS=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar` (Required)
 : Injects the tracer into the Maven build process.
 
+`DD_TEST_SESSION_NAME`
+: Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
+
 Run your tests as you normally do (for example: `mvn test` or `mvn verify`).
 
 {{% /tab %}}
@@ -155,6 +158,9 @@ Set the following environment variables to configure the tracer:
 `DD_CIVISIBILITY_ENABLED=true` (Required)
 : Enables the Test Optimization product.
 
+`DD_TEST_SESSION_NAME`
+: Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
+
 `DD_ENV` (Required)
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
@@ -176,6 +182,9 @@ Set the following environment variables to configure the tracer:
 
 `DD_CIVISIBILITY_ENABLED=true` (Required)
 : Enables the Test Optimization product.
+
+`DD_TEST_SESSION_NAME`
+: Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
 
 `DD_ENV` (Required)
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
@@ -423,6 +432,33 @@ static Stream<Arguments> randomArguments() {
     );
 }
 ```
+
+### Test session name `DD_TEST_SESSION_NAME`
+
+Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+
+- `unit-tests`
+- `integration-tests`
+- `smoke-tests`
+- `flaky-tests`
+- `ui-tests`
+- `backend-tests`
+
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+
+- CI job name
+- Command used to run the tests (such as `yarn test`)
+
+The test session name should be unique within a repository to help you distinguish different groups of tests.
+
+#### When to use `DD_TEST_SESSION_NAME`
+
+If your tests are run with commands that include a dynamic string, such as:
+
+- `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+- `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+
+The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
 
 ## Troubleshooting
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -435,7 +435,7 @@ static Stream<Arguments> randomArguments() {
 
 ### Test session name `DD_TEST_SESSION_NAME`
 
-Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+Use `DD_TEST_SESSION_NAME` to define the name of the test session and the related group of tests. Examples of values for this tag would be:
 
 - `unit-tests`
 - `integration-tests`
@@ -457,7 +457,7 @@ If your tests are run with commands that include a dynamic string, such as:
 
 - `mvn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-The default value for the test session name will be unstable. Datadog recommends using `DD_TEST_SESSION_NAME` in this case.
+Then the default value for the test session name constantly changes. Datadog recommends using `DD_TEST_SESSION_NAME` in this case.
 
 ## Troubleshooting
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -124,7 +124,7 @@ Set the following environment variables to configure the tracer:
 : Injects the tracer into the Maven build process.
 
 `DD_TEST_SESSION_NAME`
-: Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
+: Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
 
 Run your tests as you normally do (for example: `mvn test` or `mvn verify`).
 
@@ -159,7 +159,7 @@ Set the following environment variables to configure the tracer:
 : Enables the Test Optimization product.
 
 `DD_TEST_SESSION_NAME`
-: Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
+: Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
 
 `DD_ENV`
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
@@ -184,7 +184,7 @@ Set the following environment variables to configure the tracer:
 : Enables the Test Optimization product.
 
 `DD_TEST_SESSION_NAME`
-: Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
+: Identifies a group of tests (for example: `unit-tests` or `integration-tests`).
 
 `DD_ENV`
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
@@ -444,12 +444,12 @@ Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
 
 - CI job name
 - Command used to run the tests (such as `mvn test`)
 
-The test session name should be unique within a repository to help you distinguish different groups of tests.
+The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 
 #### When to use `DD_TEST_SESSION_NAME`
 
@@ -457,7 +457,7 @@ If your tests are run with commands that include a dynamic string, such as:
 
 - `mvn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
+The default value for the test session name will be unstable. Datadog recommends using `DD_TEST_SESSION_NAME` in this case.
 
 ## Troubleshooting
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -111,10 +111,10 @@ Set the following environment variables to configure the tracer:
 `DD_CIVISIBILITY_ENABLED=true` (Required)
 : Enables the Test Optimization product.
 
-`DD_ENV` (Required)
+`DD_ENV`
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
-`DD_SERVICE` (Required)
+`DD_SERVICE`
 : Name of the service or library being tested.
 
 `DD_TRACER_FOLDER` (Required)
@@ -136,10 +136,10 @@ Set the following environment variables to configure the tracer:
 `DD_CIVISIBILITY_ENABLED=true` (Required)
 : Enables the Test Optimization product.
 
-`DD_ENV` (Required)
+`DD_ENV`
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
-`DD_SERVICE` (Required)
+`DD_SERVICE`
 : Name of the service or library being tested.
 
 `DD_TRACER_FOLDER` (Required)
@@ -161,10 +161,10 @@ Set the following environment variables to configure the tracer:
 `DD_TEST_SESSION_NAME`
 : Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
 
-`DD_ENV` (Required)
+`DD_ENV`
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
-`DD_SERVICE` (Required)
+`DD_SERVICE`
 : Name of the service or library being tested.
 
 `DD_TRACER_FOLDER` (Required)
@@ -186,10 +186,10 @@ Set the following environment variables to configure the tracer:
 `DD_TEST_SESSION_NAME`
 : Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
 
-`DD_ENV` (Required)
+`DD_ENV`
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
 
-`DD_SERVICE` (Required)
+`DD_SERVICE`
 : Name of the service or library being tested.
 
 `DD_TRACER_FOLDER` (Required)
@@ -447,7 +447,7 @@ Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test
 If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
 
 - CI job name
-- Command used to run the tests (such as `yarn test`)
+- Command used to run the tests (such as `mvn test`)
 
 The test session name should be unique within a repository to help you distinguish different groups of tests.
 
@@ -455,8 +455,7 @@ The test session name should be unique within a repository to help you distingui
 
 If your tests are run with commands that include a dynamic string, such as:
 
-- `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
-- `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+- `mvn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
 The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
 

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -803,7 +803,7 @@ When you use this approach, both the testing framework and Test Optimization can
 
 ### Test session name `DD_TEST_SESSION_NAME`
 
-Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+Use `DD_TEST_SESSION_NAME` to define the name of the test session and the related group of tests. Examples of values for this tag would be:
 
 - `unit-tests`
 - `integration-tests`
@@ -826,7 +826,7 @@ If your tests are run with commands that include a dynamic string, such as:
 - `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 - `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
+Then the default value for the test session name constantly changes. Datadog recommends using `DD_TEST_SESSION_NAME` in this case.
 
 ## Further reading
 

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -73,7 +73,7 @@ For more information, see the [Python tracer installation documentation][1].
 {{< tabs >}}
 {{% tab "pytest" %}}
 
-To enable instrumentation of `pytest` tests, add the `--ddtrace` option when running `pytest`. Specify the test session name with the `DD_TEST_SESSION_NAME` environment variable, which identifies the group of tests about to run. Examples of this values are `unit-tests`, `integration-tests` or `smoke-tests`.
+To enable instrumentation of `pytest` tests, add the `--ddtrace` option when running `pytest`. Specify the test session name with the `DD_TEST_SESSION_NAME` environment variable, which identifies the group of tests about to run. Examples of this value would be `unit-tests`, `integration-tests` or `smoke-tests`.
 
 {{< code-block lang="shell" >}}
 DD_TEST_SESSION_NAME=unit-tests pytest --ddtrace
@@ -433,7 +433,7 @@ Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test
 If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
 
 - CI job name
-- Command used to run the tests (such as `yarn test`)
+- Command used to run the tests (such as `pytest --ddtrace`)
 
 The test session name should be unique within a repository to help you distinguish different groups of tests.
 

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -420,7 +420,7 @@ All other [Datadog Tracer configuration][3] options can also be used.
 
 ### Test session name `DD_TEST_SESSION_NAME`
 
-Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+Use `DD_TEST_SESSION_NAME` to define the name of the test session and the related group of tests. Examples of values for this tag would be:
 
 - `unit-tests`
 - `integration-tests`
@@ -442,7 +442,7 @@ If your tests are run with commands that include a dynamic string, such as:
 
 - `pytest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
+Then the default value for the test session name constantly changes. Datadog recommends using `DD_TEST_SESSION_NAME` in this case.
 
 ## Known limitations
 

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -73,27 +73,19 @@ For more information, see the [Python tracer installation documentation][1].
 {{< tabs >}}
 {{% tab "pytest" %}}
 
-To enable instrumentation of `pytest` tests, add the `--ddtrace` option when running `pytest`. Specify the test session name with the `DD_TEST_SESSION_NAME` environment variable, which identifies the group of tests about to run. Examples of this value would be `unit-tests`, `integration-tests` or `smoke-tests`.
+To enable instrumentation of `pytest` tests, add the `--ddtrace` option when running `pytest`.
 
 {{< code-block lang="shell" >}}
-DD_TEST_SESSION_NAME=unit-tests pytest --ddtrace
+pytest --ddtrace
 {{< /code-block >}}
 
 If you also want to enable the rest of the APM integrations to get more information in your flamegraph, add the `--ddtrace-patch-all` option:
 
 {{< code-block lang="shell" >}}
-DD_TEST_SESSION_NAME=unit-tests pytest --ddtrace --ddtrace-patch-all
+pytest --ddtrace --ddtrace-patch-all
 {{< /code-block >}}
 
-Additionally you may pass these environment variables:
-
-`DD_SERVICE`
-: Name of the service or library under test.<br/>
-**Example**: `my-ui`
-
-`DD_ENV`
-: Name of the environment where tests are being run.<br/>
-**Examples**: `local`, `ci`
+For additional configuration see [Configuration Settings][3].
 
 ### Adding custom tags to tests
 
@@ -130,6 +122,7 @@ Read more about custom measures in the [Add Custom Measures Guide][2].
 
 [1]: /tracing/trace_collection/custom_instrumentation/python?tab=locally#adding-tags
 [2]: /tests/guides/add_custom_measures/?tab=python
+[3]: #configuration-settings
 {{% /tab %}}
 
 {{% tab "pytest-benchmark" %}}
@@ -146,6 +139,9 @@ def test_square_value(benchmark):
     assert result == 25
 ```
 
+For additional configuration see [Configuration Settings][1].
+
+[1]: #configuration-settings
 {{% /tab %}}
 
 {{% tab "unittest" %}}
@@ -170,6 +166,9 @@ def test_will_pass(self):
 assert True
 {{< /code-block >}}
 
+For additional configuration see [Configuration Settings][1].
+
+[1]: #configuration-settings
 {{% /tab %}}
 
 {{% tab "Manual instrumentation (beta)" %}}
@@ -375,8 +374,10 @@ if __name__ == "__main__":
     api.TestSession.finish()
 ```
 
-[1]: https://github.com/DataDog/dd-trace-py
+For additional configuration see [Configuration Settings][2].
 
+[1]: https://github.com/DataDog/dd-trace-py
+[2]: #configuration-settings
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -139,7 +139,7 @@ def test_square_value(benchmark):
     assert result == 25
 ```
 
-For additional configuration see [Configuration Settings][1].
+For additional configurations, see [Configuration Settings][1].
 
 [1]: #configuration-settings
 {{% /tab %}}
@@ -164,7 +164,7 @@ def test_will_pass(self):
 assert True
 {{< /code-block >}}
 
-For additional configuration see [Configuration Settings][1].
+For additional configurations, see [Configuration Settings][1].
 
 [1]: #configuration-settings
 {{% /tab %}}
@@ -372,7 +372,7 @@ if __name__ == "__main__":
     api.TestSession.finish()
 ```
 
-For additional configuration see [Configuration Settings][2].
+For additional configurations, see [Configuration Settings][2].
 
 [1]: https://github.com/DataDog/dd-trace-py
 [2]: #configuration-settings
@@ -385,7 +385,7 @@ For additional configuration see [Configuration Settings][2].
 The following is a list of the most important configuration settings that can be used with the tracer, either in code or using environment variables:
 
 `DD_TEST_SESSION_NAME`
-: Use it to identify a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
+: Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
 **Environment variable**: `DD_TEST_SESSION_NAME`<br/>
 **Default**: (CI job name + test command)<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
@@ -429,12 +429,12 @@ Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
 
 - CI job name
 - Command used to run the tests (such as `pytest --ddtrace`)
 
-The test session name should be unique within a repository to help you distinguish different groups of tests.
+The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 
 #### When to use `DD_TEST_SESSION_NAME`
 

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -149,10 +149,8 @@ For additional configuration see [Configuration Settings][1].
 To enable instrumentation of `unittest` tests, run your tests by appending `ddtrace-run` to the beginning of your `unittest` command.
 
 {{< code-block lang="shell" >}}
-DD_TEST_SESSION_NAME=python-integration-tests ddtrace-run python -m unittest
+ddtrace-run python -m unittest
 {{< /code-block >}}
-
-Optionally specify the name of the service or library under test in the `DD_SERVICE` environment variable.
 
 Alternatively, if you wish to enable `unittest` instrumentation manually, use `patch()` to enable the integration:
 

--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -457,7 +457,7 @@ Datadog::CI.active_test_session&.finish
 
 ### Test session name `DD_TEST_SESSION_NAME`
 
-Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+Use `DD_TEST_SESSION_NAME` to define the name of the test session and the related group of tests. Examples of values for this tag would be:
 
 - `unit-tests`
 - `integration-tests`
@@ -480,7 +480,7 @@ If your tests are run with commands that include a dynamic string, such as:
 - `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 - `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
+Then the default value for the test session name constantly changes. Datadog recommends using `DD_TEST_SESSION_NAME` in this case.
 
 ## Further reading
 

--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -466,12 +466,12 @@ Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
 
 - CI job name
 - Command used to run the tests (such as `yarn test`)
 
-The test session name should be unique within a repository to help you distinguish different groups of tests.
+The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 
 #### When to use `DD_TEST_SESSION_NAME`
 

--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -57,7 +57,7 @@ To report test results to Datadog, you need to configure the `datadog-ci` gem:
 {{% ci-autoinstrumentation %}}
 
 <div class="alert alert-warning">
-  <strong>Note</strong>: Auto-instrumentation is not supported for JRuby. Follow the <a href="/tests/setup/ruby/?tab=ciproviderwithautoinstrumentationsupport#manually-instrumenting-your-tests">manual instrumentation steps</a> instead.  
+  <strong>Note</strong>: Auto-instrumentation is not supported for JRuby. Follow the <a href="/tests/setup/ruby/?tab=ciproviderwithautoinstrumentationsupport#manually-instrumenting-your-tests">manual instrumentation steps</a> instead.
 </div>
 
 {{% /tab %}}
@@ -99,6 +99,9 @@ Follow these steps if your CI Provider is not supported for auto-instrumentation
 
 `DD_CIVISIBILITY_ENABLED=true` (Required)
 : Enables the Test Optimization product.
+
+`DD_TEST_SESSION_NAME`
+: Use this to identify a group of tests (for example: `unit-tests` or `integration-tests`).
 
 `DD_ENV` (Required)
 : Environment where the tests are being run (for example: `local` when running tests on a developer workstation or `ci` when running them on a CI provider).
@@ -206,11 +209,11 @@ For the full list of available instrumentation methods, see the [tracing documen
 ## Manually instrumenting your tests
 
 <div class="alert alert-info">
-<strong>Attention</strong>: when using manual instrumentation, run your tests like you normally do: 
+<strong>Attention</strong>: when using manual instrumentation, run your tests like you normally do:
 don't change `RUBYOPT` env variable and don't prepend `bundle exec ddcirb exec` to your test command
 </div>
 
-Auto-instrumentation adds additional performance overhead at the code loading stage. It can be especially noticeable for 
+Auto-instrumentation adds additional performance overhead at the code loading stage. It can be especially noticeable for
 large repositories with a lot of dependencies. If your project takes 20+ seconds to start, you are likely
 to benefit from manually instrumenting your tests.
 
@@ -449,6 +452,35 @@ Datadog::CI.active_test_module&.finish
 Datadog::CI.active_test_session&.passed!
 Datadog::CI.active_test_session&.finish
 ```
+
+## Best practices
+
+### Test session name `DD_TEST_SESSION_NAME`
+
+Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+
+- `unit-tests`
+- `integration-tests`
+- `smoke-tests`
+- `flaky-tests`
+- `ui-tests`
+- `backend-tests`
+
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+
+- CI job name
+- Command used to run the tests (such as `yarn test`)
+
+The test session name should be unique within a repository to help you distinguish different groups of tests.
+
+#### When to use `DD_TEST_SESSION_NAME`
+
+If your tests are run with commands that include a dynamic string, such as:
+
+- `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+- `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+
+The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
 
 ## Further reading
 

--- a/content/en/tests/setup/swift.md
+++ b/content/en/tests/setup/swift.md
@@ -155,7 +155,7 @@ Set all these variables in your test target:
 **Default**: `(empty)`
 
 `DD_TEST_SESSION_NAME`
-: Use it to identify a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
+: Identifies a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
 **Environment variable**: `DD_TEST_SESSION_NAME`<br/>
 **Default**: (CI job name + test command)<br/>
 **Example**: `unit-tests`, `integration-tests`, `smoke-tests`
@@ -639,12 +639,12 @@ Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test
 - `ui-tests`
 - `backend-tests`
 
-If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of the:
 
 - CI job name
 - Command used to run the tests (such as `swift test`)
 
-The test session name should be unique within a repository to help you distinguish different groups of tests.
+The test session name needs to be unique within a repository to help you distinguish different groups of tests.
 
 #### When to use `DD_TEST_SESSION_NAME`
 

--- a/content/en/tests/setup/swift.md
+++ b/content/en/tests/setup/swift.md
@@ -642,7 +642,7 @@ Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test
 If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
 
 - CI job name
-- Command used to run the tests (such as `yarn test`)
+- Command used to run the tests (such as `swift test`)
 
 The test session name should be unique within a repository to help you distinguish different groups of tests.
 
@@ -650,8 +650,7 @@ The test session name should be unique within a repository to help you distingui
 
 If your tests are run with commands that include a dynamic string, such as:
 
-- `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
-- `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+- `swift test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
 The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
 

--- a/content/en/tests/setup/swift.md
+++ b/content/en/tests/setup/swift.md
@@ -630,7 +630,7 @@ Disable the sandbox by adding Entitlements to the UI Test runner bundle, then ad
 
 ### Test session name `DD_TEST_SESSION_NAME`
 
-Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+Use `DD_TEST_SESSION_NAME` to define the name of the test session and the related group of tests. Examples of values for this tag would be:
 
 - `unit-tests`
 - `integration-tests`
@@ -652,7 +652,7 @@ If your tests are run with commands that include a dynamic string, such as:
 
 - `swift test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
+Then the default value for the test session name constantly changes. Datadog recommends using `DD_TEST_SESSION_NAME` in this case.
 
 ## Further reading
 

--- a/content/en/tests/setup/swift.md
+++ b/content/en/tests/setup/swift.md
@@ -154,6 +154,12 @@ Set all these variables in your test target:
 : The [Datadog API key][2] used to upload the test results.<br/>
 **Default**: `(empty)`
 
+`DD_TEST_SESSION_NAME`
+: Use it to identify a group of tests, such as `integration-tests`, `unit-tests` or `smoke-tests`.<br/>
+**Environment variable**: `DD_TEST_SESSION_NAME`<br/>
+**Default**: (CI job name + test command)<br/>
+**Example**: `unit-tests`, `integration-tests`, `smoke-tests`
+
 `DD_SERVICE`
 : Name of the service or library under test.<br/>
 **Default**: The repository name<br/>
@@ -621,6 +627,33 @@ Disable the sandbox by adding Entitlements to the UI Test runner bundle, then ad
 <key>com.apple.security.app-sandbox</key>
  <false/>
 {{< /code-block >}}
+
+### Test session name `DD_TEST_SESSION_NAME`
+
+Use `DD_TEST_SESSION_NAME` to define the test session name for your tests (`test_session.name` tag). Use this to identify a group of tests. Examples of values for this tag would be:
+
+- `unit-tests`
+- `integration-tests`
+- `smoke-tests`
+- `flaky-tests`
+- `ui-tests`
+- `backend-tests`
+
+If `DD_TEST_SESSION_NAME` is not specified, the default value used is a combination of:
+
+- CI job name
+- Command used to run the tests (such as `yarn test`)
+
+The test session name should be unique within a repository to help you distinguish different groups of tests.
+
+#### When to use `DD_TEST_SESSION_NAME`
+
+If your tests are run with commands that include a dynamic string, such as:
+
+- `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+- `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+
+The default value for the test session name will be unstable. It is recommended to use `DD_TEST_SESSION_NAME` in this case.
 
 ## Further reading
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?
* Make `DD_TEST_SESSION_NAME` more prominent. 
* Try to reduce the importance of `DD_ENV` and `DD_SERVICE`


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
