### PR TITLE
update dd-trace-api-py docs link to be prettier

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/python/dd-api.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/python/dd-api.md
@@ -317,4 +317,4 @@ See that package's [API definition][9] for the full list of supported API calls.
 [6]: /tracing/setup/python/
 [7]: https://github.com/DataDog/trace-examples/tree/master/python/flask-baggage
 [8]: https://pypi.org/project/ddtrace-api/
-[9]: https://github.com/DataDog/dd-trace-api-py/blob/master/api.yaml
+[9]: https://datadoghq.dev/dd-trace-api-py/pdocs/ddtrace_api.html


### PR DESCRIPTION
This change points the dd-trace-api-py documentation link to a prettier HTML version than the previous bare YAML file.

Merge readiness:
- [x] Ready for merge