### PR TITLE
Update Tab Style (Take 2)

### DIFF
--- a/assets/styles/components/_tab-toggle.scss
+++ b/assets/styles/components/_tab-toggle.scss
@@ -1,34 +1,302 @@
-.nav-tabs.response-toggle {
-    margin-bottom: 20px;
-    a {
-        -moz-osx-font-smoothing: grayscale;
-        font-size:16px;
-        background: #ffffff;
-        border: transparent;
-        padding: 6px 10px 7px 10px;
-        font-weight: 600;
-        border-radius: 3px;
-        display: inline-block;
-        &.active,
-        &[aria-expanded="true"] {
-            box-shadow: 2px 5px 12px rgba(0, 0, 0, 0.1);
-            border-radius: 3px;
-            background-color: $ddpurple;
-            color: white;
-        }
+// Variables for tab styling
+$tab-border-color: rgba(0, 0, 0, 0.15);
+$tab-active-color: $ddpurple;
+$tab-hover-bg: rgba($ddpurple, 0.05);
+$tab-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
+$tab-active-shadow: 0 -4px 12px rgba(99, 44, 166, 0.08);
 
-        &:hover {
-            box-shadow: 2px 5px 12px rgba(0, 0, 0, 0.1);
-            border: none;
+// Common tab styles
+.code-tabs {
+  position: relative;
+  min-height: 200px;
+  padding-top: 8px;
+
+  // Base styles for all tab links - provides consistent padding, font, and positioning
+  %tab-link-base {
+    background: transparent;
+    border: 1px solid transparent;
+    padding: 8px 16px;
+    font-weight: 600;
+    font-size: 16px;
+    display: inline-block;
+    position: relative;
+    color: rgba(0, 0, 0, 0.6);
+    outline: none !important;
+    transition: none;
+
+    &:focus {
+      outline: none !important;
+      box-shadow: none !important;
+    }
+  }
+
+  // Styles for the currently active tab - includes white background, purple text, and subtle shadow
+  %active-tab-base {
+    background: #FFFFFF;
+    color: $tab-active-color;
+    box-shadow: $tab-active-shadow;
+    border: 1px solid $tab-border-color;
+    border-bottom-color: #FFFFFF;
+    font-weight: 600;
+    position: relative;
+    z-index: 3;
+    margin-bottom: -1px;
+    padding-bottom: 9px;
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    outline: none !important;
+    transition: none;
+
+    &:focus {
+      outline: none !important;
+      box-shadow: $tab-active-shadow !important;
+    }
+  }
+
+  // Container for tab content - white background with border and shadow
+  .tab-content {
+    background: #FFFFFF;
+    border: 1px solid $tab-border-color;
+    padding: 24px;
+    margin: -1px 0 32px 0;
+    position: relative;
+    z-index: 1;
+    box-shadow: $tab-shadow;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+
+    dl {
+      background-color: transparent;
+    }
+
+    h2 > a,
+    h3 > a,
+    h4 > a,
+    h5 > a {
+      color: #000;
+      border-bottom: 1px solid transparent;
+      &:hover {
+        color: #000;
+        border-bottom: 1px solid #000;
+      }
+    }
+
+    .text-center img {
+      border: 1px solid $ddgray;
+      border-radius: 8px;
+    }
+
+    .card-body img {
+      border: 0px solid $ddgray;
+    }
+  }
+
+  // Horizontal tab navigation container
+  .nav-tabs {
+    list-style-type: none;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    margin: 0;
+    position: relative;
+    z-index: 2;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.2) transparent;
+    border-bottom: none;
+    padding-left: 0 !important;
+    overflow-y: hidden;
+
+    &::-webkit-scrollbar {
+      height: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(0, 0, 0, 0.2);
+      border-radius: 4px;
+    }
+
+    li {
+      padding: 0;
+      position: relative;
+      flex: 0 0 auto;
+      white-space: nowrap;
+      box-sizing: border-box;
+
+      &:before {
+        content: '' !important;
+        margin: 0 !important;
+        float: none !important;
+      }
+
+      &:lang(ja) {
+        font-style: normal;
+        font-weight: bold;
+        font-size: 14px;
+        line-height: 24px;
+      }
+
+      &.active {
+        z-index: 3;
+
+        a {
+          @extend %active-tab-base;
+          transition: none;
+          box-sizing: border-box;
+
+          // Gradient line indicator for active tab
+          &:after {
+            content: '';
+            position: absolute;
+            top: -1px;
+            left: -1px;
+            width: calc(100% + 2px);
+            height: 3px;
+            background: linear-gradient(90deg, $tab-active-color, lighten($tab-active-color, 20%));
+            border-radius: 3px 3px 0 0;
+          }
+
+          &:hover {
+            color: $tab-active-color;
+            transition: none;
+          }
+
+          &::before {
+            display: none;
+          }
+        }
+      }
+
+      &:not(.active) {
+        a {
+          transition: none;
+          box-sizing: border-box;
+
+          &:hover {
+            color: $tab-active-color;
+            background: $tab-hover-bg;
+            border-color: transparent;
+            border-top-left-radius: 4px;
+            border-top-right-radius: 4px;
+            transition: color 0.2s ease, background-color 0.2s ease;
+          }
+        }
+      }
+
+      a {
+        @extend %tab-link-base;
+        box-sizing: border-box;
+
+        // Subtle gradient overlay effect on hover
+        &::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          width: 100%;
+          height: 100%;
+          background: linear-gradient(45deg, rgba(255,255,255,0.2), rgba(255,255,255,0));
+          opacity: 0;
+          transition: opacity 0.3s ease;
         }
 
         &:active {
-            box-shadow: 0px 1px 4px rgba(30, 5, 36, 0.24),
-                0px 1px 1px rgba(30, 5, 36, 0.16);
-            border-radius: 3px;
+          box-shadow: 0 -2px 8px rgba(99, 44, 166, 0.15);
         }
+      }
     }
-  .nav-item::before {
-    content: "";
+  }
+
+  // Mobile tabs
+  .nav-tabs-mobile {
+    .dropdown-item:hover {
+      color: $tab-active-color;
+    }
+  }
+
+  // Wrapped tabs layout - Matches customizable docs style
+  &.tabs-wrap-layout {
+    .nav-tabs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      border-bottom: none;
+      margin-bottom: 16px;
+      padding-top: 10px;
+      min-height: 40px;
+      overflow-x: visible;
+      overflow-y: hidden;
+
+      li {
+        margin-bottom: 6px;
+        flex: 0 0 auto;
+        box-sizing: border-box;
+
+        &.active a {
+          color: white;
+          background-color: $tab-active-color;
+          border: 1px solid $tab-active-color;
+          box-shadow: none;
+          border-radius: 4px;
+          padding: 0 10px;
+          font-weight: 400;
+          font-size: 16px;
+          height: 31px;
+          display: inline-flex;
+          align-items: center;
+          transition: none;
+          box-sizing: border-box;
+
+          &:hover {
+            transition: none;
+          }
+        }
+
+        &:not(.active) a {
+          color: black;
+          background-color: white;
+          border: 1px solid rgb(199, 199, 199);
+          border-radius: 4px;
+          display: inline-flex;
+          align-items: center;
+          margin-right: 0;
+          cursor: pointer;
+          font-weight: 400;
+          font-size: 16px;
+          height: 31px;
+          padding: 0 10px;
+          position: relative;
+          overflow: visible;
+          transition: none;
+          box-sizing: border-box;
+
+          &:hover {
+            color: $tab-active-color;
+            transition: color 0.2s ease;
+          }
+
+          &:active {
+            box-shadow: none;
+          }
+        }
+
+        &::before {
+          content: "";
+        }
+      }
+    }
+
+    .tab-content {
+      margin-top: 0;
+      border-radius: 4px;
+    }
   }
 }

--- a/assets/styles/components/_tab-toggle.scss
+++ b/assets/styles/components/_tab-toggle.scss
@@ -300,3 +300,41 @@ $tab-active-shadow: 0 -4px 12px rgba(99, 44, 166, 0.08);
     }
   }
 }
+
+// Styles for API page response tabs
+.nav-tabs.response-toggle {
+    margin-bottom: 20px;
+
+    a {
+        -moz-osx-font-smoothing: grayscale;
+        font-size: 16px;
+        background: #ffffff;
+        border: transparent;
+        padding: 6px 10px 7px 10px;
+        font-weight: 600;
+        border-radius: 3px;
+        display: inline-block;
+        &.active,
+        &[aria-expanded="true"] {
+            box-shadow: 2px 5px 12px rgba(0, 0, 0, 0.1);
+            border-radius: 3px;
+            background-color: $ddpurple;
+            color: white;
+        }
+
+        &:hover {
+            box-shadow: 2px 5px 12px rgba(0, 0, 0, 0.1);
+            border: none;
+        }
+
+        &:active {
+            box-shadow: 0px 1px 4px rgba(30, 5, 36, 0.24),
+                        0px 1px 1px rgba(30, 5, 36, 0.16);
+            border-radius: 3px;
+        }
+    }
+
+    .nav-item::before {
+        content: "";
+    }
+}

--- a/assets/styles/pages/_global.scss
+++ b/assets/styles/pages/_global.scss
@@ -169,7 +169,7 @@ pre {
 tbody {
     code {
         word-wrap: normal;
-        word-break: break-word;
+        word-break: normal;
     }
 }
 
@@ -635,83 +635,7 @@ h5 {
 }
 
 /* codetabs inside content */
-.code-tabs {
-    min-height: 200px;
-
-    & > ul {
-        list-style-type: none;
-        padding-top: 6px;
-
-        li {
-            padding-bottom: 6px;
-
-            &:lang(ja) {
-                font-style: normal;
-                font-weight: bold;
-                font-size: 14px;
-                line-height: 24px;
-            }
-
-            &:before {
-                content: '' !important;
-                margin: 0 !important;
-                float: none !important;
-            }
-            &.active {
-                a {
-                    box-shadow: 2px 5px 12px rgba(0, 0, 0, 0.1);
-                    border-radius: 3px;
-                    background-color: $ddpurple;
-                    color: white;
-                }
-            }
-            a {
-                background: #ffffff;
-                border: transparent;
-                padding: 6px 10px 7px 10px;
-                font-weight: 600;
-                font-size: 16px;
-                border-radius: 3px;
-                display: inline-block;
-                margin-right: 0.625rem;
-
-                &:hover {
-                    box-shadow: 2px 5px 12px rgba(0, 0, 0, 0.1);
-                    border: none;
-                }
-            }
-        }
-    }
-    .nav-tabs-mobile {
-        .dropdown-item:hover {
-            color: white;
-        }
-    }
-    .nav-tabs {
-        border-bottom: none;
-        padding-left: 0 !important;
-    }
-    .tab-content {
-        padding-top: 12px;
-        h2 > a,
-        h3 > a,
-        h4 > a,
-        h5 > a {
-            color: #000;
-            border-bottom: 1px solid transparent;
-            &:hover {
-                color: #000;
-                border-bottom: 1px solid #000;
-            }
-        }
-        .text-center img {
-            border: 1px solid $ddgray;
-        }
-        .card-body img {
-            border: 0px solid $ddgray;
-        }
-    }
-}
+// Tab styling has been moved to _tab-toggle.scss
 
 .sticky {
     position: -webkit-sticky;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Update after revert of https://github.com/DataDog/documentation/pull/28476.

TODO
- [ ] Make sure this doesn't break the tabs for API docs which use `.api-reference` class for programming language tabs and `.response-toggle` for api response tabs`.
- [ ] Also apply style to programming language tabs outside of the API docs.

- The update aims to improve the styling of our tabs.
- The main reason for this is to add better visual separation between tab content and the rest of the page.
- There are two tab styles: One for when the tabs don't wrap; one for when the tab are forced to wrap.
- Note: This does not update the tab style for multi-code-lang pages.

### Summary of changes
**SCSS**:

- Refactored all tab styles into a dedicated component partial (_tab-toggle.scss).
- Implemented enhanced styling for active, hover, and focus states.
- Created a distinct secondary style for a "wrapped" tab layout (.tabs-wrap-layout).

**JavaScript** (codetabs.js):

- Added cleanup logic to prevent duplicate tabs during re-renders (integrated with clientFiltersManager).
- Implemented dynamic detection of tab wrapping, automatically applying .tabs-wrap-layout when needed based on content width.
- Improved active tab persistence across re-renders through cdocs.
- Ensured only unique tab titles are rendered.

`content/en/tracing/metrics/runtime_metrics/_index.md`
- Note: This is intentionally included as I need to undo some formatting workarounds that are no longer relevant with this change.

#### No wrapping

![image](https://github.com/user-attachments/assets/68cdee05-24d5-479d-b7e4-2f2bc340f413)

#### Wrapping
Note: This copies cdocs pill style

![image](https://github.com/user-attachments/assets/fe68d07b-0a9f-459a-8272-565da991e9d3)

### Testing instructions

Note: I tested these myself. Tested the tab wrap style locally for cdocs too, which works as expected.

- Make sure tabs behave as expected, especially when they contain other complex content like collapsed sections.
- Verify that tabs work correctly on new cdocs pages.
- Verify that tabs wrap and use cdocs pill style when they overflow due to too many (or reduced screen width).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
