### PR TITLE
[ AGNTLOG-172 ] document the close_timeout setting for log rotations in the datadog agent

### DIFF
--- a/content/en/logs/guide/mechanisms-ensure-logs-not-lost.md
+++ b/content/en/logs/guide/mechanisms-ensure-logs-not-lost.md
@@ -20,7 +20,7 @@ further_reading:
 ## Log rotate
 
 When a file is rotated, the Agent keeps [tailing][1] the old file while starting to tail the newly created file in parallel.
-Although the Agent continues to tail the old file, it will prioritize using its resources to tail the most up-to-date files. 60 seconds after the rotation has been detected, the agent will close the rotated file and all remaining data will be lost. If this window is too short for your environment, it can be adjusted through the `logs_config.close_timeout` setting or the `DD_LOGS_CONFIG_CLOSE_TIMEOUT` env variable.
+Although the Agent continues to tail the old file, it prioritizes using its resources to tail the most up-to-date files. 60 seconds after the rotation has been detected, the agent closes the rotated file and all remaining data is lost. If this window is too short for your environment, it can be adjusted through the `logs_config.close_timeout` setting or the `DD_LOGS_CONFIG_CLOSE_TIMEOUT` env variable.
 
 ## Network issues
 

--- a/content/en/logs/guide/mechanisms-ensure-logs-not-lost.md
+++ b/content/en/logs/guide/mechanisms-ensure-logs-not-lost.md
@@ -20,7 +20,7 @@ further_reading:
 ## Log rotate
 
 When a file is rotated, the Agent keeps [tailing][1] the old file while starting to tail the newly created file in parallel.
-Although the Agent continues to tail the old file, it prioritizes using its resources to tail the most up-to-date files. 60 seconds after the rotation has been detected, the agent closes the rotated file and all remaining data is lost. If this window is too short for your environment, it can be adjusted through the `logs_config.close_timeout` setting or the `DD_LOGS_CONFIG_CLOSE_TIMEOUT` env variable.
+Although the Agent continues to tail the old file, it prioritizes using its resources to tail the most up-to-date files. 60 seconds after the rotation has been detected, the Agent closes the rotated file and all remaining data is lost. If this window is too short for your environment, it can be adjusted through the `logs_config.close_timeout` setting or the `DD_LOGS_CONFIG_CLOSE_TIMEOUT` environment variable.
 
 ## Network issues
 

--- a/content/en/logs/guide/mechanisms-ensure-logs-not-lost.md
+++ b/content/en/logs/guide/mechanisms-ensure-logs-not-lost.md
@@ -20,7 +20,7 @@ further_reading:
 ## Log rotate
 
 When a file is rotated, the Agent keeps [tailing][1] the old file while starting to tail the newly created file in parallel.
-Although the Agent continues to tail the old file, a 60-second timeout after the log rotation is set to ensure the agent is using its resources to tail the most up-to-date files.
+Although the Agent continues to tail the old file, it will prioritize using its resources to tail the most up-to-date files. 60 seconds after the rotation has been detected, the agent will close the rotated file and all remaining data will be lost. If this window is too short for your environment, it can be adjusted through the `logs_config.close_timeout` setting or the `DD_LOGS_CONFIG_CLOSE_TIMEOUT` env variable.
 
 ## Network issues
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Document the `logs_config.close_timeout` configuration setting
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
