### PR TITLE
Force Session Replay update

### DIFF
--- a/content/en/real_user_monitoring/session_replay/browser/_index.md
+++ b/content/en/real_user_monitoring/session_replay/browser/_index.md
@@ -81,6 +81,8 @@ To force Session Replay recording for the rest of the current session, call `sta
 
 When using the force option, the session is upgraded to a replayed session for the remainder of its duration, regardless of its initial sampling decision.
 
+<div class="alert alert-warning">The force option only upgrades an existing session to a replayed one if it is already being sampled. In other words, if sampling hasn't started yet, using the force option won't initiate one, and no replay will be recorded.</div>
+
 ## Disable Session Replay
 
 To stop session recordings, set `sessionReplaySampleRate` to `0`. This stops collecting data for the [Browser RUM & Session Replay plan][6].

--- a/content/en/real_user_monitoring/session_replay/browser/_index.md
+++ b/content/en/real_user_monitoring/session_replay/browser/_index.md
@@ -81,7 +81,7 @@ To force Session Replay recording for the rest of the current session, call `sta
 
 When using the force option, the session is upgraded to a replayed session for the remainder of its duration, regardless of its initial sampling decision.
 
-<div class="alert alert-warning">The force option only upgrades an existing session to a replayed one if it is already being sampled. In other words, if sampling hasn't started yet, using the force option won't initiate one, and no replay will be recorded.</div>
+<div class="alert alert-warning">The force option only upgrades an existing session to a replayed one if it is already being sampled. In other words, if sampling hasn't started yet, using the force option does not initiate one, and no replay is recorded.</div>
 
 ## Disable Session Replay
 


### PR DESCRIPTION
Add a callout that using the force option will not force start sampling of a session, it will only force start a replay of an already sampled session.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Internally there has been some confusion around the force option, specifically thinking that it would force start sampling of the entire session, not just force start the replay of an already sampled session. Added a callout to clarify the behavior.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ x ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
