### PR TITLE
fix tooltip shortcode bug

### DIFF
--- a/assets/styles/components/_tooltip.scss
+++ b/assets/styles/components/_tooltip.scss
@@ -44,19 +44,13 @@
   box-shadow: var(--tooltip-box-shadow);
   max-width: 300px;
   width: max-content;
-  opacity: 0;
-  visibility: hidden;
+  display: none;
   transition: 
-    opacity var(--tooltip-transition-duration) ease-out,
-    visibility 0s linear var(--tooltip-transition-duration),
     width var(--tooltip-transition-duration) ease-out;
   
   &.show {
-    opacity: 1;
-    visibility: visible;
+    display: block;
     transition: 
-      opacity var(--tooltip-transition-duration) ease-out,
-      visibility 0s linear,
       width var(--tooltip-transition-duration) ease-out;
   }
 

--- a/layouts/shortcodes/tooltip.html
+++ b/layouts/shortcodes/tooltip.html
@@ -48,7 +48,12 @@
 
 <!-- Render tooltip -->
 {{- if or $shortDefMatch (and $text $tooltip) -}}
-<span class="tooltip-container"><button class="tooltip-trigger" aria-describedby="tooltip-{{- $displayText | anchorize -}}">{{- $displayText -}}</button><span id="tooltip-{{- $displayText | anchorize -}}" class="tooltip-content" role="tooltip">{{- $tooltipContent | safeHTML -}}{{- if $fullDefinitionLink -}}<a href="{{- $fullDefinitionLink -}}" class="tooltip-full-link" aria-label="View full definition">Glossary</a>{{- end -}}</span></span>
+<span class="tooltip-container">
+  <button class="tooltip-trigger" aria-describedby="tooltip-{{- $displayText | anchorize -}}">{{- $displayText -}}</button>
+  <span id="tooltip-{{- $displayText | anchorize -}}" class="tooltip-content" role="tooltip">
+    {{- $tooltipContent | safeHTML -}}{{- if $fullDefinitionLink -}}<a href="{{- $fullDefinitionLink -}}" class="tooltip-full-link" aria-label="View full definition">Glossary</a>{{- end -}}
+  </span>
+</span>
 {{- else -}}
 {{- $displayText -}}
 {{- end -}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

fixes a bug with tooltip shortcode where the hidden tooltip is taking up space in the `.table-wrapper`.
- removes tooltip from the document layout until the event listener is triggered (mouseenter)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

motivation: https://datadoghq.atlassian.net/browse/WEB-6273
preview: 

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
