### PR TITLE
fixed broken links for sca + asm in each tab for devsecops tiers

### DIFF
--- a/content/en/getting_started/devsecops/_index.md
+++ b/content/en/getting_started/devsecops/_index.md
@@ -40,7 +40,7 @@ Learn more about the features included with APM DevSecOps:
 [6]: /tracing/trace_collection/
 [7]: /universal_service_monitoring/setup/
 [9]: /tracing/metrics/
-[10]: /getting_started/code_security/software_composition_analysis/
+[10]: /security/code_security/software_composition_analysis/
 
 {{% /tab %}}
 {{% tab "APM DevSecOps Pro" %}}
@@ -77,7 +77,7 @@ Learn more about the features included with APM DevSecOps Pro:
 [7]: /tracing/trace_collection/
 [8]: /universal_service_monitoring/setup/
 [9]: /data_streams/#setup
-[10]: /getting_started/code_security/software_composition_analysis/
+[10]: /security/code_security/software_composition_analysis/
 [11]: /tracing/metrics/
 
 {{% /tab %}}
@@ -120,7 +120,7 @@ Learn more about the features included with APM DevSecOps Enterprise:
 [10]: /data_streams/#setup
 [11]: /profiler/enabling
 [13]: /tracing/metrics/
-[14]: /getting_started/code_security/software_composition_analysis/
+[14]: /security/application_security/ 
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
On the "Getting Started with the DevSecOps Bundles" documentation page, there are a total of 3 broken links, one under each bundle tab.

The broken links relate to:
> After you install the Agent, enable Software Composition Analysis (SCA) for your environment.
> After you install the Agent, configure ASM for your environment.

**BEFORE**: I have attached a recording of the behavior that lead to the broken links.

https://github.com/user-attachments/assets/849531d6-c2ce-415d-8424-05e7b585d424


**AFTER**:
I changed the links to what I believe would be the best course of action [[SCA](https://docs.datadoghq.com/security/code_security/software_composition_analysis/)] [[ASM](https://docs.datadoghq.com/security/application_security/)], but please let me know if I should redirect to a different page/section of the page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
I changed the links to what I believe would be the best course of action, but please let me know if I should redirect to a different page/section of the page.