### PR TITLE
Add UTMs to DASH link in announcement banner

### DIFF
--- a/config/_default/params.en.yaml
+++ b/config/_default/params.en.yaml
@@ -5,5 +5,5 @@ disclaimer: "This page is not yet available in English. We are working on its tr
 announcement_banner:
   desktop_message: "Join us in NYC for the observability event of the year, DASH! June 10-11"
   mobile_message: "Join us in NYC for DASH! June 10-11"
-  external_link: "https://www.dashcon.io/"
+  external_link: "https://www.dashcon.io/?utm_source=inbound&utm_medium=corpsite-display&utm_campaign=summit-202506dash&utm_term=banner"
 translate_status_banner: "This translation isn't up-to-date. For the latest English version, click here"

--- a/config/_default/params.ja.yaml
+++ b/config/_default/params.ja.yaml
@@ -1,7 +1,7 @@
 announcement_banner:
   desktop_message: "Join us in NYC for the observability event of the year, DASH! June 10-11"
   mobile_message: "Join us in NYC for DASH! June 10-11"
-  external_link: "https://www.dashcon.io/"
+  external_link: "https://www.dashcon.io/?utm_source=inbound&utm_medium=corpsite-display&utm_campaign=summit-202506dash&utm_term=banner"
 disclaimer: このページは日本語には対応しておりません。随時翻訳に取り組んでいます。<br>翻訳に関してご質問やご意見ございましたら、<a href="https://docs.datadoghq.com/fr/help/">お気軽にご連絡ください</a>。
 meta_description: Datadogが大規模なクラウドのモニタリングサービスをリードします。
 meta_title: Datadogを始めてみましょう


### PR DESCRIPTION
### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/WEB-5938: Adds UTMs to announcement banner link to DASH site

### Merge instructions
Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
Homepage: https://docs-staging.datadoghq.com/davidweid/update-announcement-banner-link/
