### PR TITLE
Fix doc for troubleshooting Lambda

### DIFF
--- a/content/en/serverless/aws_lambda/troubleshooting.md
+++ b/content/en/serverless/aws_lambda/troubleshooting.md
@@ -76,7 +76,7 @@ If you have followed all the troubleshooting steps above and want help from [Dat
     datadog-ci lambda flare -f <function_arn> -e <email> -c <case_id> --with-logs
     ```
 
-<div class="alert alert-info">For more information about Serverless Flare, read the <a href="https://github.com/DataDog/datadog-ci/blob/master/src/commands/lambda/README.md#troubleshooting-serverless-instrumentation">command documentation</a>.</div>
+<div class="alert alert-info">For more information about Serverless Flare, read the <a href="https://docs.datadoghq.com/serverless/libraries_integrations/cli/#troubleshooting-lambda-instrumentation">command documentation</a>.</div>
 {{% /tab %}}
 {{% tab "Manually" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### Problem
1. The link is partially broken. It points to a section which has been renamed, so the link actually goes to the top of the page.
2. The link points to a README file in GitHub instead of to our doc site, which doesn't have translation support.

### What does this PR do?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Change the broken link to one pointing to Datadog's doc site and make it point to the correct section.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
