### PR TITLE
Updated docs for Tags Cardinality Explorer GA Access

### DIFF
--- a/content/en/metrics/guide/custom_metrics_governance.md
+++ b/content/en/metrics/guide/custom_metrics_governance.md
@@ -61,10 +61,6 @@ Additionally, review [Usage Attribution][3] information for a total breakdown of
 
 #### Metric-level visibility
 
-{{< callout url="https://forms.gle/H3dG9tTdR6bqzHAX9" >}}
-Custom Metrics Tags Cardinality Explorer is in Preview. Use this form to request access today.
-{{< /callout >}} 
-
 {{< img src="metrics/tagsexplorer.png" alt="Custom Metrics Tags Cardinality Explorer for a spiking metric name" style="width:80%;">}}
 
 Once you've identified which metric names are driving up your account's monthly usage and costs, you can navigate to the metric's details side panel to view the Custom Metrics Tags Cardinality Explorer. This shows you which tag keys are driving a particular metric's cardinality to spike. Any spammy or unbounded tag keys with large increases in the number of unique tag values are the likely cause. Exclude them using Metrics without Limits™ to achieve immediate cost savings.

--- a/content/en/metrics/summary.md
+++ b/content/en/metrics/summary.md
@@ -154,10 +154,6 @@ To determine the value of any metric name to your organization, use Metrics Rela
    
 ## Custom Metrics Tags Cardinality Explorer 
 
-{{< callout url="https://forms.gle/H3dG9tTdR6bqzHAX9" >}}
-Custom Metrics Tags Cardinality Explorer is in Preview. Use this form to request access today.
-{{< /callout >}} 
-
 {{< img src="metrics/tagsexplorer.png" alt="Custom Metrics Tags Cardinality Explorer for a spiking metric name" style="width:80%;">}}
 To determine why a particular metric name is emitting a large number of custom metrics, or spiking, use the Custom Metrics Tags Cardinality Explorer. This helps you pinpoint the tag keys driving the spike, which you can immediately exclude using Metrics without Limits™ for cost savings.
 


### PR DESCRIPTION
Preparing docs for GA launch of Tags Cardinality Explorer on the Metrics Summary and Volume Management page.

Don't merge until given green light, as I'm waiting for engineering to fix the API.