### PR TITLE
Bump lambda-datadog Terraform Module version to 3.1.0 and Lambda Layers to latest supported versions

### DIFF
--- a/content/en/serverless/aws_lambda/installation/dotnet.md
+++ b/content/en/serverless/aws_lambda/installation/dotnet.md
@@ -206,7 +206,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.1.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -216,8 +216,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_dotnet_layer_version = 16
+  datadog_extension_layer_version = 81
+  datadog_dotnet_layer_version = 20
 
   # aws_lambda_function arguments
 }
@@ -242,8 +242,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog .NET Lambda layer to use. Defaults to the latest layer versions.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_dotnet_layer_version = 16
+  datadog_extension_layer_version = 81
+  datadog_dotnet_layer_version = 20
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/go.md
+++ b/content/en/serverless/aws_lambda/installation/go.md
@@ -82,6 +82,60 @@ For more information and additional settings, see the [plugin documentation][1].
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [3]: /serverless/configuration/
 {{% /tab %}}
+{{% tab "Terraform" %}}
+
+The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] resource and automatically configures your Lambda function for Datadog Serverless Monitoring by:
+
+- Adding the Datadog Lambda layers
+- Redirecting the Lambda handler
+- Enabling the collection and sending of metrics, traces, and logs to Datadog
+
+```tf
+module "lambda-datadog" {
+  source  = "DataDog/lambda-datadog/aws"
+  version = "3.1.0"
+
+  environment_variables = {
+    "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
+    "DD_ENV" : "<ENVIRONMENT>"
+    "DD_SERVICE" : "<SERVICE_NAME>"
+    "DD_SITE": "<DATADOG_SITE>"
+    "DD_VERSION" : "<VERSION>"
+  }
+
+  datadog_extension_layer_version = 81
+
+  # aws_lambda_function arguments
+}
+```
+
+1. Replace the `aws_lambda_function` resource with the `lambda-datadog` Terraform module. Then, specify the `source` and `version` of the module.
+
+2. Set the `aws_lambda_function` arguments:
+
+   All of the arguments available in the `aws_lambda_function` resource are available in this Terraform module. Arguments defined as blocks in the `aws_lambda_function` resource are redefined as variables with their nested arguments.
+
+   For example, in `aws_lambda_function`, `environment` is defined as a block with a `variables` argument. In the `lambda-datadog` Terraform module, the value for the `environment_variables` is passed to the `environment.variables` argument in `aws_lambda_function`. See [inputs][3] for a complete list of variables in this module.
+
+3. Fill in the environment variable placeholders:
+
+   - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+   - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+   - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+   - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][4] is selected on this page).
+   - Replace `<VERSION>` with the version number of the Lambda function
+
+4. Select the version of the Datadog Extension Lambda layer to use. If left blank the latest layer version will be used.
+
+```
+  datadog_extension_layer_version = 81
+```
+
+[1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest
+[2]: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function
+[3]: https://github.com/DataDog/terraform-aws-lambda-datadog?tab=readme-ov-file#inputs
+[4]: /getting_started/site/
+{{% /tab %}}
 {{% tab "Custom" %}}
 ### Install the Datadog Lambda Extension
 

--- a/content/en/serverless/aws_lambda/installation/java.md
+++ b/content/en/serverless/aws_lambda/installation/java.md
@@ -279,7 +279,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.1.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -289,8 +289,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_java_layer_version = 15
+  datadog_extension_layer_version = 81
+  datadog_java_layer_version = 21
 
   # aws_lambda_function arguments
 }
@@ -315,8 +315,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Java Lambda layer to use. If left blank the latest layer versions will be used.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_java_layer_version = 15
+  datadog_extension_layer_version = 81
+  datadog_java_layer_version = 21
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -277,7 +277,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.1.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -287,8 +287,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_node_layer_version = 117
+  datadog_extension_layer_version = 81
+  datadog_node_layer_version = 125
 
   # aws_lambda_function arguments
 }
@@ -313,8 +313,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Node.js Lambda layer to use. Defaults to the latest layer versions.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_node_layer_version = 117
+  datadog_extension_layer_version = 81
+  datadog_node_layer_version = 125
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -264,7 +264,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.1.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -274,8 +274,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_python_layer_version = 104
+  datadog_extension_layer_version = 81
+  datadog_python_layer_version = 110
 
   # aws_lambda_function arguments
 }
@@ -300,8 +300,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Python Lambda layer to use. If left blank the latest layer versions will be used.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_python_layer_version = 104
+  datadog_extension_layer_version = 81
+  datadog_python_layer_version = 110
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Updates the Datadog Lambda Layers to the latest supported versions for Terraform. Also bumps the lambda-datadog Terraform module version to 3.1.0, which supports Go lambda function deployment in Terraform.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->
https://github.com/DataDog/terraform-aws-lambda-datadog

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
