### PR TITLE
Update Runtime SCA Nginx Requirements

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/nginx.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/nginx.md
@@ -5,20 +5,15 @@ type: multi-code-lang
 code_lang_weight: 40
 ---
 
-## Application Security capabilities support
+## Code Security capabilities support
 
-The following application security capabilities are supported in the nginx integration, for the
+The following code security capabilities are supported in the nginx integration, for the
 specified tracer version:
 
-| Application Security capability        | Minimum nginx module version |
-|----------------------------------------|------------------------------|
-| Threat Detection                       | 1.2.0                        |
-| Threat Protection                      | 1.2.0                        |
-| Customize response to blocked requests | 1.2.0                        |
+| Code Security capability               | Minimum nginx module version |
+|----------------------------------------|------------------------------
 | Software Composition Analysis (SCA)    | not applicable               |
-| Code Security                          | not applicable               |
-| Automatic user activity event tracking | not supported                |
-| API Security                           | not supported                |
+| Runtime Code Analysis (IAST)           | not applicable               |
 
 Please review nginx version 1.2.0 [limitations][1].
 


### PR DESCRIPTION
new PR because old PR (gorkavicente-runtime-sca-nginx-requirements) didn't follow naming convention