### PR TITLE
Update minimum tracer versions for Exception Replay and remove deprecate config

### DIFF
--- a/content/en/error_tracking/backend/exception_replay.md
+++ b/content/en/error_tracking/backend/exception_replay.md
@@ -44,12 +44,11 @@ Exception Replay is only available in APM Error Tracking. Error Tracking for Log
 
 1. Install or upgrade your Agent to version `7.44.0` or higher.
 2. Ensure that you are using:
-   * `ddtrace` version `1.16.0` or higher.
-   * `dd-trace-java` version `1.35.0` or higher.
-   * `dd-trace-dotnet` version `2.53.0` or higher.
-4. Set the `DD_EXCEPTION_DEBUGGING_ENABLED` environment variable to `true` to run your service with Error Tracking Exception Replay enabled.
-
-For `dd-trace-php` version `1.4.0` or higher, set the `DD_EXCEPTION_REPLAY_ENABLED` environment variable to `true`.
+   * `ddtrace` version `2.18.0` or higher.
+   * `dd-trace-java` version `1.46.0` or higher.
+   * `dd-trace-dotnet` version `3.91.0` or higher.
+   * `dd-trace-php` version `1.4.0` or higher
+4. Set the `DD_EXCEPTION_REPLAY_ENABLED` environment variable to `true` to run your service with Error Tracking Exception Replay enabled.
 
 ### Redacting sensitive data
 

--- a/content/en/error_tracking/backend/exception_replay.md
+++ b/content/en/error_tracking/backend/exception_replay.md
@@ -48,7 +48,7 @@ Exception Replay is only available in APM Error Tracking. Error Tracking for Log
    * `dd-trace-java` version `1.46.0` or higher.
    * `dd-trace-dotnet` version `3.91.0` or higher.
    * `dd-trace-php` version `1.4.0` or higher
-4. Set the `DD_EXCEPTION_REPLAY_ENABLED` environment variable to `true` to run your service with Error Tracking Exception Replay enabled.
+3. Set the `DD_EXCEPTION_REPLAY_ENABLED` environment variable to `true` to run your service with Error Tracking Exception Replay enabled.
 
 ### Redacting sensitive data
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?
To reduce confusion, we the doc on the new environment variable name, `DD_EXCEPTION_REPLAY_ENABLED`, and remove all mention of the old, deprecated name `DD_EXCEPTION_DEBUGGING_ENABLED`. We update the minimum required client library version for the feature to ensure a good customer experience with the latest relevant improvements and bug fixes.

### Merge instructions
Please wait for the reviewers I've assigned to approve before merging 

