### PR TITLE
Add a section for defining rules for process tags

### DIFF
--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -396,7 +396,7 @@ Datadog automatically generates a `command` tag, so that you can filter for:
 
 In addition to all existing host-level tags, processes are tagged by `user`.
 
-#### Containerized environments tags
+#### Containerized environment tags
 
 Furthermore, processes in ECS containers are also tagged by:
 
@@ -426,8 +426,8 @@ You can create rule definitions to add manual tags to processes based on the com
 
 1. On the "Manage Process Tags" tab, select _New Process Tag Rule_ button
 2. Select a process to use as a reference
-3. Use standard grok syntax to define the match criteria for your tag
-4. If validation passes, create a new rule.
+3. Define the parsing and match criteria for your tag
+4. If validation passes, create a new rule
 
 After a rule is created, tags are available for all process command line values that match the rule criteria. These tags are be available in search and can be used in the definition of [Live Process Monitors][6] and [Custom Metrics][13].
 

--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -429,7 +429,7 @@ You can create rule definitions to add manual tags to processes based on the com
 3. Use standard grok syntax to define the match criteria for your tag
 4. If validation passes, create a new rule.
 
-Once defined, tags are available for all process command line values that match the rule criteria. These tags will be available in search and can be used in the definition of [Live Process Monitors][6] and [Custom Metrics][13].
+After a rule is created, tags are available for all process command line values that match the rule criteria. These tags are be available in search and can be used in the definition of [Live Process Monitors][6] and [Custom Metrics][13].
 
 ## Scatter plot
 

--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -420,6 +420,17 @@ If you have configuration for [Unified Service Tagging][4] in place, `env`, `ser
 Having these tags available lets you tie together APM, logs, metrics, and process data.
 **Note**: This setup applies to containerized environments only.
 
+#### Defining rules to create process tags
+
+You can create rule definitions to add manual tags to processes based on the command line.
+
+1. On the "Manage Process Tags" tab, select _New Process Tag Rule_ button
+2. Select a process to use as a reference
+3. Use standard grok syntax to define the match criteria for your tag
+4. If validation passes, create a new rule.
+
+Once defined, tags are available for all process command line values that match the rule criteria. These tags will be available in search and can be used in the definition of [Live Process Monitors][6] and [Custom Metrics][13].
+
 ## Scatter plot
 
 Use the scatter plot analytic to compare two metrics with one another in order to better understand the performance of your containers.
@@ -519,4 +530,5 @@ Processes are normally collected at 10s resolution. While actively working with 
 [10]: /tracing/
 [11]: /network_monitoring/cloud_network_monitoring/network_analytics
 [12]: /agent/configuration/agent-commands/#restart-the-agent
+[13]: /metrics/custom_metrics/
 

--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -394,9 +394,9 @@ Datadog automatically generates a `command` tag, so that you can filter for:
 - Container management software, for example:  `command:docker`, `command:kubelet`)
 - Common workloads, for example:  `command:ssh`, `command:CRON`)
 
-### Aggregating processes
+In addition to all existing host-level tags, processes are tagged by `user`.
 
-[Tagging][3] enhances navigation. In addition to all existing host-level tags, processes are tagged by `user`.
+#### Containerized environments tags
 
 Furthermore, processes in ECS containers are also tagged by:
 
@@ -420,7 +420,7 @@ If you have configuration for [Unified Service Tagging][4] in place, `env`, `ser
 Having these tags available lets you tie together APM, logs, metrics, and process data.
 **Note**: This setup applies to containerized environments only.
 
-#### Defining rules to create process tags
+#### Rules to create custom tags
 
 You can create rule definitions to add manual tags to processes based on the command line.
 

--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -422,7 +422,7 @@ Having these tags available lets you tie together APM, logs, metrics, and proces
 
 You can create rule definitions to add manual tags to processes based on the command line.
 
-1. On the "Manage Process Tags" tab, select _New Process Tag Rule_ button
+1. On the **Manage Process Tags** tab, select _New Process Tag Rule_ button
 2. Select a process to use as a reference
 3. Define the parsing and match criteria for your tag
 4. If validation passes, create a new rule

--- a/content/en/infrastructure/process/_index.md
+++ b/content/en/infrastructure/process/_index.md
@@ -394,8 +394,6 @@ Datadog automatically generates a `command` tag, so that you can filter for:
 - Container management software, for example:  `command:docker`, `command:kubelet`)
 - Common workloads, for example:  `command:ssh`, `command:CRON`)
 
-In addition to all existing host-level tags, processes are tagged by `user`.
-
 #### Containerized environment tags
 
 Furthermore, processes in ECS containers are also tagged by:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
There is a new GA feature for creating custom rules to tag the commandline of processes. This provides guidance on where these rules can be defined and possible use cases.

[CTK-4763
](https://datadoghq.atlassian.net/browse/CTK-4763)
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
