### PR TITLE
[error tracking] Remove redundant `features.apm.enabled:true` config

### DIFF
--- a/content/en/error_tracking/backend/getting_started/single_step_instrumentation.md
+++ b/content/en/error_tracking/backend/getting_started/single_step_instrumentation.md
@@ -94,7 +94,6 @@ Follow these steps to enable Single Step Instrumentation across your entire clus
            value: "false"
      features:
        apm:
-         enabled: true
          errorTrackingStandalone:
            enabled: true
          instrumentation:

--- a/content/en/error_tracking/guides/enable_apm.md
+++ b/content/en/error_tracking/guides/enable_apm.md
@@ -130,7 +130,6 @@ For a Datadog agent installed with the Datadog Operator:
    -         value: "false"
        features:
          apm:
-           enabled: true
    -       errorTrackingStandalone:
    -         enabled: true
            instrumentation:

--- a/content/en/error_tracking/guides/enable_infra.md
+++ b/content/en/error_tracking/guides/enable_infra.md
@@ -127,7 +127,6 @@ For a Datadog agent installed with the Datadog Operator:
    -         value: "false"
        features:
          apm:
-           enabled: true
            errorTrackingStandalone:
              enabled: true
            instrumentation:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Update datadog operator setup instructions for standalone backend error tracking, to remove redundant`features.apm.enabled:true` flag.