### PR TITLE
Document EnvVar precedence

### DIFF
--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -55,7 +55,10 @@ In general, use the following rules:
       # DD_CONTAINER_ENV_AS_TAGS='{"ENVVAR_NAME": "tag_name"}'
    ```
 
-**Note**: Specifying a nested option with an environment variable overrides _all_ the nested options specified under the config option. The exception to this rule is the `proxy` config option. Reference the [Agent proxy documentation][3] for more details.
+### Notes
+
+- If a property is defined in both the global configuration file (`datadog.yaml`) and as an environment variable, the environment variable takes precedence.
+- Specifying a nested option with an environment variable overrides _all_ the nested options specified under the config option. The exception to this rule is the `proxy` config option. Reference the [Agent proxy documentation][3] for more details.
 
 ### Exceptions
 

--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -55,7 +55,7 @@ In general, use the following rules:
       # DD_CONTAINER_ENV_AS_TAGS='{"ENVVAR_NAME": "tag_name"}'
    ```
 
-### Notes
+### Property definition priority
 
 - If a property is defined in both the global configuration file (`datadog.yaml`) and as an environment variable, the environment variable takes precedence.
 - Specifying a nested option with an environment variable overrides _all_ the nested options specified under the config option. The exception to this rule is the `proxy` config option. Reference the [Agent proxy documentation][3] for more details.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Document EnvVar precedence over local config file.

Also mentioned in the following but it makes sense to be mentioned on this page as well

- https://docs.datadoghq.com/agent/configuration/proxy/?tab=linux#environment-variables
- https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration/?tab=npm#environment-variables

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
