### PR TITLE
[DOCS-10378] Add alert box for linux RPM

### DIFF
--- a/layouts/shortcodes/observability_pipelines/install_worker/linux_rpm.en.md
+++ b/layouts/shortcodes/observability_pipelines/install_worker/linux_rpm.en.md
@@ -1,3 +1,5 @@
+<div class="alert alert-warning">The Observability Pipelines Worker supports RHEL and CentOS versions 8.0 or later.</div>
+
 1. Click **Select API key** to choose the Datadog API key you want to use.
 1. Run the one-step command provided in the UI to install the Worker.
 

--- a/layouts/shortcodes/observability_pipelines/install_worker/linux_rpm.en.md
+++ b/layouts/shortcodes/observability_pipelines/install_worker/linux_rpm.en.md
@@ -1,4 +1,4 @@
-<div class="alert alert-warning">The Observability Pipelines Worker supports RHEL and CentOS versions 8.0 or later.</div>
+<div class="alert alert-warning">For RHEL and CentOS, the Observability Pipelines Worker supports versions 8.0 or later.</div>
 
 1. Click **Select API key** to choose the Datadog API key you want to use.
 1. Run the one-step command provided in the UI to install the Worker.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds an alert box for OP Linux RPM installation.

Preview: https://docs-staging.datadoghq.com/may/add-worker-apt-alert-box/observability_pipelines/set_up_pipelines/dual_ship_logs/amazon_data_firehose/?tab=linuxrpm#install-the-observability-pipelines-worker

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
