### PR TITLE
Fix broken proxy pages

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -125,6 +125,10 @@ code_language_ids:
     notebooks_legacy: "Notebooks (Legacy)"
     notebooks_new: "Notebooks (New)"
     envoy: "Envoy"
+    httpd: "Apache HTTP Server"
+    istio: "Istio"
+    kong: "Kong"
+    nginx: "NGINX"
     gcp-service-extensions: "GCP Service Extensions"
 branch: ""
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Proxy pages got broken from https://github.com/DataDog/documentation/pull/26912 (seemed to accidentally remove the params).
- This change just adds them back.
- These pages are located at /tracing/trace_collection/proxy_setup/

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
