### PR TITLE
Update collecting_browser_errors.md

### DIFF
--- a/content/en/real_user_monitoring/browser/collecting_browser_errors.md
+++ b/content/en/real_user_monitoring/browser/collecting_browser_errors.md
@@ -57,7 +57,7 @@ addError(
 );
 {{< /code-block >}}
 
-**Note**: [Error Tracking][4] processes errors that are sent with the source set to `custom`, `source`, `report`, `network` or `console`, and contain a stack trace. Errors sent with any other source (such as `network`) or sent from browser extensions are not processed by Error Tracking.
+**Note**: [Error Tracking][4] processes errors that are sent with the source set to `custom`, `source`, `report` or `console`, and contain a stack trace. Errors sent with any other source (such as `network`) or sent from browser extensions are not processed by Error Tracking.
 
 {{< tabs >}}
 {{% tab "NPM" %}}


### PR DESCRIPTION
The documentation mentions:

Note: Error Tracking processes errors that are sent with the source set to custom, source, report, network or console, and contain a stack trace. Errors sent with any other source (such as network) or sent from browser extensions are not processed by Error Tracking.

The current typo is misleading. I confirmed with Product manager for Error tracking that network errors are not supported in error tracking. 

**Propose change:**
Remove "network" from this part "Error Tracking processes errors that are sent with the source set to custom, source, report, network or console, and contain a stack trace".

**It should be:**

Note: Error Tracking processes errors that are sent with the source set to custom, source, report or console, and contain a stack trace. Errors sent with any other source (such as network) or sent from browser extensions are not processed by Error Tracking.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Fix current paragraph which is misleading.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
