### PR TITLE
Update Logs <> Traces correlation documentation for Opentelemetry

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -51,6 +51,9 @@ class CustomDatadogLogProcessor(object):
             # if trace_id > 2**64 store as hex otherwise store the id as an integer
             event_dict["dd.trace_id"] = str(context.trace_id) if context.trace_id < 2**64 else f"{context.trace_id:032x}"
             event_dict["dd.span_id"] = str(context.span_id)
+            event_dict["dd.service"] = span.attributes.get("service.name")
+            event_dict["dd.env"] = span.attributes.get("deployment.environment")
+            event_dict["dd.version"] = span.attributes.get("service.version")
 
         return event_dict        
 # ##########

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -48,6 +48,7 @@ class CustomDatadogLogProcessor(object):
 
         context = current_span.get_span_context() if current_span is not None else None
         if context is not None:
+            event_dict["dd.trace_id"] = str(context.trace_id)
             event_dict["dd.span_id"] = str(context.span_id)
 
         return event_dict        

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -139,7 +139,8 @@ original_formatter = Logger::Formatter.new
 logger.formatter  = proc do |severity, datetime, progname, msg|
   current_span = OpenTelemetry::Trace.current_span(OpenTelemetry::Context.current).context
   
-  dd_trace_id = current_span.trace_id
+  trace_id_int = current_span.trace_id.unpack1('H*').to_i(16)
+  dd_trace_id = trace_id_int < 2**64 ? trace_id_int.to_s : format("%032x", trace_id_int)
   dd_span_id = current_span.span_id.unpack1('H*').to_i(16).to_s
   
   if current_span

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -48,7 +48,8 @@ class CustomDatadogLogProcessor(object):
 
         context = current_span.get_span_context() if current_span is not None else None
         if context is not None:
-            event_dict["dd.trace_id"] = str(context.trace_id)
+            # if trace_id > 2**64 store as hex otherwise store the id as an integer
+            event_dict["dd.trace_id"] = str(context.trace_id) if context.trace_id < 2**64 else f"{context.trace_id:032x}"
             event_dict["dd.span_id"] = str(context.span_id)
 
         return event_dict        

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -21,11 +21,9 @@ further_reading:
   text: 'Ease troubleshooting with cross product correlation.'
 ---
 
-<div class="alert alert-info">If you are using the latest versions of Datadog tracing libraries, Datadog automatically links OpenTelemetry traces and logs using <code>TraceId</code>. If you're using older versions, follow the steps on this page to manually correlate traces and logs.</div>
-
 Connecting OpenTelemetry language SDK logs and traces within Datadog is similar to connecting [Datadog SDK logs and traces][1], with a few additional steps:
 
-1. OpenTelemetry `TraceId` and `SpanId` properties differ from Datadog conventions. Therefore it's necessary to translate `TraceId` and `SpanId` from their OpenTelemetry formats ([a 128bit unsigned int and 64bit unsigned int represented as a 32-hex-character and 16-hex-character lowercase string, respectively][2]) into their Datadog Formats([a 64bit unsigned int][3]). 
+1. Datadog supports the Opentelemetry standard of 128-bit Trace IDs by default, but the `SpanId` formats differ between vendors. Therefore it's necessary to translate the `SpanId` from its OpenTelemetry format ([a 16-hex-character lowercase string][2]) into its Datadog Formats([a 64bit unsigned int][3]). 
 
 2. Ensure your logs are sent as JSON, because your language level logs must be turned into Datadog attributes for trace-log correlation to work.
 
@@ -34,7 +32,7 @@ See the following examples for language-specific information about how to correl
 {{< tabs >}}
 {{% tab "Python" %}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [structlog logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Python application with trace and log correlation][3] in the `trace-examples` GitHub repository.
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates the OpenTelemetry formatted `span_id` into Datadog format. The following example uses the [structlog logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Python application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```python
 # ########## injection.py
@@ -43,14 +41,13 @@ from opentelemetry import trace
 class CustomDatadogLogProcessor(object):
     def __call__(self, logger, method_name, event_dict):
         # An example of adding datadog formatted trace context to logs
-        # from: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/b53b9a012f76c4fc883c3c245fddc29142706d0d/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py#L122-L129 
+        # from: https://github.com/open-telemetry/opentelemetry-python-contrib/blob/b53b9a012f76c4fc883c3c245fddc29142706d0d/exporter/opentelemetry-exporter-datadog/src/opentelemetry/exporter/datadog/propagator.py#L127-L129 
         current_span = trace.get_current_span()
         if not current_span.is_recording():
             return event_dict
 
         context = current_span.get_span_context() if current_span is not None else None
         if context is not None:
-            event_dict["dd.trace_id"] = str(context.trace_id & 0xFFFFFFFFFFFFFFFF)
             event_dict["dd.span_id"] = str(context.span_id)
 
         return event_dict        
@@ -82,7 +79,7 @@ log.info("Example log line with trace correlation info")
 
 {{% tab "Node.js" %}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [winston logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Node.js application with trace and log correlation][3] in the `trace-examples` GitHub repository.
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates the OpenTelemetry formatted `span_id` into Datadog format. The following example uses the [winston logging library][1]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Node.js application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```js
 // ########## logger.js
@@ -96,9 +93,7 @@ const tracingFormat = function () {
   return winston.format(info => {
     const span = opentelemetry.trace.getSpan(opentelemetry.context.active());
     if (span) {
-      const { spanId, traceId } = span.spanContext();
-      const traceIdEnd = traceId.slice(traceId.length / 2);
-      info['dd.trace_id'] = BigInt(`0x${traceIdEnd}`).toString();
+      const { spanId } = span.spanContext();
       info['dd.span_id'] = BigInt(`0x${spanId}`).toString();
     }
     return info;
@@ -133,7 +128,7 @@ logger.info("Example log line with trace correlation info")
 
 {{% tab "Ruby" %}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [Ruby Standard Logging Library][1]. For Rails applications or other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Ruby application with trace and log correlation][3] in the `trace-examples` GitHub repository.
+To manually correlate your traces with your logs, patch the logging module you are using with a processor that translates the OpenTelemetry formatted `span_id` into Datadog format. The following example uses the [Ruby Standard Logging Library][1]. For Rails applications or other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][2]. You can also find [an example OpenTelemetry instrumented Ruby application with trace and log correlation][3] in the `trace-examples` GitHub repository.
 
 ```ruby
 logger = Logger.new(STDOUT)
@@ -142,7 +137,7 @@ original_formatter = Logger::Formatter.new
 logger.formatter  = proc do |severity, datetime, progname, msg|
   current_span = OpenTelemetry::Trace.current_span(OpenTelemetry::Context.current).context
   
-  dd_trace_id = current_span.trace_id.unpack1('H*')[16, 16].to_i(16).to_s
+  dd_trace_id = current_span.trace_id
   dd_span_id = current_span.span_id.unpack1('H*').to_i(16).to_s
   
   if current_span
@@ -165,19 +160,17 @@ logger.info("Example log line with trace correlation info")
 
 {{% tab "Java" %}}
 
-To manually correlate your traces with your logs, first enable the [openTelemetry-java-instrumentation Logger MDC Instrumentation][1]. Then, patch the logging module you are using with a processor that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses [Spring Boot and Logback][2]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][3]. 
+To manually correlate your traces with your logs, first enable the [openTelemetry-java-instrumentation Logger MDC Instrumentation][1]. Then, patch the logging module you are using with a processor that translates the OpenTelemetry formatted `span_id` into Datadog format. The following example uses [Spring Boot and Logback][2]. For other logging libraries, it may be more appropriate to [modify the Datadog SDK examples][3]. 
 
 ```java
 String traceIdValue = Span.current().getSpanContext().getTraceId();
 String traceIdHexString = traceIdValue.substring(traceIdValue.length() - 16 );
-long datadogTraceId = Long.parseUnsignedLong(traceIdHexString, 16);
-String datadogTraceIdString = Long.toUnsignedString(datadogTraceId);
 
 String spanIdHexString = Span.current().getSpanContext().getSpanId();
 long datadogSpanId = Long.parseUnsignedLong(spanIdHexString, 16);
 String datadogSpanIdString = Long.toUnsignedString(datadogSpanId);
 
-logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg dd.trace_id=%X{datadogTraceIdString} dd.span_id=%X{datadogSpanIdString} %n
+logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg dd.trace_id=%X{traceIdHexString} dd.span_id=%X{datadogSpanIdString} %n
 ```
 
 See [Java Log Collection][4] on how to send your Java logs to Datadog.
@@ -203,7 +196,7 @@ For trace and log correlation in PHP, modify the [Datadog SDK PHP examples][1] t
 
 {{% tab "Go" %}}
 
-To manually correlate your traces with your logs, patch the logging module you are using with a function that translates OpenTelemetry formatted `trace_id` and `span_id` into the Datadog format. The following example uses the [logrus Library][1].
+To manually correlate your traces with your logs, patch the logging module you are using with a function that translates the OpenTelemetry formatted `span_id` into Datadog format. The following example uses the [logrus Library][1].
 
 ```go
 package main
@@ -224,8 +217,8 @@ func main() {
 	log.SetFormatter(&log.JSONFormatter{})
 
 	standardFields := log.Fields{
-		"dd.trace_id": convertTraceID(span.SpanContext().TraceID().String()),
-		"dd.span_id":  convertTraceID(span.SpanContext().SpanID().String()),
+		"dd.trace_id": span.SpanContext().TraceID().String(),
+		"dd.span_id":  convertSpanID(span.SpanContext().SpanID().String()),
 		"dd.service":  "serviceName",
 		"dd.env":      "serviceEnv",
 		"dd.version":  "serviceVersion",
@@ -234,7 +227,7 @@ func main() {
 	log.WithFields(standardFields).WithContext(ctx).Info("hello world")
 }
 
-func convertTraceID(id string) string {
+func convertSpanID(id string) string {
 	if len(id) < 16 {
 		return ""
 	}
@@ -261,13 +254,12 @@ func convertTraceID(id string) string {
 
 {{% tab ".NET" %}}
 
-To manually correlate traces with logs, convert the OpenTelemetry `TraceId` and `SpanId` into the format used by Datadog. Add those IDs to your logs under the `dd.trace_id` and `dd.span_id` attributes. The following example uses the [Serilog library][1], and shows how to convert the OpenTelemetry (`System.DiagnosticSource.Activity`) trace and span IDs into Datadog's required format:
+To manually correlate traces with logs, convert the OpenTelemetry `SpanId` into the format used by Datadog. Add the trace ID to your logs along with the converted span ID, under `dd.trace_id` and `dd.span_id` attributes, respectively. The following example uses the [Serilog library][1], and shows how to convert the OpenTelemetry (`System.DiagnosticSource.Activity`) span ID into Datadog's required format:
 
 ```csharp
-var stringTraceId = Activity.Current.TraceId.ToString();
-var stringSpanId = Activity.Current.SpanId.ToString();
+var ddTraceId = Activity.Current.TraceId.ToString();
 
-var ddTraceId = Convert.ToUInt64(stringTraceId.Substring(16), 16).ToString();
+var stringSpanId = Activity.Current.SpanId.ToString();
 var ddSpanId = Convert.ToUInt64(stringSpanId, 16).ToString();
 
 using (LogContext.PushProperty("dd.trace_id", ddTraceId))

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -176,7 +176,10 @@ String spanIdHexString = Span.current().getSpanContext().getSpanId();
 long datadogSpanId = Long.parseUnsignedLong(spanIdHexString, 16);
 String datadogSpanIdString = Long.toUnsignedString(datadogSpanId);
 
-logging.pattern.console = %d{yyyy-MM-dd HH:mm:ss} - %logger{36} - %msg dd.trace_id=%X{traceIdHexString} dd.span_id=%X{datadogSpanIdString} %n
+MDC.put("dd.trace_id", traceIdHexString);
+MDC.put("dd.span_id", datadogSpanIdString);
+
+logger.info("Log Message");
 ```
 
 See [Java Log Collection][4] on how to send your Java logs to Datadog.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR removes any reference to mapping 128bit Otel trace IDs to Datadog 64bit trace IDs, while still maintaining instructions for mapping Otel span IDs to Datadog span IDs.
This documentation is outdated, as 128bit trace IDs have been supported in the Datadog logs backend [for correlating logs and traces] for quite some time. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
