### PR TITLE
Add Next.js-specific bundling information

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -230,7 +230,7 @@ npm install @datadog/native-metrics@2.0.0 @datadog/pprof@5.0.0
 cp -R ./node_modules path/to/bundle
 ```
 
-(In case of Next.js the `path/to/bundle` is usually the `.next/standalone` directory of your app.)
+**Note**: In case of Next.js the `path/to/bundle` is usually the `.next/standalone` directory of your app.
 
 At this stage you should be able to deploy your bundle, (which is your application code and most of your dependencies), with the `node_modules/` directory, which contains the native modules and their dependencies.
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -130,7 +130,7 @@ Datadog recommends you have custom-built bundler plugins. These plugins are able
 
 **Note**: Some applications can have 100% of modules bundled, however native modules still need to remain external to the bundle.
 
-#### Esbuild support
+#### Bundling with Esbuild
 
 This library provides experimental esbuild support in the form of an esbuild plugin, and requires at least Node.js v16.17 or v18.7. To use the plugin, make sure you have `dd-trace@3+` installed, and then require the `dd-trace/esbuild` module when building your bundle.
 
@@ -148,7 +148,7 @@ esbuild.build({
   platform: 'node', // allows built-in modules to be required
   target: ['node16'],
   external: [
-    // esbuild cannot bundle native modules
+    // required if you use native metrics
     '@datadog/native-metrics',
 
     // required if you use profiling
@@ -170,6 +170,48 @@ esbuild.build({
 })
 ```
 
+#### Bundling with Next.js
+
+If you are using Next.js or another framework relying on webpack to bundle your application, add a declaration
+similar to the one for webpack inside your `next.config.js` configuration file:
+
+```javascript
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // ... non-relevant parts omitted, substitute your own config ...
+
+  // this custom webpack config is required for Datadog tracing to work
+  webpack: (
+    config,
+    { buildId, dev, isServer, defaultLoaders, nextRuntime, webpack }
+  ) => {
+    const externals = [
+      // required if you use native metrics
+      '@datadog/native-metrics',
+
+      // required if you use profiling
+      '@datadog/pprof',
+
+      // required if you use Datadog security features
+      '@datadog/native-appsec',
+      '@datadog/native-iast-taint-tracking',
+      '@datadog/native-iast-rewriter',
+
+      // required if you encounter graphql errors during the build step
+      'graphql/language/visitor',
+      'graphql/language/printer',
+      'graphql/utilities'
+    ];
+    config.externals.push(...externals);
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+#### General bundling remarks
+
 **Note**: Due to the usage of native modules in the tracer, which are compiled C++ code, (usually ending with a `.node` file extension), you need to add entries to your `external` list. Currently native modules used in the Node.js tracer live inside of `@datadog` prefixed packages. This will also require that you ship a `node_modules/` directory alongside your bundled application. You don't need to ship your entire `node_modules/` directory as it would contain many superfluous packages that should be contained in your bundle.
 
 To generate a smaller `node_modules/` directory with only the required native modules, (and their dependencies) you can first determine the versions of packages that you need, then create a temporary directory to install them into, and copy the resulting `node_modules/` directory from it. For example:
@@ -187,6 +229,8 @@ npm init -y
 npm install @datadog/native-metrics@2.0.0 @datadog/pprof@5.0.0
 cp -R ./node_modules path/to/bundle
 ```
+
+(In case of Next.js the `path/to/bundle` is usually the `.next/standalone` directory of your app.)
 
 At this stage you should be able to deploy your bundle, (which is your application code and most of your dependencies), with the `node_modules/` directory, which contains the native modules and their dependencies.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The document already has a bundling section describing Esbuild, but a lot of customers encounter the same problem with Next.js, so we should provide Next.js-specific information too to have easily accessible piece of knowledge about it that we can point them to.

### Merge instructions

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes

JIRA: [PROF-11291]


[PROF-11291]: https://datadoghq.atlassian.net/browse/PROF-11291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ