### PR TITLE
[CXP-2003] Add Infrastructure Monitoring section to Audit Trail Events

### DIFF
--- a/content/en/account_management/audit_trail/events.md
+++ b/content/en/account_management/audit_trail/events.md
@@ -36,6 +36,7 @@ further_reading:
 - [Cloud Security Platform](#cloud-security-platform-events)
 - [Dynamic Instrumentation](#dynamic-instrumentation-events)
 - [Error Tracking](#error-tracking-events)
+- [Infrastructure Monitoring](#infrastructure-monitoring)
 - [Log Management](#log-management-events)
 - [Metrics](#metrics-events)
 - [Real User Monitoring](#real-user-monitoring-events)
@@ -358,9 +359,9 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 | [Delete a schedule override][150]  | A user deleted a schedule override.   | `@evt.name:"On-Call" @asset.type:override @action:deleted`           |
 
 ### Infrastructure Monitoring
-| Name                               | Description of audit event            | Query in audit explorer                                              |
-|------------------------------------|---------------------------------------|----------------------------------------------------------------------|
-| [Enable Container Image Trends][151] | A user enabled Container Image Trends. | `@evt.name:"Infrastructure Monitoring" @asset.type:configure_container_image_trends @action:enabled` |
+| Name                                  | Description of audit event              | Query in audit explorer                                                                               |
+|---------------------------------------|-----------------------------------------|-------------------------------------------------------------------------------------------------------|
+| [Enable Container Image Trends][151]  | A user enabled Container Image Trends.  | `@evt.name:"Infrastructure Monitoring" @asset.type:configure_container_image_trends @action:enabled`  |
 | [Disable Container Image Trends][152] | A user disabled Container Image Trends. | `@evt.name:"Infrastructure Monitoring" @asset.type:configure_container_image_trends @action:disabled` |
 
 ## Further Reading

--- a/content/en/account_management/audit_trail/events.md
+++ b/content/en/account_management/audit_trail/events.md
@@ -357,6 +357,12 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 | [Modify a schedule override][149]  | A user modified a schedule override.  | `@evt.name:"On-Call" @asset.type:override @action:modified`          |
 | [Delete a schedule override][150]  | A user deleted a schedule override.   | `@evt.name:"On-Call" @asset.type:override @action:deleted`           |
 
+### Infrastructure Monitoring
+| Name                               | Description of audit event            | Query in audit explorer                                              |
+|------------------------------------|---------------------------------------|----------------------------------------------------------------------|
+| [Enable Container Image Trends][151] | A user enabled Container Image Trends. | `@evt.name:"Infrastructure Monitoring" @asset.type:configure_container_image_trends @action:enabled` |
+| [Disable Container Image Trends][152] | A user disabled Container Image Trends. | `@evt.name:"Infrastructure Monitoring" @asset.type:configure_container_image_trends @action:disabled` |
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -511,3 +517,5 @@ See the [Audit Trail documentation][2] for more information on setting up and co
 [148]:https://app.datadoghq.com/audit-trail?query=%40evt.name%3AOn-Call%20%40action%3Acreated%20%40asset.type%3Aoverride
 [149]:https://app.datadoghq.com/audit-trail?query=%40evt.name%3AOn-Call%20%40action%3Amodified%20%40asset.type%3Aoverride
 [150]:https://app.datadoghq.com/audit-trail?query=%40evt.name%3AOn-Call%20%40action%3Adeleted%20%40asset.type%3Aoverride
+[151]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Infrastructure%20Monitoring%22%20%40asset.type%3Aconfigure_container_image_trends%20%40action%3Aenabled
+[152]: https://app.datadoghq.com/audit-trail?query=%40evt.name%3A%22Infrastructure%20Monitoring%22%20%40asset.type%3Aconfigure_container_image_trends%20%40action%3Adisabled


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR adds a new Infrastructure Monitoring section to the Audit Trail Events documentation. It includes two new events for Container Image Trends configuration:
- Enable Container Image Trends
- Disable Container Image Trends

This addition helps users track and audit changes to Container Image Trends settings in their Datadog account.

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
This change follows the existing format of the Audit Trail Events documentation and maintains consistency with other sections. 