### PR TITLE
📝 [LOGSAC-845] Add private action runners events to audit docs

### DIFF
--- a/content/en/account_management/audit_trail/events.md
+++ b/content/en/account_management/audit_trail/events.md
@@ -46,6 +46,7 @@ further_reading:
 - [Workflows](#workflow-events)
 - [App Datastore](#app-datastore)
 - [Event Management](#event-management)
+- [Private Action Runners](#private-action-runners)
 
 
 See the [Audit Trail documentation][2] for more information on setting up and configuring Audit Trail.
@@ -306,6 +307,13 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 | [Correlation pattern][118] | A user created a correlation pattern. | `@evt.name:"Event Management" @asset.type:event_correlation_pattern` |
 | [Custom metrics][119] | A user created modified or deleted a custom metric. | `@evt.name:"Event Management" @asset.type:custom_metrics` |
 
+### Private Action Runners
+| Name                     | Description of audit event                                          | Query in audit explorer                           |
+| ------------------------ | ------------------------------------------------------------------- | --------------------------------------------------|
+| [Private action runner][120] | A user successfully accessed, created, deleted, or modified a runner, or a user attached a runner to a connection. | `@evt.name:"Private Action Runners" @asset.type:private_action_runner @action:(accessed OR created OR deleted OR modified OR attached)` |
+| [Query intent][121] | A user successfully created a query intent, or a runner successfully validated a query intent. | `@evt.name:"Private Action Runners" @asset.type:query_intent @action:(validated OR created)` |
+| [Runner enrollment token][122] | A user successfully created a runner enrollment token, or a runner successfully completed enrollment. | `@evt.name:"Private Action Runners" @asset.type:runner_enrollment @action:(completed OR created)` |
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -429,3 +437,6 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 [117]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Apps%20Datastore%22%20%40asset.type%3A%28item%20OR%20item_query%29%20%40action%3A%28created%20OR%20deleted%20OR%20modified%20OR%20queried%29&agg_m=count&agg_m_source=base&agg_q=%40evt.name&agg_q_source=base&agg_t=count&cols=log_usr.id%2Clog_action%2Clog_evt.name&fromUser=true&messageDisplay=expanded-md&refresh_mode=sliding&stream_sort=desc&top_n=10&top_o=top&viz=stream&x_missing=true&from_ts=1740047539454&to_ts=1740048439454&live=true
 [118]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Event%20Management%22%20%40asset.type%3Aevent_correlation&agg_m=count&agg_m_source=base&agg_q=%40evt.name&agg_q_source=base&agg_t=count&cols=log_usr.id%2Clog_action%2Clog_evt.name
 [119]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Event%20Management%22%20%40asset.type%3Acustom_metrics&agg_m=count&agg_m_source=base&agg_q=%40evt.name
+[120]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Private%20Action%20Runners%22%20%40asset.type%3Aprivate_action_runner%20%40action%3A%28accessed%20OR%20created%20OR%20deleted%20OR%20modified%20OR%20attached%29&agg_m=count&agg_m_source=base&agg_q=%40evt.name&
+[121]:https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Private%20Action%20Runners%22%20%40asset.type%3Aquery_intent%20%40action%3A%28validated%20OR%20created%29&agg_m=count&agg_m_source=base&agg_q=%40evt.name
+[122]:https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Private%20Action%20Runners%22%20%40asset.type%3Arunner_enrollment%20%40action%3A%28completed%20OR%20created%29&agg_m=count&agg_m_source=base&agg_q=%40evt.name


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Add missing documentation for event management event to audit docs
Document containing all the information: https://docs.google.com/document/d/1r9_0KGe93X1a1pFS4Zfe32joke6d-iGP6YNFG54wGAI/edit?tab=t.0

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
