### PR TITLE
Fix Terraform code for Google Cloud Run

### DIFF
--- a/content/en/serverless/google_cloud_run/_index.md
+++ b/content/en/serverless/google_cloud_run/_index.md
@@ -368,6 +368,9 @@ resource "google_cloud_run_service" "terraform_with_sidecar" {
         # Correctly formatted container-dependencies annotation
         "run.googleapis.com/container-dependencies" = jsonencode({main-app = ["sidecar-container"]})
       }
+      labels = {
+        service = "<SERVICE_NAME>"
+      }
     }
     spec {
       # Define shared volume
@@ -487,9 +490,6 @@ resource "google_cloud_run_service" "terraform_with_sidecar" {
           }
         }
       }
-      labels = {
-       service : "<SERVICE_NAME>"
-      } 
     }
   }
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Problem: The Terraform code for instrumenting Google Cloud Run is wrong. I tried to follow the doc to add "labels", which resulted in an error:
> An argument named "labels" is not expected here.

This PR fixes the way to add labels. Labels should be at: `google_cloud_run_service.template.metadata.labels`. See more in the doc: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_service#argument-reference

I tested it and it worked.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
