### PR TITLE
Fix broken link on `Ingestion Sampling with OpenTelemetry` page

### DIFF
--- a/content/en/opentelemetry/ingestion_sampling.md
+++ b/content/en/opentelemetry/ingestion_sampling.md
@@ -31,7 +31,7 @@ With this method, the OpenTelemetry Collector receives traces from OpenTelemetry
 
 {{< img src="/opentelemetry/guide/ingestion_otel/otel_apm_metrics_computation_collector.png" alt="OpenTelemetry APM Metrics computation using the Collector" style="width:100%;" >}}
 
-Choose this method if you require the advanced processing capabilities of the OpenTelemetry Collector, such as tail-based sampling. To configure the Collector to receive traces, follow the instructions on [OpenTelemetry Collector and Datadog Exporter][16].
+Choose this method if you require the advanced processing capabilities of the OpenTelemetry Collector, such as tail-based sampling. To configure the Collector to receive traces, follow the instructions on [OpenTelemetry Collector and Datadog Exporter][1].
 
 ### Using Datadog Agent OTLP ingestion
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR fixes a broken link on the **"Ingestion Sampling with OpenTelemetry"** page.  
The link in question was meant to direct users to instructions on how to configure the OpenTelemetry Collector, but it currently points to a page about head-based sampling instead.

It looks like the link was unintentionally replaced in [this PR](https://github.com/DataDog/documentation/pull/23481/files#diff-c612b782556f66748b7627c7c962ffcdf0832a8098ed819c44150e6f5ae1cf53L135-R141), so this change restores it to the correct reference.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. Your branch name MUST follow the `<slack_username>/<branch_name>` convention, or your pull request will not pass in CI. If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
