### PR TITLE
Add PHP I/O profiling

### DIFF
--- a/content/en/profiler/enabling/supported_versions.md
+++ b/content/en/profiler/enabling/supported_versions.md
@@ -36,7 +36,7 @@ To collect profile types, use at least the minimum versions summarized in the fo
 | {{< ci-details title="Heap" >}}The amount of heap memory allocated that remains in use.{{< /ci-details >}}   | [JDK&nbsp;11+][17]<br>tracer&nbsp;1.39.0+ | Python 3.6+<br> tracer&nbsp;0.50+ | tracer&nbsp;1.23+ | alpha<br>Ruby 3.1+<br>tracer&nbsp;2.3.0+ | tracer&nbsp;0.23+ | beta<br>.NET 7+<br>tracer&nbsp;2.22+ |       | Preview<br>ddprof&nbsp;0.15+ |
 | {{< ci-details title="Wall time" >}}The elapsed time spent in each function/method. Elapsed time includes time when code is running on CPU, waiting for I/O, and anything else that happens while the function/method is running.{{< /ci-details >}}   |                 [JDK&nbsp;8+][17]                 | tracer&nbsp;0.35+ |       | tracer&nbsp;0.48+ | tracer&nbsp;0.23+ | tracer&nbsp;2.7+ | tracer&nbsp;0.71+ |       |
 | {{< ci-details title="Locks" >}}The time each function/method spent waiting for and holding locks, and the number of times each function acquired a lock.{{< /ci-details >}}   |                 [JDK&nbsp;8+][17]                 | tracer&nbsp;0.45+ | tracer&nbsp;1.47+ |      |       | .NET 5+ and .NET Framework beta (requires Datadog Agent 7.51+)<br>tracer&nbsp;2.49+ |       |      |
-| {{< ci-details title="I/O" >}}The time each method spent reading from and writing to files and sockets.{{< /ci-details >}}   |                 [JDK&nbsp;8+][17]                 |       |       |       |       |       |       |       |
+| {{< ci-details title="I/O" >}}The time each method spent reading from and writing to files and sockets.{{< /ci-details >}}   |                 [JDK&nbsp;8+][17]                 |       |       |       |       |       | Preview<br>tracer&nbsp;1.7.2+ |       |
 
 
 ## Other features

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -241,6 +241,12 @@ _Note: Not available when JIT is active on PHP `8.0.0`-`8.1.20` and `8.2.0`-`8.2
 Thrown Exceptions (v0.92+)
 : The number of caught or uncaught exceptions raised by each method, as well as their type.
 
+File I/O (in beta, v1.7.2+)
+: The time each method spent reading from and writing to files, as well as the amount of bytes read from and written to files.
+
+Socket I/O (in beta, v1.7.2+)
+: The time each method spent reading from and writing to a socket, as well as the amount of bytes read from and written to sockets.
+
 [1]: /profiler/enabling/php/#requirements
 {{< /programming-lang >}}
 {{< programming-lang lang="ddprof" >}}

--- a/content/en/tracing/trace_collection/library_config/php.md
+++ b/content/en/tracing/trace_collection/library_config/php.md
@@ -481,6 +481,11 @@ Configure the sampling distance for exceptions. The higher the sampling distance
 Enable the timeline profile type. Added in version `0.89.0`.<br><br>
 **Note**: This supersedes the `DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED` environment variable (`datadog.profiling.experimental_timeline_enabled` INI setting), which was available since `0.89` (default `0`). If both are set, this one takes precedence.
 
+`DD_PROFILING_EXPERIMENTAL_IO_ENABLED`
+: **INI**: `datadog.profiling.experimental_io_enabled`. INI available since `1.7.2`.<br>
+**Default**: `1`<br>
+Enable the I/O profile type. Added as beta in version `1.7.2`.
+
 `DD_PROFILING_LOG_LEVEL`
 : **INI**: `datadog.profiling.log_level`. INI available since `0.82.0`.<br>
 **Default**: `off`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds I/O profiling for PHP to the docs. Granted, `v1.7.2` looks oddly specific, but this is due to a bug in `v1.7.0` that got fixed in the `v1.7.2` release which made sure that nearly no I/O was sampled before version `v1.7.2`.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
