### PR TITLE
correct datadog-ci sourcemaps examples

### DIFF
--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -97,9 +97,9 @@ The best way to upload source maps is to add an extra step in your CI pipeline a
 
    ```bash
    datadog-ci sourcemaps upload /path/to/dist \
-     --service=my-service \
-     --release-version=v35.2395005 \
-     --minified-path-prefix=https://hostname.com/static/js
+     --service my-service \
+     --release-version v35.2395005 \
+     --minified-path-prefix https://hostname.com/static/js
    ```
 
 
@@ -113,9 +113,9 @@ The best way to upload source maps is to add an extra step in your CI pipeline a
 4. Run the following command once per service in your application:
    ```bash
    datadog-ci sourcemaps upload /path/to/dist \
-     --service=my-service \
-     --release-version=v35.2395005 \
-     --minified-path-prefix=https://hostname.com/static/js
+     --service my-service \
+     --release-version v35.2395005 \
+     --minified-path-prefix https://hostname.com/static/js
    ```
 
 


### PR DESCRIPTION
Correct invalid examples of `datadog-ci sourcemaps` usage.

### What does this PR do? What is the motivation?
https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps has examples which result in errors when you run them. https://github.com/DataDog/datadog-ci/blob/master/src/commands/sourcemaps/README.md, for comparison, has a correct example. Update the examples to use a correct arguments syntax.

### Merge instructions

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```
