### PR TITLE
[INA-7075] Update incident integration settings docs to include Zoom and slack channel bookmarks

### DIFF
--- a/content/en/service_management/incident_management/incident_settings/integrations.md
+++ b/content/en/service_management/incident_management/incident_settings/integrations.md
@@ -28,6 +28,7 @@ Changing your channel name template does not rename any existing incident channe
 
 The following features are available to use with the Incident Management Slack integration. Enable or configure these options in **[Service Management > Incidents > Settings > Integrations][1]**.
 - Mirror Slack channel messages, to import and retain all Slack conversations in the incident timeline. **Note**: This counts every Slack message commenter as a monthly active user. Alternately, push pinned message to your timeline to create a system of record for all incident-related conversations.
+- Add important links from integrations such as Jira and Zoom to the incident channel's bookmarks.
 - You can also automatically add [team members][3] to an incident Slack channel when a team is added to the incident. Only members who have connected their Slack and Datadog accounts by running the "/datadog connect" command in Slack are added to the channel.
 - Automatically archive a Slack channel after a certain amount of time.
 
@@ -41,6 +42,7 @@ In addition to integrating with [Slack][4], Incident Management also integrates 
 - [Webhooks][9] to send incident notifications using webhooks (for example, [sending SMS to Twilio][10]).
 - [Statuspage][11] to create and update Statuspage incidents.
 - [ServiceNow][12] to create a ServiceNow ticket for an incident.
+- [Zoom][13] to create Zoom meetings for an incident.
 
 [1]: https://app.datadoghq.com/incidents/settings#Integrations
 [2]: https://app.datadoghq.com/account/settings#integrations
@@ -54,3 +56,4 @@ In addition to integrating with [Slack][4], Incident Management also integrates 
 [10]: /integrations/webhooks/#sending-sms-through-twilio
 [11]: /integrations/statuspage/
 [12]: /integrations/servicenow/
+[13]: /integrations/zoom_incident_management/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates the documentation for incident integration settings to include:
- The 'Add important links to the incident channel’s bookmarks' setting for Slack channels
  - I'll be referencing this in a future Zoom docs update.
- Zoom integration

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
