### PR TITLE
Additional allowlist rules for locked-down kubernetes environments

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -373,7 +373,7 @@ To avoid running out of storage space, the Agent stores the metrics on disk only
 
 ## Installing the Operator
 
-If you are installing the Datadog Operator in Kubernetes environment with limited connectivity, you also want to allowlist the following endpoints for TCP port 443, based on your location:
+If you are installing the Datadog Operator in a Kubernetes environment with limited connectivity, you need to allowlist the following endpoints for TCP port 443, based on your location:
 
 - `gcr.io/datadoghq` (GCR US)
 - `eu.gcr.io/datadoghq` (GCR Europe)

--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -371,7 +371,7 @@ The metrics are stored in the folder defined by the `forwarder_storage_path` set
 
 To avoid running out of storage space, the Agent stores the metrics on disk only if the total storage space used is less than 80 percent. This limit is defined by `forwarder_storage_max_disk_ratio` setting.
 
-## Installing the Operator
+## Installing the Datadog Operator
 
 If you are installing the Datadog Operator in a Kubernetes environment with limited connectivity, you need to allowlist the following endpoints for TCP port 443, based on your location:
 

--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -371,6 +371,18 @@ The metrics are stored in the folder defined by the `forwarder_storage_path` set
 
 To avoid running out of storage space, the Agent stores the metrics on disk only if the total storage space used is less than 80 percent. This limit is defined by `forwarder_storage_max_disk_ratio` setting.
 
+## Installing the Operator
+
+If you are installing the Datadog Operator in Kubernetes environment with limited connectivity, you also want to allowlist the following endpoints for TCP port 443, based on your location:
+
+- `gcr.io/datadoghq` (GCR US)
+- `eu.gcr.io/datadoghq` (GCR Europe)
+- `asia.gcr.io/datadoghq` (GCR Asia)
+- `datadoghq.azurecr.io` (Azure)
+- `public.ecr.aws/datadog` (AWS)
+- `docker.io/datadog` (DockerHub)
+
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds additional allowlist rules for locked-down kubernetes environments (source: [link](https://github.com/DataDog/helm-charts/blob/main/charts/datadog-operator/values.yaml))

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
