### PR TITLE
[WEB-6549] Adds redirect for section pages without content

### DIFF
--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,10 +1,6 @@
 {{ define "main" }}
     {{ if not .Content }}
-        <meta http-equiv="refresh" content="0; url='{{ "" | relURL }}'">
-        <script>
-            window.location.href = '{{ "" | relURL }}';
-        </script>
-        <p>If you are not redirected, <a href='{{ "" | relURL}}'>click here</a>.</p>
+        {{ partial "meta-http-equiv.html" . }}
     {{ else }}
         <div class="row">
             <div class="col-12 order-1">

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,14 +1,22 @@
 {{ define "main" }}
-    <div class="row">
-        <div class="col-12 order-1">
-            <h1 id="pagetitle">{{ .Title }}</h1>
+    {{ if not .Content }}
+        <meta http-equiv="refresh" content="0; url='{{ "" | relURL }}'">
+        <script>
+            window.location.href = '{{ "" | relURL }}';
+        </script>
+        <p>If you are not redirected, <a href='{{ "" | relURL}}'>click here</a>.</p>
+    {{ else }}
+        <div class="row">
+            <div class="col-12 order-1">
+                <h1 id="pagetitle">{{ .Title }}</h1>
+            </div>
+            <div class="col-12">
+                {{ partial "breadcrumbs.html" . }}
+            </div>
         </div>
-        <div class="col-12">
-            {{ partial "breadcrumbs.html" . }}
-        </div>
-    </div>
-    {{ partial "translate_status_banner/translate_status_banner.html" . }}
-    
-    {{ $wrappedTable := printf "<div class=table-wrapper> ${1} </div>" }} 
-    {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
+        {{ partial "translate_status_banner/translate_status_banner.html" . }}
+        
+        {{ $wrappedTable := printf "<div class=table-wrapper> ${1} </div>" }} 
+        {{ .Content | replaceRE "(<table>(?:.|\n)+?</table>)" $wrappedTable | safeHTML }}
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
For specific sections, where there isn't a top-level page, the current behavior is to display a default section page template. Since there isn't content defined, this results in an empty page. 

This PR introduces logic that will redirect sections where there is not a defined _index.md file with specific content. 

https://datadoghq.atlassian.net/browse/WEB-6549

### Merge instructions

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
