### PR TITLE
Fix broken link in Correlate RUM and Traces for Flutter

### DIFF
--- a/content/en/real_user_monitoring/correlate_with_other_telemetry/apm/_index.md
+++ b/content/en/real_user_monitoring/correlate_with_other_telemetry/apm/_index.md
@@ -281,7 +281,7 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
 
 1. Set up [RUM Flutter Monitoring][1].
 
-2. Follow the instructions under [Automatic Resource Tracking][2] to include the Datadog Tracking HTTP Client package and enable HTTP tracking. This includes the following changes to your initialization to add a list of internal, first-party origins called by your Flutter application:
+2. Follow the instructions under [Automatically track resources][2] to include the Datadog Tracking HTTP Client package and enable HTTP tracking. This includes the following changes to your initialization to add a list of internal, first-party origins called by your Flutter application:
     ```dart
     final configuration = DatadogConfiguration(
       // ...
@@ -291,8 +291,7 @@ To start sending just your iOS application's traces to Datadog, see [iOS Trace C
     ```
 
 [1]: /real_user_monitoring/mobile_and_tv_monitoring/flutter/setup/
-[2]: /real_user_monitoring/mobile_and_tv_monitoring/flutter/setup/#automatic-resource-tracking
-
+[2]: /real_user_monitoring/mobile_and_tv_monitoring/flutter/advanced_configuration#automatically-track-resources
 {{% /tab %}}
 
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Docs linked to the Setup page which had no section for Automatic Resource Tracking. Moved to the Advanced Configuration page under "Automatically track resources"

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
None
