### PR TITLE
S3 Archives using Role Delegation on us1.fed is now GA

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -44,10 +44,6 @@ See how to [archive your logs with Observability Pipelines][4] if you want to ro
 {{< tabs >}}
 {{% tab "AWS S3" %}}
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning"><em>Setting up S3 Archives using Role Delegation is currently in limited availability. Contact <a href="https://docs.datadoghq.com/help/">Datadog Support</a> to request this feature in your Datadog for Government account</em>.</div>
-{{< /site-region >}}
-
 If not already configured, set up the [AWS integration][1] for the AWS account that holds your S3 bucket.
    * In the general case, this involves creating a role that Datadog can use to integrate with AWS S3.
    * Specifically for AWS China accounts, use access keys as an alternative to role delegation.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We currently display the following note when configuring a Logs Archive ([docs](https://docs.datadoghq.com/logs/log_configuration/archives/?tab=awss3&site=gov#set-up-an-integration)):
> Setting up S3 Archives using Role Delegation is currently in limited availability. Contact [Datadog Support](https://docs.datadoghq.com/help/) to request this feature in your Datadog for Government account.

This is no longer necessary as this functionality is now available to all customers.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

<!--Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```-->

<!-- ### Additional notes -->
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
