### PR TITLE
Update otlphttp config for OTLP direct ingest endpoints

### DIFF
--- a/content/en/opentelemetry/otlp_endpoint.md
+++ b/content/en/opentelemetry/otlp_endpoint.md
@@ -14,7 +14,7 @@ further_reading:
 ---
 {{< callout header="false" btn_hidden="true">}}
   The Datadog OTLP traces intake endpoint is in Preview.
-{{< /callout >}} 
+{{< /callout >}}
 
 {{< site-region region="ap1,gov" >}}
 <div class="alert alert-warning">Datadog OTLP traces intake endpoint is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
@@ -66,7 +66,7 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto'
 const exporter = new OTLPTraceExporter({
   url: '${YOUR_ENDPOINT}', // Replace this with the correct endpoint
   headers: {
-    'dd-protocol': 'otlp', 
+    'dd-protocol': 'otlp',
     'dd-api-key': process.env.DD_API_KEY,
     'dd-otel-span-mapping': '{span_name_as_resource_name: true}',
     'dd-otlp-source': '${YOUR_SITE}', // Replace this with the correct site
@@ -109,7 +109,7 @@ traceExporter, err := otlptracehttp.New(
 	otlptracehttp.WithURLPath("/api/v0.2/traces"),
 	otlptracehttp.WithHeaders(
 		map[string]string{
-			"dd-protocol": "otlp", 
+			"dd-protocol": "otlp",
 			"dd-api-key": os.Getenv("DD_API_KEY"),
 			"dd-otel-span-mapping": "{span_name_as_resource_name: true}",
       "dd-otlp-source": "${YOUR_SITE}", // Replace this with the correct site
@@ -130,7 +130,7 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 exporter = OTLPSpanExporter(
     endpoint="${YOUR_ENDPOINT}", # Replace this with the correct endpoint
     headers={
-        "dd-protocol": "otlp", 
+        "dd-protocol": "otlp",
         "dd-api-key": os.environ.get("DD_API_KEY"),
         "dd-otel-span-mapping": "{span_name_as_resource_name: true}",
         "dd-otlp-source": "${YOUR_SITE}" # Replace this with the correct site
@@ -175,7 +175,7 @@ For example, configure your `config.yaml` like this:
 
 exporters:
   otlphttp:
-    endpoint: {{< region-param key="otlp_trace_endpoint" >}}
+    traces_endpoint: {{< region-param key="otlp_trace_endpoint" >}}
     headers:
       dd-protocol: "otlp"
       dd-api-key: ${env:DD_API_KEY}
@@ -197,11 +197,11 @@ service:
 
 If you receive a `403 Forbidden` error when sending traces to the Datadog OTLP traces intake endpoint, it indicates one of the following issues:
 
-- The API key belongs to an organization that is not allowed to access the Datadog OTLP traces intake endpoint.  
+- The API key belongs to an organization that is not allowed to access the Datadog OTLP traces intake endpoint.
    **Solution**: Verify that you are using an API key from an organization that is allowed to access the Datadog OTLP traces intake endpoint.
-- The `dd-otlp-source` header is missing or has an incorrect value.  
+- The `dd-otlp-source` header is missing or has an incorrect value.
    **Solution**: Ensure that the `dd-otlp-source` header is set with the proper value for your site. You should have received an allowlisted value for this header from Datadog if you are a platform partner.
-- The endpoint URL is incorrect for your organization.  
+- The endpoint URL is incorrect for your organization.
    **Solution**: Use the correct endpoint URL for your organization. Your site is {{< region-param key=dd_datacenter code="true" >}}, so you need to use the {{< region-param key="otlp_trace_endpoint" code="true" >}} endpoint.
 
 ### Error: 413 Request Entity Too Large
@@ -213,7 +213,7 @@ This error usually occurs when the OpenTelemetry SDK batches too much telemetry 
 **Solution**: Reduce the export batch size of the SDK's batch span processor. Here's an example of how to modify the `BatchSpanProcessorBuilder` in the OpenTelemetry Java SDK:
 
 ```java
-CopyBatchSpanProcessor batchSpanProcessor = 
+CopyBatchSpanProcessor batchSpanProcessor =
     BatchSpanProcessor
         .builder(exporter)
         .setMaxExportBatchSize(10)  // Default is 512

--- a/content/en/opentelemetry/otlp_metrics.md
+++ b/content/en/opentelemetry/otlp_metrics.md
@@ -24,7 +24,7 @@ further_reading:
 
 {{< callout header="false" btn_hidden="true">}}
   The Datadog OTLP metrics intake endpoint is in Preview.
-{{< /callout >}} 
+{{< /callout >}}
 
 {{< site-region region="ap1,gov" >}}
 <div class="alert alert-warning">Datadog OTLP metrics intake endpoint is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
@@ -88,7 +88,7 @@ If you are using manual instrumentation with OpenTelemetry SDKs, configure the O
 The JavaScript exporter is [`@opentelemetry/exporter-metrics-otlp-proto`][100]. To configure the exporter, use the following code snippet:
 
 ```javascript
-const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-proto'); 
+const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-proto');
 
 const exporter = new OTLPMetricExporter({
   url: 'https://api.datadoghq.com/api/intake/otlp/v1/metrics',
@@ -231,7 +231,7 @@ For example, your `config.yaml` file would look like this:
 ...
 exporters:
   otlphttp:
-    endpoint: https://api.datadoghq.com/api/intake/otlp/v1/metrics
+    metrics_endpoint: {{< region-param key="otlp_metrics_endpoint" >}}
     headers:
       dd-api-key: ${env:DD_API_KEY}
       dd-otel-metric-config: "{resource_attributes_as_tags: true}"
@@ -253,13 +253,13 @@ service:
 
 If you receive a `403 Forbidden` error when sending metrics to the Datadog OTLP metrics intake endpoint, it indicates one of the following issues:
 
-- The API key belongs to an organization that is not allowed to access the Datadog OTLP metrics intake endpoint.  
+- The API key belongs to an organization that is not allowed to access the Datadog OTLP metrics intake endpoint.
    **Solution**: Verify that you are using an API key from an organization that is allowed to access the Datadog OTLP metrics intake endpoint.
-   
-- The `dd-otlp-source` header is missing or has an incorrect value.  
+
+- The `dd-otlp-source` header is missing or has an incorrect value.
    **Solution**: Ensure that the `dd-otlp-source` header is set with the proper value for your site. You should have received an allowlisted value for this header from Datadog if you are a platform partner.
 
-- The endpoint URL is incorrect for your organization.  
+- The endpoint URL is incorrect for your organization.
    **Solution**: Use the correct endpoint URL for your organization. Your site is {{< region-param key=dd_datacenter code="true" >}}, so you need to use the {{< region-param key="otlp_metrics_endpoint" code="true" >}} endpoint.
 
 ### Error: 413 Request Entity Too Large


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Setting otlphttp endpoint as described in the guide would not work properly - it would result in 404s. If you use the general "endpoint" option in otlphttp exporter, the exporter appends `/v1/traces` or `/v1/metrics` to the given endpoint for each signal, which means the final URL is wrong. Setting `traces_endpoint` and `metrics_endpoint` for their respective signals instead is correct.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
