### PR TITLE
RUM-8504 Add warning on instrumenting SwiftUI actions

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
@@ -479,7 +479,7 @@ struct BarView: View {
 
 ## Track iOS errors
 
-[iOS Crash Reporting and Error Tracking][8] displays any issues in your application and the latest available errors. You can view error details and attributes including JSON in the [RUM Explorer][10].
+[iOS Crash Reporting and Error Tracking][8] displays any issues in your application and the latest available errors. You can view error details and attributes including JSON in the [RUM Explorer][9].
 
 ## Sending data when device is offline
 
@@ -491,7 +491,7 @@ This means that even if users open your application while offline, no data is lo
 
 ## Supported versions
 
-See [Supported versions][11] for a list operating system versions and platforms that are compatible with the iOS SDK.
+See [Supported versions][10] for a list operating system versions and platforms that are compatible with the iOS SDK.
 
 ## Further Reading
 
@@ -505,6 +505,5 @@ See [Supported versions][11] for a list operating system versions and platforms 
 [6]: /real_user_monitoring/ios/advanced_configuration/#initialization-parameters
 [7]: https://github.com/DataDog/dd-sdk-ios
 [8]: /real_user_monitoring/error_tracking/ios/
-[9]: /real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration#custom-actions
-[10]: /real_user_monitoring/explorer/
-[11]: /real_user_monitoring/mobile_and_tv_monitoring/supported_versions/ios/
+[9]: /real_user_monitoring/explorer/
+[10]: /real_user_monitoring/mobile_and_tv_monitoring/supported_versions/ios/

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
@@ -458,6 +458,8 @@ The `trackRUMView(name:)` method starts and stops a view when the `SwiftUI` view
 
 The Datadog iOS SDK allows you to instrument tap actions of `SwiftUI` applications. The instrumentation also works with hybrid `UIKit` and `SwiftUI` applications.
 
+<div class="alert alert-warning">**Known Issue**: Using `.trackRUMTapAction(name:)` for `SwiftUI` controls inside a `List` can break their default gestures (for example, disabling `Button` action or breaking `NavigationLink`). To track taps in a `List` elements, please use [Custom Actions][9] API.</div>
+
 To instrument a tap action on a `SwiftUI.View`, add the following method to your view declaration:
 
 ```swift
@@ -477,7 +479,7 @@ struct BarView: View {
 
 ## Track iOS errors
 
-[iOS Crash Reporting and Error Tracking][8] displays any issues in your application and the latest available errors. You can view error details and attributes including JSON in the [RUM Explorer][9].
+[iOS Crash Reporting and Error Tracking][8] displays any issues in your application and the latest available errors. You can view error details and attributes including JSON in the [RUM Explorer][10].
 
 ## Sending data when device is offline
 
@@ -489,7 +491,7 @@ This means that even if users open your application while offline, no data is lo
 
 ## Supported versions
 
-See [Supported versions][10] for a list operating system versions and platforms that are compatible with the iOS SDK.
+See [Supported versions][11] for a list operating system versions and platforms that are compatible with the iOS SDK.
 
 ## Further Reading
 
@@ -503,5 +505,6 @@ See [Supported versions][10] for a list operating system versions and platforms 
 [6]: /real_user_monitoring/ios/advanced_configuration/#initialization-parameters
 [7]: https://github.com/DataDog/dd-sdk-ios
 [8]: /real_user_monitoring/error_tracking/ios/
-[9]: /real_user_monitoring/explorer/
-[10]: /real_user_monitoring/mobile_and_tv_monitoring/supported_versions/ios/
+[9]: /real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration#custom-actions
+[10]: /real_user_monitoring/explorer/
+[11]: /real_user_monitoring/mobile_and_tv_monitoring/supported_versions/ios/

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
@@ -458,7 +458,7 @@ The `trackRUMView(name:)` method starts and stops a view when the `SwiftUI` view
 
 The Datadog iOS SDK allows you to instrument tap actions of `SwiftUI` applications. The instrumentation also works with hybrid `UIKit` and `SwiftUI` applications.
 
-<div class="alert alert-warning">**Known Issue**: Using `.trackRUMTapAction(name:)` for `SwiftUI` controls inside a `List` can break their default gestures (for example, disabling `Button` action or breaking `NavigationLink`). To track taps in a `List` elements, please use [Custom Actions][9] API.</div>
+<div class="alert alert-warning">Using <code>.trackRUMTapAction(name:)</code> for <code>SwiftUI</code> controls inside a <code>List</code> can break its default gestures. For example, it may disable the <code>Button</code> action or break <code>NavigationLink</code>. To track taps in a <code>List</code> element, use the <a href="/real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration#custom-actions">Custom Actions</a> API instead.</div>
 
 To instrument a tap action on a `SwiftUI.View`, add the following method to your view declaration:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

We identified an issue with using on of iOS SDK APIs, where it can disrupt existing app behaviors when applied within a `List`. Recognizing this as a known issue in our SDK, we are adding a warning to the documentation to inform developers and prevent misuse.

For more context see: https://github.com/DataDog/dd-sdk-ios/pull/2192

### Merge instructions

Merge readiness:
- [x] Ready for merge
