### PR TITLE
[Synthetics PL] Add new `proxyTestRequestsBypassList` option

### DIFF
--- a/content/en/synthetics/platform/private_locations/configuration.md
+++ b/content/en/synthetics/platform/private_locations/configuration.md
@@ -114,7 +114,7 @@ Proxy URL used by the private location to send test requests to the endpoint. PA
 `proxyTestRequestsBypassList`
 : **Type**: Array of Strings <br>
 **Default**: `none`<br>
-Hosts for which the proxy defined with `proxyTestRequests` will not be used, for example: `--proxyTestRequestsBypassList="example.org" --proxyTestRequestsBypassList="*.com"`.
+Hosts for which the proxy defined with `proxyTestRequests` is not used, for example: `--proxyTestRequestsBypassList="example.org" --proxyTestRequestsBypassList="*.com"`.
 
 ### Advanced configuration
 
@@ -211,7 +211,7 @@ Proxy URL used by the private location to send test requests to the endpoint. PA
 `proxyTestRequestsBypassList`
 : **Type**: Array of Strings <br>
 **Default**: `none`<br>
-Hosts for which the proxy defined with `proxyTestRequests` will not be used, for example: `--proxyTestRequestsBypassList="example.org" --proxyTestRequestsBypassList="*.com"`.
+Hosts for which the proxy defined with `proxyTestRequests` is not used, for example: `--proxyTestRequestsBypassList="example.org" --proxyTestRequestsBypassList="*.com"`.
 
 `--proxyIgnoreSSLErrors`
 : **Type**: Boolean <br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Add the new Synthetics Private Location command option `proxyTestRequestsBypassList` to the documentation.

`proxyTestRequestsBypassList` acts as a bypass list against any proxy defined with `proxyTestRequests`, it can be used for multiple hosts and supports `*`wildcards.


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] [Private Location 1.55.0 is fully released](https://hub.docker.com/layers/datadog/synthetics-private-location-worker/1.55.0/images/sha256-9c63c66e1b210ab2f1b10c736c1c4fea03dc1bdaec502adcbc0fdb2e7220fd76)
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
