### PR TITLE
Fix a typo in Jenkins log collection port config example

### DIFF
--- a/content/en/continuous_integration/pipelines/jenkins.md
+++ b/content/en/continuous_integration/pipelines/jenkins.md
@@ -539,7 +539,7 @@ def datadog = jenkins.getDescriptorByType(DatadogGlobalConfiguration)
 
 def agentHost = 'localhost' // Configure your Datadog Agent host
 def agentPort = 8125
-def agentLogCollectionPort = 8126 // (Optional) Configure logs collection port as configured in your Datadog Agent
+def agentLogCollectionPort = 10518 // (Optional) Configure logs collection port as configured in your Datadog Agent
 def agentTraceCollectionPort = 8126 // Configure traces collection port
 datadog.datadogClientConfiguration = new DatadogAgentConfiguration(agentHost, agentPort, agentLogCollectionPort, agentTraceCollectionPort)
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Fixes a typo in the Datadog Jenkins plugin Groovy configuration example: the same port is used for traces collection and logs collection.
The port should be different, and the default value is 10518.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
