### PR TITLE
Update the TOC logic to use the new Cdocs hooks interface

### DIFF
--- a/assets/scripts/components/table-of-contents.js
+++ b/assets/scripts/components/table-of-contents.js
@@ -246,24 +246,18 @@ window.addEventListener('scroll', () => {
     onScroll();
 });
 
-// Expose the necessary functions to cdocs
-window.cdocsHooks = {};
-
-const phases = ['beforeReveal', 'afterReveal', 'afterRerender'];
-phases.forEach((phase) => {
-    window.cdocsHooks[phase] = [];
-});
+/* Tell Cdocs to refresh the TOC when content changes */
 
 // Update the TOC after the page is initially rendered
 // and before it is revealed
-cdocsHooks.beforeReveal.push(buildTOCMap);
+clientFiltersManager.registerHook('beforeReveal', buildTOCMap);
 
 // Update the active header in the TOC after the page is revealed
-cdocsHooks.afterReveal.push(buildTOCMap);
-cdocsHooks.afterReveal.push(onScroll);
+clientFiltersManager.registerHook('afterReveal', buildTOCMap);
+clientFiltersManager.registerHook('afterReveal', onScroll);
 
-// Update the TOC any time the page is re-rendered
-cdocsHooks.afterRerender.push(buildTOCMap);
-cdocsHooks.afterRerender.push(onScroll);
+// Update the active header in the TOC after the page is re-rendered
+clientFiltersManager.registerHook('afterRerender', buildTOCMap);
+clientFiltersManager.registerHook('afterRerender', onScroll);
 
 DOMReady(handleAPIPage);

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@popperjs/core": "^2.11.8",
         "alpinejs": "^3.13.7",
         "bootstrap": "^5.2",
-        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.3.tgz",
+        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.3.tgz",
         "del": "4.1.1",
         "fancy-log": "^1.3.3",
         "geo-locate": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.1.tgz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6536,9 +6536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.3.tgz":
-  version: 1.0.3
-  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.3.tgz"
+"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.3.tgz":
+  version: 1.1.3
+  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.3.tgz"
   dependencies:
     "@prettier/sync": ^0.5.2
     "@types/markdown-it": ^14.1.2
@@ -6562,7 +6562,7 @@ __metadata:
     vite: ^5.4.10
     vite-plugin-singlefile: ^2.0.2
     zod: ^3.22.4
-  checksum: 042246b45b97a299b75b4e80ed0eb191e33de2447504c998f2cda7bb3e70213bdcb5be00f5e5f9b9a8ebe50772864f7a22ede3f45fe3e872b797d7a8da7f27b5
+  checksum: ff34cf6e59fd167b373818ae555046adeb74d27103f18b6941c00dd0a6e698faed21b622839cfaf67947d3eca3e6da2620166433da9502301b2611b41b1649a4
   languageName: node
   linkType: hard
 
@@ -7595,7 +7595,7 @@ __metadata:
     acorn: ^7.4.1
     alpinejs: ^3.13.7
     bootstrap: ^5.2
-    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.0.3.tgz"
+    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.3.tgz"
     cross-env: ^5.2.1
     del: 4.1.1
     eslint: ^6.8.0


### PR DESCRIPTION
Update the Cdocs build to use the hooks interface [shipped in v1.1.3](https://github.com/DataDog/corp-node-packages/pull/103) of the Cdocs-Hugo integration.

This PR is against a feature branch. It doesn't require your review unless you're @hestonhoffman.

Staging link: https://docs-staging.datadoghq.com/jen.gilbert/cdocs-hooks-refactor/real_user_monitoring/guide/proxy-mobile-rum-data