### PR TITLE
Add clarification on node visualization for service map

### DIFF
--- a/content/en/tracing/services/services_map.md
+++ b/content/en/tracing/services/services_map.md
@@ -84,7 +84,7 @@ Additionally, monitors can be tagged by service in the **Say what's happening** 
 
 Nodes represent services exactly as instrumented in APM and match those in your [Software Catalog][4]. Edges represent aggregate calls from one service to another. These interactions are shown on the flame graph for each individual [trace][5].
 
-New services or connections appear within moments of being instrumented and age out if there are no corresponding traces seen for 30 days. This takes into account services that do work infrequently, but are an important part of a functioning system.
+New services or connections appear within moments of being instrumented and automatically age out if no corresponding traces are seen for 30 days. You can query any service map with a timeframe of up to 30 days; however, nodes only appear in the graph if they have data within the selected timeframe.
 
 {{< img src="tracing/visualization/services_map/servicenodes.mp4" alt="Service Map nodes" video="true" width="90%">}}
 

--- a/content/en/tracing/services/services_map.md
+++ b/content/en/tracing/services/services_map.md
@@ -84,7 +84,7 @@ Additionally, monitors can be tagged by service in the **Say what's happening** 
 
 Nodes represent services exactly as instrumented in APM and match those in your [Software Catalog][4]. Edges represent aggregate calls from one service to another. These interactions are shown on the flame graph for each individual [trace][5].
 
-New services or connections appear within moments of being instrumented and automatically age out if no corresponding traces are seen for 30 days. You can query any service map with a timeframe of up to 30 days; however, nodes only appear in the graph if they have data within the selected timeframe.
+New services or connections appear within moments of being instrumented and automatically age out if no corresponding traces are seen for 30 days. You can query any service map to view nodes that have data within the last 30 days; however, nodes only appear in the graph if they have data within the selected time frame.
 
 {{< img src="tracing/visualization/services_map/servicenodes.mp4" alt="Service Map nodes" video="true" width="90%">}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Clarify that while you can query nodes up to 30 days, only nodes with data appear in the graph.
- [DOCS-10484](https://datadoghq.atlassian.net/browse/DOCS-10484)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->


[DOCS-10484]: https://datadoghq.atlassian.net/browse/DOCS-10484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ