### PR TITLE
Update Runtime SCA Go Requirements

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/go.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/go.md
@@ -5,32 +5,23 @@ type: multi-code-lang
 code_lang_weight: 20
 ---
 
-## Application Security capabilities
+## Code Security capabilities
 
-The following application security capabilities are supported in the Go library, for the specified tracer version:
+The following code security capabilities are supported in the Go library, for the specified tracer version:
 
-| Application Security capability                   | Minimum Go tracer version |
-| -------------------------------- | ----------------------------|
-| Threat Detection| 1.47.0  |
-| API Security | 1.59.0 |
-| Threat Protection |  1.50.0   |
-| Customize response to blocked requests | 1.53.0 |
-| Software Composition Analysis (SCA) | 1.49.0 |
-| Code Security  | not supported |
-| Automatic user activity event tracking | not supported |
-
-The minimum tracer version to get all supported application security capabilities for Go is 1.59.0.
-
-**Note**: Threat Protection requires enabling [Remote Configuration][1], which is included in the listed minimum tracer version.
+| Code Security capability                    | Minimum Go tracer version   |
+| ------------------------------------------- | ----------------------------|
+| Runtime Software Composition Analysis (SCA) | 1.49.0                      |
+| Runtime Code Analysis (IAST)                | not supported               |
 
 ### Supported deployment types
-| Type        | Threat Detection support | Software Composition Analysis |
-|-------------|--------------------------|-------------------------------|
-| Docker      | {{< X >}}                | {{< X >}}                     |
-| Kubernetes  | {{< X >}}                | {{< X >}}                     |
-| Amazon ECS  | {{< X >}}                | {{< X >}}                     |
-| AWS Fargate | {{< X >}}                | {{< X >}}                     |
-| AWS Lambda  | {{< X >}}                |                               |
+| Type              | Runtime Software Composition Analysis (SCA) | Runtime Code Analysis (IAST)        |
+|------------------ | ------------------------------------------- | ----------------------------------- |
+| Docker            | {{< X >}}                                   | {{< X >}}                           |
+| Kubernetes        | {{< X >}}                                   | {{< X >}}                           |
+| Amazon ECS        | {{< X >}}                                   | {{< X >}}                           |
+| AWS Fargate       | {{< X >}}                                   |                                     |
+| AWS Lambda        |                                             |                                     |
 
 ## Language and framework compatibility
 
@@ -42,13 +33,13 @@ The Datadog Go Tracing Library has a [version support policy][3] defined for Go 
 
 You must be running Datadog Agent v5.21.1+
 
-Starting from tracer version 1.53.0, application security capabilities do not require [CGO][15].
+Starting from tracer version 1.53.0, code security capabilities do not require [CGO][15].
 
 ## Integrations
 
 The Go tracer includes support for the following frameworks, data stores and libraries.
 
-The Go packages listed in this page are relevant for Application Security capabilities. You can also find more tracing integrations in [APM's tracing compatibility page][16].
+The Go packages listed in this page are relevant for Code Security capabilities. You can also find more tracing integrations in [APM's tracing compatibility page][16].
 
 {{< tabs >}}
 {{% tab "v1" %}}
@@ -59,31 +50,15 @@ The Go packages listed in this page are relevant for Application Security capabi
 
 ### Web framework compatibility
 
-| Framework         | Threat Detection supported? | Threat Protection supported? |
-|-------------------|-----------------------------|------------------------------|
-| [net/http][13]     | <i class="icon-check-bold"></i>  | <i class="icon-check-bold"></i> |
-| [Gin][7]          | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [Gorilla Mux][8] | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [gRPC][11]          | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [echo v4][9]     | <i class="icon-check-bold"></i>  | <i class="icon-check-bold"></i> |
-| [echo v3][10]     | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [chi][12] | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [graphql-go][17] | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [gqlgen][18] | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
 
 ### Networking framework compatibility
 
-| Framework             | Threat Detection supported? | Threat Protection supported? |
-|-----------------------|-----------------------------|------------------------------|
-| [gRPC client][11]     | <i class="icon-check-bold"></i>                   | <i class="icon-check-bold"></i> |
-| [net/http client][13] | <i class="icon-check-bold"></i>                   | <i class="icon-check-bold"></i> |
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
 
 ### Data store compatibility
 
-| Framework         | Threat Detection supported?    | Threat Protection supported?                                              |
-|-------------------|-----------------|--------------------------------------------------------------------------|
-| [sql][14]          | <i class="icon-check-bold"></i> |   <i class="icon-check-bold"></i>    |
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
 
 [6]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib
 [7]: https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib/gin-gonic/gin
@@ -108,30 +83,15 @@ The Go packages listed in this page are relevant for Application Security capabi
 
 ### Web framework compatibility
 
-| Framework         | Threat Detection supported? | Threat Protection supported? |
-|-------------------|-----------------------------|------------------------------|
-| [net/http][26]     | <i class="icon-check-bold"></i>  | <i class="icon-check-bold"></i> |
-| [Gin][20]          | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [Gorilla Mux][21] | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [gRPC][24]          | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [echo v4][22]     | <i class="icon-check-bold"></i>  | <i class="icon-check-bold"></i> |
-| [chi][25] | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [graphql-go][17] | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-| [gqlgen][18] | <i class="icon-check-bold"></i> | <i class="icon-check-bold"></i> |
-
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
 
 ### Networking framework compatibility
 
-| Framework             | Threat Detection supported? | Threat Protection supported? |
-|-----------------------|-----------------------------|------------------------------|
-| [gRPC client][24]     | <i class="icon-check-bold"></i>                   | <i class="icon-check-bold"></i> |
-| [net/http client][26] | <i class="icon-check-bold"></i>                   | <i class="icon-check-bold"></i> |
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
 
 ### Data store compatibility
 
-| Framework         | Threat Detection supported?    | Threat Protection supported?                                              |
-|-------------------|-----------------|--------------------------------------------------------------------------|
-| [sql][27]          | <i class="icon-check-bold"></i> |   <i class="icon-check-bold"></i>    |
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
 
 [17]: https://pkg.go.dev/github.com/graphql-go/graphql
 [18]: https://pkg.go.dev/github.com/99designs/gqlgen/graphql


### PR DESCRIPTION
new PR because old PR (gorkavicente-runtime-sca-go-requirements) didn't follow naming convention