### PR TITLE
Adding Baggage Span Tags docs

### DIFF
--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -225,12 +225,12 @@ The following configuration options behave consistently across the latest versio
 `DD_TRACE_BAGGAGE_MAX_ITEMS`
 : **Default**: `64` <br>
 **Supported Input**:  A positive integer <br>
-**Description**: Maximum number of name/value pairs that can be propagated via baggage.
+**Description**: The maximum number of key-value pairs in the baggage header.
 
 `DD_TRACE_BAGGAGE_MAX_BYTES`
 : **Default**: `8192` <br>
 **Supported Input**:  A positive integer <br>
-**Description**: Maximum number of bytes in the baggage header value. Values less than 3 bytes prevent propagation, because this is the minimum size for a valid key-value pair (for example, `k=v`).
+**Description**: The maximum number of bytes in the baggage header value. Values less than 3 bytes prevent propagation, because this is the minimum size for a valid key-value pair (for example, `k=v`).
 
 `DD_TRACE_BAGGAGE_TAG_KEYS`
 : **Default**: `user.id,session.id,account.id` <br>

--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -230,7 +230,7 @@ The following configuration options behave consistently across the latest versio
 `DD_TRACE_BAGGAGE_MAX_BYTES`
 : **Default**: `8192` <br>
 **Supported Input**:  A positive integer <br>
-**Description**: Maximum number of bytes in the baggage header value. Values less than 3 will prevent propagation (3 bytes is the shortest possible data, e.g. `a=b`).
+**Description**: Maximum number of bytes in the baggage header value. Values less than 3 bytes prevent propagation, because this is the minimum size for a valid key-value pair (for example, `k=v`).
 
 `DD_TRACE_BAGGAGE_TAG_KEYS`
 : **Default**: `user.id,session.id,account.id` <br>

--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -229,7 +229,7 @@ The following configuration options behave consistently across the latest versio
 
 `DD_TRACE_BAGGAGE_MAX_BYTES`
 : **Default**: `8192` <br>
-**Supported Input**:  A non-zero positive integer <br>
+**Supported Input**:  A positive integer <br>
 **Description**: Maximum number of bytes in the baggage header value. Values less than 3 will prevent propagation (3 bytes is the shortest possible data, e.g. `a=b`).
 
 `DD_TRACE_BAGGAGE_TAG_KEYS`

--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -224,7 +224,7 @@ The following configuration options behave consistently across the latest versio
 ### Context propagation
 `DD_TRACE_BAGGAGE_MAX_ITEMS`
 : **Default**: `64` <br>
-**Supported Input**:  A non-zero positive integer <br>
+**Supported Input**:  A positive integer <br>
 **Description**: Maximum number of name/value pairs that can be propagated via baggage.
 
 `DD_TRACE_BAGGAGE_MAX_BYTES`

--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -235,7 +235,7 @@ The following configuration options behave consistently across the latest versio
 `DD_TRACE_BAGGAGE_TAG_KEYS`
 : **Default**: `user.id,session.id,account.id` <br>
 **Supported Input**:  A comma-separated string representing a list of case-sensitive baggage keys <br>
-**Caveats**: Not supported in Java, Ruby, Go, C++, and .NET <br/>
+**Caveats**: Not supported in Java, Ruby, Go, C++, and .NET <br>
 **Description**: A comma-separated list of baggage keys, sent via HTTP headers, to automatically tag as `baggage.<key>` (e.g. `bagagge.user.id`) on the local root span. Only baggage extracted from incoming headers is supported. Baggage set via the baggage API is not included.
 Set to `*` to tag all baggage keys (use with caution to avoid exposing sensitive data). Set to an empty string to disable the feature.
 

--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -236,7 +236,7 @@ The following configuration options behave consistently across the latest versio
 : **Default**: `user.id,session.id,account.id` <br>
 **Supported Input**:  A comma-separated string representing a list of case-sensitive baggage keys <br>
 **Caveats**: Not supported in Java, Ruby, Go, C++, and .NET <br>
-**Description**: A comma-separated list of baggage keys that are automatically applied as span tags to the local root span. For example, a baggage item `user.id:123` is tagged as `baggage.user.id:123`.<br>
+**Description**: A comma-separated list of baggage keys that are automatically applied as span tags to the local root span. For example, a baggage key `user.id` is tagged as `baggage.user.id` <br>
 This feature only applies to baggage extracted from incoming HTTP headers. Baggage set with the baggage API is not included.
   - To tag all baggage items, set the value to `*`. Use this with caution to avoid exposing sensitive data in tags.
   - To disable this feature, set the value to an empty string.

--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -221,6 +221,24 @@ The following configuration options behave consistently across the latest versio
   - `cf-connecting-ip`
   - `cf-connecting-ipv6`
 
+### Context Propagation
+`DD_TRACE_BAGGAGE_MAX_ITEMS`
+: **Default**: `64` <br>
+**Supported Input**:  A non-zero positive integer <br>
+**Description**: Maximum number of name/value pairs that can be propagated via baggage.
+
+`DD_TRACE_BAGGAGE_MAX_BYTES`
+: **Default**: `8192` <br>
+**Supported Input**:  A non-zero positive integer <br>
+**Description**: Maximum number of bytes in the baggage header value. Values less than 3 will prevent propagation (3 bytes is the shortest possible data, e.g. `a=b`).
+
+`DD_TRACE_BAGGAGE_TAG_KEYS`
+: **Default**: `user.id,session.id,account.id` <br>
+**Supported Input**:  A comma-separated string representing a list of case-sensitive baggage keys <br>
+**Caveats**: Not supported in Java, Ruby, Go, C++, and .NET <br/>
+**Description**: A comma-separated list of baggage keys, sent via HTTP headers, to automatically tag as `baggage.<key>` (e.g. `bagagge.user.id`) on the local root span. Only baggage extracted from incoming headers is supported. Baggage set via the baggage API is not included.
+Set to `*` to tag all baggage keys (use with caution to avoid exposing sensitive data). Set to an empty string to disable the feature.
+
 
 [1]: /developers/community/libraries/#apm-tracing-client-libraries
 [2]: /tracing/trace_collection/compatibility/java/#framework-integrations-disabled-by-default

--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -221,7 +221,7 @@ The following configuration options behave consistently across the latest versio
   - `cf-connecting-ip`
   - `cf-connecting-ipv6`
 
-### Context Propagation
+### Context propagation
 `DD_TRACE_BAGGAGE_MAX_ITEMS`
 : **Default**: `64` <br>
 **Supported Input**:  A non-zero positive integer <br>

--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -236,8 +236,10 @@ The following configuration options behave consistently across the latest versio
 : **Default**: `user.id,session.id,account.id` <br>
 **Supported Input**:  A comma-separated string representing a list of case-sensitive baggage keys <br>
 **Caveats**: Not supported in Java, Ruby, Go, C++, and .NET <br>
-**Description**: A comma-separated list of baggage keys, sent via HTTP headers, to automatically tag as `baggage.<key>` (e.g. `bagagge.user.id`) on the local root span. Only baggage extracted from incoming headers is supported. Baggage set via the baggage API is not included.
-Set to `*` to tag all baggage keys (use with caution to avoid exposing sensitive data). Set to an empty string to disable the feature.
+**Description**: A comma-separated list of baggage keys that are automatically applied as span tags to the local root span. For example, a baggage item `user.id:123` is tagged as `baggage.user.id:123`.<br>
+This feature only applies to baggage extracted from incoming HTTP headers. Baggage set with the baggage API is not included.
+  - To tag all baggage items, set the value to `*`. Use this with caution to avoid exposing sensitive data in tags.
+  - To disable this feature, set the value to an empty string.
 
 
 [1]: /developers/community/libraries/#apm-tracing-client-libraries

--- a/content/en/tracing/trace_collection/trace_context_propagation/_index.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/_index.md
@@ -641,9 +641,12 @@ When the Datadog SDK is configured with the None format for extraction or inject
 
 ### Baggage
 
-_Currently available in Python, Ruby, PHP, Java, Node.js, C++, Go and .NET. For other languages, please reach out to [Support][11]_ 
-
 By default, Baggage is automatically propagated through a distributed request using OpenTelemetry's [W3C-compatible headers][10]. To disable baggage, set [DD_TRACE_PROPAGATION_STYLE][12] to `datadog,tracecontext`.
+
+### Adding Baggage as Span Tags
+_Currently available in Python, PHP, and Node.js. For other languages, please reach out to [Support][11]_ 
+
+By default, `user.id,session.id,account.id` baggage keys will be added as span tags. To customize this configuration see [Context Propagation Configuration][13]. Specificed baggage keys will be automatically added as span tags `baggage.<key>` (e.g. `bagagge.user.id`).
 
 ## Further reading
 
@@ -661,3 +664,4 @@ By default, Baggage is automatically propagated through a distributed request us
 [10]: https://www.w3.org/TR/baggage/
 [11]: /help
 [12]: #customize-trace-context-propagation
+[13]: /tracing/trace_collection/library_config#context-propagation

--- a/content/en/tracing/trace_collection/trace_context_propagation/_index.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/_index.md
@@ -643,10 +643,10 @@ When the Datadog SDK is configured with the None format for extraction or inject
 
 By default, Baggage is automatically propagated through a distributed request using OpenTelemetry's [W3C-compatible headers][10]. To disable baggage, set [DD_TRACE_PROPAGATION_STYLE][12] to `datadog,tracecontext`.
 
-### Adding Baggage as Span Tags
-_Currently available in Python, PHP, and Node.js. For other languages, please reach out to [Support][11]_ 
+#### Adding baggage as span tags
+_Available in Python, PHP, and Node.js. For other languages, reach out to [Support][11]_ 
 
-By default, `user.id,session.id,account.id` baggage keys will be added as span tags. To customize this configuration see [Context Propagation Configuration][13]. Specificed baggage keys will be automatically added as span tags `baggage.<key>` (e.g. `bagagge.user.id`).
+By default, `user.id,session.id,account.id` baggage keys are added as span tags. To customize this configuration, see [Context Propagation Configuration][13]. Specified baggage keys are automatically added as span tags `baggage.<key>` (for example, `baggage.user.id`).
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds `DD_TRACE_BAGGAGE_TAG_KEYS` in configuration docs and APM trace context propagation docs. 
- Adds configuration for baggage limits including `DD_TRACE_BAGGAGE_MAX_ITEMS` and `DD_TRACE_BAGGAGE_MAX_BYTES`

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
