### PR TITLE
Fix minor formatting issues in trace metrics documentation

### DIFF
--- a/content/en/tracing/metrics/metrics_namespace.md
+++ b/content/en/tracing/metrics/metrics_namespace.md
@@ -49,7 +49,7 @@ With the following definitions:
 
 `<TAGS>`
 : Trace metrics tags, possible tags are: `env`, `service`, `version`, `resource`, `http.status_code`, `http.status_class`, and Datadog Agent tags (including the host and second primary tag). 
-**Note:** Other tags set on spans are not available as tags on traces metrics.
+: **Note:** Other tags set on spans are not available as tags on traces metrics.
 
 ## Metric suffix
 
@@ -111,7 +111,7 @@ The following metrics are maintained for backward compatibility. For all latency
 : **Prerequisite:** This metric exists for any APM service.<br>
 **Description:** Measure the total time for a collection of spans within a time interval, including child spans seen in the collecting service. For most use cases, Datadog recommends using the [Latency Distribution](#latency-distribution) for calculation of average latency or percentiles. To calculate the average latency with host tag filters, you can use this metric with the following formula: <br>
 `sum:trace.<SPAN_NAME>.duration{<FILTER>}.rollup(sum).fill(zero) / sum:trace.<SPAN_NAME>.hits{<FILTER>}.rollup(sum).fill(zero)` <br>
-This metric does not support percentile aggregations. Read the [Latency Distribution](#latency-distribution) section for more information.
+This metric does not support percentile aggregations. Read the [Latency Distribution](#latency-distribution) section for more information. <br>
 **Metric type:** [GAUGE][7].<br>
 **Tags:** `env`, `service`, `resource`, `http.status_code`, all host tags from the Datadog Host Agent, and [the second primary tag][4].
 
@@ -141,9 +141,9 @@ Very few tracing libraries support this setting, and using it is generally not r
 
 The OpenTelemetry SDK's native sampling mechanisms lower the number of spans sent to the Datadog collector, resulting in sampled and potentially inaccurate trace metrics.
 
-### XRay sampling
+### X-Ray sampling
 
-XRay spans are sampled before they are sent to Datadog, which means trace metrics might not reflect all traffic.
+X-Ray spans are sampled before they are sent to Datadog, which means trace metrics might not reflect all traffic.
 
 
 ## Further Reading


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR fixes minor formatting inconsistencies in the trace metrics documentation, including
- Ensuring the `Note` block is visually separated from the description
- Displaying `Metric Type` as a separate block for better clarity
- Renaming `XRay` to `X-Ray` to align with the official naming

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
