### PR TITLE
Document DD_TRACE_CLIENT_IP_ENABLED and dd.appsec.enabled in Java config

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -96,6 +96,10 @@ The URL to send traces to. If the [Agent configuration][6] sets `receiver_port` 
 **Default**: `10`<br>
 Timeout in seconds for network interactions with the Datadog Agent.
 
+`dd.trace.client-ip.enabled`
+: **Default**: `false` <br>
+Enable client IP collection from relevant IP headers in HTTP request spans. Automatically enabled when `dd.appsec.enabled=true'.
+
 `dd.trace.header.tags`
 : **Environment Variable**: `DD_TRACE_HEADER_TAGS`<br>
 **Default**: `null`<br>
@@ -288,6 +292,13 @@ When set to `true` db spans get assigned the instance name as the service name
 : **Environment Variable**: `DD_TRACE_DB_CLIENT_SPLIT_BY_HOST` <br>
 **Default**: `false`<br>
 When set to `true` db spans get assigned the remote database hostname as the service name
+
+## ASM
+
+`dd.appsec.enabled`
+: **Environment Variable**: `DD_APPSEC_ENABLED`<br>
+**Default**: `false`<br>
+When `true`, enables Datadog Application Security Monitoring. Additionally, this automatically enables client IP collection (`dd.trace.client-ip.enabled`).
 
 ### Errors
 

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -98,7 +98,7 @@ Timeout in seconds for network interactions with the Datadog Agent.
 
 `dd.trace.client-ip.enabled`
 : **Default**: `false` <br>
-Enable client IP collection from relevant IP headers in HTTP request spans. Automatically enabled when `dd.appsec.enabled=true'.
+Enable client IP collection from relevant IP headers in HTTP request spans. Automatically enabled when `dd.appsec.enabled=true`.
 
 `dd.trace.header.tags`
 : **Environment Variable**: `DD_TRACE_HEADER_TAGS`<br>
@@ -293,12 +293,13 @@ When set to `true` db spans get assigned the instance name as the service name
 **Default**: `false`<br>
 When set to `true` db spans get assigned the remote database hostname as the service name
 
-## ASM
+### ASM
 
 `dd.appsec.enabled`
 : **Environment Variable**: `DD_APPSEC_ENABLED`<br>
 **Default**: `false`<br>
-When `true`, enables Datadog Application Security Monitoring. Additionally, this automatically enables client IP collection (`dd.trace.client-ip.enabled`).
+When `true`, enables Datadog Application Security Monitoring. Additionally, this automatically enables client IP collection (`dd.trace.client-ip.enabled`).<br>
+For more information, see [Enabling ASM for Java][19].
 
 ### Errors
 
@@ -602,3 +603,4 @@ Deprecated since version 1.9.0
 [16]: /tracing/trace_collection/custom_instrumentation/java/otel/
 [17]: /opentelemetry/interoperability/environment_variable_support
 [18]: /tracing/guide/aws_payload_tagging/?code-lang=java
+[19]: /security/application_security/threats/setup/threat_detection/java/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
* Missing documentation for `DD_TRACE_CLIENT_IP_ENABLED` and subsequently `dd.appsec.enabled` in Java config docs.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
