### PR TITLE
Update AWS Lambda containerized ruby instructions with new gem name

### DIFF
--- a/content/en/serverless/aws_lambda/installation/ruby.md
+++ b/content/en/serverless/aws_lambda/installation/ruby.md
@@ -167,11 +167,11 @@ To install and configure the Datadog Serverless Plugin, follow these steps:
     Add the following to your Gemfile:
 
     ```Gemfile
+    gem 'datadog'
     gem 'datadog-lambda'
-    gem 'ddtrace'
     ```
 
-    `ddtrace` contains native extensions that must be compiled for Amazon Linux to work with AWS Lambda.
+    `datadog` contains native extensions that must be compiled for Amazon Linux to work with AWS Lambda.
 
     Install `gcc`, `gmp-devel`, and `make` prior to running `bundle install` in your function's Dockerfile to ensure that the native extensions can be successfully compiled.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

ddtrace gem was used for 1.x, from 2.0 it must be replaced with `datadog`: https://github.com/DataDog/dd-trace-rb/releases/tag/v2.0.0

Using the `ddtrace` gem results in mysterious circular require warnings.

Merge readiness:
- [x] Ready for merge

```
/merge
```