### PR TITLE
Remove extraneous `=` character from Code Security Guides page

### DIFF
--- a/content/en/security/code_security/guides/_index.md
+++ b/content/en/security/code_security/guides/_index.md
@@ -9,4 +9,4 @@ disable_toc: false
 {{< whatsnext desc="" >}}
     {{< nextlink href="/security/code_security/guides/automate_risk_reduction_sca/" >}}Automate open source risk reduction with Datadog SCA{{< /nextlink >}}
 
-{{< /whatsnext >}}=
+{{< /whatsnext >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
There's an unnecessary `=` character on the Code Security > Guides page. This PR removes it to keep the page clean.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
