### PR TITLE
chore: warn on unsigned commits

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -24,4 +24,5 @@ rules:
     excluded_emails:
       - 'robot-guacbot-guacamole@datadoghq.com'
       - 'guacbot@users.noreply.github.com'
+      - '41898282+github-actions[bot]@users.noreply.github.com'
     allow_unsigned_external: true


### PR DESCRIPTION
This patch configures merge gate to send warning Slack messages to authors of pull requests that contain unsigned commits.

There are built in exception filters for two known bots that create unsigned commits to this repository. We'll eventually remove these exceptions as bots begin signing commits.
