### PR TITLE
[CLOUDCRAFT 1192] Update EKS documentation to reflect modern expectations

### DIFF
--- a/content/en/cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft.md
+++ b/content/en/cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft.md
@@ -4,9 +4,7 @@ title: Connect an Amazon EKS Cluster with Cloudcraft
 
 By scanning your Amazon EKS clusters, Cloudcraft allows you to generate system architecture diagrams to help visualize your deployed workloads and pods.
 
-Cloudcraft uses the [role-based access control (RBAC) authorization method provided by Kubernetes][1] to authorize [Cloudcraft's existing read-only IAM entity role][2]. That means Cloudcraft requires no special software or agent.
-
-To learn more about RBAC configuration and IAM entities, see [Managing users or IAM roles for your cluster][3].
+Cloudcraft uses [access entries][1] to grant [Cloudcraft's existing read-only IAM entity role][2] access to the Kubernetes API. That means Cloudcraft requires no special software or agent to be installed on your cluster.
 
 <div class="alert alert-info">The ability to scan Amazon EKS clusters and AWS accounts is only available to Cloudcraft Pro subscribers. Check out <a href="https://www.cloudcraft.co/pricing">our pricing page</a> for more information.</div>
 
@@ -15,48 +13,37 @@ To learn more about RBAC configuration and IAM entities, see [Managing users or 
 Before connecting your Amazon EKS clusters with Cloudcraft, you must connect your AWS account and generate diagrams that include your clusters.
 
 To connect your AWS account and familiarize yourself with Cloudcraft, see the following articles:
-- [Connect your AWS account with Cloudcraft][4]
-- [Create your first live AWS diagram][5]
+- [Connect your AWS account with Cloudcraft][3]
+- [Crafting Better Diagrams: Cloudcraft's Live Diagramming and Filtering][4]
 
-[Install and configure `kubectl`][7], a tool that allows you to control Kubernetes clusters through the command line. Cloudcraft recommends using the latest version to avoid issues.
+[Install and configure `kubectl`][6], a tool that allows you to control Kubernetes clusters through the command line. Cloudcraft recommends using the latest version to avoid issues.
 
-In addition, in order to scan your cluster successfully, Cloudcraft requires clusters to have public access enabled and no IP filtering applied. The **Public Access Source Allow List** option in the networking configuration must remain set to its default value of 0.0.0.0/0.
+In addition, you'll want to [install and configure the AWS CLI][8] to manage your AWS services from the command line. As with `kubectl`, Cloudcraft recommends using the latest version.
 
-## Authorizing the Cloudcraft IAM role for view-only
+Finally, in order to scan your cluster successfully, Cloudcraft requires clusters to have public access enabled and no IP filtering applied. The **Public Access Source Allow List** option in the networking configuration must remain set to its default value of 0.0.0.0/0.
 
-Start by opening a blueprint with an existing Amazon EKS cluster or using the **Auto Layout** feature to generate a new blueprint.
+## Create access entries
+
+Start by opening a blueprint with an existing Amazon EKS cluster or creating a new blueprint to scan an account with Amazon EKS clusters.
 
 With your AWS environment mapped into a blueprint, select the Amazon EKS cluster that you wish to scan, and click the **Enable cluster scanning** button that appears in the component toolbar.
 
 {{< img src="cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft/enable-cluster-scanning.png" alt="Interactive Cloudcraft diagram showing an AWS EKS cluster with enable cluster scanning button highlighted." responsive="true" style="width:100%;">}}
 
-The next screen provides step-by-step commands to run in Terminal.
+The next screen provides step-by-step commands to run in your favorite terminal application.
 
-As the Amazon EKS cluster creator or user with admin access, open the aws-auth ConfigMap file with `kubectl`.
-
-```
-kubectl edit -n kube-system configmap/aws-auth
-```
-
-With the `aws-auth.yaml` file open in a text editor, add the role details to the *mapRoles* section of the file, just after under the *data* section.
+As the Amazon EKS cluster creator or user with admin access, run the following command to map the Cloudcraft IAM role to the Kubernetes group `cloudcraft-view-only`:
 
 ```
-data:
-  mapRoles: |
-    - rolearn: <arn-for-the-readonly-cloudcraft-iam-role>
-      groups:
-        - cloudcraft-view-only
+aws eks create-access-entry \
+  --cluster-name ${EKS_CLUSTER_NAME} \
+  --principal-arn ${CLOUDCRAFT_IAM_ROLE_ARN} \
+  --kubernetes-groups 'cloudcraft-view-only'
 ```
-
-If the section does not exist, add it. Once done, save the file and exit.
-
-<div class="alert alert-info">`groups` refer to groups in your cluster to which the role is mapped. For more information, see [Default Roles and Role Bindings][8] in the Kubernetes documentation.</div>
-
-<div class="alert alert-danger">Typos and syntax errors can affect the permissions of all IAM users and roles updated in the ConfigMap file. To prevent this from occuring, Cloudcraft recommends adding a YAML linter to your text editor.</div>
 
 ## Granting view-only access to the Cloudcraft IAM role
 
-Next, use [ClusterRoleBinding][6] to bind the IAM role to a Kubernetes role.
+Next, use [ClusterRoleBinding][5] to bind the IAM role to a Kubernetes role.
 
 A ClusterRoleBinding grants permissions defined in a role to a user or set of users in all namespaces in a cluster. Kubernetes defines some default user-facing roles. For Cloudcraft, use the predefined "view" role that allows view-only access to most objects in a namespace.
 
@@ -65,6 +52,7 @@ Enter the following multi-line command to create the ClusterRoleBinding and gran
 ```
 cat << EOF | kubectl apply -f -
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
 metadata:
   name: cloudcraft-view-only
 subjects:
@@ -86,11 +74,11 @@ To test that Cloudcraft can access to the cluster, click **Test cluster access**
 
 To scan other clusters, repeat the process as many times as needed.
 
-[1]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
+[1]: https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html
 [2]: /cloudcraft/faq/how-cloudcraft-connects-to-aws/
-[3]: https://docs.aws.amazon.com/eks/latest/userguide/add-user-role.html
-[4]: /cloudcraft/getting-started/connect-aws-account-with-cloudcraft/
-[5]: /cloudcraft/getting-started/create-your-first-cloudcraft-diagram/
-[6]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding
-[7]: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
-[8]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+[3]: /cloudcraft/getting-started/connect-aws-account-with-cloudcraft/
+[4]: /cloudcraft/getting-started/crafting-better-diagrams/
+[5]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#rolebinding-and-clusterrolebinding
+[6]: https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+[7]: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+[8]: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html

--- a/content/en/cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft.md
+++ b/content/en/cloudcraft/getting-started/connect-amazon-eks-cluster-with-cloudcraft.md
@@ -4,7 +4,7 @@ title: Connect an Amazon EKS Cluster with Cloudcraft
 
 By scanning your Amazon EKS clusters, Cloudcraft allows you to generate system architecture diagrams to help visualize your deployed workloads and pods.
 
-Cloudcraft uses [access entries][1] to grant [Cloudcraft's existing read-only IAM entity role][2] access to the Kubernetes API. That means Cloudcraft requires no special software or agent to be installed on your cluster.
+Cloudcraft uses [access entries][1] to grant [Cloudcraft's existing read-only IAM entity role][2] access to the Kubernetes API. Cloudcraft does not require any special software or agent to be installed on your cluster.
 
 <div class="alert alert-info">The ability to scan Amazon EKS clusters and AWS accounts is only available to Cloudcraft Pro subscribers. Check out <a href="https://www.cloudcraft.co/pricing">our pricing page</a> for more information.</div>
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Update the Cloudcraft EKS documentation to remove usage of `aws-auth ConfigMap` as it's deprecated, and use access entries instead.

Instructions need to be updated in `web-ui` too. @srividya-rajagopalan should this wait to be merged until I send the PR for that part?

### Merge instructions
Please wait until someone from the Cloudcraft team review the changes before merging.

Merge readiness:
- [ ] Ready for merge