### PR TITLE
Update cross org api docs to include auth headers 

### DIFF
--- a/content/en/account_management/org_settings/cross_org_visibility_api.md
+++ b/content/en/account_management/org_settings/cross_org_visibility_api.md
@@ -22,9 +22,9 @@ List all the connections this organization participates in, either as a source o
 https://{datadog_site}/api/v2/org_connections
 
 ### Header
-Content-Type: application/json
-DD-API-KEY: <YOUR_DATADOG_API_KEY>
-DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
+- Content-Type: application/json
+- DD-API-KEY: <YOUR_DATADOG_API_KEY>
+- DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
 
 ## Create a connection
 
@@ -35,9 +35,9 @@ Creates a connection from this organization to the destination organization. You
 **Note:** The payload of this call requires the destination organization UUID. Get the destination organization's UUID from the "List your managed organizations" [endpoint][3].
 
 ### Header
-Content-Type: application/json
-DD-API-KEY: <YOUR_DATADOG_API_KEY>
-DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
+- Content-Type: application/json
+- DD-API-KEY: <YOUR_DATADOG_API_KEY>
+- DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
 
 ### Payload
 
@@ -69,9 +69,9 @@ Deletes a connection. Perform this operation either from the source organization
 <span style="padding:3px" class="font-semibold text-api-delete bg-bg-api-delete">DELETE</span> https://{datadog_site}/api/v2/org_connections/{connection_id}
 
 ### Header
-Content-Type: application/json
-DD-API-KEY: <YOUR_DATADOG_API_KEY>
-DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
+- Content-Type: application/json
+- DD-API-KEY: <YOUR_DATADOG_API_KEY>
+- DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
 
 ### Failure scenarios
 

--- a/content/en/account_management/org_settings/cross_org_visibility_api.md
+++ b/content/en/account_management/org_settings/cross_org_visibility_api.md
@@ -4,7 +4,7 @@ title: Cross-Organization Connections API
 
 {{< callout url="#" btn_hidden="true">}}
   Cross-organization visibility is in beta.
-{{< /callout >}} 
+{{< /callout >}}
 
 [Cross-organization visibility][1] allows customers to share data between different organizations in the same account, and show insights from multiple organizations in one place.
 
@@ -19,19 +19,25 @@ Configure connections through the public API `/api/v2/org_connections` endpoint.
 List all the connections this organization participates in, either as a source organization or as a destination organization. Listing connections requires the _Org Connections Read_ permission.
 
 <span style="padding:3px" class="font-semibold text-api-get bg-bg-api-get">GET</span>
-https://{datadog_site}/api/v2/org_connections?api_key={datadog_api_key}&application_key={datadog_application_key}
+https://{datadog_site}/api/v2/org_connections
+
+### Header
+Content-Type: application/json
+DD-API-KEY: <YOUR_DATADOG_API_KEY>
+DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
 
 ## Create a connection
 
 Creates a connection from this organization to the destination organization. You must perform this operation in the to-be-source organization. Creating connections requires the _Org Connections Write_ permission.
 
-<span style="padding:3px" class="font-semibold text-api-post bg-bg-api-post">POST</span> https://{datadog_site}/api/v2/org_connections?api_key={datadog_api_key}&application_key={datadog_application_key}
+<span style="padding:3px" class="font-semibold text-api-post bg-bg-api-post">POST</span> https://{datadog_site}/api/v2/org_connections
 
 **Note:** The payload of this call requires the destination organization UUID. Get the destination organization's UUID from the "List your managed organizations" [endpoint][3].
 
 ### Header
-
 Content-Type: application/json
+DD-API-KEY: <YOUR_DATADOG_API_KEY>
+DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
 
 ### Payload
 
@@ -60,7 +66,12 @@ Content-Type: application/json
 
 Deletes a connection. Perform this operation either from the source organization or the destination organization. Reference the connection to delete with its ID, which you can get from the [List connections](#list-connections) request. Deleting connections requires the _Org Connections Write_ permission.
 
-<span style="padding:3px" class="font-semibold text-api-delete bg-bg-api-delete">DELETE</span> https://{datadog_site}/api/v2/org_connections/{connection_id}?api_key={datadog_api_key}&application_key={datadog_application_key}
+<span style="padding:3px" class="font-semibold text-api-delete bg-bg-api-delete">DELETE</span> https://{datadog_site}/api/v2/org_connections/{connection_id}
+
+### Header
+Content-Type: application/json
+DD-API-KEY: <YOUR_DATADOG_API_KEY>
+DD-APPLICATION-KEY: <YOUR_DATADOG_APPLICATION_KEY>
 
 ### Failure scenarios
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
When writing synthetic [tests](https://github.com/DataDog/terraform-config/pull/32976/files#diff-00b055ff406ac59521c957be38784622c32facbaf86a39e0259982518b1c4072) for cross org, we noticed that the
[documentation](https://docs.datadoghq.com/account_management/org_settings/cross_org_visibility_api/#api-endpoint) incorrectly stated that api and app key need to be passed in as query parameters. 

The app and api key need to be passed in as request headers for the cross org api to work properly. See linked synthetic test PR for usage of these headers. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
