### PR TITLE
Clarify the known issue regarding Inferred services metrics in 7.57.x.

### DIFF
--- a/content/en/tracing/services/inferred_services.md
+++ b/content/en/tracing/services/inferred_services.md
@@ -27,7 +27,8 @@ Starting from version [7.60.0][1] of the Datadog Agent, these configurations are
 {{% tab "Agent v7.55.1+" %}}
 
 For Datadog Agent versions [7.55.1][2] or later, add the following to your `datadog.yaml` configuration file:
-If you use 7.57.x, please update to 7.58.x or above. 7.57.x contains the bug that was resolved by https://github.com/DataDog/datadog-agent/pull/28370.
+
+**Note**: Update to 7.58.x or later to avoid [a bug with the `apm_config.compute_stats_by_span_kind` setting][4].
 
 {{< code-block lang="yaml" filename="datadog.yaml" collapsible="true" >}}
 
@@ -80,6 +81,7 @@ If you are using Helm, include these environment variables in your `values.yaml`
 [1]: https://github.com/DataDog/datadog-agent/releases/tag/7.50.3
 [2]: https://github.com/DataDog/datadog-agent/releases/tag/7.54.1
 [3]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml
+[4]: https://github.com/DataDog/datadog-agent/pull/28370
 {{% /tab %}}
 {{% tab "OpenTelemetry Collector" %}}
 

--- a/content/en/tracing/services/inferred_services.md
+++ b/content/en/tracing/services/inferred_services.md
@@ -27,6 +27,7 @@ Starting from version [7.60.0][1] of the Datadog Agent, these configurations are
 {{% tab "Agent v7.55.1+" %}}
 
 For Datadog Agent versions [7.55.1][2] or later, add the following to your `datadog.yaml` configuration file:
+If you use 7.57.x, please update to 7.58.x or above. 7.57.x contains the bug that was resolved by https://github.com/DataDog/datadog-agent/pull/28370.
 
 {{< code-block lang="yaml" filename="datadog.yaml" collapsible="true" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

In version 7.57.x, Inferred services metrics are not available.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
