### PR TITLE
Update documentation with automatic incident creation from monitors

### DIFF
--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -85,7 +85,7 @@ After you add the monitor trigger, [add an existing workflow to your monitor][8]
 For more information on building a workflow, see [Build workflows][9].
 
 ### Incidents 
-Incidents can be automatically created from a monitor when the monitor transitions to an alert, warn, or no data status. Click on **Add Incident** and select an @incident- option. Admins can create @incident- options in [Incident Settings][22].
+Incidents can be automatically created from a monitor when the monitor transitions to an `alert`, `warn`, or `no data` status. Click on **Add Incident** and select an `@incident-` option. Admins can create `@incident-` options in [Incident Settings][22].
 
 Incidents created from a monitor will inherit its [field values][20] from the monitor's tags. To send automated notifications from incidents, add tags to the monitor so that created incidents match the criteria of [notification rules][21].
 

--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -28,6 +28,7 @@ Use the **Configure notifications and automations** section to:
 - Send notifications to your team through email, Slack, PagerDuty, and other integrations.
 - Trigger a workflow or create a workflow from a monitor.
 - [Automatically create a case][19].
+- Automatically create an incident.
 
 ### Title
 
@@ -82,6 +83,11 @@ After you add the monitor trigger, [add an existing workflow to your monitor][8]
    {{< img src="/monitors/notifications/create-workflow.png" alt="Click the + button to add a new workflow" style="width:90%;">}}
 
 For more information on building a workflow, see [Build workflows][9].
+
+### Incidents 
+Incidents can be automatically created from a monitor when the monitor transitions to an alert, warn, or no data status. Click on **Add Incident** and select an @incident- option. Admins can create @incident- options in [Incident Settings][22].
+
+Incidents created from a monitor will inherit its [field values][20] from the monitor's tags. To send automated notifications from incidents, add tags to the monitor so that created incidents match the criteria of [notification rules][21].
 
 ### Priority
 
@@ -216,3 +222,6 @@ Message variables auto-populate with a randomly selected group based on the scop
 [17]: /service_management/workflows/trigger/#add-a-monitor-trigger-to-your-workflow
 [18]: /monitors/configuration/#set-alert-aggregation
 [19]: /service_management/case_management/create_case/#automatic-case-creation
+[20]: /service_management/incident_management/incident_settings/property_fields
+[21]: /service_management/incident_management/incident_settings/notification_rules
+[22]: https://app.datadoghq.com/incidents/settings?section=global-settings

--- a/content/en/service_management/incident_management/declare.md
+++ b/content/en/service_management/incident_management/declare.md
@@ -23,6 +23,10 @@ You can declare an incident directly from a monitor from the Actions dropdown. S
 
 {{< img src="service_management/incidents/declare/declare_monitor.png" alt="Actions dropdown menu on monitors where you can select the Declare incident option" style="width:50%;" >}}
 
+Alternatively, you can have a monitor automatically create an incident when it transitions to a warn, alert, or no data status. To enable this, click **Add Incident** in the **Configure notifications and automations** section of a monitor and select an @incident- option. Admins can create @incident- options in [Incident Settings][9].
+
+Incidents created from a monitor will inherit [field values][10] from the monitor's tags. To send automated notifications from incidents, add tags to a monitor so that created incidents match the criteria of [notification rules][11].
+
 ## From a Security Signal
 
 Declare an incident directly from a Cloud SIEM or Cloud Security Management Threats signal side panel, by clicking **Declare incident** or **Escalate Investigation**. For more information, see [Investigate Security Signals][3] for Cloud Security Management.
@@ -78,3 +82,6 @@ After you declare an incident from Slack, it generates an incident channel.
 [6]: /service_management/incident_management/datadog_clipboard
 [7]: /integrations/slack/?tab=slackapplicationbeta#using-the-slack-app
 [8]: https://app.datadoghq.com/synthetics/tests
+[9]: https://app.datadoghq.com/incidents/settings?section=global-settings
+[10]: /service_management/incident_management/incident_settings/property_fields
+[11]: /service_management/incident_management/incident_settings/notification_rules

--- a/content/en/service_management/incident_management/declare.md
+++ b/content/en/service_management/incident_management/declare.md
@@ -23,7 +23,7 @@ You can declare an incident directly from a monitor from the Actions dropdown. S
 
 {{< img src="service_management/incidents/declare/declare_monitor.png" alt="Actions dropdown menu on monitors where you can select the Declare incident option" style="width:50%;" >}}
 
-Alternatively, you can have a monitor automatically create an incident when it transitions to a warn, alert, or no data status. To enable this, click **Add Incident** in the **Configure notifications and automations** section of a monitor and select an @incident- option. Admins can create @incident- options in [Incident Settings][9].
+Alternatively, you can have a monitor automatically create an incident when it transitions to a `warn`, `alert`, or `no data` status. To enable this, click **Add Incident** in the **Configure notifications and automations** section of a monitor and select an `@incident-` option. Admins can create `@incident-` options in [Incident Settings][9].
 
 Incidents created from a monitor will inherit [field values][10] from the monitor's tags. To send automated notifications from incidents, add tags to a monitor so that created incidents match the criteria of [notification rules][11].
 

--- a/content/en/service_management/incident_management/incident_settings/_index.md
+++ b/content/en/service_management/incident_management/incident_settings/_index.md
@@ -25,6 +25,7 @@ To create an incident type:
 | Setting     | Description    |
 | ---  | ----------- |
 | Analytics&nbsp;Dashboard | Customize the dashboard for the Analytics button on the Incidents homepage. By default, this links to the template Incident Management Overview dashboard for [Analytics][1]. |
+| Monitor&nbsp;Automations| Create incident @-mentions that can be used in a [monitor's notification message][2] to automatically create incidents when the monitor triggers. |
 
 ## Customize incident response
 
@@ -38,3 +39,4 @@ To create an incident type:
 {{< /whatsnext >}}
 
 [1]: https://app.datadoghq.com/incidents/settings
+[2]: /monitors/notify/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Incident app has a feature that allows automatically creating incidents from monitors using @incident- mentions in a monitor's notification message. This is similar to the way cases can be automatically created from monitors. This PR adds some explanation on this feature.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
