### PR TITLE
replace multi / in alias with just one

### DIFF
--- a/layouts/_default/list.redirects.txt
+++ b/layouts/_default/list.redirects.txt
@@ -1,7 +1,9 @@
 {{- $pattern := `^security_monitoring/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$|^security/default_rules/([a-zA-Z0-9]{3}-[a-zA-Z0-9]{3}-[a-zA-Z0-9]{3})$` -}}
 {{- range $p := .Site.Pages -}}
     {{- range .Aliases -}}
-        {{- $temp := strings.TrimPrefix "/" . -}}
+        {{- /* Normalize by replacing multi slashes with one */ -}}
+        {{- $temp := (replaceRE `(?m)(\/\/+)` "/" .) -}}
+        {{- $temp = strings.TrimPrefix "/" $temp -}}
         {{- $alias := strings.TrimSuffix "/" $temp -}}
         {{- if not (findRE $pattern $alias) -}}
             {{- $target := strings.TrimSuffix "/" $p.RelPermalink -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

We already deal with leading and trialing slashes from the redirects file aliases. However if multiple `/` exist this ends up creating a bad path via the redirect we generate in a post deploy which in turn conflicts with regular deploys.

This PR normalizes the initial alias string so that multiple slashes just become one and in turn avoid deploy conflicts.
e.g
```
/foo///bar////baz/foo///    ->    /foo/bar/baz/foo/
```

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
