### PR TITLE
[SDTEST-1941] Remove `test.bundle` tag mention from JUnitXML fingerprint computation

### DIFF
--- a/content/en/tests/setup/junit_xml.md
+++ b/content/en/tests/setup/junit_xml.md
@@ -305,10 +305,6 @@ You can specify these special tags using the `--tags` parameter when calling `da
 
 All of these tags are optional, and only the ones you specify will be used to differentiate between environment configurations.
 
-`test.bundle`
-: Used to execute groups of test suites separately.<br/>
-**Examples**: `ApplicationUITests`, `ModelTests`
-
 `os.platform`
 : Name of the operating system.<br/>
 **Examples**: `windows`, `linux`, `darwin`


### PR DESCRIPTION
### What does this PR do? What is the motivation?

We don't use the `test.bundle` tag for computing test fingerprints for JUnitXML tests ([code](https://github.com/DataDog/logs-backend/blob/prod/domains/event-platform/libs/processing/processing-common/src/main/java/com/dd/logs/processing/processors/CITestFingerprintProcessor.java#L78)).

This was causing confusion for a customer.
Merge readiness:
- [x] Ready for merge
