### PR TITLE
Fix C# syntax for AddUserExtraInfo documentation

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration.md
@@ -164,9 +164,10 @@ To remove an existing attribute, set it to `null`.
 For example:
 
 ```cs
-DatadogSdk.Instance.AddUserExtraInfo({
- 'attribute_1': 'foo',
- 'attribute_2': null,
+DatadogSdk.Instance.AddUserExtraInfo(new ()
+{
+ { "attribute_1", "foo" },
+ { "attribute_2", null },
 });
 ```
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Minor fix for some C# syntax in the Unity documentation

### Merge instructions

Merge readiness:
- [x] Ready for merge
