### PR TITLE
Update Threat Intel docs to add disposable_email category

### DIFF
--- a/content/en/security/threat_intelligence.md
+++ b/content/en/security/threat_intelligence.md
@@ -86,6 +86,7 @@ Sources, categories, and intents are available as facets and filters on relevant
 | scanner | suspicious | IP addresses | Reputation for scanners | ASM and Cloud SIEM |
 | hosting_proxy | suspicious | IP addresses | Datacenter IPs with a reputation of abuse, such as for distributed credential stuffing attacks | ASM and Cloud SIEM |
 | tor | suspicious | IP addresses  | Corporate policy violations for user activity | ASM and Cloud SIEM |
+| disposable_email | suspicious | Email domain  | Detect product usage from disposable email addresses | ASM |
 
 ### Threat Intelligence Intents
 | Intent | Use Case |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Update Threat Intel docs to add `disposable_email` category
- [Product initiative](https://datadoghq.atlassian.net/wiki/spaces/Attacks/pages/4531947103/New+user+behaviour+-+Disposable+e-mail+use)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
