### PR TITLE
Update powershell_metrics_submission.md

### DIFF
--- a/content/en/metrics/custom_metrics/powershell_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/powershell_metrics_submission.md
@@ -18,41 +18,89 @@ Datadog can collect metrics from the Agent as well as from the API independently
 This method doesn't require you to have the Agent installed on the system running the PowerShell script. You have to explicitly pass your [API key][1] as well as an application key when making the POST request.
 
 ```powershell
-# Tested on Windows Server 2012 R2 w/ PSVersion 4.0
+# This script sends a custom metric to Datadog v2 API from PowerShell.
+# Tested on Windows 10 Pro (version 10.0.1945) with PSVersion 5.1 (Build 19041, Revision 5486)
 
-function unixTime() {
-  Return (Get-Date -date ((get-date).ToUniversalTime()) -UFormat %s) -Replace("[,\.]\d*", "")
+function Send-DatadogMetric {
+    param(
+        [Parameter(Mandatory=$true)]
+        [string]$MetricName,
+
+        [Parameter(Mandatory=$true)]
+        [int]$MetricValue,
+
+        [Parameter(Mandatory=$false)]
+        [string[]]$Tags = @()
+    )
+
+    # ==================================
+    # 1) Set Datadog API keys (v2)
+    # ================================== 
+    # - $url: The API endpoint for sending metric data to Datadog.
+    #   By default, it is set to the US1 data center. If you are 
+    #   operating in a different region, update this URL accordingly:
+    #     * EU:         https://api.datadoghq.eu/api/v2/series
+    #     * US3:        https://api.us3.datadoghq.com/api/v2/series
+    #     * US5:        https://api.us5.datadoghq.com/api/v2/series
+    #     * AP1:        https://api.ap1.datadoghq.com/api/v2/series
+    #     * US1-FED:    https://api.ddog-gov.com/api/v2/series
+    $api_key = "<DATADOG_APPLICATION_KEY>"  #provide your valid app key
+    $app_key = "<DATADOG_API_KEY>"          #provide your valid api key
+    $url     = "https://api.datadoghq.com/api/v2/series" # Default endpoint for US1; update based on your Datadog data center
+
+    # ==================================
+    # 2) Request headers
+    # ==================================
+    $headers = @{
+        "DD-API-KEY"         = $api_key
+        "DD-APPLICATION-KEY" = $app_key
+        "Content-Type"       = "application/json"
+    }
+
+    # ==================================
+    # 3) Build JSON payload for v2
+    # ==================================
+    # Current time in epoch seconds
+    $currentTime = [int](Get-Date -date ((get-date).ToUniversalTime()) -UFormat %s) -Replace("[,\.]\d*", "")
+
+
+    # The body for the /api/v2/series endpoint
+    $body = @{
+        "series" = @(
+            @{
+                "metric" = $MetricName
+                "points" = @(
+                    @{
+                        "timestamp" = $currentTime
+                        "value"     = $MetricValue
+                    }
+                )
+                "type"  = 1                 # (1) count, (2) rate, (3) gauge
+                "tags"  = $Tags             # optional parameter should be an array of tags
+            }
+        )
+    }
+
+    # Convert hash to JSON
+    $jsonBody = $body | ConvertTo-Json -Depth 5 -Compress
+
+    # ==================================
+    # 4) Send the POST request
+    # ==================================
+    $response = Invoke-RestMethod -Method Post -Uri $url -Headers $headers -Body $jsonBody
+
+    Write-Host "Datadog response: $($response | ConvertTo-Json -Depth 5)"
 }
 
-function postMetric($metric,$tags) {
-  $currenttime = unixTime
-  $host_name = $env:COMPUTERNAME #optional parameter .
 
-  # Construct JSON
-  $points = ,@($currenttime, $metric.amount)
-  $post_obj = [pscustomobject]@{"series" = ,@{"metric" = $metric.name;
-      "points" = $points;
-      "type" = "gauge";
-      "host" = $host_name;
-      "tags" = $tags}}
-  $post_json = $post_obj | ConvertTo-Json -Depth 5 -Compress
-  # POST to DD API
-  $response = Invoke-RestMethod -Method Post -Uri $url -Body $post_json -ContentType "application/json"
-}
-
-# Datadog account, API information and optional parameters
-$app_key = "<DATADOG_APPLICATION_KEY>" #provide your valid app key
-$api_key = "<DATADOG_API_KEY>" #provide your valid api key
-$url_base = "https://app.datadoghq.com/"
-$url_signature = "api/v2/series"
-$url = $url_base + $url_signature + "?api_key=$api_key" + "&" + "application_key=$app_key"
-$tags = "[env:test]" #optional parameter
-
-# Select what to send to Datadog. In this example, the number of handles opened by process "mmc" is being sent
-$metric_ns = "ps1." # your desired metric namespace
-$temp = Get-Process mmc
-$metric = @{"name"=$metric_ns + $temp.Name; "amount"=$temp.Handles}
-postMetric($metric)($tags) # pass your metric as a parameter to postMetric()
+# ----------------------------
+# Example Usage:
+# ----------------------------
+# This sends a custom count metric called "my.custom.metric" with a value of 42
+# and adds "env:test" + "version:1.0" + host as tags.
+Send-DatadogMetric -MetricName "my.custom.metric" `
+                   -MetricValue 42 `
+                   -Tags @("env:test","version:1.0", "host:$env:COMPUTERNAME")
 ```
 
 ## Submitting metrics with PowerShell with DogStatsD


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

#### Summary of Changes

I encountered several issues while attempting to follow the "**Metric submission: PowerShell**" documentation for the **API v2** endpoint. Specifically:

1. **API Key / Application Key in Headers**  
   - **Issue**: With API v2, Datadog expects `DD-API-KEY` and `DD-APPLICATION-KEY` in the request headers instead of query parameters. The docs currently show including `?api_key=...&application_key=...` in the URL, causing errors like:
     ```
     {"errors":["No API key specified in DD-API-KEY header"]}
     ```
   - **Fix**: Updated the sample script to use headers (`DD-API-KEY` and `DD-APPLICATION-KEY`) instead of the URL query parameters.

2. **JSON Payload Structure**  
   - **Issue**: The example JSON in the doc used fields not recognized by API v2 (e.g., `"host"`) and used `"gauge"` as a string, causing parse errors:
     ```
     {"errors":["Invalid JSON structure: unknown field \"host\" in datadoghq.api.series.v2.MetricSeries"]}
     ```
   - **Fix**: 
     - Replaced `"host"` with a `"host:..."` tag inside the `tags` array.  
     - Used the **numeric `type`** in v2 (`1` = count, `2` = rate, `3` = gauge) instead of strings like `"gauge"`.

3. **Endpoint URL and Data Center Variation**  
   - **Issue**: The doc references `https://app.datadoghq.com/` for the base URL. For API v2 in US1, the correct endpoint is `https://api.datadoghq.com/api/v2/series`. Other data centers (EU, US3, US5, AP1, etc.) require different domains (`api.datadoghq.eu`, `api.us3.datadoghq.com`, etc.).
   - **Fix**: Updated the script to default to `https://api.datadoghq.com/api/v2/series` and added comments for other regions.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
