### PR TITLE
Update Minimum layer version for nodejs profiling

### DIFF
--- a/content/en/serverless/aws_lambda/profiling.md
+++ b/content/en/serverless/aws_lambda/profiling.md
@@ -36,7 +36,7 @@ Depending on your runtime, this feature requires the following tracer and layer 
 | Runtime | Minimum tracer version | Minimum layer version |
 | ------- | ---------------------- | --------------------- |
 | Python | 1.4.0 | 62 |
-| Node.js | 2.22.1, 3.9.0 | 87 |
+| Node.js | 2.22.1, 3.9.0 | 78 |
 
 ## Further Reading
 


### PR DESCRIPTION
There was a typo in Minimum layer version requirement for nodejs. Its mentioned as 87, but our latest release is 78

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
