### PR TITLE
Changed double backslashes to single

### DIFF
--- a/content/en/security/code_security/troubleshooting/_index.md
+++ b/content/en/security/code_security/troubleshooting/_index.md
@@ -166,9 +166,9 @@ The generated lock file is used by [`osv-scanner`][7] to extract dependencies an
 
 Datadog-hosted scanning for Software Composition Analysis (SCA) does not support repositories that use [Git Large File Storage][18] (`git-lfs`). If your repository uses `git-lfs`, [set up the analysis in a CI pipeline][19] and upload the results to Datadog instead.
 
-### Datadog-hosted scan did not run for a repository with `\\` in the file path
+### Datadog-hosted scan did not run for a repository with a backslash (`\`) in the file path
 
-Datadog-hosted scanning for Software Composition Analysis (SCA) does not support repositories containing files with paths that include backslashes (`\\`). If your repository includes such paths,
+Datadog-hosted scanning for Software Composition Analysis (SCA) does not support repositories containing files with paths that include backslashes (`\`). If your repository includes such paths,
 you can [set up the analysis in a CI pipeline][19] and upload the results to Datadog manually. Alternatively, you can update the affected file paths to remove the backslashes and continue using Datadog-hosted scanning.
 
 ## No vulnerabilities detected by Software Composition Analysis


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Updates the text to mention single backslashes and not double backslashes

### Merge instructions

Merge readiness:
- [X] Ready for merge