### PR TITLE
Fix anchors in profiler troubleshooting docs

### DIFF
--- a/content/en/profiler/profiler_troubleshooting/dotnet.md
+++ b/content/en/profiler/profiler_troubleshooting/dotnet.md
@@ -265,6 +265,6 @@ If an application hangs, or otherwise becomes unresponsive on Linux, CPU and Wal
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /tracing/troubleshooting/#tracer-debug-logs
+[1]: /tracing/troubleshooting/#debugging-and-logging
 [2]: /help/
 [3]: /profiler/profile_types/?code-lang=dotnet

--- a/content/en/profiler/profiler_troubleshooting/java.md
+++ b/content/en/profiler/profiler_troubleshooting/java.md
@@ -169,5 +169,5 @@ Override templates let you specify profiling properties to override. However, th
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/troubleshooting/#tracer-debug-logs
+[1]: /tracing/troubleshooting/#debugging-and-logging
 [2]: /help/

--- a/content/en/profiler/profiler_troubleshooting/python.md
+++ b/content/en/profiler/profiler_troubleshooting/python.md
@@ -23,6 +23,6 @@ Refer to the python APM client [troubleshooting documentation][3] for additional
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/troubleshooting/#tracer-debug-logs
+[1]: /tracing/troubleshooting/#debugging-and-logging
 [2]: /help/
 [3]: https://ddtrace.readthedocs.io/en/stable/troubleshooting.html

--- a/content/en/profiler/profiler_troubleshooting/ruby.md
+++ b/content/en/profiler/profiler_troubleshooting/ruby.md
@@ -92,7 +92,7 @@ end
 {{< partial name="whats-next/whats-next.html" >}}
 
 
-[1]: /tracing/troubleshooting/#tracer-debug-logs
+[1]: /tracing/troubleshooting/#debugging-and-logging
 [2]: /help/
 [3]: https://github.com/datadog/dd-trace-rb/releases/tag/v1.21.0
 [4]: https://github.com/resque/resque


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
`/tracing/troubleshooting/` no longer has a `#tracer-debug-logs` anchor since #24686, now it has a `#debugging-and-logging` one. This went on undetected since August 2024.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
JIRA: [PROF-11317]

[PROF-11317]: https://datadoghq.atlassian.net/browse/PROF-11317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ