### PR TITLE
Add link to case management doc

### DIFF
--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -27,7 +27,7 @@ Notifications are a key component of monitors that keep your team informed of is
 Use the **Configure notifications and automations** section to:
 - Send notifications to your team through email, Slack, PagerDuty, and other integrations.
 - Trigger a workflow or create a workflow from a monitor.
-- Add a case to your monitor.
+- [Automatically create a case][19].
 
 ### Title
 
@@ -215,3 +215,4 @@ Message variables auto-populate with a randomly selected group based on the scop
 [16]: /monitors/guide/recovery-thresholds/
 [17]: /service_management/workflows/trigger/#add-a-monitor-trigger-to-your-workflow
 [18]: /monitors/configuration/#set-alert-aggregation
+[19]: /service_management/case_management/create_case/#automatic-case-creation


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Users can automatically create a case from a monitor notification when the monitor transitions. 

Adding a cross link to case management documentation that explains how to do that in details

### Merge instructions

Merge readiness:
- [x] Ready for merge
