### PR TITLE
Adjust headers NDM

### DIFF
--- a/content/en/network_monitoring/devices/troubleshooting.md
+++ b/content/en/network_monitoring/devices/troubleshooting.md
@@ -12,7 +12,7 @@ further_reading:
 
 Use the information below for troubleshooting Datadog Network Device Monitoring. If you need additional help, contact [Datadog support][1].
 
-### Device not visible in Datadog
+## Device not visible in Datadog
 
 The following assumes you are running Datadog Agent v7.61.0+.
 
@@ -80,15 +80,15 @@ The output should look similar to the following:
 
     Refer to your vendor specific documentation for additional information on running these commands.
 
-### Troubleshooting SNMP Errors
+## Troubleshooting SNMP Errors
 
 If either the SNMP status or Agent walk shows an error, it could indicate one of the following issues:
 
-#### Permission denied
+### Permission denied
 
 If you see a permission denied error while port binding in agent logs, the port number you've indicated may require elevated permissions. To bind to a port number under 1024, see [Using the default SNMP Trap port 162][8].
 
-#### Unreachable or misconfigured device:
+### Unreachable or misconfigured device:
 
    **Error**:
    ```plaintext
@@ -112,7 +112,7 @@ If you see a permission denied error while port binding in agent logs, the port 
       ```
    3. Ensure your community string matches.
 
-#### Incorrect SNMPv2 credentials
+### Incorrect SNMPv2 credentials
 
    **Error**:
    ```
@@ -123,7 +123,7 @@ If you see a permission denied error while port binding in agent logs, the port 
 
    If using SNMPv2, ensure that a community string is set.
 
-#### Incorrect SNMPv3 privacy protocol
+### Incorrect SNMPv3 privacy protocol
 
    **Error**:
    ```
@@ -145,7 +145,7 @@ If you see a permission denied error while port binding in agent logs, the port 
    - privKey
    - privProtocol
 
-### Traps not being received for devices
+## Traps not being received for devices
 
 1. Check the Datadog `agent.log` file to ensure that you can bind to the traps port. The following error indicates that you are unable to bind to the traps port:
 
@@ -160,7 +160,7 @@ If you see a permission denied error while port binding in agent logs, the port 
    sudo setcap 'cap_net_bind_service=+ep' /opt/datadog-agent/bin/agent/agent
    ```
 
-#### Traps incorrectly formatted
+## Traps incorrectly formatted
 
 1. Navigate to the troubleshooting dashboard in NDM:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
While reviewing another [PR](https://github.com/DataDog/documentation/pull/29124), I noticed that some of the headers were so small that they blended in with the Error and Solution headers, so this PR makes the headers below Overview at least one level larger. I would consider nesting the **trap** sections under their own section, but will leave it to the product area owner to decide if that makes the most sense.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
