### PR TITLE
CoTerm: Mention Homebrew install method and explorer page

### DIFF
--- a/content/en/coterm/_index.md
+++ b/content/en/coterm/_index.md
@@ -33,7 +33,7 @@ For your security, CoTerm uses [Sensitive Data Scanner][2] to detect and obfusca
 
 You can review your recorded terminal sessions and process data in Datadog:
 
-- **As replays**: Watch terminal sessions in a video-like player.
+- **As replays**: Watch [terminal sessions][6] in a video-like player.
 - **As events**: In [Event Explorer][4], each recorded command appears as an event.
 - **As logs**: In [Log Explorer][5], you can perform full-text searches and queries of terminal sessions as multi-line logs.
 
@@ -52,3 +52,4 @@ You can review your recorded terminal sessions and process data in Datadog:
 [3]: /service_management/case_management/
 [4]: http://app.datadoghq.com/event/explorer?query=source%3Acoterm_process_info
 [5]: https://app.datadoghq.com/logs?query=service%3Addcoterm
+[6]: https://app.datadoghq.com/terminal-streams

--- a/content/en/coterm/install.md
+++ b/content/en/coterm/install.md
@@ -12,13 +12,15 @@ further_reading:
   text: "CoTerm Configuration Rules"
 ---
 
-1. Install Datadog CoTerm by running:
+CoTerm is currently supported on macOS and Linux.
+
+1. Install Datadog CoTerm by running `brew install coterm` (macOS only), or:
 
    ```shell
    curl --tlsv1.2 --proto '=https' -sSf 'https://coterm.datadoghq.com/install-ddcoterm.sh' | bash
    ```
 
-   This command downloads the latest version of CoTerm to `.ddcoterm/bin/ddcoterm` and updates your PATH in `.bashrc` and `.zshrc`. Restart your terminal or source your profile. If you are using a shell other than Bash or Zsh, add `path/to/.ddcoterm/bin` to your PATH manually. 
+   This command downloads the latest version of CoTerm to `.ddcoterm/bin/ddcoterm` and updates your PATH in `.bashrc` and `.zshrc`. Restart your terminal or source your profile. If you are using a shell other than Bash or Zsh, add `path/to/.ddcoterm/bin` to your PATH manually.
 
 2. If your [Datadog site][6] is not `https://app.datadoghq.com`, set your site in `.ddcoterm/config.yaml` under `connection_config.host`:
    ```yaml
@@ -27,7 +29,7 @@ further_reading:
      host: {{< region-param key=dd_full_site code="true" >}}
    ...
    ```
-  
+
 3. Initialize your configuration file by running:
 
    ```shell
@@ -59,7 +61,7 @@ The `~/.ddcoterm/config.yaml` file contains your CoTerm configurations:
 : Enable or disable experimental `ptrace`-based process monitoring on Linux. Defaults to `false`.
 
 `connection_config`
-: 
+:
   `host`
   : Host for connecting to Datadog. Defaults to `https://app.datadoghq.com`.
 

--- a/content/en/coterm/install.md
+++ b/content/en/coterm/install.md
@@ -12,14 +12,20 @@ further_reading:
   text: "CoTerm Configuration Rules"
 ---
 
-CoTerm is currently supported on macOS and Linux.
+CoTerm is supported on macOS and Linux.
 
-1. Install Datadog CoTerm by running `brew install coterm` (macOS only), or:
+1. Install Datadog CoTerm with Homebrew or curl:
 
+   **brew** (macOS only)
+   ```shell
+   brew install coterm
+   ```
+  
+   **curl**
    ```shell
    curl --tlsv1.2 --proto '=https' -sSf 'https://coterm.datadoghq.com/install-ddcoterm.sh' | bash
    ```
-
+   
    This command downloads the latest version of CoTerm to `.ddcoterm/bin/ddcoterm` and updates your PATH in `.bashrc` and `.zshrc`. Restart your terminal or source your profile. If you are using a shell other than Bash or Zsh, add `path/to/.ddcoterm/bin` to your PATH manually.
 
 2. If your [Datadog site][6] is not `https://app.datadoghq.com`, set your site in `.ddcoterm/config.yaml` under `connection_config.host`:
@@ -61,7 +67,7 @@ The `~/.ddcoterm/config.yaml` file contains your CoTerm configurations:
 : Enable or disable experimental `ptrace`-based process monitoring on Linux. Defaults to `false`.
 
 `connection_config`
-:
+: 
   `host`
   : Host for connecting to Datadog. Defaults to `https://app.datadoghq.com`.
 

--- a/content/en/coterm/usage.md
+++ b/content/en/coterm/usage.md
@@ -12,6 +12,10 @@ further_reading:
   text: "CoTerm Configuration Rules"
 ---
 
+## View all recorded terminal sessions
+
+Recordings are listed [here](https://app.datadoghq.com/terminal-streams) in the Datadog UI.
+
 ## CoTerm CLI command structure
 
 ```shell
@@ -24,7 +28,7 @@ Run `ddcoterm --help` for all options and commands.
 
 CoTerm records terminal sessions that you can play back and review in Datadog. For your security, sensitive data (such as passwords and API keys) are [automatically redacted][1]. Any processes launched in the terminal session are recorded as [events][2].
 
-### Launch a recorded terminal session
+### Launch and record an interactive terminal session
 To manually launch Datadog CoTerm and record the entirety of your terminal session:
 
 ```shell
@@ -75,7 +79,7 @@ process_config:
           end
    {{< /code-block >}}
 
-With this configuration, CoTerm intercepts any `kubectl scale` command without a `--context` flag. 
+With this configuration, CoTerm intercepts any `kubectl scale` command without a `--context` flag.
 
 {{< img src="coterm/linter-warning.png" alt="Command line interface. The user has run 'kubectl scale foo'. The output says 'Warning from CoTerm: No kubectl context specified (effective context: 'minikube'). It is recommended to always explicitly specify the context when running kubectl scale. Do you want to continue? (y/n)'" style="width:70%;" >}}
 
@@ -108,7 +112,7 @@ With this configuration, when you run a `kubectl scale --context prod` command, 
 To create an approval request manually, run:
 
 ```shell
-ddcoterm approve 
+ddcoterm approve
 ```
 
 #### Bypass approval

--- a/content/en/coterm/usage.md
+++ b/content/en/coterm/usage.md
@@ -12,9 +12,8 @@ further_reading:
   text: "CoTerm Configuration Rules"
 ---
 
-## View all recorded terminal sessions
-
-Recordings are listed [here](https://app.datadoghq.com/terminal-streams) in the Datadog UI.
+## View recorded terminal sessions
+At the beginning and end of every recorded terminal session, CoTerm displays a link to view the session in Datadog. You can also [view all recorded terminal sessions][7].
 
 ## CoTerm CLI command structure
 
@@ -135,3 +134,4 @@ COTERM_BREAK_GLASS=true kubectl delete foo
 [4]: /coterm/rules
 [5]: /service_management/incident_management/
 [6]: /coterm/install
+[7]: https://app.datadoghq.com/terminal-streams


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

[CoTerm can now be installed via Homebrew](https://github.com/Homebrew/homebrew-cask/pull/205004), on macOS only. This PR mentions that in the CoTerm docs.

CoTerm now has [a page where you can view all recordings in your org](https://app.datadoghq.com/terminal-streams). This PR links to that page in the usage docs. 

It also unintentionally includes a few tiny formatting cleanups (sorry for the noise, VS Code makes them automatically when saving a Markdown file).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
