### PR TITLE
Update supported DBM recommendation types

### DIFF
--- a/content/en/database_monitoring/recommendations/index.md
+++ b/content/en/database_monitoring/recommendations/index.md
@@ -101,7 +101,7 @@ Low Disk Space
 
 {{% /tab %}}
 
-{{% tab "Mongo" %}}
+{{% tab "MongoDB" %}}
 
 Unused Index
 : The index has not been used in any execution plans recently.

--- a/content/en/database_monitoring/recommendations/index.md
+++ b/content/en/database_monitoring/recommendations/index.md
@@ -55,6 +55,9 @@ High Impact Blocker
 High Row Count
 : The query returns a large number of rows in its result set.
 
+Unused Index
+: The index has not been used in any execution plans recently.
+
 Long Running Query
 : The query has durations that have exceeded a threshold of 30 seconds.
 
@@ -95,6 +98,13 @@ Low Disk Space
 : The database instance is running low on disk space.
 
 **Note**: The Low Disk Space recommendation is only available for instances hosted on AWS RDS.
+
+{{% /tab %}}
+
+{{% tab "Mongo" %}}
+
+Unused Index
+: The index has not been used in any execution plans recently.
 
 {{% /tab %}}
 


### PR DESCRIPTION
We now support our unused index recommendation for sqlserver and mongo.