### PR TITLE
[DOCS-10351] fixing broken further reading links

### DIFF
--- a/content/en/getting_started/synthetics/mobile_app_testing.md
+++ b/content/en/getting_started/synthetics/mobile_app_testing.md
@@ -5,7 +5,7 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/test-creation-best-practices/"
   tag: "Blog"
   text: "Best practices for creating end-to-end tests"
-- link: "/synthetics/mobile_app_testing/mobile_app_tests"
+- link: "/synthetics/mobile_app_testing/"
   tag: "Documentation"
   text: "Learn how to create Synthetic mobile app tests"
 - link: "/synthetics/mobile_app_testing/settings"

--- a/content/en/synthetics/mobile_app_testing/_index.md
+++ b/content/en/synthetics/mobile_app_testing/_index.md
@@ -8,7 +8,7 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/test-creation-best-practices/"
   tag: "Blog"
   text: "Best practices for creating end-to-end tests"
-- link: "/synthetics/mobile_app_testing/mobile_app_tests"
+- link: "/synthetics/mobile_app_testing/"
   tag: "Documentation"
   text: "Learn how to create Synthetic mobile app tests"
 - link: "/synthetics/mobile_app_testing/settings"

--- a/content/en/synthetics/mobile_app_testing/mobile_app_tests/advanced_options.md
+++ b/content/en/synthetics/mobile_app_testing/mobile_app_tests/advanced_options.md
@@ -8,7 +8,7 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/test-maintenance-best-practices/"
   tag: "Blog"
   text: "Best practices for maintaining end-to-end tests"
-- link: "/synthetics/mobile_app_testing/mobile_app_tests/"
+- link: "/synthetics/mobile_app_testing/"
   tag: "Documentation"
   text: "Learn how to create mobile app tests"
 - link: "/synthetics/mobile_app_testing/mobile_app_tests/steps/"

--- a/content/en/synthetics/mobile_app_testing/mobile_app_tests/restricted_networks.md
+++ b/content/en/synthetics/mobile_app_testing/mobile_app_tests/restricted_networks.md
@@ -5,7 +5,7 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/test-creation-best-practices/"
   tag: "Blog"
   text: "Best practices for creating end-to-end tests"
-- link: "/synthetics/mobile_app_testing/mobile_app_tests"
+- link: "/synthetics/mobile_app_testing/"
   tag: "Documentation"
   text: "Learn how to create Synthetic mobile app tests"
 - link: "/synthetics/mobile_app_testing/settings"

--- a/content/en/synthetics/mobile_app_testing/mobile_app_tests/results.md
+++ b/content/en/synthetics/mobile_app_testing/mobile_app_tests/results.md
@@ -5,7 +5,7 @@ aliases:
 - /mobile_testing/mobile_app_tests/results
 - /mobile_app_testing/mobile_app_tests/results
 further_reading:
-- link: "/synthetics/mobile_app_testing/mobile_app_tests/"
+- link: "/synthetics/mobile_app_testing/"
   tag: "Documentation"
   text: "Learn about Synthetic mobile tests"
 - link: "/service_management/events/explorer"

--- a/content/en/synthetics/mobile_app_testing/mobile_app_tests/steps.md
+++ b/content/en/synthetics/mobile_app_testing/mobile_app_tests/steps.md
@@ -5,7 +5,7 @@ aliases:
 - /mobile_testing/mobile_app_tests/steps
 - /mobile_app_testing/mobile_app_tests/steps
 further_reading:
-- link: "/synthetics/mobile_app_testing/mobile_app_tests/"
+- link: "/synthetics/mobile_app_testing/"
   tag: "Documentation"
   text: "Learn about Synthetic mobile tests"
 - link: "/synthetics/mobile_app_testing/mobile_app_tests/advanced_options"

--- a/content/en/synthetics/mobile_app_testing/settings/_index.md
+++ b/content/en/synthetics/mobile_app_testing/settings/_index.md
@@ -5,7 +5,7 @@ aliases:
 - /mobile_testing/settings
 - /mobile_app_testing/settings
 further_reading:
-- link: "/synthetics/mobile_app_testing/mobile_app_tests"
+- link: "/synthetics/mobile_app_testing/"
   tag: "Documentation"
   text: "Learn how to create a mobile test"
 - link: "/continuous_testing/cicd_integrations"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Missed fixing some further reading links with the Mobile App reorg

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
