### PR TITLE
Update CoTerm install URL

### DIFF
--- a/content/en/coterm/_index.md
+++ b/content/en/coterm/_index.md
@@ -11,7 +11,7 @@ For your security, CoTerm uses [Sensitive Data Scanner][2] to detect and obfusca
 1. Install CoTerm:
 
    ```shell
-   curl --tlsv1.2 --proto '=https' -sSf 'https://update.coscreen.org/install-ddcoterm.sh' | bash
+   curl --tlsv1.2 --proto '=https' -sSf 'https://coterm.datadoghq.com/install-ddcoterm.sh' | bash
    ```
 
 2. Initialize and authenticate CoTerm:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

CoTerm can now be installed from `coterm.datadoghq.com`, which is nicer for branding than the current `update.coscreen.org`. This PR just updates the URL in the docs.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
