### PR TITLE
remove overview link from Overview section

### DIFF
--- a/content/en/security/cloud_security_management/setup/_index.md
+++ b/content/en/security/cloud_security_management/setup/_index.md
@@ -30,7 +30,6 @@ further_reading:
 
 To get started with Cloud Security, review the following:
 
-- [Overview](#overview)
 - [Enable Agentless Scanning](#enable-agentless-scanning)
 - [Deploy the Agent for additional coverage](#deploy-the-agent-for-additional-coverage)
 - [Enable additional features](#enable-additional-features)


### PR DESCRIPTION
Looks like Visual Studio Code's TOC generator added the Overview heading to its own list.

Just removing it as it is unnecessary.

### Merge instructions

]Merge readiness:
- [x] Ready for merge

