### PR TITLE
remove SCA guide from ASM section

### DIFF
--- a/content/en/security/application_security/guide/_index.md
+++ b/content/en/security/application_security/guide/_index.md
@@ -8,10 +8,6 @@ disable_toc: true
     {{< nextlink href="/getting_started/application_security/" >}}First steps with Application Security Management{{< /nextlink >}}
 {{< /whatsnext >}}
 
-{{< whatsnext desc="Software Composition Analysis" >}}
-    {{< nextlink href="/security/code_security/guides/automate_risk_reduction_sca/" >}}Automate open source risk reduction with Datadog SCA{{< /nextlink >}}
-{{< /whatsnext >}}
-
 {{< whatsnext desc="Advanced Topics" >}}
     {{< nextlink href="/security/application_security/guide/standalone_application_security/" >}}Standalone Application Security{{< /nextlink >}}
 {{< /whatsnext >}}


### PR DESCRIPTION
We already redirect from this guide to a copy in the Code Security section. 
We should delete the original since SCA is not part of ASM now.

### Merge instructions

Merge readiness:
- [ ] Ready for merge
