### PR TITLE
Python profiling: remove section to enable code provenance

### DIFF
--- a/content/en/profiler/enabling/python.md
+++ b/content/en/profiler/enabling/python.md
@@ -117,14 +117,6 @@ prof.start()  # Should be as early as possible, eg before other imports, to ensu
 
 You can configure the profiler using the [environment variables][6].
 
-### Code provenance
-
-The Python profiler supports code provenance reporting, which provides
-insight into the library that is running the code. While this is
-disabled by default, you can turn it on by setting
-`DD_PROFILING_ENABLE_CODE_PROVENANCE=1`.
-
-
 ### Stack V2
 
 Stack V2 is the new stack sampler implementation for CPython 3.8+ on x86_64 Linux.

--- a/content/en/profiler/enabling/python.md
+++ b/content/en/profiler/enabling/python.md
@@ -117,6 +117,14 @@ prof.start()  # Should be as early as possible, eg before other imports, to ensu
 
 You can configure the profiler using the [environment variables][6].
 
+### Code provenance
+
+The Python profiler supports code provenance reporting, which provides
+insight into the library that is running the code. While this is
+enabled by default, you can turn it off by setting
+`DD_PROFILING_ENABLE_CODE_PROVENANCE=0`.
+
+
 ### Stack V2
 
 Stack V2 is the new stack sampler implementation for CPython 3.8+ on x86_64 Linux.


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The "code provenance" feature is enabled by default in the Python integration, so the section to enable it explicitly is not needed.

I think it was [enabled by default](https://github.com/DataDog/dd-trace-py/blob/a5e3552f94982d69332ae158c5ef77b3a0204ebe/ddtrace/settings/profiling.py#L197) (accidentally?) by [this PR 2 years ago](https://github.com/DataDog/dd-trace-py/pull/5643).

This default value can be seen in dd-trace-py docs:
<img width="849" alt="SCR-20250217-ljgg" src="https://github.com/user-attachments/assets/4a245f6e-3bee-4d8b-873d-17e6abf2f3c0" />

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
