### PR TITLE
Adding "()" at the end of "ComposeExtensionSupport"

### DIFF
--- a/content/en/real_user_monitoring/session_replay/mobile/setup_and_configuration.md
+++ b/content/en/real_user_monitoring/session_replay/mobile/setup_and_configuration.md
@@ -51,7 +51,7 @@ To set up Mobile Session Replay for Android:
     // in case you need Material extension support
     .addExtensionSupport(MaterialExtensionSupport())
     // in case you need Jetpack Compose support
-    .addExtensionSupport(ComposeExtensionSupport)
+    .addExtensionSupport(ComposeExtensionSupport())
     .build()
    SessionReplay.enable(sessionReplayConfig)
    {{< /code-block >}}


### PR DESCRIPTION
I guess the current content is a typo. I had the error mentioned below on my environment following the current document and I was able to solve it with this PR's correction.
* Error I had: `Cannot access 'Companion': it is internal in 'ComposeExtensionSupport'`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->
You see `MaterialExtensionSupport()` in the same way above the line in question, which works just fine.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
