### PR TITLE
Fixed wrong field name in json template in mobile app testing documentation

### DIFF
--- a/content/en/synthetics/mobile_app_testing/_index.md
+++ b/content/en/synthetics/mobile_app_testing/_index.md
@@ -153,7 +153,7 @@ In this example, the test `aaa-aaa-aaa` runs with the override application versi
   "tests": [
     {
       "id": "aaa-aaa-aaa",
-      "config": {
+      "testOverrides": {
         "mobileApplicationVersionFilePath": "application/path"
       }
     }

--- a/content/es/synthetics/mobile_app_testing/_index.md
+++ b/content/es/synthetics/mobile_app_testing/_index.md
@@ -156,7 +156,7 @@ En este ejemplo, el test `aaa-aaa-aaa` se ejecuta con la versión de la aplicaci
   "tests": [
     {
       "id": "aaa-aaa-aaa",
-      "config": {
+      "testOverrides": {
         "mobileApplicationVersionFilePath": "application/path"
       }
     }

--- a/content/ja/synthetics/mobile_app_testing/_index.md
+++ b/content/ja/synthetics/mobile_app_testing/_index.md
@@ -154,7 +154,7 @@ Datadog では、不安定なテストを防ぐために、ロケータのセッ
   "tests": [
     {
       "id": "aaa-aaa-aaa",
-      "config": {
+      "testOverrides": {
         "mobileApplicationVersionFilePath": "application/path"
       }
     }

--- a/content/ko/synthetics/mobile_app_testing/_index.md
+++ b/content/ko/synthetics/mobile_app_testing/_index.md
@@ -121,7 +121,7 @@ Datadog은 실제 기기에서 이러한 테스트를 실행하여 주요 애플
   "tests": [
     {
       "id": "aaa-aaa-aaa",
-      "config": {
+      "testOverrides": {
         "mobileApplicationVersionFilePath": "application/path"
       }
     }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This documentation fix prevents customers from encountering issues when trying to configure mobile application version paths in their CI pipelines. Using the incorrect field name (config) would just cause the field to be skipped, while the correct field name (testOverrides) allows proper test execution using the specified mobile application.
The change ensures the documentation accurately reflects the required JSON structure for successful mobile app test configuration in CI environments.

The field is correctly used here : https://docs.datadoghq.com/continuous_testing/cicd_integrations/configuration/?tab=npm#test-files
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
