### PR TITLE
Adjustments to the 2020 description of wallclock profiling for the JVM

### DIFF
--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -41,7 +41,7 @@ Heap Live Size (in Preview, 1.39.0+)
 _Requires: Java 11.0.23+, 17.0.11+, 21.0.3+ or 22+_ <br />
 
 Wall Time in Native Code
-: The elapsed time spent in native code. Elapsed time includes time when code is running on CPU, waiting for I/O, and anything else that happens while the method is running. This profile does not include time spent running JVM bytecode, which is typically most of your application code.
+: The elapsed time spent by each method. Elapsed time includes time when code is running on CPU, waiting for I/O, and anything else that happens while the method is running.
 
 Class Load
 : The number of classes loaded by each method.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This modifies the original Java profile types documentation from 2020 to more accurately reflect the wallclock profiling from functionality, based on some internal discussions with sales & support engineering recently.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
