### PR TITLE
Remove random links from Ingestion Control page

### DIFF
--- a/content/en/tracing/trace_pipeline/ingestion_controls.md
+++ b/content/en/tracing/trace_pipeline/ingestion_controls.md
@@ -164,14 +164,14 @@ Find below the minimum tracing library version required for the feature:
 
 Language  | Minimum version required
 ----------|--------------------------
-Java      | [v1.34.0][5]
-Go        | [v1.64.0][6]
-Python    | [v.2.9.0][10]
-Ruby      | [v2.0.0][11]
-Node.js   | [v5.16.0][12]
-PHP       | [v1.4.0][15]
-.NET      | [v.2.53.2][13]
-C++       | [v0.2.2][14]
+Java      | v1.34.0
+Go        | v1.64.0
+Python    | v.2.9.0
+Ruby      | v2.0.0
+Node.js   | v5.16.0
+PHP       | v1.4.0
+.NET      | v2.53.2
+C++       | v0.2.2
 
 ## Managing Datadog Agent ingestion configuration
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The links in the Minimum Version Required column of the table link to seemingly random pages. It seems like they made have previously been specified in a meaningful way, but are now inappropriately re-using random links from elsewhere on the page. This PR removes those links.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```