### PR TITLE
.NET Trace <> Log Correlation: Adds clarification that the trace-id and span-id correlation identifiers are 64-bit decimal numbers

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/dotnet.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/dotnet.md
@@ -229,8 +229,8 @@ If you prefer to manually correlate your traces with your logs, you can add corr
   | `dd.env`       | Globally configures the `env` for the tracer. Defaults to `""` if not set. |
   | `dd.service`   | Globally configures the root service name. Defaults to the name of the application or IIS site name if not set.  |
   | `dd.version`   | Globally configures `version` for the service. Defaults to `""` if not set.  |
-  | `dd.trace_id`  | Active trace ID during the log statement. Defaults to `0` if no trace.  |
-  | `dd.span_id`   | Active span ID during the log statement. Defaults to `0` if no trace. |
+  | `dd.trace_id`  | Active trace ID (represented as a 64-bit decimal number) during the log statement. Defaults to `0` if no trace.  |
+  | `dd.span_id`   | Active span ID (represented as a 64-bit decimal number) during the log statement. Defaults to `0` if no trace. |
 
 **Note:** If you are not using a [Datadog Log Integration][7] to parse your logs, custom log parsing rules must parse `dd.trace_id` and `dd.span_id` as strings. For information, see [Correlated Logs Not Showing Up in the Trace ID Panel][10].
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds a note about the trace-id and span-id being 64-bit decimal numbers.

[APMAPI-1205]

### Merge instructions
Merge readiness:
- [X] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


[APMAPI-1205]: https://datadoghq.atlassian.net/browse/APMAPI-1205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ