### PR TITLE
DOCS-10117: Add .NET instructions to AAS

### DIFF
--- a/content/en/serverless/azure_app_services/azure_app_services_container.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_container.md
@@ -87,7 +87,7 @@ Instrument your main application with the `dd-trace-dotnet` library.
    RUN mkdir -p /home/LogFiles/dotnet
 
    ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.51.0/datadog-dotnet-apm-2.51.0.tar.gz /datadog/tracer
-   RUN cd /datadog/tracer && tar -zxf datadog-dotnet-apm-2.49.0.tar.gz
+   RUN cd /datadog/tracer && tar -zxf datadog-dotnet-apm-2.51.0.tar.gz
    {{< /code-block >}}
 
 2. Build the image and push it to your preferred container registry.
@@ -120,8 +120,8 @@ COPY --from=build /app/out ./
 RUN mkdir -p /datadog/tracer
 RUN mkdir -p /home/LogFiles/dotnet
 
-ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.49.0/datadog-dotnet-apm-2.49.0.tar.gz /datadog/tracer
-RUN cd /datadog/tracer && tar -zxf datadog-dotnet-apm-2.49.0.tar.gz
+ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.51.0/datadog-dotnet-apm-2.51.0.tar.gz /datadog/tracer
+RUN cd /datadog/tracer && tar -zxf datadog-dotnet-apm-2.51.0.tar.gz
 
 # Set the entry point for the application
 ENTRYPOINT ["dotnet", "<your dotnet app>.dll"]

--- a/content/en/serverless/azure_app_services/azure_app_services_container.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_container.md
@@ -86,7 +86,7 @@ Instrument your main application with the `dd-trace-dotnet` library.
    RUN mkdir -p /datadog/tracer
    RUN mkdir -p /home/LogFiles/dotnet
 
-   ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.51.0/datadog-dotnet-apm-2.49.0.tar.gz /datadog/tracer
+   ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v2.51.0/datadog-dotnet-apm-2.51.0.tar.gz /datadog/tracer
    RUN cd /datadog/tracer && tar -zxf datadog-dotnet-apm-2.49.0.tar.gz
    {{< /code-block >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds a tab for .NET instructions to Azure App Services install for Linux containers. Previously information was hidden in [this guide](https://docs.datadoghq.com/serverless/guide/azure_app_service_linux_sidecar/).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
