### PR TITLE
chore(fleet): Add HAProxy example for install.datadoghq.com

### DIFF
--- a/content/en/agent/faq/proxy_example_haproxy.md
+++ b/content/en/agent/faq/proxy_example_haproxy.md
@@ -201,7 +201,7 @@ frontend network_path_frontend
     option tcplog
     default_backend datadog-network-path
 
-# This declares the endpoint where your Agents connects to
+# This declares the endpoint where your Agents connect to
 # retrieve agent packages for Remote Agent Management.
 frontend install-forwarder
     bind *:3848
@@ -501,7 +501,7 @@ frontend network_path_frontend
     option tcplog
     default_backend datadog-network-path
 
-# This declares the endpoint where your Agents connects to
+# This declares the endpoint where your Agents connect to
 # retrieve agent packages for Remote Agent Management.
 frontend install-forwarder
     bind *:3848 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>

--- a/content/en/agent/faq/proxy_example_haproxy.md
+++ b/content/en/agent/faq/proxy_example_haproxy.md
@@ -15,7 +15,7 @@ private: true
 Datadog discourages forwarding traffic using software like HAProxy or NGINX because it requires you to manually configure and maintain the list of specific Datadog endpoints the Agent needs to reach. This list can change, leading to potential data loss if not kept up-to-date. The only exception is if you need Deep Packet Inspection (DPI) capabilities, in which case you might consider using HAProxy or NGINX as they allow you to disable TLS or use your own TLS certificates and inspect the traffic.
 </div>
 
-While [HAProxy][3] is usually used as a load balancer to distribute incoming requests to pool servers, it also offers proxying for TCP and HTTP applications, so you can use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity. 
+While [HAProxy][3] is usually used as a load balancer to distribute incoming requests to pool servers, it also offers proxying for TCP and HTTP applications, so you can use it to proxy Agent traffic to Datadog from hosts that have no outside connectivity.
 
 `agent ---> haproxy ---> Datadog`
 
@@ -201,6 +201,14 @@ frontend network_path_frontend
     option tcplog
     default_backend datadog-network-path
 
+# This declares the endpoint where your Agents connects to
+# retrieve agent packages for Remote Agent Management.
+frontend install-forwarder
+    bind *:3848
+    mode http
+    option tcplog
+    default_backend datadog-install
+
 # This is the Datadog server. In effect, any TCP request coming
 # to the forwarder frontends defined above are proxied to
 # Datadog's public endpoints.
@@ -321,6 +329,15 @@ backend datadog-network-path
     server-template mothership 5 netpath-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
     # server mothership netpath-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES>
+
+backend datadog-install
+    balance roundrobin
+    mode http
+    http-request set-header Host install.datadoghq.com
+    # The following configuration is for HAProxy 1.8 and newer
+    server-template mothership 5 install.datadoghq.com:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> sni str(install.datadoghq.com) check resolvers my-dns init-addr none resolve-prefer ipv4
+    # Uncomment the following configuration for older HAProxy versions
+    # server mothership install.datadoghq.com:443 check port 443 ssl verify required ca-file <PATH_TO_CERTIFICATES> sni install.datadoghq.com
 ```
 
 ##### HTTPS
@@ -484,6 +501,14 @@ frontend network_path_frontend
     option tcplog
     default_backend datadog-network-path
 
+# This declares the endpoint where your Agents connects to
+# retrieve agent packages for Remote Agent Management.
+frontend install-forwarder
+    bind *:3848 ssl crt <PATH_TO_PROXY_CERTIFICATE_PEM>
+    mode http
+    option tcplog
+    default_backend datadog-install
+
 # This is the Datadog server. In effect any TCP request coming
 # to the forwarder frontends defined above are proxied to
 # Datadog's public endpoints.
@@ -604,6 +629,15 @@ backend datadog-network-path
     server-template mothership 5 netpath-intake.{{< region-param key="dd_site" >}}:443  check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> check resolvers my-dns init-addr none resolve-prefer ipv4
     # Uncomment the following configuration for older HAProxy versions
     # server mothership netpath-intake.{{< region-param key="dd_site" >}}:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>
+
+backend datadog-install
+    balance roundrobin
+    mode http
+    http-request set-header Host install.datadoghq.com
+    # The following configuration is for HAProxy 1.8 and newer
+    server-template mothership 5 install.datadoghq.com:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> sni str(install.datadoghq.com) check resolvers my-dns init-addr none resolve-prefer ipv4
+    # Uncomment the following configuration for older HAProxy versions
+    # server mothership install.datadoghq.com:443 check port 443 ssl verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT> sni install.datadoghq.com
 ```
 
 **Note**: You can use `verify none` instead of `verify required ca-file <PATH_TO_DATADOG_CERTIFICATES_CRT>` if you are unable to get the certificates on the proxy host, but be aware that HAProxy will not be able to verify Datadog's intake certificate in that case.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR adds install.datadoghq.com to the HAProxy configuration example per customer request.
**Note:** The URL is _not_ datacenter-specific!

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
