### PR TITLE
fix Error Tracking retention docs

### DIFF
--- a/content/en/data_security/data_retention_periods.md
+++ b/content/en/data_security/data_retention_periods.md
@@ -86,7 +86,8 @@ attributes:
        - **Dashboards, Notebooks, Monitors**: Retained for the duration of the account
   - product: Error Tracking
     data_type: | 
-       - **Errors**: 1 year after last access
+       - **Error samples**: 15 days
+       - **Issues**: 1 year after last activity
   - product: Event Management
     data_type: | 
        - **Events**: 15 months


### PR DESCRIPTION
The docs update to Error Tracking retention from [this change](https://github.com/DataDog/documentation/pull/27418/files) got lost on the new data retention page.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

Merge queue is enabled in this repo. To have it automatically merged after it receives the required reviews, create the PR (from a branch that follows the `<yourname>/description` naming convention) and then add the following PR comment:

```
/merge
```