### PR TITLE
DOCS-10022: Call out limited kubernetes.* metrics for Windows

### DIFF
--- a/content/en/agent/troubleshooting/windows_containers.md
+++ b/content/en/agent/troubleshooting/windows_containers.md
@@ -20,9 +20,9 @@ Containerized Windows Applications Monitoring requires Datadog Agent 7.19+.
 
 The supported OS versions are:
 - Windows Server 2019 (LTSC / 1809)
-- Windows Server 2019 1909 (until Agent 7.39, as not supported by Microsoft anymore)
-- Windows Server 2019 2004 or 20H1 (until Agent 7.39, as not supported by Microsoft anymore)
-- Windows Server 2019 20H2 (Agent 7.33 to 7.39, as not supported by Microsoft anymore)
+- Windows Server 2019 1909 (until Agent 7.39, no longer supported by Microsoft)
+- Windows Server 2019 2004 or 20H1 (until Agent 7.39, no longer supported by Microsoft)
+- Windows Server 2019 20H2 (Agent 7.33 to 7.39, no longer supported by Microsoft)
 - Windows Server 2022 LTSC (Agent >=7.34)
 
 Hyper-V isolation mode is not supported.
@@ -43,23 +43,25 @@ The recommended way of deploying the Datadog Agent on a mixed cluster is to perf
 
 The Datadog Agent uses a `nodeSelector` to automatically select Linux or Windows nodes based on `targetSystem`.
 
-However it's not the case for Kube State Metrics (which is installed by default), leading to situations where Kube State Metrics cannot be scheduled on Windows nodes.
+However, this is not the case for Kube State Metrics (which is installed by default), leading to situations where Kube State Metrics cannot be scheduled on Windows nodes.
 
 Three options are available to avoid this issue:
 
 * Taint your Windows nodes. On Windows, the Agent always allows the `node.kubernetes.io/os=windows:NoSchedule` taint.
 * Set Kube State Metrics node selector through Datatog Helm chart `values.yaml`:
 
-```
-kube-state-metrics:
-  nodeSelector:
-    beta.kubernetes.io/os: linux // Kubernetes < 1.14
-    kubernetes.io/os: linux // Kubernetes >= 1.14
-```
+   ```
+   kube-state-metrics:
+     nodeSelector:
+       beta.kubernetes.io/os: linux // Kubernetes < 1.14
+       kubernetes.io/os: linux // Kubernetes >= 1.14
+   ```
 
 * Deploy Kube State Metrics yourself separately by setting `datadog.kubeStateMetricsEnabled` to `false`.
 
 **Note**: When using two Datadog installations (one with `targetSystem: linux`, one with `targetSystem: windows`), make sure the second one has `datadog.kubeStateMetricsEnabled` set to `false` to avoid deploying two instances of Kube State Metrics.
+
+Some metrics are not available for Windows deployments. See [available metrics](#limited-metrics-for-windows-deployments).
 
 #### Mixed clusters with the Datadog Cluster Agent
 
@@ -119,16 +121,16 @@ If your setup does not meet these requirements, APM and DogStatsD will only work
 ### Kubelet check
 
 Depending on your Kubernetes version, some Kubelet metrics might not be available (or Kubelet check might timeout).
-For optimal experience, please use any of the following:
+For optimal experience, please use any of the following with Datadog Agent v7.19.2+:
 
-* Kubelet >= 1.16.13 (1.16.11 on GKE)
-* Kubelet >= 1.17.9 (1.17.6 on GKE)
-* Kubelet >= 1.18.6
-* Kubelet >= 1.19
+* Kubelet v1.16.13+ (v1.16.11+ on GKE)
+* Kubelet v1.17.9+ (v1.17.6+ on GKE)
+* Kubelet v1.18.6+
+* Kubelet v1.19+
 
-With Agent version >= 7.19.2
+### Limited metrics for Windows deployments
 
-Please note that not all `kubernetes.*` are available on Windows, you can find the list of available ones below:
+The following `kubernetes.*` metrics are available for Windows containers:
 
 * `kubernetes.cpu.usage.total`
 * `kubernetes.containers.restarts`

--- a/content/en/containers/kubernetes/data_collected.md
+++ b/content/en/containers/kubernetes/data_collected.md
@@ -24,9 +24,9 @@ further_reading:
   text: "Assign tags to all data emitted by a container"
 ---
 
-This page lists data collected by the Datadog Agent when deployed on a Kubernetes cluster. 
+This page lists data collected by the Datadog Agent when deployed on a Kubernetes cluster. The set of metrics collected may vary depending on the version of Kubernetes in use.
 
-The set of metrics collected may vary depending on the version of Kubernetes in use.
+**Note**: For Windows containers, see [Limited metrics for Windows deployments][7].
 
 ## Metrics
 
@@ -178,3 +178,4 @@ For more information, see the documentation for the [Kubernetes state metrics co
 [4]: /integrations/kube_metrics_server
 [5]: /integrations/kube_scheduler
 [6]: /integrations/kubernetes_state_core/
+[7]: /agent/troubleshooting/windows_containers/#limited-metrics-for-windows-deployments


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
That Windows Containers Troubleshooting page seems to have not been updated in a long time, so I also did some formatting and edits there.

Otherwise, this PR makes the list of available `kubernetes.*` metrics for Windows containers a bit more visible.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
