### PR TITLE
Add info on snapshots limitations notebooks_legacy.md

### DIFF
--- a/content/en/notebooks/notebooks_legacy.md
+++ b/content/en/notebooks/notebooks_legacy.md
@@ -160,6 +160,8 @@ Notebooks can be grouped into types, giving you quick access to relevant informa
 
 ### Graph snapshots
 
+<div class="alert alert-info">Snapshots are not supported for every widget type as you suspected. Supported widgets will display a yellow SNAPSHOTS label and render the static image. Unsupported widgets will render a live widget just like in the live view.</div>
+
 Notebooks can be set to automatically take snapshots of graphs that might expire. Enable this by clicking **Turn on snapshots** in the cog menu of any notebook. Use the cog menu to view snapshots or turn off automatic snapshots. Turn off automatic snapshots to remove access to existing snapshots.
 
 {{< img src="notebooks/cog_snapshots.png" alt="Cog menu option to turn on snapshots" style="width:100%;">}}

--- a/content/en/notebooks/notebooks_legacy.md
+++ b/content/en/notebooks/notebooks_legacy.md
@@ -160,7 +160,7 @@ Notebooks can be grouped into types, giving you quick access to relevant informa
 
 ### Graph snapshots
 
-<div class="alert alert-info">Snapshots are not supported for every widget type as you suspected. Supported widgets will display a yellow SNAPSHOTS label and render the static image. Unsupported widgets will render a live widget just like in the live view.</div>
+<div class="alert alert-info">Snapshots are not supported for every widget type as you suspected. Supported widgets will display a yellow `SNAPSHOTS` label and render the static image. Unsupported widgets will render a live widget just like in the live view.</div>
 
 Notebooks can be set to automatically take snapshots of graphs that might expire. Enable this by clicking **Turn on snapshots** in the cog menu of any notebook. Use the cog menu to view snapshots or turn off automatic snapshots. Turn off automatic snapshots to remove access to existing snapshots.
 

--- a/content/en/notebooks/notebooks_legacy.md
+++ b/content/en/notebooks/notebooks_legacy.md
@@ -160,7 +160,7 @@ Notebooks can be grouped into types, giving you quick access to relevant informa
 
 ### Graph snapshots
 
-<div class="alert alert-info">Snapshots are not supported for every widget type as you suspected. Supported widgets will display a yellow `SNAPSHOTS` label and render the static image. Unsupported widgets will render a live widget just like in the live view.</div>
+<div class="alert alert-info">Supported widgets display a yellow `SNAPSHOTS` label and render the static image. Unsupported widgets render a live widget just like in the live view.</div>
 
 Notebooks can be set to automatically take snapshots of graphs that might expire. Enable this by clicking **Turn on snapshots** in the cog menu of any notebook. Use the cog menu to view snapshots or turn off automatic snapshots. Turn off automatic snapshots to remove access to existing snapshots.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Snapshots don't work for all widgets and data sources. I found this out the hard way because I glanced over the documentation and got the impression everything could become a snapshot.

This PR adds a notification that informs a notebook editor how to check in snapshots view if all the desired widgets will turn into snapshots.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Honestly, I don't need this to be merged because I can't provide the translations for all languages. I just need something in documentation that will avoid writing my own documentation which might get stale.

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
