### PR TITLE
Include -- in cluster agent commands

### DIFF
--- a/content/en/containers/troubleshooting/cluster-agent.md
+++ b/content/en/containers/troubleshooting/cluster-agent.md
@@ -25,7 +25,7 @@ This document contains troubleshooting information for the following components:
 To execute the troubleshooting commands for the Cluster Agent, you first need to be inside the Cluster Agent or the node-based Agent pod. For this, use:
 
 ```text
-kubectl exec -it <DATADOG_CLUSTER_AGENT_POD_NAME> bash
+kubectl exec -it <DATADOG_CLUSTER_AGENT_POD_NAME> -- bash
 ```
 
 To see what cluster level metadata is served by the Datadog Cluster Agent, run:

--- a/content/en/containers/troubleshooting/cluster-and-endpoint-checks.md
+++ b/content/en/containers/troubleshooting/cluster-and-endpoint-checks.md
@@ -34,7 +34,7 @@ In this case, the leader Pod is `cluster-agent-rhttz`. If the Pod is deleted or 
 To ensure a configuration (static or Autodiscovered) is picked up by the Cluster Agent, use the `configcheck` command in the leader Cluster Agent:
 
 ```text
-# kubectl exec <CLUSTER_AGENT_POD_NAME> agent configcheck
+# kubectl exec <CLUSTER_AGENT_POD_NAME> -- agent configcheck
 ...
 === http_check cluster check ===
 Source: kubernetes-services
@@ -61,7 +61,7 @@ The `clusterchecks` command allows you to inspect the state of the dispatching l
 - Which checks are dispatched on each node.
 
 ```text
-# kubectl exec <CLUSTER_AGENT_POD_NAME> agent clusterchecks
+# kubectl exec <CLUSTER_AGENT_POD_NAME> -- agent clusterchecks
 
 === 3 node-agents reporting ===
 Name                                            Running checks
@@ -98,7 +98,7 @@ In this case, this configuration is dispatched to the `default-pool-bce5cd34-ttw
 The Agent `configcheck` command should show the instance, with the `cluster-checks` source:
 
 ```text
-# kubectl exec <NODE_AGENT_POD_NAME> agent configcheck
+# kubectl exec <NODE_AGENT_POD_NAME> -- agent configcheck
 ...
 === http_check check ===
 Source: cluster-checks
@@ -124,7 +124,7 @@ The Instance ID matches the one you had earlier.
 The Agent `status` command should show the check instance running and reporting successfully.
 
 ```text
-# kubectl exec <NODE_AGENT_POD_NAME> agent status
+# kubectl exec <NODE_AGENT_POD_NAME> -- agent status
 ...
     http_check (3.1.1)
     ------------------
@@ -147,7 +147,7 @@ Troubleshooting endpoint checks is similar to [troubleshooting cluster checks](#
 The Agent `configcheck` command shows the instance, with the `endpoints-checks` source:
 
 ```shell
-# kubectl exec <NODE_AGENT_POD_NAME> agent configcheck
+# kubectl exec <NODE_AGENT_POD_NAME> -- agent configcheck
 ...
 === nginx check ===
 Configuration provider: endpoints-checks
@@ -176,7 +176,7 @@ State: dispatched to gke-cluster-default-pool-4658d5d4-qfnt
 The Agent `status` command should show the check instance running and reporting successfully.
 
 ```shell
-# kubectl exec <NODE_AGENT_POD_NAME> agent status
+# kubectl exec <NODE_AGENT_POD_NAME> -- agent status
 ...
     nginx (4.0.0)
     -------------
@@ -194,7 +194,7 @@ The Agent `status` command should show the check instance running and reporting 
 The Cluster Agent `clusterchecks` command shows the instance(s), with the `kubernetes-endpoints` source:
 
 ```shell
-# kubectl exec <CLUSTER_AGENT_POD_NAME> agent clusterchecks
+# kubectl exec <CLUSTER_AGENT_POD_NAME> -- agent clusterchecks
 ...
 ===== 3 Pod-backed Endpoints-Checks scheduled =====
 


### PR DESCRIPTION
The commands in the following docs did not include `--`:
https://docs.datadoghq.com/containers/troubleshooting/cluster-agent
https://docs.datadoghq.com/containers/troubleshooting/cluster-and-endpoint-checks/#dispatching-logic-in-the-cluster-agent

`kubectl exec -it` commands without the double dashes is deprecated and users will either run into a deprecated notice when running these commands or are blocked completely in newer Kubernetes versions with the following message:
```
error: exec [POD] [COMMAND] is not supported anymore. Use exec [POD] -- [COMMAND] instead
See 'kubectl exec -h' for help and examples
```