### PR TITLE
Fix reference to IAM authentication from Aurora Autodiscovery

### DIFF
--- a/content/en/database_monitoring/guide/aurora_autodiscovery.md
+++ b/content/en/database_monitoring/guide/aurora_autodiscovery.md
@@ -211,7 +211,7 @@ For more information on configuring Autodiscovery with integrations, see the [Au
 | %%extra_managed_authentication_enabled%% | Whether IAM authentication enabled on the cluster. <br/>This is used to determine if managed authentication should be used for Postgres. |
 
 [1]: /database_monitoring/setup_postgres/aurora/?tab=postgres10
-[2]: /database_monitoring/guide/managed_authentication/#configure-iam-authentication
+[2]: /database_monitoring/guide/managed_authentication/?tab=aurora#configure-iam-authentication
 [3]: https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonRDSReadOnlyAccess.html
 [4]: /getting_started/containers/autodiscovery/?tab=adannotationsv2agent736
 [5]: /containers/docker/integrations/?tab=dockeradv2

--- a/content/en/database_monitoring/guide/aurora_autodiscovery.md
+++ b/content/en/database_monitoring/guide/aurora_autodiscovery.md
@@ -163,6 +163,7 @@ instances:
 
 The template variable `%%extra_managed_authentication_enabled%%` resolves to `true` if the instance is using IAM authentication.
 
+[2]: /database_monitoring/guide/managed_authentication/?tab=aurora#configure-iam-authentication
 {{% /tab %}}
 {{% tab "MySQL" %}}
 
@@ -211,7 +212,6 @@ For more information on configuring Autodiscovery with integrations, see the [Au
 | %%extra_managed_authentication_enabled%% | Whether IAM authentication enabled on the cluster. <br/>This is used to determine if managed authentication should be used for Postgres. |
 
 [1]: /database_monitoring/setup_postgres/aurora/?tab=postgres10
-[2]: /database_monitoring/guide/managed_authentication/?tab=aurora#configure-iam-authentication
 [3]: https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AmazonRDSReadOnlyAccess.html
 [4]: /getting_started/containers/autodiscovery/?tab=adannotationsv2agent736
 [5]: /containers/docker/integrations/?tab=dockeradv2


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
I _think_ this will fix the doc reference to the IAM authentication page from the Aurora Autodiscovery page. Right now the raw markdown is shown on the page rather than the actual link to documentation page

![image](https://github.com/user-attachments/assets/11035894-8e9a-4013-bda3-013e4fe12119)

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
