### PR TITLE
Update Runtime SCA Ruby Requirements

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/ruby.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/ruby.md
@@ -5,35 +5,27 @@ type: multi-code-lang
 code_lang_weight: 30
 ---
 
-## Application Security capabilities support
+## Code Security capabilities support
 
-The following application security capabilities are supported in the Ruby library, for the specified tracer version:
+The following code security capabilities are supported in the Ruby library, for the specified tracer version:
 
-| Application Security capability  | Minimum Ruby tracer version |
-| -------------------------------- | ----------------------------|
-| Threat Detection  | 1.9.0  |
-| Threat Protection | 1.11.0 |
-| Customize response to blocked requests | 1.15.0 |
-| Software Composition Analysis (SCA) | 1.11.0 |
-| Code Security        | not supported |
-| Automatic user activity event tracking | 1.14.0 |
-| API Security | 1.15.0 |
-
-The minimum tracer version to get all supported application security capabilities for Ruby is 1.15.0.
+| Code Security capability                    | Minimum Ruby tracer version |
+| ------------------------------------------- | ----------------------------|
+| Runtime Software Composition Analysis (SCA) | 1.11.0                      |
+| Runtime Code Analysis (IAST)                | not supported               |
 
 <div class="alert alert-info">If you would like to see support added for any of the unsupported capabilities, or for your Ruby framework, let us know! Fill out <a href="https://forms.gle/gHrxGQMEnAobukfn7">this short form to send details</a>.</div>
 
 ### Supported deployment types
-| Type        | Threat Detection support | Software Composition Analysis |
-|-------------|--------------------------|-------------------------------|
-| Docker      | {{< X >}}                |                               |
-| Kubernetes  | {{< X >}}                |                               |
-| Amazon ECS  | {{< X >}}                |                               |
-| AWS Fargate | {{< X >}}                |                               |
-| AWS Lambda  |                          |                               |
+| Type              | Runtime Software Composition Analysis (SCA) | Runtime Code Analysis (IAST)        |
+|------------------ | ------------------------------------------- | ----------------------------------- |
+| Docker            | <i class="icon-check-bold"></i>             | <i class="icon-check-bold"></i>     |
+| Kubernetes        | <i class="icon-check-bold"></i>             | <i class="icon-check-bold"></i>     |
+| Amazon ECS        | <i class="icon-check-bold"></i>             | <i class="icon-check-bold"></i>     |
+| AWS Fargate       | <i class="icon-check-bold"></i>             | Preview (1.15.0)                    |
+| AWS Lambda        |                                             |                                     |
 
 ## Language and framework compatibility
-
 
 **Supported Ruby interpreters**
 The Datadog Ruby library supports the latest gem for the following Ruby interpreters:
@@ -46,77 +38,29 @@ These are supported on the following architectures:
 - macOS (Darwin) x86-64, arm64
 
 ### Supported web servers
-- Attacker source HTTP request details
 - Tags for the HTTP request (status code, method, etc)
 - Distributed Tracing to see attack flows through your applications
 
-##### Application Security Capability Notes
-- **Code Security** is not supported
-
-| Framework                | Threat Detection supported? | Threat Protection supported? |
-| ------------------------ | ----------- | --------------- |
-| Rack          |  {{< X >}} |  {{< X >}} |
-| Rails         |  {{< X >}} |  {{< X >}} |
-| Sinatra       |  {{< X >}} |  {{< X >}} |
-| Grape         |  {{< X >}} |  {{< X >}} |
-| Unicorn       |  {{< X >}} |  {{< X >}} |
-| Passenger     |  {{< X >}} |  {{< X >}} |
-
-| Framework Web Server    | Minimum Framework Version   |
-| ----------------------- | --------------------------- |
-| Rack                    | 1.1                         |
-| Rails                   | 3.2 (also depends on Ruby version) |
-| Sinatra                 | 1.4                         |
+##### Code Security Capability Notes
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks.
+- **Runtime Code Analysis (IAST)** is not supported
 
 ### Networking framework compatibility
 
-**Networking tracing provides:**
-
-- Distributed tracing through your applications
-- Request-based blocking
-
-##### Application Security Capability Notes
-- **Code Security** is not supported
-
-| Framework         | Threat Detection supported?    | Threat Protection supported?                                              |
-|-------------------|-----------------|--------------------------------------------------------------------------|
-| Rack         | {{< X >}} | {{< X >}}  |
-
-<div class="alert alert-info">If you don't see your framework of choice listed, let us know! Fill out <a href="https://forms.gle/gHrxGQMEnAobukfn7">this short form to send details</a>.</div>
-
+##### Code Security Capability Notes
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks.
+- **Runtime Code Analysis (IAST)** is not supported
 
 ### Data store compatibility
 
 **Datastore tracing provides:**
 
-- SQL attack detection
 - query info (for example, a sanitized query string)
 - error and stacktrace capturing
 
-##### Application Security Capability Notes
-- **Code Security** is not supported
-- **Threat Protection** also works at the HTTP request (input) layer, and so works for all databases by default, even those not listed in the table below.
-
-| Framework         | Threat Detection supported?    | Threat Protection supported?                                              |
-|-------------------|-----------------|--------------------------------------------------------------------------|
-| MongoDB        | {{< X >}} |   {{< X >}}    |
-| Active Record        | {{< X >}} |   {{< X >}}    |
-| MySQL2        | {{< X >}} |   {{< X >}}    |
-| Presto        | {{< X >}} |   {{< X >}}    |
-| Resque        | {{< X >}} |   {{< X >}}    |
-| Sequel        | {{< X >}} |   {{< X >}}    |
-| Elasticsearch     | {{< X >}} |   {{< X >}}    |
-
-### User Authentication Frameworks compatibility
-
-**Integrations to User Authentication Frameworks provide:**
-
-- User login events, including the user IDs
-- Account Takeover detection monitoring for user login events
-
-| Framework         | Minimum Framework Version   |
-|-------------------| --------------------------- |
-| Devise            | 3.2.1
+##### Code Security Capability Notes
+- **Runtime Software Composition Analysis (SCA)** is supported on all databases.
+- **Runtime Code Analysis (IAST)** is not supported
 
 [1]: /tracing/trace_collection/compatibility/ruby/
 [2]: https://www.ruby-lang.org/


### PR DESCRIPTION
new PR because the old PR (gorkavicente-runtime-sca-ruby-requirements) didn't follow naming convention