### PR TITLE
RUM-mobile - Add SDWebImage to supported integrations

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/integrated_libraries.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/integrated_libraries.md
@@ -41,7 +41,23 @@ URLSessionInstrumentation.enable(with: .init(delegateClass: Apollo.URLSessionCli
 ```
 For additional information on sampling rate, distributed tracing, and adding custom attributes to tracked RUM resources, refer to [Advanced Configuration > Automatically track network requests][4].
 
+## SDWebImage
+
+Starting from version `2.5.0`, the RUM iOS SDK can automatically track [SDWebImage][5] requests.
+
+1. Configure RUM monitoring by following the [Setup][2] guide.
+2. Enable `URLSessionInstrumentation` for `SDWebImageDownloader`:
+
+```swift
+import SDWebImage
+import DatadogRUM
+
+URLSessionInstrumentation.enable(with: .init(delegateClass: SDWebImageDownloader.self as! URLSessionDataDelegate.Type))
+```
+For additional information on sampling rate, distributed tracing, and adding custom attributes to tracked RUM resources, refer to [Advanced Configuration > Automatically track network requests][4].
+
 [1]: https://github.com/Alamofire/Alamofire
 [2]: https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/ios/setup
 [3]: https://github.com/apollographql/apollo-ios
 [4]: /real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration/#automatically-track-network-requests
+[5]: https://github.com/SDWebImage/SDWebImage

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/integrated_libraries.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/integrated_libraries.md
@@ -54,7 +54,7 @@ import DatadogRUM
 
 URLSessionInstrumentation.enable(with: .init(delegateClass: SDWebImageDownloader.self as! URLSessionDataDelegate.Type))
 ```
-For additional information on sampling rate, distributed tracing, and adding custom attributes to tracked RUM resources, refer to [Advanced Configuration > Automatically track network requests][4].
+For additional information on sampling rate, distributed tracing, and adding custom attributes to tracked RUM resources, see [Advanced Configuration > Automatically track network requests][4].
 
 [1]: https://github.com/Alamofire/Alamofire
 [2]: https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/ios/setup


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adding `SDWebImage` as one of the supported libraries in RUM network instrumentation, along `Alamofire` and `Apollo GraphQL`. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
