### PR TITLE
[DJM-637] Add step redirecting to integration Log setup

### DIFF
--- a/content/en/data_jobs/dataproc.md
+++ b/content/en/data_jobs/dataproc.md
@@ -62,8 +62,10 @@ When you create a new **Dataproc Cluster on Compute Engine** in the [Google Clou
 
 1. On the **Customize cluster** page, locate the **Initialization Actions** section. Enter the path where you saved the script from the previous step.
 
+    When your cluster is created, this initialization action installs the Datadog Agent and downloads the Java tracer on each node of the cluster.
 
-When your cluster is created, this initialization action installs the Datadog Agent and downloads the Java tracer on each node of the cluster.
+1. **Optional**: Enable logs collection for your cluster by following the Dataproc integration [Log collection setup][14] steps. Application logs will be correlated to Spark job run traces.
+
 
 ### Specify service tagging per Spark application
 
@@ -108,3 +110,4 @@ In Datadog, view the [Data Jobs Monitoring][8] page to see a list of all your da
 [11]: https://docs.datadoghq.com/data_jobs/kubernetes/
 [12]: https://cloud.google.com/secret-manager/docs/access-control
 [13]: https://github.com/DataDog/datadog-agent/blob/main/pkg/fleet/installer/setup/djm/dataproc.go
+[14]: /integrations/google_cloud_dataproc/#log-collection

--- a/content/en/data_jobs/dataproc.md
+++ b/content/en/data_jobs/dataproc.md
@@ -64,7 +64,7 @@ When you create a new **Dataproc Cluster on Compute Engine** in the [Google Clou
 
     When your cluster is created, this initialization action installs the Datadog Agent and downloads the Java tracer on each node of the cluster.
 
-1. **Optional**: Enable logs collection for your cluster by following the Dataproc integration [Log collection setup][14] steps. Application logs will be correlated to Spark job run traces.
+1. **Optional**: Enable logs collection for your cluster by following the Dataproc integration [Log collection setup][14] steps. This correlates application logs to Spark job run traces.
 
 
 ### Specify service tagging per Spark application


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR tells DJM users how to setup Dataproc logs collection by redirecting them to the log setup section of the Dataproc integration.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
