### PR TITLE
Fix description for is_less function

### DIFF
--- a/content/en/metrics/nested_queries.md
+++ b/content/en/metrics/nested_queries.md
@@ -249,7 +249,7 @@ In the UI or JSON tab, it would look as follows:
 {{% /collapse-content %}} 
 
 {{% collapse-content title="is_less() example query" level="h5" %}}
-`is_less()` returns 1.0 for each point where the query is greater than a constant of 30 and 0.0 elsewhere.
+`is_less()` returns 1.0 for each point where the query is less than a constant of 30 and 0.0 elsewhere.
 
 In the UI or JSON tab, it would look as follows:
 {{< img src="/metrics/nested_queries/is_less_ui.png" alt="example of is_less mapping function in UI" style="width:100%;" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
@Stoovles flagged a typo in our docs - the descriptions for `is_greater` and `is_less` were the same. This PR makes them different 🙂 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
