### PR TITLE
Michelle.deng/update logs archives encryption info

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -350,11 +350,14 @@ Alternatively, Datadog supports server-side encryption with a CMK from [AWS KMS]
 
 3. Go to the **Properties** tab in your S3 bucket and select **Default Encryption**. Choose the "AWS-KMS" option, select your CMK ARN, and save.
 
-For any changes to existing KSM keys, reach out to [Datadog support][3] for further assistance.
+For any changes to existing KMS keys, reach out to [Datadog support][3] for further assistance.
+
+Users can also set encryption directly in the object upload request by configuring encryption settings. This configuration can set when you create or update an S3 archive via [Logs Archives API][4].
 
 [1]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-bucket-encryption.html
 [2]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
 [3]: /help/
+[4]: https://docs.datadoghq.com/api/latest/logs-archives/
 {{% /tab %}}
 
 {{< /tabs >}}

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -352,7 +352,7 @@ Alternatively, Datadog supports server-side encryption with a CMK from [AWS KMS]
 
 For any changes to existing KMS keys, reach out to [Datadog support][3] for further assistance.
 
-Users can also set encryption directly in the object upload request by configuring encryption settings. This configuration can set when you create or update an S3 archive via [Logs Archives API][4].
+Users can also set encryption directly in the object upload request by configuring encryption settings. Optionally specify the encryption when you create or update an S3 archive via [Logs Archives API][4].
 
 [1]: https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-bucket-encryption.html
 [2]: https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We now support configuring server-side encryption for s3 archives through Datadog Logs Archives public APi. Previously, it was only possible for a user to set encryption on the s3 side by defining it on their s3 bucket-- this is the method we currently have documented. This PR adds information about the new method of defining encryption.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
