### PR TITLE
 fix page jumps on synced tab navigation

### DIFF
--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -82,8 +82,7 @@ const initCodeTabs = () => {
 
     const scrollToAnchor = (tab, anchorname) => {
         const anchor = document.querySelectorAll(`[data-lang='${tab}'] ${anchorname}`)[0];
-        console.log('tab: ', tab);
-        console.log('scrolling to anchor: ', anchor);
+        
         if (anchor) {
             anchor.scrollIntoView();
         } else {

--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -120,23 +120,20 @@ const initCodeTabs = () => {
                 allTabLinksNodeList.forEach(link => {
                     link.addEventListener('click', e => {
                         e.preventDefault();
-                        const region = getCookieByName('site');
-                        const regionalCodeTabs = codeTabParameters[region];
-                        const targetTop = e.target.getBoundingClientRect().top + window.scrollY;
-                        let offsetY = 0;
+
+                        const previousTabPosition = e.target.getBoundingClientRect().top
+
                         activateCodeTab(link);
                         getContentTabHeight();
-                        for(const [idx, codeTab] of Object.entries(regionalCodeTabs)) {
-                            if (codeTab.elementTop < targetTop && codeTab.elementCurrentHeight > 0) {
-                                offsetY += codeTab.elementHeightDifference;
-                            }
-                        }
+                        
+                        // ensures page doesnt jump when navigating tabs.
+                        // takes into account page shifting that occurs due to navigating tabbed content w/ height changes.
+                        // implementation of synced tabs from https://github.com/withastro/starlight/blob/main/packages/starlight/user-components/Tabs.astro
                         window.scrollTo({
-                            top: window.scrollY + offsetY,
+                            top: (window.scrollY + e.target.getBoundingClientRect().top) - previousTabPosition,
                             behavior: "instant"
                         });
                         getContentTabHeight();
-                        offsetY = 0;
                     })
                 });
             });


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

fixes page jump on synced tab navigation by calculating window Y-axis position based on previously active tab position. (related to [#27974](https://github.com/DataDog/documentation/pull/27974))

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

previews: 
- https://docs-staging.datadoghq.com/stefon.simmons/fix-page-jump-on-tabs2/real_user_monitoring/feature_flag_tracking/setup/?tab=android#flagsmith-integration
- https://docs-staging.datadoghq.com/stefon.simmons/fix-page-jump-on-tabs2/dora_metrics/setup/deployments/?tab=apiorcli#selecting-and-configuring-a-deployment-data-source


Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
