### PR TITLE
[DJM Airflow on Astro] Remove OL install as it's already there on Astro

### DIFF
--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -172,14 +172,7 @@ For Astronomer customers using Astro, <a href=https://www.astronomer.io/docs/lea
 
 ## Setup
 
-1. Install the OpenLineage provider (`apache-airflow-providers-openlineage`) 1.11.0+ and [`openlineage-python`][8] 1.23.0+. Add the following to your `requirements.txt` file inside your [Astro project][4]:
-
-   ```text
-   apache-airflow-providers-openlineage>=1.11.0
-   openlineage-python>=1.23.0
-   ```
-
-2. To set up the OpenLineage provider, define the following environment variables. You can configure these variables in your Astronomer deployment using either of the following methods:
+1. To set up the OpenLineage provider, define the following environment variables. You can configure these variables in your Astronomer deployment using either of the following methods:
 
     - [From the Astro UI][5]: Navigate to your deployment settings and add the environment variables directly.
     - [In the Dockerfile][11]: Define the environment variables in your `Dockerfile` to ensure they are included during the build process.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Remove the OpenLineage installation guidelines for Airflow DJM on Astronomer as OpenLineage is already there. This streamlines the DJM onboarding and makes sure we don't introduce version conflicts on OpenLineage.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
