### PR TITLE
Remove documentation files for data deletion API

### DIFF
--- a/content/en/api/latest/data-deletion/_index.md
+++ b/content/en/api/latest/data-deletion/_index.md
@@ -1,3 +1,0 @@
----
-title: Data Deletion
----

--- a/content/en/api/v2/data-deletion/_index.md
+++ b/content/en/api/v2/data-deletion/_index.md
@@ -1,4 +1,0 @@
----
-title: Data Deletion
-headless: true
----


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This endpoint was [created](https://github.com/DataDog/documentation/pull/26227), but the documentation was removed [[PR](https://github.com/DataDog/documentation/pull/26804)]. However, the _index.md files were not removed and caused it to show up in Google search results that led to a blank page.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
