### PR TITLE
hotfix: pin tj-actions/changed-files by SHA

### DIFF
--- a/.github/workflows/gif_check.yml
+++ b/.github/workflows/gif_check.yml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Find changed files
       id: changed_files
-      uses: tj-actions/changed-files@v42
+      uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
 
     - name: Look for gifs
       env:

--- a/.github/workflows/preview_link.yml
+++ b/.github/workflows/preview_link.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Find changed files
       id: changed_files
-      uses: tj-actions/changed-files@v42
+      uses: tj-actions/changed-files@9200e69727eb73eb060652b19946b8a2fdfb654b # v45.0.8
       with:
         include_all_old_new_renamed_files: true
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR pins the `tj-actions/changed-files` GitHub action to a SHA corresponding to a version that is not compromised. For details on the compromise, see:

- https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

Compromised versions leak CI secrets, so this repo's CI secrets will need to be rotated.

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
