### PR TITLE
dd-trace-js: document instrumentation at *import* time before init

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -59,6 +59,8 @@ After you have completed setup, if you are not receiving complete traces, includ
 
 When using a transpiler such as TypeScript, Webpack, Babel, or others, import and initialize the tracer library in an external file and then import that file as a whole when building your application.
 
+**Note**: `DD_TRACE_ENABLED` is true by default, thus some minimal instrumentation will happen by default **at import time, before initialization**. If you want to fully disable all instrumentation, you may make the import conditional, or (e.g. if impossible because using static / top-level ESM imports) you may explicitly set `DD_TRACE_ENABLED=false`.
+
 #### Option 1: Add the tracer in code
 
 ##### JavaScript


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This is a followup to:

- https://github.com/DataDog/dd-trace-js/issues/5211
- Internal Zendesk support ticket 2029106, where support engineer Emmi acknowledges this behavior, and recommends documenting it explicitly here.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

-