### PR TITLE
Fix hostname in Sending Data from the OpenTelemetry Demo to Datadog

### DIFF
--- a/content/en/opentelemetry/guide/otel_demo_to_datadog.md
+++ b/content/en/opentelemetry/guide/otel_demo_to_datadog.md
@@ -99,7 +99,7 @@ Complete the following steps to configure these three components.
         traces:
           span_name_as_resource_name: true
           trace_buffer: 500
-        hostname: "otelcol-docker"
+        hostname: "otel-collector-docker"
         api:
           site: ${env:DD_SITE_PARAMETER}
           key: ${env:DD_API_KEY}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Address Hotjar feedback:
> To configure the OpenTelemetry Collector, open src/otelcollector/otelcol-config-extras.yml and add the following to the file: is incorrect hostname: "otelcol-docker" should be hostname: "otel-collector-docker" based on the docker-compose.yml file service name.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
