### PR TITLE
Add OpenTelemetry API instructions for custom test tags

### DIFF
--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -213,8 +213,7 @@ The tracer exposes a set of APIs that can be used to extend its functionality pr
 {{< tabs >}}
 {{% tab "OpenTelemetry API" %}}
 
-To add custom tags include [opentelemetry-api][1] library as a compile-time dependency to your project
-and set the `dd.trace.otel.enabled` system property or the `DD_TRACE_OTEL_ENABLED` environment variable to `true`.
+To add custom tags, include the [opentelemetry-api][1] library as a compile-time dependency and set `dd.trace.otel.enabled` (system property) or `DD_TRACE_OTEL_ENABLED` (environment variable) to `true`.
 
 You can then add custom tags to your tests by using the active span:
 
@@ -237,7 +236,7 @@ For more information about adding tags, see the [Adding Tags][2] section of the 
 {{% /tab %}}
 {{% tab "OpenTracing API" %}}
 
-To add custom tags include [opentracing-util][1] library as a compile-time dependency to your project.
+To add custom tags, include the [opentracing-util][1] library as a compile-time dependency to your project.
 
 You can then add custom tags to your tests by using the active span:
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -210,7 +210,34 @@ The tracer exposes a set of APIs that can be used to extend its functionality pr
 
 ### Adding custom tags to tests
 
-To add custom tags include [opentracing-util][4] library as a compile-time dependency to your project.
+{{< tabs >}}
+{{% tab "OpenTelemetry API" %}}
+
+To add custom tags include [opentelemetry-api][1] library as a compile-time dependency to your project
+and set the `dd.trace.otel.enabled` system property or the `DD_TRACE_OTEL_ENABLED` environment variable to `true`.
+
+You can then add custom tags to your tests by using the active span:
+
+```java
+import io.opentelemetry.api.trace.Span;
+
+// ...
+// inside your test
+Span span = Span.current();
+span.setAttribute("test_owner", "my_team");
+// test continues normally
+// ...
+```
+
+For more information about adding tags, see the [Adding Tags][2] section of the Java custom instrumentation documentation.
+
+[1]: https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-api
+[2]: /tracing/trace_collection/custom_instrumentation/java?tab=locally#adding-tags
+
+{{% /tab %}}
+{{% tab "OpenTracing API" %}}
+
+To add custom tags include [opentracing-util][1] library as a compile-time dependency to your project.
 
 You can then add custom tags to your tests by using the active span:
 
@@ -230,11 +257,34 @@ if (span != null) {
 
 To create filters or `group by` fields for these tags, you must first create facets.
 
-For more information about adding tags, see the [Adding Tags][5] section of the Java custom instrumentation documentation.
+For more information about adding tags, see the [Adding Tags][2] section of the Java custom instrumentation documentation.
+
+[1]: https://mvnrepository.com/artifact/io.opentracing/opentracing-util
+[2]: /tracing/trace_collection/custom_instrumentation/java?tab=locally#adding-tags
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Adding custom measures to tests
 
 Just like tags, you can add custom measures to your tests by using the current active span:
+
+{{< tabs >}}
+{{% tab "OpenTelemetry API" %}}
+
+```java
+import io.opentelemetry.api.trace.Span;
+
+// ...
+// inside your test
+Span span = Span.current();
+span.setAttribute("test.memory.usage", 1e8);
+// test continues normally
+// ...
+```
+
+{{% /tab %}}
+{{% tab "OpenTracing API" %}}
 
 ```java
 import io.opentracing.Span;
@@ -249,6 +299,9 @@ if (span != null) {
 // test continues normally
 // ...
 ```
+
+{{% /tab %}}
+{{< /tabs >}}
 
 For more information about custom measures, see the [Add Custom Measures guide][6].
 
@@ -483,8 +536,6 @@ To disable all integrations, augment the list of `-javaagent` arguments with `dd
 [1]: #using-manual-testing-api
 [2]: https://app.datadoghq.com/ci/setup/test?language=java
 [3]: /tracing/trace_collection/library_config/java/?tab=containers#configuration
-[4]: https://mvnrepository.com/artifact/io.opentracing/opentracing-util
-[5]: /tracing/trace_collection/custom_instrumentation/java?tab=locally#adding-tags
 [6]: /tests/guides/add_custom_measures/?tab=java
 [7]: https://mvnrepository.com/artifact/com.datadoghq/dd-trace-api
 [8]: /tests/#parameterized-test-configurations


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Updates documentation for Test Optimization for Java.
Instructions on how to add custom tags and measures to test spans are extended with OpenTelemetry API.
The reason for adding OpenTelemetry API is that OpenTracing API used in existing instructions has been deprecated.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
