### PR TITLE
Add alias to SDS custom rules page

### DIFF
--- a/content/en/security/sensitive_data_scanner/scanning_rules/custom_rules.md
+++ b/content/en/security/sensitive_data_scanner/scanning_rules/custom_rules.md
@@ -4,6 +4,7 @@ disable_toc: false
 aliases:
   - /sensitive_data_scanner/regular_expression_syntax/
   - /sensitive_data_scanner/scanning_rules/custom_rules
+  - /security/sensitive_data_scanner/regular_expression_syntax
 further_reading:
     - link: "/security/sensitive_data_scanner/"
       tag: "Documentation"


### PR DESCRIPTION
Currently, `security/sensitive_data_scanner/guide/best_practices_for_creating_custom_rules/` contains a link to `security/sensitive_data_scanner/regular_expression_syntax` that doesn't work.

I've opted to add `security/sensitive_data_scanner/regular_expression_syntax` as an alias to what I assume is the intended page, both to fix this particular link but also to allow external links to that page to work.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
