### PR TITLE
Update distributions.md

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -95,9 +95,8 @@ spec:
       appKey: <DATADOG_APP_KEY>
     kubelet:
       host:
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
+        fieldRef:
+          fieldPath: spec.nodeName
       hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
   override:
     clusterAgent:
@@ -123,9 +122,8 @@ datadog:
   appKey: <DATADOG_APP_KEY>
   kubelet:
     host:
-      valueFrom:
-        fieldRef:
-          fieldPath: spec.nodeName
+      fieldRef:
+        fieldPath: spec.nodeName
     hostCAPath: /etc/kubernetes/certs/kubeletserver.crt
 
 providers:


### PR DESCRIPTION
Removed invalid `valueFrom` property from `datadog.kubelet.host`

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
I tried using the `valueFrom` property as suggested in the docs, but that was rejected. Looks like that doesn't exist in the schema

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
