### PR TITLE
Update ECS resources crawl frequency

### DIFF
--- a/content/en/infrastructure/containers/amazon_elastic_container_explorer.md
+++ b/content/en/infrastructure/containers/amazon_elastic_container_explorer.md
@@ -155,9 +155,9 @@ Some resources have specific tags. The following tags are available in addition 
 | **Resource**        | **With Datadog Agent** | **Without Datadog Agent** |
 |---------------------|------------------------|--------------------------|
 | **Cluster**         | ~15 minutes             | ~15 minutes               |
-| **Task**            | ~15 seconds             | ~24 hours                 |
-| **Task Definition** | ~15 seconds             | ~24 hours                 |
-| **Service**         | ~15 seconds             | ~24 hours                 |
+| **Task**            | ~15 seconds             | ~15 minutes                 |
+| **Task Definition** | ~15 seconds             | ~15 minutes                 |
+| **Service**         | ~15 seconds             | ~15 minutes                 |
 | **Container Instance**         | ~24 hours               | ~24 hours                 |
 
 * A newly created ECS Service is typically collected within approximately 15 seconds. However, for status changes in an existing Service, a refresh within 15 seconds is not guaranteed.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The AWS integration team recently changed their crawler schedule and ECS resources are now crawled every ~15 minutes rather than ~1d.

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
