### PR TITLE
Update ruby version for resource based sampling

### DIFF
--- a/content/en/tracing/guide/resource_based_sampling.md
+++ b/content/en/tracing/guide/resource_based_sampling.md
@@ -31,7 +31,7 @@ Language  | Minimum version required
 Java      | [v1.34.0][5]
 Go        | [v1.64.0][6]
 Python    | [v.2.9.0][10]
-Ruby      | [v2.0.0][11]
+Ruby      | [v2.4.0][11]
 Node.js   | [v5.16.0][12]
 PHP       | [v1.4.0][15]
 .NET      | [v.2.53.2][13]
@@ -77,7 +77,7 @@ From the **Service Ingestion Summary**, resources for which the sampling rate ar
 [8]: /tracing/trace_pipeline/ingestion_mechanisms#in-the-agent
 [9]: /tracing/trace_explorer/#live-search-for-15-minutes
 [10]: https://github.com/DataDog/dd-trace-py/releases/tag/v2.9.0
-[11]: https://github.com/DataDog/dd-trace-rb/releases/tag/v2.0.0
+[11]: https://github.com/DataDog/dd-trace-rb/releases/tag/v2.4.0
 [12]: https://github.com/DataDog/dd-trace-js/releases/tag/v5.16.0
 [13]: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v2.53.2
 [14]: https://github.com/DataDog/dd-trace-cpp/releases/tag/v0.2.2


### PR DESCRIPTION
The Ruby Tracer supports resource-based sampling since v2.4.0.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
