### PR TITLE
Rate Limit Visibility Documentation Updates

### DIFF
--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -33,6 +33,13 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 
 All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
 
+{{% site-region region="us" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.com/dash/integration/31668/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="eu1" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.eu/dash/integration/1386/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="us3" %}}[Datadog API Rate Limit Usage Dashboard](https://us3.datadoghq.com/dash/integration/2248/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="us5" %}}[Datadog API Rate Limit Usage Dashboard](https://us5.datadoghq.com/dash/integration/1421/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
+
 {{< h4 >}}Available Metrics{{< /h4 >}}
 
 <table>

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -29,6 +29,160 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
 | `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
+{{< h3 >}}Datadog API Usage Metrics{{< /h3 >}}
+
+All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
+
+{{< h4 >}}Available Metrics{{< /h4 >}}
+
+<table>
+  <thead>
+    <th>Dimensions</th>
+    <th>Usage metric</th>
+    <th>Description</th>
+    <th>Available Tags</th>
+  </thead>
+  <tr>
+    <td rowspan="2"><strong>Org</strong></td>
+    <td><code>datadog.apis.usage.per_org</code></td>
+    <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_org_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td rowspan="2"><strong>User (UUID)</strong></td>
+    <td><code>datadog.apis.usage.per_user</code></td>
+    <td>Number of API requests made for a specific API endpoint that is rate limited per unique user.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_user_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td rowspan="2"><strong>API Key</strong></td>
+    <td><code>datadog.apis.usage.per_api_key</code></td>
+    <td>Number of API requests made for a specific API endpoint that is rate limited per unique API Key used</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_api_key_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+</table>
+
+
+{{< h4 >}}Tag Key{{< /h4 >}}
+
+
+| Tag Name | Description |
+| -------- | ----------- |
+| app_key_id | Application Key ID used by API Client. This can be N/A for web or mobile users and open endpoints. |
+| child_org | Name of child org, if viewing from the parent org. Otherwise, set to N/A. This only applies within the same datacenter. |
+| limit_count | Number of requests available to each rate limit name during a request period. |
+| limit_name | Name of rate limit. Different endpoints can share the same name. |
+| limit_period | Time in seconds for each rate limit name before the consumption count is reset. |
+| rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
+| user_uuid | UUID of user for API consumption. |
+
+{{< h4 >}}Rollup in widgets{{< /h4 >}}
+Metric visualizations should generally be rolled up to the minute using sum(60s) to aggregate the total number of requests per minute.
+
+Ratio metrics are already normalized to the corresponding `limit_period`.
+
+{{< h5 >}}Example use cases{{< /h5 >}}
+
+| Use Case | Example |
+| -------- | ------- |
+| Requests by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` group by `limit_name`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})` |
+| Blocked by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})` |
+| Blocked Endpoint by User | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})` |
+| Blocked Endpoint by App Key ID | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})` |
+| Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
+
+
+{{< h3 >}}Increasing your Rate Limit{{< /h3 >}}
+On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
+
+    Title:
+        Request to increase rate limit on endpoint: X
+
+    Details:
+        We would like to request a rate limit increase for API endpoint: X
+        Example use cases/queries:
+            Example API call as CURL or as URL with example payload
+
+        Motivation for increasing rate limit:
+            Example - Our organization uses this endpoint to right size a container before we deploy. This deployment takes place every X hours or up to Y times per day.
+
+        Desired target rate limit:
+            Having a specific limit increase in mind or a percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
+
+Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
+
+{{< h3 >}}Audit Logs{{< /h3 >}}
+API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
+
+With Audit Trail, you can for instance view:
+* **IP address & geolocation** – Identify where API requests originated.
+* **Actor type** – Distinguish between service accounts and user accounts.
+* **API vs. App Key authentication** – See whether requests were made through an API key or directly by a user.
+* **Correlated events** – View other events occurring at the same time, such as configuration changes or security-related actions.
+
+Audit Trail can help teams troubleshoot rate limit issues by providing more context on API consumption and blocked requests. It also enables tracking of API usage across an organization for security and compliance purposes.
+
+For more detailed visibility into API activity, consider using **[Audit Trail][4]**.
+
+
 [1]: /help/
 [2]: /api/v1/metrics/
 [3]: /metrics/custom_metrics/
+[4]: /account_management/audit_trail/events/

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -29,7 +29,7 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
 | `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
-{{< h3 >}}Datadog API Usage Metrics{{< /h3 >}}
+### Datadog API Usage Metrics
 
 All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
 

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -38,15 +38,6 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 {{% site-region region="us3" %}}[Datadog API Rate Limit Usage Dashboard](https://us3.datadoghq.com/dash/integration/2248/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="us5" %}}[Datadog API Rate Limit Usage Dashboard](https://us5.datadoghq.com/dash/integration/1421/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
-{{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}### Datadog API Usage Metrics
-
-All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
-
-{{% site-region region="us" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.com/dash/integration/31668/datadog-api-rate-limit-usage){{% /site-region %}}
-{{% site-region region="eu1" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.eu/dash/integration/1386/datadog-api-rate-limit-usage){{% /site-region %}}
-{{% site-region region="us3" %}}[Datadog API Rate Limit Usage Dashboard](https://us3.datadoghq.com/dash/integration/2248/datadog-api-rate-limit-usage){{% /site-region %}}
-{{% site-region region="us5" %}}[Datadog API Rate Limit Usage Dashboard](https://us5.datadoghq.com/dash/integration/1421/datadog-api-rate-limit-usage){{% /site-region %}}
-{{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
 
 #### Available Metrics

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -38,9 +38,18 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 {{% site-region region="us3" %}}[Datadog API Rate Limit Usage Dashboard](https://us3.datadoghq.com/dash/integration/2248/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="us5" %}}[Datadog API Rate Limit Usage Dashboard](https://us5.datadoghq.com/dash/integration/1421/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}### Datadog API Usage Metrics
+
+All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
+
+{{% site-region region="us" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.com/dash/integration/31668/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="eu1" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.eu/dash/integration/1386/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="us3" %}}[Datadog API Rate Limit Usage Dashboard](https://us3.datadoghq.com/dash/integration/2248/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="us5" %}}[Datadog API Rate Limit Usage Dashboard](https://us5.datadoghq.com/dash/integration/1421/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
 
-{{< h4 >}}Available Metrics{{< /h4 >}}
+#### Available Metrics
 
 <table>
   <thead>
@@ -127,7 +136,7 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 </table>
 
 
-{{< h4 >}}Tag Key{{< /h4 >}}
+#### Tag Key
 
 
 | Tag Name | Description |
@@ -140,12 +149,13 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 | rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
 | user_uuid | UUID of user for API consumption. |
 
-{{< h4 >}}Rollup in widgets{{< /h4 >}}
+#### Rollup in widgets
+
 Metric visualizations should generally be rolled up to the minute using sum(60s) to aggregate the total number of requests per minute.
 
 Ratio metrics are already normalized to the corresponding `limit_period`.
 
-{{< h5 >}}Example use cases{{< /h5 >}}
+##### Example use cases
 
 | Use Case | Example |
 | -------- | ------- |
@@ -156,7 +166,7 @@ Ratio metrics are already normalized to the corresponding `limit_period`.
 | Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
 
 
-{{< h3 >}}Increasing your Rate Limit{{< /h3 >}}
+### Increasing your Rate Limit
 On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
 
     Title:
@@ -175,7 +185,7 @@ On a case by case basis, users can request rate limits to be increased by provid
 
 Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
 
-{{< h3 >}}Audit Logs{{< /h3 >}}
+### Audit Logs
 API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
 
 With Audit Trail, you can for instance view:

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -27,11 +27,11 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 | `X-RateLimit-Period`    | length of time in seconds for resets (calendar aligned). |
 | `X-RateLimit-Remaining` | number of allowed requests left in the current time period.  |
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
-| `X-RateLimit-Name`      | name of the rate limit for increase requests             |
+| `X-RateLimit-Name`      | name of the rate limit for increase requests.            |
 
-### Datadog API Usage Metrics
+### Datadog API usage metrics
 
-All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
+All Datadog APIs have a usage limit for a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (excluding metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests, and are provided with the following dimensions and available tags:
 
 {{% site-region region="us" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.com/dash/integration/31668/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="eu1" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.eu/dash/integration/1386/datadog-api-rate-limit-usage){{% /site-region %}}
@@ -40,11 +40,11 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 {{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
 
-#### Available Metrics
+#### Available metrics
 
 <table>
   <thead>
-    <th>Dimensions</th>
+    <th>Dimension</th>
     <th>Usage metric</th>
     <th>Description</th>
     <th>Available Tags</th>
@@ -54,24 +54,30 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_org</code></td>
     <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_org_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
@@ -79,24 +85,30 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_user</code></td>
     <td>Number of API requests made for a specific API endpoint that is rate limited per unique user.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_user_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code><br /></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code><br /></li>
+      <li><code>limit_name</code><br /></li>
+      <li><code>limit_period</code><br /></li>
+      <li><code>rate_limit_status</code><br /></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
@@ -104,41 +116,47 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_api_key</code></td>
     <td>Number of API requests made for a specific API endpoint that is rate limited per unique API Key used</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_api_key_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
 </table>
 
 
-#### Tag Key
+#### Tag key
 
 
-| Tag Name | Description |
-| -------- | ----------- |
-| app_key_id | Application Key ID used by API Client. This can be N/A for web or mobile users and open endpoints. |
-| child_org | Name of child org, if viewing from the parent org. Otherwise, set to N/A. This only applies within the same datacenter. |
-| limit_count | Number of requests available to each rate limit name during a request period. |
-| limit_name | Name of rate limit. Different endpoints can share the same name. |
-| limit_period | Time in seconds for each rate limit name before the consumption count is reset. |
-| rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
-| user_uuid | UUID of user for API consumption. |
+| Tag name            | Description                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `app_key_id`        | Application Key ID used by API client. This can be `N/A` for web or mobile users and open endpoints.                      |
+| `child_org`         | Name of child org, if viewing from the parent org. Otherwise, set to `N/A`. This only applies within the same datacenter. |
+| `limit_count`       | Number of requests available to each rate limit name during a request period.                                             |
+| `limit_name`        | Name of rate limit. Different endpoints can share the same name.                                                          |
+| `limit_period`      | Time in seconds for each rate limit name before the consumption count is reset.                                           |
+| `rate_limit_status` | `passed`: Request was not blocked.<br />`blocked`: Request was blocked due to rate limits breached.                       |
+| `user_uuid`         | UUID of user for API consumption.                                                                                         |
 
 #### Rollup in widgets
 
@@ -148,17 +166,29 @@ Ratio metrics are already normalized to the corresponding `limit_period`.
 
 ##### Example use cases
 
-| Use Case | Example |
-| -------- | ------- |
-| Requests by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` group by `limit_name`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})` |
-| Blocked by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})` |
-| Blocked Endpoint by User | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})` |
-| Blocked Endpoint by App Key ID | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})` |
-| Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
+Requests by rate limit name
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `limit_name`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})`
+
+Blocked by rate limit name
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})`
+
+Blocked endpoint by user
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})`
+
+Blocked endpoint by app key ID
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})`
+
+Ratio of Rate Limits Used by Rate Limit Name
+: Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio`, and `datadog.apis.usage.per_api_key_ratio` by `limit_name`<br /><br />
+  **Example:** `default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})`
 
 
-### Increasing your Rate Limit
-On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
+### Increase your rate limit
+You can request increased rate limits by creating a Support ticket with the below details under **Help** > **New Support Ticket**. Upon receiving a rate limit increase, our Support Engineering team reviews the request on a case-by-case basis and, if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
 
     Title:
         Request to increase rate limit on endpoint: X
@@ -166,23 +196,23 @@ On a case by case basis, users can request rate limits to be increased by provid
     Details:
         We would like to request a rate limit increase for API endpoint: X
         Example use cases/queries:
-            Example API call as CURL or as URL with example payload
+            Example API call as cURL or as URL with example payload
 
         Motivation for increasing rate limit:
             Example - Our organization uses this endpoint to right size a container before we deploy. This deployment takes place every X hours or up to Y times per day.
 
         Desired target rate limit:
-            Having a specific limit increase in mind or a percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
+            Tip - Having a specific limit increase or percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
 
-Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
+After Datadog Support reviews and approves the use case, they can apply the rate limit increase behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
 
-### Audit Logs
+### Audit logs
 API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
 
-With Audit Trail, you can for instance view:
+With Audit Trail, you can view data such as:
 * **IP address & geolocation** – Identify where API requests originated.
 * **Actor type** – Distinguish between service accounts and user accounts.
-* **API vs. App Key authentication** – See whether requests were made through an API key or directly by a user.
+* **API vs. app key authentication** – See whether requests were made through an API key or directly by a user.
 * **Correlated events** – View other events occurring at the same time, such as configuration changes or security-related actions.
 
 Audit Trail can help teams troubleshoot rate limit issues by providing more context on API consumption and blocked requests. It also enables tracking of API usage across an organization for security and compliance purposes.

--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -52,7 +52,7 @@ All Datadog APIs have a usage limit for a given period of time. APIs can have un
   <tr>
     <td rowspan="2"><strong>Org</strong></td>
     <td><code>datadog.apis.usage.per_org</code></td>
-    <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
+    <td>The organization-wide rate limit of the number of API requests made to a specific endpoint</td>
     <td>
     <ul>
       <li><code>app_key_id</code></li>

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -33,6 +33,13 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 
 All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
 
+{{% site-region region="us" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.com/dash/integration/31668/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="eu1" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.eu/dash/integration/1386/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="us3" %}}[Datadog API Rate Limit Usage Dashboard](https://us3.datadoghq.com/dash/integration/2248/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="us5" %}}[Datadog API Rate Limit Usage Dashboard](https://us5.datadoghq.com/dash/integration/1421/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
+
 {{< h4 >}}Available Metrics{{< /h4 >}}
 
 <table>

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -29,7 +29,7 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
 | `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
-{{< h3 >}}Datadog API Usage Metrics{{< /h3 >}}
+### Datadog API Usage Metrics
 
 All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
 
@@ -40,7 +40,7 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 {{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
 
-{{< h4 >}}Available Metrics{{< /h4 >}}
+#### Available Metrics
 
 <table>
   <thead>
@@ -127,7 +127,7 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 </table>
 
 
-{{< h4 >}}Tag Key{{< /h4 >}}
+#### Tag Key
 
 
 | Tag Name | Description |
@@ -140,12 +140,13 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 | rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
 | user_uuid | UUID of user for API consumption. |
 
-{{< h4 >}}Rollup in widgets{{< /h4 >}}
+#### Rollup in widgets
+
 Metric visualizations should generally be rolled up to the minute using sum(60s) to aggregate the total number of requests per minute.
 
 Ratio metrics are already normalized to the corresponding `limit_period`.
 
-{{< h5 >}}Example use cases{{< /h5 >}}
+##### Example use cases
 
 | Use Case | Example |
 | -------- | ------- |
@@ -156,7 +157,7 @@ Ratio metrics are already normalized to the corresponding `limit_period`.
 | Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
 
 
-{{< h3 >}}Increasing your Rate Limit{{< /h3 >}}
+### Increasing your Rate Limit
 On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
 
     Title:
@@ -175,7 +176,7 @@ On a case by case basis, users can request rate limits to be increased by provid
 
 Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
 
-{{< h3 >}}Audit Logs{{< /h3 >}}
+### Audit Logs
 API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
 
 With Audit Trail, you can for instance view:

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -7,15 +7,19 @@ type: api
 
 All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
-If you are rate limited, you will see a 429 in the response code. Datadog recommends to either wait the time designated by the `X-RateLimit-Limit` before making calls again, or you should switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` / `X-RateLimit-Period`.
+If you are rate limited, you can see a 429 in the response code. You can either wait the designated time by the `X-RateLimit-Period` before making calls again, or switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` or `X-RateLimit-Period`.
 
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].
 
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
+- The API for sending logs is not rate limited.
 - The rate limit for event submission is `500,000` events per hour per organization.
 - The rate limits for endpoints vary and are included in the headers detailed below. These can be extended on demand.
+
+<div class="alert alert-warning">
+The list above is not comprehensive of all rate limits on Datadog APIs. If you are experiencing rate limiting, reach out to <a href="https://www.datadoghq.com/support/">support</a> for more information about the APIs you're using and their limits.</div>
 
 | Rate Limit Headers      | Description                                              |
 | ----------------------- | -------------------------------------------------------- |
@@ -25,6 +29,160 @@ Regarding the API rate limit policy:
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
 | `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
+{{< h3 >}}Datadog API Usage Metrics{{< /h3 >}}
+
+All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
+
+{{< h4 >}}Available Metrics{{< /h4 >}}
+
+<table>
+  <thead>
+    <th>Dimensions</th>
+    <th>Usage metric</th>
+    <th>Description</th>
+    <th>Available Tags</th>
+  </thead>
+  <tr>
+    <td rowspan="2"><strong>Org</strong></td>
+    <td><code>datadog.apis.usage.per_org</code></td>
+    <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_org_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td rowspan="2"><strong>User (UUID)</strong></td>
+    <td><code>datadog.apis.usage.per_user</code></td>
+    <td>Number of API requests made for a specific API endpoint that is rate limited per unique user.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_user_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td rowspan="2"><strong>API Key</strong></td>
+    <td><code>datadog.apis.usage.per_api_key</code></td>
+    <td>Number of API requests made for a specific API endpoint that is rate limited per unique API Key used</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_api_key_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+</table>
+
+
+{{< h4 >}}Tag Key{{< /h4 >}}
+
+
+| Tag Name | Description |
+| -------- | ----------- |
+| app_key_id | Application Key ID used by API Client. This can be N/A for web or mobile users and open endpoints. |
+| child_org | Name of child org, if viewing from the parent org. Otherwise, set to N/A. This only applies within the same datacenter. |
+| limit_count | Number of requests available to each rate limit name during a request period. |
+| limit_name | Name of rate limit. Different endpoints can share the same name. |
+| limit_period | Time in seconds for each rate limit name before the consumption count is reset. |
+| rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
+| user_uuid | UUID of user for API consumption. |
+
+{{< h4 >}}Rollup in widgets{{< /h4 >}}
+Metric visualizations should generally be rolled up to the minute using sum(60s) to aggregate the total number of requests per minute.
+
+Ratio metrics are already normalized to the corresponding `limit_period`.
+
+{{< h5 >}}Example use cases{{< /h5 >}}
+
+| Use Case | Example |
+| -------- | ------- |
+| Requests by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` group by `limit_name`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})` |
+| Blocked by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})` |
+| Blocked Endpoint by User | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})` |
+| Blocked Endpoint by App Key ID | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})` |
+| Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
+
+
+{{< h3 >}}Increasing your Rate Limit{{< /h3 >}}
+On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
+
+    Title:
+        Request to increase rate limit on endpoint: X
+
+    Details:
+        We would like to request a rate limit increase for API endpoint: X
+        Example use cases/queries:
+            Example API call as CURL or as URL with example payload
+
+        Motivation for increasing rate limit:
+            Example - Our organization uses this endpoint to right size a container before we deploy. This deployment takes place every X hours or up to Y times per day.
+
+        Desired target rate limit:
+            Having a specific limit increase in mind or a percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
+
+Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
+
+{{< h3 >}}Audit Logs{{< /h3 >}}
+API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
+
+With Audit Trail, you can for instance view:
+* **IP address & geolocation** – Identify where API requests originated.
+* **Actor type** – Distinguish between service accounts and user accounts.
+* **API vs. App Key authentication** – See whether requests were made through an API key or directly by a user.
+* **Correlated events** – View other events occurring at the same time, such as configuration changes or security-related actions.
+
+Audit Trail can help teams troubleshoot rate limit issues by providing more context on API consumption and blocked requests. It also enables tracking of API usage across an organization for security and compliance purposes.
+
+For more detailed visibility into API activity, consider using **[Audit Trail][4]**.
+
+
 [1]: /help/
 [2]: /api/v1/metrics/
 [3]: /metrics/custom_metrics/
+[4]: /account_management/audit_trail/events/

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -7,7 +7,7 @@ type: api
 
 All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
-If you are rate limited, you can see a 429 in the response code. You can either wait the designated time indicated by the `X-RateLimit-Period` before making calls again, or switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` or `X-RateLimit-Period`.
+If you are rate limited, you can see a 429 in the response code. You can either wait the designated time by the `X-RateLimit-Period` before making calls again, or switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` or `X-RateLimit-Period`.
 
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].
 
@@ -27,11 +27,11 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 | `X-RateLimit-Period`    | length of time in seconds for resets (calendar aligned). |
 | `X-RateLimit-Remaining` | number of allowed requests left in the current time period.  |
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
-| `X-RateLimit-Name`      | name of the rate limit for increase requests             |
+| `X-RateLimit-Name`      | name of the rate limit for increase requests.            |
 
-### Datadog API Usage Metrics
+### Datadog API usage metrics
 
-All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
+All Datadog APIs have a usage limit for a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (excluding metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests, and are provided with the following dimensions and available tags:
 
 {{% site-region region="us" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.com/dash/integration/31668/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="eu1" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.eu/dash/integration/1386/datadog-api-rate-limit-usage){{% /site-region %}}
@@ -40,11 +40,11 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 {{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
 
-#### Available Metrics
+#### Available metrics
 
 <table>
   <thead>
-    <th>Dimensions</th>
+    <th>Dimension</th>
     <th>Usage metric</th>
     <th>Description</th>
     <th>Available Tags</th>
@@ -54,24 +54,30 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_org</code></td>
     <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_org_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
@@ -79,24 +85,30 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_user</code></td>
     <td>Number of API requests made for a specific API endpoint that is rate limited per unique user.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_user_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code><br /></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code><br /></li>
+      <li><code>limit_name</code><br /></li>
+      <li><code>limit_period</code><br /></li>
+      <li><code>rate_limit_status</code><br /></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
@@ -104,41 +116,47 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_api_key</code></td>
     <td>Number of API requests made for a specific API endpoint that is rate limited per unique API Key used</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_api_key_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
 </table>
 
 
-#### Tag Key
+#### Tag key
 
 
-| Tag Name | Description |
-| -------- | ----------- |
-| app_key_id | Application Key ID used by API Client. This can be N/A for web or mobile users and open endpoints. |
-| child_org | Name of child org, if viewing from the parent org. Otherwise, set to N/A. This only applies within the same datacenter. |
-| limit_count | Number of requests available to each rate limit name during a request period. |
-| limit_name | Name of rate limit. Different endpoints can share the same name. |
-| limit_period | Time in seconds for each rate limit name before the consumption count is reset. |
-| rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
-| user_uuid | UUID of user for API consumption. |
+| Tag name            | Description                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `app_key_id`        | Application Key ID used by API client. This can be `N/A` for web or mobile users and open endpoints.                      |
+| `child_org`         | Name of child org, if viewing from the parent org. Otherwise, set to `N/A`. This only applies within the same datacenter. |
+| `limit_count`       | Number of requests available to each rate limit name during a request period.                                             |
+| `limit_name`        | Name of rate limit. Different endpoints can share the same name.                                                          |
+| `limit_period`      | Time in seconds for each rate limit name before the consumption count is reset.                                           |
+| `rate_limit_status` | `passed`: Request was not blocked.<br />`blocked`: Request was blocked due to rate limits breached.                       |
+| `user_uuid`         | UUID of user for API consumption.                                                                                         |
 
 #### Rollup in widgets
 
@@ -148,17 +166,29 @@ Ratio metrics are already normalized to the corresponding `limit_period`.
 
 ##### Example use cases
 
-| Use Case | Example |
-| -------- | ------- |
-| Requests by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` group by `limit_name`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})` |
-| Blocked by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})` |
-| Blocked Endpoint by User | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})` |
-| Blocked Endpoint by App Key ID | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})` |
-| Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
+Requests by rate limit name
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `limit_name`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})`
+
+Blocked by rate limit name
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})`
+
+Blocked endpoint by user
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})`
+
+Blocked endpoint by app key ID
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})`
+
+Ratio of Rate Limits Used by Rate Limit Name
+: Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio`, and `datadog.apis.usage.per_api_key_ratio` by `limit_name`<br /><br />
+  **Example:** `default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})`
 
 
-### Increasing your Rate Limit
-On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
+### Increase your rate limit
+You can request increased rate limits by creating a Support ticket with the below details under **Help** > **New Support Ticket**. Upon receiving a rate limit increase, our Support Engineering team reviews the request on a case-by-case basis and, if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
 
     Title:
         Request to increase rate limit on endpoint: X
@@ -166,23 +196,23 @@ On a case by case basis, users can request rate limits to be increased by provid
     Details:
         We would like to request a rate limit increase for API endpoint: X
         Example use cases/queries:
-            Example API call as CURL or as URL with example payload
+            Example API call as cURL or as URL with example payload
 
         Motivation for increasing rate limit:
             Example - Our organization uses this endpoint to right size a container before we deploy. This deployment takes place every X hours or up to Y times per day.
 
         Desired target rate limit:
-            Having a specific limit increase in mind or a percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
+            Tip - Having a specific limit increase or percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
 
-Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
+After Datadog Support reviews and approves the use case, they can apply the rate limit increase behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
 
-### Audit Logs
+### Audit logs
 API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
 
-With Audit Trail, you can for instance view:
+With Audit Trail, you can view data such as:
 * **IP address & geolocation** – Identify where API requests originated.
 * **Actor type** – Distinguish between service accounts and user accounts.
-* **API vs. App Key authentication** – See whether requests were made through an API key or directly by a user.
+* **API vs. app key authentication** – See whether requests were made through an API key or directly by a user.
 * **Correlated events** – View other events occurring at the same time, such as configuration changes or security-related actions.
 
 Audit Trail can help teams troubleshoot rate limit issues by providing more context on API consumption and blocked requests. It also enables tracking of API usage across an organization for security and compliance purposes.

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -7,7 +7,7 @@ type: api
 
 All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
-If you are rate limited, you can see a 429 in the response code. You can either wait the designated time by the `X-RateLimit-Period` before making calls again, or switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` or `X-RateLimit-Period`.
+If you are rate limited, you can see a 429 in the response code. You can either wait the designated time indicated by the `X-RateLimit-Period` before making calls again, or switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` or `X-RateLimit-Period`.
 
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].
 

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -52,7 +52,7 @@ All Datadog APIs have a usage limit for a given period of time. APIs can have un
   <tr>
     <td rowspan="2"><strong>Org</strong></td>
     <td><code>datadog.apis.usage.per_org</code></td>
-    <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
+    <td>The organization-wide rate limit of the number of API requests made to a specific endpoint</td>
     <td>
     <ul>
       <li><code>app_key_id</code></li>

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -7,15 +7,19 @@ type: api
 
 All of the API endpoints are rate limited. Once you exceed a certain number of requests in a specific period, Datadog returns an error.
 
-If you are rate limited, you will see a 429 in the response code. Datadog recommends to either wait the time designated by the `X-RateLimit-Period` before making calls again, or you should switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` / `X-RateLimit-Period`.
+If you are rate limited, you can see a 429 in the response code. You can either wait the designated time by the `X-RateLimit-Period` before making calls again, or switch to making calls at a frequency slightly longer than the `X-RateLimit-Limit` or `X-RateLimit-Period`.
 
 Rate limits can be increased from the defaults by [contacting the Datadog support team][1].
 
 Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
+- The API for sending logs is not rate limited.
 - The rate limit for event submission is `500,000` events per hour per organization.
 - The rate limits for endpoints vary and are included in the headers detailed below. These can be extended on demand.
+
+<div class="alert alert-warning">
+The list above is not comprehensive of all rate limits on Datadog APIs. If you are experiencing rate limiting, reach out to <a href="https://www.datadoghq.com/support/">support</a> for more information about the APIs you're using and their limits.</div>
 
 | Rate Limit Headers      | Description                                              |
 | ----------------------- | -------------------------------------------------------- |
@@ -25,6 +29,160 @@ Regarding the API rate limit policy:
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
 | `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
+{{< h3 >}}Datadog API Usage Metrics{{< /h3 >}}
+
+All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
+
+{{< h4 >}}Available Metrics{{< /h4 >}}
+
+<table>
+  <thead>
+    <th>Dimensions</th>
+    <th>Usage metric</th>
+    <th>Description</th>
+    <th>Available Tags</th>
+  </thead>
+  <tr>
+    <td rowspan="2"><strong>Org</strong></td>
+    <td><code>datadog.apis.usage.per_org</code></td>
+    <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_org_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td rowspan="2"><strong>User (UUID)</strong></td>
+    <td><code>datadog.apis.usage.per_user</code></td>
+    <td>Number of API requests made for a specific API endpoint that is rate limited per unique user.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_user_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td rowspan="2"><strong>API Key</strong></td>
+    <td><code>datadog.apis.usage.per_api_key</code></td>
+    <td>Number of API requests made for a specific API endpoint that is rate limited per unique API Key used</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+  <tr>
+    <td><code>datadog.apis.usage.per_api_key_ratio</code></td>
+    <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
+    <td>
+      <code>app_key_id</code><br />
+      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
+      <code>limit_name</code><br />
+      <code>limit_period</code><br />
+      <code>rate_limit_status</code><br />
+      <code>user_uuid</code>
+    </td>
+  </tr>
+</table>
+
+
+{{< h4 >}}Tag Key{{< /h4 >}}
+
+
+| Tag Name | Description |
+| -------- | ----------- |
+| app_key_id | Application Key ID used by API Client. This can be N/A for web or mobile users and open endpoints. |
+| child_org | Name of child org, if viewing from the parent org. Otherwise, set to N/A. This only applies within the same datacenter. |
+| limit_count | Number of requests available to each rate limit name during a request period. |
+| limit_name | Name of rate limit. Different endpoints can share the same name. |
+| limit_period | Time in seconds for each rate limit name before the consumption count is reset. |
+| rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
+| user_uuid | UUID of user for API consumption. |
+
+{{< h4 >}}Rollup in widgets{{< /h4 >}}
+Metric visualizations should generally be rolled up to the minute using sum(60s) to aggregate the total number of requests per minute.
+
+Ratio metrics are already normalized to the corresponding `limit_period`.
+
+{{< h5 >}}Example use cases{{< /h5 >}}
+
+| Use Case | Example |
+| -------- | ------- |
+| Requests by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` group by `limit_name`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})` |
+| Blocked by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})` |
+| Blocked Endpoint by User | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})` |
+| Blocked Endpoint by App Key ID | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})` |
+| Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
+
+
+{{< h3 >}}Increasing your Rate Limit{{< /h3 >}}
+On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
+
+    Title:
+        Request to increase rate limit on endpoint: X
+
+    Details:
+        We would like to request a rate limit increase for API endpoint: X
+        Example use cases/queries:
+            Example API call as CURL or as URL with example payload
+
+        Motivation for increasing rate limit:
+            Example - Our organization uses this endpoint to right size a container before we deploy. This deployment takes place every X hours or up to Y times per day.
+
+        Desired target rate limit:
+            Having a specific limit increase in mind or a percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
+
+Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
+
+{{< h3 >}}Audit Logs{{< /h3 >}}
+API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
+
+With Audit Trail, you can for instance view:
+* **IP address & geolocation** – Identify where API requests originated.
+* **Actor type** – Distinguish between service accounts and user accounts.
+* **API vs. App Key authentication** – See whether requests were made through an API key or directly by a user.
+* **Correlated events** – View other events occurring at the same time, such as configuration changes or security-related actions.
+
+Audit Trail can help teams troubleshoot rate limit issues by providing more context on API consumption and blocked requests. It also enables tracking of API usage across an organization for security and compliance purposes.
+
+For more detailed visibility into API activity, consider using **[Audit Trail][4]**.
+
+
 [1]: /help/
 [2]: /api/v1/metrics/
 [3]: /metrics/custom_metrics/
+[4]: /account_management/audit_trail/events/

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -33,6 +33,13 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 
 All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
 
+{{% site-region region="us" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.com/dash/integration/31668/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="eu1" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.eu/dash/integration/1386/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="us3" %}}[Datadog API Rate Limit Usage Dashboard](https://us3.datadoghq.com/dash/integration/2248/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="us5" %}}[Datadog API Rate Limit Usage Dashboard](https://us5.datadoghq.com/dash/integration/1421/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
+{{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
+
 {{< h4 >}}Available Metrics{{< /h4 >}}
 
 <table>

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -29,7 +29,7 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
 | `X-RateLimit-Name`      | name of the rate limit for increase requests             |
 
-{{< h3 >}}Datadog API Usage Metrics{{< /h3 >}}
+### Datadog API Usage Metrics
 
 All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
 
@@ -40,7 +40,7 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 {{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
 
-{{< h4 >}}Available Metrics{{< /h4 >}}
+#### Available Metrics
 
 <table>
   <thead>
@@ -127,7 +127,7 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 </table>
 
 
-{{< h4 >}}Tag Key{{< /h4 >}}
+#### Tag Key
 
 
 | Tag Name | Description |
@@ -140,12 +140,13 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 | rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
 | user_uuid | UUID of user for API consumption. |
 
-{{< h4 >}}Rollup in widgets{{< /h4 >}}
+#### Rollup in widgets
+
 Metric visualizations should generally be rolled up to the minute using sum(60s) to aggregate the total number of requests per minute.
 
 Ratio metrics are already normalized to the corresponding `limit_period`.
 
-{{< h5 >}}Example use cases{{< /h5 >}}
+##### Example use cases
 
 | Use Case | Example |
 | -------- | ------- |
@@ -156,7 +157,7 @@ Ratio metrics are already normalized to the corresponding `limit_period`.
 | Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
 
 
-{{< h3 >}}Increasing your Rate Limit{{< /h3 >}}
+### Increasing your Rate Limit
 On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
 
     Title:
@@ -175,7 +176,7 @@ On a case by case basis, users can request rate limits to be increased by provid
 
 Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
 
-{{< h3 >}}Audit Logs{{< /h3 >}}
+### Audit Logs
 API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
 
 With Audit Trail, you can for instance view:

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -27,11 +27,11 @@ The list above is not comprehensive of all rate limits on Datadog APIs. If you a
 | `X-RateLimit-Period`    | length of time in seconds for resets (calendar aligned). |
 | `X-RateLimit-Remaining` | number of allowed requests left in the current time period.  |
 | `X-RateLimit-Reset`     | time in seconds until next reset.                        |
-| `X-RateLimit-Name`      | name of the rate limit for increase requests             |
+| `X-RateLimit-Name`      | name of the rate limit for increase requests.            |
 
-### Datadog API Usage Metrics
+### Datadog API usage metrics
 
-All Datadog APIs have a limit to the amount of usage in a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (exclusive of metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests and are provided with the following dimensions and available tags:
+All Datadog APIs have a usage limit for a given period of time. APIs can have unique, distinct rate limit buckets or be grouped together into a single bucket depending on the resource(s) being used. For example, the monitor status API has a rate limit that allows a human or automation script to query only so many times per minute. The endpoint rejects excess requests with a 429 response code and a hint to back off until a reset period has expired. API usage metrics allow Datadog users to self-service and audit API rate limit consumption for API endpoints (excluding metrics, logs, and event submission endpoints). These metrics provide a picture of allowed and blocked requests, and are provided with the following dimensions and available tags:
 
 {{% site-region region="us" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.com/dash/integration/31668/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="eu1" %}}[Datadog API Rate Limit Usage Dashboard](https://app.datadoghq.eu/dash/integration/1386/datadog-api-rate-limit-usage){{% /site-region %}}
@@ -40,11 +40,11 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
 {{% site-region region="ap1" %}}[Datadog API Rate Limit Usage Dashboard](https://ap1.datadoghq.com/dash/integration/2698/datadog-api-rate-limit-usage){{% /site-region %}}
 {{% site-region region="gov" %}}[Datadog API Rate Limit Usage Dashboard](https://app.ddog-gov.com/dash/integration/1330/datadog-api-rate-limit-usage){{% /site-region %}}
 
-#### Available Metrics
+#### Available metrics
 
 <table>
   <thead>
-    <th>Dimensions</th>
+    <th>Dimension</th>
     <th>Usage metric</th>
     <th>Description</th>
     <th>Available Tags</th>
@@ -54,24 +54,30 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_org</code></td>
     <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_org_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
@@ -79,24 +85,30 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_user</code></td>
     <td>Number of API requests made for a specific API endpoint that is rate limited per unique user.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_user_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code><br /></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code><br /></li>
+      <li><code>limit_name</code><br /></li>
+      <li><code>limit_period</code><br /></li>
+      <li><code>rate_limit_status</code><br /></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
@@ -104,41 +116,47 @@ All Datadog APIs have a limit to the amount of usage in a given period of time. 
     <td><code>datadog.apis.usage.per_api_key</code></td>
     <td>Number of API requests made for a specific API endpoint that is rate limited per unique API Key used</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
   <tr>
     <td><code>datadog.apis.usage.per_api_key_ratio</code></td>
     <td>Ratio of API requests by available dimensions to total number of requests (<code>limit_count</code>) allowed.</td>
     <td>
-      <code>app_key_id</code><br />
-      <code>child_org</code> (on parent only)<br /><code>limit_count</code><br />
-      <code>limit_name</code><br />
-      <code>limit_period</code><br />
-      <code>rate_limit_status</code><br />
-      <code>user_uuid</code>
+    <ul>
+      <li><code>app_key_id</code></li>
+      <li><code>child_org</code> (on parent only)</li>
+      <li><code>limit_count</code></li>
+      <li><code>limit_name</code></li>
+      <li><code>limit_period</code></li>
+      <li><code>rate_limit_status</code></li>
+      <li><code>user_uuid</code></li>
+    </ul>
     </td>
   </tr>
 </table>
 
 
-#### Tag Key
+#### Tag key
 
 
-| Tag Name | Description |
-| -------- | ----------- |
-| app_key_id | Application Key ID used by API Client. This can be N/A for web or mobile users and open endpoints. |
-| child_org | Name of child org, if viewing from the parent org. Otherwise, set to N/A. This only applies within the same datacenter. |
-| limit_count | Number of requests available to each rate limit name during a request period. |
-| limit_name | Name of rate limit. Different endpoints can share the same name. |
-| limit_period | Time in seconds for each rate limit name before the consumption count is reset. |
-| rate_limit_status | `passed`: Request was not blocked<br />`blocked`: Request was blocked due to rate limits breached |
-| user_uuid | UUID of user for API consumption. |
+| Tag name            | Description                                                                                                               |
+|---------------------|---------------------------------------------------------------------------------------------------------------------------|
+| `app_key_id`        | Application Key ID used by API client. This can be `N/A` for web or mobile users and open endpoints.                      |
+| `child_org`         | Name of child org, if viewing from the parent org. Otherwise, set to `N/A`. This only applies within the same datacenter. |
+| `limit_count`       | Number of requests available to each rate limit name during a request period.                                             |
+| `limit_name`        | Name of rate limit. Different endpoints can share the same name.                                                          |
+| `limit_period`      | Time in seconds for each rate limit name before the consumption count is reset.                                           |
+| `rate_limit_status` | `passed`: Request was not blocked.<br />`blocked`: Request was blocked due to rate limits breached.                       |
+| `user_uuid`         | UUID of user for API consumption.                                                                                         |
 
 #### Rollup in widgets
 
@@ -148,17 +166,29 @@ Ratio metrics are already normalized to the corresponding `limit_period`.
 
 ##### Example use cases
 
-| Use Case | Example |
-| -------- | ------- |
-| Requests by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` group by `limit_name`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})` |
-| Blocked by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})` |
-| Blocked Endpoint by User | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})` |
-| Blocked Endpoint by App Key ID | Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user` and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />`default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})` |
-| Ratio of Rate Limits Used by Rate Limit Name | Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio` and `datadog.apis.usage.per_api_key_ratio` group by `limit_name`<br /><br />`default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})` |
+Requests by rate limit name
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `limit_name`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{*} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{*} by {limit_name})`
+
+Blocked by rate limit name
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `limit_name` with `rate_limit_status:blocked`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked} by {limit_name}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked} by {limit_name})`
+
+Blocked endpoint by user
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `user_uuid` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {user_uuid}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {user_uuid})`
+
+Blocked endpoint by app key ID
+: Graph the sum of `datadog.apis.usage.per_org`, `datadog.apis.usage.per_user`, and `datadog.apis.usage.per_api_key` by `app_key_id` with `rate_limit_status:blocked` and `limit_name:example`<br /><br />
+  **Example:** `default_zero(sum:datadog.apis.usage.per_org{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_user{rate_limit_status:blocked,limit_name:example} by {app_key_id}) + default_zero(sum:datadog.apis.usage.per_api_key{rate_limit_status:blocked,limit_name:example} by {app_key_id})`
+
+Ratio of Rate Limits Used by Rate Limit Name
+: Graph the sum of `datadog.apis.usage.per_org_ratio`, `datadog.apis.usage.per_user_ratio`, and `datadog.apis.usage.per_api_key_ratio` by `limit_name`<br /><br />
+  **Example:** `default_zero(max:datadog.apis.usage.per_org_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_user_ratio{*} by {limit_name}) + default_zero(max:datadog.apis.usage.per_api_key_ratio{*} by {limit_name})`
 
 
-### Increasing your Rate Limit
-On a case by case basis, users can request rate limits to be increased by providing the following details in a Support ticket under Help -> New Support Ticket. Upon receiving a rate limit increase, our Support Engineering team reviews the use case and if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
+### Increase your rate limit
+You can request increased rate limits by creating a Support ticket with the below details under **Help** > **New Support Ticket**. Upon receiving a rate limit increase, our Support Engineering team reviews the request on a case-by-case basis and, if needed, works with internal engineering resources to confirm the viability of the rate limit increase request.
 
     Title:
         Request to increase rate limit on endpoint: X
@@ -166,23 +196,23 @@ On a case by case basis, users can request rate limits to be increased by provid
     Details:
         We would like to request a rate limit increase for API endpoint: X
         Example use cases/queries:
-            Example API call as CURL or as URL with example payload
+            Example API call as cURL or as URL with example payload
 
         Motivation for increasing rate limit:
             Example - Our organization uses this endpoint to right size a container before we deploy. This deployment takes place every X hours or up to Y times per day.
 
         Desired target rate limit:
-            Having a specific limit increase in mind or a percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
+            Tip - Having a specific limit increase or percentage increase in mind helps Support Engineering expedite the request to internal Engineering teams for review.
 
-Once Datadog Support reviews and approves the use case, a rate limit increase can be applied behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
+After Datadog Support reviews and approves the use case, they can apply the rate limit increase behind the scenes. Note that there is a maximum to how much a rate limit can be increased due to the SaaS nature of Datadog. Datadog Support reserves the right to reject rate limit increases based on use cases and Engineering recommendations.
 
-### Audit Logs
+### Audit logs
 API limit and usage metrics provide insight into usage patterns and blocked requests. If you need additional details, Audit Trail offers more granular visibility into API activity.
 
-With Audit Trail, you can for instance view:
+With Audit Trail, you can view data such as:
 * **IP address & geolocation** – Identify where API requests originated.
 * **Actor type** – Distinguish between service accounts and user accounts.
-* **API vs. App Key authentication** – See whether requests were made through an API key or directly by a user.
+* **API vs. app key authentication** – See whether requests were made through an API key or directly by a user.
 * **Correlated events** – View other events occurring at the same time, such as configuration changes or security-related actions.
 
 Audit Trail can help teams troubleshoot rate limit issues by providing more context on API consumption and blocked requests. It also enables tracking of API usage across an organization for security and compliance purposes.

--- a/content/en/api/v2/rate-limits/_index.md
+++ b/content/en/api/v2/rate-limits/_index.md
@@ -52,7 +52,7 @@ All Datadog APIs have a usage limit for a given period of time. APIs can have un
   <tr>
     <td rowspan="2"><strong>Org</strong></td>
     <td><code>datadog.apis.usage.per_org</code></td>
-    <td>Number of API requests made to a specific API endpoint that is an organization wide rate limit.</td>
+    <td>The organization-wide rate limit of the number of API requests made to a specific endpoint</td>
     <td>
     <ul>
       <li><code>app_key_id</code></li>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
We are updating our rate limit documentation to show new metrics available to all customers on seeing their own usage. Related to ENGDOC-144

### Merge instructions


Merge readiness:
- [x] Ready for merge


### Additional notes
This is related to ENGDOC-144
