### PR TITLE
Update ASM home to remove references to Code Security capabilities

### DIFF
--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -80,19 +80,10 @@ To start configuring your environment to detect and protect threats with ASM, fo
 
 In the [Security Signals Explorer][6], click on any security signal to see what happened and the suggested steps to mitigate the attack. In the same panel, view traces with their correlated attack flow and request information to gain further context.
 
-## Investigate risk introduced in upstream open source libraries and dependencies
-
-[Software Composition Analysis (SCA)][8] shows you when your services are at risk because they use or have dependencies on open source libraries that have known vulnerabilities. Investigate vulnerability findings and secure your software by following remediation advice or researching the cause of the vulnerability.
-
-## Detect vulnerabilities in your application's code
-Datadog [Code Security][9] scans your first-party code and open source libraries used in your applications in both your repositories and running services, providing end-to-end visibility of application vulnerabilities from development to production.
-
 ## Disable ASM
 For information on disabling ASM or its features, see the following:
 
 - [Disabling threat management and protection][10]
-- [Disabling Software Composition Analysis][11]
-- [Disabling Code Security][12]
 
 ## Next steps
 

--- a/content/en/security/application_security/how-appsec-works.md
+++ b/content/en/security/application_security/how-appsec-works.md
@@ -19,7 +19,6 @@ further_reading:
 Datadog Application Security provides observability into application-level attacks that aim to exploit code-level vulnerabilities or abuse the business logic of your application, and into any bad actors targeting your systems. It provides:
 
 - **Observability into attacks**: Provides insight into application-level attacks targeting code vulnerabilities or business logic.
-- **Vulnerability detection**: Identifies code and library vulnerabilities in your applications from development to runtime with [Code Security][29]
 - **Trace-based monitoring**: Utilizes the same tracing libraries as Datadog APM to monitor traffic and detect security threats.
 - **Security signals**: Automatically generates security signals when attacks or business logic abuses are detected, focusing on meaningful threats rather than individual attempts.
 - **Notification Options**: Offers notifications through Slack, email, or PagerDuty based on security signal settings.
@@ -36,14 +35,6 @@ Datadog Threat Monitoring and Detection identifies bad actors by collecting clie
 
 <div class="alert alert-info"><strong>1-Click Enablement</strong><br>
 If your service is running with <a href="/agent/remote_config/#enabling-remote-configuration">an Agent with Remote Configuration enabled and a tracing library version that supports it</a>, you can <a href="https://app.datadoghq.com/security/configuration/asm/setup">enable Application Security</a> from the Datadog UI without additional configuration of the Agent or tracing libraries.</div>
-
-### Identify vulnerabilities in open source libraries used by services
-
-Datadog [Software Composition Analysis][5] uses various known vulnerability data sources related to open source software libraries, plus information provided by the Datadog security research team, to match the libraries your application depends on at runtime with their potential vulnerabilities, and to make remediation recommendations.
-
-### Identify code-level vulnerabilities and open source risks in your services and repositories
-
-Datadog [Code Security][9] scans your first-party code and open source libraries used in your applications in both your repositories and running services, providing end-to-end visibility of application vulnerabilities from development to production.
 
 ## Compatibility
 
@@ -122,12 +113,6 @@ Datadog Application Security includes over 100 attack signatures that help prote
 * NoSQL injections
 * Cross-Site Scripting (XSS)
 * Server-side Request Forgery (SSRF)
-
-## Built-in vulnerability detection
-
-Datadog Application Security offers built-in detection capabilities that warn you about the vulnerabilities detected in your application code and open source dependencies. Details of that information are shown in the [Vulnerability Explorer][15], identifying the severity, affected services and repositories, and remediation instructions to solve the surfaced risks.
-
-To learn more about Datadog's vulnerability detection capabilities, visit [Code Security][29].
 
 ## API security
 


### PR DESCRIPTION
Remove references to Code Security capabilities (SCA and runte code security) in the ASM home

### Merge instructions
Pls merge 

Merge readiness:
- [X] Ready for merge
