### PR TITLE
Usage monitor are available in status page v2

### DIFF
--- a/content/en/monitors/status/status_page.md
+++ b/content/en/monitors/status/status_page.md
@@ -76,7 +76,6 @@ The following monitor types are not supported by the provisional status page:
 - Database Monitoring
 - Forecast
 - Outlier
-- Usage
 
 ## Further reading
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Usage monitors are now available in status page v2

### Merge instructions

Merge readiness:
- [x] Ready for merge
