### PR TITLE
[ACTP-631] add permissions handling to private action runner docs

### DIFF
--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -55,4 +55,4 @@ A user with the `user_access_manage` permission can elevate their access to any 
 [15]: /actions/connections/?tab=workflowautomation#connection-groups
 [16]: /actions/datastore/
 [17]: /service_management/workflows/access/#restrict-access-on-a-specific-workflow
-[18]: /actions/private_actions/s
+[18]: /actions/private_actions

--- a/content/en/account_management/rbac/granular_access.md
+++ b/content/en/account_management/rbac/granular_access.md
@@ -24,6 +24,7 @@ Use the different principals to control access patterns in your organization and
 | [Integration Webhooks][11]                       | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Monitors][3]                                    | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Notebooks][4]                                   | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
+| [Private Action Runner][18]                      | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Powerpacks][5]                                  | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Security rules][6]                              | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
 | [Security suppressions][7]                       | {{< X >}}         | {{< X >}}         | {{< X >}}                           |
@@ -54,3 +55,4 @@ A user with the `user_access_manage` permission can elevate their access to any 
 [15]: /actions/connections/?tab=workflowautomation#connection-groups
 [16]: /actions/datastore/
 [17]: /service_management/workflows/access/#restrict-access-on-a-specific-workflow
+[18]: /actions/private_actions/s

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -201,7 +201,7 @@ Editor
 
 1. Navigate to the Edit page of the runner.
 2. Go to the **Who Has Access?** section and click on the button **Edit access** .
-3. Select a user, a service account, a role or a team from the dropdown menu. Click **Add**. The principal you selected populates into the bottom of the dialog box.
+3. Select a user, service account, role, or team from the dropdown menu, then click **Add**. The selected principal appears at the bottom of the dialog box.
 4. Next to the principal name, select your desired permission from the dropdown menu.
 5. To remove access from a principal, select **Remove access** from the permissions dropdown menu.
 6. Click **Done** to finalize the permissions setup.

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -200,7 +200,7 @@ Editor
 ### Set permissions on a runner
 
 1. Navigate to the Edit page of the runner.
-2. Go to the **Who Has Access?** section and click on the button **Edit access** .
+2. In the **Who Has Access?** section, click **Edit access**.
 3. Select a user, service account, role, or team from the dropdown menu, then click **Add**. The selected principal appears at the bottom of the dialog box.
 4. Next to the principal name, select your desired permission from the dropdown menu.
 5. To remove access from a principal, select **Remove access** from the permissions dropdown menu.

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -178,6 +178,35 @@ When you see the **Ready to use** status, you can create a new connection for th
 
 See [Connect a runner](#connect-a-runner) for more information on pairing your runner with a connection.
 
+## Private action runner permissions
+
+Use [role-based access control (RBAC)][18] to control access to your private action runner. To see the list of permissions that apply to private action runner, see [Datadog Role Permissions][19].
+
+Set permissions on the runner to restrict its modifications or attachment of new connections to it. The granular permissions include **Viewer**, **Contributor**, and **Editor**. 
+
+By default, only the creator of the runner receives **Editor** access. The creator can choose to grant access to additional users, service accounts, roles, or teams.
+
+### Permission levels
+
+Viewer
+: Can view the runner and connections attached to it
+
+Contributor
+: Can view and contribute to the runner by attaching new connections to it
+
+Editor
+: Can view, contribute (attach new connections), and edit the runner
+
+### Set permissions on a runner
+
+1. Navigate to the Edit page of the runner.
+2. Go to the **Who Has Access?** section and click on the button **Edit access** .
+3. Select a user, a service account, a role or a team from the dropdown menu. Click **Add**. The principal you selected populates into the bottom of the dialog box.
+4. Next to the principal name, select your desired permission from the dropdown menu.
+5. If you would like to remove access from a principal, in the dropdown for permissions choose **Remove access**.
+6. Click **Done** to finalize the permissions setup.
+7. Click **Save** to apply the new permissions to the runner.
+
 ## Connect a runner
 
 Before you can use an action runner, you must pair it with one or more connections.
@@ -413,3 +442,5 @@ To edit the allowlist for a Private Action Runner:
 [14]: /service_management/app_builder/build
 [15]: /service_management/workflows/build/#build-a-workflow-with-the-workflow-builder
 [17]: /actions/private_actions/
+[18]: /account_management/rbac/
+[19]: /account_management/rbac/permissions/#app-builder--workflow-automations

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -182,7 +182,7 @@ See [Connect a runner](#connect-a-runner) for more information on pairing your r
 
 Use [role-based access control (RBAC)][18] to control access to your private action runner. To see the list of permissions that apply to private action runner, see [Datadog Role Permissions][19].
 
-Set permissions on the runner to restrict its modifications or attachment of new connections to it. The granular permissions include **Viewer**, **Contributor**, and **Editor**. 
+You can set permissions on the runner to restrict modifications or prevent new connections from being attached. Available granular permissions include **Viewer**, **Contributor**, and **Editor**. 
 
 By default, only the creator of the runner receives **Editor** access. The creator can choose to grant access to additional users, service accounts, roles, or teams.
 

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -189,7 +189,7 @@ By default, only the creator of the runner receives **Editor** access. The creat
 ### Permission levels
 
 Viewer
-: Can view the runner and connections attached to it
+: Can view the runner and the connections attached to it
 
 Contributor
 : Can view and contribute to the runner by attaching new connections to it

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -203,7 +203,7 @@ Editor
 2. Go to the **Who Has Access?** section and click on the button **Edit access** .
 3. Select a user, a service account, a role or a team from the dropdown menu. Click **Add**. The principal you selected populates into the bottom of the dialog box.
 4. Next to the principal name, select your desired permission from the dropdown menu.
-5. If you would like to remove access from a principal, in the dropdown for permissions choose **Remove access**.
+5. To remove access from a principal, select **Remove access** from the permissions dropdown menu.
 6. Click **Done** to finalize the permissions setup.
 7. Click **Save** to apply the new permissions to the runner.
 

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -178,7 +178,7 @@ When you see the **Ready to use** status, you can create a new connection for th
 
 See [Connect a runner](#connect-a-runner) for more information on pairing your runner with a connection.
 
-## Private action runner permissions
+## Manage access
 
 Use [role-based access control (RBAC)][18] to control access to your private action runner. To see the list of permissions that apply to private action runner, see [Datadog Role Permissions][19].
 

--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -184,7 +184,7 @@ Use [role-based access control (RBAC)][18] to control access to your private act
 
 You can set permissions on the runner to restrict modifications or prevent new connections from being attached. Available granular permissions include **Viewer**, **Contributor**, and **Editor**. 
 
-By default, only the creator of the runner receives **Editor** access. The creator can choose to grant access to additional users, service accounts, roles, or teams.
+By default, only the runner's creator has **Editor** access. The creator can grant access to additional users, service accounts, roles, or teams.
 
 ### Permission levels
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR adds to Private Actions documentation to cover runner permissions handling:
- updates the doc `use_private_actions`
- adds runner to the list of grace resources in `account_management`

This PR doesn't do the i18n for this new part.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready for merge (only needs PM review & approval)

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
