### PR TITLE
[web-6011] prevents translated data partials being added to transifex as sources

### DIFF
--- a/translate.yaml
+++ b/translate.yaml
@@ -20,14 +20,10 @@ ignores:
   - "content/en/api/v1/**/*.md"
   - "content/en/api/v2/**/*.md"
   - "config/_default/menus/menus.en.yaml"
-  - "**/*.fr.md"
-  - "**/*.fr.yaml"
-  - "**/*.fr.json"
-  - "**/fr.json"
-  - "**/*.ja.md"
-  - "**/*.ja.yaml"
-  - "**/*.ja.json"
-  - "**/ja.json"
+  - "**/*.{fr,ja,ko,es}.md"
+  - "**/*.{fr,ja,ko,es}.yaml"
+  - "**/*.{fr,ja,ko,es}.json"
+  - "**/{fr,ja,ko,es}.json"
 
 # These files will be uploaded to Transifex for translation when syncing.
 sources:

--- a/translate.yaml
+++ b/translate.yaml
@@ -20,10 +20,22 @@ ignores:
   - "content/en/api/v1/**/*.md"
   - "content/en/api/v2/**/*.md"
   - "config/_default/menus/menus.en.yaml"
-  - "**/*.{fr,ja,ko,es}.md"
-  - "**/*.{fr,ja,ko,es}.yaml"
-  - "**/*.{fr,ja,ko,es}.json"
-  - "**/{fr,ja,ko,es}.json"
+  - "**/*.fr.md"
+  - "**/*.fr.yaml"
+  - "**/*.fr.json"
+  - "**/fr.json"
+  - "**/*.ja.md"
+  - "**/*.ja.yaml"
+  - "**/*.ja.json"
+  - "**/ja.json"
+  - "**/*.ko.md"
+  - "**/*.ko.yaml"
+  - "**/*.ko.json"
+  - "**/ko.json"
+  - "**/*.es.md"
+  - "**/*.es.yaml"
+  - "**/*.es.json"
+  - "**/es.json"
 
 # These files will be uploaded to Transifex for translation when syncing.
 sources:
@@ -53,4 +65,3 @@ sources:
   dst: "content/{lang}/workflows/actions_catalog/_index.md"
 - src: "content/en/workflows/actions_catalog/generic_actions.md"
   dst: "content/{lang}/workflows/actions_catalog/generic_actions.md"
-


### PR DESCRIPTION
### What does this PR do? What is the motivation?
prevents translated data partials being added to transifex as sources


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
Worth noting `The fnmatch module in Python does not natively support the {} syntax for grouping multiple patterns like some shells do` which is why every file to ignore has to be listed out per language.
