### PR TITLE
Update outdated / broken links

### DIFF
--- a/content/en/dora_metrics/setup/deployments.md
+++ b/content/en/dora_metrics/setup/deployments.md
@@ -176,7 +176,7 @@ https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=githu
 {{% tab "GitHub" %}}
 
 <div class="alert alert-warning">
-GitHub workflows running on <a href="https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request"> <code>pull_request</code> trigger </a> are not currently supported by the GitHub integration.
+GitHub workflows running on <a href="https://docs.github.com/es/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request"> <code>pull_request</code> trigger </a> are not currently supported by the GitHub integration.
 If you are using the <code>pull_request</code> trigger, use the alternative method.
 </div>
 

--- a/content/es/agent/basic_agent_usage/saltstack.md
+++ b/content/es/agent/basic_agent_usage/saltstack.md
@@ -218,5 +218,5 @@ Las fórmulas Salt son estados Salt previamente redactados. En la fórmula de Da
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [3]: https://docs.datadoghq.com/es/integrations/directory/
 [4]: https://github.com/DataDog/datadog-formula/blob/master/pillar.example
-[5]: https://docs.saltstack.com/en/latest/ref/configuration/master.html#pillar-merge-lists
+[5]: https://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-merge-lists
 [6]: https://github.com/DataDog/datadog-formula

--- a/content/es/integrations/apollo.md
+++ b/content/es/integrations/apollo.md
@@ -140,6 +140,6 @@ La integración Apollo no incluye checks de servicios en este momento.
 [4]: https://www.apollographql.com/docs/studio/org/graphs/#viewing-graph-information
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-link.png
 [6]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-toggle.png
-[7]: https://www.apollographql.com/docs/studio/datadog-integration/
+[7]: https://www.apollographql.com/docs/graphos/platform/insights/datadog-forwarding
 [8]: https://github.com/DataDog/integrations-extras/blob/master/apollo/metadata.csv
 [9]: https://docs.datadoghq.com/es/help/

--- a/content/es/integrations/avi_vantage.md
+++ b/content/es/integrations/avi_vantage.md
@@ -109,7 +109,7 @@ Avi Vantage no incluye ningún evento.
 
 ¿Necesitas ayuda? [Consulta el servicio de asistencia de Datadog][9].
 
-[1]: https://avinetworks.com/why-avi/multi-cloud-load-balancing/
+[1]: https://www.vmware.com/products/cloud-infrastructure/avi-load-balancer
 [2]: https://docs.datadoghq.com/es/agent/kubernetes/integrations/
 [3]: https://app.datadoghq.com/account/settings/agent/latest
 [4]: https://github.com/DataDog/integrations-core/blob/master/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example

--- a/content/fr/agent/basic_agent_usage/saltstack.md
+++ b/content/fr/agent/basic_agent_usage/saltstack.md
@@ -218,5 +218,5 @@ Les formules Salt sont des states Salt pré-écrits. Les states suivants sont di
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [3]: https://docs.datadoghq.com/fr/integrations/directory/
 [4]: https://github.com/DataDog/datadog-formula/blob/master/pillar.example
-[5]: https://docs.saltstack.com/en/latest/ref/configuration/master.html#pillar-merge-lists
+[5]: https://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-merge-lists
 [6]: https://github.com/DataDog/datadog-formula

--- a/content/fr/integrations/apollo.md
+++ b/content/fr/integrations/apollo.md
@@ -116,6 +116,6 @@ Besoin d'aide ? Contactez [l'assistance Datadog][9].
 [4]: https://www.apollographql.com/docs/studio/org/graphs/#viewing-graph-information
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-link.png
 [6]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-toggle.png
-[7]: https://www.apollographql.com/docs/studio/datadog-integration/
+[7]: https://www.apollographql.com/docs/graphos/platform/insights/datadog-forwarding
 [8]: https://github.com/DataDog/integrations-extras/blob/master/apollo/metadata.csv
 [9]: https://docs.datadoghq.com/fr/help/

--- a/content/fr/integrations/avi_vantage.md
+++ b/content/fr/integrations/avi_vantage.md
@@ -82,7 +82,7 @@ Avi Vantage n'inclut aucun événement.
 
 Besoin d'aide ? Contactez [l'assistance Datadog][9].
 
-[1]: https://avinetworks.com/why-avi/multi-cloud-load-balancing/
+[1]: https://www.vmware.com/products/cloud-infrastructure/avi-load-balancer
 [2]: https://docs.datadoghq.com/fr/agent/kubernetes/integrations/
 [3]: https://app.datadoghq.com/account/settings#agent
 [4]: https://github.com/DataDog/integrations-core/blob/master/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example

--- a/content/fr/metrics/guide/micrometer.md
+++ b/content/fr/metrics/guide/micrometer.md
@@ -1,6 +1,6 @@
 ---
 further_reading:
-- link: https://micrometer.io/docs/registry/otlp
+- link: https://docs.micrometer.io/micrometer/reference/implementations/otlp.html
   tag: Micrometer
   text: Micrometer OTLP
 - link: https://micrometer.io/docs/registry/prometheus

--- a/content/ja/agent/basic_agent_usage/saltstack.md
+++ b/content/ja/agent/basic_agent_usage/saltstack.md
@@ -218,5 +218,5 @@ Salt Formula には Salt の状態が事前に記述されています。Datadog
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [3]: https://docs.datadoghq.com/ja/integrations/directory/
 [4]: https://github.com/DataDog/datadog-formula/blob/master/pillar.example
-[5]: https://docs.saltstack.com/en/latest/ref/configuration/master.html#pillar-merge-lists
+[5]: https://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-merge-lists
 [6]: https://github.com/DataDog/datadog-formula

--- a/content/ja/integrations/apollo.md
+++ b/content/ja/integrations/apollo.md
@@ -140,6 +140,6 @@ Apollo Datadog インテグレーションは、Studio に Datadog API キーと
 [4]: https://www.apollographql.com/docs/studio/org/graphs/#viewing-graph-information
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-link.png
 [6]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-toggle.png
-[7]: https://www.apollographql.com/docs/studio/datadog-integration/
+[7]: https://www.apollographql.com/docs/graphos/platform/insights/datadog-forwarding
 [8]: https://github.com/DataDog/integrations-extras/blob/master/apollo/metadata.csv
 [9]: https://docs.datadoghq.com/ja/help/

--- a/content/ja/integrations/avi_vantage.md
+++ b/content/ja/integrations/avi_vantage.md
@@ -107,7 +107,7 @@ Avi Vantage には、イベントは含まれません。
 
 ご不明な点は、[Datadog のサポートチーム][9]までお問い合わせください。
 
-[1]: https://avinetworks.com/why-avi/multi-cloud-load-balancing/
+[1]: https://www.vmware.com/products/cloud-infrastructure/avi-load-balancer
 [2]: https://docs.datadoghq.com/ja/agent/kubernetes/integrations/
 [3]: https://app.datadoghq.com/account/settings/agent/latest
 [4]: https://github.com/DataDog/integrations-core/blob/master/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example

--- a/content/ko/agent/basic_agent_usage/saltstack.md
+++ b/content/ko/agent/basic_agent_usage/saltstack.md
@@ -218,5 +218,5 @@ Salt 공식은 사전에 작성된 Salt State입니다. Datadog 공식에서 사
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [3]: https://docs.datadoghq.com/ko/integrations/directory/
 [4]: https://github.com/DataDog/datadog-formula/blob/master/pillar.example
-[5]: https://docs.saltstack.com/en/latest/ref/configuration/master.html#pillar-merge-lists
+[5]: https://docs.saltproject.io/en/latest/ref/configuration/master.html#pillar-merge-lists
 [6]: https://github.com/DataDog/datadog-formula

--- a/content/ko/integrations/apollo.md
+++ b/content/ko/integrations/apollo.md
@@ -139,6 +139,6 @@ Apollo 통합에는 아직 서비스 점검이 포함되지 않습니다.
 [4]: https://www.apollographql.com/docs/studio/org/graphs/#viewing-graph-information
 [5]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-link.png
 [6]: https://raw.githubusercontent.com/DataDog/integrations-extras/master/apollo/images/settings-toggle.png
-[7]: https://www.apollographql.com/docs/studio/datadog-integration/
+[7]: https://www.apollographql.com/docs/graphos/platform/insights/datadog-forwarding
 [8]: https://github.com/DataDog/integrations-extras/blob/master/apollo/metadata.csv
 [9]: https://docs.datadoghq.com/ko/help/

--- a/content/ko/integrations/avi_vantage.md
+++ b/content/ko/integrations/avi_vantage.md
@@ -106,7 +106,7 @@ Avi Vantage는 이벤트를 포함하지 않습니다.
 
 도움이 필요하신가요? [Datadog 지원팀][9]에 문의하세요.
 
-[1]: https://avinetworks.com/why-avi/multi-cloud-load-balancing/
+[1]: https://www.vmware.com/products/cloud-infrastructure/avi-load-balancer
 [2]: https://docs.datadoghq.com/ko/agent/kubernetes/integrations/
 [3]: https://app.datadoghq.com/account/settings/agent/latest
 [4]: https://github.com/DataDog/integrations-core/blob/master/avi_vantage/datadog_checks/avi_vantage/data/conf.yaml.example

--- a/content/ko/metrics/guide/micrometer.md
+++ b/content/ko/metrics/guide/micrometer.md
@@ -1,9 +1,9 @@
 ---
 further_reading:
-- link: https://micrometer.io/docs/registry/otlp
+- link: https://docs.micrometer.io/micrometer/reference/implementations/otlp.html
   tag: 마이크로미터
   text: 마이크로미터 OTLP
-- link: https://micrometer.io/docs/registry/prometheus
+- link: https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html
   tag: 마이크로미터
   text: 마이크로미터 프로메테우스(Prometheus)
 title: 마이크로미터(Micrometer)를 사용한 메트릭 전송


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR fixes around 15 links that were discovered broken / outdated after running a Lychee scan on the repo. More info on the issue here : https://github.com/DataDog/documentation/issues/28281
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. Your branch name MUST follow the `<slack_username>/<branch_name>` convention, or your pull request will not pass in CI. If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
I'm not (yet) a Datadog employee but if possible I will try to work on a GitHub Action step that will generate a report after the deployment is done to get the broken / outdated links. I could also create one step that will generate an issue once a broken link is detected once the number of dead links is reduced from around 300 to just a few. 

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
