### PR TITLE
[web-6028] integration carousel images bucket is dynamic per env

### DIFF
--- a/layouts/partials/integrations-carousel/integrations-carousel-modal.html
+++ b/layouts/partials/integrations-carousel/integrations-carousel-modal.html
@@ -4,6 +4,8 @@
 {{ $asset_len := ($media | default slice) | len  }}
 {{ $title := .Params.integration_title | default .Title}}
 {{ $app_id := .Params.app_id | default "" }}
+{{- $app_listings_bucket := cond (eq hugo.Environment "live") "dd-app-listings" "dd-app-listings-staging" -}}
+
 <div 
 x-data="{
     shouldShowActiveHorizontalSlide (idx) {
@@ -44,14 +46,14 @@ x-cloak x-show="$store.integrationsModal.isOpen"
                     x-cloak x-show="shouldShowActiveHorizontalSlide({{ $idx }})"
                     x-transition.opacity.duration.500ms>
                         {{ if eq $elm.media_type "image"}}
-                        <img class="h-100 w-100 rounded-1" src="https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }}" alt="{{ $elm.caption }}" >
+                        <img class="h-100 w-100 rounded-1" src="https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }}" alt="{{ $elm.caption }}" >
                         {{ else }}
                         <iframe x-ref="iframe" class="d-none" src="https://player.vimeo.com/video/{{ $elm.vimeo_id }}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;z-index:3;"></iframe>
                         <img 
                         @click="$store.integrationsModal.playVideo($refs)"
                         x-ref="playOverlay"
                         class="play-overlay position-relative h-100 w-100 rounded-1" 
-                        src="https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }}" 
+                        src="https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }}" 
                         alt="{{ $elm.caption }}">
                         <button 
                         @click="$store.integrationsModal.playVideo($refs)"
@@ -92,7 +94,7 @@ x-cloak x-show="$store.integrationsModal.isOpen"
             class="modal-item-btn p-0"
             :class="shouldShowActiveHorizontalSlide({{ $idx }}) && 'active'"
             @click="selectCarouselItem({{ $idx }})"
-            :style="{backgroundImage: 'url(https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }})'}"
+            :style="{backgroundImage: 'url(https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }})'}"
             >
             </button>
             {{ end }}

--- a/layouts/partials/integrations-carousel/integrations-carousel.html
+++ b/layouts/partials/integrations-carousel/integrations-carousel.html
@@ -3,6 +3,7 @@
 {{ $asset_len := ($media | default slice) | len  }}
 {{ $is_scrollable_carousel := (gt $asset_len 3)}}
 {{ $carousel_item_vertical := newScratch }}
+{{- $app_listings_bucket := cond (eq hugo.Environment "live") "dd-app-listings" "dd-app-listings-staging" -}}
 
 <div 
 @keydown.window.left="navigateCarousel('prev')"
@@ -112,13 +113,13 @@ x-data="{
                 x-cloak x-show="shouldShowActiveHorizontalSlide({{ $idx }})"
                 x-transition.opacity.duration.500ms>
                     {{ if eq $elm.media_type "image"}}
-                    <img class="h-100 w-100 rounded-1" src="https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }}" alt="{{ $elm.caption }}" >
+                    <img class="h-100 w-100 rounded-1" src="https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }}" alt="{{ $elm.caption }}" >
                     {{ else }}
                     <iframe x-ref="iframe" class="d-none" src="https://player.vimeo.com/video/{{ $elm.vimeo_id }}" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;z-index:3"></iframe>
                     <img 
                     x-ref="playOverlay"
                     class="play-overlay position-relative h-100 w-100 rounded-1" 
-                    src="https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }}" 
+                    src="https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }}" 
                     alt="{{ $elm.caption }}">
                     <button 
                     @click="$store.integrationsModal.playVideo($refs)"
@@ -161,7 +162,7 @@ x-data="{
                 class="carousel-item__vertical row g-0 p-0 w-100 mx-auto rounded-1"
                 :class="isActiveVertical({{$idx}}, $el)"
                 @click="navigateCarousel(chooseVerticalDirection($el))"
-                :style="{transform: `translateY(-${scrollByHeight * 2}px)`, backgroundImage: 'url(https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }})'}"
+                :style="{transform: `translateY(-${scrollByHeight * 2}px)`, backgroundImage: 'url(https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }})'}"
                 >
                 </button>
                 {{ end }}
@@ -174,7 +175,7 @@ x-data="{
             class="carousel-item__vertical row g-0 p-0 w-100 mx-auto rounded-1"
             :class="isActiveVertical({{$idx}}, $el)"
             @click="navigateCarousel(chooseVerticalDirection($el, {{ $idx }}))"
-            :style="{transform: `translateY(-${scrollByHeight * 2}px)`, backgroundImage: 'url(https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }})'}"
+            :style="{transform: `translateY(-${scrollByHeight * 2}px)`, backgroundImage: 'url(https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }})'}"
             >
             </button>
             {{ end }}
@@ -187,7 +188,7 @@ x-data="{
                 class="carousel-item__vertical row g-0 p-0 w-100 mx-auto rounded-1"
                 :class="isActiveVertical({{$idx}}, $el)"
                 @click="navigateCarousel(chooseVerticalDirection($el))"
-                :style="{transform: `translateY(-${scrollByHeight * 2}px)`, backgroundImage: 'url(https://s3.amazonaws.com/dd-app-listings/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }})'}"
+                :style="{transform: `translateY(-${scrollByHeight * 2}px)`, backgroundImage: 'url(https://s3.amazonaws.com/{{ $app_listings_bucket }}/{{ $app_id }}/media/{{ replaceRE `(./)?images/` "" $elm.image_url }})'}"
                 >
                 </button>
                 {{ end }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/WEB-6028
images in the integration carousel component should dynamically set the s3 bucket based on env
integrations in review should have images uploaded to staging bucket but may not be in prod bucket.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
- check an integration page featuring the image carousel, for example: [buoyant](https://docs-staging.datadoghq.com/brian.deutsch/test-int-forked/integrations/buoyant_inc_buoyant_cloud/).  Inspect the source of the images and confirm the s3 bucket is `dd-app-listings-staging`.   All images on the page and in the modal should render.
