### PR TITLE
[SDTEST-426] docs for agentless logs submission in Ruby

### DIFF
--- a/content/en/tests/correlate_logs_and_tests/_index.md
+++ b/content/en/tests/correlate_logs_and_tests/_index.md
@@ -77,11 +77,10 @@ Use the following environment variables to enable and configure log submission:
 
 ### Ruby
 
-Agentless logs submission with Test Optimization is supported for Rails applications.
-You need to [instrument your app with Datadog tracing][1] before enabling this feature.
+Agentless logs submission with Test Optimization is supported for Rails applications. Before enabling, ensure
+that your application is [instrumented with Datadog tracing][1].
 
-Agentless log submission requires `datadog-ci` version `0.16` or newer.
-It supports the following logging libraries:
+To use agentless log submission, you need `datadog-ci` version `0.16` or later. The following logging libraries are supported:
 
 -   `activesupport >= 5.0` (only when using `ActiveSupport::TaggedLogging`)
 -   `lograge >= 0.14`

--- a/content/en/tests/correlate_logs_and_tests/_index.md
+++ b/content/en/tests/correlate_logs_and_tests/_index.md
@@ -2,12 +2,13 @@
 title: Correlate Logs and Tests
 description: Correlate your logs with your test traces.
 further_reading:
-  - link: "/tests"
-    tag: "Documentation"
-    text: "Learn about Test Optimization"
+    - link: '/tests'
+      tag: 'Documentation'
+      text: 'Learn about Test Optimization'
 ---
 
 {{< site-region region="gov" >}}
+
 <div class="alert alert-warning">Test Optimization is not available in the selected site ({{< region-param key="dd_site_name" >}}) at this time.</div>
 {{< /site-region >}}
 
@@ -25,54 +26,74 @@ Correlation can be configured differently depending on how you [send your tests 
 {{< tabs >}}
 {{% tab "Cloud CI provider (Agentless)" %}}
 
-
 ### Java
+
 Agentless log submission is supported for the following languages and frameworks:
 
-- `dd-trace-java >= 1.35.2` and Log4j2.
+-   `dd-trace-java >= 1.35.2` and Log4j2.
 
 Use the following environment variables to enable and configure Agentless log submission:
 
-| Name | Description | Default value |
-|---|---|---|
-| `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` (required) | Enables/disables log submission | `false`
-| `DD_AGENTLESS_LOG_SUBMISSION_LEVEL` (optional) | Sets log level for Agentless submission | `INFO`
-| `DD_AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE` (optional) | Sets the maximum size of pending logs queue | `1024`
-| `DD_AGENTLESS_LOG_SUBMISSION_URL` (optional) | Sets custom URL for submitting logs | -
+| Name                                                | Description                                 | Default value |
+| --------------------------------------------------- | ------------------------------------------- | ------------- |
+| `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` (required)    | Enables/disables log submission             | `false`       |
+| `DD_AGENTLESS_LOG_SUBMISSION_LEVEL` (optional)      | Sets log level for Agentless submission     | `INFO`        |
+| `DD_AGENTLESS_LOG_SUBMISSION_QUEUE_SIZE` (optional) | Sets the maximum size of pending logs queue | `1024`        |
+| `DD_AGENTLESS_LOG_SUBMISSION_URL` (optional)        | Sets custom URL for submitting logs         | -             |
 
 ### Javascript/Typescript
 
 Agentless log submission is supported for the following languages and frameworks:
 
-- `dd-trace-js >= 5.24.0` and `dd-trace-js >= 4.48.0` and `winston`.
+-   `dd-trace-js >= 5.24.0` and `dd-trace-js >= 4.48.0` and `winston`.
 
 Use the following environment variables to enable and configure Agentless log submission:
 
-| Name | Description | Default value |
-|---|---|---|
-| `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` (required) | Enables/disables log submission | `false`
-| `DD_AGENTLESS_LOG_SUBMISSION_URL` (optional) | Sets custom URL for submitting logs | -
+| Name                                             | Description                         | Default value |
+| ------------------------------------------------ | ----------------------------------- | ------------- |
+| `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` (required) | Enables/disables log submission     | `false`       |
+| `DD_AGENTLESS_LOG_SUBMISSION_URL` (optional)     | Sets custom URL for submitting logs | -             |
 
 ### .NET
 
 Agentless log submission is supported for the following languages and frameworks:
 
-- `dd-trace-dotnet >= 2.50.0` and XUnit TestOutputHelper.
+-   `dd-trace-dotnet >= 2.50.0` and XUnit TestOutputHelper.
 
 Use the following environment variables to enable and configure Agentless log submission:
 
-| Name | Description | Default value |
-|---|---|---|
-| `DD_CIVISIBILITY_LOGS_ENABLED` (required) | Enables/disables CI Visibility log submission | `false`
+| Name                                      | Description                                   | Default value |
+| ----------------------------------------- | --------------------------------------------- | ------------- |
+| `DD_CIVISIBILITY_LOGS_ENABLED` (required) | Enables/disables CI Visibility log submission | `false`       |
 
 ### Swift
 
 Use the following environment variables to enable and configure log submission:
 
-| Name | Description | Default value |
-|---|---|---|
-| `DD_ENABLE_STDOUT_INSTRUMENTATION` | Enables/disables stdout log submission | `false`
-| `DD_ENABLE_STDERR_INSTRUMENTATION` | Enables/disables stderr log submission | `false`
+| Name                               | Description                            | Default value |
+| ---------------------------------- | -------------------------------------- | ------------- |
+| `DD_ENABLE_STDOUT_INSTRUMENTATION` | Enables/disables stdout log submission | `false`       |
+| `DD_ENABLE_STDERR_INSTRUMENTATION` | Enables/disables stderr log submission | `false`       |
+
+### Ruby
+
+Agentless logs submission with Test Optimization is supported for Rails applications.
+You need to [instrument your app with Datadog tracing][1] before enabling this feature.
+
+Agentless log submission requires `datadog-ci` version `0.16` or newer.
+It supports the following logging libraries:
+
+-   `activesupport >= 5.0` (only when using `ActiveSupport::TaggedLogging`)
+-   `lograge >= 0.14`
+-   `semantic_logger >= 4.0`
+
+Use the following environment variable to enable log submission:
+
+| Name                                             | Description                     | Default value |
+| ------------------------------------------------ | ------------------------------- | ------------- |
+| `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` (required) | Enables/disables log submission | `false`       |
+
+[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/ruby/#rails-or-hanami-applications
 
 {{% /tab %}}
 {{% tab "On-Premises CI provider (Datadog Agent)" %}}
@@ -80,12 +101,11 @@ Use the following environment variables to enable and configure log submission:
 1. [Set up log collection][1] through the Datadog Agent.
 2. Follow the steps described in [Correlate Logs and Traces][2].
 
-
 [1]: /logs/log_collection/
 [2]: /tracing/other_telemetry/connect_logs_and_traces/
+
 {{% /tab %}}
 {{< /tabs >}}
-
 
 ## Further Reading
 

--- a/content/en/tests/correlate_logs_and_tests/_index.md
+++ b/content/en/tests/correlate_logs_and_tests/_index.md
@@ -53,19 +53,8 @@ Use the following environment variables to enable and configure Agentless log su
 | `DD_AGENTLESS_LOG_SUBMISSION_ENABLED` (required) | Enables/disables log submission | `false`
 | `DD_AGENTLESS_LOG_SUBMISSION_URL` (optional) | Sets custom URL for submitting logs | -
 
-{{% /tab %}}
-{{% tab "On-Premises CI provider (Datadog Agent)" %}}
-
-1. [Set up log collection][1] through the Datadog Agent.
-2. Follow the steps described in [Correlate Logs and Traces][2].
-
-
-[1]: /logs/log_collection/
-[2]: /tracing/other_telemetry/connect_logs_and_traces/
-{{% /tab %}}
-{{< /tabs >}}
-
 ### .NET
+
 Agentless log submission is supported for the following languages and frameworks:
 
 - `dd-trace-dotnet >= 2.50.0` and XUnit TestOutputHelper.
@@ -84,6 +73,19 @@ Use the following environment variables to enable and configure log submission:
 |---|---|---|
 | `DD_ENABLE_STDOUT_INSTRUMENTATION` | Enables/disables stdout log submission | `false`
 | `DD_ENABLE_STDERR_INSTRUMENTATION` | Enables/disables stderr log submission | `false`
+
+{{% /tab %}}
+{{% tab "On-Premises CI provider (Datadog Agent)" %}}
+
+1. [Set up log collection][1] through the Datadog Agent.
+2. Follow the steps described in [Correlate Logs and Traces][2].
+
+
+[1]: /logs/log_collection/
+[2]: /tracing/other_telemetry/connect_logs_and_traces/
+{{% /tab %}}
+{{< /tabs >}}
+
 
 ## Further Reading
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for agentless logs submission in Ruby. Fixes small issue with agentless logs submission page: .NET and Swift agentless instructions were outside of agentless tab.

### Merge instructions


Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```
