### PR TITLE
fix(docs): Update Growthbook Feature Flag integration docs

### DIFF
--- a/content/en/real_user_monitoring/feature_flag_tracking/setup.md
+++ b/content/en/real_user_monitoring/feature_flag_tracking/setup.md
@@ -601,6 +601,92 @@ Flagsmith does not currently support this integration. Create a ticket with Flag
 {{% /tab %}}
 {{< /tabs >}}
 
+### GrowthBook integration
+
+{{< tabs >}}
+{{% tab "Browser" %}}
+
+When initializing the GrowthBook SDK, report feature flag evaluations to Datadog by using the `onFeatureUsage` callback.
+
+For more information about initializing GrowthBook's SDK, see [GrowthBook's JavaScript SDK documentation][1].
+
+```javascript
+const gb = new GrowthBook({
+  ...,
+  onFeatureUsage: (featureKey, result) => {
+    datadogRum.addFeatureFlagEvaluation(featureKey, result.value);
+  },
+});
+
+gb.init();
+```
+
+[1]: https://docs.growthbook.io/lib/js#step-1-configure-your-app
+
+{{% /tab %}}
+{{% tab "iOS" %}}
+
+GrowthBook does not support this integration. Contact GrowthBook to request this feature.
+
+{{% /tab %}}
+{{% tab "Android" %}}
+
+When initializing the GrowthBook SDK, report feature flag evaluations to Datadog by calling `setFeatureUsageCallback`.
+
+For more information about initializing GrowthBook's SDK, see [GrowthBook's Android SDK documentation][1].
+
+```kotlin
+val gbBuilder = GBSDKBuilder(...)
+
+gbBuilder.setFeatureUsageCallback { featureKey, result ->
+  GlobalRumMonitor.get().addFeatureFlagEvaluation(featureKey, result.value);
+}
+
+val gb = gbBuilder.initialize()
+```
+
+[1]: https://docs.growthbook.io/lib/kotlin#quick-usage
+
+{{% /tab %}}
+{{% tab "Flutter" %}}
+
+When initializing the GrowthBook SDK, report feature flag evaluations to Datadog by calling `setFeatureUsageCallback`.
+
+For more information about initializing GrowthBook's SDK, see [GrowthBook's Flutter SDK documentation][1].
+
+```dart
+final gbBuilder = GBSDKBuilderApp(...);
+gbBuilder.setFeatureUsageCallback((featureKey, result) {
+  DatadogSdk.instance.rum?.addFeatureFlagEvaluation(featureKey, result.value);
+});
+final gb = await gbBuilder.initialize();
+```
+
+[1]: https://docs.growthbook.io/lib/flutter#quick-usage
+
+{{% /tab %}}
+{{% tab "React Native" %}}
+
+When initializing the GrowthBook SDK, report feature flag evaluations to Datadog by using the `onFeatureUsage` callback.
+
+For more information about initializing GrowthBook's SDK, see [GrowthBook's React Native SDK documentation][1].
+
+```javascript
+const gb = new GrowthBook({
+  ...,
+  onFeatureUsage: (featureKey, result) => {
+    datadogRum.addFeatureFlagEvaluation(featureKey, result.value);
+  },
+});
+
+gb.init();
+```
+
+[1]: https://docs.growthbook.io/lib/react-native#step-1-configure-your-app
+
+{{% /tab %}}
+{{< /tabs >}}
+
 ### LaunchDarkly integration
 
 Before you initialize this feature flag integration, make sure you've [set up RUM monitoring](#set-up-rum-monitoring).

--- a/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
+++ b/content/en/real_user_monitoring/guide/setup-feature-flag-data-collection.md
@@ -42,7 +42,7 @@ If you are using a version previous to 5.17.0, initialize the RUM SDK and config
     ...
 });
 ```
-{{% /collapse-content %}} 
+{{% /collapse-content %}}
 
 {{% collapse-content title="CDN async" level="h4" %}}
 ```javascript
@@ -54,7 +54,7 @@ window.DD_RUM.onReady(function() {
     })
 })
 ```
-{{% /collapse-content %}} 
+{{% /collapse-content %}}
 
 {{% collapse-content title="CDN sync" level="h4" %}}
 ```javascript

--- a/layouts/partials/rum/rum-feature-flag-tracking.html
+++ b/layouts/partials/rum/rum-feature-flag-tracking.html
@@ -72,7 +72,7 @@
             <div class="col">
              <a
                  class="card h-100"
-                 href="/real_user_monitoring/guide/setup-feature-flag-data-collection/?tab=browser#growthbook-integration"
+                 href="/real_user_monitoring/feature_flag_tracking/setup/?tab=npm#growthbook-integration"
              >
                  <div class="card-body text-center py-2 px-1">
                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/growthbook_large.svg" "class"

--- a/layouts/partials/rum/rum-feature-flag-tracking.html
+++ b/layouts/partials/rum/rum-feature-flag-tracking.html
@@ -72,7 +72,7 @@
             <div class="col">
              <a
                  class="card h-100"
-                 href="/real_user_monitoring/feature_flag_tracking/setup/?tab=npm#growthbook-integration"
+                 href="/real_user_monitoring/feature_flag_tracking/setup/#growthbook-integration"
              >
                  <div class="card-body text-center py-2 px-1">
                      {{ partial "img.html" (dict "root" . "src" "integrations_logos/growthbook_large.svg" "class"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

#26999 was merged yesterday (Feb 10) but between the time it was created & merged the docs for Feature Flags was changed/consolidated on #25073 so it is not showing up on the [live docs website](https://docs.datadoghq.com/real_user_monitoring/feature_flag_tracking/setup).

So this updates it to use the new URL format & include the instructions on the new document.

### Merge instructions

Merge readiness:
- [x] Ready for merge