### PR TITLE
Update cluster_agent_disable_admission_controller.md

### DIFF
--- a/content/en/containers/guide/cluster_agent_disable_admission_controller.md
+++ b/content/en/containers/guide/cluster_agent_disable_admission_controller.md
@@ -27,7 +27,7 @@ Datadog Cluster Agent v7.63+
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}
 To disable the Admission Controllers with your Cluster Agent managed by the Datadog Operator:
-1. Set `features.admissionController.enabled` to `true` in your `DatadogAgent` configuration.
+1. Set `features.admissionController.enabled` to `false` in your `DatadogAgent` configuration.
 2. Set `features.admissionController.validation.enabled` to `false` in your `DatadogAgent` configuration.
 3. Set `features.admissionController.mutation.enabled` to `false` in your `DatadogAgent` configuration.
 
@@ -39,20 +39,19 @@ To disable the Admission Controllers with your Cluster Agent managed by the Data
   spec:
     features:
       admissionController:
-        enabled: true
+        enabled: false
         validation:
           enabled: false
         mutation:
           enabled: false
 ```
 
-**Note**: The `features.admissionController.enabled` parameter is set to `true` to allow the Cluster Agent to manage the Kubernetes Admission Controllers.
 
 After redeploying the Cluster Agent with the updated configuration, the Admission Controllers are removed.
 {{% /tab %}}
 {{% tab "Helm" %}}
 To disable the Admission Controllers with your Cluster Agent managed by the Datadog Helm Chart:
-1. Set `clusterAgent.admissionController.enabled` to `true`.
+1. Set `clusterAgent.admissionController.enabled` to `false`.
 2. Set `clusterAgent.admissionController.validation.enabled` to `false`.
 3. Set `clusterAgent.admissionController.mutation.enabled` to `false`.
 
@@ -60,7 +59,7 @@ To disable the Admission Controllers with your Cluster Agent managed by the Data
 clusterAgent:
   enabled: true
   admissionController:
-    enabled: true
+    enabled: false
     validation:
       enabled: false
     mutation:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR fixes the doc.
https://docs.datadoghq.com/containers/guide/cluster_agent_disable_admission_controller/?tab=helm

`features.admissionController.enabled`(DD Operator),  `clusterAgent.admissionController.enabled`(Helm) should be `false` to disable Datadog Admission Controller.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
