### PR TITLE
Update container-images-for-docker-environments.md

### DIFF
--- a/content/en/containers/guide/container-images-for-docker-environments.md
+++ b/content/en/containers/guide/container-images-for-docker-environments.md
@@ -28,13 +28,13 @@ If you are using Docker, there are several container images available through GC
 
 
 [1]: /agent/docker/
-[2]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/agent
+[2]: https://console.cloud.google.com/artifacts/docker/datadoghq/us/gcr.io/agent
 [3]: /developers/dogstatsd/
-[4]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/dogstatsd
+[4]: https://console.cloud.google.com/artifacts/docker/datadoghq/us/gcr.io/dogstatsd
 [5]: /agent/cluster_agent/
-[6]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/cluster-agent
+[6]: https://console.cloud.google.com/artifacts/docker/datadoghq/us/gcr.io/cluster-agent
 [7]: /getting_started/synthetics/private_location/
-[8]: https://console.cloud.google.com/gcr/images/datadoghq/GLOBAL/synthetics-private-location-worker
+[8]: https://console.cloud.google.com/artifacts/docker/datadoghq/us/gcr.io/synthetics-private-location-worker
 {{% /tab %}}
 {{% tab "ECR" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The links in the GCR column lead to the Google Container Registry, but there’s a big notice at the top that the Container Registry is deprecated and will no longer be available after March 18, 2025.

The replacement is the Artifact Registry ([gcr.io/datadoghq](http://gcr.io/datadoghq)).

This PR modifies the link in the GCR column to lead to the Artifact Registry
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
