### PR TITLE
📝 adjust click collection documentation

### DIFF
--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -35,13 +35,7 @@ To control which information is sent to Datadog, you can [mask action names with
 
 ## Track user interactions
 
-The RUM Browser SDK automatically tracks clicks. A click action is created if **all of the following** conditions are met:
-
-* Activity following the click is detected. See [How page activity is calculated][2] for details.
-* The click does not lead to a new page being loaded, in which case, the Datadog Browser SDK generates another RUM View event.
-* A name can be computed for the action. See [Declaring a name for click actions](#declare-a-name-for-click-actions) for details.
-
-**Note**: When an action is being tracked, other actions within the next `100 ms` do not get sent, unless they are [custom actions][5].
+The RUM Browser SDK automatically tracks clicks to generate click actions. In general, one click action represents one user click, except when the same element is clicked multiple times in a row, which is considered a single action (for more information, see [Frustration Signals "rage clicks"][7]).
 
 ## Action timing metrics
 
@@ -126,3 +120,4 @@ For more information, see [Send Custom Actions][5].
 [4]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v2160
 [5]: /real_user_monitoring/guide/send-rum-custom-actions
 [6]: /data_security/real_user_monitoring/#mask-action-names
+[7]: /real_user_monitoring/browser/frustration_signals/

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -35,7 +35,7 @@ To control which information is sent to Datadog, you can [mask action names with
 
 ## Track user interactions
 
-The RUM Browser SDK automatically tracks clicks to generate click actions. In general, one click action represents one user click, except when the same element is clicked multiple times in a row, which is considered a single action (for more information, see [Frustration Signals "rage clicks"][7]).
+The RUM Browser SDK automatically tracks clicks to generate click actions. A one-click action generally represents one user click, except when the same element is clicked multiple times in a row, which is considered a single action (see [Frustration Signals "rage clicks"][7]).
 
 ## Action timing metrics
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?

Since v5 (2023) the Browser SDK collects Click actions most of the time, all those bullet points are not relevant anymore. Replaced with a mention about rage clicks, which should be more relevent.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
