### PR TITLE
Add note about parsing support for query-time vs ingest-time

### DIFF
--- a/content/en/logs/log_configuration/parsing.md
+++ b/content/en/logs/log_configuration/parsing.md
@@ -72,6 +72,9 @@ After processing, the following structured log is generated:
 
 ### Matcher and filter
 
+<div class="alert alert-warning"><a href="/logs/workspaces/#transformation-cell">Workspaces</a> and <a href="/logs/explorer/calculated_fields/">Log Explorer</a> only support <em>query-time</em> parsing which includes the following subset of matchers: <strong>date</strong>, <strong>notSpace</strong>, <strong>number</strong>, and <strong>word</strong>.<br><br>
+The matchers on this page are specific to <em>ingest-time</em> <a href="/logs/log_configuration/processors/?tab=ui#grok-parser">Grok Parser</a> functionality.</div>
+
 Here is a list of all the matchers and filters natively implemented by Datadog:
 
 {{< tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Add a note letting customers know that Logs parsing matchers are not universally supported across all Logs products, specifically Log Explore and Workspaces.
- @usmankhan-dd 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
