### PR TITLE
docs deploy use one group

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -44,7 +44,7 @@ markup:
     guessSyntax: true
 
 module:
-  imports:  
+  imports:
    - path: github.com/DataDog/websites-modules
      disabled: false
      mounts:
@@ -150,6 +150,39 @@ security:
     osEnv:
       # as suggested here https://github.com/gohugoio/hugo/issues/9333#issuecomment-1022435616
       - (?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM|HOME|SSH_AUTH_SOCK|USERPROFILE|XDG_CONFIG_HOME)$
+
+deployment:
+    order:
+      - "^.+\\.(woff2|woff|ttf|css|js|jpg|jpeg|png|avif|gif|mp4|vtt)$"
+    matchers:
+      # temporarily lets nocache this sh file
+      - pattern: "^resources/sh/rpm_check.sh$"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+      # dont cache rum/logs config
+      - pattern: "^static/dd-browser-logs-rum.js$"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+        gzip: true
+      - pattern: "^.+\\.(js|css|svg)$"
+        cacheControl: "max-age=31536000, no-transform, public"
+        gzip: true
+      - pattern: "^.+\\.(eot|ttf|woff|woff2|ico)$"
+        cacheControl: "max-age=31536000, no-transform, public"
+        gzip: false
+      - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
+        cacheControl: "max-age=31536000, no-transform, public"
+        gzip: false
+      - pattern: "^.+\\.html$"
+        gzip: true
+        contentType: "text/html; charset=utf-8"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+      - pattern: "^.+\\.xml$"
+        gzip: true
+        contentType: "text/xml; charset=utf-8"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
+      - pattern: "^.+\\.json$"
+        gzip: true
+        contentType: "application/json; charset=utf-8"
+        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
 
 outputFormats:
   Search:

--- a/config/live/config.yaml
+++ b/config/live/config.yaml
@@ -4,8 +4,6 @@ builddrafts: false
 enableGitInfo: true
 
 deployment:
-    order:
-      - "^.+\\.(woff2|woff|css|js|jpg|png|gif|mp4)$"
 
     targets:
     - name: "live"
@@ -15,33 +13,3 @@ deployment:
     - name: "liveAssets"
       URL: "s3://origin-static-assets?region=us-east-1&prefix=documentation/"
       include: "**.{jpg,jpeg,png,gif,mp4,svg,json}"
-
-    matchers:
-      # temporarily lets nocache this sh file
-      - pattern: "^resources/sh/rpm_check.sh$"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      # dont cache rum/logs config
-      - pattern: "^static/dd-browser-logs-rum.js$"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-        gzip: true
-      - pattern: "^.+\\.(js|css|svg)$"
-        cacheControl: "max-age=31536000, no-transform, public"
-        gzip: true
-      - pattern: "^.+\\.(eot|ttf|woff|woff2|ico)$"
-        cacheControl: "max-age=31536000, no-transform, public"
-        gzip: false
-      - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
-        cacheControl: "max-age=31536000, no-transform, public"
-        gzip: false
-      - pattern: "^.+\\.html$"
-        gzip: true
-        contentType: "text/html; charset=utf-8"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      - pattern: "^.+\\.xml$"
-        gzip: true
-        contentType: "text/xml; charset=utf-8"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      - pattern: "^.+\\.json$"
-        gzip: true
-        contentType: "application/json; charset=utf-8"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"

--- a/config/preview/config.yaml
+++ b/config/preview/config.yaml
@@ -4,8 +4,6 @@ builddrafts: true
 enableGitInfo: true
 
 deployment:
-    order:
-      - "^.+\\.(woff2|woff|css|js|jpg|png|gif|mp4)$"
 
     targets:
     - name: "preview"
@@ -15,33 +13,3 @@ deployment:
     - name: "previewAssets"
       URL: "s3://dd-staging-static-assets?region=us-east-1&prefix=documentation/"
       include: "**.{jpg,jpeg,png,gif,mp4,mov,svg,json}"
-
-    matchers:
-      # temporarily lets nocache this sh file
-      - pattern: "^resources/sh/rpm_check.sh$"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      # dont cache rum/logs config
-      - pattern: "^static/dd-browser-logs-rum.js$"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-        gzip: true
-      - pattern: "^.+\\.(js|css|svg)$"
-        cacheControl: "max-age=31536000, no-transform, public"
-        gzip: true
-      - pattern: "^.+\\.(eot|ttf|woff|woff2|ico)$"
-        cacheControl: "max-age=31536000, no-transform, public"
-        gzip: false
-      - pattern: "^.+\\.(png|jpg|jpeg|gif|mp4|zip|pdf|txt|csv)$"
-        cacheControl: "max-age=31536000, no-transform, public"
-        gzip: false
-      - pattern: "^.+\\.html$"
-        gzip: true
-        contentType: "text/html; charset=utf-8"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      - pattern: "^.+\\.xml$"
-        gzip: true
-        contentType: "text/xml; charset=utf-8"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"
-      - pattern: "^.+\\.json$"
-        gzip: true
-        contentType: "application/json; charset=utf-8"
-        cacheControl: "public, must-revalidate, proxy-revalidate, max-age=0"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Hugo deployment order creates a group for each item and uploads everything in that group before moving onto the next group.
 
This PR:

-  condenses our definitions into one group instead of 7. This gives us 2 final groups our definition and everything else and should deploy a tiny bit faster.
- moves the matches and order to default config so we don't have to define it twice, it should be the same regardless or environment

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
