### PR TITLE
[DOCS-9971] fixing Japanese menu

### DIFF
--- a/config/_default/menus/main.ja.yaml
+++ b/config/_default/menus/main.ja.yaml
@@ -2774,32 +2774,32 @@ menu:
       parent: infrastructure_heading
       weight: 40000
     - name: ネットワークパフォーマンスモニタリング
-      url: network_monitoring/performance/
+      url: network_monitoring/cloud_network_monitoring/
       parent: nm_parent
       identifier: npm
       weight: 1
     - name: セットアップ
-      url: network_monitoring/performance/setup/
+      url: network_monitoring/cloud_network_monitoring/setup/
       parent: npm
       identifier: npm_setup
       weight: 101
     - name: Overview Page
-      url: network_monitoring/performance/overview_page/
+      url: network_monitoring/cloud_network_monitoring/overview_page/
       parent: npm
       identifier: npm_overview_page
       weight: 102
     - name: Network Analytics
-      url: network_monitoring/performance/network_analytics/
+      url: network_monitoring/cloud_network_monitoring/network_analytics/
       parent: npm
       identifier: npm_analytics
       weight: 103
     - name: ネットワークマップ
-      url: network_monitoring/performance/network_map/
+      url: network_monitoring/cloud_network_monitoring/network_map/
       parent: npm
       identifier: npm_map
       weight: 104
     - name: ガイド
-      url: network_monitoring/performance/guide/
+      url: network_monitoring/cloud_network_monitoring/guide/
       identifier: npm_guides
       parent: npm
       weight: 105


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Per the linked Jira ticket, the Japanese menu item URL's are out of sync from the English pages and therefore not showing the content on the page. Upon reviewing Transifex I can see that the new page names and pages _are_ there and at least mostly translated, but the Japanese menu file is not yet updated. Per [slack](https://dd.slack.com/archives/GGHR55PNV/p1738599593027609) conversation, I am updating the ja menu file until the translation gets updated.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
