### PR TITLE
[SYNTH-18459] Add Synthetics Mobile IP ranges for HTTP steps

### DIFF
--- a/content/en/synthetics/mobile_app_testing/mobile_app_tests/restricted_networks.md
+++ b/content/en/synthetics/mobile_app_testing/mobile_app_tests/restricted_networks.md
@@ -41,6 +41,19 @@ The following is the list of IP ranges associated with the real devices used for
 `185.94.24.0/22`</br>
 `34.96.70.78`</br>
 
+The following is the list of IP ranges associated with Synthetics Mobile HTTP steps. Please disregard if your company does not use this feature.
+
+`52.13.151.244/32`<br>
+`54.201.250.26/32`<br>
+`44.236.137.143/3`<br>
+`52.35.189.191/32`<br>
+`34.208.32.189/32`<br>
+`52.35.61.232/32`<br>
+`52.89.221.151/3`<br>
+`3.120.223.25/32`<br>
+`3.121.24.234/32`<br>
+`18.195.155.52/32`<br>
+
 ## Troubleshooting
 
 If you experience issues with Mobile App Testing on restricted networks, use the following troubleshooting guidelines. If you need further assistance, contact [Datadog support][1].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This updates the list of IP ranges that Synthetics Mobile customers with restrictive networks have to allow in order to use the new (still unreleased) HTTP steps feature.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->
Waiting for the Synthetics Mobile HTTP steps to be released (ETA week of February 24th)
Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
