### PR TITLE
Update snmp_traps.md

### DIFF
--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -37,7 +37,7 @@ Datadog Agent v7.37+ supports listening for SNMP Traps, enabling you to set up [
          authKey: myAuthKey
          authProtocol: "SHA"
          privKey: myPrivKey
-         privProtocol: "AES" # choices: MD5, SHA, SHA224, SHA256, SHA384, SHA512
+         privProtocol: "AES" 
        - user: "user"
          authKey: myAuthKey
          authProtocol: "MD5"
@@ -45,7 +45,7 @@ Datadog Agent v7.37+ supports listening for SNMP Traps, enabling you to set up [
          privProtocol: "DES"
        - user: "user2"
          authKey: myAuthKey2
-         authProtocol: "SHA"
+         authProtocol: "SHA" # choices: MD5, SHA, SHA224, SHA256, SHA384, SHA512
          privKey: myPrivKey2
          privProtocol: "AES" # choices: DES, AES (128 bits), AES192, AES192C, AES256, AES256C
    ```


### PR DESCRIPTION
The choices for authProtocol are listed under privProtocol, which can cause confusion when setting up the configuration file.  I've moved the comment down to the appropriate line.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
I've had multiple tickets where the customer had the incorrect value for privProtocol and noticed the docs had the choices for authProtocol listed on a line with privProtocol

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
