### PR TITLE
[AZINTS-3322] Remove Azure status metric references

### DIFF
--- a/content/en/integrations/guide/_index.md
+++ b/content/en/integrations/guide/_index.md
@@ -55,7 +55,7 @@ cascade:
     {{< nextlink href="integrations/guide/azure-cloud-adoption-framework" tag=" Azure" >}}Azure Cloud Adoption Framework with Datadog{{< /nextlink >}}
     {{< nextlink href="integrations/guide/azure-troubleshooting" tag=" Azure" >}}Azure troubleshooting{{< /nextlink >}}
     {{< nextlink href="integrations/guide/azure-architecture-and-configuration" tag=" Azure" >}}Azure architecture and configuration{{< /nextlink >}}
-    {{< nextlink href="integrations/guide/azure-status-metric" tag=" Azure" >}}Azure status and count metrics{{< /nextlink >}}
+    {{< nextlink href="integrations/guide/azure-count-metric" tag=" Azure" >}}Azure count metric{{< /nextlink >}}
     {{< nextlink href="integrations/guide/azure-vms-appear-in-app-without-metrics" tag=" Azure" >}}Azure VMs appear in the app without metrics{{< /nextlink >}}
     {{< nextlink href="integrations/guide/powered-down-azure-vm-on-infrastructure-list" tag=" Azure" >}}Powered-down Azure VMs on the Infrastructure list{{< /nextlink >}}
     {{< nextlink href="integrations/guide/powershell-command-to-install-azure-datadog-extension" tag=" Azure" >}}Commands to install the Azure Datadog extension{{< /nextlink >}}

--- a/content/en/integrations/guide/azure-count-metric.md
+++ b/content/en/integrations/guide/azure-count-metric.md
@@ -2,8 +2,10 @@
 title: Azure Count Metrics
 
 aliases:
+  - /integrations/guide/azure-status-metric
   - /integrations/faq/azure-vm-status-is-not-reporting
   - /integrations/faq/azure-status-metric
+  - /integrations/faq/azure-count-metric
 ---
 
 ## Overview

--- a/content/en/integrations/guide/azure-status-metric.md
+++ b/content/en/integrations/guide/azure-status-metric.md
@@ -1,5 +1,5 @@
 ---
-title: Azure Status and Count Metrics
+title: Azure Count Metrics
 
 aliases:
   - /integrations/faq/azure-vm-status-is-not-reporting
@@ -8,7 +8,7 @@ aliases:
 
 ## Overview
 
-Datadog generates two additional metrics for each resource monitored with the [Azure integration][1]: `azure.*.status` and `azure.*.count`. For example, Azure Virtual Machines monitored by Datadog reports `azure.vm.status` and `azure.vm.count`. These two metrics cover similar information.
+Datadog generates an additional metric for each resource monitored with the [Azure integration][1]: `azure.*.count`. For example, Azure Virtual Machines monitored by Datadog reports `azure.vm.count`.
 
 The `azure.*.count` metric is an improvement over `azure.*.status`, which is deprecated.
 
@@ -30,7 +30,7 @@ Use the `azure.*.count` metric to:
 - Create monitors to alert you about the status of different Azure resources.
 
 **Note**: In some cases, the default visualization settings can make it appear as though resources are being double counted intermittently in charts or query widgets. This does not affect monitors or widgets scoped to a specific status.
-You can reduce this effect by turning off [interpolation][2] in charts or query widgets by setting Interpolation > none or using `.fill(null)`. 
+You can reduce this effect by turning off [interpolation][2] in charts or query widgets by setting Interpolation > none or using `.fill(null)`.
 
 For most resource types, the possible statuses are:
 
@@ -52,21 +52,9 @@ Virtual machines have more detailed statuses, including:
 
 If you see a status of `query_failed` you need to enable the [Resource Health provider](#troubleshooting) in Azure.
 
-## Status metric
-
-The `azure.*.status` metric is the previous solution for this same type of information. It reports the number of available resources for each Azure resource type.
-
-### Differences
-
-The key differences between the `.status` and `.count` metric:
-
-- `azure.*.count` includes all resources that exist in the Azure account while `azure.*.status` only reports the number of available resources.
-- `azure.*.count` includes a `status` tag, which reports the specific availability state for the resource while `azure.*.status` only includes the standard tags for the resource type.
-- `azure.*.count` includes improvements in the accuracy and reliability of the metric value.
-
 ## Troubleshooting
 
-If your Azure integration is reporting metrics but not `azure.*.status`, or `azure.*.count` is returning `status:query_failed`, your Azure subscription needs to register the Azure Resource Health provider.
+If your Azure integration is reporting metrics but not `azure.*.count`, or `azure.*.count` is returning `status:query_failed`, your Azure subscription needs to register the Azure Resource Health provider.
 
 Using the Azure Command Line Interface:
 ```bash
@@ -75,7 +63,7 @@ azure config mode arm
 azure provider register Microsoft.ResourceHealth
 ```
 
-The `azure.*.status` metric should show in Datadog within 5 - 10 minutes.
+The `azure.*.count` metric should show in Datadog within 5 - 10 minutes.
 
 [1]: /integrations/azure/
 [2]: /metrics/guide/interpolation-the-fill-modifier-explained/


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Remove remaining references to the azure status (`azure.*.status`) metric, which has been deprecated since 2023 and no longer exists in the product. I've change the name of the file that used to describe it and the azure count metric to refer only to count, but retained the old name as an alias so we don't break any links. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
