### PR TITLE
[DOCS-9879] Add iOS symbols limitation for Error Tracking

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -443,8 +443,8 @@ For more information, see [dSYMs commands][11].
 
 ## Limitations
 
-dSYM files are limited in size to **2 GB** each.
-
+- dSYM files are limited in size to **2 GB** each.
+- Symbols for simulators are not supported. Symbols are only available for crashes on physical iOS and tvOS devices.
 
 ## Test your implementation
 

--- a/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -444,7 +444,7 @@ For more information, see [dSYMs commands][11].
 ## Limitations
 
 - dSYM files are limited in size to **2 GB** each.
-- Symbols for simulators are not supported. Symbols are only available for crashes on physical iOS and tvOS devices.
+- Symbols are not supported for simulators. Symbols are only available for crashes on physical iOS and tvOS devices.
 
 ## Test your implementation
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Per internal feedback, added a limitation to iOS Error Tracking about symbols support

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
