### PR TITLE
[INA-6626] Update incident management settings and analytics docs to reflect timestamp overrides

### DIFF
--- a/content/en/service_management/incident_management/analytics.md
+++ b/content/en/service_management/incident_management/analytics.md
@@ -40,7 +40,7 @@ Incident Management collects the following analytic measures to form analytic qu
 - Status Stable Duration
 - Time to Detect (detected time - customer impact start time)
 - Time to Repair (customer impact end time - detected time)
-- Time to Resolve (resolved time - created time)
+- Time to Resolve (resolved time - declared time)
 - Number of Users Impacted
 - Acknowledge
 

--- a/content/en/service_management/incident_management/analytics.md
+++ b/content/en/service_management/incident_management/analytics.md
@@ -38,13 +38,15 @@ Incident Management collects the following analytic measures to form analytic qu
 - Customer Impact Duration
 - Status Active Duration
 - Status Stable Duration
-- Time to Detect
-- Time to Repair (customer impact end time - created time)
+- Time to Detect (detected - customer impact start time)
+- Time to Repair (customer impact end time - detected time)
 - Time to Resolve (resolved time - created time)
 - Number of Users Impacted
 - Acknowledge
 
 In addition to these defaults, you can create new measures by adding custom *Number* property fields in your [Incident Settings][7]. 
+
+*Note:* If you override a timestamp, the override will be used for calculating Time to Detect, Time to Repair, and Time to Resolve.
 
 ## Visualize incident data in dashboards
 

--- a/content/en/service_management/incident_management/analytics.md
+++ b/content/en/service_management/incident_management/analytics.md
@@ -38,9 +38,9 @@ Incident Management collects the following analytic measures to form analytic qu
 - Customer Impact Duration
 - Status Active Duration
 - Status Stable Duration
-- Time to Detect (detected time - customer impact start time)
-- Time to Repair (customer impact end time - detected time)
-- Time to Resolve (resolved time - declared time)
+- Time to Detect (detected time – customer impact start time)
+- Time to Repair (customer impact end time – detected time)
+- Time to Resolve (resolved time – declared time)
 - Number of Users Impacted
 - Acknowledge
 

--- a/content/en/service_management/incident_management/analytics.md
+++ b/content/en/service_management/incident_management/analytics.md
@@ -38,7 +38,7 @@ Incident Management collects the following analytic measures to form analytic qu
 - Customer Impact Duration
 - Status Active Duration
 - Status Stable Duration
-- Time to Detect (detected - customer impact start time)
+- Time to Detect (detected time - customer impact start time)
 - Time to Repair (customer impact end time - detected time)
 - Time to Resolve (resolved time - created time)
 - Number of Users Impacted
@@ -46,7 +46,7 @@ Incident Management collects the following analytic measures to form analytic qu
 
 In addition to these defaults, you can create new measures by adding custom *Number* property fields in your [Incident Settings][7]. 
 
-*Note:* If you override a timestamp, the override will be used for calculating Time to Detect, Time to Repair, and Time to Resolve.
+**Note:** If you override a timestamp, the override value will be used to calculate Time to Detect, Time to Repair, and Time to Resolve.
 
 ## Visualize incident data in dashboards
 

--- a/content/en/service_management/incident_management/incident_settings/information.md
+++ b/content/en/service_management/incident_management/incident_settings/information.md
@@ -43,6 +43,7 @@ For the Declare Incident Helper Text settings, you can customize the helper text
 | Private&nbsp;Incidents | Enable users in your organization to make incidents private and to delete incidents. Private Incidents gives users the ability to limit access to incidents with sensitive information so that only responders of the incident can see it the details. Any previously created notification rules will not be sent when an incident is private.|
 | Incident&nbsp;Deletion | Incident Deletion gives users the ability to remove the incidents from the UI, including the analytics. By default, incident deletion is disabled. |
 | Portmortem&nbsp;Generation Anytime| Enable users to to generate a postmortem regardless of the incident status. When this setting is disabled, users can only generate postmortems after an incident has been resolved. |
+| Override Status Timestamps | Allow users to override the detection, declaration, and resolution timestamps of an incident. If an override is set, the new timestamp applies in incident search and analytics. |
 
 
 [1]: https://app.datadoghq.com/incidents/settings#Information

--- a/content/en/service_management/incident_management/incident_settings/information.md
+++ b/content/en/service_management/incident_management/incident_settings/information.md
@@ -43,7 +43,7 @@ For the Declare Incident Helper Text settings, you can customize the helper text
 | Private&nbsp;Incidents | Enable users in your organization to make incidents private and to delete incidents. Private Incidents gives users the ability to limit access to incidents with sensitive information so that only responders of the incident can see it the details. Any previously created notification rules will not be sent when an incident is private.|
 | Incident&nbsp;Deletion | Incident Deletion gives users the ability to remove the incidents from the UI, including the analytics. By default, incident deletion is disabled. |
 | Portmortem&nbsp;Generation Anytime| Enable users to to generate a postmortem regardless of the incident status. When this setting is disabled, users can only generate postmortems after an incident has been resolved. |
-| Override Status Timestamps | Allow users to override the detection, declaration, and resolution timestamps of an incident. If an override is set, the new timestamp applies in incident search and analytics. |
+| Override Status Timestamps | Enable users to override the detection, declaration, and resolution timestamps of an incident. If an override is set, the new timestamp applies in incident search and analytics. |
 
 
 [1]: https://app.datadoghq.com/incidents/settings#Information


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We're launching a feature that allows users to edit timestamps of an incident. This adds a section in the information settings docs to reflect this change and a note in the analytics section.

(copy approved by @shahgahmed)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
