### PR TITLE
Remove note about CNM not supported on GKE Autopilot

### DIFF
--- a/content/en/network_monitoring/cloud_network_monitoring/setup.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/setup.md
@@ -58,8 +58,6 @@ Datadog Cloud Network Monitoring does not support macOS platforms.
 
 CNM helps you visualize the architecture and performance of your containerized and orchestrated environments, with support for [Docker][5], [Kubernetes][6], [ECS][7], and other container technologies. Datadog's container integrations enable you to aggregate traffic by meaningful entities--such as containers, tasks, pods, clusters, and deployments--with out-of-the-box tags such as `container_name`, `task_name`, and `kube_service`.
 
-CNM is not supported for Google Kubernetes Engine (GKE) Autopilot.
-
 ### Network routing tools
 
 #### Istio


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Removes note about CNM not support on GKE autopilot as it is supported now. This was missed in a previous PR https://github.com/DataDog/documentation/pull/27954

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
