### PR TITLE
[DOCS-10691] Fix windows setup on Network path docs

### DIFF
--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -135,7 +135,45 @@ Agent `v7.61+` is required.
 
 **Note**: Windows only supports TCP traceroutes.
 
-In Windows environments, the Agent uses UDP by default to monitor individual paths. If the protocol is not specified in the configuration, the Agent attempts a UDP traceroute, and any errors are logged. To work around this, ensure the protocol is set to TCP. For example:
+1. Enable the `system-probe` traceroute module in `/etc/datadog-agent/system-probe.yaml` by adding the following:
+
+   ```
+   traceroute:
+     enabled: true
+   ```
+
+2. Enable `network_path` to monitor new destinations from this Agent by creating or editing the `/etc/datadog-agent/conf.d/network_path.d/conf.yaml` file:
+
+   ```yaml
+   init_config:
+     min_collection_interval: 60 # in seconds, default 60 seconds
+   instances:
+     # configure the endpoints you want to monitor, one check instance per endpoint
+     # warning: Do not set the port when using UDP. Setting the port when using UDP can cause traceroute calls to fail and falsely report an unreachable destination.
+
+     - hostname: api.datadoghq.eu # endpoint hostname or IP
+       protocol: TCP
+       port: 443
+       tags:
+         - "tag_key:tag_value"
+         - "tag_key2:tag_value2"
+     ## optional configs:
+     # max_ttl: 30 # max traderoute TTL, default is 30
+     # timeout: 1000 # timeout in milliseconds per hop, default is 1s
+
+     # more endpoints
+     - hostname: 1.1.1.1 # endpoint hostname or IP
+       protocol: UDP
+       tags:
+         - "tag_key:tag_value"
+         - "tag_key2:tag_value2"
+    ```
+
+   For full configuration details, reference the [example config][4].
+
+  3. Restart the Agent after making these configuration changes to start seeing network paths.
+
+**Note**: In Windows environments, the Agent uses UDP by default to monitor individual paths. If the protocol is not specified in the configuration, the Agent attempts a UDP traceroute, and any errors are logged. To work around this, ensure the protocol is set to TCP. For example:
 
 ```yaml
 init_config:
@@ -145,8 +183,13 @@ instances:
     protocol: TCP
     port: 443 # optional port number, default is 80
 ```
+
+[4]: https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/dist/conf.d/network_path.d/conf.yaml.example
+
 {{% /tab %}}
 {{% tab "Helm" %}}
+
+Agent `v7.59+` is required.
 
 To enable Network Path with Kubernetes using Helm, add the below to your `values.yaml` file.</br>
 **Note:** Helm chart v3.109.1+ **is required**. For more information, see the [Datadog Helm Chart documentation][1] and the documentation for [Kubernetes and Integrations][2].
@@ -180,9 +223,6 @@ To enable Network Path with Kubernetes using Helm, add the below to your `values
               - "tag_key:tag_value"
               - "tag_key2:tag_value2"
 ```
-
-Agent `v7.59+` is required.
-
 
 [1]: https://github.com/DataDog/helm-charts/blob/master/charts/datadog/README.md#enabling-system-probe-collection
 [2]: https://docs.datadoghq.com/containers/kubernetes/integrations/?tab=helm#configuration

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -163,7 +163,7 @@ Agent `v7.61+` is required.
 
      # more endpoints
      - hostname: 1.1.1.1 # endpoint hostname or IP
-       protocol: UDP
+       protocol: TCP
        tags:
          - "tag_key:tag_value"
          - "tag_key2:tag_value2"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds missing config to the Windows setup docs for Network Path Static paths , and moves the Helm Agent version requirement to the top of the tab as it was in the wrong place

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
