### PR TITLE
add msiexec exit code and log file params

### DIFF
--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -59,7 +59,10 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
     ```powershell
-    Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>"'
+    $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>"'
+    if ($p.ExitCode -ne 0) {
+      Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
+    }
     ```
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
@@ -136,7 +139,10 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 
 **Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
   ```powershell
-  Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
+  $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
+  if ($p.ExitCode -ne 0) {
+    Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
+  }
   ```
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -59,11 +59,11 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
     {{< code-block lang="powershell" >}}
-    $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>"'
-    if ($p.ExitCode -ne 0) {
-      Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
-    }
-    {{< /code-block >}}
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>"'
+if ($p.ExitCode -ne 0) {
+  Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
+}
+{{< /code-block >}}
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows
@@ -139,11 +139,11 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 
 **Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
   {{< code-block lang="powershell" >}}
-  $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
-  if ($p.ExitCode -ne 0) {
-    Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
-  }
-  {{< /code-block >}}
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
+if ($p.ExitCode -ne 0) {
+  Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
+}
+{{< /code-block >}}
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -59,7 +59,7 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
     {{< code-block lang="powershell" >}}
-$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>"'
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>"'
 if ($p.ExitCode -ne 0) {
   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }
@@ -68,7 +68,7 @@ if ($p.ExitCode -ne 0) {
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows
 [3]: /agent/faq/windows-agent-ddagent-user/
-[4]: https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi
+[4]: https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi
 [5]: https://app.datadoghq.com/organization-settings/api-keys
 
 {{% /tab %}}
@@ -139,7 +139,7 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 
 **Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
   {{< code-block lang="powershell" >}}
-$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
 if ($p.ExitCode -ne 0) {
   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }
@@ -150,7 +150,7 @@ if ($p.ExitCode -ne 0) {
 [3]: /agent/faq/windows-agent-ddagent-user/
 [4]: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/group-managed-service-accounts/group-managed-service-accounts/group-managed-service-accounts-overview#software-requirements
 [5]: https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/group-managed-service-accounts/group-managed-service-accounts/getting-started-with-group-managed-service-accounts
-[6]: https://ddagent-windows-stable.s3.amazonaws.com/installers_v2.json
+[6]: https://windows-agent.datadoghq.com/installers_v2.json
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -58,12 +58,12 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
-    ```powershell
+    {{< code-block lang="powershell" >}}
     $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>"'
     if ($p.ExitCode -ne 0) {
       Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
     }
-    ```
+    {{< /code-block >}}
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows
@@ -138,12 +138,12 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 2. Run the following command to install the Datadog Agent:
 
 **Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
-  ```powershell
+  {{< code-block lang="powershell" >}}
   $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
   if ($p.ExitCode -ne 0) {
     Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
   }
-  ```
+  {{< /code-block >}}
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest?platform=windows
 [2]: /agent/supported_platforms/?tab=windows

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -206,7 +206,7 @@ If you're upgrading from a Datadog Agent version < 5.12.0, first upgrade to a mo
 
 #### Installation log files
 
-You can find Agent installation log files at `%TEMP%\MSI*.LOG`.
+Set the `/log <FILENAME>` msiexec option to configure an installation log file. If this option is not set, msiexec writes the log to `%TEMP%\MSI*.LOG` by default.
 
 #### Validation
 

--- a/content/en/agent/basic_agent_usage/windows.md
+++ b/content/en/agent/basic_agent_usage/windows.md
@@ -59,7 +59,7 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 1. Open PowerShell with **Administrator** privileges.
 2. Run the following command to install the Datadog Agent:
     {{< code-block lang="powershell" >}}
-    $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>"'
+    $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>"'
     if ($p.ExitCode -ne 0) {
       Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
     }
@@ -139,7 +139,7 @@ When the install finishes, you are given the option to launch the Datadog Agent 
 
 **Note:** Replace `DatadogGMSA$` with the username of your gMSA. The username **must end with a $ symbol.**
   {{< code-block lang="powershell" >}}
-  $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
+  $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<YOUR_DOMAIN_NAME>\DatadogGMSA$"'
   if ($p.ExitCode -ne 0) {
     Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
   }

--- a/content/en/agent/guide/fips-agent.md
+++ b/content/en/agent/guide/fips-agent.md
@@ -89,12 +89,12 @@ The Datadog FIPS Agent is in Preview and has not been fully audited. Install and
 The Datadog FIPS Agent is in preview and has not been fully audited. Install and test the Agent only on hosts that are not critical to production workloads.
 
 1. Follow the [Windows instructions][1] to uninstall the Datadog Agent.
-1. Run the command below to install the FIPS Agent, replacing `MY_API_KEY` with your API key:
+1. Run the command below to install the FIPS Agent, replacing `DATADOG_API_KEY` with your API key:
 
    **Note:** FIPS support is only available on Agent versions 7.63.0 and above:
 
    {{< code-block lang="powershell" >}}
-   $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i "https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-fips-agent-7.63.0-rc.7-fips-preview-2.msi" /log C:\Windows\SystemTemp\install-datadog.log APIKEY="MY_API_KEY" SITE="ddog-gov.com"'
+   $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i "https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-fips-agent-7.63.0-rc.7-fips-preview-2.msi" /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" SITE="ddog-gov.com"'
    if ($p.ExitCode -ne 0) {
      Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
    }

--- a/content/en/agent/guide/fips-agent.md
+++ b/content/en/agent/guide/fips-agent.md
@@ -93,12 +93,12 @@ The Datadog FIPS Agent is in preview and has not been fully audited. Install and
 
    **Note:** FIPS support is only available on Agent versions 7.63.0 and above:
 
-   ```powershell
+   {{< code-block lang="powershell" >}}
    $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i "https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-fips-agent-7.63.0-rc.7-fips-preview-2.msi" /log C:\Windows\SystemTemp\install-datadog.log APIKEY="MY_API_KEY" SITE="ddog-gov.com"'
    if ($p.ExitCode -ne 0) {
      Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
    }
-   ```
+   {{< /code-block >}}
 
    To install a different preview version of the FIPS Agent, search the [list of stable Agent versions][2] for `datadog-fips-agent` and replace the MSI in the command above with your desired version.
 

--- a/content/en/agent/guide/fips-agent.md
+++ b/content/en/agent/guide/fips-agent.md
@@ -94,7 +94,7 @@ The Datadog FIPS Agent is in preview and has not been fully audited. Install and
    **Note:** FIPS support is only available on Agent versions 7.63.0 and above:
 
    {{< code-block lang="powershell" >}}
-$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i "https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-fips-agent-7.63.0-rc.7-fips-preview-2.msi" /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" SITE="ddog-gov.com"'
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i https://windows-agent.datadoghq.com/datadog-fips-agent-7.64.3.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" SITE="ddog-gov.com"'
 if ($p.ExitCode -ne 0) {
    Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }
@@ -114,7 +114,7 @@ if ($p.ExitCode -ne 0) {
 **Note**: The program name for the FIPS Agent in **Add or Remove Programs** is "Datadog FIPS Agent."
 
 [1]: /agent/basic_agent_usage/windows/#uninstall-the-agent
-[2]: https://s3.amazonaws.com/ddagent-windows-stable/beta/installers_v2.json
+[2]: https://windows-agent.datadoghq.com/installers_v2.json
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/agent/guide/fips-agent.md
+++ b/content/en/agent/guide/fips-agent.md
@@ -94,11 +94,11 @@ The Datadog FIPS Agent is in preview and has not been fully audited. Install and
    **Note:** FIPS support is only available on Agent versions 7.63.0 and above:
 
    {{< code-block lang="powershell" >}}
-   $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i "https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-fips-agent-7.63.0-rc.7-fips-preview-2.msi" /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" SITE="ddog-gov.com"'
-   if ($p.ExitCode -ne 0) {
-     Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
-   }
-   {{< /code-block >}}
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i "https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-fips-agent-7.63.0-rc.7-fips-preview-2.msi" /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" SITE="ddog-gov.com"'
+if ($p.ExitCode -ne 0) {
+   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
+}
+{{< /code-block >}}
 
    To install a different preview version of the FIPS Agent, search the [list of stable Agent versions][2] for `datadog-fips-agent` and replace the MSI in the command above with your desired version.
 

--- a/content/en/agent/guide/fips-agent.md
+++ b/content/en/agent/guide/fips-agent.md
@@ -94,7 +94,10 @@ The Datadog FIPS Agent is in preview and has not been fully audited. Install and
    **Note:** FIPS support is only available on Agent versions 7.63.0 and above:
 
    ```powershell
-   Start-Process -Wait msiexec -ArgumentList '/qn /i "https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-fips-agent-7.63.0-rc.7-fips-preview-2.msi" APIKEY="MY_API_KEY" SITE="ddog-gov.com"'
+   $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i "https://s3.amazonaws.com/ddagent-windows-stable/beta/datadog-fips-agent-7.63.0-rc.7-fips-preview-2.msi" /log C:\Windows\SystemTemp\install-datadog.log APIKEY="MY_API_KEY" SITE="ddog-gov.com"'
+   if ($p.ExitCode -ne 0) {
+     Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
+   }
    ```
 
    To install a different preview version of the FIPS Agent, search the [list of stable Agent versions][2] for `datadog-fips-agent` and replace the MSI in the command above with your desired version.

--- a/content/en/agent/guide/windows-agent-ddagent-user.md
+++ b/content/en/agent/guide/windows-agent-ddagent-user.md
@@ -35,7 +35,7 @@ If a user account is specified on the command line, but this user account is not
 To specify the optional USERNAME and PASSWORD on the command line, pass the following properties to the `msiexec` command (The bracket `<>` characters indicate a variable that should be replaced):
 
 {{< code-block lang="powershell" >}}
-$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
 if ($p.ExitCode -ne 0) {
   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }

--- a/content/en/agent/guide/windows-agent-ddagent-user.md
+++ b/content/en/agent/guide/windows-agent-ddagent-user.md
@@ -34,12 +34,12 @@ If a user account is specified on the command line, but this user account is not
 
 To specify the optional USERNAME and PASSWORD on the command line, pass the following properties to the `msiexec` command (The bracket `<>` characters indicate a variable that should be replaced):
 
-```powershell
+{{< code-block lang="powershell" >}}
 $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
 if ($p.ExitCode -ne 0) {
   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }
-```
+{{< /code-block >}}
 
 Requirements:
 * The username must be 20 characters or fewer to comply with Microsoft's [Active Directory Schema (AD Schema) SAM-Account-Name attribute][1].
@@ -66,12 +66,12 @@ If a user account is specified on the command line, but this user account is not
 
 To specify a username from a domain account, use the following form for the `DDAGENTUSER_NAME` property:
 
-```powershell
+{{< code-block lang="powershell" >}}
 $p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<DOMAIN>\<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
 if ($p.ExitCode -ne 0) {
   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }
-```
+{{< /code-block >}}
 
 The `<DOMAIN>` can either be a fully-qualified domain name (in the form `mydomain.com`) or the NETBIOS name (the pre-Windows 2000 name).
 It must be separated from the `<USERNAME>` with a backslash `\`.

--- a/content/en/agent/guide/windows-agent-ddagent-user.md
+++ b/content/en/agent/guide/windows-agent-ddagent-user.md
@@ -35,7 +35,7 @@ If a user account is specified on the command line, but this user account is not
 To specify the optional USERNAME and PASSWORD on the command line, pass the following properties to the `msiexec` command (The bracket `<>` characters indicate a variable that should be replaced):
 
 {{< code-block lang="powershell" >}}
-$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
 if ($p.ExitCode -ne 0) {
   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }
@@ -67,7 +67,7 @@ If a user account is specified on the command line, but this user account is not
 To specify a username from a domain account, use the following form for the `DDAGENTUSER_NAME` property:
 
 {{< code-block lang="powershell" >}}
-$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<DOMAIN>\<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<DOMAIN>\<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
 if ($p.ExitCode -ne 0) {
   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }

--- a/content/en/agent/guide/windows-agent-ddagent-user.md
+++ b/content/en/agent/guide/windows-agent-ddagent-user.md
@@ -67,7 +67,7 @@ If a user account is specified on the command line, but this user account is not
 To specify a username from a domain account, use the following form for the `DDAGENTUSER_NAME` property:
 
 {{< code-block lang="powershell" >}}
-$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<DOMAIN>\<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i https://windows-agent.datadoghq.com/datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<DATADOG_API_KEY>" DDAGENTUSER_NAME="<DOMAIN>\<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
 if ($p.ExitCode -ne 0) {
   Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
 }

--- a/content/en/agent/guide/windows-agent-ddagent-user.md
+++ b/content/en/agent/guide/windows-agent-ddagent-user.md
@@ -34,8 +34,11 @@ If a user account is specified on the command line, but this user account is not
 
 To specify the optional USERNAME and PASSWORD on the command line, pass the following properties to the `msiexec` command (The bracket `<>` characters indicate a variable that should be replaced):
 
-```shell
-msiexec /i ddagent.msi DDAGENTUSER_NAME=<USERNAME> DDAGENTUSER_PASSWORD=<PASSWORD>
+```powershell
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
+if ($p.ExitCode -ne 0) {
+  Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
+}
 ```
 
 Requirements:
@@ -63,8 +66,11 @@ If a user account is specified on the command line, but this user account is not
 
 To specify a username from a domain account, use the following form for the `DDAGENTUSER_NAME` property:
 
-```shell
-msiexec /i ddagent.msi DDAGENTUSER_NAME=<DOMAIN>\<USERNAME> DDAGENTUSER_PASSWORD=<PASSWORD>
+```powershell
+$p = Start-Process -Wait -PassThru msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /log C:\Windows\SystemTemp\install-datadog.log APIKEY="<YOUR_DATADOG_API_KEY>" DDAGENTUSER_NAME="<DOMAIN>\<USERNAME>" DDAGENTUSER_PASSWORD="<PASSWORD>"'
+if ($p.ExitCode -ne 0) {
+  Write-Host "msiexec failed with exit code $($p.ExitCode) please check the logs at C:\Windows\SystemTemp\install-datadog.log" -ForegroundColor Red
+}
 ```
 
 The `<DOMAIN>` can either be a fully-qualified domain name (in the form `mydomain.com`) or the NETBIOS name (the pre-Windows 2000 name).


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

By default, `msiexec` does not print if it succeeds or fails, and it puts a log file in a temporary directory with a random filename. This makes it difficult for customers and support to collect the installer log file.

Improve customer experience by
- print message if the installer fails
- include the logfile parameter with a known file path

also switches from code fence to code-block so we get the nice copy button

https://datadoghq.atlassian.net/browse/WINA-1361

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

<!-- 
**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```
 -->

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

Would be nice to add `SITE={{< region-param key="dd_site" code="true">}}` but it doesn't seem to be supported in code-block