### PR TITLE
Status page doc update

### DIFF
--- a/content/en/monitors/status/status_page.md
+++ b/content/en/monitors/status/status_page.md
@@ -84,7 +84,6 @@ The following monitor types are not supported by the provisional status page:
 
 The following features are not supported by the provisional status page:
 
-- Custom schedules
 - Notification grouping
 
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Custom schedule monitors are now supported in the new monitor status page

Merge readiness:
- [x] Ready for merge
