### PR TITLE
(maint) Redirect broken link

### DIFF
--- a/content/en/agent/basic_agent_usage/_index.md
+++ b/content/en/agent/basic_agent_usage/_index.md
@@ -4,6 +4,7 @@ aliases:
     - /guides/basic_agent_usage/
     - /agent/faq/where-is-the-configuration-file-for-the-agent/
     - /agent/faq/log-location
+    - /agent/basic_agent_usage//
 further_reading:
 - link: "/agent/faq/how-datadog-agent-determines-the-hostname/"
   tag: "FAQ"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

https://docs.datadoghq.com/agent/basic_agent_usage// is 404ing. I don't see an obvious double-slash, but we can at least redirect. 

[This should redirect](https://docs-staging.datadoghq.com/heston/DOCS-10302/agent/basic_agent_usage//)


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
