### PR TITLE
Update the EKS section to reflect the new endpoints Amazon exposed

### DIFF
--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -349,7 +349,7 @@ annotations:
 {{< /tabs >}}
 
 **Notes:**
-- Amazon exposes `kube_controller_manager` and `kube_scheduler` metrics under the [`v1.metrics.eks.amazonaws.com`][11] API Group. 
+- Amazon exposes `kube_controller_manager` and `kube_scheduler` metrics under the [`metrics.eks.amazonaws.com`][11] API Group. 
 
 
 ## Kubernetes on OpenShift 4 {#OpenShift4}

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -317,7 +317,7 @@ scheduler:
 
 ## Kubernetes on Amazon EKS {#EKS}
 
-Amazon Elastic Kubernetes Service (EKS) now supports monitoring all control plane components using cluster checks. If you use Helm to install Datadog, these metrics are available immediately by adding the following annotations to the `default/kubernetes` service. Support is coming for the Datadog Operator, but Operator installations are currently limited to API Server [metrics][5].
+Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane components using cluster checks. If you use Helm to install the Datadog agent, these metrics are available immediately by adding the following annotations to the `default/kubernetes` service. Operator installations are limited to API Server [metrics][5], but support for `kube_controller_manager` and `kube_scheduler` metrics is coming next release.
 
 ### Prerequisites
 - An EKS Cluster running on Kubernetes version >= 1.28

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -329,7 +329,7 @@ Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane co
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
 
-Operator installations are limited to API Server [metrics][1]. For support for `kube_controller_manager` and `kube_scheduler` metrics, use the Helm install.
+Add the following annotations. Operator installations are limited to API Server [metrics][1]. For support for `kube_controller_manager` and `kube_scheduler` metrics, use the Helm install.
 
 ```yaml
 annotations:

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -317,7 +317,7 @@ scheduler:
 
 ## Kubernetes on Amazon EKS {#EKS}
 
-Amazon Elastic Kubernetes Service (EKS) now supports monitoring all control plane components using cluster checks. If you use Helm to install Datadog, these metrics are available immediately by adding the following annotations to the `default/kubernetes` service. Support is coming for the Datadog Operator, but right now Operator installations are limited to API Server [metrics][5].
+Amazon Elastic Kubernetes Service (EKS) now supports monitoring all control plane components using cluster checks. If you use Helm to install Datadog, these metrics are available immediately by adding the following annotations to the `default/kubernetes` service. Support is coming for the Datadog Operator, but Operator installations are currently limited to API Server [metrics][5].
 
 ### Prerequisites
 - An EKS Cluster running on Kubernetes version >= 1.28

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -317,17 +317,20 @@ scheduler:
 
 ## Kubernetes on Amazon EKS {#EKS}
 
-Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane components using cluster checks. If you use Helm to install the Datadog agent, these metrics are available immediately by adding the following annotations to the `default/kubernetes` service. Operator installations are limited to API Server [metrics][5], but support for `kube_controller_manager` and `kube_scheduler` metrics is coming in Operator v1.13.0.
+Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane components using cluster checks. 
 
 ### Prerequisites
 - An EKS Cluster running on Kubernetes version >= 1.28
-- Deploy the Agent via one of:
-  - helm chart version >= `3.90.1`
-  - Operator >= `v1.13.0`
+- Deploy the Agent using one of:
+  - Helm chart version >= `3.90.1`
+  - Datadog Operator >= `v1.13.0`
 - Enable the Datadog [Cluster Agent][6]
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
+
+Operator installations are limited to API Server [metrics][1]. For support for `kube_controller_manager` and `kube_scheduler` metrics, use the Helm install.
+
 ```yaml
 annotations:
   ad.datadoghq.com/endpoints.check_names: '["kube_apiserver_metrics"]'
@@ -335,8 +338,13 @@ annotations:
   ad.datadoghq.com/endpoints.instances:
     '[{ "prometheus_url": "https://%%host%%:%%port%%/metrics", "bearer_token_auth": "true" }]'
 ```
+
+[1]: https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane/#monitor-control-plane-metrics
 {{% /tab %}}
 {{% tab "Helm" %}}
+
+Add the following annotations to the `default/kubernetes` service:
+
 ```yaml
 annotations:
   ad.datadoghq.com/endpoints.check_names: '["kube_apiserver_metrics"]'

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -317,11 +317,13 @@ scheduler:
 
 ## Kubernetes on Amazon EKS {#EKS}
 
-Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane components using cluster checks. If you use Helm to install the Datadog agent, these metrics are available immediately by adding the following annotations to the `default/kubernetes` service. Operator installations are limited to API Server [metrics][5], but support for `kube_controller_manager` and `kube_scheduler` metrics is coming next release.
+Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane components using cluster checks. If you use Helm to install the Datadog agent, these metrics are available immediately by adding the following annotations to the `default/kubernetes` service. Operator installations are limited to API Server [metrics][5], but support for `kube_controller_manager` and `kube_scheduler` metrics is coming in Operator v1.13.0.
 
 ### Prerequisites
 - An EKS Cluster running on Kubernetes version >= 1.28
-- Datadog installation using Helm 
+- Deploy the Agent via one of:
+  - helm chart version >= `3.90.1`
+  - Operator >= `v1.13.0`
 - Enable the Datadog [Cluster Agent][6]
 
 {{< tabs >}}
@@ -350,7 +352,7 @@ annotations:
 
 **Notes:**
 - Amazon exposes `kube_controller_manager` and `kube_scheduler` metrics under the [`metrics.eks.amazonaws.com`][11] API Group. 
-
+- The addition of `"extra_headers":{"accept":"*/*"}` prevents `HTTP 406` errors when querying the EKS metrics API.
 
 ## Kubernetes on OpenShift 4 {#OpenShift4}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Amazon recently added new functionality that allows the Agent to collect metrics for the `kube_scheduler` and `kube_controller_manager`. This PR updates the docs with the required steps to enable metric collection.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
