### PR TITLE
Add a new weekly workflow to automatically check for 404 links in the…

### DIFF
--- a/.github/workflows/404_links_finder.yml
+++ b/.github/workflows/404_links_finder.yml
@@ -1,0 +1,56 @@
+# This workflow automatically checks for broken links in the repository
+# It runs weekly on Sunday at 18:00 UTC and can also be triggered manually
+#
+# Features:
+# - Scans all markdown files in the repository for links
+# - Will ONLY return HTTP status codes 404 and timeout as errors 
+# - Creates a GitHub issue with a detailed report if broken links are found
+# - Uses lychee-action for link checking with a 30-second timeout
+# - Allows up to 10 redirects before considering a link broken
+#
+# The report is generated in markdown format and includes:
+# - List of all broken links
+# - File locations where broken links were found
+
+name: 404 Links Finder
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  schedule:
+    - cron: "00 18 * * 0"
+
+jobs:
+  linkChecker:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for peter-evans/create-issue-from-file
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@master
+        with:
+          args: |
+            --format markdown
+            --accept '100..=403, 405..=599'
+            --no-progress
+            --timeout 30
+            --max-redirects 10
+            --exclude-path "content/es" 
+            --exclude-path "content/fr" 
+            --exclude-path "content/ja" 
+            --exclude-path "content/ko/" 
+            --exclude "file://*" 
+            --exclude-all-private
+            .
+          fail: false
+
+      - name: Create Issue From File
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Weekly Link Checker Report
+          content-filepath: ./lychee/out.md
+          labels: report, automated issue


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
The goal of this PR is to set a new worflow using Lychee to check for 404 links in the documentation automatically each week. It is based on an issue (https://github.com/DataDog/documentation/issues/28281) compiling 300+ links outdated in the actual version of the documentation (around 100 if we only count the en version). 

This workflow will run each week a Lychee scan with args tailored for the constraints of the project (ignoring some files, some URL, and the other languages content directory). 
It will then create a GitHub issue based on the results of this scan. (THIS PART CAN BE EASILY REMOVED as I can understand the frustration of having a workflow creating automatically issues in the repo)

I'm looking forward to you guys questions and opinions on having this merged or not :) 

## Here is an exemple of what it will look like 

Workflow Summary : https://github.com/B-Mahdj/documentation/actions/runs/14123117740
Issue created : https://github.com/B-Mahdj/documentation/issues/1

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
