### PR TITLE
[web-6419] Fix word break on tables with code samples

### DIFF
--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -169,7 +169,7 @@ pre {
 tbody {
     code {
         word-wrap: normal;
-        word-break: normal;
+        word-break: break-word;
     }
 }
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
[Table here looks bad because there's no wrapping on code elements](https://docs.datadoghq.com/integrations/guide/prometheus-host-collection/#parameters-available)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/web-6419-brokentable/integrations/guide/prometheus-host-collection/#parameters-available
