### PR TITLE
Use ddtrace.auto in favor of patch_all for python azure function instrumentation

### DIFF
--- a/content/en/serverless/azure_functions/_index.md
+++ b/content/en/serverless/azure_functions/_index.md
@@ -51,10 +51,9 @@ This page explains how to collect traces, trace metrics, runtime metrics, and cu
 
    ```python
    from datadog_serverless_compat import start
-   from ddtrace import tracer, patch_all
+   import ddtrace.auto
 
    start()
-   patch_all()
    ```
 
 3. (Optional) **Enable runtime metrics**. See [Python Runtime Metrics][2].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates the Python Azure Function instrumentation instructions to use `ddtrace.auto` instead of `patch_all().

In the upcoming release of v3.4.0 of the Python Tracer `patch_all()` will be deprecated. `ddtrace.auto` is recommended to use instead.

https://github.com/DataDog/dd-trace-py/releases/tag/v3.4.0

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
