### PR TITLE
[SDTEST] Junitxml manually providing source file fixes

### DIFF
--- a/content/en/tests/setup/junit_xml.md
+++ b/content/en/tests/setup/junit_xml.md
@@ -348,7 +348,7 @@ To add [codeowners][9] information to your JUnit XML tests, you can use the [Git
 
 As a result, the JUnit XML tests have a `test.codeowners` tag with the owner of those tests.
 
-### Using the GitHub integration (recommended)
+### Using the GitHub integration
 
 To automatically add the `test.codeowners` tag to your tests, you need to:
 1. Have a `CODEOWNERS` file [in one of the allowed locations][11] in your repository.
@@ -385,8 +385,7 @@ The JUnit XML uses a private [GitHub App][12] to read the `CODEOWNERS` file.
 6. Give the app a name, for example, `Datadog Test Optimization`.
 7. Click **Install GitHub App** and follow the instructions on GitHub.
 
-### Manually providing the `test.source.file` tag
-This is an alternative to using the GitHub integration.
+#### Manually providing the `test.source.file` tag
 
 For those plugins that do not provide the `file` attribute in the XML report, you can provide the `test.source.file` tag.
 There is no need to provide the exact path to a specific file, [you can use any syntax you would use in the CODEOWNERS file][14]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This part of the documentation was incorrect, manually providing the source file is not an alternative as using the Github Integration at the moment. Instead, it is a workaround if the user's plugin does not generate XML files with the source file.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
