### PR TITLE
Update php.md to reflect support for CakePhp 4.x and 5.x

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/php.md
+++ b/content/en/tracing/trace_collection/compatibility/php.md
@@ -101,7 +101,7 @@ The following table enumerates some of the frameworks and versions Datadog succe
 
 | Module         | Versions                                | Support Type                | Instrumentation level           |
 |:---------------|:----------------------------------------|:----------------------------|:--------------------------------|
-| CakePHP        | 2.x, 3.x                                | All supported PHP versions  | Framework-level instrumentation |
+| CakePHP        | 2.x, 3.x, 4.x, 5.x                                | All supported PHP versions  | Framework-level instrumentation |
 | CodeIgniter    | 2.x                                     | All supported PHP versions  | Framework-level instrumentation |
 | CodeIgniter    | 3.x                                     | All supported PHP versions  | Generic web tracing             |
 | Drupal         |                                         | All supported PHP versions  | Framework-level instrumentation |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Cake PHP is supported through max version 5.x as shown in this table: https://github.com/DataDog/dd-trace-php/blob/master/integration_versions.md
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
