### PR TITLE
Bug: Trim whitespace more aggressively from tooltips

### DIFF
--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -1,54 +1,54 @@
 <!-- Get shortcode parameters -->
-{{ $text := .Get "text" }}
-{{ $tooltip := .Get "tooltip" }}
-{{ $glossary := .Get "glossary" }}
-{{ $case := .Get "case"}}
+{{- $text := .Get "text" -}}
+{{- $tooltip := .Get "tooltip" -}}
+{{- $glossary := .Get "glossary" -}}
+{{- $case := .Get "case" -}}
 
 <!-- Initialize variables -->
-{{ $displayText := $text }}
-{{ $tooltipContent := $tooltip }}
-{{ $fullDefinitionLink := "" }}
-{{ $glossaryMatch := false }}
-{{ $shortDefMatch := false }}
+{{- $displayText := $text -}}
+{{- $tooltipContent := $tooltip -}}
+{{- $fullDefinitionLink := "" -}}
+{{- $glossaryMatch := false -}}
+{{- $shortDefMatch := false -}}
 
 <!-- Handle glossary terms if provided -->
-{{ if $glossary }}
+{{- if $glossary -}}
   <!-- Add underscore to multi-word terms to match file name -->
-  {{ $glossaryTerm := replace $glossary " " "_" }}
+  {{- $glossaryTerm := replace $glossary " " "_" -}}
   <!-- Get the bundle of glossary term -->
-  {{ $headless := .Site.GetPage "/glossary/terms" }}
+  {{- $headless := .Site.GetPage "/glossary/terms" -}}
   <!-- Find the matching glossary term file -->
-  {{ with $headless.Resources.GetMatch (printf "%s.md" $glossaryTerm) }}
-    {{ $glossaryMatch = true }}
-    {{ $displayText = .Title }}
-    {{ if .Params.short_definition }}
-      {{ $shortDefMatch = true }}
+  {{- with $headless.Resources.GetMatch (printf "%s.md" $glossaryTerm) -}}
+    {{- $glossaryMatch = true -}}
+    {{- $displayText = .Title -}}
+    {{- if .Params.short_definition -}}
+      {{- $shortDefMatch = true -}}
       <!-- Use short definition if available -->
-      {{ $tooltipContent = .Params.short_definition }}
-      {{ $fullDefinitionLink = printf "/glossary/#%s" ($glossary | urlize) }}
-      {{ else }}
-        {{ warnf "Glossary term '%s' found but has no short_definition" $glossary }}
-    {{ end }}
-  {{ else }}
-    {{ $displayText = $glossary }}
-    {{ warnf "Glossary term '%s' not found" $glossary }}
-  {{ end }}
-{{ end }}
+      {{- $tooltipContent = .Params.short_definition -}}
+      {{- $fullDefinitionLink = printf "/glossary/#%s" ($glossary | urlize) -}}
+      {{- else -}}
+        {{- warnf "Glossary term '%s' found but has no short_definition" $glossary -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $displayText = $glossary -}}
+    {{- warnf "Glossary term '%s' not found" $glossary -}}
+  {{- end -}}
+{{- end -}}
 
 <!-- Apply capitalization based on the 'case' parameter -->
-{{ if eq $case "sentence" }}
-  {{ $displayText = printf "%s%s" (substr $displayText 0 1 | upper) (substr $displayText 1 | lower) }}
-{{ else if eq $case "title" }}
-  {{ $displayText = title $displayText }}
-{{ else if eq $case "lower" }}
-  {{ $displayText = lower $displayText }}
-{{ else if eq $case "upper" }}
-  {{ $displayText = upper $displayText }}
-{{ end }}
+{{- if eq $case "sentence" -}}
+  {{- $displayText = printf "%s%s" (substr $displayText 0 1 | upper) (substr $displayText 1 | lower) -}}
+{{- else if eq $case "title" -}}
+  {{- $displayText = title $displayText -}}
+{{- else if eq $case "lower" -}}
+  {{- $displayText = lower $displayText -}}
+{{- else if eq $case "upper" -}}
+  {{- $displayText = upper $displayText -}}
+{{- end -}}
 
 <!-- Render tooltip -->
 {{- if or $shortDefMatch (and $text $tooltip) -}}
-<span class="tooltip-container"><button class="tooltip-trigger" aria-describedby="tooltip-{{ $displayText | anchorize }}">{{ $displayText }}</button><span id="tooltip-{{ $displayText | anchorize }}" class="tooltip-content" role="tooltip">{{ $tooltipContent | safeHTML }}{{- if $fullDefinitionLink -}}<a href="{{ $fullDefinitionLink }}" class="tooltip-full-link" aria-label="View full definition">Glossary</a>{{- end }}</span></span>
+<span class="tooltip-container"><button class="tooltip-trigger" aria-describedby="tooltip-{{- $displayText | anchorize -}}">{{- $displayText -}}</button><span id="tooltip-{{- $displayText | anchorize -}}" class="tooltip-content" role="tooltip">{{- $tooltipContent | safeHTML -}}{{- if $fullDefinitionLink -}}<a href="{{- $fullDefinitionLink -}}" class="tooltip-full-link" aria-label="View full definition">Glossary</a>{{- end -}}</span></span>
 {{- else -}}
 {{- $displayText -}}
 {{- end -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
