### PR TITLE
Correct Operator configuration for unprivileged installation

### DIFF
--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -169,12 +169,12 @@ spec:
       apiSecret:
         secretName: datadog-secret
         keyName: api-key
-agent:
-  config:
-    securityContext:
-      runAsUser: <USER_ID>
-      supplementalGroups:
-        - <GROUP_ID>
+  override:
+    nodeAgent:
+      securityContext:
+        runAsUser: <USER_ID>
+        supplementalGroups:
+          - <GROUP_ID>
 {{< /highlight >}}
 
 - Replace `<USER_ID>` with the UID to run the Datadog Agent. Datadog recommends [setting this value to 100 since Datadog Agent v7.48+][1].


### PR DESCRIPTION
I believe this is using the old v1alpha1 configurations and need to be adjusted to correspond to these configurations in v2alpha1: https://github.com/DataDog/datadog-operator/blob/main/docs/configuration.v2alpha1.md#:~:text=SecurityContext%20takes%20precedence.-,%5Bkey%5D.securityContext.runAsUser,-The%20UID%20to