### PR TITLE
Move `Connect Logs and Traces` to Log Guides for better navigation consistency

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -5617,11 +5617,6 @@ menu:
       weight: 3
       params:
         skip: true
-    - name: Connect Logs and Traces
-      url: tracing/other_telemetry/connect_logs_and_traces/
-      parent: log_management
-      identifier: logs_traces_connection
-      weight: 4
     - name: Log Explorer
       url: logs/explorer/
       parent: log_management

--- a/content/en/logs/guide/_index.md
+++ b/content/en/logs/guide/_index.md
@@ -13,6 +13,7 @@ cascade:
 {{< whatsnext desc="Logging Without Limits™" >}}
     {{< nextlink href="logs/guide/access-your-log-data-programmatically" >}}Programmatically access log data using the Logs Search API{{< /nextlink >}}
     {{< nextlink href="logs/guide/getting-started-lwl" >}}Logging Without Limits™ Guide{{< /nextlink >}}
+    {{< nextlink href="tracing/other_telemetry/connect_logs_and_traces" >}}Correlate Logs with Traces{{< /nextlink >}}
     {{< nextlink href="logs/guide/correlate-logs-with-metrics" >}}Correlate Logs with Metrics{{< /nextlink >}}
     {{< nextlink href="logs/guide/best-practices-for-log-management" >}}Best Practices for Log Management{{< /nextlink >}}
     {{< nextlink href="logs/guide/manage_logs_and_metrics_with_terraform" >}}Manage Logs and Metrics with Terraform{{< /nextlink >}}
@@ -22,7 +23,7 @@ cascade:
 
 {{< whatsnext desc="Log Collection" >}}
     {{< nextlink href="/agent/logs/advanced_log_collection" >}}Advanced log collection configurations{{< /nextlink >}}
-    {{< nextlink href="/logs/guide/reduce_data_transfer_fees" >}}How to send logs to Datadog while reducing data transfer fees{{< /nextlink >}}    
+    {{< nextlink href="/logs/guide/reduce_data_transfer_fees" >}}How to send logs to Datadog while reducing data transfer fees{{< /nextlink >}}
     {{< nextlink href="/logs/guide/forwarder/" >}}Set up Datadog Lambda Forwarder{{< /nextlink >}}
     {{< nextlink href="/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function/" >}}Send AWS services logs with the Datadog Lambda function{{< /nextlink >}}
     {{< nextlink href="/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination/" >}}Send AWS services logs with the Datadog Amazon Data Firehose Destination{{< /nextlink >}}
@@ -44,7 +45,7 @@ cascade:
     {{< nextlink href="logs/guide/increase-number-of-log-files-tailed" >}}Increase the Number of Log Files Tailed by the Agent{{< /nextlink >}}
     {{< nextlink href="/logs/guide/container-agent-to-tail-logs-from-host" >}}Use the Container Agent to Tail Logs from the Host{{< /nextlink >}}
     {{< nextlink href="/logs/guide/mechanisms-ensure-logs-not-lost" >}}Mechanisms to Ensure Logs are Not Lost{{< /nextlink >}}
-    {{< nextlink href="/logs/guide/custom-log-file-with-heightened-read-permissions" >}}Send Logs from a Custom Log File with Heightened Read Permissions{{< /nextlink >}} 
+    {{< nextlink href="/logs/guide/custom-log-file-with-heightened-read-permissions" >}}Send Logs from a Custom Log File with Heightened Read Permissions{{< /nextlink >}}
 {{< /whatsnext >}}
 
 <br>
@@ -54,7 +55,7 @@ cascade:
     {{< nextlink href="/logs/guide/commonly-used-log-processing-rules" >}}Commonly Used Log Processing Rules{{< /nextlink >}}
     {{< nextlink href="/logs/guide/logs-not-showing-expected-timestamp" >}}Logs Not Showing the Expected Timestamp{{< /nextlink >}}
     {{< nextlink href="/logs/guide/remap-custom-severity-to-official-log-status" >}}Remap Custom Severity Values to the Official Log Status{{< /nextlink >}}
-    {{< nextlink href="logs/guide/logs-show-info-status-for-warnings-or-errors" >}}Logs Show Info Status for Warnings or Errors{{< /nextlink >}} 
+    {{< nextlink href="logs/guide/logs-show-info-status-for-warnings-or-errors" >}}Logs Show Info Status for Warnings or Errors{{< /nextlink >}}
 {{< /whatsnext >}}
 
 <br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR moves the `Connect Logs and Traces` page from the `Log Management` navigation to the `Log Guides` section.  

#### Motivation
- The `Log Management` section mostly consists of products (such as `Log Explorer`), `Guides` and `Troubleshooting`.  
- `Connect Logs and Traces` describes a procedure, making it misaligned with other items in this section.  
- Placing it under `Log Guides` ensures better categorization and improves navigation clarity.  

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
