### PR TITLE
Remove aggregation customization mention

### DIFF
--- a/content/en/metrics/metrics-without-limits.md
+++ b/content/en/metrics/metrics-without-limits.md
@@ -50,8 +50,6 @@ You can [create][2], [edit][3], [delete][4], and [estimate the impact][5] of you
 
 Set the parameter `exclude_tags_mode: true` on the Metrics API to [create][2] and [edit][3] a blocklist of tags.
 
-When configuring tags for counts, rates, and gauges, the most frequently queried time/space aggregation combination is available for query by default.
-
 **Note:** For tags to be managed on a metric, the metric must have a type declared. This is typically done when a metric is submitted, but may also be done manually using the `Edit` button for a metric in Metrics Summary.
 
 #### Use the API


### PR DESCRIPTION
per https://app.datadoghq.com/release-notes/custom-metrics-configured-using-metrics-without-limits-now-have-all-aggregations-available customers can't customize space/time aggregation anymore and they are all available at querytime now

please merge after approval; thank you!