### PR TITLE
Add auto_multi_line_aggregator_flush agent telemetry metric + description

### DIFF
--- a/content/en/data_security/agent.md
+++ b/content/en/data_security/agent.md
@@ -152,6 +152,7 @@ DD_AGENT_TELEMETRY_ENABLED=false
 | logs.dropped                                | Total number of logs dropped                                                                      |
 | logs.bytes_sent                             | Total number of bytes send before encoding, if any                                                |
 | logs.encoded_bytes_sent                     | Total number of sent bytes after encoding, if any                                                 |
+| logs.auto_multi_line_aggregator_flush       | Number of multiline logs aggregated by the Agent                                                  |
 | dogstatsd.udp_packets                       | DogStatsD UDP packets bytes                                                                       |
 | dogstatsd.uds_packets                       | DogStatsD UDS packets bytes                                                                       |
 | transactions.input_count                    | Incoming transaction count                                                                        |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds a new telemetry metric that the agent will collect. 

### Merge instructions

Do not merge this PR until agent 7.64 is available. 

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
