### PR TITLE
[K9VULN-3470] docs(code-analysis): remove deprecated fields in Code Analysis' GitHub actions

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -60,8 +60,6 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: my-app
-        dd_env: ci
         dd_site: "datadoghq.com"
 ```
 

--- a/content/es/getting_started/code_analysis/_index.md
+++ b/content/es/getting_started/code_analysis/_index.md
@@ -142,8 +142,6 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
 ```
 

--- a/content/es/getting_started/code_analysis/_index.md
+++ b/content/es/getting_started/code_analysis/_index.md
@@ -118,8 +118,6 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2
 ```

--- a/content/ja/continuous_integration/static_analysis/github_actions.md
+++ b/content/ja/continuous_integration/static_analysis/github_actions.md
@@ -53,8 +53,6 @@ jobs:
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
-          dd_service: "my-service"
-          dd_env: "ci"
 ```
 
 Datadog API キーとアプリケーションキーを GitHub リポジトリにシークレットとして設定する必要があります。詳しくは、[API とアプリケーションキー][1]を参照してください。

--- a/content/ja/getting_started/code_analysis/_index.md
+++ b/content/ja/getting_started/code_analysis/_index.md
@@ -117,8 +117,6 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2
 ```

--- a/content/ja/getting_started/code_analysis/_index.md
+++ b/content/ja/getting_started/code_analysis/_index.md
@@ -141,8 +141,6 @@ jobs:
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
 ```
 

--- a/content/ko/continuous_integration/static_analysis/github_actions.md
+++ b/content/ko/continuous_integration/static_analysis/github_actions.md
@@ -53,8 +53,6 @@ jobs:
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
-          dd_service: "my-service"
-          dd_env: "ci"
 ```
 
 GitHub 리포지토리에서 Datadog API와 애플리케이션 키를 **반드시** 비밀로 설정해야 합니다. 자세한 정보는 [API 및 애플리케이션 키][1]를 참고하세요.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR removes deprecated input fields in examples for using our github actions. The reason for this is because the fields are deprecated, and are subject to removal in the future.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```
