### PR TITLE
docs(ko): change Commonly Used Log Scrubbing Rules link

### DIFF
--- a/content/ko/agent/logs/advanced_log_collection.md
+++ b/content/ko/agent/logs/advanced_log_collection.md
@@ -858,6 +858,6 @@ Datadog 에이전트에서 수집하는 모든 로그는 전역 처리 규칙의
 [1]: /ko/agent/logs/
 [2]: https://golang.org/pkg/regexp/syntax/
 [3]: https://github.com/DataDog/datadog-agent/blob/a27c16c05da0cf7b09d5a5075ca568fdae1b4ee0/pkg/logs/internal/decoder/auto_multiline_handler.go#L187
-[4]: /ko/agent/faq/commonly-used-log-processing-rules
+[4]: /ko/logs/guide/commonly-used-log-processing-rules
 [5]: /ko/agent/configuration/agent-configuration-files/#agent-main-configuration-file
 [6]: /ko/agent/configuration/agent-commands/#agent-information


### PR DESCRIPTION
- change from `ko/agent/faq/commonly-used-log-processing-rules` to `/ko/logs/guide/commonly-used-log-processing-rules`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR fixes a broken link in the documentation.  
The existing link `/ko/agent/faq/commonly-used-log-processing-rules` was returning a **404 NOT FOUND** error.  
It has been updated to `/ko/logs/guide/commonly-used-log-processing-rules/`, which is the correct URL.  

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->
- No functional code changes, only documentation updates.  
- Please review and approve when ready.  
<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
