### PR TITLE
[DBNBK-207, CRP-1288] private slack channels are also supported

### DIFF
--- a/content/en/dashboards/sharing/scheduled_reports.md
+++ b/content/en/dashboards/sharing/scheduled_reports.md
@@ -19,7 +19,7 @@ Scheduled reports enable Datadog users to share dashboards as high-density PDFs 
 
 {{< img src="dashboards/scheduled_reports/report_pdf.png" alt="Example report PDF attachment" style="width:90%;" >}}
 
-The report PDF can be sent to public Slack channels or email addresses.
+The report PDF can be sent to Slack channels or email addresses.
 
 {{< img src="dashboards/scheduled_reports/report_slack.png" alt="Example report slack with PDF report linked" style="width:90%;" >}}
 
@@ -65,7 +65,7 @@ To see the report before saving the schedule, click **Send Test Email**. You can
 
 #### Slack recipients
 
-To add Slack recipients, select the Slack workspace and channel from the available dropdowns. If you do not see any Slack workspaces available, ensure you have the Datadog [Slack Integration][8] installed. To send a test message to Slack, add a channel recipient and click **Send Test Message**.
+To add Slack recipients, select the Slack workspace and channel from the available dropdowns. If you do not see any Slack workspaces available, ensure you have the Datadog [Slack Integration][8] installed. All public channels within the Slack workspace should be listed automatically. To select a private Slack channel, make sure to invite the Datadog Slack bot to the channel in Slack. To send a test message to Slack, add a channel recipient and click **Send Test Message**.
 
 **{{< img src="dashboards/scheduled_reports/add_slack_recipients.png" alt="The configuration modal for editing scheduled report email recipients." style="width:90%;" >}}**
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates public docs for Scheduled Reports to reflect you can also send Slack reports to private Slack channels.

### QA instructions
BEFORE: https://docs.datadoghq.com/dashboards/sharing/scheduled_reports/
AFTER: https://docs-staging.datadoghq.com/vickie/CRP-1288-slack-recipient-private-channels/dashboards/sharing/scheduled_reports/

### Merge instructions
- [x] Waiting for @DataDog/reporting-and-sharing review as well

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

Additional Notes
----
Recent similar PRs: 
- https://github.com/DataDog/documentation/pull/27078
- https://github.com/DataDog/documentation/pull/27273