### PR TITLE
Improve Cdocs logging to catch environment issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "@popperjs/core": "^2.11.8",
         "alpinejs": "^3.13.7",
         "bootstrap": "^5.2",
-        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.4.tgz",
+        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.5.tgz",
         "del": "4.1.1",
         "fancy-log": "^1.3.3",
         "geo-locate": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.1.tgz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6536,9 +6536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.4.tgz":
-  version: 1.1.4
-  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.4.tgz"
+"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.5.tgz":
+  version: 1.1.5
+  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.5.tgz"
   dependencies:
     "@prettier/sync": ^0.5.2
     "@types/markdown-it": ^14.1.2
@@ -6562,7 +6562,7 @@ __metadata:
     vite: ^5.4.10
     vite-plugin-singlefile: ^2.0.2
     zod: ^3.22.4
-  checksum: 58b7629e435b792abc9574dbc552e037c4e5a83b680102039e5f395b3273ce61b911243ead17fd9ef1b218de95d6489807a4fb8b8134dcd55390a473ef529bc9
+  checksum: 371991f1c07385f3b781317f590e05c6dd8f323f5575a7b8e6d9e70627a357d76574bfaead52cfcbea8b5fe3c18cb1830ebf2d77ac285685a449e401859b7df0
   languageName: node
   linkType: hard
 
@@ -7595,7 +7595,7 @@ __metadata:
     acorn: ^7.4.1
     alpinejs: ^3.13.7
     bootstrap: ^5.2
-    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.4.tgz"
+    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v1.1.5.tgz"
     cross-env: ^5.2.1
     del: 4.1.1
     eslint: ^6.8.0


### PR DESCRIPTION
This bumps the Cdocs package version to enable improved logging around key characteristics of the Cdocs environment.

We recently had a broken Cdocs build in the merge queue, and it surfaced two issues I wanted to resolve:

- It was not obvious that the customization config was missing, I just knew that this was logically the problem. We never want such a fundamental issue to be that opaque.
- Even knowing the config was likely missing, the cause was still difficult to pin down. Several factors contribute to how the configuration is resolved, such as the default language detected by Cdocs.

Compilation logic is not impacted, but just to verify as a reviewer:

- You can view the relevant changes in https://github.com/DataDog/corp-node-packages/pull/107, which passed all checks.
- You can see the updated build output in this PR's build [here-ish](https://gitlab.ddbuild.io/DataDog/documentation/-/jobs/911453943#L394).
- The only cdoc currently in prod can be viewed in staging [here](https://docs-staging.datadoghq.com/jen.gilbert/cdocs-logging-improvements/real_user_monitoring/guide/proxy-mobile-rum-data) once the build finishes.