### PR TITLE
[NPM-3754] Document how to set up static paths on k8s

### DIFF
--- a/content/en/network_monitoring/cloud_network_monitoring/setup.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/setup.md
@@ -210,8 +210,8 @@ To enable Cloud Network Monitoring for Windows hosts:
 {{% /tab %}}
 {{% tab "Kubernetes" %}}
 
-To enable Cloud Network Monitoring with Kubernetes using Helm, add the following to your `values.yaml` file.</br>
-**Helm chart v2.4.39+ is required**. For more information, see the [Datadog Helm Chart documentation][1].
+To enable Cloud Network Monitoring with Kubernetes using Helm, add the below to your `values.yaml` file.</br>
+**Note:**Helm chart v2.4.39+ **is required**. For more information, see the [Datadog Helm Chart documentation][1].
 
   ```yaml
   datadog:

--- a/content/en/network_monitoring/cloud_network_monitoring/setup.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/setup.md
@@ -211,7 +211,7 @@ To enable Cloud Network Monitoring for Windows hosts:
 {{% tab "Kubernetes" %}}
 
 To enable Cloud Network Monitoring with Kubernetes using Helm, add the below to your `values.yaml` file.</br>
-**Note:**Helm chart v2.4.39+ **is required**. For more information, see the [Datadog Helm Chart documentation][1].
+**Note:** Helm chart v2.4.39+ **is required**. For more information, see the [Datadog Helm Chart documentation][1].
 
   ```yaml
   datadog:

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -150,6 +150,47 @@ instances:
     port: 443 # optional port number, default is 80
 ```
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+To enable Network Path with Kubernetes using Helm, add the below to your `values.yaml` file.</br>
+**Note:** Helm chart v3.109.1+ **is required**. For more information, see the [Datadog Helm Chart documentation][1] and the documentation for [Kubernetes and Integrations][2].
+
+  ```yaml
+  datadog:
+    traceroute:
+      enabled: true
+    confd:
+      network_path.yaml: |-
+        init_config:
+          min_collection_interval: 60 # in seconds, default 60 seconds
+        instances:
+          # configure the endpoints you want to monitor, one check instance per endpoint
+          # warning: Do not set the port when using UDP. Setting the port when using UDP can cause traceroute calls to fail and falsely report an unreachable destination.
+
+          - hostname: api.datadoghq.eu # endpoint hostname or IP
+            protocol: TCP
+            port: 443
+            tags:
+              - "tag_key:tag_value"
+              - "tag_key2:tag_value2"
+          ## optional configs:
+          # max_ttl: 30 # max traderoute TTL, default is 30
+          # timeout: 1000 # timeout in milliseconds per hop, default is 1s
+
+          # more endpoints
+          - hostname: 1.1.1.1 # endpoint hostname or IP
+            protocol: UDP
+            tags:
+              - "tag_key:tag_value"
+              - "tag_key2:tag_value2"
+```
+
+Agent `v7.59+` is required.
+
+
+[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md#enabling-system-probe-collection
+[2]: https://docs.datadoghq.com/containers/kubernetes/integrations/?tab=helm#configuration
+{{% /tab %}}
 {{< /tabs >}}
 
 ### Network traffic paths (experimental)
@@ -246,45 +287,6 @@ Agent `v7.61+` is required.
 
 [3]: https://github.com/DataDog/datadog-agent/blob/2c8d60b901f81768f44a798444af43ae8d338843/pkg/config/config_template.yaml#L1731
 
-{{% /tab %}}
-{{% tab "Helm" %}}
-
-To enable Network Path with Kubernetes using Helm, add the below to your `values.yaml` file.</br>
-**Note:** Helm chart v3.109.1+ **is required**. For more information, see the [Datadog Helm Chart documentation][1] and the documentation for [Kubernetes and Integrations][2].
-
-  ```yaml
-  datadog:
-    traceroute:
-      enabled: true
-    confd:
-      network_path.yaml: |-
-        init_config:
-          min_collection_interval: 60 # in seconds, default 60 seconds
-        instances:
-          # configure the endpoints you want to monitor, one check instance per endpoint
-          # warning: Do not set the port when using UDP. Setting the port when using UDP can cause traceroute calls to fail and falsely report an unreachable destination.
-
-          - hostname: api.datadoghq.eu # endpoint hostname or IP
-            protocol: TCP
-            port: 443
-            tags:
-              - "tag_key:tag_value"
-              - "tag_key2:tag_value2"
-          ## optional configs:
-          # max_ttl: 30 # max traderoute TTL, default is 30
-          # timeout: 1000 # timeout in milliseconds per hop, default is 1s
-
-          # more endpoints
-          - hostname: 1.1.1.1 # endpoint hostname or IP
-            protocol: UDP
-            tags:
-              - "tag_key:tag_value"
-              - "tag_key2:tag_value2"
-```
-
-
-[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md#enabling-system-probe-collection
-[2]: https://docs.datadoghq.com/containers/kubernetes/integrations/?tab=helm#configuration
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -250,7 +250,7 @@ Agent `v7.61+` is required.
 {{% tab "Helm" %}}
 
 To enable Network Path with Kubernetes using Helm, add the below to your `values.yaml` file.</br>
-**Note:** Helm chart v3.106.2+ **is required**. For more information, see the [Datadog Helm Chart documentation][1] and the documentation for [Kubernetes and Integrations][2].
+**Note:** Helm chart v3.109.1+ **is required**. For more information, see the [Datadog Helm Chart documentation][1] and the documentation for [Kubernetes and Integrations][2].
 
   ```yaml
   datadog:

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -247,6 +247,45 @@ Agent `v7.61+` is required.
 [3]: https://github.com/DataDog/datadog-agent/blob/2c8d60b901f81768f44a798444af43ae8d338843/pkg/config/config_template.yaml#L1731
 
 {{% /tab %}}
+{{% tab "Helm" %}}
+
+To enable Cloud Network Monitoring with Kubernetes using Helm, add the following to your `values.yaml` file.</br>
+**Helm chart v3.106.2+ is required**. For more information, see the [Datadog Helm Chart documentation][1] and the documentation for [Kubernetes and Integrations][2].
+
+  ```yaml
+  datadog:
+    traceroute:
+      enabled: true
+    confd:
+      network_path.yaml: |-
+        init_config:
+          min_collection_interval: 60 # in seconds, default 60 seconds
+        instances:
+          # configure the endpoints you want to monitor, one check instance per endpoint
+          # warning: Do not set the port when using UDP. Setting the port when using UDP can cause traceroute calls to fail and falsely report an unreachable destination.
+
+          - hostname: api.datadoghq.eu # endpoint hostname or IP
+            protocol: TCP
+            port: 443
+            tags:
+              - "tag_key:tag_value"
+              - "tag_key2:tag_value2"
+          ## optional configs:
+          # max_ttl: 30 # max traderoute TTL, default is 30
+          # timeout: 1000 # timeout in milliseconds per hop, default is 1s
+
+          # more endpoints
+          - hostname: 1.1.1.1 # endpoint hostname or IP
+            protocol: UDP
+            tags:
+              - "tag_key:tag_value"
+              - "tag_key2:tag_value2"
+```
+
+
+[1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md#enabling-system-probe-collection
+[2]: https://docs.datadoghq.com/containers/kubernetes/integrations/?tab=helm#configuration
+{{% /tab %}}
 {{< /tabs >}}
 
 ## Further Reading

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -249,8 +249,8 @@ Agent `v7.61+` is required.
 {{% /tab %}}
 {{% tab "Helm" %}}
 
-To enable Cloud Network Monitoring with Kubernetes using Helm, add the following to your `values.yaml` file.</br>
-**Helm chart v3.106.2+ is required**. For more information, see the [Datadog Helm Chart documentation][1] and the documentation for [Kubernetes and Integrations][2].
+To enable Network Path with Kubernetes using Helm, add the below to your `values.yaml` file.</br>
+**Note:** Helm chart v3.106.2+ **is required**. For more information, see the [Datadog Helm Chart documentation][1] and the documentation for [Kubernetes and Integrations][2].
 
   ```yaml
   datadog:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This documents how to set up static paths on kubernetes.
This PR documents how to set up "individual paths" tracing for Network Path in Kubernetes.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->
This PR is dependent on [\[NPM-3754\] Add config to enable traceroute in sysprobe](https://github.com/DataDog/helm-charts/pull/1744) which creates a new version of the Agent helm chart.

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


[NPM-3754]: https://datadoghq.atlassian.net/browse/NPM-3754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ