### PR TITLE
[Exception Replay Docs] Bump `dd-trace-java` required version from `1.35.0` -> `1.47.0`

### DIFF
--- a/content/en/error_tracking/backend/exception_replay.md
+++ b/content/en/error_tracking/backend/exception_replay.md
@@ -45,7 +45,7 @@ Exception Replay is only available in APM Error Tracking. Error Tracking for Log
 1. Install or upgrade your Agent to version `7.44.0` or higher.
 2. Ensure that you are using:
    * `ddtrace` version `1.16.0` or higher.
-   * `dd-trace-java` version `1.35.0` or higher.
+   * `dd-trace-java` version `1.47.0` or higher.
    * `dd-trace-dotnet` version `2.53.0` or higher.
 4. Set the `DD_EXCEPTION_DEBUGGING_ENABLED` environment variable to `true` to run your service with Error Tracking Exception Replay enabled.
 


### PR DESCRIPTION
## Description
Exception Replay is still in private java, allowing us to update the required version without constraints. Version `1.47.0` includes important stability fixes, making it the preferred requirement over the previous `1.35.0`.