### PR TITLE
add new `ddsql` icon

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -1408,7 +1408,7 @@ menu:
       weight: 1
     - name: DDSQL Editor
       url: ddsql_editor/
-      pre: inventories
+      pre: ddsql
       identifier: ddsql_editor
       parent: platform_heading
       weight: 30000

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module documentation
 go 1.14
 
 require (
-	github.com/DataDog/websites-modules v1.5.1-0.20250224163508-6f0203e90aa5 // indirect
+	github.com/DataDog/websites-modules v1.4.213 // indirect
 	github.com/DataDog/websites-sources v0.0.0-20250117185032-4a2553fdc82d // indirect
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module documentation
 go 1.14
 
 require (
-	github.com/DataDog/websites-modules v1.4.208 // indirect
+	github.com/DataDog/websites-modules v1.5.1-0.20250224163508-6f0203e90aa5 // indirect
 	github.com/DataDog/websites-sources v0.0.0-20250117185032-4a2553fdc82d // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/DataDog/websites-modules v1.5.1-0.20250224163508-6f0203e90aa5 h1:tU330P1tT3kwiQN048XeETqxNZrtSunY6f+tA5l3jZk=
-github.com/DataDog/websites-modules v1.5.1-0.20250224163508-6f0203e90aa5/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.4.213 h1:xB6GmcntxBIGm8MJHuBn3dNUl0W2c/iO2bieR2azuww=
+github.com/DataDog/websites-modules v1.4.213/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
 github.com/DataDog/websites-sources v0.0.0-20250117185032-4a2553fdc82d h1:1lr/eHDZbd5deqAdEK6TLFuDbwX7QVy8Z8NVVFmlXCI=
 github.com/DataDog/websites-sources v0.0.0-20250117185032-4a2553fdc82d/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/DataDog/websites-modules v1.4.208 h1:229NbMXeXJ5ndgbDdVMX+HtANm60bdh4qpYh84pKEiQ=
-github.com/DataDog/websites-modules v1.4.208/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
+github.com/DataDog/websites-modules v1.5.1-0.20250224163508-6f0203e90aa5 h1:tU330P1tT3kwiQN048XeETqxNZrtSunY6f+tA5l3jZk=
+github.com/DataDog/websites-modules v1.5.1-0.20250224163508-6f0203e90aa5/go.mod h1:CcQxAmCXoiFr3hNw6Q+1si65C3uOP1gB+7aX4S3h+CQ=
 github.com/DataDog/websites-sources v0.0.0-20250117185032-4a2553fdc82d h1:1lr/eHDZbd5deqAdEK6TLFuDbwX7QVy8Z8NVVFmlXCI=
 github.com/DataDog/websites-sources v0.0.0-20250117185032-4a2553fdc82d/go.mod h1:RvGhXV0uQC6Ocs+n84QyL97kows6vg6VG5ZLQMHw4Fs=


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
(Generated by websites-modules)

add new ddsql icon to top level DDSQL Editor menu item

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

motivation: https://datadoghq.atlassian.net/browse/WEB-6061

preview: https://docs-staging.datadoghq.com/websites-modules/generated/395/ddsql_editor/
- check that left menu has new icon

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
