### PR TITLE
Java profiler: Clarify allocation engine pre-requisits

### DIFF
--- a/content/en/profiler/enabling/java.md
+++ b/content/en/profiler/enabling/java.md
@@ -235,10 +235,13 @@ The wallclock engine does not depend on the `/proc/sys/kernel/perf_event_paranoi
 
 {{< tabs >}}
 {{% tab "JFR" %}}
-The JFR based allocation profiling engine is enabled by default since JDK 16.
-The reason it's not enabled by default for JDK 8 and 11, is that an allocation intensive
-application can lead to high overhead and large recording sizes.
-To enable it for JDK 8 and 11, add the following:
+The JFR based allocation profiling engine is enabled by default since JDK 16. For older JDKs, manual activation and performance considerations should be taken into account.
+
+This is not supported for Oracle JDK 8 and IBM J9 JDK 8. A paid license version of Oracle JDK 8 enables the usage of JFR events on which this feature relies.
+
+It is not enabled by default for OpenJDK 8 and JDK 11 because an allocation intensive application can lead to high overhead and large recording sizes.
+
+To enable it for OpenJDK 8 and JDK 11, add the following:
 
 ```
 export DD_PROFILING_ENABLED_EVENTS=jdk.ObjectAllocationInNewTLAB,jdk.ObjectAllocationOutsideTLAB
@@ -249,6 +252,7 @@ or:
 ```
 -Ddd.profiling.enabled.events=jdk.ObjectAllocationInNewTLAB,jdk.ObjectAllocationOutsideTLAB
 ```
+
 {{% /tab %}}
 
 {{% tab "Datadog Profiler" %}}


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

All JDK 8 versions do not support allocation profiling

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
