### PR TITLE
[dd-trace-go v2] mark v1 maintenance date as tbd

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/go.md
+++ b/content/en/tracing/trace_collection/compatibility/go.md
@@ -33,7 +33,7 @@ The Go Tracer v2 is in Preview! See <a href="/tracing/trace_collection/custom_in
 | Version	| Preview	   | General Availability (GA)	| Maintenance	| End-of-life (EOL) |
 |---------|------------|----------------------------|-------------|-------------------|
 | v2      | 2024-11-27 | TBD     | TBD         | TBD               |
-| v1      | 2018-06-06 | 2018-06-06                 | 2025-02-05  | 2025-12-31        |
+| v1      | 2018-06-06 | 2018-06-06                 | TBD  | 2025-12-31        |
 | v0      | 2016-12-12 | 2016-12-12                 | 2018-06-06  | 2019-06-06        |
 
 | Level	                    |  Support provided                                       |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The maintenance date for dd-trace-go v1 is misleading and incorrect. For now, we mark it as `TBD` until we make v2 GA.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
