### PR TITLE
[RUM][RWOL] Fix name of rum.measure.view.time_spent metric

### DIFF
--- a/content/en/real_user_monitoring/rum_without_limits/metrics.md
+++ b/content/en/real_user_monitoring/rum_without_limits/metrics.md
@@ -54,7 +54,7 @@ Datadog provides the below out-of-the-box metrics for a comprehensive overview o
 | `rum.measure.view.network_settled` | Network settled | Default, Percentiles breakdown | Mobile only |
 | `rum.measure.view.refresh_rate` | Average of user's refresh rate (FPS) | Default, Percentiles breakdown | Mobile only |
 | `rum.measure.view.slow_rendered` | Count of slow rendered views | Default | Mobile only |
-| `rum.measure.rum.measure.view.time_spent` | Time spent on the current view | Default | Mobile & Browser |
+| `rum.measure.view.time_spent` | Time spent on the current view | Default | Mobile & Browser |
 
 ## API
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
