### PR TITLE
Add CakePHP 3.x support

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -101,7 +101,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 
 | Module         | Versions                                | Support Type                | Instrumentation level           |
 |:---------------|:----------------------------------------|:----------------------------|:--------------------------------|
-| CakePHP        | 2.x                                     | All supported PHP versions  | Framework-level instrumentation |
+| CakePHP        | 2.x, 3.x                                | All supported PHP versions  | Framework-level instrumentation |
 | CodeIgniter    | 2.x                                     | All supported PHP versions  | Framework-level instrumentation |
 | CodeIgniter    | 3.x                                     | All supported PHP versions  | Generic web tracing             |
 | Drupal         |                                         | All supported PHP versions  | Framework-level instrumentation |
@@ -133,7 +133,7 @@ Tracing from the CLI SAPI is enabled by default. To selectively disable tracing 
 
 | Module          | Versions            | Support Type               |
 |:----------------|:--------------------|:---------------------------|
-| CakePHP Console | 2.x                 | All supported PHP versions |
+| CakePHP Console | 2.x, 3.x            | All supported PHP versions |
 | Laravel Artisan | 5.x, 8.x, 9.x, 10.x | All supported PHP versions |
 | Symfony CLI     | 4.x, 5.x, 6.x, 7.x  | All supported PHP versions |
 


### PR DESCRIPTION
Support for CakePHP 3.x was added in early 2024: https://github.com/DataDog/dd-trace-php/tree/f514dc232cd52e375ef0f1e387705a5e24515172/src/DDTrace/Integrations/CakePHP

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
