### PR TITLE
Fixes the incorrect link to custom-feature-flag-management

### DIFF
--- a/content/en/real_user_monitoring/feature_flag_tracking/_index.md
+++ b/content/en/real_user_monitoring/feature_flag_tracking/_index.md
@@ -50,7 +50,7 @@ To get started with feature flags, set up feature flag tracking for the browser 
 
 [1]: /real_user_monitoring/setup/
 [2]: /real_user_monitoring/browser#setup
-[3]: /real_user_monitoring/setup/?tab=npm#custom-feature-flag-management
+[3]: /real_user_monitoring/feature_flag_tracking/setup/?tab=browser#custom-feature-flag-management
 [4]: https://app.datadoghq.com/rum/feature-flags
 [5]: /real_user_monitoring/session_replay/browser/
 [6]: /real_user_monitoring/error_tracking/explorer/#explore-your-issues


### PR DESCRIPTION
The label "custom-feature-flag-management" currently points to a document lacking any information on feature flag management. I have corrected this by adding the appropriate link.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
