### PR TITLE
Added that TCP is not available for gov site

### DIFF
--- a/content/en/agent/logs/log_transport.md
+++ b/content/en/agent/logs/log_transport.md
@@ -107,7 +107,9 @@ When logs are sent through HTTPS, use the same [set of proxy settings][3] as the
 [2]: /agent/basic_agent_usage/#agent-overhead
 [3]: /agent/configuration/proxy/
 {{% /tab %}}
+
 {{% tab "TCP" %}}
+{{< site-region region="us,eu,us3,us5,ap1" >}}
 
 To enforce TCP transport, update the Agent's [main configuration file][1] (`datadog.yaml`) with:
 
@@ -122,6 +124,13 @@ To send logs with environment variables, configure the following:
 * `DD_LOGS_CONFIG_FORCE_USE_TCP=true`
 
 By default, the Datadog Agent sends its logs to Datadog over TLS-encrypted TCP. This requires outbound communication (on port `10516` for Datadog US site and port `443`for Datadog EU site).
+
+{{< /site-region >}}
+
+{{< site-region region="gov" >}}
+The TCP endpoint is not supported for this site.
+
+{{< /site-region >}}
 
 [1]: /agent/configuration/agent-configuration-files/
 {{% /tab %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The [log transport doc](https://docs.datadoghq.com/agent/logs/log_transport/?tab=tcp&site=gov) mentions that the USfed site supports TCP but [it does not](https://docs.datadoghq.com/logs/log_collection/?tab=tcp&site=gov#custom-log-forwarding).  This PR changes that
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
