### PR TITLE
added snippet for aliases in frontmatter

### DIFF
--- a/snippets/markdown.json
+++ b/snippets/markdown.json
@@ -334,5 +334,13 @@
 				"{{< /is_loggedin >}}"
 			],
 			"description": "Conditionally display content if user is a known Datadog customer."
-	}
+	},
+    "Aliases frontmatter": {
+      "prefix": ";;aliases",
+      "body": [
+          "aliases:",
+          "  - ${1:/your/url/here}"
+      ],
+      "description": "YAML frontmatter for aliases with a single URL entry"
+  }
 }


### PR DESCRIPTION
Added a snippet in case you want to add an `aliases` item to the file frontmatter

### Merge instructions

Merge readiness:
- [X] Ready for merge
