### PR TITLE
[Test Optimization] Remove beta warning for EFD and ATR in Python

### DIFF
--- a/content/en/tests/flaky_test_management/auto_test_retries.md
+++ b/content/en/tests/flaky_test_management/auto_test_retries.md
@@ -172,11 +172,9 @@ Customize the Auto Test Retries with the following environment variables:
 
 {{% tab "Python" %}}
 
-<div class="alert alert-info">Auto Test Retries is available using the beta of the new pytest plugin. Set the <code>DD_PYTEST_USE_NEW_PLUGIN_BETA</code> environment variable to <code>true</code> to enable it.</div>
-
 ### Compatibility
 
-`dd-trace-py >= 2.18.0` (`pytest >= 7.2.0`)
+`dd-trace-py >= 3.0.0` (`pytest >= 7.2.0`)
 
 ### Configuration
 

--- a/content/en/tests/flaky_test_management/early_flake_detection.md
+++ b/content/en/tests/flaky_test_management/early_flake_detection.md
@@ -88,9 +88,7 @@ The test framework compatibility is the same as [Test Optimization Compatibility
 
 {{% tab "Python" %}}
 
-<div class="alert alert-info">Early Flake Detection is available using the beta of the new pytest plugin. Set the <code>DD_PYTEST_USE_NEW_PLUGIN_BETA</code> environment variable to <code>true</code> to enable it.</div>
-
-`dd-trace-py>=2.18.0` (`pytest>=7.2.0`)
+`dd-trace-py >= 3.0.0` (`pytest >= 7.2.0`)
 
 {{% /tab %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

EFD and ATR were initially available as beta features in dd-trace-py 2.18. They are now available by default in dd-trace-py 3.x. This PR removes the beta warning and updates the minimum ddtrace version to 3.0.0.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
