### PR TITLE
Remove deprecated HPA /v2beta1 samples for cleanup

### DIFF
--- a/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
+++ b/content/en/containers/guide/cluster_agent_autoscaling_metrics.md
@@ -280,8 +280,6 @@ Once your Cluster Agent has been set up and `DatadogMetric` created, update your
 #### Example HPAs with DatadogMetric
 An HPA using the `DatadogMetric` named `nginx-requests`, assuming both objects are in namespace `nginx-demo`.
 
-Using `apiVersion: autoscaling/v2`:
-
 ```yaml
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
@@ -304,28 +302,7 @@ spec:
         value: 9
 ```
 
-Using `apiVersion: autoscaling/v2beta1`:
-
-```yaml
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: nginxext
-spec:
-  minReplicas: 1
-  maxReplicas: 3
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: nginx
-  metrics:
-  - type: External
-    external:
-      metricName: datadogmetric@nginx-demo:nginx-requests
-      targetValue: 9
-```
-
-In these manifests:
+In this manifest:
 - The HPA is configured to autoscale the deployment called `nginx`.
 - The maximum number of replicas created is `3`, and the minimum is `1`.
 - The HPA relies on the `DatadogMetric` `nginx-requests` in the `nginx-demo` namespace.
@@ -349,7 +326,7 @@ spec:
 ```
 
 ### Example HPAs without DatadogMetric
-An HPA manifest to autoscale off an NGINX deployment based off of the `nginx.net.request_per_s` Datadog metric using `apiVersion: autoscaling/v2`:
+An HPA manifest to autoscale off an NGINX deployment based off of the `nginx.net.request_per_s` Datadog metric:
 
 ```yaml
 apiVersion: autoscaling/v2
@@ -373,30 +350,7 @@ spec:
         value: 9
 ```
 
-The following is the same HPA manifest as above using `apiVersion: autoscaling/v2beta1`:
-```yaml
-apiVersion: autoscaling/v2beta1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: nginxext
-spec:
-  minReplicas: 1
-  maxReplicas: 3
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: nginx
-  metrics:
-  - type: External
-    external:
-      metricName: nginx.net.request_per_s
-      metricSelector:
-        matchLabels:
-            kube_container_name: nginx
-      targetValue: 9
-```
-
-In these manifests:
+In this manifest:
 
 - The HPA is configured to autoscale the deployment called `nginx`.
 - The maximum number of replicas created is `3`, and the minimum is `1`.
@@ -502,8 +456,6 @@ Whereas `AverageValue` looks like:
         type: AverageValue
         averageValue: <METRIC_VALUE>
 ```
-
-For `apiVersion: autoscaling/v2beta1` the respective options are `targetValue` and `targetAverageValue`.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Remove the samples for the HPA `autoscaling/v2beta1` options to clean up and simplify the steps leaving only the `autoscaling/v2` configuration. 

For reference, `/v2` was added in Kubernetes 1.23 (Dec 2021) and `/v2beta1` was deprecated in this version and removed in Kubernetes 1.25. Kubernetes 1.25 is pretty old by now and for major distributions:
- AKS ended support 1.28 in Jan 2025 
- GKE ended support 1.26 in June 2024
- EKS ended support of 1.25 in May 2024 

So should be fine to remove, pretty much everyone should be at least on 1.25 by now, or at least using the `/v2` structure. 
 
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->
Follow up from: 
- https://github.com/DataDog/documentation/pull/17176
- https://datadoghq.atlassian.net/browse/CT-95

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
