### PR TITLE
Remove '$' since one is automatically added when showing bash script

### DIFF
--- a/content/en/agent/configuration/secrets-management.md
+++ b/content/en/agent/configuration/secrets-management.md
@@ -239,7 +239,7 @@ Here's an example showing how to set it up:
        backend_type: aws.secrets
    ```
 4. Set the correct access rights for the binary as described in [Agent security requirements](#agent-security-requirements):
-   ```bash
+   ```sh
    chown dd-agent:dd-agent datadog-secret-backend
    chmod 500 datadog-secret-backend
    ```

--- a/content/en/agent/configuration/secrets-management.md
+++ b/content/en/agent/configuration/secrets-management.md
@@ -357,7 +357,7 @@ On Linux, the command outputs file mode, owner and group for the executable. On 
 
 Example on Linux:
 
-```bash
+```sh
 datadog-agent secret
 === Checking executable rights ===
 Executable path: /path/to/you/executable

--- a/content/en/agent/configuration/secrets-management.md
+++ b/content/en/agent/configuration/secrets-management.md
@@ -239,9 +239,9 @@ Here's an example showing how to set it up:
        backend_type: aws.secrets
    ```
 4. Set the correct access rights for the binary as described in [Agent security requirements](#agent-security-requirements):
-   ```
-   $> chown dd-agent:dd-agent datadog-secret-backend
-   $> chmod 500 datadog-secret-backend
+   ```bash
+   chown dd-agent:dd-agent datadog-secret-backend
+   chmod 500 datadog-secret-backend
    ```
 5. Configure the Agent to use the binary to resolve secrets and use the AWS secret (here as the `api_key`):
    ```
@@ -357,8 +357,8 @@ On Linux, the command outputs file mode, owner and group for the executable. On 
 
 Example on Linux:
 
-```shell
-$> datadog-agent secret
+```bash
+datadog-agent secret
 === Checking executable rights ===
 Executable path: /path/to/you/executable
 Check Rights: OK, the executable has the correct rights


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Remove '$' since one is automatically added when showing bash script. Adding one manually produce double dollar signs.

### Merge instructions

None

Merge readiness:
- [x] Ready for merge