### PR TITLE
SDCD-1160: specifying dora change lead time limitation if previous deployment was too far in the past

### DIFF
--- a/content/en/dora_metrics/setup/deployments.md
+++ b/content/en/dora_metrics/setup/deployments.md
@@ -161,7 +161,7 @@ For deployments identified through APM Deployment Tracking, the change lead time
 
 For service deployments tracked by APM to contribute to change lead time, ensure the following:
 
-### Requirements for calculating change lead time 
+### Requirements for calculating change lead time
 - Your application telemetry is tagged with Git information. You can enable this [in APM][101] or see the [Source Code Integration documentation][102].
 - Your repository metadata is synchronized to Datadog through the [GitHub integration][103] or by the `datadog-ci git-metadata upload` command.
 
@@ -297,6 +297,7 @@ If the two metadata entries are defined for a service, only `extensions[datadogh
 
 - Change lead time stage breakdown metrics are only available for GitHub and GitLab.
 - Change lead time is not available for the first deployment of a service that includes Git information.
+- Change lead time is not available if the most recent previous deployment of a service was more than 60 days in the past.
 - The Change Lead Time calculation includes a maximum of 5000 commits per deployment.
 - For rebased branches, *change lead time* calculations consider the new commits created during the rebase, not the original commits.
 - When using "Squash" to merge pull requests:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
It has come to our attention that there is an additional limitation on the cases we will calculate change lead time. The previous deployment for the service needs to be within the last 60 days.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->
I am waiting for a release that actually bumps the limit from 30 days to 60 days, so I will wait until that is released before merging this.

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
