### PR TITLE
[WF-10420] Add the software catalog trigger to the public docs

### DIFF
--- a/content/en/service_management/workflows/trigger.md
+++ b/content/en/service_management/workflows/trigger.md
@@ -167,7 +167,7 @@ To run a workflow from a software catalog entity, you must first add a software 
 
 Run the workflow from your Software Catalog entity:
 
-1. On the [Software Catalog page][14], choose an entity from the list
+1. On the [Software Catalog page][14], choose an entity from the list.
 1. Click **Run Workflow** at the top of the side panel.
 1. In the search modal, enter the name of the workflow you want to run and select it. Only workflows with software catalog triggers appear in the list.
 2. If your workflow requires input parameters, enter the values as required.

--- a/content/en/service_management/workflows/trigger.md
+++ b/content/en/service_management/workflows/trigger.md
@@ -167,9 +167,9 @@ Run the workflow from your Software Catalog entity:
 
 1. On the [Software Catalog page][14], choose an entity from the list.
 1. Click **Run Workflow** at the top of the side panel.
-1. In the search modal, enter the name of the workflow you want to run and select it. Only workflows with software catalog triggers appear in the list.
-2. If your workflow requires input parameters, enter the values as required.
-3. Click **Run** to run the workflow.
+1. In the search modal, enter the name of the workflow you want to run and select it. Only workflows with Software Catalog triggers appear in the list.
+1. If your workflow requires input parameters, enter the values as required.
+1. Click **Run** to run the workflow.
 
 ## GitHub triggers
 

--- a/content/en/service_management/workflows/trigger.md
+++ b/content/en/service_management/workflows/trigger.md
@@ -152,6 +152,27 @@ You can manually start a workflow from a Cloud SIEM Security Signal panel.
 
 For additional examples of security workflows you can automate, see [Automate Security Workflows with Workflow Automation][4].
 
+## Software Catalog triggers
+
+To run a workflow from a software catalog entity, you must first add a software catalog trigger to your workflow:
+
+### Add a software catalog trigger to your workflow
+
+1. Add a software catalog trigger to your workflow:
+   - If your workflow doesn't have any triggers, click **Add Trigger** > **Software Catalog**.
+   - If your workflow already has one or more triggers and you're adding the software catalog as an additional trigger, click the **Add Trigger** (lightning bolt) icon and select **Software Catalog**.
+2. Make sure the trigger is connected to a step in the workflow. You can connect the trigger to a step by clicking and dragging the plus icon (**+**) under the trigger.
+3. Save your Workflow.
+4. Click **Publish** to publish your workflow. Published workflows accrue costs based on workflow executions. For more information, see the [Datadog Pricing page][11].
+
+Run the workflow from your Software Catalog entity:
+
+1. On the [Software Catalog page][14], choose an entity from the list
+1. Click **Run Workflow** at the top of the side panel.
+1. In the search modal, enter the name of the workflow you want to run and select it. Only workflows with software catalog triggers appear in the list.
+2. If your workflow requires input parameters, enter the values as required.
+3. Click **Run** to run the workflow.
+
 ## GitHub triggers
 
 <div class="alert alert-info"><strong>Note</strong>: Your GitHub account must have permission to create webhooks to use this feature.</div>
@@ -270,3 +291,4 @@ After you trigger a workflow, the workflow page switches to the workflow's **Run
 [11]: https://www.datadoghq.com/pricing/?product=workflow-automation#products
 [12]: /service_management/workflows/test_and_debug/#test-a-monitor-trigger
 [13]: /service_management/workflows/test_and_debug/#debug-a-failed-step
+[14]: https://app.datadoghq.com/software

--- a/content/en/service_management/workflows/trigger.md
+++ b/content/en/service_management/workflows/trigger.md
@@ -156,8 +156,6 @@ For additional examples of security workflows you can automate, see [Automate Se
 
 To run a workflow from a software catalog entity, you must first add a software catalog trigger to your workflow:
 
-### Add a software catalog trigger to your workflow
-
 1. Add a software catalog trigger to your workflow:
    - If your workflow doesn't have any triggers, click **Add Trigger** > **Software Catalog**.
    - If your workflow already has one or more triggers and you're adding the software catalog as an additional trigger, click the **Add Trigger** (lightning bolt) icon and select **Software Catalog**.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR adds Software Catalog triggers to the Workflow Automation Triggers page, as requested by Dan Green (Software Catalog PM)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
