### PR TITLE
Add WebStorm as supported IDE

### DIFF
--- a/content/en/developers/ide_plugins/_index.md
+++ b/content/en/developers/ide_plugins/_index.md
@@ -11,7 +11,7 @@ aliases:
 Use Datadog plugins in your preferred integrated development environment (IDE) to interact with Datadog services as you code.
 
 {{< whatsnext desc="See the documentation for information about the following integrations:">}}
-    {{< nextlink href="developers/ide_plugins/idea/" >}}<u>JetBrains IDEs</u>: The Datadog plugin for IntelliJ IDEA, GoLand, PhpStorm, and PyCharm.{{< /nextlink >}}
+    {{< nextlink href="developers/ide_plugins/idea/" >}}<u>JetBrains IDEs</u>: The Datadog plugin for IntelliJ IDEA, GoLand, PyCharm, WebStorm, and PhpStorm.{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/vscode/" >}}<u>Visual Studio Code</u>: The Datadog extension for VS Code.{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/visual_studio/" >}}<u>Visual Studio</u>: The Datadog extension for .NET developers.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/developers/ide_plugins/idea/_index.md
+++ b/content/en/developers/ide_plugins/idea/_index.md
@@ -21,7 +21,7 @@ further_reading:
 
 ## Overview
 
-The Datadog plugin for JetBrains IDEs is available for IntelliJ IDEA, GoLand, PhpStorm, and PyCharm. It helps you improve software performance by providing meaningful code-level insights directly in the IDE based on real-time observability data.
+The Datadog plugin for JetBrains IDEs is available for IntelliJ IDEA, GoLand, PyCharm, WebStorm, and PhpStorm. It helps you improve software performance by providing meaningful code-level insights directly in the IDE based on real-time observability data.
 
 {{< img src="/developers/ide_plugins/idea/overview1.png" alt="The Datadog tool window open in IDEA" style="width:100%;" >}}
 

--- a/content/en/getting_started/code_security/_index.md
+++ b/content/en/getting_started/code_security/_index.md
@@ -44,7 +44,7 @@ Install the [Datadog IDE plugins][5] to run Static Code Analysis (SAST) scans lo
 To start running code scans in your IDE, see the respective documentation for your code editor of choice.
 
 {{< whatsnext desc="See the documentation for information about the following integrations:">}}
-    {{< nextlink href="developers/ide_plugins/idea/#static-analysis" >}}<u>JetBrains IDEs</u>: IntelliJ IDEA, GoLand, PhpStorm, and PyCharm{{< /nextlink >}}
+    {{< nextlink href="developers/ide_plugins/idea/#static-analysis" >}}<u>JetBrains IDEs</u>: IntelliJ IDEA, GoLand, PyCharm, WebStorm, and PhpStorm{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/vscode/#static-analysis" >}}<u>Visual Studio Code</u>{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/visual_studio/#static-analysis" >}}<u>Visual Studio</u>{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/security/code_security/dev_tool_int/ide_plugins/_index.md
+++ b/content/en/security/code_security/dev_tool_int/ide_plugins/_index.md
@@ -11,7 +11,7 @@ disable_toc: false
 [Code Security][1] integrates directly with integrated development environment (IDE) tools to provide real-time feedback on the quality and security of your first-party code as it's being written.
 
 {{< whatsnext desc="See the documentation for information about the following integrations:">}}
-    {{< nextlink href="developers/ide_plugins/idea/#static-analysis" >}}<u>JetBrains IDEs</u>: IntelliJ IDEA, GoLand, PhpStorm, and PyCharm{{< /nextlink >}}
+    {{< nextlink href="developers/ide_plugins/idea/#static-analysis" >}}<u>JetBrains IDEs</u>: IntelliJ IDEA, GoLand, PyCharm, WebStorm, and PhpStorm{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/vscode/#static-analysis" >}}<u>Visual Studio Code</u>{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/visual_studio/#static-analysis" >}}<u>Visual Studio</u>{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Since version 1.8.6 the Datadog Plugin support WebStorm too. Add it to the list of supported JetBrains IDEs.

### Merge instructions

Merge readiness:
- [x] Ready for merge

