### PR TITLE
[EKS control plane metrics] Unify both operator and Helm configuration

### DIFF
--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -154,7 +154,7 @@ agents:
 
 #### Insecure ports
 
-If the insecure ports of your Controller Manager and Scheduler instances are enabled, the Datadog Agent discovers the integrations and starts collecting metrics without any additional configuration. 
+If the insecure ports of your Controller Manager and Scheduler instances are enabled, the Datadog Agent discovers the integrations and starts collecting metrics without any additional configuration.
 
 #### Secure ports
 
@@ -317,7 +317,7 @@ scheduler:
 
 ## Kubernetes on Amazon EKS {#EKS}
 
-Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane components using cluster checks. 
+Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane components using cluster checks.
 
 ### Prerequisites
 - An EKS Cluster running on Kubernetes version >= 1.28
@@ -326,40 +326,20 @@ Amazon Elastic Kubernetes Service (EKS) supports monitoring all control plane co
   - Datadog Operator >= `v1.13.0`
 - Enable the Datadog [Cluster Agent][6]
 
-{{< tabs >}}
-{{% tab "Datadog Operator" %}}
-
-Add the following annotations. Operator installations are limited to API Server [metrics][1]. For support for `kube_controller_manager` and `kube_scheduler` metrics, use the Helm install.
-
-```yaml
-annotations:
-  ad.datadoghq.com/endpoints.check_names: '["kube_apiserver_metrics"]'
-  ad.datadoghq.com/endpoints.init_configs: '[{}]'
-  ad.datadoghq.com/endpoints.instances:
-    '[{ "prometheus_url": "https://%%host%%:%%port%%/metrics", "bearer_token_auth": "true" }]'
-```
-
-[1]: https://aws.github.io/aws-eks-best-practices/reliability/docs/controlplane/#monitor-control-plane-metrics
-{{% /tab %}}
-{{% tab "Helm" %}}
-
 Add the following annotations to the `default/kubernetes` service:
 
 ```yaml
 annotations:
   ad.datadoghq.com/endpoints.check_names: '["kube_apiserver_metrics"]'
   ad.datadoghq.com/endpoints.init_configs: '[{}]'
-  ad.datadoghq.com/endpoints.instances:
-    '[{ "prometheus_url": "https://%%host%%:%%port%%/metrics", "bearer_token_auth": "true" }]'
+  ad.datadoghq.com/endpoints.instances: '[{ "prometheus_url": "https://%%host%%:%%port%%/metrics", "bearer_token_auth": "true" }]'
   ad.datadoghq.com/service.check_names: '["kube_controller_manager","kube_scheduler"]'
   ad.datadoghq.com/service.init_configs: '[{},{}]'
   ad.datadoghq.com/service.instances: '[{"prometheus_url":"https://%%host%%:%%port%%/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics","extra_headers":{"accept":"*/*"},"tls_ignore_warning":"true","tls_verify":"false","bearer_token_auth":"true"},{"prometheus_url":"https://%%host%%:%%port%%/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics","extra_headers":{"accept":"*/*"},"tls_ignore_warning":"true","tls_verify":"false","bearer_token_auth":"true"}]'
 ```
-{{% /tab %}}
-{{< /tabs >}}
 
 **Notes:**
-- Amazon exposes `kube_controller_manager` and `kube_scheduler` metrics under the [`metrics.eks.amazonaws.com`][11] API Group. 
+- Amazon exposes `kube_controller_manager` and `kube_scheduler` metrics under the [`metrics.eks.amazonaws.com`][11] API Group.
 - The addition of `"extra_headers":{"accept":"*/*"}` prevents `HTTP 406` errors when querying the EKS metrics API.
 
 ## Kubernetes on OpenShift 4 {#OpenShift4}
@@ -470,7 +450,7 @@ oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.resolve=i
 
 The Datadog Cluster Agent schedules the checks as endpoint checks and dispatches them to Cluster Check Runners.
 
-{{% /collapse-content %}} 
+{{% /collapse-content %}}
 
 
 {{% collapse-content title="Etcd OpenShift 4.14 and higher" level="h4" %}}
@@ -531,7 +511,7 @@ clusterChecksRunner:
       readOnly: true
     - name: disable-etcd-autoconf
       mountPath: /etc/datadog-agent/conf.d/etcd.d
-      
+
 {{< /code-block >}}
 
 {{% /tab %}}
@@ -550,7 +530,7 @@ oc annotate service etcd -n openshift-etcd 'ad.datadoghq.com/endpoints.resolve=i
 
 The Datadog Cluster Agent schedules the checks as endpoint checks and dispatches them to Cluster Check Runners.
 
-{{% /collapse-content %}} 
+{{% /collapse-content %}}
 
 
 ### Controller Manager

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -330,12 +330,45 @@ Add the following annotations to the `default/kubernetes` service:
 
 ```yaml
 annotations:
-  ad.datadoghq.com/endpoints.check_names: '["kube_apiserver_metrics"]'
-  ad.datadoghq.com/endpoints.init_configs: '[{}]'
-  ad.datadoghq.com/endpoints.instances: '[{ "prometheus_url": "https://%%host%%:%%port%%/metrics", "bearer_token_auth": "true" }]'
-  ad.datadoghq.com/service.check_names: '["kube_controller_manager","kube_scheduler"]'
-  ad.datadoghq.com/service.init_configs: '[{},{}]'
-  ad.datadoghq.com/service.instances: '[{"prometheus_url":"https://%%host%%:%%port%%/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics","extra_headers":{"accept":"*/*"},"tls_ignore_warning":"true","tls_verify":"false","bearer_token_auth":"true"},{"prometheus_url":"https://%%host%%:%%port%%/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics","extra_headers":{"accept":"*/*"},"tls_ignore_warning":"true","tls_verify":"false","bearer_token_auth":"true"}]'
+  ad.datadoghq.com/endpoints.checks: |-
+    {
+      "kube_apiserver_metrics": {
+        "init_config": {},
+        "instances": [
+          {
+            "prometheus_url": "https://%%host%%:%%port%%/metrics",
+            "bearer_token_auth": "true"
+          }
+        ]
+      }
+    }
+  ad.datadoghq.com/service.checks: |-
+    {
+      "kube_controller_manager": {
+        "init_config": {},
+        "instances": [
+          {
+            "prometheus_url": "https://%%host%%:%%port%%/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics",
+            "extra_headers": {"accept":"*/*"},
+            "bearer_token_auth": "true",
+            "tls_ignore_warning":"true",
+            "tls_verify":"false"
+          }
+        ]
+      },
+      "kube_scheduler": {
+        "init_config": {},
+        "instances": [
+          {
+            "prometheus_url": "https://%%host%%:%%port%%/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics",
+            "extra_headers": {"accept":"*/*"},
+            "bearer_token_auth": "true",
+            "tls_ignore_warning":"true",
+            "tls_verify":"false"
+          }
+        ]
+      }
+    }
 ```
 
 **Notes:**

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -351,8 +351,7 @@ annotations:
             "prometheus_url": "https://%%host%%:%%port%%/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics",
             "extra_headers": {"accept":"*/*"},
             "bearer_token_auth": "true",
-            "tls_ignore_warning":"true",
-            "tls_verify":"false"
+            "tls_ca_cert": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           }
         ]
       },
@@ -363,8 +362,7 @@ annotations:
             "prometheus_url": "https://%%host%%:%%port%%/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics",
             "extra_headers": {"accept":"*/*"},
             "bearer_token_auth": "true",
-            "tls_ignore_warning":"true",
-            "tls_verify":"false"
+            "tls_ca_cert": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
           }
         ]
       }


### PR DESCRIPTION
### What does this PR do? What is the motivation?

* Remove the differences between Helm and Operator Agent installation. Both methods support the same set of metrics for EKS control plane.
* Switch to autodiscovery v2 as it's easier to configure multiple checks
* Rely on tls_ca_cert instead of ignoring TLS handshake
* Remove some white spaces

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
