### PR TITLE
feat: add an interactive REPL for EL evaluation

### DIFF
--- a/assets/scripts/components/expression-evaluator.js
+++ b/assets/scripts/components/expression-evaluator.js
@@ -1,9 +1,17 @@
 // Expression Evaluator Component
 // This component allows users to run and see the results of expression language examples
 
+import ExpressionLanguageParser from './expression-language-parser';
+
 class ExpressionEvaluator {
   constructor() {
-    document.querySelectorAll('.expression-evaluator').forEach(evaluator => this.setupEvaluator(evaluator));
+    // Find all expression evaluators on the page
+    const evaluators = document.querySelectorAll('.expression-evaluator');
+    evaluators.forEach(evaluator => this.setupEvaluator(evaluator));
+
+    // Find and set up the REPL if it exists
+    const repl = document.querySelector('.expression-repl');
+    if (repl) this.setupRepl(repl);
   }
 
   setupEvaluator(evaluator) {
@@ -27,6 +35,81 @@ class ExpressionEvaluator {
         void resultContainer.offsetWidth;
       });
     }
+  }
+
+  setupRepl(repl) {
+    const input = repl.querySelector('#repl-input');
+    const runButton = repl.querySelector('#repl-run-btn');
+    const history = repl.querySelector('#repl-history');
+
+    if (!input || !runButton || !history) return;
+
+    // Create a new instance of the expression language parser
+    const parser = new ExpressionLanguageParser();
+
+    // Function to add an entry to the history
+    const addToHistory = (expr, result, isError = false) => {
+      const entry = document.createElement('div');
+      entry.className = 'repl-entry';
+
+      const command = document.createElement('div');
+      command.className = 'repl-command';
+
+      const prompt = document.createElement('span');
+      prompt.className = 'repl-prompt';
+      prompt.textContent = '→';
+
+      const expression = document.createElement('span');
+      expression.className = 'repl-expression';
+      expression.textContent = expr;
+
+      command.appendChild(prompt);
+      command.appendChild(expression);
+
+      const resultElement = document.createElement('div');
+      resultElement.className = isError ? 'repl-error' : 'repl-result';
+      resultElement.textContent = result;
+
+      entry.appendChild(command);
+      entry.appendChild(resultElement);
+
+      history.appendChild(entry);
+
+      // Scroll to the bottom
+      history.scrollTop = history.scrollHeight;
+    };
+
+    // Handle the run button click
+    runButton.addEventListener('click', () => {
+      const expr = input.value.trim();
+      if (!expr) return; // Don't process empty expressions
+
+      const evaluation = parser.evaluate(expr);
+
+      if (evaluation.success) {
+        addToHistory(expr, evaluation.result);
+      } else {
+        addToHistory(expr, evaluation.error, true);
+      }
+
+      // Clear the input
+      input.value = '';
+      input.focus();
+    });
+
+    // Handle Enter key in the input
+    input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        runButton.click();
+        e.preventDefault();
+      }
+    });
+
+    // Scroll to the bottom of history on load
+    history.scrollTop = history.scrollHeight;
+
+    // Focus the input on load
+    input.focus();
   }
 }
 

--- a/assets/scripts/components/expression-language-parser.js
+++ b/assets/scripts/components/expression-language-parser.js
@@ -1,0 +1,925 @@
+/**
+ * Expression Language Parser
+ *
+ * This module handles parsing and evaluating expressions for the Expression Language REPL.
+ * It provides a Pythonic syntax for the Dynamic Instrumentation Expression Language.
+ */
+
+class ExpressionLanguageParser {
+  constructor() {
+    // Built-in functions
+    this.builtinFunctions = {
+      // String functions
+      len: (value) => {
+        if (typeof value === 'string') return value.length;
+        if (Array.isArray(value)) return value.length;
+        if (typeof value === 'object' && value !== null) return Object.keys(value).length;
+        throw new Error('len() requires a string, array, or object argument');
+      },
+      isEmpty: (value) => {
+        if (typeof value === 'string') return value.length === 0;
+        if (Array.isArray(value)) return value.length === 0;
+        if (typeof value === 'object' && value !== null) return Object.keys(value).length === 0;
+        throw new Error('isEmpty() requires a string, array, or object argument');
+      },
+      substring: (str, start, end) => {
+        if (typeof str !== 'string') throw new Error('substring() requires a string as first argument');
+        return str.substring(start, end);
+      },
+      startsWith: (str, prefix) => {
+        if (typeof str !== 'string') throw new Error('startsWith() requires a string as first argument');
+        return str.startsWith(prefix);
+      },
+      endsWith: (str, suffix) => {
+        if (typeof str !== 'string') throw new Error('endsWith() requires a string as first argument');
+        return str.endsWith(suffix);
+      },
+      contains: (container, value) => {
+        if (typeof container === 'string') return container.includes(value);
+        if (Array.isArray(container)) return container.includes(value);
+        if (typeof container === 'object' && container !== null) {
+          return Object.values(container).includes(value);
+        }
+        throw new Error('contains() requires a string, array, or object argument');
+      },
+      matches: (str, pattern) => {
+        if (typeof str !== 'string') throw new Error('matches() requires a string as first argument');
+        return new RegExp(pattern).test(str);
+      },
+
+      // Collection functions
+      filter: (collection, predicate) => {
+        if (!Array.isArray(collection) && (typeof collection !== 'object' || collection === null)) {
+          throw new Error('filter() requires an array or object as first argument');
+        }
+
+        if (Array.isArray(collection)) {
+          return collection.filter(item => {
+            const tempEnv = { '@it': item };
+            return this._evaluateWithEnvironment(predicate, tempEnv);
+          });
+        } else {
+          const result = {};
+          Object.entries(collection).forEach(([key, value]) => {
+            const tempEnv = { '@key': key, '@value': value };
+            if (this._evaluateWithEnvironment(predicate, tempEnv)) {
+              result[key] = value;
+            }
+          });
+          return result;
+        }
+      },
+      any: (collection, predicate) => {
+        if (!Array.isArray(collection) && (typeof collection !== 'object' || collection === null)) {
+          throw new Error('any() requires an array or object as first argument');
+        }
+
+        if (Array.isArray(collection)) {
+          if (collection.length === 0) return false;
+          return collection.some(item => {
+            const tempEnv = { '@it': item };
+            return this._evaluateWithEnvironment(predicate, tempEnv);
+          });
+        } else {
+          const entries = Object.entries(collection);
+          if (entries.length === 0) return false;
+          return entries.some(([key, value]) => {
+            const tempEnv = { '@key': key, '@value': value };
+            return this._evaluateWithEnvironment(predicate, tempEnv);
+          });
+        }
+      },
+      all: (collection, predicate) => {
+        if (!Array.isArray(collection) && (typeof collection !== 'object' || collection === null)) {
+          throw new Error('all() requires an array or object as first argument');
+        }
+
+        if (Array.isArray(collection)) {
+          if (collection.length === 0) return true;
+          return collection.every(item => {
+            const tempEnv = { '@it': item };
+            return this._evaluateWithEnvironment(predicate, tempEnv);
+          });
+        } else {
+          const entries = Object.entries(collection);
+          if (entries.length === 0) return true;
+          return entries.every(([key, value]) => {
+            const tempEnv = { '@key': key, '@value': value };
+            return this._evaluateWithEnvironment(predicate, tempEnv);
+          });
+        }
+      }
+    };
+
+    // Initialize the environment with default variables
+    this.environment = {
+      myCollection: [1, 2, 3],
+      newCollection: [1, "b", 2.5, true],
+      newDictionary: {"a": 1, "b": 2, "c": 3}
+    };
+
+    // Add built-in functions to the environment
+    Object.keys(this.builtinFunctions).forEach(key => {
+      this.environment[key] = this.builtinFunctions[key];
+    });
+  }
+
+  /**
+   * Evaluate an expression
+   * @param {string} expr - The expression to evaluate
+   * @returns {Object} - The result of the evaluation
+   */
+  evaluate(expr) {
+    try {
+      if (!expr.trim()) {
+        return {
+          success: false,
+          error: 'Empty expression'
+        };
+      }
+
+      // Split the expression into statements
+      const statements = this._splitStatements(expr);
+      let result;
+
+      // Evaluate each statement
+      for (const statement of statements) {
+        result = this._evaluateStatement(statement);
+      }
+
+      // Format the result
+      return {
+        success: true,
+        result: this._formatValue(result)
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error.message
+      };
+    }
+  }
+
+  /**
+   * Split an expression into statements
+   * @param {string} expr - The expression to split
+   * @returns {string[]} - The statements
+   * @private
+   */
+  _splitStatements(expr) {
+    const statements = [];
+    let currentStatement = '';
+    let inString = false;
+    let stringChar = '';
+    let bracketCount = 0;
+    let parenCount = 0;
+    let curlyCount = 0;
+
+    for (let i = 0; i < expr.length; i++) {
+      const char = expr[i];
+
+      // Handle string literals
+      if ((char === '"' || char === "'") && (i === 0 || expr[i-1] !== '\\')) {
+        if (!inString) {
+          inString = true;
+          stringChar = char;
+        } else if (char === stringChar) {
+          inString = false;
+        }
+      }
+
+      // Count brackets and parentheses
+      if (!inString) {
+        if (char === '[') bracketCount++;
+        else if (char === ']') bracketCount--;
+        else if (char === '(') parenCount++;
+        else if (char === ')') parenCount--;
+        else if (char === '{') curlyCount++;
+        else if (char === '}') curlyCount--;
+
+        // Split on semicolons, but only if not inside any brackets or strings
+        if (char === ';' && bracketCount === 0 && parenCount === 0 && curlyCount === 0) {
+          statements.push(currentStatement.trim());
+          currentStatement = '';
+          continue;
+        }
+      }
+
+      currentStatement += char;
+    }
+
+    if (currentStatement.trim()) {
+      statements.push(currentStatement.trim());
+    }
+
+    return statements;
+  }
+
+  /**
+   * Evaluate a single statement
+   * @param {string} statement - The statement to evaluate
+   * @returns {*} - The result of the evaluation
+   * @private
+   */
+  _evaluateStatement(statement) {
+    // Tokenize the statement
+    const tokens = this._tokenize(statement);
+
+    // Parse the tokens into an AST
+    const ast = this._parse(tokens);
+
+    // Evaluate the AST
+    return this._evaluateAst(ast);
+  }
+
+  /**
+   * Tokenize a statement
+   * @param {string} statement - The statement to tokenize
+   * @returns {Array} - The tokens
+   * @private
+   */
+  _tokenize(statement) {
+    const tokens = [];
+    let i = 0;
+
+    while (i < statement.length) {
+      const char = statement[i];
+
+      // Skip whitespace
+      if (/\s/.test(char)) {
+        i++;
+        continue;
+      }
+
+      // Numbers
+      if (/[0-9]/.test(char) || (char === '-' && /[0-9]/.test(statement[i+1]))) {
+        let number = char;
+        let j = i + 1;
+        let isFloat = false;
+
+        while (j < statement.length) {
+          const nextChar = statement[j];
+          if (/[0-9]/.test(nextChar)) {
+            number += nextChar;
+            j++;
+          } else if (nextChar === '.' && !isFloat) {
+            number += nextChar;
+            isFloat = true;
+            j++;
+          } else {
+            break;
+          }
+        }
+
+        tokens.push({
+          type: 'NUMBER',
+          value: isFloat ? parseFloat(number) : parseInt(number, 10)
+        });
+
+        i = j;
+        continue;
+      }
+
+      // Strings
+      if (char === '"' || char === "'") {
+        let string = '';
+        let j = i + 1;
+        const quote = char;
+
+        while (j < statement.length) {
+          const nextChar = statement[j];
+          if (nextChar === quote && statement[j-1] !== '\\') {
+            break;
+          }
+          string += nextChar;
+          j++;
+        }
+
+        tokens.push({
+          type: 'STRING',
+          value: string
+        });
+
+        i = j + 1;
+        continue;
+      }
+
+      // Identifiers (variables and functions)
+      if (/[a-zA-Z_@]/.test(char)) {
+        let identifier = char;
+        let j = i + 1;
+
+        while (j < statement.length) {
+          const nextChar = statement[j];
+          if (/[a-zA-Z0-9_@]/.test(nextChar)) {
+            identifier += nextChar;
+            j++;
+          } else {
+            break;
+          }
+        }
+
+        // Check for keywords
+        if (identifier === 'true') {
+          tokens.push({ type: 'BOOLEAN', value: true });
+        } else if (identifier === 'false') {
+          tokens.push({ type: 'BOOLEAN', value: false });
+        } else if (identifier === 'null') {
+          tokens.push({ type: 'NULL', value: null });
+        } else if (identifier === 'not') {
+          tokens.push({ type: 'NOT' });
+        } else {
+          tokens.push({ type: 'IDENTIFIER', value: identifier });
+        }
+
+        i = j;
+        continue;
+      }
+
+      // Operators
+      if (char === '+') {
+        tokens.push({ type: 'PLUS' });
+        i++;
+      } else if (char === '-') {
+        tokens.push({ type: 'MINUS' });
+        i++;
+      } else if (char === '*') {
+        tokens.push({ type: 'MULTIPLY' });
+        i++;
+      } else if (char === '/') {
+        tokens.push({ type: 'DIVIDE' });
+        i++;
+      } else if (char === '=') {
+        if (statement[i+1] === '=') {
+          tokens.push({ type: 'EQUALS' });
+          i += 2;
+        } else {
+          tokens.push({ type: 'ASSIGN' });
+          i++;
+        }
+      } else if (char === '!') {
+        if (statement[i+1] === '=') {
+          tokens.push({ type: 'NOT_EQUALS' });
+          i += 2;
+        } else {
+          tokens.push({ type: 'NOT' });
+          i++;
+        }
+      } else if (char === '<') {
+        if (statement[i+1] === '=') {
+          tokens.push({ type: 'LESS_THAN_EQUALS' });
+          i += 2;
+        } else {
+          tokens.push({ type: 'LESS_THAN' });
+          i++;
+        }
+      } else if (char === '>') {
+        if (statement[i+1] === '=') {
+          tokens.push({ type: 'GREATER_THAN_EQUALS' });
+          i += 2;
+        } else {
+          tokens.push({ type: 'GREATER_THAN' });
+          i++;
+        }
+      } else if (char === '&' && statement[i+1] === '&') {
+        tokens.push({ type: 'AND' });
+        i += 2;
+      } else if (char === '|' && statement[i+1] === '|') {
+        tokens.push({ type: 'OR' });
+        i += 2;
+      } else if (char === '(') {
+        tokens.push({ type: 'LEFT_PAREN' });
+        i++;
+      } else if (char === ')') {
+        tokens.push({ type: 'RIGHT_PAREN' });
+        i++;
+      } else if (char === '[') {
+        tokens.push({ type: 'LEFT_BRACKET' });
+        i++;
+      } else if (char === ']') {
+        tokens.push({ type: 'RIGHT_BRACKET' });
+        i++;
+      } else if (char === '{') {
+        tokens.push({ type: 'LEFT_BRACE' });
+        i++;
+      } else if (char === '}') {
+        tokens.push({ type: 'RIGHT_BRACE' });
+        i++;
+      } else if (char === ',') {
+        tokens.push({ type: 'COMMA' });
+        i++;
+      } else if (char === ':') {
+        tokens.push({ type: 'COLON' });
+        i++;
+      } else {
+        throw new Error(`Unexpected character: ${char}`);
+      }
+    }
+
+    return tokens;
+  }
+
+  /**
+   * Parse tokens into an AST
+   * @param {Array} tokens - The tokens to parse
+   * @returns {Object} - The AST
+   * @private
+   */
+  _parse(tokens) {
+    let position = 0;
+
+    // Helper function to peek at the current token
+    const peek = () => tokens[position];
+
+    // Helper function to consume the current token and move to the next
+    const consume = () => tokens[position++];
+
+    // Helper function to check if we've reached the end of the tokens
+    const isAtEnd = () => position >= tokens.length;
+
+    // Helper function to match a token type
+    const match = (type) => {
+      if (isAtEnd()) return false;
+      if (peek().type !== type) return false;
+      consume();
+      return true;
+    };
+
+    // Helper function to expect a token type
+    const expect = (type, message) => {
+      if (peek().type === type) return consume();
+      throw new Error(message || `Expected ${type}, got ${peek().type}`);
+    };
+
+    // Grammar rules
+    const expression = () => {
+      return assignment();
+    };
+
+    const assignment = () => {
+      const expr = logicalOr();
+
+      if (match('ASSIGN')) {
+        const value = assignment();
+
+        if (expr.type === 'VARIABLE') {
+          return {
+            type: 'ASSIGN',
+            name: expr.name,
+            value
+          };
+        }
+
+        throw new Error('Invalid assignment target');
+      }
+
+      return expr;
+    };
+
+    const logicalOr = () => {
+      let expr = logicalAnd();
+
+      while (match('OR')) {
+        const right = logicalAnd();
+        expr = {
+          type: 'LOGICAL',
+          operator: 'OR',
+          left: expr,
+          right
+        };
+      }
+
+      return expr;
+    };
+
+    const logicalAnd = () => {
+      let expr = equality();
+
+      while (match('AND')) {
+        const right = equality();
+        expr = {
+          type: 'LOGICAL',
+          operator: 'AND',
+          left: expr,
+          right
+        };
+      }
+
+      return expr;
+    };
+
+    const equality = () => {
+      let expr = comparison();
+
+      while (match('EQUALS') || match('NOT_EQUALS')) {
+        const operator = tokens[position - 1].type === 'EQUALS' ? '==' : '!=';
+        const right = comparison();
+        expr = {
+          type: 'BINARY',
+          operator,
+          left: expr,
+          right
+        };
+      }
+
+      return expr;
+    };
+
+    const comparison = () => {
+      let expr = term();
+
+      while (
+        match('LESS_THAN') ||
+        match('LESS_THAN_EQUALS') ||
+        match('GREATER_THAN') ||
+        match('GREATER_THAN_EQUALS')
+      ) {
+        let operator;
+        switch (tokens[position - 1].type) {
+          case 'LESS_THAN': operator = '<'; break;
+          case 'LESS_THAN_EQUALS': operator = '<='; break;
+          case 'GREATER_THAN': operator = '>'; break;
+          case 'GREATER_THAN_EQUALS': operator = '>='; break;
+        }
+
+        const right = term();
+        expr = {
+          type: 'BINARY',
+          operator,
+          left: expr,
+          right
+        };
+      }
+
+      return expr;
+    };
+
+    const term = () => {
+      let expr = factor();
+
+      while (match('PLUS') || match('MINUS')) {
+        const operator = tokens[position - 1].type === 'PLUS' ? '+' : '-';
+        const right = factor();
+        expr = {
+          type: 'BINARY',
+          operator,
+          left: expr,
+          right
+        };
+      }
+
+      return expr;
+    };
+
+    const factor = () => {
+      let expr = unary();
+
+      while (match('MULTIPLY') || match('DIVIDE')) {
+        const operator = tokens[position - 1].type === 'MULTIPLY' ? '*' : '/';
+        const right = unary();
+        expr = {
+          type: 'BINARY',
+          operator,
+          left: expr,
+          right
+        };
+      }
+
+      return expr;
+    };
+
+    const unary = () => {
+      if (match('MINUS') || match('NOT')) {
+        const operator = tokens[position - 1].type === 'MINUS' ? '-' : '!';
+        const right = unary();
+        return {
+          type: 'UNARY',
+          operator,
+          right
+        };
+      }
+
+      return call();
+    };
+
+    const call = () => {
+      let expr = primary();
+
+      while (true) {
+        if (match('LEFT_PAREN')) {
+          expr = finishCall(expr);
+        } else if (match('LEFT_BRACKET')) {
+          const index = expression();
+          expect('RIGHT_BRACKET', 'Expected "]" after index');
+          expr = {
+            type: 'INDEX',
+            object: expr,
+            index
+          };
+        } else {
+          break;
+        }
+      }
+
+      return expr;
+    };
+
+    const finishCall = (callee) => {
+      const args = [];
+
+      if (peek().type !== 'RIGHT_PAREN') {
+        do {
+          if (peek().type === 'LEFT_BRACE') {
+            // Special case for predicates in collection functions
+            consume(); // Consume LEFT_BRACE
+            const predicate = expression();
+            expect('RIGHT_BRACE', 'Expected "}" after predicate');
+            args.push({
+              type: 'PREDICATE',
+              expression: predicate
+            });
+          } else {
+            args.push(expression());
+          }
+        } while (match('COMMA'));
+      }
+
+      expect('RIGHT_PAREN', 'Expected ")" after arguments');
+
+      return {
+        type: 'CALL',
+        callee,
+        args
+      };
+    };
+
+    const primary = () => {
+      if (match('NUMBER')) {
+        return {
+          type: 'LITERAL',
+          value: tokens[position - 1].value
+        };
+      }
+
+      if (match('STRING')) {
+        return {
+          type: 'LITERAL',
+          value: tokens[position - 1].value
+        };
+      }
+
+      if (match('BOOLEAN')) {
+        return {
+          type: 'LITERAL',
+          value: tokens[position - 1].value
+        };
+      }
+
+      if (match('NULL')) {
+        return {
+          type: 'LITERAL',
+          value: null
+        };
+      }
+
+      if (match('IDENTIFIER')) {
+        return {
+          type: 'VARIABLE',
+          name: tokens[position - 1].value
+        };
+      }
+
+      if (match('LEFT_PAREN')) {
+        const expr = expression();
+        expect('RIGHT_PAREN', 'Expected ")" after expression');
+        return {
+          type: 'GROUPING',
+          expression: expr
+        };
+      }
+
+      if (match('LEFT_BRACKET')) {
+        return array();
+      }
+
+      if (match('LEFT_BRACE')) {
+        return dictionary();
+      }
+
+      throw new Error(`Unexpected token: ${peek().type}`);
+    };
+
+    const array = () => {
+      const elements = [];
+
+      if (peek().type !== 'RIGHT_BRACKET') {
+        do {
+          elements.push(expression());
+        } while (match('COMMA'));
+      }
+
+      expect('RIGHT_BRACKET', 'Expected "]" after array elements');
+
+      return {
+        type: 'ARRAY',
+        elements
+      };
+    };
+
+    const dictionary = () => {
+      const entries = [];
+
+      if (peek().type !== 'RIGHT_BRACE') {
+        do {
+          // Key can be a string or number
+          let key;
+          if (peek().type === 'STRING' || peek().type === 'NUMBER' || peek().type === 'IDENTIFIER') {
+            key = consume().value;
+          } else {
+            throw new Error('Dictionary key must be a string, number, or identifier');
+          }
+
+          expect('COLON', 'Expected ":" after dictionary key');
+
+          const value = expression();
+
+          entries.push({
+            key,
+            value
+          });
+        } while (match('COMMA'));
+      }
+
+      expect('RIGHT_BRACE', 'Expected "}" after dictionary entries');
+
+      return {
+        type: 'DICTIONARY',
+        entries
+      };
+    };
+
+    // Start parsing
+    return expression();
+  }
+
+  /**
+   * Evaluate an AST
+   * @param {Object} ast - The AST to evaluate
+   * @returns {*} - The result of the evaluation
+   * @private
+   */
+  _evaluateAst(ast) {
+    switch (ast.type) {
+      case 'LITERAL':
+        return ast.value;
+
+      case 'VARIABLE':
+        if (this.environment.hasOwnProperty(ast.name)) {
+          return this.environment[ast.name];
+        }
+        throw new Error(`Undefined variable: ${ast.name}`);
+
+      case 'ASSIGN':
+        const value = this._evaluateAst(ast.value);
+        this.environment[ast.name] = value;
+        return value;
+
+      case 'BINARY':
+        const left = this._evaluateAst(ast.left);
+        const right = this._evaluateAst(ast.right);
+
+        switch (ast.operator) {
+          case '+': return left + right;
+          case '-': return left - right;
+          case '*': return left * right;
+          case '/':
+            if (right === 0) throw new Error('Division by zero');
+            return left / right;
+          case '==': return left === right;
+          case '!=': return left !== right;
+          case '<': return left < right;
+          case '<=': return left <= right;
+          case '>': return left > right;
+          case '>=': return left >= right;
+          default: throw new Error(`Unknown binary operator: ${ast.operator}`);
+        }
+
+      case 'UNARY':
+        const operand = this._evaluateAst(ast.right);
+
+        switch (ast.operator) {
+          case '-': return -operand;
+          case '!': return !operand;
+          default: throw new Error(`Unknown unary operator: ${ast.operator}`);
+        }
+
+      case 'LOGICAL':
+        const leftExpr = this._evaluateAst(ast.left);
+
+        if (ast.operator === 'AND') {
+          return leftExpr ? this._evaluateAst(ast.right) : false;
+        } else if (ast.operator === 'OR') {
+          return leftExpr ? true : this._evaluateAst(ast.right);
+        }
+
+        throw new Error(`Unknown logical operator: ${ast.operator}`);
+
+      case 'GROUPING':
+        return this._evaluateAst(ast.expression);
+
+      case 'CALL':
+        const callee = this._evaluateAst(ast.callee);
+        const args = ast.args.map(arg => {
+          if (arg.type === 'PREDICATE') {
+            return arg;
+          }
+          return this._evaluateAst(arg);
+        });
+
+        if (typeof callee === 'function') {
+          return callee(...args);
+        }
+
+        throw new Error(`${ast.callee.name} is not a function`);
+
+      case 'INDEX':
+        const object = this._evaluateAst(ast.object);
+        const index = this._evaluateAst(ast.index);
+
+        if (Array.isArray(object)) {
+          if (index < 0 || index >= object.length) {
+            throw new Error('Array index out of bounds');
+          }
+          return object[index];
+        } else if (typeof object === 'object' && object !== null) {
+          if (!object.hasOwnProperty(index)) {
+            throw new Error(`Key not found in object: ${index}`);
+          }
+          return object[index];
+        }
+
+        throw new Error('Cannot index non-array or non-object');
+
+      case 'ARRAY':
+        return ast.elements.map(element => this._evaluateAst(element));
+
+      case 'DICTIONARY':
+        const dict = {};
+        for (const entry of ast.entries) {
+          dict[entry.key] = this._evaluateAst(entry.value);
+        }
+        return dict;
+
+      default:
+        throw new Error(`Unknown AST node type: ${ast.type}`);
+    }
+  }
+
+  /**
+   * Evaluate an expression with a temporary environment
+   * @param {Object} predicate - The predicate AST node
+   * @param {Object} tempEnv - The temporary environment
+   * @returns {*} - The result of the evaluation
+   * @private
+   */
+  _evaluateWithEnvironment(predicate, tempEnv) {
+    // Save the current environment
+    const savedEnv = { ...this.environment };
+
+    // Merge the temporary environment with the current environment
+    Object.assign(this.environment, tempEnv);
+
+    // Evaluate the predicate
+    const result = this._evaluateAst(predicate.expression);
+
+    // Restore the original environment
+    this.environment = savedEnv;
+
+    return result;
+  }
+
+  /**
+   * Format a value for display
+   * @param {*} value - The value to format
+   * @returns {string} - The formatted value
+   * @private
+   */
+  _formatValue(value) {
+    if (value === undefined) return 'undefined';
+    if (value === null) return 'null';
+    if (typeof value === 'boolean') return value ? 'True' : 'False';
+    if (typeof value === 'string') return `"${value}"`;
+    if (Array.isArray(value)) return `[${value.map(item => this._formatValue(item)).join(', ')}]`;
+    if (typeof value === 'object') {
+      // For dictionaries, we need to maintain the order of keys as specified in the tests
+      // We'll sort the keys to ensure consistent output
+      const sortedKeys = Object.keys(value).sort();
+      const entries = sortedKeys.map(k => `"${k}": ${this._formatValue(value[k])}`);
+      return `{${entries.join(', ')}}`;
+    }
+    return String(value);
+  }
+}
+
+export default ExpressionLanguageParser;
+

--- a/assets/scripts/tests/expression-language-parser.test.js
+++ b/assets/scripts/tests/expression-language-parser.test.js
@@ -1,0 +1,760 @@
+/**
+ * Tests for the Expression Language Parser
+ */
+
+import ExpressionLanguageParser from '../components/expression-language-parser';
+
+describe('ExpressionLanguageParser', () => {
+  let parser;
+
+  beforeEach(() => {
+    parser = new ExpressionLanguageParser();
+    // Set up the myCollection variable that's used in examples
+    const initResult = parser.evaluate('myCollection = [1, 2, 3]');
+  });
+
+  describe('Literals', () => {
+    test('should evaluate number literals', () => {
+      const result = parser.evaluate('42');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('42');
+    });
+
+    test('should evaluate string literals', () => {
+      const result = parser.evaluate('"hello"');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('"hello"');
+    });
+
+    test('should evaluate boolean literals', () => {
+      const trueResult = parser.evaluate('true');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('false');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should evaluate array literals', () => {
+      const result = parser.evaluate('[1, 2, 3]');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('[1, 2, 3]');
+    });
+  });
+
+  describe('Variables', () => {
+    test('should assign and access variables', () => {
+      const assignResult = parser.evaluate('x = 5');
+      expect(assignResult.success).toBe(true);
+      expect(assignResult.result).toBe('5');
+
+      const accessResult = parser.evaluate('x');
+      expect(accessResult.success).toBe(true);
+      expect(accessResult.result).toBe('5');
+    });
+
+    test('should reassign variables', () => {
+      parser.evaluate('x = 5');
+
+      const reassignResult = parser.evaluate('x = 10');
+      expect(reassignResult.success).toBe(true);
+      expect(reassignResult.result).toBe('10');
+
+      const accessResult = parser.evaluate('x');
+      expect(accessResult.success).toBe(true);
+      expect(accessResult.result).toBe('10');
+    });
+
+    test('should handle different variable types', () => {
+      const strResult = parser.evaluate('str = "hello"');
+      expect(strResult.success).toBe(true);
+      expect(strResult.result).toBe('"hello"');
+
+      const boolResult = parser.evaluate('flag = true');
+      expect(boolResult.success).toBe(true);
+      expect(boolResult.result).toBe('True');
+
+      const arrResult = parser.evaluate('arr = [1, 2, 3]');
+      expect(arrResult.success).toBe(true);
+      expect(arrResult.result).toBe('[1, 2, 3]');
+    });
+  });
+
+  describe('Arithmetic', () => {
+    test('should perform basic arithmetic', () => {
+      const addResult = parser.evaluate('5 + 3');
+      expect(addResult.success).toBe(true);
+      expect(addResult.result).toBe('8');
+
+      const subResult = parser.evaluate('5 - 3');
+      expect(subResult.success).toBe(true);
+      expect(subResult.result).toBe('2');
+
+      const mulResult = parser.evaluate('5 * 3');
+      expect(mulResult.success).toBe(true);
+      expect(mulResult.result).toBe('15');
+
+      const divResult = parser.evaluate('6 / 3');
+      expect(divResult.success).toBe(true);
+      expect(divResult.result).toBe('2');
+    });
+
+    test('should respect operator precedence', () => {
+      const noParenResult = parser.evaluate('2 + 3 * 4');
+      expect(noParenResult.success).toBe(true);
+      expect(noParenResult.result).toBe('14');
+
+      const parenResult = parser.evaluate('(2 + 3) * 4');
+      expect(parenResult.success).toBe(true);
+      expect(parenResult.result).toBe('20');
+    });
+
+    test('should handle variables in arithmetic', () => {
+      parser.evaluate('x = 10');
+
+      const result = parser.evaluate('x + 5');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('15');
+    });
+
+    test('should handle negative numbers', () => {
+      const result = parser.evaluate('-5');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('-5');
+    });
+
+    test('should handle decimal numbers', () => {
+      const result = parser.evaluate('3.14');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('3.14');
+    });
+  });
+
+  describe('Comparisons', () => {
+    test('should evaluate equality', () => {
+      const trueResult = parser.evaluate('5 == 5');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('5 == 6');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should evaluate inequality', () => {
+      const trueResult = parser.evaluate('5 != 6');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('5 != 5');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should evaluate greater than', () => {
+      const trueResult = parser.evaluate('5 > 3');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('3 > 5');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should evaluate less than', () => {
+      const trueResult = parser.evaluate('3 < 5');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('5 < 3');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should evaluate greater than or equal', () => {
+      const trueResult = parser.evaluate('5 >= 5');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('3 >= 5');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should evaluate less than or equal', () => {
+      const trueResult = parser.evaluate('5 <= 5');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('5 <= 3');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should compare strings', () => {
+      const result = parser.evaluate('"abc" == "abc"');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('True');
+    });
+  });
+
+  describe('Logical Operations', () => {
+    test('should evaluate logical AND', () => {
+      const trueResult = parser.evaluate('true && true');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('true && false');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should evaluate logical OR', () => {
+      const trueResult = parser.evaluate('true || false');
+      expect(trueResult.success).toBe(true);
+      expect(trueResult.result).toBe('True');
+
+      const falseResult = parser.evaluate('false || false');
+      expect(falseResult.success).toBe(true);
+      expect(falseResult.result).toBe('False');
+    });
+
+    test('should evaluate logical NOT', () => {
+      const notFalseResult = parser.evaluate('!false');
+      expect(notFalseResult.success).toBe(true);
+      expect(notFalseResult.result).toBe('True');
+
+      const notTrueResult = parser.evaluate('!true');
+      expect(notTrueResult.success).toBe(true);
+      expect(notTrueResult.result).toBe('False');
+
+      const wordNotFalseResult = parser.evaluate('not false');
+      expect(wordNotFalseResult.success).toBe(true);
+      expect(wordNotFalseResult.result).toBe('True');
+
+      const wordNotTrueResult = parser.evaluate('not true');
+      expect(wordNotTrueResult.success).toBe(true);
+      expect(wordNotTrueResult.result).toBe('False');
+    });
+
+    test('should evaluate complex logical expressions', () => {
+      const result = parser.evaluate('(5 > 3) && (2 < 4)');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('True');
+    });
+  });
+
+  describe('Array Access', () => {
+    test('should access array elements', () => {
+      const result = parser.evaluate('myCollection[0]');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('1');
+    });
+
+    test('should access elements of array variables', () => {
+      parser.evaluate('arr = [1, 2, 3]');
+
+      const result = parser.evaluate('arr[1]');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('2');
+    });
+
+    test('should handle array access in arithmetic', () => {
+      const result = parser.evaluate('myCollection[0] + 2');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('3');
+    });
+
+    test('should handle array access in comparisons', () => {
+      const result = parser.evaluate('myCollection[1] > myCollection[0]');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('True');
+    });
+  });
+
+  describe('Functions', () => {
+    test('should evaluate len function', () => {
+      const strResult = parser.evaluate('len("hello")');
+      expect(strResult.success).toBe(true);
+      expect(strResult.result).toBe('5');
+
+      const arrResult = parser.evaluate('len(myCollection)');
+      expect(arrResult.success).toBe(true);
+      expect(arrResult.result).toBe('3');
+    });
+
+    test('should evaluate contains function', () => {
+      const strResult = parser.evaluate('contains("hello world", "world")');
+      expect(strResult.success).toBe(true);
+      expect(strResult.result).toBe('True');
+
+      const arrResult = parser.evaluate('contains(myCollection, 2)');
+      expect(arrResult.success).toBe(true);
+      expect(arrResult.result).toBe('True');
+    });
+
+    test('should evaluate string functions', () => {
+      const startsWithResult = parser.evaluate('startsWith("hello", "he")');
+      expect(startsWithResult.success).toBe(true);
+      expect(startsWithResult.result).toBe('True');
+
+      const endsWithResult = parser.evaluate('endsWith("hello", "lo")');
+      expect(endsWithResult.success).toBe(true);
+      expect(endsWithResult.result).toBe('True');
+
+      const substringResult = parser.evaluate('substring("hello", 1, 3)');
+      expect(substringResult.success).toBe(true);
+      expect(substringResult.result).toBe('"el"');
+
+      const isEmptyFalseResult = parser.evaluate('isEmpty("hello")');
+      expect(isEmptyFalseResult.success).toBe(true);
+      expect(isEmptyFalseResult.result).toBe('False');
+
+      const isEmptyTrueResult = parser.evaluate('isEmpty("")');
+      expect(isEmptyTrueResult.success).toBe(true);
+      expect(isEmptyTrueResult.result).toBe('True');
+    });
+
+    test('should evaluate matches function', () => {
+      const result = parser.evaluate('matches("Hello", "^H.*o$")');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('True');
+    });
+
+    test('should evaluate collection functions', () => {
+      const result = parser.evaluate('filter(myCollection, {@it > 1})');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('[2, 3]');
+    });
+  });
+
+  describe('Multi-Statement Expressions', () => {
+    test('should evaluate multiple statements', () => {
+      const result = parser.evaluate('x = 5; y = 10; x + y');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('15');
+    });
+
+    test('should handle arrays in multi-statements', () => {
+      const result = parser.evaluate('a = [1, 2]; a[0] + a[1]');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('3');
+    });
+
+    test('should handle functions in multi-statements', () => {
+      const result = parser.evaluate('str = "hello"; len(str)');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('5');
+    });
+  });
+
+  describe('Parenthesized Expressions', () => {
+    test('should evaluate simple parenthesized expressions', () => {
+      const result = parser.evaluate('(2 + 3)');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('5');
+    });
+
+    test('should respect operator precedence with parentheses', () => {
+      const result = parser.evaluate('(2 + 3) * 4');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('20');
+    });
+  });
+
+  describe('Complex Logical Expressions', () => {
+    test('should evaluate complex logical expressions', () => {
+      const result = parser.evaluate('(5 > 3) && (2 < 4)');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('True');
+    });
+  });
+
+  describe('Function Calls', () => {
+    test('should evaluate matches function', () => {
+      const result = parser.evaluate('matches("Hello", "^H.*o$")');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('True');
+    });
+
+    test('should evaluate collection functions', () => {
+      const result = parser.evaluate('filter(myCollection, {@it > 1})');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('[2, 3]');
+    });
+  });
+
+  describe('Simple Tests', () => {
+    test('should evaluate expressions with variables', () => {
+      const result1 = parser.evaluate('x = 10');
+      expect(result1.success).toBe(true);
+
+      const result2 = parser.evaluate('x + 5');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('15');
+    });
+
+    test('should handle multi-statement expressions', () => {
+      const result = parser.evaluate('x = 5; x + 2');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('7');
+    });
+
+    test('should handle array access in arithmetic expressions', () => {
+      const result = parser.evaluate('myCollection[0] + 2');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('3');
+    });
+  });
+
+  describe('Operator precedence tests', () => {
+    test('should respect operator precedence in arithmetic expressions', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test multiplication before addition
+      const result1 = parser.evaluate('2 + 3 * 4');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('14');
+
+      // Test division before addition
+      const result2 = parser.evaluate('2 + 8 / 4');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('4');
+
+      // Test multiplication before subtraction
+      const result3 = parser.evaluate('10 - 2 * 3');
+      expect(result3.success).toBe(true);
+      expect(result3.result).toBe('4');
+
+      // Test complex expression with multiple operators
+      const result4 = parser.evaluate('2 + 3 * 4 - 6 / 2');
+      expect(result4.success).toBe(true);
+      expect(result4.result).toBe('11');
+    });
+
+    test('should respect simple parentheses', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test parentheses overriding precedence
+      const result1 = parser.evaluate('(2 + 3) * 4');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('20');
+    });
+  });
+
+  describe('String comparison format tests', () => {
+    test('should return "True" and "False" for string comparisons', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test equality
+      const result1 = parser.evaluate('"hello" == "hello"');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('True');
+
+      // Test inequality
+      const result2 = parser.evaluate('"hello" != "world"');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('True');
+
+      // Test false equality
+      const result3 = parser.evaluate('"hello" == "world"');
+      expect(result3.success).toBe(true);
+      expect(result3.result).toBe('False');
+    });
+  });
+
+  describe('Collection function tests', () => {
+    test('should correctly evaluate filter function', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('myCollection = [1, 2, 3, 4, 5]');
+
+      // Test filter with greater than
+      const result1 = parser.evaluate('filter(myCollection, {@it > 3})');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('[4, 5]');
+
+      // Test filter with equality
+      const result2 = parser.evaluate('filter(myCollection, {@it == 3})');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('[3]');
+    });
+
+    test('should correctly evaluate all function', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('myCollection = [1, 2, 3, 4, 5]');
+
+      // Test all with true condition
+      const result1 = parser.evaluate('all(myCollection, {@it > 0})');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('True');
+
+      // Test all with false condition
+      const result2 = parser.evaluate('all(myCollection, {@it > 3})');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('False');
+    });
+
+    test('should correctly evaluate any function', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('myCollection = [1, 2, 3, 4, 5]');
+
+      // Test any with true condition
+      const result1 = parser.evaluate('any(myCollection, {@it > 4})');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('True');
+
+      // Test any with false condition
+      const result2 = parser.evaluate('any(myCollection, {@it > 5})');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('False');
+    });
+
+    test('should handle empty collections in collection functions', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('emptyCollection = []');
+
+      // Test filter with empty collection
+      const result1 = parser.evaluate('filter(emptyCollection, {@it > 0})');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('[]');
+
+      // Test all with empty collection (should be true by definition)
+      const result2 = parser.evaluate('all(emptyCollection, {@it > 0})');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('True');
+
+      // Test any with empty collection (should be false by definition)
+      const result3 = parser.evaluate('any(emptyCollection, {@it > 0})');
+      expect(result3.success).toBe(true);
+      expect(result3.result).toBe('False');
+    });
+
+    test('should handle invalid predicate formats in collection functions', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('myCollection = [1, 2, 3]');
+
+      // Test missing curly braces
+      const result1 = parser.evaluate('filter(myCollection, @it > 0)');
+      expect(result1.success).toBe(false);
+
+      // Test empty predicate
+      const result2 = parser.evaluate('filter(myCollection, {})');
+      expect(result2.success).toBe(false);
+    });
+  });
+
+  describe('Edge case tests', () => {
+    test('should handle simple comparison expressions correctly', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test simple comparison
+      const result1 = parser.evaluate('5 > 3');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('True');
+
+      // Test nested function calls
+      const result2 = parser.evaluate('len(substring("hello world", 0, 5))');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('5');
+    });
+
+    test('should handle division by zero', () => {
+      const parser = new ExpressionLanguageParser();
+
+      const result = parser.evaluate('5 / 0');
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Division by zero');
+    });
+
+    test('should handle variable access in complex expressions', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('x = 5');
+      parser.evaluate('y = 10');
+
+      const result = parser.evaluate('x * 2 + y');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('20');
+    });
+  });
+
+  describe('Error handling tests', () => {
+    test('should handle invalid expressions gracefully', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test invalid arithmetic expression
+      const result1 = parser.evaluate('2 + * 3');
+      expect(result1.success).toBe(false);
+
+      // Test unmatched parentheses
+      const result2 = parser.evaluate('(2 + 3');
+      expect(result2.success).toBe(false);
+
+      // Test invalid function call
+      const result3 = parser.evaluate('unknownFunction(123)');
+      expect(result3.success).toBe(false);
+    });
+
+    test('should handle empty expressions', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test empty expression
+      const result = parser.evaluate('');
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('Multiple statement tests', () => {
+    test('should handle multiple statements separated by semicolons', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test multiple statements
+      const result = parser.evaluate('x = 5; y = 10; x + y');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('15');
+    });
+  });
+
+  describe('Variable assignment and access tests', () => {
+    test('should handle variable assignment and access', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test variable assignment
+      const result1 = parser.evaluate('myVar = 42');
+      expect(result1.success).toBe(true);
+
+      // Test variable access
+      const result2 = parser.evaluate('myVar');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('42');
+
+      // Test variable reassignment
+      const result3 = parser.evaluate('myVar = "hello"');
+      expect(result3.success).toBe(true);
+
+      // Test variable access after reassignment
+      const result4 = parser.evaluate('myVar');
+      expect(result4.success).toBe(true);
+      expect(result4.result).toBe('"hello"');
+    });
+  });
+
+  describe('Dictionary support tests', () => {
+    test('should evaluate dictionary literals', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test simple dictionary
+      const result1 = parser.evaluate('{"a": 2, "b": 3}');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('{"a": 2, "b": 3}');
+
+      // Test dictionary with mixed key types
+      const result2 = parser.evaluate('{"a": 2, 5: 2, "c": true}');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('{"5": 2, "a": 2, "c": True}');
+    });
+
+    test('should assign and access dictionaries', () => {
+      const parser = new ExpressionLanguageParser();
+
+      // Test dictionary assignment
+      const assignResult = parser.evaluate('x = {"a": 2, "b": 3}');
+      expect(assignResult.success).toBe(true);
+      expect(assignResult.result).toBe('{"a": 2, "b": 3}');
+
+      // Test dictionary access
+      const accessResult = parser.evaluate('x');
+      expect(accessResult.success).toBe(true);
+      expect(accessResult.result).toBe('{"a": 2, "b": 3}');
+    });
+
+    test('should access dictionary values by key', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('x = {"a": 2, "b": 3, "c": true}');
+
+      // Test accessing by string key
+      const result1 = parser.evaluate('x["a"]');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('2');
+
+      // Test accessing by numeric key
+      parser.evaluate('y = {5: 10, 10: 20}');
+      const result2 = parser.evaluate('y[5]');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('10');
+    });
+
+    test('should handle dictionary values in expressions', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('x = {"a": 2, "b": 3}');
+
+      // Test using dictionary value in arithmetic
+      const result = parser.evaluate('x["a"] + 5');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('7');
+    });
+
+    test('should filter dictionaries with key and value variables', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('x = {"a": 2, "b": 1, "c": 3}');
+
+      // Test filter with value condition
+      const result1 = parser.evaluate('filter(x, {@value > 1})');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('{"a": 2, "c": 3}');
+
+      // Test filter with key condition
+      const result2 = parser.evaluate('filter(x, {@key == "a"})');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('{"a": 2}');
+
+      // Test filter with both key and value
+      const result3 = parser.evaluate('filter(x, {@key == "c" || @value == 3})');
+      expect(result3.success).toBe(true);
+      expect(result3.result).toBe('{"c": 3}');
+    });
+
+    test('should handle any and all functions with dictionaries', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('x = {"a": 2, "b": 1, "c": 3}');
+
+      // Test any with value condition
+      const result1 = parser.evaluate('any(x, {@value > 2})');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('True');
+
+      // Test all with value condition
+      const result2 = parser.evaluate('all(x, {@value > 0})');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('True');
+
+      // Test all with false condition
+      const result3 = parser.evaluate('all(x, {@value > 2})');
+      expect(result3.success).toBe(true);
+      expect(result3.result).toBe('False');
+    });
+
+    test('should handle len function with dictionaries', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('x = {"a": 2, "b": 3, "c": 4}');
+
+      const result = parser.evaluate('len(x)');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('3');
+    });
+
+    test('should handle isEmpty function with dictionaries', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('emptyDict = {}');
+      parser.evaluate('nonEmptyDict = {"a": 1}');
+
+      const result1 = parser.evaluate('isEmpty(emptyDict)');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('True');
+
+      const result2 = parser.evaluate('isEmpty(nonEmptyDict)');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('False');
+    });
+  });
+});

--- a/assets/styles/components/_expression-evaluator.scss
+++ b/assets/styles/components/_expression-evaluator.scss
@@ -15,6 +15,7 @@
     overflow-x: auto;
     width: calc(100% - 40px);
     border-radius: 0;
+    background-color: transparent;
   }
 
   .run-expression-btn {
@@ -48,11 +49,135 @@
     .expression-result {
       font-family: monospace;
       font-size: 0.85rem; // Same size as code
+      background-color: transparent;
       white-space: pre;
       overflow-x: auto;
       color: #28a745;
       display: block;
       border-radius: 0;
+    }
+  }
+}
+
+// Expression REPL Component Styles
+.expression-repl {
+  margin: 1.5rem 0;
+  border: 1px solid #e5e5e5;
+  border-radius: 4px;
+  overflow: hidden;
+
+  .repl-header {
+    background-color: #f8f8f8;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid #e5e5e5;
+
+    h4 {
+      margin: 0;
+      font-size: 1rem;
+      color: #333;
+    }
+  }
+
+  .repl-container {
+    background-color: #f5f5f5;
+    padding: 0.75rem;
+    height: 400px; // Increased height
+    display: flex;
+    flex-direction: column;
+  }
+
+  .repl-history {
+    font-family: monospace;
+    font-size: 0.85rem;
+    margin-bottom: 0.75rem;
+    flex: 1;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+
+    .repl-entry {
+      margin-bottom: 0.5rem;
+
+      .repl-command {
+        display: flex;
+        align-items: flex-start;
+
+        .repl-prompt {
+          color: #632ca6;
+          margin-right: 0.5rem;
+          flex-shrink: 0;
+        }
+
+        .repl-expression {
+          white-space: pre;
+          overflow-x: auto;
+          word-break: break-all;
+        }
+      }
+
+      .repl-result {
+        margin-left: 1.25rem;
+        color: #28a745;
+        white-space: pre;
+        overflow-x: auto;
+        word-break: break-all;
+        padding: 0.25rem 0;
+      }
+
+      .repl-error {
+        margin-left: 1.25rem;
+        color: #dc3545;
+        white-space: pre;
+        overflow-x: auto;
+        word-break: break-all;
+        padding: 0.25rem 0;
+      }
+    }
+  }
+
+  .repl-input-container {
+    display: flex;
+    align-items: center;
+    background-color: white;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    padding: 0.5rem;
+    margin-top: auto;
+
+    .repl-prompt {
+      color: #632ca6;
+      margin-right: 0.5rem;
+      font-family: monospace;
+      font-weight: bold;
+    }
+
+    .repl-input {
+      flex: 1;
+      border: none;
+      outline: none;
+      font-family: monospace;
+      font-size: 0.85rem;
+      background: transparent;
+      padding: 0.25rem 0;
+    }
+
+    .run-expression-btn {
+      background-color: #632ca6;
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      min-width: 32px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.7rem;
+      padding: 0 8px;
+      margin-left: 0.5rem;
+
+      &:hover {
+        background-color: #7847a6;
+      }
     }
   }
 }

--- a/content/en/dynamic_instrumentation/expression-language.md
+++ b/content/en/dynamic_instrumentation/expression-language.md
@@ -69,3 +69,12 @@ The following examples use a variable named `myCollection` defined as `[1,2,3]`:
 [4]: /tracing/trace_collection/custom_instrumentation/java/#adding-spans
 [5]: /tracing/trace_collection/custom_instrumentation/java/#adding-tags
 [6]: /dynamic_instrumentation/symdb/
+
+## Expression Language REPL
+
+This interactive REPL tool helps you experiment with the Expression Language syntax before using it in your Dynamic Instrumentation probes. Try the examples from the documentation above or create your own expressions to see how they work.
+
+The REPL below includes some predefined variables like `myCollection` with the value `[1, 2, 3]` that you can use in your expressions. You can also define your own variables and use them in subsequent expressions.
+
+{{< expression-repl >}}
+

--- a/layouts/shortcodes/expression-repl.html
+++ b/layouts/shortcodes/expression-repl.html
@@ -1,0 +1,36 @@
+<div class="expression-repl">
+  <div class="repl-header">
+    <h4>Expression Language REPL</h4>
+  </div>
+  <div class="repl-container">
+    <div class="repl-history" id="repl-history">
+      <!-- Pre-populated examples -->
+      <div class="repl-entry">
+        <div class="repl-command">
+          <span class="repl-prompt">→</span>
+          <span class="repl-expression">len(myCollection)</span>
+        </div>
+        <div class="repl-result">3</div>
+      </div>
+      <div class="repl-entry">
+        <div class="repl-command">
+          <span class="repl-prompt">→</span>
+          <span class="repl-expression">newCollection = [1, "b", 2.5, true]; newCollection[1]</span>
+        </div>
+        <div class="repl-result">b</div>
+      </div>
+      <div class="repl-entry">
+        <div class="repl-command">
+          <span class="repl-prompt">→</span>
+          <span class="repl-expression">newDictionary = {"a": 1, "b": 2, "c": 3}; filter(newDictionary,{@key == "a" || @value == 3})</span>
+        </div>
+        <div class="repl-result">{a: 1, c: 3}</div>
+      </div>
+    </div>
+    <div class="repl-input-container">
+      <span class="repl-prompt">→</span>
+      <input type="text" class="repl-input" id="repl-input" placeholder="Enter an expression..." aria-label="Expression input">
+      <button type="button" class="run-expression-btn" id="repl-run-btn" aria-label="Evaluate expression">▶</button>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This pull request introduces a new REPL (Read-Eval-Print Loop) feature for the Expression Language allowing interactive experimentation with expressions directly within the documentation. The most important changes include adding the REPL setup in the JavaScript component, defining the styles for the REPL, updating the documentation to include the REPL, and creating a shortcode for the REPL.

Note that this is part two of #28079 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
