### PR TITLE
Clarify inferred services setup by Agent version

### DIFF
--- a/content/en/tracing/services/inferred_services.md
+++ b/content/en/tracing/services/inferred_services.md
@@ -24,9 +24,15 @@ To see inferred services, you must enable some configurations.
 Starting from version [7.60.0][1] of the Datadog Agent, these configurations are enabled by default. 
 
 {{< tabs >}}
-{{% tab "Agent v7.55.1+" %}}
+{{% tab "Agent v7.60.0+" %}}
+Starting from Datadog Agent version [7.60.0][1], no manual configuration is needed to see inferred services. The required configurations—`apm_config.compute_stats_by_span_kind` and `apm_config.peer_tags_aggregation`—are enabled by default.
 
-For Datadog Agent versions [7.55.1][2] or later, add the following to your `datadog.yaml` configuration file:
+[1]: https://github.com/DataDog/datadog-agent/releases/tag/7.60.0
+
+{{% /tab %}}
+{{% tab "Agent v7.55.1 - v7.59.1" %}}
+
+For Datadog Agent versions [7.55.1][1] through [7.59.1][2], add the following to your `datadog.yaml` configuration file:
 
 {{< code-block lang="yaml" filename="datadog.yaml" collapsible="true" >}}
 
@@ -47,8 +53,8 @@ DD_APM_PEER_TAGS_AGGREGATION=true
 
 If you are using Helm, include these environment variables in your `values.yaml` [file][3].
 
-[1]: https://github.com/DataDog/datadog-agent/releases/tag/7.60.0
-[2]: https://github.com/DataDog/datadog-agent/releases/tag/7.55.1
+[1]: https://github.com/DataDog/datadog-agent/releases/tag/7.55.1
+[2]: https://github.com/DataDog/datadog-agent/releases/tag/7.59.1
 [3]: https://github.com/DataDog/helm-charts/blob/main/charts/datadog/values.yaml
 {{% /tab %}}
 {{% tab "Agent v7.50.3 - v7.54.1" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR improves the inferred services setup guide by **clearly categorizing** instructions based on Datadog Agent versions:
- **v7.60.0+**: Settings are enabled by default (no manual configuration required).
- **v7.55.1–v7.59.1**: Users must manually enable `compute_stats_by_span_kind` and `peer_tags_aggregation`.


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
