### PR TITLE
Remove redundant note about custom metrics

### DIFF
--- a/content/en/metrics/custom_metrics/_index.md
+++ b/content/en/metrics/custom_metrics/_index.md
@@ -46,7 +46,7 @@ The following are also considered custom metrics:
 - In general, any metric submitted through [DogStatsD][3] or through a [custom Agent Check][4]
 - Metrics submitted by [Marketplace integrations][29]
 - Certain [standard integrations](#standard-integrations) can potentially emit custom metrics
-- Metrics submitted from an integration that is not one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1]. **Note**: Marketplace integrations emit custom metrics.
+- Metrics submitted from an integration that is not one of the [more than {{< translate key="integration_count" >}} Datadog integrations][1].
 
 **Note**: Users with the Datadog Admin role or `usage_read` permission can see the monthly average number of custom metrics per hour and the top 5000 custom metrics for their account in the [usage details page][5]. Learn more about [how custom metrics are counted][6].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The note "Marketplace integrations emit custom metrics." is redundant because the previous bullet point "Metrics submitted by Marketplace integrations" already conveys the same information. This PR removes the unnecessary note to improve clarity and avoid duplication in the documentation.

Let me know if you’d like any refinements! 🚀

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
