### PR TITLE
Revert "[MLOB] reflect python openai/langchain tracing support versions"

### DIFF
--- a/content/en/llm_observability/setup/auto_instrumentation.md
+++ b/content/en/llm_observability/setup/auto_instrumentation.md
@@ -23,8 +23,8 @@ Datadog's [LLM Observability Python SDK][16] provides integrations that automati
 
 | Framework                                  | Supported Versions | Tracer Version    |
 |--------------------------------------------|--------------------|-------------------|
-| [OpenAI](#openai), [Azure OpenAI](#openai) | >= 1.0.0           | >= 3.0.0          |
-| [Langchain](#langchain)                    | >= 0.1.0           | >= 3.0.0          |
+| [OpenAI](#openai), [Azure OpenAI](#openai) | >= 0.26.5          | >= 2.9.0          |
+| [Langchain](#langchain)                    | >= 0.0.192         | >= 2.9.0          |
 | [Amazon Bedrock](#amazon-bedrock)          | >= 1.31.57         | >= 2.9.0          |
 | [Anthropic](#anthropic)                    | >= 0.28.0          | >= 2.10.0         |
 | [Google Gemini](#google-gemini)            | >= 0.7.2           | >= 2.14.0         |


### PR DESCRIPTION
Reverts DataDog/documentation#27324

Reverting temporarily since ddtrace 3.0.0 version is not yet released.