### PR TITLE
OTAGENT-391 Add otel-agent evn var to enable OTel Collector

### DIFF
--- a/content/en/opentelemetry/setup/ddot_collector/install.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install.md
@@ -132,6 +132,18 @@ By default, the Agent image is pulled from Google Artifact Registry (`gcr.io/dat
 
 {{< code-block lang="yaml" filename="datadog-agent.yaml" collapsible="true" >}}
   ...
+  override:
+    # Node Agent configuration
+    nodeAgent:
+      image:
+        name: "gcr.io/datadoghq/agent:{{< version key="agent_tag" >}}"
+        pullPolicy: Always
+      containers:
+        otel-agent:
+          env:
+            - name: DD_OTELCOLLECTOR_ENABLED
+              value: "true"
+  ...
   # Enable Features
   features:
     otelCollector:
@@ -412,6 +424,11 @@ spec:
       image:
         name: "gcr.io/datadoghq/agent:{{< version key="agent_tag" >}}"
         pullPolicy: Always
+      containers:
+        otel-agent:
+          env:
+            - name: DD_OTELCOLLECTOR_ENABLED
+              value: "true"
 
   # Enable Features
   features:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Explicitly add required `DD_OTELCOLLECTOR_ENABLED` env variable to the `otel-agent` collector.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### Additional notes

This fix is required for Operator v1.14; after 1.15 release we could remove it.