### PR TITLE
add in condition to fill in toc for custom processor page

### DIFF
--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -7,7 +7,23 @@
             {{ end }}
             <p class="text-uppercase text-gray-darkish font-semibold mb-2 toc-title js-toc-title {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">{{ i18n "table_of_contents_heading"}}</p>
             {{ if ne .Params.disable_toc true }}
-              {{ if eq .Page.Type "reference" }}
+              {{ if eq .Page.File.TranslationBaseName "custom_processor" }}
+              {{ $functions := $.Site.Data.reference.functions | default (dict) }}
+              <nav id="TableOfContents">
+                <ul>
+                  {{ range $category, $arrayOfFunctionObjs := $functions }}
+                    <li>
+                      <a href="#{{ $category | anchorize }}">{{ $category }} Functions</a>
+                      <ul>
+                      {{ range $obj := $arrayOfFunctionObjs }}
+                        <li><a href="#{{ $obj.name | anchorize }}">{{ $obj.name }}</a></li>
+                      {{ end }}
+                      </ul>
+                    </li>
+                  {{ end }}
+                </ul>
+              </nav>
+              {{ else if eq .Page.Type "reference" }}
                 {{ if eq .Page.File.TranslationBaseName "errors" }}
                     {{ $errors := $.Site.Data.reference.errors | default (dict) }}
                     <nav id="TableOfContents">
@@ -33,7 +49,7 @@
                         {{ end }}
                       </ul>
                     </nav>
-                {{ else }}
+            {{ else }}
                     {{ $t := (index .Site.Data.reference "schema.tables") }}
                     {{ $iterable_data := (index $t (.Title | lower)) }}
                     <nav id="TableOfContents">

--- a/layouts/partials/table-of-contents/table-of-contents.html
+++ b/layouts/partials/table-of-contents/table-of-contents.html
@@ -7,7 +7,7 @@
             {{ end }}
             <p class="text-uppercase text-gray-darkish font-semibold mb-2 toc-title js-toc-title {{ if .Params.disable_toc }} d-none {{ else }} {{ end }}">{{ i18n "table_of_contents_heading"}}</p>
             {{ if ne .Params.disable_toc true }}
-              {{ if eq .Page.File.TranslationBaseName "custom_processor" }}
+              {{ if eq .Page.Name "Custom Processor" }}
               {{ $functions := $.Site.Data.reference.functions | default (dict) }}
               <nav id="TableOfContents">
                 <ul>


### PR DESCRIPTION
[page with changes](https://docs-staging.datadoghq.com/jackie.robson/add-custom-processors-functions-toc/observability_pipelines/processors/custom_processor/)

[page with ToC for comparison (no changes)](https://docs-staging.datadoghq.com/jackie.robson/add-custom-processors-functions-toc/internal_developer_portal/software_catalog/entity_model/)

### What does this PR do? What is the motivation?
[Jira Ticket](https://datadoghq.atlassian.net/jira/software/projects/WEB/boards/102?jql=assignee%20%3D%20712020%3A206da1a2-8512-4e6b-8cb0-928de2146e7c&selectedIssue=WEB-6643)

Adding in TOC for observability pipelines customs processor page.


### Merge instructions


Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
