### PR TITLE
Disable the merge queue

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,15 +14,12 @@ Merge readiness:
 - [ ] Ready for merge
 
 **For Datadog employees**:
-Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.
+
+Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.
 
 If your branch doesn't follow this format, rename it or create a new branch and PR.
 
-To have your PR automatically merged after it receives the required reviews, add the following PR comment:
-
-```
-/merge
-```
+[6/5/2025] Merge queue has been disabled on the documentation repo. If you write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.
 
 ### Additional notes
 <!-- Anything else we should know when reviewing?-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Your branch name MUST follow the `<name>/<description>` convention and include t
 
 If your branch doesn't follow this format, rename it or create a new branch and PR.
 
-[6/5/2025] Merge queue has been disabled on the documentation repo. If you write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.
+[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.
 
 ### Additional notes
 <!-- Anything else we should know when reviewing?-->

--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,7 +1,7 @@
 ---
 schema-version: v1
 kind: mergequeue
-enable: true
+enable: false # disable merge queue for now until we can get the github reporting issues resolved
 merge_method: squash
 workflow_type: speculative # (default)
 speculative_fallback_enable: true # When enabled, a fallback build will get started when there is more than 2 pull requests.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Due to the delay in github reporting status updates, we're going to disable the ability to use `/merge` for now and will use the integrated system of the merge button in github
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
Merge queue is enabled in this repo. Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass in CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

To have your PR automatically merged after it receives the required reviews, add the following PR comment:

```
/merge
```

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
