### PR TITLE
Fix incorrect Unity `AddError` documentation.

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration.md
@@ -110,7 +110,7 @@ The `string` used for `resourceKey` in both calls must be unique for the resourc
 
 ### Track custom errors
 
-To track specific errors, notify `DdRum` when an error occurs the exception, the source, and any additional attributes.
+To track specific errors, notify `DdRum` when an error occurs with the exception, the source, and any additional attributes.
 
 ```cs
 try

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/unity/advanced_configuration.md
@@ -110,10 +110,17 @@ The `string` used for `resourceKey` in both calls must be unique for the resourc
 
 ### Track custom errors
 
-To track specific errors, notify `DdRum` when an error occurs with the message, source, exception, and additional attributes.
+To track specific errors, notify `DdRum` when an error occurs the exception, the source, and any additional attributes.
 
 ```cs
-DatadogSdk.Instance.Rum.AddError("This is an error message.");
+try
+{
+  // Error prone code
+}
+catch(Exception e)
+{
+  DatadogSdk.Instance.Rum.AddError(e, RumErrorSource.Source);
+}
 ```
 
 ## Track custom global attributes


### PR DESCRIPTION
### What does this PR do? What is the motivation?
API for the Unity `AddError` method was incorrect. I updated it with a better example.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
