### PR TITLE
[Code Origin] Use tabs to split language specific docs

### DIFF
--- a/content/en/tracing/code_origins/_index.md
+++ b/content/en/tracing/code_origins/_index.md
@@ -47,14 +47,14 @@ In Trace Explorer, select a span to see Code Origin details on the Overview tab:
 - [Source Code Integration][7] is enabled (recommended for code previews).
 - Your service meets the [compatibility requirements](#compatibility-requirements).
 
+{{% tabs %}}
+
+{{% tab ".NET" %}}
+
 ### Compatibility requirements
 
-| Runtime Language | Tracing Library Version | Frameworks |
-|---|---|---|
-| Java | 1.47.0+ | Spring Boot/Data, gRPC servers, Micronaut 4, Kafka consumers|
-| Python | 2.15.0+ | Django, Flask, Starlette and derivatives|
-| Node.js | 4.49.0+ | Fastify|
-| .NET | 3.15.0+ | ASP.NET, ASP.NET Core| 
+- **Tracing Library Version:** 3.15.0+
+- **Supported frameworks:** ASP.NET, ASP.NET Core
 
 ### Enable Code Origins
 
@@ -63,6 +63,57 @@ Run your service with the following environment variable:
 ```shell
 export DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true
 ```
+
+{{% /tab %}}
+
+{{% tab "Java" %}}
+
+### Compatibility requirements
+
+- **Tracing Library Version:** 1.47.0+
+- **Supported frameworks:** Spring Boot/Data, gRPC servers, Micronaut 4, Kafka consumers
+
+### Enable Code Origins
+
+Run your service with the following environment variable:
+
+```shell
+export DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true
+```
+
+{{% /tab %}}
+
+{{% tab "Node.js" %}}
+
+### Compatibility requirements
+
+- **Tracing Library Version:** 4.49.0+
+- **Supported frameworks:** Fastify
+
+### Enable Code Origins
+
+Code Origin for Spans is enabled by default.
+
+{{% /tab %}}
+
+{{% tab "Python" %}}
+
+### Compatibility requirements
+
+- **Tracing Library Version:** 2.15.0+
+- **Supported frameworks:** Django, Flask, Starlette and derivatives
+
+### Enable Code Origins
+
+Run your service with the following environment variable:
+
+```shell
+export DD_CODE_ORIGIN_FOR_SPANS_ENABLED=true
+```
+
+{{% /tab %}}
+
+{{% /tabs %}}
 
 ## Using Code Origins
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The language specific documentation for Code Origin for Spans are starting to diverge. This PR introduces tabs for each language, to make the documentation easier to read.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
