### PR TITLE
Updates rate limit documentation for events submission

### DIFF
--- a/content/en/api/latest/rate-limits/_index.md
+++ b/content/en/api/latest/rate-limits/_index.md
@@ -15,7 +15,7 @@ Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
 - The API for sending logs is not rate limited.
-- The rate limit for event submission is `500,000` events per hour per organization.
+- The rate limit for event submission is `50,000` events per minute per organization.
 - The rate limits for endpoints vary and are included in the headers detailed below. These can be extended on demand.
 
 <div class="alert alert-warning">

--- a/content/en/api/v1/rate-limits/_index.md
+++ b/content/en/api/v1/rate-limits/_index.md
@@ -15,7 +15,7 @@ Regarding the API rate limit policy:
 
 - Datadog **does not rate limit** on data point/metric submission (see [metrics section][2] for more info on how the metric submission rate is handled). Limits encounter is dependent on the quantity of [custom metrics][3] based on your agreement.
 - The API for sending logs is not rate limited.
-- The rate limit for event submission is `500,000` events per hour per organization.
+- The rate limit for event submission is `50,000` events per minute per organization.
 - The rate limits for endpoints vary and are included in the headers detailed below. These can be extended on demand.
 
 <div class="alert alert-warning">


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This small change updates the rate limit documentation related to events submission, which is required to keep this documentation up to date with the team's latest developments.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
