### PR TITLE
Change report-to header to reporting-endpoints

### DIFF
--- a/content/en/integrations/content_security_policy_logs.md
+++ b/content/en/integrations/content_security_policy_logs.md
@@ -21,6 +21,7 @@ algolia:
   - 'csp'
   - 'report-uri'
   - 'report-to'
+  - 'reporting-endpoints'
   - 'Content-Security-Policy'
   - 'violated-directive'
   - 'blocked-uri'
@@ -83,21 +84,17 @@ You can either embed the URL in an HTTP header (recommended), or embed it in a `
 
 ### Embed the policy in an HTTP header
 
-Datadog recommends embedding the Content Security Policy in an HTTP header. You can either use the `report-uri` directive or the `report-to` directive. The `report-to` directive will eventually supersede `report-uri`, but is not yet supported by all browsers.
+Datadog recommends embedding the Content Security Policy in an HTTP header. You can either use the `report-uri` directive or the `reporting-endpoints` directive. The `reporting-endpoints` directive will eventually supersede `report-uri`, but is not yet supported by all browsers.
 
 - If you're using the `report-uri` directive:
   ```bash
   Content-Security-Policy: ...; report-uri https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report
   ```
 
-- If you're using the `report-to` directive:
+- If you're using the `reporting-endpoints` directive:
   ```json
   Content-Security-Policy: ...; report-to browser-intake-datadoghq
-  Report-To: { "group": "browser-intake-datadoghq",
-              "max_age": 10886400,
-              "endpoints": [
-                  { "url": "https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report" }
-              ] }
+  Reporting-Endpoints: browser-intake-datadoghq="https://{{< region-param key=browser_sdk_endpoint_domain >}}/api/v2/logs?dd-api-key=<client-token>&dd-evp-origin=content-security-policy&ddsource=csp-report"
   ```
 
 ### Policy embedded in a `<meta>` HTML tag


### PR DESCRIPTION
Report-To header is currently deprecated in favor of the simpler reporting-endpoints header.

Additional information regarding the new `reporting-endpoints` header can be found on [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Reporting-Endpoints)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The `report-to` header for Content Security Policy is currently marked as deprecated according to the [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Report-To). Instead, servers should return a `reporting-endpoints` header. The new header is simpler to reason about, but contains the same compatibility issues as `report-to`, namely that Firefox does not currently implement it.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
