### PR TITLE
[MLOB-2227] Update LLM Observability + AWS Lambda instructions

### DIFF
--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -111,7 +111,7 @@ Enable LLM Observability by specifying the required environment variables in you
 
 If you are only expecting traces from LLM Observability, set `DD_LLMOBS_AGENTLESS_ENABLED` to `true` in your Lambda function's environment variables.
 
-If you are expecting APM traces from your Lambda function in addition to LLM Observability, unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer. Otherwise, set `DD_EXTENSION_VERSION` to `compatibility` if you are using `v67` or later.
+If you are expecting APM traces from your Lambda function in addition to LLM Observability, leave `DD_EXTENSION_VERSION` unset in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer. Otherwise, set `DD_EXTENSION_VERSION` to `compatibility` if you are using `v67` or later.
 
 **Note**: Using the `Datadog-Python` and `Datadog-Extension` layers automatically turns on all LLM Observability integrations, and force flushes spans at the end of the Lambda function.
 

--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -109,7 +109,7 @@ LLMObs.enable(
 
 Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers. Additionally, set `DD_TRACE_ENABLED` to `true` in your Lambda function's environment variables.
 
-If you are not expecting APM traces additionally from your Lambda function, and only LLM Observability, set `DD_LLMOBS_AGENTLESS_ENABLED` to `true` in your Lambda function's environment variables.
+If you are only expecting traces from LLM Observability, set `DD_LLMOBS_AGENTLESS_ENABLED` to `true` in your Lambda function's environment variables.
 
 If you are expecting APM traces from your Lambda function in addition to LLM Observability, unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer. Otherwise, set `DD_EXTENSION_VERSION` to `compatibility` if you are using `v67` or later.
 

--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -107,7 +107,11 @@ LLMObs.enable(
 
 ### AWS Lambda setup
 
-Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers. In addition:
+Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers.
+
+If you are not expecting APM traces from your Lambda function, and only LLM Observability, set `DD_LLMOBS_AGENTLESS_ENABLED` to `true` in your Lambda function's environment variables.
+
+If you are expecting APM traces from your Lambda function:
 
 - Set `DD_TRACE_ENABLED` to `true` in your Lambda function's environment variables.
 - Unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using `v67` or later.

--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -110,7 +110,7 @@ LLMObs.enable(
 Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers. In addition:
 
 - Set `DD_TRACE_ENABLED` to `true` in your Lambda function's environment variables.
-- Unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using version 66 or prior of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using version 67 or later.
+- Unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using `v67` or later.
 
 **Note**: Using the `Datadog-Python` and `Datadog-Extension` layers automatically turns on all LLM Observability integrations, and force flushes spans at the end of the Lambda function.
 

--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -111,7 +111,7 @@ Enable LLM Observability by specifying the required environment variables in you
 
 If you are not expecting APM traces additionally from your Lambda function, and only LLM Observability, set `DD_LLMOBS_AGENTLESS_ENABLED` to `true` in your Lambda function's environment variables.
 
-If you are expecting APM traces from your Lambda function in addition to LLM Observability, unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using `v67` or later.
+If you are expecting APM traces from your Lambda function in addition to LLM Observability, unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer. Otherwise, set `DD_EXTENSION_VERSION` to `compatibility` if you are using `v67` or later.
 
 **Note**: Using the `Datadog-Python` and `Datadog-Extension` layers automatically turns on all LLM Observability integrations, and force flushes spans at the end of the Lambda function.
 

--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -107,14 +107,11 @@ LLMObs.enable(
 
 ### AWS Lambda setup
 
-Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers.
+Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers. Additionally, set `DD_TRACE_ENABLED` to `true` in your Lambda function's environment variables.
 
-If you are not expecting APM traces from your Lambda function, and only LLM Observability, set `DD_LLMOBS_AGENTLESS_ENABLED` to `true` in your Lambda function's environment variables.
+If you are not expecting APM traces additionally from your Lambda function, and only LLM Observability, set `DD_LLMOBS_AGENTLESS_ENABLED` to `true` in your Lambda function's environment variables.
 
-If you are expecting APM traces from your Lambda function:
-
-- Set `DD_TRACE_ENABLED` to `true` in your Lambda function's environment variables.
-- Unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using `v67` or later.
+If you are expecting APM traces from your Lambda function in addition to LLM Observability, unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using `v66` or earlier of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using `v67` or later.
 
 **Note**: Using the `Datadog-Python` and `Datadog-Extension` layers automatically turns on all LLM Observability integrations, and force flushes spans at the end of the Lambda function.
 

--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -110,7 +110,7 @@ LLMObs.enable(
 Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers. In addition:
 
 - Set `DD_TRACE_ENABLED` to `true` in your Lambda function's environment variables.
-- Unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using less than version 67 of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using version 67 or later.
+- Unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using version 66 or prior of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using version 67 or later.
 
 **Note**: Using the `Datadog-Python` and `Datadog-Extension` layers automatically turns on all LLM Observability integrations, and force flushes spans at the end of the Lambda function.
 

--- a/content/en/llm_observability/setup/sdk/python.md
+++ b/content/en/llm_observability/setup/sdk/python.md
@@ -107,7 +107,10 @@ LLMObs.enable(
 
 ### AWS Lambda setup
 
-Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers.
+Enable LLM Observability by specifying the required environment variables in your [command line setup](#command-line-setup) and following the setup instructions for the [Datadog-Python and Datadog-Extension][14] AWS Lambda layers. In addition:
+
+- Set `DD_TRACE_ENABLED` to `true` in your Lambda function's environment variables.
+- Unset `DD_EXTENSION_VERSION` in your Lambda function's environment variables if you are using less than version 67 of the Datadog-Extension layer, otherwise set `DD_EXTENSION_VERSION` to `compatibility` if using version 67 or later.
 
 **Note**: Using the `Datadog-Python` and `Datadog-Extension` layers automatically turns on all LLM Observability integrations, and force flushes spans at the end of the Lambda function.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates the `AWS Lambda setup` section with some more specific wording to alleviate onboarding friction while we work on addressing `DD_EXTENSION_VERSION` (which is a know incompatibility with the `next` version for LLMObs) issues.

The change specifies that:
- all serverless + LLMObs users need to set `DD_TRACE_ENABLED=true`
- if they are expecting APM traces in addition to LLMObs, they need to unset `DD_EXTENSION_VERSION` if using `Datadog-Extension` version less than 67, otherwise if using version >= 67 set `DD_EXTENSION_VERSION=compatibility`
- if they are not expecting APM traces/only expecting LLMObs traces, they need to set `DD_LLMOBS_AGENTLESS_ENABLED=true`

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
