### PR TITLE
[DOCS-10126] Explain branch naming convention as a hard requirement

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ If the PR is ready to be merged once it receives the required reviews, check the
 Merge readiness:
 - [ ] Ready for merge
 
-Merge queue is enabled in this repo. Your branch name MUST follow the `<username>/<branch_name>` convention, or your pull request will not pass in CI. If your branch doesn't follow this format, rename it or create a new branch and PR.
+Merge queue is enabled in this repo. Your branch name MUST follow the `<slack_username>/<branch_name>` convention, or your pull request will not pass in CI. If your branch doesn't follow this format, rename it or create a new branch and PR.
 
 To have your PR automatically merged after it receives the required reviews, add the following PR comment:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,7 @@ If the PR is ready to be merged once it receives the required reviews, check the
 Merge readiness:
 - [ ] Ready for merge
 
-Merge queue is enabled in this repo. Your branch name MUST follow the `<username>/<branch_name>` convention, or your pull request will not pass CI. If your branch doesn't follow this format, rename it or create a new branch and PR.
+Merge queue is enabled in this repo. Your branch name MUST follow the `<username>/<branch_name>` convention, or your pull request will not pass in CI. If your branch doesn't follow this format, rename it or create a new branch and PR.
 
 To have your PR automatically merged after it receives the required reviews, add the following PR comment:
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,9 @@ If the PR is ready to be merged once it receives the required reviews, check the
 Merge readiness:
 - [ ] Ready for merge
 
-Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:
+Merge queue is enabled in this repo. Your branch name MUST follow the `<username>/<branch_name>` convention, or your pull request will not pass CI. If your branch doesn't follow this format, rename it or create a new branch and PR.
+
+To have your PR automatically merged after it receives the required reviews, add the following PR comment:
 
 ```
 /merge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ This document is a guide to writing and editing documentation for the [Datadog D
 
 Some of these guidelines are enforced by [the Datadog docs implementation of the Vale linter][4]. After you make a PR, check its **Files changed** tab to see and fix warnings and errors flagged by the linter.
 
-See our [README][9] for additional contribution requirements, including the `<username>/<branch_name>` branch naming convention for all pull requests.
+See our [README][9] for additional contribution requirements, including the `<slack_username>/<branch_name>` branch naming convention for all pull requests.
 
 ## Language
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ This document is a guide to writing and editing documentation for the [Datadog D
 
 Some of these guidelines are enforced by [the Datadog docs implementation of the Vale linter][4]. After you make a PR, check its **Files changed** tab to see and fix warnings and errors flagged by the linter.
 
+See our [README][9] for additional contribution requirements, including the `<username>/<branch_name>` branch naming convention for all pull requests.
+
 ## Language
 
 - Use the American English **en_US** dialect when writing documentation, code comments, [wiki entries][1], and more in the English language. This is the default language for all `*.md` files.
@@ -205,3 +207,4 @@ Use text formatting to clarify and enhance content.
 [6]: https://github.com/DataDog/documentation/wiki/Import-an-Image-or-a-mp4-video
 [7]: https://docs.datadoghq.com/
 [8]: https://www.markdownguide.org/basic-syntax/#reference-style-links
+[9]: https://github.com/DataDog/documentation/blob/master/README.md

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more information on contributing, see the [contribution guidelines][18].
 ### Datadog Staff
 
 - Always branch off of master; never commit directly to master.
-- You MUST name your branch `<slack_username>/<branch_name>`. If you don't include the forward slash (`/`), the GitLab pipeline won't run, you won't get a branch preview, and your pull request will not pass CI. Getting a branch preview makes it easier for us to check for any issues with your PR, such as broken links. Using a [Slack username][21] also ensures you get build notifications in Slack.
+- You MUST name your branch `<slack_username>/<branch_name>`. If you do not include the forward slash (`/`), the GitLab pipeline won't run, you won't get a branch preview, and your pull request will not pass in CI. Getting a branch preview makes it easier for us to check for any issues with your PR, such as broken links. Using a [Slack username][21] also ensures you get build notifications in Slack.
 - Consult our [contributing guidelines][8].
 - When you're ready to commit, create a new pull request to master from your branch.
 - Use GitHub's [draft pull request][15] feature and appropriate labels such as "Do Not Merge" or "Work in Progress" until your PR is ready to be merged and live on production.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For more information on contributing, see the [contribution guidelines][18].
 ### Datadog Staff
 
 - Always branch off of master; never commit directly to master.
-- Name your branch `slack_username/branch_name`. If you don't include the forward slash (`/`), the Gitlab pipeline won't run and you won't get a branch preview. Getting a branch preview makes it easier for us to check for any issues with your PR, such as broken links. Using a [Slack username][21] ensures you get build notifications in Slack.
+- You MUST name your branch `<slack_username>/<branch_name>`. If you don't include the forward slash (`/`), the GitLab pipeline won't run, you won't get a branch preview, and your pull request will not pass CI. Getting a branch preview makes it easier for us to check for any issues with your PR, such as broken links. Using a [Slack username][21] also ensures you get build notifications in Slack.
 - Consult our [contributing guidelines][8].
 - When you're ready to commit, create a new pull request to master from your branch.
 - Use GitHub's [draft pull request][15] feature and appropriate labels such as "Do Not Merge" or "Work in Progress" until your PR is ready to be merged and live on production.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Per [DOCS-10126: Advertise branch naming convention as a hard requirement](https://datadoghq.atlassian.net/browse/DOCS-10126), this PR updates descriptions of our branch naming convention (`<username>/<branch_name>`) in contributor-facing content to make it clear that this is required for PRs to pass CI.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
