### PR TITLE
tracing: update istio env variable configuration

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/istio.md
+++ b/content/en/tracing/trace_collection/proxy_setup/istio.md
@@ -104,27 +104,12 @@ value is a JSON array of objects.
 
 -->
 
-## Environment variables
-
-Environment variables for Istio sidecars can be set on a per-deployment basis using the `apm.datadoghq.com/env` annotation. This is unique for deployments employing Istio sidecars and is set in addition to the [labels for unified service tagging][10].
-```yaml
-apiVersion: apps/v1
-...
-kind: Deployment
-...
-spec:
-  template:
-    metadata:
-      annotations:
-        apm.datadoghq.com/env: '{ "DD_ENV": "prod", "DD_SERVICE": "my-service", "DD_VERSION": "v1.1"}'
-```
-
 ## Deployment and service
 
 If the Agents on your cluster are running as a deployment and service instead of the default DaemonSet, then an additional option is required to specify the DNS address and port of the Agent.
 For a service named `datadog-agent` in the `default` namespace, that address would be `datadog-agent.default.svc.cluster.local:8126`.
 
-- `--set values.global.tracer.datadog.address=datadog-agent.default:8126`
+- `--set values.global.tracer.datadog.address=datadog-agent.default.svc.cluster.local:8126`
 
 If Mutual TLS is enabled for the cluster, then the Agent's deployment should disable sidecar injection, and you should add a traffic policy that disables TLS.
 
@@ -153,6 +138,25 @@ spec:
 Automatic Protocol Selection may determine that traffic between the sidecar and Agent is HTTP, and enable tracing.
 This can be disabled using [manual protocol selection][12] for this specific service. The port name in the `datadog-agent` Service can be changed to `tcp-traceport`.
 If using Kubernetes 1.18+, `appProtocol: tcp` can be added to the port specification.
+
+## Environment variables
+
+Environment variables for Istio sidecars can be set on a per-deployment basis using the `proxy.istio.io/config` annotation. This is unique for deployments employing Istio sidecars.
+```yaml
+apiVersion: apps/v1
+...
+kind: Deployment
+...
+spec:
+  template:
+    metadata:
+      annotations:
+        proxy.istio.io/config: |
+          proxyMetadata:
+            "DD_ENV": "prod"
+            "DD_SERVICE": "my-service"
+            "DD_VERSION": "v1.1"
+```
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR updates Istio's instruction to configure environment variables. The `apm.datadoghq.com/env` annotation is not working with Istio's sidecar injection, instead, we recommend setting env variables via `istio.proxy.io/config` annotation.
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


### Additional notes
I move the deployment section before the env var configuration because I do think it's more important.