### PR TITLE
DOCS-10913 remove php support in Exploit Prevention

### DIFF
--- a/content/en/security/application_security/exploit-prevention.md
+++ b/content/en/security/application_security/exploit-prevention.md
@@ -63,9 +63,9 @@ AAP Exploit Prevention intercepts all SQL queries to determine if a user paramet
 
 | Exploit Type                       | [.NET][5]        | [Python][6]      | [Go][7]                 | [Java][8]        | [Node.js][9]     | [PHP][10]        | [Ruby][11]        |
 |------------------------------------|------------------|------------------|-------------------------|------------------|------------------|------------------|-------------------|
-| Server-side Request Forgery (SSRF) | v3.3.0           | v2.15.0          | v1.70.1                 | v1.42.0          | v5.20.0, v4.44.0 | v1.7.0           | v2.15.0           |
-| Local File Inclusion (LFI)         | v3.5.0           | v2.15.0          | [orchestrion][3] v1.0.0 | v1.42.0          | v5.24.0, v4.48.0 | v1.6.0           | Not supported     |
-| SQL Injection (SQLi)               | v3.4.0           | v2.16.0          | v1.70.1                 | v1.42.0          | v5.25.0, v4.49.0 | v1.9.0           | v2.15.0           |
+| Server-side Request Forgery (SSRF) | v3.3.0           | v2.15.0          | v1.70.1                 | v1.42.0          | v5.20.0, v4.44.0 | Not supported           | v2.15.0           |
+| Local File Inclusion (LFI)         | v3.5.0           | v2.15.0          | [orchestrion][3] v1.0.0 | v1.42.0          | v5.24.0, v4.48.0 | Not supported           | Not supported     |
+| SQL Injection (SQLi)               | v3.4.0           | v2.16.0          | v1.70.1                 | v1.42.0          | v5.25.0, v4.49.0 | Not supported           | v2.15.0           |
 | Command Injection                  | v3.4.0           | v2.15.0          | Not supported           | v1.45.0          | v5.25.0, v4.49.0 | Not supported    | Not supported     |
 
 


### PR DESCRIPTION
DOCS-10913

EM has asked for this update because all of PHP is not supported in the end because not enabled by default.

### Merge instructions

Merge readiness:
- [X] Ready for merge
