### PR TITLE
[test optimization] Follow-up: Better DD_TEST_SESSION_NAME explanation

### DIFF
--- a/content/en/tests/setup/dotnet.md
+++ b/content/en/tests/setup/dotnet.md
@@ -389,11 +389,11 @@ The test session name needs to be unique within a repository to help you disting
 
 #### When to use `DD_TEST_SESSION_NAME`
 
-There's a set of parameters that the product checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. Some examples of unstable test commands are:
+There's a set of parameters that Datadog checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. For example:
 
-- `DD_TEST_SESSION_NAME=integration-tests dotnet test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
+- `dotnet test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands varies between executions.
+Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary between executions.
 
 ## Further reading
 

--- a/content/en/tests/setup/java.md
+++ b/content/en/tests/setup/java.md
@@ -505,11 +505,11 @@ The test session name needs to be unique within a repository to help you disting
 
 #### When to use `DD_TEST_SESSION_NAME`
 
-There's a set of parameters that the product checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. Some examples of unstable test commands are:
+There's a set of parameters that Datadog checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. For example:
 
 - `mvn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands varies between executions.
+Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary between executions.
 
 ## Troubleshooting
 

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -821,12 +821,12 @@ The test session name should be unique within a repository to help you distingui
 
 #### When to use `DD_TEST_SESSION_NAME`
 
-There's a set of parameters that the product checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. Some examples of unstable test commands are:
+There's a set of parameters that Datadog checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. For example:
 
 - `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 - `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands varies between executions.
+Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary between executions.
 
 ## Further reading
 

--- a/content/en/tests/setup/python.md
+++ b/content/en/tests/setup/python.md
@@ -438,11 +438,11 @@ The test session name needs to be unique within a repository to help you disting
 
 #### When to use `DD_TEST_SESSION_NAME`
 
-There's a set of parameters that the product checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. Some examples of unstable test commands are:
+There's a set of parameters that Datadog checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. For example:
 
 - `pytest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands varies between executions.
+Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary between executions.
 
 ## Known limitations
 

--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -475,12 +475,12 @@ The test session name needs to be unique within a repository to help you disting
 
 #### When to use `DD_TEST_SESSION_NAME`
 
-There's a set of parameters that the product checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. Some examples of unstable test commands are:
+There's a set of parameters that Datadog checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. For example:
 
 - `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 - `pnpm vitest --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands varies between executions.
+Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary between executions.
 
 ## Further reading
 

--- a/content/en/tests/setup/swift.md
+++ b/content/en/tests/setup/swift.md
@@ -648,11 +648,11 @@ The test session name needs to be unique within a repository to help you disting
 
 #### When to use `DD_TEST_SESSION_NAME`
 
-There's a set of parameters that the product checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. Some examples of unstable test commands are:
+There's a set of parameters that Datadog checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. For example:
 
 - `swift test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 
-Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands varies between executions.
+Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary between executions.
 
 ## Further reading
 

--- a/content/en/tests/troubleshooting/_index.md
+++ b/content/en/tests/troubleshooting/_index.md
@@ -155,7 +155,7 @@ The best way to fix this is to make sure that the test parameters are the same b
 
 ## Session history, performance or code coverage tab only show a single execution
 
-This is likely caused by an unstable test session fingerprint. There's a set of parameters that the product checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. Some examples of unstable test commands are:
+This is likely caused by an unstable test session fingerprint. There's a set of parameters that Datadog checks to establish correspondence between test sessions. The test command used to execute the tests is one of them. If the test command contains a string that changes for every execution, such as a temporary folder, Datadog considers the sessions to be unrelated to each other. For example:
 
 - `yarn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`
 - `mvn test --temp-dir=/var/folders/t1/rs2htfh55mz9px2j4prmpg_c0000gq/T`


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This is a follow-up of https://github.com/DataDog/documentation/pull/27639, which improved the explanation of the `DD_TEST_SESSION_NAME` environment variable for Test Optimization. 

This PR updates the test command example for .NET to include just the test command (similar to examples in other languages), instead of also including the variable assignment. Also adds a few other small edits.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

I've added the original contributor of https://github.com/DataDog/documentation/pull/27639 (@juan-fernandez) as a reviewer to make sure the revised test command example is valid.
