### PR TITLE
[MLOB-2691] Small Evaluations documentation fixes

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4507,7 +4507,7 @@ menu:
       parent: llm_obs_evaluations
       identifier: llm_obs_ootb_evaluations
       weight: 401
-    - name: Submit Evaluations
+    - name: Submit Custom Evaluations
       url: llm_observability/evaluations/submit_evaluations
       parent: llm_obs_evaluations
       identifier: llm_obs_submit_evaluations

--- a/content/en/llm_observability/evaluations/_index.md
+++ b/content/en/llm_observability/evaluations/_index.md
@@ -18,9 +18,9 @@ LLM Observability offers several ways to support evaluations:
 
 Datadog builds and supports [Out of the Box Evaluations][1] to support common use cases. You can enable and configure them within the LLM Observability application.
 
-### Submit Evaluations
+### Submit Custom Evaluations
 
-You can also [Submit Evaluations][2] using Datadog's API. This mechanism is great if you have your own evaluation system, but would like to centralize that information within Datadog.
+You can also [Submit Custom Evaluations][2] using Datadog's API. This mechanism is great if you have your own evaluation system, but would like to centralize that information within Datadog.
 
 ### Evaluation Integrations
 

--- a/content/en/llm_observability/evaluations/_index.md
+++ b/content/en/llm_observability/evaluations/_index.md
@@ -14,9 +14,9 @@ aliases:
 
 LLM Observability offers several ways to support evaluations:
 
-### Out of the Box Evaluations
+### Out-of-the-Box Evaluations
 
-Datadog builds and supports [Out of the Box Evaluations][1] to support common use cases. You can enable and configure them within the LLM Observability application.
+Datadog builds and supports [Out-of-the-Box Evaluations][1] to support common use cases. You can enable and configure them within the LLM Observability application.
 
 ### Submit Custom Evaluations
 

--- a/content/en/llm_observability/evaluations/ootb_evaluations.md
+++ b/content/en/llm_observability/evaluations/ootb_evaluations.md
@@ -99,7 +99,7 @@ Connect your Amazon Bedrock account to LLM Observability with your AWS Account. 
 1. Select **OpenAI**, **Azure OpenAI**, **Anthropic**, or **Amazon Bedrock** as your LLM provider and choose an account.
 1. Configure the data to run the evaluation on:
    - Select **traces** (the root span of each trace) or **spans** (LLM, Workflow, and Agent).
-   - If you selected spans, you must select at least one **span name**, otherwise they are optional.
+   - If you selected spans, you must select at least one **span name**.
    - (Optional) Specify any or all **tags** you want this evaluation to run on.
    - (Optional) Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than `0` and less than or equal to `100` (sampling all spans).
 1. (Optional) Configure evaluation options by selecting what subcategories should be flagged. Only available on some evaluations.

--- a/content/en/llm_observability/evaluations/ootb_evaluations.md
+++ b/content/en/llm_observability/evaluations/ootb_evaluations.md
@@ -99,9 +99,9 @@ Connect your Amazon Bedrock account to LLM Observability with your AWS Account. 
 1. Select **OpenAI**, **Azure OpenAI**, **Anthropic**, or **Amazon Bedrock** as your LLM provider and choose an account.
 1. Configure the data to run the evaluation on:
    - Select **traces** (the root span of each trace) or **spans** (LLM, Workflow, and Agent).
-   - If you select spans, you must select at least one **span name**, otherwise they are optional.
-   - Optionally, specify any or all **tags** you want this evaluation to run on.
-   - Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than 0 and less than or equal to 100 (evaluating all spans).
+   - If you selected spans, you must select at least one **span name**, otherwise they are optional.
+   - (Optional) Specify any or all **tags** you want this evaluation to run on.
+   - (Optional) Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than 0 and less than or equal to 100 (evaluating all spans).
 1. (Optional) Configure evaluation options by selecting what subcategories should be flagged. Only available on some evaluations.
 
 After you click **Save**, LLM Observability uses the LLM account you connected to power the evaluation you enabled.

--- a/content/en/llm_observability/evaluations/ootb_evaluations.md
+++ b/content/en/llm_observability/evaluations/ootb_evaluations.md
@@ -94,14 +94,13 @@ Connect your Amazon Bedrock account to LLM Observability with your AWS Account. 
    - Configure an evaluation for all of your LLM applications by selecting **Configure Evaluation**, or you select the edit icon to configure the evaluation for an individual LLM application.
    - Evaluations can be disabled by selecting the disable icon for an individual LLM application.
 1. If you select **Configure Evaluation**, select the LLM application(s) you want to configure your evaluation for.
-1. Select **OpenAI**, **Azure OpenAI**, **Anthropic**, or **Amazon Bedrock** as your LLM provider.
-1. Select the account you want to run the evaluation on.
-1. Choose whether you want the evaluation to run on traces (the root span of each trace) or spans (which include LLM, Workflow, and Agent spans).
-   - If you select to run the evaluation on spans, you must select at least one span name to save your configured evaluation.
-1. Select the span names you would like your evaluation to run on. (Optional if traces is selected).
-1. Optionally, specify the tags you want this evaluation to run on and choose whether to apply the evaluation to spans that match any of the selected tags (Any of), or all of the selected tags (All of).
-1. Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than 0 and less than or equal to 100. A sampling percentage of 100% means that the evaluation runs on all valid spans, whereas a sampling percentage of 50% means that the evaluation runs on 50% of valid spans.
-1. (Optional) For Failure to Answer, if OpenAI or Azure OpenAI is selected, configure the evaluation by selecting what types of answers should be considered Failure to Answer. This configuration is detailed in [Failure to Answer Configuration][5].
+1. Select **OpenAI**, **Azure OpenAI**, **Anthropic**, or **Amazon Bedrock** as your LLM provider and an account.
+1. Configure the data to run the evaluation on:
+   - Select traces (the root span of each trace) or spans (which include LLM, Workflow, and Agent spans). If you select spans, you must select at least one span name too.
+   - Select the span names you would like your evaluation to run on. (Optional if traces is selected).
+   - Optionally, specify the tags you want this evaluation to run on and choose whether to apply the evaluation to spans that match any of the selected tags (Any of), or all of the selected tags (All of).
+   - Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than 0 and less than or equal to 100. A sampling percentage of 100% means that the evaluation runs on all valid spans, whereas a sampling percentage of 50% means that the evaluation runs on 50% of valid spans.
+1. (Optional) Configure evaluation options by selecting what subcategories should be flagged, when available.
 
 After you click **Save**, LLM Observability uses the LLM account you connected to power the evaluation you enabled.
 
@@ -279,4 +278,4 @@ This check ensures that sensitive information is handled appropriately and secur
 [2]: https://app.datadoghq.com/llm/settings/evaluations
 [3]: /llm_observability/terms/#topic-relevancy
 [4]: https://app.datadoghq.com/llm/applications
-[5]: /llm_observability/evaluations/ootb_evaluations/#failure-to-answer-configuration
+[5]: /security/sensitive_data_scanner/

--- a/content/en/llm_observability/evaluations/ootb_evaluations.md
+++ b/content/en/llm_observability/evaluations/ootb_evaluations.md
@@ -279,4 +279,4 @@ This check ensures that sensitive information is handled appropriately and secur
 [2]: https://app.datadoghq.com/llm/settings/evaluations
 [3]: /llm_observability/terms/#topic-relevancy
 [4]: https://app.datadoghq.com/llm/applications
-[5]: /llm_observability/terms/#failure-to-answer-configuration
+[5]: /llm_observability/evaluations/ootb_evaluations/#failure-to-answer-configuration

--- a/content/en/llm_observability/evaluations/ootb_evaluations.md
+++ b/content/en/llm_observability/evaluations/ootb_evaluations.md
@@ -101,7 +101,7 @@ Connect your Amazon Bedrock account to LLM Observability with your AWS Account. 
    - Select **traces** (the root span of each trace) or **spans** (LLM, Workflow, and Agent).
    - If you selected spans, you must select at least one **span name**, otherwise they are optional.
    - (Optional) Specify any or all **tags** you want this evaluation to run on.
-   - (Optional) Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than 0 and less than or equal to 100 (evaluating all spans).
+   - (Optional) Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than `0` and less than or equal to `100` (sampling all spans).
 1. (Optional) Configure evaluation options by selecting what subcategories should be flagged. Only available on some evaluations.
 
 After you click **Save**, LLM Observability uses the LLM account you connected to power the evaluation you enabled.
@@ -206,7 +206,7 @@ This check identifies instances where the LLM fails to deliver an appropriate re
 | Evaluated on Output | Evaluated using LLM | Failure To Answer flags whether each prompt-response pair demonstrates that the LLM application has provided a relevant and satisfactory answer to the user's question.  |
 
 ##### Failure to Answer Configuration
-The types of Failure to Answer are defined below and can be configured when the Failure to Answer evaluation is enabled.
+You can configure the evaluation by selecting what types of answers should be considered Failure to Answer. This feature is only available if OpenAI or Azure OpenAI is selected for the LLM provider.
 
 | Configuration Option | Description | Example(s) |
 |---|---|---|

--- a/content/en/llm_observability/evaluations/ootb_evaluations.md
+++ b/content/en/llm_observability/evaluations/ootb_evaluations.md
@@ -106,8 +106,6 @@ Connect your Amazon Bedrock account to LLM Observability with your AWS Account. 
 
 After you click **Save**, LLM Observability uses the LLM account you connected to power the evaluation you enabled.
 
-For more information about evaluations, see [Terms and Concepts][1].
-
 ### Estimated token usage
 
 LLM Observability provides metrics to help you monitor and manage the token usage associated with evaluations that power LLM Observability. The following metrics allow you to track the LLM resources consumed to power evaluations:
@@ -131,7 +129,7 @@ This check identifies and flags user inputs that deviate from the configured acc
 
 You can provide topics for this evaluation.
 
-1. Go to [**LLM Observability > Applications**][4].
+1. Go to [**LLM Observability > Applications**][3].
 1. Select the application you want to add topics for.
 1. At the right corner of the top panel, select **Settings**.
 1. Beside **Topic Relevancy**, click **Configure Evaluation**.
@@ -270,14 +268,12 @@ This check ensures that sensitive information is handled appropriately and secur
   
 | Evaluation Stage | Evaluation Method | Evaluation Definition | 
 |---|---|---|
-| Evaluated on Input and Output | Sensitive Data Scanner | Powered by the [Sensitive Data Scanner][5], LLM Observability scans, identifies, and redacts sensitive information within every LLM application's prompt-response pairs. This includes personal information, financial data, health records, or any other data that requires protection due to privacy or security concerns. |
+| Evaluated on Input and Output | Sensitive Data Scanner | Powered by the [Sensitive Data Scanner][4], LLM Observability scans, identifies, and redacts sensitive information within every LLM application's prompt-response pairs. This includes personal information, financial data, health records, or any other data that requires protection due to privacy or security concerns. |
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /llm_observability/terms/
 [2]: https://app.datadoghq.com/llm/settings/evaluations
-[3]: /llm_observability/terms/#topic-relevancy
-[4]: https://app.datadoghq.com/llm/applications
-[5]: /security/sensitive_data_scanner/
+[3]: https://app.datadoghq.com/llm/applications
+[4]: /security/sensitive_data_scanner/

--- a/content/en/llm_observability/evaluations/ootb_evaluations.md
+++ b/content/en/llm_observability/evaluations/ootb_evaluations.md
@@ -101,7 +101,7 @@ Connect your Amazon Bedrock account to LLM Observability with your AWS Account. 
    - Select **traces** (the root span of each trace) or **spans** (LLM, Workflow, and Agent).
    - If you select spans, you must select at least one **span name**, otherwise they are optional.
    - Optionally, specify any or all **tags** you want this evaluation to run on.
-   - Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than 0 and less than or equal to 100. A sampling percentage of 100% means that the evaluation runs on all valid spans, whereas a sampling percentage of 50% means that the evaluation runs on 50% of valid spans.
+   - Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than 0 and less than or equal to 100 (evaluating all spans).
 1. (Optional) Configure evaluation options by selecting what subcategories should be flagged. Only available on some evaluations.
 
 After you click **Save**, LLM Observability uses the LLM account you connected to power the evaluation you enabled.

--- a/content/en/llm_observability/evaluations/ootb_evaluations.md
+++ b/content/en/llm_observability/evaluations/ootb_evaluations.md
@@ -24,6 +24,8 @@ LLM Observability out-of-the-box evaluations leverage LLMs. To connect your LLM 
 
 ## Connect your LLM provider account
 
+Configure the LLM provider you would like to use for bring-your-own-key evaluations. You only have to complete this step once.
+
 {{< tabs >}}
 {{% tab "OpenAI" %}}
 
@@ -93,14 +95,14 @@ Connect your Amazon Bedrock account to LLM Observability with your AWS Account. 
 1. Click on the evaluation you want to enable.
    - Configure an evaluation for all of your LLM applications by selecting **Configure Evaluation**, or you select the edit icon to configure the evaluation for an individual LLM application.
    - Evaluations can be disabled by selecting the disable icon for an individual LLM application.
-1. If you select **Configure Evaluation**, select the LLM application(s) you want to configure your evaluation for.
-1. Select **OpenAI**, **Azure OpenAI**, **Anthropic**, or **Amazon Bedrock** as your LLM provider and an account.
+1. If you chose **Configure Evaluation**, select the LLM application(s) you want to configure your evaluation for.
+1. Select **OpenAI**, **Azure OpenAI**, **Anthropic**, or **Amazon Bedrock** as your LLM provider and choose an account.
 1. Configure the data to run the evaluation on:
-   - Select traces (the root span of each trace) or spans (which include LLM, Workflow, and Agent spans). If you select spans, you must select at least one span name too.
-   - Select the span names you would like your evaluation to run on. (Optional if traces is selected).
-   - Optionally, specify the tags you want this evaluation to run on and choose whether to apply the evaluation to spans that match any of the selected tags (Any of), or all of the selected tags (All of).
+   - Select **traces** (the root span of each trace) or **spans** (LLM, Workflow, and Agent).
+   - If you select spans, you must select at least one **span name**, otherwise they are optional.
+   - Optionally, specify any or all **tags** you want this evaluation to run on.
    - Select what percentage of spans you would like this evaluation to run on by configuring the **sampling percentage**. This number must be greater than 0 and less than or equal to 100. A sampling percentage of 100% means that the evaluation runs on all valid spans, whereas a sampling percentage of 50% means that the evaluation runs on 50% of valid spans.
-1. (Optional) Configure evaluation options by selecting what subcategories should be flagged, when available.
+1. (Optional) Configure evaluation options by selecting what subcategories should be flagged. Only available on some evaluations.
 
 After you click **Save**, LLM Observability uses the LLM account you connected to power the evaluation you enabled.
 

--- a/content/en/llm_observability/evaluations/submit_evaluations.md
+++ b/content/en/llm_observability/evaluations/submit_evaluations.md
@@ -1,5 +1,5 @@
 ---
-title: Submit Evaluations
+title: Submit Custom Evaluations
 aliases:
     - /tracing/llm_observability/submit_evaluations
     - /llm_observability/submit_evaluations
@@ -25,7 +25,7 @@ While LLM Observability provides a few out-of-the-box evaluations for your trace
 
 ## Submitting evaluations with the SDK
 
-The LLM Observability SDK provides the methods `LLMObs.submit_evaluation_for()` and `LLMObs.export_span()` to help your traced LLM application submit evaluations to LLM Observability. See the [Python][3] or [NodeJS][4] SDK documentation for more details.
+The LLM Observability SDK provides the methods `LLMObs.submit_evaluation_for()` and `LLMObs.export_span()` to help your traced LLM application submit custom evaluations to LLM Observability. See the [Python][3] or [NodeJS][4] SDK documentation for more details.
 
 ### Example
 

--- a/content/en/llm_observability/evaluations/submit_evaluations.md
+++ b/content/en/llm_observability/evaluations/submit_evaluations.md
@@ -23,7 +23,7 @@ further_reading:
 In the context of LLM applications, it's important to track user feedback and evaluate the quality of your LLM application's responses.
 While LLM Observability provides a few out-of-the-box evaluations for your traces, you can submit your own evaluations to LLM Observability in two ways: with Datadog's [SDK](#submitting-evaluations-with-the-sdk), or with the [LLM Observability API](#submitting-evaluations-with-the-api). See [Naming custom metrics][1] for guidelines on how to choose an appropriate label for your evaluations.
 
-## Submitting evaluations with the SDK
+## Submitting custom evaluations with the SDK
 
 The LLM Observability SDK provides the methods `LLMObs.submit_evaluation_for()` and `LLMObs.export_span()` to help your traced LLM application submit custom evaluations to LLM Observability. See the [Python][3] or [NodeJS][4] SDK documentation for more details.
 
@@ -55,7 +55,7 @@ def llm_call():
 {{< /code-block >}}
 
 
-## Submitting evaluations with the API
+## Submitting custom evaluations with the API
 
 You can use the evaluations API provided by LLM Observability to send evaluations associated with spans to Datadog. See the [Evaluations API][2] for more details on the API specifications.
 

--- a/content/en/llm_observability/guide/_index.md
+++ b/content/en/llm_observability/guide/_index.md
@@ -16,6 +16,6 @@ cascade:
 {{< whatsnext desc="LLM Observability Guides:" >}}
     {{< nextlink href="/llm_observability/quickstart#trace-an-llm-application" >}}Trace an LLM Application{{< /nextlink >}}
     {{< nextlink href="/llm_observability/quickstart#trace-an-llm-application-in-aws-lambda" >}}Trace an LLM Application in AWS Lambda{{< /nextlink >}}
-    {{< nextlink href="/llm_observability/evaluations/evaluations" >}}Evaluations{{< /nextlink >}}
+    {{< nextlink href="/llm_observability/evaluations/" >}}Evaluations{{< /nextlink >}}
     {{< nextlink href="/llm_observability/guide/llm_observability_and_apm" >}}Using LLM Observability and APM{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/llm_observability/guide/_index.md
+++ b/content/en/llm_observability/guide/_index.md
@@ -16,8 +16,6 @@ cascade:
 {{< whatsnext desc="LLM Observability Guides:" >}}
     {{< nextlink href="/llm_observability/quickstart#trace-an-llm-application" >}}Trace an LLM Application{{< /nextlink >}}
     {{< nextlink href="/llm_observability/quickstart#trace-an-llm-application-in-aws-lambda" >}}Trace an LLM Application in AWS Lambda{{< /nextlink >}}
-    {{< nextlink href="/llm_observability/evaluations/" >}}Evaluations{{< /nextlink >}}
-    {{< nextlink href="/llm_observability/evaluations/submit_nemo_evaluations" >}}Submit NVIDIA NeMo Custom Evaluations{{< /nextlink >}}
-    {{< nextlink href="/llm_observability/guide/ragas_quickstart" >}}Ragas Quickstart{{< /nextlink >}}
+    {{< nextlink href="/llm_observability/evaluations/evaluations" >}}Evaluations{{< /nextlink >}}
     {{< nextlink href="/llm_observability/guide/llm_observability_and_apm" >}}Using LLM Observability and APM{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/llm_observability/setup/_index.md
+++ b/content/en/llm_observability/setup/_index.md
@@ -7,9 +7,9 @@ further_reading:
     - link: 'https://www.datadoghq.com/blog/llm-observability-chain-tracing/'
       tag: 'Blog'
       text: 'Get granular LLM observability by instrumenting your LLM chains'
-    - link: '/llm_observability/evaluations/submit_evaluations'
+    - link: '/llm_observability/evaluations'
       tag: 'Guide'
-      text: 'Submit Evaluations to LLM Observability'
+      text: 'Evaluation options for LLM Observability'
 ---
 
 {{< site-region region="gov" >}}

--- a/content/en/llm_observability/terms/_index.md
+++ b/content/en/llm_observability/terms/_index.md
@@ -9,9 +9,9 @@ further_reading:
     - link: '/llm_observability/setup'
       tag: 'Documentation'
       text: 'Learn how to set up LLM Observability'
-    - link: '/llm_observability/evaluations/submit_evaluations'
+    - link: '/llm_observability/evaluations'
       tag: 'Guide'
-      text: 'Submit Evaluations to LLM Observability'
+      text: 'Evaluation options for LLM Observability'
 ---
 
 {{< site-region region="gov" >}}
@@ -159,7 +159,7 @@ LLM Observability offers out-of-the-box evaluations and quality checks to evalua
 
 Datadog provides a variety of options for your evaluations:
 - Use [out-of-the-box evaluations][12] for your traces
-- [Submit your own evaluations][6] to LLM Observability
+- [Submit custom evaluations][6] to LLM Observability
 - Integrate with frameworks like [Ragas][13] and [NeMo][14]
 
 In addition, Datadog's [Sensitive Data Scanner][5] is natively integrated with LLM Observability, so you can ensure any sensitive data in your input and output is scanned and redacted.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

 - Standardize around "Submit Custom Evaluations" for evals submitted via the API/SDK. The [original review](https://github.com/DataDog/documentation/pull/29421#discussion_r2103320152) suggested to use "submit evaluations" but we would like to more clearly distinguish between this feature and OOTB evals.
 - Clean up further reading links to point to the top level Evaluations section
 - Reduce verbiage for the "Select and enable evaluations" section, create sub bullet points, highlight optional steps
