### PR TITLE
Update to remove agent override (only keep clusterAgent)

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm/_index.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm/_index.md
@@ -124,8 +124,6 @@ To enable Single Step Instrumentation with the Datadog Operator:
      name: datadog
    spec:
      override:
-       agent:
-         image: 7.64.1
        clusterAgent:
          image: 7.64.1
      global:


### PR DESCRIPTION

### What does this PR do? What is the motivation?

Fixes an override on the agent setup for the operator.


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
