### PR TITLE
RUM-6479 - Add documentation for RumMonitor#addViewLoadingTime API on React Native guide

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/advanced_configuration.md
@@ -294,7 +294,7 @@ Use the `overwrite` parameter to replace the previously calculated loading time 
 
 After the loading time is sent, it is accessible as `@view.loading_time` and is visible in the RUM UI.
 
-**Note**: This API is still experimental and might change in the future.
+**Note**: This API is experimental.
 
 ### Add custom timings
 You can add custom timings:

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/advanced_configuration.md
@@ -281,6 +281,21 @@ DdRum.startResource('<res-key>', 'GET', 'http://www.example.com/api/v1/test', {}
 DdRum.stopResource('<res-key>', 200, 'xhr', (size = 1337), {}, Date.now());
 ```
 
+### Notify the SDK that your view finished loading
+
+You can notify the SDK that your view has finished loading by calling the `addViewLoadingTime` method on `DdRum`. 
+Call this method when your view is fully loaded and ready to be displayed to the user:
+
+```javascript
+DdRum.addViewLoadingTime(true);
+```
+
+Use the `overwrite` parameter to replace the previously calculated loading time for the current view.
+
+After the loading time is sent, it is accessible as `@view.loading_time` and is visible in the RUM UI.
+
+**Note**: This API is still experimental and might change in the future.
+
 ### Add custom timings
 You can add custom timings:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the Advanced Configuration guide to include documentation regarding addViewLoadingTime API exposed by React Native SDK release v2.6.4 as described on  [RUM-6479](https://datadoghq.atlassian.net/browse/RUM-6479).

### Merge instructions

- [x] Please merge after reviewing


[RUM-6479]: https://datadoghq.atlassian.net/browse/RUM-6479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ