### PR TITLE
Update set user info docs

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/android/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/android/advanced_configuration.md
@@ -235,13 +235,13 @@ Adding user information to your RUM sessions makes it easy to:
 
 {{< img src="real_user_monitoring/browser/advanced_configuration/user-api.png" alt="User API in RUM UI" >}}
 
-The following attributes are **optional**, you should provide **at least one** of them:
+The `id` attribute is the only **mandatory** field. All other attributes are **optional**:
 
-| Attribute  | Type | Description                                                                                              |
-|------------|------|----------------------------------------------------------------------------------------------------|
-| usr.id    | String | Unique user identifier.                                                                                  |
-| usr.name  | String | User friendly name, displayed by default in the RUM UI.                                                  |
-| usr.email | String | User email, displayed in the RUM UI if the user name is not present. It is also used to fetch Gravatars. |
+| Attribute | Type   | Description                                                                                       |
+|-----------|--------|---------------------------------------------------------------------------------------------------|
+| `usr.id`    | String | (Required) Unique user identifier.                                                              |
+| `usr.name`  | String | (Optional) User friendly name, displayed by default in the RUM UI.                              |
+| `usr.email` | String | (Optional) User email, displayed in the RUM UI if the user name is not present.                 |
 
 To identify user sessions, use the `setUserInfo` API, for example:
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/flutter/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/flutter/advanced_configuration.md
@@ -316,13 +316,13 @@ Adding user information to your RUM sessions makes it easy to:
 
 {{< img src="real_user_monitoring/browser/advanced_configuration/user-api.png" alt="User API in the RUM UI" style="width:90%" >}}
 
-The following attributes are **optional**, provide **at least** one of them:
+The `id` attribute is the only **mandatory** field. All other attributes are **optional**:
 
 | Attribute | Type   | Description                                                                                              |
 |-----------|--------|----------------------------------------------------------------------------------------------------------|
-| `usr.id`    | String | Unique user identifier.                                                                                  |
-| `usr.name`  | String | User friendly name, displayed by default in the RUM UI.                                                  |
-| `usr.email` | String | User email, displayed in the RUM UI if the user name is not present. It is also used to fetch Gravatars. |
+| `usr.id`    | String | (Required) Unique user identifier.                                                                     |
+| `usr.name`  | String | (Optional) User friendly name, displayed by default in the RUM UI.                                     |
+| `usr.email` | String | (Optional) User email, displayed in the RUM UI if the user name is not present.                        |
 
 To identify user sessions, use `DatadogSdk.setUserInfo`.
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/advanced_configuration.md
@@ -214,13 +214,13 @@ Adding user information to your RUM sessions makes it easy to:
 
 {{< img src="real_user_monitoring/browser/advanced_configuration/user-api.png" alt="User API in the RUM UI" >}}
 
-The following attributes are **optional**, you should provide **at least one** of them:
+The `id` attribute is the only **mandatory** field. All other attributes are **optional**:
 
-| Attribute   | Type   | Description                                                                                              |
-|-------------|--------|----------------------------------------------------------------------------------------------------------|
-| `usr.email` | String | User email, displayed in the RUM UI if the user name is not present. It is also used to fetch Gravatars. |
-| `usr.id`    | String | Unique user identifier.                                                                                  |
-| `usr.name`  | String | User friendly name, displayed by default in the RUM UI.                                                  
+| Attribute | Type   | Description                                                                                       |
+|-----------|--------|---------------------------------------------------------------------------------------------------|
+| `usr.id`    | String | (Required) Unique user identifier.                                                              |
+| `usr.name`  | String | (Optional) User friendly name, displayed by default in the RUM UI.                              |
+| `usr.email` | String | (Optional) User email, displayed in the RUM UI if the user name is not present.                 |
 
 To identify user sessions, use the `Datadog.setUserInfo(id:name:email:)` API.
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/advanced_configuration.md
@@ -163,13 +163,13 @@ Adding user information to your RUM sessions helps you to:
 
 {{< img src="real_user_monitoring/browser/advanced_configuration/user-api.png" alt="User API in RUM UI" >}}
 
-The following attributes are optional, but you should provide **at least one** of them:
+The `id` attribute is the only **mandatory** field. All other attributes are **optional**:
 
-| Attribute  | Type | Description                                                                                              |
-|------------|------|----------------------------------------------------------------------------------------------------|
-| usr.id    | String | Unique user identifier.                                                                                  |
-| usr.name  | String | User friendly name, displayed by default in the RUM UI.                                                  |
-| usr.email | String | User email, displayed in the RUM UI if the user name is not present. It is also used to fetch Gravatars. |
+| Attribute | Type   | Description                                                                                       |
+|-----------|--------|---------------------------------------------------------------------------------------------------|
+| `usr.id`    | String | (Required) Unique user identifier.                                                              |
+| `usr.name`  | String | (Optional) User friendly name, displayed by default in the RUM UI.                              |
+| `usr.email` | String | (Optional) User email, displayed in the RUM UI if the user name is not present.                 |
 
 To identify user sessions, use the `setUserInfo` API, for example:
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/advanced_configuration.md
@@ -301,9 +301,24 @@ DdTrace.finishSpan(spanId, { custom: 21 }, Date.now());
 
 You can attach user information to all RUM events to get more detailed information from your RUM sessions.
 
-### User information
+### Track User Sessions
 
-For user-specific information, use the following code wherever you want in your app (after the SDK has been initialized). The `id`, `name`, and `email` attributes are built into Datadog, and you can add other attributes that makes sense for your app.
+Adding user information to your RUM sessions makes it easy to:
+* Follow the journey of a given user
+* Know which users are the most impacted by errors
+* Monitor performance for your most important users
+
+{{< img src="real_user_monitoring/browser/advanced_configuration/user-api.png" alt="User API in RUM UI" >}}
+
+The `id` attribute is the only **mandatory** field. All other attributes are **optional**:
+
+| Attribute | Type   | Description                                                                                       |
+|-----------|--------|---------------------------------------------------------------------------------------------------|
+| `usr.id`    | String | (Required) Unique user identifier.                                                              |
+| `usr.name`  | String | (Optional) User friendly name, displayed by default in the RUM UI.                              |
+| `usr.email` | String | (Optional) User email, displayed in the RUM UI if the user name is not present.                 |
+
+To identify user sessions, use the `setUser` API, for example:
 
 ```js
 DdSdkReactNative.setUser({

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/roku/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/roku/advanced_configuration.md
@@ -109,13 +109,13 @@ Adding user information to your RUM sessions makes it easy to:
 * Know which users are the most impacted by errors.
 * Monitor performance for your most important users.
 
-The following attributes are **optional**, but you should provide **at least one** of them:
+The `id` attribute is the only **mandatory** field. All other attributes are **optional**:
 
-| Attribute | Type   | Description                                                                                              |
-| --------- | ------ | -------------------------------------------------------------------------------------------------------- |
-| id        | String | Unique user identifier.                                                                                  |
-| name      | String | User friendly name, displayed by default in the RUM UI.                                                  |
-| email     | String | User email, displayed in the RUM UI if the user name is not present. It is also used to fetch Gravatars. |
+| Attribute | Type   | Description                                                                                       |
+|-----------|--------|---------------------------------------------------------------------------------------------------|
+| `usr.id`    | String | (Required) Unique user identifier.                                                              |
+| `usr.name`  | String | (Optional) User friendly name, displayed by default in the RUM UI.                              |
+| `usr.email` | String | (Optional) User email, displayed in the RUM UI if the user name is not present.                 |
 
 To identify user sessions, use the `datadogUserInfo` global field, after initializing the SDK, for example:
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration.md
@@ -139,13 +139,13 @@ Adding user information to your RUM sessions makes it easy to:
 
 {{< img src="real_user_monitoring/browser/advanced_configuration/user-api.png" alt="User API in the RUM UI" style="width:90%" >}}
 
-The following attributes are **optional**, provide **at least** one of them:
+The `id` attribute is the only **mandatory** field. All other attributes are **optional**:
 
-| Attribute | Type   | Description                                                                                              |
-|-----------|--------|----------------------------------------------------------------------------------------------------------|
-| `usr.id`    | String | Unique user identifier.                                                                                  |
-| `usr.name`  | String | User friendly name, displayed by default in the RUM UI.                                                  |
-| `usr.email` | String | User email, displayed in the RUM UI if the user name is not present. It is also used to fetch Gravatars. |
+| Attribute | Type   | Description                                                                                       |
+|-----------|--------|---------------------------------------------------------------------------------------------------|
+| `usr.id`    | String | (Required) Unique user identifier.                                                              |
+| `usr.name`  | String | (Optional) User friendly name, displayed by default in the RUM UI.                              |
+| `usr.email` | String | (Optional) User email, displayed in the RUM UI if the user name is not present.                 |
 
 To identify user sessions, use `DatadogSdk.SetUserInfo`.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates the documentation of `setUserInfo` to mention that now `id` field is mandatory.
https://github.com/DataDog/dd-sdk-ios/pull/2195
https://github.com/DataDog/dd-sdk-android/pull/2509

### Merge instructions

Native SDKs got released. We're still pending cross-platform. We can merge this, because it's not a breaking change, as we kept old API deprecated.

Merge readiness:
- [x] Ready for merge