### PR TITLE
Avoid object access error in tabs

### DIFF
--- a/assets/scripts/components/codetabs.js
+++ b/assets/scripts/components/codetabs.js
@@ -223,13 +223,11 @@ const initCodeTabs = () => {
                         scrollToAnchor(tabQueryParameter, window.location.hash);
                     }, 300);
                 }
-            } else {
+            } else if (firstTab) {
                 activateCodeTab(firstTab);
             }
-        } else {
-            if (codeTabsList.length > 0) {
-                activateCodeTab(firstTab);
-            }
+        } else if (firstTab) {
+            activateCodeTab(firstTab);
         }
     };
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

I'm seeing an occasional error in my Cdocs monitors that the tabs script is trying to access an object that doesn't exist ([example](https://dd-corpsite.datadoghq.com/error-tracking?query=-application.id%3A%28c0bd0f01-a704-40c6-a9ef-b130b5bf397e%20OR%20c23606e0-13b5-4fb7-a781-0f10c953a9e0%20OR%203991b4e1-7e40-42d3-aca1-d8d8e9b27ad0%20OR%203b790c5f-d5de-4638-9e78-6561c7974180%20OR%2032f6fed5-b978-4424-84d1-e9914d678fec%20OR%200b95923b-b06d-445b-893f-a861e93d6ea3%20OR%20e339848b-a1c6-45ee-aca8-54647534fe83%20OR%20ab2ea872-6da3-4783-910b-ad76ac76bdcf%20OR%200b5f6572-bf79-48f3-a2ec-38f2c227d5f7%29%20-service%3A%28security-labs%20OR%20corp%20OR%20datadog-training-lti-http-client%20OR%20opensource-hub%29%20%40view.url%3A%2Ahttps%5C%3A%2F%2Fdocs.datadoghq.com%2Freal_user_monitoring%2Fsession_replay%2Fmobile%2Fsetup_and_configuration%2A&et-viz=sample&refresh_mode=paused&source=all&sp=%5B%7B%22p%22%3A%7B%22issueId%22%3A%2298c656dc-406d-11f0-ba2a-da7ad0900002%22%7D%2C%22i%22%3A%22error-tracking-issue%22%7D%5D&from_ts=1749564480000&to_ts=1749650880000&live=false)).

In this update, I'm just making sure the object exists before trying to manipulate it, because we know that trying to manipulate `null` will definitely cause an error that breaks the page. 

This issue has been difficult to reproduce (I'm not able to reproduce it even if I follow the same steps the user did in the session replay), so it's hard to pin down the conditions that cause this error. It seems to happen when a Cdocs page technically has tabs, but is not actually displaying them, in which case it is fine to just skip processing (since the tabs will re-process anyway if Cdocs reveals them later).

There may still be a deeper underlying problem we can't see yet, but regardless, it's good practice to make sure the result of a DOM query object exists before trying to use it, so I'm starting there.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
