### PR TITLE
Doc updates to include new FIPS Synthetics PL image

### DIFF
--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -54,7 +54,9 @@ Private locations are Docker containers that you can install anywhere inside you
 
 {{< site-region region="gov" >}}
 
-Customers who require FIPS support should use the [FIPS compliant image][26] on Docker hub.
+If you require FIPS support, use the [FIPS compliant image][26] on Docker hub.
+
+[26]: https://hub.docker.com/repository/docker/datadog/synthetics-private-location-worker-fips/general
 
 {{< /site-region >}}
 
@@ -1016,5 +1018,4 @@ Use [granular access control][24] to limit who has access to your test based on 
 [23]: /continuous_testing/cicd_integrations/configuration
 [24]: /account_management/rbac/granular_access
 [25]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-tutorial.html
-[26]: https://hub.docker.com/repository/docker/datadog/synthetics-private-location-worker-fips/general
 

--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -52,6 +52,12 @@ To use private locations for [Continuous Testing tests][23], you need v1.27.0 or
 
 Private locations are Docker containers that you can install anywhere inside your private network. You can access the [private location worker image][101] on Docker hub. It can run on a Linux-based OS or Windows OS if the [Docker engine][102] is available on your host and can run in Linux containers mode.**\***
 
+{{< site-region region="gov" >}}
+
+Customers who require FIPS support should use the [FIPS compliant image][26] on Docker hub.
+
+{{< /site-region >}}
+
 **\*** **Use and operation of this software is governed by the End User License Agreement available [here][103].**
 
 [101]: https://hub.docker.com/r/datadog/synthetics-private-location-worker
@@ -1010,4 +1016,5 @@ Use [granular access control][24] to limit who has access to your test based on 
 [23]: /continuous_testing/cicd_integrations/configuration
 [24]: /account_management/rbac/granular_access
 [25]: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data-tutorial.html
+[26]: https://hub.docker.com/repository/docker/datadog/synthetics-private-location-worker-fips/general
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
As a part of the FedRAMP High project the Synthetics team has built a new FIPS-compliant Private Location image. Customers who need FIPS compliance with the Datadog product will need to switch to using the new FIPS-compliant image. 

### Merge instructions

Eventually we would like to drop FIPS support from the current image. It is mentioned in a couple of places but [this mention of disabling it](https://github.com/DataDog/documentation/blob/c31c551847134990558abdcba193fee575c8186e/content/en/synthetics/platform/private_locations/configuration.md#L175-L179) would need to have a "after this version this flag is not supported" message. I am also curious if there's a pattern for a deprecation like this? As a part of the PR to update the removal of that flag would I also just add a note that PL versions after and including X.Y.Z are no longer FIPS compliant and customers must use the new image?

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
