### PR TITLE
Update View name explanation

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -35,7 +35,7 @@ There are various ways you can modify the [data and context collected][1] by RUM
 
 ## Override default RUM view names
 
-The RUM Browser SDK automatically generates a [view event][2] for each new page visited by your users, or when the page URL is changed (for single-page applications). A view name is computed from the current page URL, where variable alphanumeric IDs are removed automatically. For example, `/dashboard/1234` becomes `/dashboard/?`.
+The RUM Browser SDK automatically generates a [view event][2] for each new page visited by your users, or when the page URL is changed (for single-page applications). A view name is computed from the current page URL, where variable IDs are removed automatically. A path segment that contains at least one number is considered a variable ID. For example, `/dashboard/1234` and `/dashboard/9a` become `/dashboard/?`.
 
 Starting with [version 2.17.0][3], you can add view names and assign them to a dedicated service owned by a team by tracking view events manually with the `trackViewsManually` option:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
RUM View name behavior is a common source of confusion amongst customers ([example ticket](https://datadog.zendesk.com/agent/tickets/1748310)).

In particular, the word `alphanumeric` is not specific enough because it can include special characters. In reality, all the SDK is checking for is the presence of a number in the URL path segment ([reference](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/2962292956/How+are+url_path_group+fields+computed+from+url_path+ones)).

This explanation is slightly more specific and will hopefully reduce customer confusion.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
