### PR TITLE
Update Runtime SCA Java Requirements

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/java.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_runtime/compatibility/java.md
@@ -5,76 +5,63 @@ type: multi-code-lang
 code_lang_weight: 0
 ---
 
-## Application Security capabilities
+## Code Security capabilities
 
-The following application security capabilities are supported in the Java library, for the specified tracer version:
+The following code security capabilities are supported in the Java library, for the specified tracer version:
 
 | Application Security capability  | Minimum Java tracer version |
 | -------------------------------- | ----------------------------|
-| Threat Detection | 1.8.0  |
-| API Security | 1.31.0 |
-| Threat Protection| 1.9.0 |
-| Customize response to blocked requests | 1.11.0 |
-| Software Composition Analysis (SCA) | 1.1.4 |
-| Code Security  | 1.15.0|
-| Automatic user activity event tracking | 1.20.0 |
+| Runtime Software Composition Analysis (SCA) | 1.1.4 |
+| Runtime Code Analysis (IAST)  | 1.15.0|
 
-The minimum tracer version to get all supported application security capabilities for Java is 1.31.0.
+The minimum tracer version to get all supported code security capabilities for Java is 1.15.0.
 
-**Note**: Threat Protection requires enabling [Remote Configuration][2], which is included in the listed minimum tracer version.
+**Note**: **Static Software Composition Analysis (SCA)** and **Static Code Analysis (SAST)** capabilities do not require Datadog's tracing library. Therefore, the requirements listd above do not apply to these two Code Security capabilities.
 
 ### Supported deployment types
-| Type              | Threat Detection support | Software Composition Analysis |
-|-------------------|--------------------------|-------------------------------|
-| Docker            | {{< X >}}                | {{< X >}}                     |
-| Kubernetes        | {{< X >}}                | {{< X >}}                     |
-| Amazon ECS        | {{< X >}}                | {{< X >}}                     |
-| AWS Fargate       | {{< X >}}                | {{< X >}}                     |
-| AWS Lambda        | {{< X >}}                |                               |
-| Azure App Service | {{< X >}}                | {{< X >}}                     |
+| Type              | Runtime Software Composition Analysis (SCA) | Runtime Code Analysis (IAST) |
+|-------------------|---------------------------------------------|------------------------------|
+| Docker            | {{< X >}}                                   | {{< X >}}                    |   
+| Kubernetes        | {{< X >}}                                   | {{< X >}}                    |   
+| Amazon ECS        | {{< X >}}                                   | {{< X >}}                    |   
+| AWS Fargate       | {{< X >}}                                   | Preview (1.15.0)             |
+| AWS Lambda        | not supported                               | not supported                |
+| Azure App Service | {{< X >}}                                   | {{< X >}}                    |   
 
-**Note**: Azure App Service is supported for **web applications only**. Application Security doesn't support Azure Functions.
+**Note**: Azure App Service is supported for **web applications only**. Code Security doesn't support Azure Functions.
 
 ## Language and framework compatibility
 
 ### Supported Java versions
 The Java Tracer supports automatic instrumentation for the following Oracle JDK and OpenJDK JVM runtimes.
 
-| JVM versions | Operating Systems                                                               | Support level                       | Tracer version |
-| -------------| ------------------------------------------------------------------------------- | ----------------------------------- | -------------- |
-| 8 to 17      | Windows (x86-64)<br>Linux (glibc, musl) (arm64, x86-64)<br>MacOS (arm64, x86-64)               | Supported                | Latest         |
+| JVM versions | Operating Systems                                                                     | Support level                       | Tracer version |
+| -------------| ------------------------------------------------------------------------------------- | ----------------------------------- | -------------- |
+| 8 to 17      | Windows (x86-64)<br>Linux (glibc, musl) (arm64, x86-64)<br>MacOS (arm64, x86-64)      | Supported                           | Latest         |
 
 
 Datadog does not officially support any early-access versions of Java.
 
-
-
-
-
-
 ### Web framework compatibility
 
-- Attacker source HTTP request details
 - Tags for the HTTP request (status code, method, etc)
 - Distributed Tracing to see attack flows through your applications
 
-##### Application Security Capability Notes
-- **Software Composition Analysis** is supported on all frameworks
-- If **Code Security** does not support your framework, it will still detect Weak Cipher, Weak Hashing, Insecure Cookie, Cookie without HttpOnly Flag, and Cookie without SameSite Flag vulnerabilities.
+##### Code Security Capability Notes
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
+- If **Runtime Code Analysis (IAST)** does not support your framework, it will still detect Weak Cipher, Weak Hashing, Insecure Cookie, Cookie without HttpOnly Flag, and Cookie without SameSite Flag vulnerabilities.
 
-
-
-| Framework                  | Versions   | Threat Detection supported? | Threat Protection supported? |Code Security? |
-| ----------------------- | ---------- | --------------- | ---------------------------------------------- | ---------------------------------------------- |
-| Grizzly                 | 2.0+       |  {{< X >}} |  {{< X >}} |  {{< X >}} |
-| Glassfish               |            |  {{< X >}} |  {{< X >}} |  {{< X >}} |
-| Java Servlet | 2.3+, 3.0+ |   {{< X >}} |  {{< X >}} |  {{< X >}} |
-| Jetty                   | 7.0-9.x, 10.x    |  {{< X >}} |  {{< X >}} |  {{< X >}} |
-| Spring Boot             | 1.5        |  {{< X >}} |  {{< X >}} |  {{< X >}} |
-| Spring Web (MVC)        | 4.0+       |  {{< X >}} |  {{< X >}} |  {{< X >}} |
-| Spring WebFlux          | 5.0+       |            |            |  {{< X >}} |
-| Tomcat                  | 5.5+       |   {{< X >}} |  {{< X >}} |  {{< X >}} |
-| Vert.x                  | 3.4-3.9.x  |   {{< X >}} |  {{< X >}} |  {{< X >}} |
+| Framework                   | Versions         | Runtime Code Analysis (IAST)      |
+| --------------------------- | ---------------- | --------------------------------- |
+| Grizzly                     | 2.0+             | <i class="icon-check-bold"></i>   |
+| Glassfish                   |                  | <i class="icon-check-bold"></i>   |
+| Java Servlet                | 2.3+, 3.0+       | <i class="icon-check-bold"></i>   |
+| Jetty                       | 7.0-9.x, 10.x    | <i class="icon-check-bold"></i>   |
+| Spring Boot                 | 1.5              | <i class="icon-check-bold"></i>   |
+| Spring Web (MVC)            | 4.0+             | <i class="icon-check-bold"></i>   |
+| Spring WebFlux              | 5.0+             | <i class="icon-check-bold"></i>   |
+| Tomcat                      | 5.5+             | <i class="icon-check-bold"></i>   |
+| Vert.x                      | 3.4-3.9.x        | <i class="icon-check-bold"></i>   |
 
 **Note**: Many application servers are Servlet compatible and are automatically covered by that instrumentation, such as Websphere, Weblogic, and JBoss. Also, frameworks like Spring Boot (version 3) inherently work because they usually use a supported embedded application server, such as Tomcat, Jetty, or Netty.
 
@@ -86,24 +73,21 @@ Datadog does not officially support any early-access versions of Java.
 
 **Networking tracing provides:**
 
-- Distributed tracing through your applications
-- Request-based blocking
-
-##### Application Security Capability Notes
-- **Software Composition Analysis** is supported on all frameworks
-- If **Code Security** does not support your framework, it will still detect Weak Cipher, Weak Hashing, Insecure Cookie, Cookie without HttpOnly Flag, and Cookie without SameSite Flag vulnerabilities.
+##### Code Security Capability Notes
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
+- If **Runtime Code Analysis (IAST)** does not support your framework, it will still detect Weak Cipher, Weak Hashing, Insecure Cookie, Cookie without HttpOnly Flag, and Cookie without SameSite Flag vulnerabilities.
 
 
-| Framework                | Versions    | Threat Detection supported? | Threat Protection supported? | Code Security? |
-| ------------------------ | ----------- | --------------- | ---------------------------------------------- | ---------------------------------------------- |
-| Apache HTTP Client       | 4.0+        |  {{< X >}} |  |  |
-| gRPC                     | 1.5+        |  {{< X >}} |  |  |
-| HttpURLConnection        | all         |  {{< X >}} |  |  |
-| Jax RS Clients           | 2.0+        |  {{< X >}} |  {{< X >}} |  {{< X >}}  |
-| Jersey Server            | 1.9-2.29    |  {{< X >}} |  {{< X >}} |  {{< X >}} |
-| Netty HTTP Server        |  3.8+           |  {{< X >}} |    |  |
-| RESTEasy                 |  3.0.x          |  {{< X >}} |    |  |
-| Spring SessionAwareMessageListener     | 3.1+            |  {{< X >}} |  |  |
+| Framework                              | Versions    | Runtime Code Analysis (IAST)                   |
+| -------------------------------------- | ----------- | ---------------------------------------------- |
+| Apache HTTP Client                     | 4.0+        |                                                |
+| gRPC                                   | 1.5+        |                                                |
+| HttpURLConnection                      | all         |                                                |
+| Jax RS Clients                         | 2.0+        |  <i class="icon-check-bold"></i>               |
+| Jersey Server                          | 1.9-2.29    |  <i class="icon-check-bold"></i>               |
+| Netty HTTP Server                      |  3.8+       |                                                |
+| RESTEasy                               |  3.0.x      |                                                |
+| Spring SessionAwareMessageListener     | 3.1+        |                                                |
 
 <div class="alert alert-info">If you don't see your framework of choice listed, let us know! Fill out <a href="https://forms.gle/gHrxGQMEnAobukfn7">this short form to send details</a>.</div>
 
@@ -113,49 +97,19 @@ Datadog does not officially support any early-access versions of Java.
 
 **Datastore tracing provides:**
 
-- Timing request to response
 - Query info (for example, a sanitized query string)
 - Error and stacktrace capturing
 
-##### Application Security Capability Notes
-- **Software Composition Analysis** is supported on all frameworks
-- **Threat Protection** also works at the HTTP request (input) layer, and so works for all databases by default, even those not listed in the table below.
-- If your framework is not supported below, **Code Security** won’t detect SQL Injection vulnerabilities, but will still detect the rest of vulnerability types listed [here][3].
+##### Code Security Capability Notes
+- **Runtime Software Composition Analysis (SCA)** is supported on all frameworks
+- If your framework is not supported below, **Runtime Code Analysis (IAST)** won’t detect SQL Injection vulnerabilities, but will still detect the rest of vulnerability types listed [here][3].
 
-| Database                | Versions | Threat Detection supported? |  Code Security? |
-| ----------------------- | -------- |  ------------------------| ---------------------------------------------------------------- |
-| Aerospike               | 4.0+     |  {{< X >}} |   |
-| Couchbase               | 2.0+     |  {{< X >}} |   |
-| JDBC                    | N/A      |  {{< X >}} |   {{< X >}} |
-| MongoDB                 | 3.0-4.0+ |  {{< X >}} |   |
-
-`dd-java-agent` is also compatible with common JDBC drivers for Threat Detection, such as:
-
-- Apache Derby
-- Firebird SQL
-- H2 Database Engine
-- HSQLDB
-- IBM DB2
-- MariaDB
-- MSSQL (Microsoft SQL Server)
-- MySQL
-- Oracle
-- Postgres SQL
-- ScalikeJDBC
-
-<div class="alert alert-info">If you don't see your framework of choice listed, let us know! Fill out <a href="https://forms.gle/gHrxGQMEnAobukfn7">this short form to send details</a>.</div>
-
-### User Authentication Frameworks compatibility
-
-**Integrations to User Authentication Frameworks provide:**
-
-- User login events, including the user IDs
-- Account Takeover detection monitoring for user login events
-
-| Framework         | Minimum Framework Version |
-|-------------------|---------------------------|
-| Spring Security   | 5.5+                      |
-
+| Database                | Versions | Runtime Code Analysis (IAST)     |
+| ----------------------- | -------- | -------------------------------- |
+| Aerospike               | 4.0+     |                                  |
+| Couchbase               | 2.0+     |                                  |
+| JDBC                    | N/A      | <i class="icon-check-bold"></i>  |
+| MongoDB                 | 3.0-4.0+ |                                  |
 
 [1]: /tracing/trace_collection/compatibility/java/
 [2]: /agent/remote_config/?tab=configurationyamlfile#enabling-remote-configuration


### PR DESCRIPTION
new PR because old PR (gorkavicente-runtime-sca-java-requirements) doesn't follow naming conventions