### PR TITLE
Static Analysis: fix ignore instructions

### DIFF
--- a/content/en/security/code_security/static_analysis/setup/_index.md
+++ b/content/en/security/code_security/static_analysis/setup/_index.md
@@ -328,7 +328,8 @@ rulesets:
   - javascript-express:
     rules:
       reduce-server-fingerprinting:
-        ignore: "**"
+        ignore:
+          - "**"
 ```
 
 #### Ignore for a file or directory
@@ -339,7 +340,8 @@ rulesets:
   - javascript-express:
     rules:
       reduce-server-fingerprinting:
-        ignore: "ad-server/src/app.js"
+        ignore:
+          - "ad-server/src/app.js"
 ```
 
 #### Ignore for a specific instance


### PR DESCRIPTION
## Problem

The instructions for ignoring a path are wrong. This changes fixes it.

## Merge instructions

Merge after review