### PR TITLE
Add the Page Wizard and improved Quick Filter builder to the cdocs build

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@popperjs/core": "^2.11.8",
         "alpinejs": "^3.13.7",
         "bootstrap": "^5.2",
-        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.1.tgz",
+        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.3.tgz",
         "del": "4.1.1",
         "fancy-log": "^1.3.3",
         "geo-locate": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.1.tgz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6525,9 +6525,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.1.tgz":
-  version: 1.0.1
-  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.1.tgz"
+"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.3.tgz":
+  version: 1.0.3
+  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.3.tgz"
   dependencies:
     "@prettier/sync": ^0.5.2
     "@types/markdown-it": ^14.1.2
@@ -6551,7 +6551,7 @@ __metadata:
     vite: ^5.4.10
     vite-plugin-singlefile: ^2.0.2
     zod: ^3.22.4
-  checksum: 2ca76bd74d8dba8081b7c6005c93c1ba6dc74fa5c5a9487c766cf01c92401ccf8ff9eb882729da0d85d185bc173f9b81faa2521cbe6fa1617e7872f2560fabd0
+  checksum: 042246b45b97a299b75b4e80ed0eb191e33de2447504c998f2cda7bb3e70213bdcb5be00f5e5f9b9a8ebe50772864f7a22ede3f45fe3e872b797d7a8da7f27b5
   languageName: node
   linkType: hard
 
@@ -7584,7 +7584,7 @@ __metadata:
     acorn: ^7.4.1
     alpinejs: ^3.13.7
     bootstrap: ^5.2
-    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.1.tgz"
+    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.3.tgz"
     cross-env: ^5.2.1
     del: 4.1.1
     eslint: ^6.8.0


### PR DESCRIPTION
This is a PR to a feature branch, no review needed except for @hestonhoffman.

This just bumps the cdocs integration package version to include the updated author console template. To view the console, just go to localhost:1313/cdocs/console once your build is running.