### PR TITLE
Fix link on AWS Lambda documentation

### DIFF
--- a/content/en/serverless/aws_lambda/configuration.md
+++ b/content/en/serverless/aws_lambda/configuration.md
@@ -57,9 +57,7 @@ To enable threat monitoring, add the following environment variables to your dep
      AWS_LAMBDA_EXEC_WRAPPER: /opt/datadog_wrapper
    ```
 
-Redeploy the function and invoke it. After a few minutes, it appears in [AAP views][3].
-
-[3]: https://app.datadoghq.com/security/appsec?column=time&order=desc
+Redeploy the function and invoke it. After a few minutes, it appears in [AAP views][49].
 
 To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send an HTTP header with value `acunetix-product` to trigger a [security scanner attack][44] attempt:
    ```sh
@@ -742,3 +740,5 @@ If you have trouble configuring your installations, set the environment variable
 [46]: https://docs.datadoghq.com/tracing/glossary/#services
 [47]: /logs/
 [48]: /tracing/trace_collection/otel_instrumentation/
+[49]: https://app.datadoghq.com/security/appsec?column=time&order=desc
+


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fix incorrect link for "Datadog AWS integration", bug because of an incorrect link numbering.

The "Datadog AWS integration" link was incorrectly linking to https://app.datadoghq.com/security/appsec?column=time&order=desc

[See live documentation](https://docs.datadoghq.com/serverless/aws_lambda/configuration/?tab=datadogcli#connect-telemetry-using-tags)
<img width="636" alt="Screenshot 2025-04-22 at 15 57 45" src="https://github.com/user-attachments/assets/5d41acd9-ed6c-4d41-97c7-a46932234bf2" />


### Merge instructions

Merge readiness:
- [x] Ready for merge
