### PR TITLE
Update ecs explorer doc - remove processes in listed tabs

### DIFF
--- a/content/en/infrastructure/containers/amazon_elastic_container_explorer.md
+++ b/content/en/infrastructure/containers/amazon_elastic_container_explorer.md
@@ -103,7 +103,6 @@ Other tabs provide additional information for troubleshooting the selected resou
 * [**Logs**][5]: Access logs from your container or resource. Click on any log entry to view the full log details in the Log Explorer.
 * [**Metrics**][6]: View live metrics for your container or resource. You can maximize any graph for full-screen viewing, share a snapshot, or export it from this tab.
 * [**APM**][7]: Access traces from your container or resource, including details such as date, service, duration, method, and status code.
-* **Processes**: See all processes running in the resource's containers.
 * **Network**: View network performance metrics for a container or resource, including source and destination, sent and received volume, and throughput. Use the **Destination** field to filter by tags like `DNS` or `ip_type`, or use the **Group by** filter to group network data by tags, such as `task_name` or `service`.
 * **Monitors**: View monitors that are tagged, scoped, or grouped for this resource.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Processes tab doesn't exist anymore => they have been added to the RelatedEntityTable above
![Screenshot 2025-02-19 at 17 35 41](https://github.com/user-attachments/assets/390bc4c5-22fa-449c-9ae3-576266e8f62f)

| [Before](https://docs.datadoghq.com/infrastructure/containers/amazon_elastic_container_explorer/?tab=taskdefinition) | After |
|--------|--------|
| <img width="798" alt="Screenshot 2025-02-19 at 17 37 06" src="https://github.com/user-attachments/assets/5ec87375-3f88-43b0-91c1-e5ec8c36ef4b" /> | Cell |


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
