### PR TITLE
Change the word pipeline to index in index documentation

### DIFF
--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -77,7 +77,7 @@ But because your logs are not all and equally valuable, exclusion filters contro
 To add an exclusion filter:
 
 1. Navigate to [Log Indexes][11].
-2. Expand the pipeline for which you want to add an exclusion filter. 
+2. Expand the index for which you want to add an exclusion filter. 
 3. Click **Add an Exclusion Filter**.
 
 Exclusion filters are defined by a query, a sampling rule, and an active/inactive toggle:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
In the documentation for log indexes under `Exclusion Filters`, the second step uses the word "pipeline" rather than "index." This caused confusion for a user in the [Datadog Public Slack channel](https://datadoghq.slack.com/archives/C8PV5LVDX/p1741712562340849).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
