### PR TITLE
Remove incorrect DORA limitation about rebase

### DIFF
--- a/content/en/dora_metrics/setup/deployments.md
+++ b/content/en/dora_metrics/setup/deployments.md
@@ -299,7 +299,6 @@ If the two metadata entries are defined for a service, only `extensions[datadogh
 - Change lead time is not available for the first deployment of a service that includes Git information.
 - Change lead time is not available if the most recent deployment of a service was more than 60 days ago.
 - The Change Lead Time calculation includes a maximum of 5000 commits per deployment.
-- For rebased branches, *change lead time* calculations consider the new commits created during the rebase, not the original commits.
 - When using "Squash" to merge pull requests:
   - For GitHub and GitLab: Metrics are emitted for the original commits.
   - For other Git providers: Metrics are emitted for the new commit added to the target branch.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes a limitation that was added incorrectly: for rebased branches and commits, we consider the timestamp at which the original commit was created. This is the desired logic, so no need to make any clarification about it.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
