### PR TITLE
[SDTEST-179] Remove phrase that rails parallel testing is not supported for Test Impact Analysis

### DIFF
--- a/content/en/tests/test_impact_analysis/setup/ruby.md
+++ b/content/en/tests/test_impact_analysis/setup/ruby.md
@@ -23,7 +23,6 @@ Test Impact Analysis is only supported in the following versions and testing fra
   * JRuby is not supported.
 * `rspec >= 3.0.0`
 * `minitest >= 5.0.0`
-  * [Rails parallel testing][2] is not supported.
 * `cucumber >= 3.0.0`
 
 ## Setup

--- a/content/en/tests/test_impact_analysis/setup/ruby.md
+++ b/content/en/tests/test_impact_analysis/setup/ruby.md
@@ -163,4 +163,3 @@ Test Impact Analysis can be disabled locally by setting the `DD_CIVISIBILITY_ITR
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tests/setup/ruby
-[2]: https://edgeguides.rubyonrails.org/testing.html#parallel-testing


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Removes phrase that rails parallel testing is not supported for Test Impact Analysis, because it is supported now.

### Merge instructions

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
