### PR TITLE
Mention Case Automation Rules in CoTerm docs

### DIFF
--- a/content/en/coterm/usage.md
+++ b/content/en/coterm/usage.md
@@ -104,7 +104,7 @@ process_config:
           actions: ["record", "logs", "process_info", "approval"]
    {{< /code-block >}}
 
-With this configuration, when you run a `kubectl scale --context prod` command, CoTerm creates an approval request in [Case Management][3]. If you opt to associate the approval request with an active [incident][5], other incident responders are automatically added as approvers. After this request is approved, your command executes.
+With this configuration, when you run a `kubectl scale --context prod` command, CoTerm creates an approval request in [Case Management][3]. If you opt to associate the approval request with an active [incident][5], other incident responders are automatically added as approvers. After this request is approved, your command executes. You can also [configure automation rules][8] to trigger workflows based on approval requests.
 
 #### Manually require approval
 
@@ -135,3 +135,4 @@ COTERM_BREAK_GLASS=true kubectl delete foo
 [5]: /service_management/incident_management/
 [6]: /coterm/install
 [7]: https://app.datadoghq.com/terminal-streams
+[8]: https://docs.datadoghq.com/service_management/case_management/automation_rules/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR mentions and links to the new [Case Automation Rules](https://groups.google.com/a/datadoghq.com/g/product-announcements/c/8Mq9Pqd358s/m/HkE0Xq5RCgAJ?utm_medium=email&utm_source=footer) feature, which works very well with CoTerm. CoTerm users can now trigger custom workflows when a CoTerm approval request is created/approved/rejected.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
