### PR TITLE
Menu ordering: put secrets below SCA

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6371,7 +6371,7 @@ menu:
       identifier: sec_secret_scanning
       url: /security/code_security/secret_scanning/
       parent: code_security
-      weight: 1
+      weight: 3
     - name: GitHub Actions
       identifier: sec_secret_scanning_github_actions
       url: /security/code_security/secret_scanning/github_actions/
@@ -6386,7 +6386,7 @@ menu:
       identifier: sec_iast
       url: /security/code_security/iast/
       parent: code_security
-      weight: 3
+      weight: 4
     - name: Setup
       identifier: sec_iast_setup
       url: /security/code_security/iast/setup/
@@ -6396,7 +6396,7 @@ menu:
       identifier: dev_tool_int
       url: /security/code_security/dev_tool_int/
       parent: code_security
-      weight: 4
+      weight: 5
     - name: GitHub Pull Requests
       identifier: dev_tool_int_github_pull_requests
       url: /security/code_security/dev_tool_int/github_pull_requests/
@@ -6416,12 +6416,12 @@ menu:
       identifier: sec_code_sec_tshoot
       url: /security/code_security/troubleshooting/
       parent: code_security
-      weight: 5
+      weight: 6
     - name: Guides
       identifier: code_security_guides
       url: /security/code_security/guides/
       parent: code_security
-      weight: 6
+      weight: 7
     - name: Synthetic Testing and Monitoring
       url: synthetics/
       pre: synthetics


### PR DESCRIPTION
## What problem are you trying to solve?

In the menu, `Secrets Scanning` should be below `Software Composition Analysis`

![Screenshot 2025-03-03 at 3 47 45 PM](https://github.com/user-attachments/assets/ffb884fa-c4c7-4e0f-93d5-85c0dea80c7d)

## Solution

Change the menu numbering.


