### PR TITLE
[RUM] Update react native logs to suggest to use DatadogProviderConfiguration instead of DdSdkReactNativeConfiguration

### DIFF
--- a/content/en/logs/log_collection/reactnative.md
+++ b/content/en/logs/log_collection/reactnative.md
@@ -47,10 +47,10 @@ Then install the added pod:
 ```js
 import {
     DdSdkReactNative,
-    DdSdkReactNativeConfiguration
+    DatadogProviderConfiguration
 } from '@datadog/mobile-react-native';
 
-const config = new DdSdkReactNativeConfiguration(
+const config = new DatadogProviderConfiguration(
     '<CLIENT_TOKEN>',
     '<ENVIRONMENT_NAME>',
     '<RUM_APPLICATION_ID>',
@@ -65,10 +65,10 @@ config.site = 'US1';
 ```js
 import {
     DdSdkReactNative,
-    DdSdkReactNativeConfiguration
+    DatadogProviderConfiguration
 } from '@datadog/mobile-react-native';
 
-const config = new DdSdkReactNativeConfiguration(
+const config = new DatadogProviderConfiguration(
     '<CLIENT_TOKEN>',
     '<ENVIRONMENT_NAME>',
     '<RUM_APPLICATION_ID>',
@@ -83,10 +83,10 @@ config.site = 'US3';
 ```js
 import {
     DdSdkReactNative,
-    DdSdkReactNativeConfiguration
+    DatadogProviderConfiguration
 } from '@datadog/mobile-react-native';
 
-const config = new DdSdkReactNativeConfiguration(
+const config = new DatadogProviderConfiguration(
     '<CLIENT_TOKEN>',
     '<ENVIRONMENT_NAME>',
     '<RUM_APPLICATION_ID>',
@@ -103,10 +103,10 @@ await DdSdkReactNative.initialize(config);
 ```js
 import {
     DdSdkReactNative,
-    DdSdkReactNativeConfiguration
+    DatadogProviderConfiguration
 } from '@datadog/mobile-react-native';
 
-const config = new DdSdkReactNativeConfiguration(
+const config = new DatadogProviderConfiguration(
     '<CLIENT_TOKEN>',
     '<ENVIRONMENT_NAME>',
     '<RUM_APPLICATION_ID>',
@@ -121,10 +121,10 @@ config.site = 'EU1';
 ```js
 import {
     DdSdkReactNative,
-    DdSdkReactNativeConfiguration
+    DatadogProviderConfiguration
 } from '@datadog/mobile-react-native';
 
-const config = new DdSdkReactNativeConfiguration(
+const config = new DatadogProviderConfiguration(
     '<CLIENT_TOKEN>',
     '<ENVIRONMENT_NAME>',
     '<RUM_APPLICATION_ID>',
@@ -139,10 +139,10 @@ config.site = 'US1_FED';
 ```js
 import {
     DdSdkReactNative,
-    DdSdkReactNativeConfiguration
+    DatadogProviderConfiguration
 } from '@datadog/mobile-react-native';
 
-const config = new DdSdkReactNativeConfiguration(
+const config = new DatadogProviderConfiguration(
     '<CLIENT_TOKEN>',
     '<ENVIRONMENT_NAME>',
     '<RUM_APPLICATION_ID>',


### PR DESCRIPTION
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Update react native logs page to suggest to use DatadogProviderConfiguration instead of DdSdkReactNativeConfiguration

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/5490a657-b0c1-4286-ab95-7b2f55cfde88" />


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

Merge queue is enabled in this repo. Your branch name MUST follow the `<slack_username>/<branch_name>` convention, or your pull request will not pass in CI. If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

