### PR TITLE
Autodiscovery filtering doc updates [CONTP-828]

### DIFF
--- a/content/en/containers/guide/container-discovery-management.md
+++ b/content/en/containers/guide/container-discovery-management.md
@@ -112,7 +112,7 @@ DD_CONTAINER_EXCLUDE = "image:.*"
 DD_CONTAINER_INCLUDE = "image:^docker.io/library/ubuntu(@sha256)?:.* image:^docker.io/library/debian(@sha256)?:.*"
 ```
 
-The only exception to this rule is pod exclusion annotations like `ad.datadoghq.com/exclude`. When an application has an exclusion annotation set to `true`, this takes precedence, and the container is excluded from being autodiscovered for monitoring. For example, having a condition that includes every container like `DD_CONTAINER_INCLUDE = "image:.*"` does not guarantee a container is included if it has an exclusion annotation set on it. See [Pod exclude configuration](3) for more information.
+The only exception to this rule is pod exclusion annotations like `ad.datadoghq.com/exclude`. When an application has an exclusion annotation set to `true`, this takes precedence, and the container is excluded from being autodiscovered for monitoring. For example, having a condition that includes every container like `DD_CONTAINER_INCLUDE = "image:.*"` does not guarantee a container is included if it has an exclusion annotation set on it. See [Container Discovery Management - Pod exclude configuration](#pod-exclude-configuration) for more information.
 
 You cannot mix cross-category inclusion/exclusion rules. For instance, if you want to include a container with the image name `foo` and exclude only metrics from a container with the image name `bar`, the following is **not sufficient**:
 
@@ -315,4 +315,3 @@ metadata:
 
 [1]: /containers/kubernetes/log/?tab=helm#log-collection
 [2]: /getting_started/containers/autodiscovery
-[3]: /containers/guide/container-discovery-management/?tab=datadogoperator#pod-exclude-configuration

--- a/content/en/containers/guide/container-discovery-management.md
+++ b/content/en/containers/guide/container-discovery-management.md
@@ -112,7 +112,7 @@ DD_CONTAINER_EXCLUDE = "image:.*"
 DD_CONTAINER_INCLUDE = "image:^docker.io/library/ubuntu(@sha256)?:.* image:^docker.io/library/debian(@sha256)?:.*"
 ```
 
-The only exception to this rule is pod exclusion annotations like `ad.datadoghq.com/exclude`. Whenever an application has an exclusion annotation set to `true` this will take precedence and exclude the container from being autodiscovered for monitoring. For example, having a condition that would include every container like `DD_CONTAINER_INCLUDE = "image:.*"` does not gaurantee a container will be included if it has an exclusion annotation set on it. See [Pod exclude configuration](3) for more information.
+The only exception to this rule is pod exclusion annotations like `ad.datadoghq.com/exclude`. When an application has an exclusion annotation set to `true`, this takes precedence, and the container is excluded from being autodiscovered for monitoring. For example, having a condition that includes every container like `DD_CONTAINER_INCLUDE = "image:.*"` does not guarantee a container is included if it has an exclusion annotation set on it. See [Pod exclude configuration](3) for more information.
 
 You cannot mix cross-category inclusion/exclusion rules. For instance, if you want to include a container with the image name `foo` and exclude only metrics from a container with the image name `bar`, the following is **not sufficient**:
 
@@ -257,7 +257,7 @@ In **Agent v7.45+** you can set annotations on your Kubernetes pods to control A
 
 The `ad.datadoghq.com/exclude` annotation set on the application pod takes the highest priority. This means that even if a container matches inclusion through `DD_CONTAINER_INCLUDE`, the Agent will still ignore monitoring for that container. The same applies for the respective filtering configurations specific for metrics and logs.
 
-When applying annotation-based exclusions, the Agent checks for all relevant exclusion annotations on the container. For example, when configuring logs for an nginx container, the Agent will look for `ad.datadoghq.com/exclude`, `ad.datadoghq.com/logs_exclude`, `ad.datadoghq.com/nginx.exclude`, or `ad.datadoghq.com/nginx.logs_exclude` annotations to be `true` on the pod. The same applies for metrics.
+When applying annotation-based exclusions, the Agent checks for all relevant exclusion annotations on the container. For example, when configuring logs for an NGINX container, the Agent will look for `ad.datadoghq.com/exclude`, `ad.datadoghq.com/logs_exclude`, `ad.datadoghq.com/nginx.exclude`, or `ad.datadoghq.com/nginx.logs_exclude` annotations to be `true` on the pod. The same applies for metrics.
 
 #### Exclude the entire pod:
 ```yaml

--- a/content/en/containers/guide/container-discovery-management.md
+++ b/content/en/containers/guide/container-discovery-management.md
@@ -255,7 +255,7 @@ In **Agent v7.45+** you can set annotations on your Kubernetes pods to control A
 | `ad.datadoghq.com/<CONTAINER_NAME>.logs_exclude`    | Excludes log collection from the container with `<CONTAINER_NAME>` in the pod    |
 | `ad.datadoghq.com/<CONTAINER_NAME>.metrics_exclude` | Excludes metric collection from the container with `<CONTAINER_NAME>` in the pod |
 
-The `ad.datadoghq.com/exclude` annotation set on the application pod takes the highest priority. This means that even if a container matches inclusion through `DD_CONTAINER_INCLUDE`, the Agent will still ignore monitoring for that container. The same applies for the respective filtering configurations specific for metrics and logs.
+The `ad.datadoghq.com/exclude` annotation set on the application pod takes the highest priority. This means that even if a container matches inclusion through `DD_CONTAINER_INCLUDE`, the Agent still ignores monitoring for that container. The same applies for the respective filtering configurations specific for metrics and logs.
 
 When applying annotation-based exclusions, the Agent checks for all relevant exclusion annotations on the container. For example, when configuring logs for an NGINX container, the Agent will look for `ad.datadoghq.com/exclude`, `ad.datadoghq.com/logs_exclude`, `ad.datadoghq.com/nginx.exclude`, or `ad.datadoghq.com/nginx.logs_exclude` annotations to be `true` on the pod. The same applies for metrics.
 

--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -156,9 +156,11 @@ The Datadog Agent in Kubernetes is deployed by a DaemonSet (managed by the Datad
 
 When "Container Collect All" is enabled you can configure which containers you want to collect logs from. This can be useful to prevent the collection of the Datadog Agent logs, if desired. You can do this by passing configurations to the Datadog Agent to control what it pulls, or by passing configurations to the Kubernetes Pod to exclude certain logs more explicitly.
 
-When "Container Collect All" is disabled (default) this is not necessary as you enable log configurations by Autodiscovery annotations or config files.
+When filtering out logs through methods like `DD_CONTAINER_EXCLUDE_LOGS` or `ad.datadoghq.com/logs_exclude`, the Agent will ignore log collection regardless of explicitly defined log collection configurations in [Autodiscovery annotations](19) or [Autodiscovery configuration files](20).
 
-See [Container Discovery Management][8] to learn more.
+When "Container Collect All" is disabled (default) you don't need to add any filtering since all will be excluded by default. To include collection for only selected pods, you can enable the log configuration by [Autodiscovery annotations](19) or [Autodiscovery configuration files](20) for the desired pods.
+
+See [Container Discovery Management][8] to learn more about filtering.
 
 ### Tagging
 
@@ -541,3 +543,5 @@ datadog:
 [16]: https://app.datadoghq.com/logs/pipelines/pipeline/library
 [17]: /containers/guide/template_variables/
 [18]: https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/
+[19]: /containers/kubernetes/log/?tab=helm#autodiscovery-annotations
+[20]: /containers/kubernetes/log/?tab=helm#autodiscovery-configuration-files

--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -156,9 +156,9 @@ The Datadog Agent in Kubernetes is deployed by a DaemonSet (managed by the Datad
 
 When "Container Collect All" is enabled you can configure which containers you want to collect logs from. This can be useful to prevent the collection of the Datadog Agent logs, if desired. You can do this by passing configurations to the Datadog Agent to control what it pulls, or by passing configurations to the Kubernetes Pod to exclude certain logs more explicitly.
 
-When filtering out logs through methods like `DD_CONTAINER_EXCLUDE_LOGS` or `ad.datadoghq.com/logs_exclude`, the Agent will ignore log collection regardless of explicitly defined log collection configurations in [Autodiscovery annotations](19) or [Autodiscovery configuration files](20).
+When filtering out logs through methods like `DD_CONTAINER_EXCLUDE_LOGS` or `ad.datadoghq.com/logs_exclude`, the Agent ignores log collection regardless of explicitly defined log collection configurations in [Autodiscovery annotations](19) or [Autodiscovery configuration files](20).
 
-When "Container Collect All" is disabled (default) you don't need to add any filtering since all will be excluded by default. To include collection for only selected pods, you can enable the log configuration by [Autodiscovery annotations](19) or [Autodiscovery configuration files](20) for the desired pods.
+When "Container Collect All" is disabled (default) you don't need to add any filtering because everything is excluded by default. To include collection for only selected pods, you can enable the log configuration by [Autodiscovery annotations](19) or [Autodiscovery configuration files](20) for the desired pods.
 
 See [Container Discovery Management][8] to learn more about filtering.
 

--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -156,9 +156,9 @@ The Datadog Agent in Kubernetes is deployed by a DaemonSet (managed by the Datad
 
 When "Container Collect All" is enabled you can configure which containers you want to collect logs from. This can be useful to prevent the collection of the Datadog Agent logs, if desired. You can do this by passing configurations to the Datadog Agent to control what it pulls, or by passing configurations to the Kubernetes Pod to exclude certain logs more explicitly.
 
-When filtering out logs through methods like `DD_CONTAINER_EXCLUDE_LOGS` or `ad.datadoghq.com/logs_exclude`, the Agent ignores log collection regardless of explicitly defined log collection configurations in [Autodiscovery annotations](19) or [Autodiscovery configuration files](20).
+When filtering out logs through methods like `DD_CONTAINER_EXCLUDE_LOGS` or `ad.datadoghq.com/logs_exclude`, the Agent ignores log collection regardless of explicitly defined log collection configurations in [Autodiscovery annotations][19] or [Autodiscovery configuration files][20].
 
-When "Container Collect All" is disabled (default) you don't need to add any filtering because everything is excluded by default. To include collection for only selected pods, you can enable the log configuration by [Autodiscovery annotations](19) or [Autodiscovery configuration files](20) for the desired pods.
+When "Container Collect All" is disabled (default) you don't need to add any filtering because everything is excluded by default. To include collection for only selected pods, you can enable the log configuration by [Autodiscovery annotations][19] or [Autodiscovery configuration files][20] for the desired pods.
 
 See [Container Discovery Management][8] to learn more about filtering.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

1. Provides more context on autodiscovery log filtering 
2. Explains relation between Agent config filtering and pod annotation filtering

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
