### PR TITLE
[Test Optimization] Remove Preview warning to the Go library

### DIFF
--- a/content/en/tests/code_coverage.md
+++ b/content/en/tests/code_coverage.md
@@ -295,8 +295,6 @@ This feature is enabled by default. Use `DD_CIVISIBILITY_SIMPLECOV_INSTRUMENTATI
 
 {{% tab "Go" %}}
 
-<div class="alert alert-info">Test optimization for Go is in Preview.</div>
-
 ### Compatibility
 
 * `go test -cover`

--- a/content/en/tests/flaky_test_management/auto_test_retries.md
+++ b/content/en/tests/flaky_test_management/auto_test_retries.md
@@ -126,8 +126,6 @@ Customize the Auto Test Retries with the following environment variables:
 
 {{% tab "Go" %}}
 
-<div class="alert alert-info">Test optimization for Go is in Preview.</div>
-
 ### Compatibility
 
 `orchestrion >= 0.9.4` + `dd-trace-go >= 1.69.1`

--- a/content/en/tests/flaky_test_management/early_flake_detection.md
+++ b/content/en/tests/flaky_test_management/early_flake_detection.md
@@ -106,8 +106,6 @@ The test framework compatibility is the same as [Test Optimization Compatibility
 
 {{% tab "Go" %}}
 
-<div class="alert alert-info">Test optimization for Go is in Preview.</div>
-
 `orchestrion >= 0.9.4 + dd-trace-go >= 1.69.1`
 
 {{% /tab %}}

--- a/content/en/tests/setup/go.md
+++ b/content/en/tests/setup/go.md
@@ -26,10 +26,6 @@ further_reading:
 <div class="alert alert-warning">Test Optimization is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
-{{< callout url="#" btn_hidden="true" header="Join the Preview!" >}}
-Test optimization for Go is in Preview.
-{{< /callout >}}
-
 ## Compatibility
 
 Supported test frameworks:

--- a/content/en/tests/test_impact_analysis/setup/go.md
+++ b/content/en/tests/test_impact_analysis/setup/go.md
@@ -16,10 +16,6 @@ further_reading:
       text: "Troubleshooting CI Visibility"
 ---
 
-{{< callout url="#" btn_hidden="true" header="Join the Preview!" >}}
-Test optimization for Go is in Preview.
-{{< /callout >}}
-
 ## Compatibility
 
 Test Impact Analysis is only supported on `orchestrion >= 0.9.4 + dd-trace-go >= 1.70.0`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Removes the Preview warnings/flags from the Go library

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
