### PR TITLE
Adds a preceding "-D" for java system property

### DIFF
--- a/content/en/database_monitoring/connect_dbm_and_apm.md
+++ b/content/en/database_monitoring/connect_dbm_and_apm.md
@@ -189,7 +189,7 @@ You must also enable the `jdbc-datasource` [instrumentation][2].
 
 Enable the database monitoring propagation feature using **one** of the following methods:
 
-- Set the system property `dd.dbm.propagation.mode=full`
+- Set the system property `-Ddd.dbm.propagation.mode=full`
 - Set the environment variable `DD_DBM_PROPAGATION_MODE=full`
 
 Full example:
@@ -219,7 +219,7 @@ public class Application {
 
 **Tracer versions 1.44 and above**:
 Enable the prepared statements tracing for Postgres using **one** of the following methods:
-- Set the system property `dd.dbm.trace_prepared_statements=true`
+- Set the system property `-Ddd.dbm.trace_prepared_statements=true`
 - Set the environment variable `export DD_DBM_TRACE_PREPARED_STATEMENTS=true`
 
 **Note**: The prepared statements instrumentation overwrites the `Application` property with the text `_DD_overwritten_by_tracer`, and causes an extra round trip to the database. This additional round trip normally has a negligible impact on the SQL statement execution time.


### PR DESCRIPTION
To set a java system property, each option must start with a hyphen (-), followed by a capital letter "D". Some customers are not aware of this requirement. Our documentation should be more explicit about how to add these options.

e.g. dd.dbm.propagation.mode=full  >> -Ddd.dbm.propagation.mode=full

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
