### PR TITLE
Update advanced_configuration.md to fix incorrect link

### DIFF
--- a/content/en/real_user_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/browser/advanced_configuration.md
@@ -1319,7 +1319,7 @@ Some events cannot be attributed to an origin, therefore they do not have an ass
 [11]: https://developer.mozilla.org/en-US/docs/Web/API/Response
 [12]: https://developer.mozilla.org/en-US/docs/Web//Reference/Global_Objects/Error
 [13]: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming
-[14]: /real_user_monitoring/feature_flag_tracking/using_feature_flags/#feature-flag-naming
+[14]: /real_user_monitoring/guide/enrich-and-control-rum-data/
 [15]: https://github.com/DataDog/browser-sdk/blob/main/packages/rum-core/src/rumEvent.types.ts
 [16]: /logs/log_configuration/attributes_naming_convention/#user-related-attributes
 [17]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v4130


### PR DESCRIPTION
The current link under the heading "Enrich and Control RUM Data" has an incorrect embedded link for the text "Enrich and control RUM data guide"

Current link leads to feature flag tracking: https://docs.datadoghq.com/real_user_monitoring/feature_flag_tracking/using_feature_flags/#feature-flag-naming

Proposed change (which refers to the actual guide): https://docs.datadoghq.com/real_user_monitoring/guide/enrich-and-control-rum-data/

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
