### PR TITLE
removing alias bug from Cloud Run page

### DIFF
--- a/content/en/security/application_security/setup/gcp/cloud-run/_index.md
+++ b/content/en/security/application_security/setup/gcp/cloud-run/_index.md
@@ -1,8 +1,6 @@
 ---
 title: Setup App and API Protection on Google Cloud Run functions
 disable_sidebar: true
-aliases:
-  - /security/application_security/
 further_reading:
 - link: "/security/application_security/"
   tag: "Documentation"


### PR DESCRIPTION
A recent reorg of the docs in a diff PR added a redirect for the main landing page > the Cloud Run page.

This PR removes that alias.

### Merge instructions

Merge readiness:
- [X] Ready for merge
