### PR TITLE
Document timestamp constraint of Event Custom Metrics

### DIFF
--- a/content/en/service_management/events/guides/usage.md
+++ b/content/en/service_management/events/guides/usage.md
@@ -13,7 +13,7 @@ further_reading:
 
 ## Custom metrics
 
-[Generate metrics][5] with 15-month retention from any event search query to create and monitor historical events and alerts. For more information, see [Event Analytics][6].
+[Generate metrics][5] with 15-month retention from any event search query to create and monitor historical events and alerts. Events ingested with a timestamp within the past 20 minutes are considered for aggregation. For more information, see [Event Analytics][6].
 
 {{< img src="service_management/events/guides/usage/generate-metrics.png" alt="Image of metrics with the events search query." >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Documents a constraint for this functionality, shared by a TEE [here](https://datadoghq.atlassian.net/browse/SOCE-1517?focusedCommentId=2034728).

This similar to the constraint on [Logs custom metrics](https://docs.datadoghq.com/logs/log_configuration/logs_to_metrics/), but it has yet to be publicly documented for Events:

> Only logs ingested with a timestamp within the past 20 minutes are considered for aggregation.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
