### PR TITLE
[Docs] Update OP docs for fallback template syntax behavior for Splunk source_type field

### DIFF
--- a/content/en/observability_pipelines/destinations/_index.md
+++ b/content/en/observability_pipelines/destinations/_index.md
@@ -45,16 +45,16 @@ When the Observability Pipelines Worker cannot resolve the field with the templa
 
 The following table lists the destinations and fields that support template syntax, and what happens when the Worker cannot resolve the field:
 
-| Destination       | Fields that support template syntax | Behavior when the field cannot be resolved                                                                                 |
-|-------------------|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| Amazon Opensearch | Index                               | The Worker writes logs to the `datadog-op` index.                                                                          |
-| Amazon S3         | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
-| Azure Blob        | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
-| Elasticsearch     | Source type                         | The Worker writes logs to the `datadog-op` index.                                                                          |
-| Google Chronicle  | Log type                            | Defaults to `DATADOG` log type.                                                                                            |
-| Google Cloud      | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
-| Opensearch        | Index                               | The Worker writes logs to the `datadog-op` index.                                                                          |
-| Splunk HEC        | Index<br>Source type                | The Worker sends the logs to the default index configured in Splunk.<br>The Worker will default to `httpevent` source_type |
+| Destination       | Fields that support template syntax | Behavior when the field cannot be resolved                                                                                |
+|-------------------|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
+| Amazon Opensearch | Index                               | The Worker writes logs to the `datadog-op` index.                                                                         |
+| Amazon S3         | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                               |
+| Azure Blob        | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                               |
+| Elasticsearch     | Source type                         | The Worker writes logs to the `datadog-op` index.                                                                         |
+| Google Chronicle  | Log type                            | Defaults to `DATADOG` log type.                                                                                           |
+| Google Cloud      | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                               |
+| Opensearch        | Index                               | The Worker writes logs to the `datadog-op` index.                                                                         |
+| Splunk HEC        | Index<br>Source type                | The Worker sends the logs to the default index configured in Splunk.<br>The Worker will default to `httpevent` sourcetype |
 
 #### Example
 

--- a/content/en/observability_pipelines/destinations/_index.md
+++ b/content/en/observability_pipelines/destinations/_index.md
@@ -45,16 +45,16 @@ When the Observability Pipelines Worker cannot resolve the field with the templa
 
 The following table lists the destinations and fields that support template syntax, and what happens when the Worker cannot resolve the field:
 
-| Destination       | Fields that support template syntax | Behavior when the field cannot be resolved                                                                                |
-|-------------------|-------------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| Amazon Opensearch | Index                               | The Worker writes logs to the `datadog-op` index.                                                                         |
-| Amazon S3         | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                               |
-| Azure Blob        | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                               |
-| Elasticsearch     | Source type                         | The Worker writes logs to the `datadog-op` index.                                                                         |
-| Google Chronicle  | Log type                            | Defaults to `DATADOG` log type.                                                                                           |
-| Google Cloud      | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                               |
-| Opensearch        | Index                               | The Worker writes logs to the `datadog-op` index.                                                                         |
-| Splunk HEC        | Index<br>Source type                | The Worker sends the logs to the default index configured in Splunk.<br>The Worker will default to `httpevent` sourcetype |
+| Destination       | Fields that support template syntax | Behavior when the field cannot be resolved                                                                                 |
+|-------------------|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Amazon Opensearch | Index                               | The Worker writes logs to the `datadog-op` index.                                                                          |
+| Amazon S3         | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
+| Azure Blob        | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
+| Elasticsearch     | Source type                         | The Worker writes logs to the `datadog-op` index.                                                                          |
+| Google Chronicle  | Log type                            | Defaults to `DATADOG` log type.                                                                                            |
+| Google Cloud      | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
+| Opensearch        | Index                               | The Worker writes logs to the `datadog-op` index.                                                                          |
+| Splunk HEC        | Index<br>Source type                | The Worker sends the logs to the default index configured in Splunk.<br>The Worker defaults to the `httpevent` sourcetype. |
 
 #### Example
 

--- a/content/en/observability_pipelines/destinations/_index.md
+++ b/content/en/observability_pipelines/destinations/_index.md
@@ -45,16 +45,16 @@ When the Observability Pipelines Worker cannot resolve the field with the templa
 
 The following table lists the destinations and fields that support template syntax, and what happens when the Worker cannot resolve the field:
 
-| Destination       | Fields that support template syntax  | Behavior when the field cannot be resolved                                                     |
-| ----------------- | -------------------------------------| -----------------------------------------------------------------------------------------------|
-| Amazon Opensearch | Index                                | The Worker writes logs to the `datadog-op` index.                       |
-| Amazon S3         | Prefix                               | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there. |
-| Azure Blob        | Prefix                               | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there. |
-| Elasticsearch     | Source type                          | The Worker writes logs to the `datadog-op` index.                        |
-| Google Chronicle  | Log type                             | Defaults to `DATADOG` log type.                                                             |
-| Google Cloud      | Prefix                               | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there. |
-| Opensearch        | Index                                | The Worker writes logs to the `datadog-op` index.                        |
-| Splunk HEC        | Index<br>Source type                 | The Worker sends the logs to the default index configured in Splunk.                    |
+| Destination       | Fields that support template syntax | Behavior when the field cannot be resolved                                                                             |
+|-------------------|-------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| Amazon Opensearch | Index                               | The Worker writes logs to the `datadog-op` index.                                                                      |
+| Amazon S3         | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                            |
+| Azure Blob        | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                            |
+| Elasticsearch     | Source type                         | The Worker writes logs to the `datadog-op` index.                                                                      |
+| Google Chronicle  | Log type                            | Defaults to `DATADOG` log type.                                                                                        |
+| Google Cloud      | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                            |
+| Opensearch        | Index                               | The Worker writes logs to the `datadog-op` index.                                                                      |
+| Splunk HEC        | Index<br>Source type                | The Worker sends the logs to the default index configured in Splunk.<br>The Worker will default to `_json` source_type |
 
 #### Example
 

--- a/content/en/observability_pipelines/destinations/_index.md
+++ b/content/en/observability_pipelines/destinations/_index.md
@@ -45,16 +45,16 @@ When the Observability Pipelines Worker cannot resolve the field with the templa
 
 The following table lists the destinations and fields that support template syntax, and what happens when the Worker cannot resolve the field:
 
-| Destination       | Fields that support template syntax | Behavior when the field cannot be resolved                                                                             |
-|-------------------|-------------------------------------|------------------------------------------------------------------------------------------------------------------------|
-| Amazon Opensearch | Index                               | The Worker writes logs to the `datadog-op` index.                                                                      |
-| Amazon S3         | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                            |
-| Azure Blob        | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                            |
-| Elasticsearch     | Source type                         | The Worker writes logs to the `datadog-op` index.                                                                      |
-| Google Chronicle  | Log type                            | Defaults to `DATADOG` log type.                                                                                        |
-| Google Cloud      | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                            |
-| Opensearch        | Index                               | The Worker writes logs to the `datadog-op` index.                                                                      |
-| Splunk HEC        | Index<br>Source type                | The Worker sends the logs to the default index configured in Splunk.<br>The Worker will default to `_json` source_type |
+| Destination       | Fields that support template syntax | Behavior when the field cannot be resolved                                                                                 |
+|-------------------|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Amazon Opensearch | Index                               | The Worker writes logs to the `datadog-op` index.                                                                          |
+| Amazon S3         | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
+| Azure Blob        | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
+| Elasticsearch     | Source type                         | The Worker writes logs to the `datadog-op` index.                                                                          |
+| Google Chronicle  | Log type                            | Defaults to `DATADOG` log type.                                                                                            |
+| Google Cloud      | Prefix                              | The Worker creates a folder named `OP_UNRESOLVED_TEMPLATE_LOGS/` and writes the logs there.                                |
+| Opensearch        | Index                               | The Worker writes logs to the `datadog-op` index.                                                                          |
+| Splunk HEC        | Index<br>Source type                | The Worker sends the logs to the default index configured in Splunk.<br>The Worker will default to `httpevent` source_type |
 
 #### Example
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation on the template syntax fallback behavior for the Splunk destination's `Source Type` field