### PR TITLE
[container autoscaling] Update autoscaling docs to use newer agent version

### DIFF
--- a/content/en/containers/monitoring/autoscaling.md
+++ b/content/en/containers/monitoring/autoscaling.md
@@ -115,10 +115,6 @@ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
 
 ```yaml
 datadog:
-  orchestratorExplorer:
-    customResources:
-    - datadoghq.com/v1alpha1/datadogpodautoscalers
-    - datadoghq.com/v1alpha2/datadogpodautoscalers
   autoscaling:
     workload:
       enabled: true

--- a/content/en/containers/monitoring/autoscaling.md
+++ b/content/en/containers/monitoring/autoscaling.md
@@ -63,6 +63,7 @@ spec:
     orchestratorExplorer:
       customResources:
       - datadoghq.com/v1alpha1/datadogpodautoscalers
+      - datadoghq.com/v1alpha2/datadogpodautoscalers
     autoscaling:
       workload:
         enabled: true
@@ -71,13 +72,21 @@ spec:
   override:
     clusterAgent:
       image:
-        tag: 7.58.1
+        tag: 7.66.1
+      env:
+        - name: DD_AUTOSCALING_FAILOVER_ENABLED
+          value: "true"
     nodeAgent:
       image:
-        tag: 7.58.1 # or 7.58.1-jmx
+        tag: 7.66.1 # or 7.66.1-jmx
+      env:
+        - name: DD_AUTOSCALING_FAILOVER_ENABLED
+          value: "true"
+        - name: DD_AUTOSCALING_FAILOVER_METRICS
+          value: container.memory.usage container.cpu.usage
     clusterChecksRunner
       image:
-        tag: 7.58.1 # or 7.58.1-jmx
+        tag: 7.66.1 # or 7.66.1-jmx
 ```
 
 3. [Admission Controller][1] is enabled by default with the Datadog Operator. If you disabled it, re-enable it by adding the following highlighted lines to `datadog-agent.yaml`:
@@ -102,27 +111,19 @@ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
 {{% /tab %}}
 {{% tab "Helm" %}}
 
-1. Add the following to your `datadog-values.yaml` configuration file:
+1. Ensure you are using Agent and Cluster Agent v7.66.1+. Add the following to your `datadog-values.yaml` configuration file:
 
 ```yaml
 datadog:
   orchestratorExplorer:
     customResources:
     - datadoghq.com/v1alpha1/datadogpodautoscalers
+    - datadoghq.com/v1alpha2/datadogpodautoscalers
   autoscaling:
     workload:
       enabled: true
   kubernetesEvents:
     unbundleEvents: true
-clusterAgent:
-  image:
-    tag: 7.58.1
-agents:
-  image:
-    tag: 7.58.1 # or 7.58.1-jmx
-clusterChecksRunner:
-  image:
-    tag: 7.58.1 # or 7.58.1-jmx
 ```
 
 2. [Admission Controller][1] is enabled by default in the Datadog Helm chart. If you disabled it, re-enable it by adding the following highlighted lines to `datadog-values.yaml`:
@@ -130,7 +131,7 @@ clusterChecksRunner:
 ...
 clusterAgent:
   image:
-    tag: 7.58.1
+    tag: 7.66.1
   admissionController:
     enabled: true
 ...

--- a/content/en/containers/monitoring/autoscaling.md
+++ b/content/en/containers/monitoring/autoscaling.md
@@ -62,7 +62,6 @@ spec:
   features:
     orchestratorExplorer:
       customResources:
-      - datadoghq.com/v1alpha1/datadogpodautoscalers
       - datadoghq.com/v1alpha2/datadogpodautoscalers
     autoscaling:
       workload:
@@ -84,7 +83,7 @@ spec:
           value: "true"
         - name: DD_AUTOSCALING_FAILOVER_METRICS
           value: container.memory.usage container.cpu.usage
-    clusterChecksRunner
+    clusterChecksRunner:
       image:
         tag: 7.66.1 # or 7.66.1-jmx
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Make some minor updates to the autoscaling documentation:
* Use a newer agent version
* Update some typos in the operator configuration
* Configure collection of the new `datadogpodautoscaler` resource version
* Configure local fallback
* Remove fields that are available by default in helm

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
