### PR TITLE
fixing a 404 in Software Composition Analysis overview topic

### DIFF
--- a/layouts/partials/code_security/sca-getting-started.html
+++ b/layouts/partials/code_security/sca-getting-started.html
@@ -1,14 +1,14 @@
 {{ $root := . }}
 {{ $supported_languages := slice
-    (dict "name" "Python" "href" "/security/code_security/software_composition_analysis/setup_static#lockfiles" "src" "integrations_logos/python_avatar.svg" "width" "50")
-    (dict "name" "JavaScript" "href" "/security/code_security/software_composition_analysis/setup_static#lockfiles" "src" "integrations_logos/javascript_large.png" "width" "50")
-    (dict "name" "Java" "href" "/security/code_security/software_composition_analysis/setup_static#lockfiles" "src" "integrations_logos/java_avatar.svg" "width" "50")
-    (dict "name" "CSharp" "href" "/security/code_security/software_composition_analysis/setup_static#lockfiles" "src" "integrations_logos/dotnet_avatar.svg" "width" "50")
-    (dict "name" "Go" "href" "/security/code_security/software_composition_analysis/setup_static#lockfiles" "src" "integrations_logos/golang-avatar.png" "width" "60")
-    (dict "name" "Rust" "href" "/security/code_security/software_composition_analysis/setup_static#lockfiles" "src" "integrations_logos/rust.png" "width" "60")
-    (dict "name" "Ruby" "href" "/security/code_security/software_composition_analysis/setup_static#lockfiles" "src" "integrations_logos/ruby_avatar.svg" "width" "45")
-    (dict "name" "PHP" "href" "/security/code_security/software_composition_analysis/setup_static#lockfiles" "src" "integrations_logos/php_opcache.png" "width" "80")
-    (dict "name" "Other" "href" "/security/code_security/software_composition_analysis/setup_static/generic_ci_providers" "src" "integrations_logos/datadog_avatar.svg" "width" "50")
+    (dict "name" "Python" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/python_avatar.svg" "width" "50")
+    (dict "name" "JavaScript" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/javascript_large.png" "width" "50")
+    (dict "name" "Java" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/java_avatar.svg" "width" "50")
+    (dict "name" "CSharp" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/dotnet_avatar.svg" "width" "50")
+    (dict "name" "Go" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/golang-avatar.png" "width" "60")
+    (dict "name" "Rust" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/rust.png" "width" "60")
+    (dict "name" "Ruby" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/ruby_avatar.svg" "width" "45")
+    (dict "name" "PHP" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/php_opcache.png" "width" "80")
+    (dict "name" "Other" "href" "/security/code_security/software_composition_analysis/setup_static" "src" "integrations_logos/datadog_avatar.svg" "width" "50")
 }}
 
 <div class="sca-supported-languages">


### PR DESCRIPTION
- the Datadog card was a 404.
- updated the link to point to https://docs.datadoghq.com/security/code_security/software_composition_analysis/setup_static/
- removes `#lockfiles` from all the links as that anchor no longer  exists

### Merge instructions

Merge readiness:
- [X] Ready for merge

