### PR TITLE
[SYNTH-18711] Update comment about sed syntax support

### DIFF
--- a/content/en/continuous_testing/environments/multiple_env.md
+++ b/content/en/continuous_testing/environments/multiple_env.md
@@ -78,6 +78,11 @@ Consider the following `<regex>|<rewriting-rule>` string:
 With this override, the URL `https://my-app.com/some/path` gets rewritten as `https://<deployment-prefix>.my-app.com/some/path`.
 Notice that the URL path is not affected by the rewrite because it is not part of the substitution regex.
 
+<div class="alert alert-info">
+Apart from the pipe <code>|</code> syntax presented above, <code>startUrlSubstitutionRegex</code> also supports the sed syntax: <code>s/&lt;regex&gt;/&lt;rewriting rule&gt;/&lt;modifiers&gt;</code>.</br></br>
+But given this syntax uses a slash <code>/</code> separator, it may require escaping slashes from the URL which is error-prone. Unless you need regex modifiers, Datadog recommends using the pipe <code>|</code> syntax for better readability.
+</div>
+
 With this tool, any scheduled test used on your production environment can be reused to point to a development environment.
 
 ## Introducing a change in an existing environment
@@ -122,7 +127,7 @@ As a result, the URL `https://prod.my-app.com/assets/js/chunk-123.js` is rewritt
 Consider the following `<regex>|<rewriting-rule>` string:
 
 ```
-`(https?://)([^/]*)|$1<deployment-prefix>.$2`
+(https?://)([^/]*)|$1<deployment-prefix>.$2
 ```
 
 With this override, the URL `https://my-app.com/some/path` gets rewritten as `https://<deployment-prefix>.my-app.com/some/path`. Notice that the URL path is not affected by the rewrite because it is not part of the substitution regex.
@@ -131,6 +136,10 @@ With this override, the URL `https://my-app.com/some/path` gets rewritten as `ht
 The <code>resourceUrlSubstitutionRegexes</code> is also applied to the first request, similarly to <code>startUrl</code> and <code>startUrlSubstitutionRegex</code>.
 </div>
 
+<div class="alert alert-info">
+Apart from the pipe <code>|</code> syntax presented above, <code>resourceUrlSubstitutionRegexes</code> also supports the sed syntax: <code>s/&lt;regex&gt;/&lt;rewriting rule&gt;/&lt;modifiers&gt;</code>.</br></br>
+But given this syntax uses a slash <code>/</code> separator, it may require escaping slashes from the URL which is error-prone. Unless you need regex modifiers, Datadog recommends using the pipe <code>|</code> syntax for better readability.
+</div>
 
 ## Further reading
 

--- a/content/en/continuous_testing/environments/multiple_env.md
+++ b/content/en/continuous_testing/environments/multiple_env.md
@@ -51,7 +51,7 @@ datadog-ci synthetics run-tests \
   --override startUrlSubstitutionRegex="<regex>|<rewriting-rule>"
 ```
 
-This field expects a string containing two parts, separated by a pipe character `|`: 
+This field expects a string containing two parts, separated by a pipe character `|`:
 
 `<regex>|<rewriting-rule>`
 - `<regex>`: Regular expression (regex) to apply to the default starting URL
@@ -79,8 +79,7 @@ With this override, the URL `https://my-app.com/some/path` gets rewritten as `ht
 Notice that the URL path is not affected by the rewrite because it is not part of the substitution regex.
 
 <div class="alert alert-info">
-Apart from the pipe <code>|</code> syntax presented above, <code>startUrlSubstitutionRegex</code> also supports the sed syntax with modifiers: <code>s|&lt;regex&gt;|&lt;rewritting rule&gt;|&lt;modifiers&gt;</code>.</br></br>
-The sed syntax is often used with a slash <code>/</code> separator, for example: <code>s/&lt;regex&gt;/&lt;rewritting rule&gt;/&lt;modifier&gt;</code>. However, it can use any character as a delimiter. When working on a URL containing an abundant number of slashes, Datadog recommends using another character rather than escaping all slashes of the URL.
+Only the pipe <code>|</code> syntax is supported for URL substitution regexes. Sed syntax and other delimiter characters are not supported.
 </div>
 
 With this tool, any scheduled test used on your production environment can be reused to point to a development environment.
@@ -102,7 +101,7 @@ datadog-ci synthetics run-tests \
   --override resourceUrlSubstitutionRegexes="<regex2>|<rewriting-rule2>"
 ```
 
-The `resourceUrlSubstitutionRegexes` field expects strings, each containing two parts, separated by a pipe character `|`: 
+The `resourceUrlSubstitutionRegexes` field expects strings, each containing two parts, separated by a pipe character `|`:
 
 `<regex>|<rewriting-rule>`
 - `<regex>`: Regular expression (regex) to apply to the resource URL
@@ -116,9 +115,9 @@ Consider the following `<regex>|<rewriting-rule>` string:
 https://prod.my-app.com/assets/(.*)|https://staging.my-app.com/assets/$1
 ```
 
-The regex, `https://prod.my-app.com/assets/(.*)`, uses a capture group to capture the path of the resource URL. 
+The regex, `https://prod.my-app.com/assets/(.*)`, uses a capture group to capture the path of the resource URL.
 
-The rewriting rule, `https://staging.my-app.com/assets/$1`, produces a similar-looking URL that points to `staging.my-app.com` and appends the captured group using `$1`. 
+The rewriting rule, `https://staging.my-app.com/assets/$1`, produces a similar-looking URL that points to `staging.my-app.com` and appends the captured group using `$1`.
 
 As a result, the URL `https://prod.my-app.com/assets/js/chunk-123.js` is rewritten as `https://staging.my-app.com/assets/js/chunk-123.js`.
 
@@ -135,9 +134,8 @@ With this override, the URL `https://my-app.com/some/path` gets rewritten as `ht
 <div class="alert alert-info">
 The <code>resourceUrlSubstitutionRegexes</code> is also applied to the first request, similarly to <code>startUrl</code> and <code>startUrlSubstitutionRegex</code>.
 </div>
-
 <div class="alert alert-info">
-Apart from the pipe <code>|</code> syntax presented above, <code>resourceUrlSubstitutionRegexes</code> also supports the sed syntax with modifiers: <code>s|&lt;regex&gt;|&lt;rewriting rule&gt;|&lt;modifiers&gt;</code>.</br></br> The sed syntax is often used with a slash <code>/</code> separator, for example: <code>s/&lt;regex&gt;/&lt;rewriting rule&gt;/&lt;modifier&gt;</code>. However, it can use any character as a delimiter. When working on a URL containing an abundant number of slashes, Datadog recommends using another character rather than escaping all slashes of the URL.
+Only the pipe <code>|</code> syntax is supported for URL substitution regexes. Sed syntax and other delimiter characters are not supported.
 </div>
 
 ## Further reading

--- a/content/en/continuous_testing/environments/multiple_env.md
+++ b/content/en/continuous_testing/environments/multiple_env.md
@@ -80,7 +80,7 @@ Notice that the URL path is not affected by the rewrite because it is not part o
 
 <div class="alert alert-info">
 Apart from the pipe <code>|</code> syntax presented above, <code>startUrlSubstitutionRegex</code> also supports the sed syntax: <code>s/&lt;regex&gt;/&lt;rewriting rule&gt;/&lt;modifiers&gt;</code>.</br></br>
-But given this syntax uses a slash <code>/</code> separator, it may require escaping slashes from the URL which is error-prone. Unless you need regex modifiers, Datadog recommends using the pipe <code>|</code> syntax for better readability.
+Because sed syntax uses a slash <code>/</code> separator, it may require escaping slashes from the URL, which is error-prone. Unless you need regex modifiers, Datadog recommends using the pipe <code>|</code> syntax for better readability.
 </div>
 
 With this tool, any scheduled test used on your production environment can be reused to point to a development environment.
@@ -138,7 +138,7 @@ The <code>resourceUrlSubstitutionRegexes</code> is also applied to the first req
 
 <div class="alert alert-info">
 Apart from the pipe <code>|</code> syntax presented above, <code>resourceUrlSubstitutionRegexes</code> also supports the sed syntax: <code>s/&lt;regex&gt;/&lt;rewriting rule&gt;/&lt;modifiers&gt;</code>.</br></br>
-But given this syntax uses a slash <code>/</code> separator, it may require escaping slashes from the URL which is error-prone. Unless you need regex modifiers, Datadog recommends using the pipe <code>|</code> syntax for better readability.
+Because this syntax uses a slash <code>/</code> separator, it may require escaping slashes from the URL, which is error-prone. Unless you need regex modifiers, Datadog recommends using the pipe <code>|</code> syntax for better readability.
 </div>
 
 ## Further reading

--- a/content/en/continuous_testing/environments/multiple_env.md
+++ b/content/en/continuous_testing/environments/multiple_env.md
@@ -78,10 +78,6 @@ Consider the following `<regex>|<rewriting-rule>` string:
 With this override, the URL `https://my-app.com/some/path` gets rewritten as `https://<deployment-prefix>.my-app.com/some/path`.
 Notice that the URL path is not affected by the rewrite because it is not part of the substitution regex.
 
-<div class="alert alert-info">
-Only the pipe <code>|</code> syntax is supported for URL substitution regexes. Sed syntax and other delimiter characters are not supported.
-</div>
-
 With this tool, any scheduled test used on your production environment can be reused to point to a development environment.
 
 ## Introducing a change in an existing environment
@@ -134,9 +130,7 @@ With this override, the URL `https://my-app.com/some/path` gets rewritten as `ht
 <div class="alert alert-info">
 The <code>resourceUrlSubstitutionRegexes</code> is also applied to the first request, similarly to <code>startUrl</code> and <code>startUrlSubstitutionRegex</code>.
 </div>
-<div class="alert alert-info">
-Only the pipe <code>|</code> syntax is supported for URL substitution regexes. Sed syntax and other delimiter characters are not supported.
-</div>
+
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR fixes incorrect documentation about URL substitution syntax in Continuous Testing. The documentation previously claimed support for sed syntax and different delimiters, which was incorrect. The changes remove this misleading information.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
