### PR TITLE
Explain Tracer Options for Quantization of APM Data

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -210,6 +210,16 @@ When `true`, user principal is collected. Available for versions 0.61+.
 **Default**: `100`<br>
 Maximum number of spans to sample per second, per process, when `DD_TRACE_SAMPLING_RULES` or `DD_TRACE_SAMPLE_RATE` is set. Otherwise, the Datadog Agent controls rate limiting.
 
+`dd.http.server.tag.query-string`
+: **Environment Variable**: `DD_HTTP_SERVER_TAG_QUERY_STRING`<br>
+**Default**: `true`<br>
+When set to `true` query string parameters and fragment get added to web server spans
+
+`dd.http.server.route-based-naming`
+: **Environment Variable**: `DD_HTTP_SERVER_ROUTE_BASED_NAMING`<br>
+**Default**: `true`<br>
+When set to `false` http framework routes are not used for resource names. _This can change resource names and derived metrics if changed._
+
 `dd.trace.http.server.path-resource-name-mapping`<br>
 : **Environment Variable**: `DD_TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING`<br>
 **Default**: `{}` (empty) <br>
@@ -221,16 +231,6 @@ Request path | Resource path
 `/admin/index.jsp` | `/admin-page`
 `/admin/user/12345/delete` | `/admin/user`
 `/user/12345` | `/user/?`
-
-`dd.http.server.tag.query-string`
-: **Environment Variable**: `DD_HTTP_SERVER_TAG_QUERY_STRING`<br>
-**Default**: `true`<br>
-When set to `true` query string parameters and fragment get added to web server spans
-
-`dd.http.server.route-based-naming`
-: **Environment Variable**: `DD_HTTP_SERVER_ROUTE_BASED_NAMING`<br>
-**Default**: `true`<br>
-When set to `false` http framework routes are not used for resource names. _This can change resource names and derived metrics if changed._
 
 `dd.trace.128.bit.traceid.generation.enabled`
 : **Environment Variable**: `DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED`<br>

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -223,9 +223,12 @@ When set to `false` http framework routes are not used for resource names. _This
 `dd.trace.http.server.path-resource-name-mapping`<br>
 : **Environment Variable**: `DD_TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING`<br>
 **Default**: `{}` (empty) <br>
-Maps HTTP request paths to custom resource names. Provide a comma‑separated list of `pattern:resource_name` pairs, where `pattern` is an [Ant‑style path pattern][20] that must match the value of the `http.path_group` span tag. Mappings are evaluated in order of priority, and the first matching rule applies. Unmatched request paths use the default normalization behavior.<br>
-**Example:**  
-Using `-Ddd.trace.http.server.path-resource-name-mapping=/admin/*.jsp:/admin-page,/admin/user/**:/admin/user` yields:
+Maps HTTP request paths to custom resource names. Provide a comma‑separated list of `pattern:resource_name` pairs:<br>
+&nbsp;&nbsp;&nbsp;&ndash; `pattern`: An [Ant‑style path pattern][20] that must match the value of the `http.path_group` span tag.<br>
+&nbsp;&nbsp;&nbsp;&ndash; `resource_name`: The custom resource name to assign if the pattern matches.<br>
+If `*` is used as the `resource_name` for a matching pattern, the original, unnormalized request path combined with the HTTP method is used as the resource name. For example, given the rule `/test/**:*`, a `GET` request for `/test/some/path` results in the resource name `GET /test/some/path`.<br>
+Mappings are evaluated in order of priority, and the first matching rule applies. Unmatched request paths use the default normalization behavior.<br>
+**Example**: Using `-Ddd.trace.http.server.path-resource-name-mapping=/admin/*.jsp:/admin-page,/admin/user/**:/admin/user` yields:<br>
 Request path | Resource path
 ------------ | -------------
 `/admin/index.jsp` | `/admin-page`

--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -210,6 +210,18 @@ When `true`, user principal is collected. Available for versions 0.61+.
 **Default**: `100`<br>
 Maximum number of spans to sample per second, per process, when `DD_TRACE_SAMPLING_RULES` or `DD_TRACE_SAMPLE_RATE` is set. Otherwise, the Datadog Agent controls rate limiting.
 
+`dd.trace.http.server.path-resource-name-mapping`<br>
+: **Environment Variable**: `DD_TRACE_HTTP_SERVER_PATH_RESOURCE_NAME_MAPPING`<br>
+**Default**: `{}` (empty) <br>
+Maps HTTP request paths to custom resource names. Provide a comma‑separated list of `pattern:resource_name` pairs, where `pattern` is an [Ant‑style path pattern][20] that must match the value of the `http.path_group` span tag. Mappings are evaluated in order of priority, and the first matching rule applies. Unmatched request paths use the default normalization behavior.<br>
+**Example:**  
+Using `-Ddd.trace.http.server.path-resource-name-mapping=/admin/*.jsp:/admin-page,/admin/user/**:/admin/user` yields:
+Request path | Resource path
+------------ | -------------
+`/admin/index.jsp` | `/admin-page`
+`/admin/user/12345/delete` | `/admin/user`
+`/user/12345` | `/user/?`
+
 `dd.http.server.tag.query-string`
 : **Environment Variable**: `DD_HTTP_SERVER_TAG_QUERY_STRING`<br>
 **Default**: `true`<br>
@@ -604,3 +616,4 @@ Deprecated since version 1.9.0
 [17]: /opentelemetry/interoperability/environment_variable_support
 [18]: /tracing/guide/aws_payload_tagging/?code-lang=java
 [19]: /security/application_security/threats/setup/threat_detection/java/
+[20]: https://ant.apache.org/manual/dirtasks.html#patterns

--- a/content/en/tracing/troubleshooting/quantization.md
+++ b/content/en/tracing/troubleshooting/quantization.md
@@ -72,7 +72,37 @@ Alternatively, you can use the `DD_APM_REPLACE_TAGS` environment variable with a
 export DD_APM_REPLACE_TAGS = '[{"name": "span.name", "pattern": "get id_[0-9]+", "repl": "get id_x"}, {...}, …]'
 ```
 
-## Further Reading
+### Tracer-specific configuration
+
+Some tracers provide options to customize resource name generation directly:
+
+{{< tabs >}}
+{{% tab "Java" %}}
+
+The Java tracer allows customization of HTTP resource names with the `dd.trace.http.server.path-resource-name-mapping` option, which maps HTTP request paths to custom resource names using Ant-style patterns.
+
+For more information, read [Configuring the Java Tracing Library][4]
+
+[4]: /tracing/trace_collection/library_config/java/#traces
+
+{{% /tab %}}
+
+{{% tab "PHP" %}}
+
+The PHP tracer provides several options for URI normalization:
+
+- `DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX` identifies path fragments corresponding to IDs
+- `DD_TRACE_RESOURCE_URI_MAPPING_INCOMING` normalizes resource naming for incoming requests
+- `DD_TRACE_RESOURCE_URI_MAPPING_OUTGOING` normalizes resource naming for outgoing requests
+
+For more information, read [Configuring the PHP Tracing Library][5]
+
+[5]: /tracing/trace_collection/library_config/php/#traces
+
+{{% /tab %}}
+{{< /tabs >}}
+
+## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
* Adds tracer-specific config for quantization of APM data.
* Documents `dd.trace.http.server.path-resource-name-mapping` which was missing. [Added here](https://github.com/DataDog/dd-trace-java/pull/2761).
* Links to related Java and PHP options in Library Config pages.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
