### PR TITLE
[container autoscaling] Update autoscaling docs to use agent `v7.67.0`

### DIFF
--- a/content/en/containers/monitoring/autoscaling.md
+++ b/content/en/containers/monitoring/autoscaling.md
@@ -70,13 +70,13 @@ spec:
   override:
     clusterAgent:
       image:
-        tag: 7.66.1
+        tag: 7.67.0
       env:
         - name: DD_AUTOSCALING_FAILOVER_ENABLED
           value: "true"
     nodeAgent:
       image:
-        tag: 7.66.1 # or 7.66.1-jmx
+        tag: 7.67.0 # or 7.67.0-jmx
       env:
         - name: DD_AUTOSCALING_FAILOVER_ENABLED
           value: "true"
@@ -84,7 +84,7 @@ spec:
           value: container.memory.usage container.cpu.usage
     clusterChecksRunner:
       image:
-        tag: 7.66.1 # or 7.66.1-jmx
+        tag: 7.67.0 # or 7.67.0-jmx
 ```
 
 3. [Admission Controller][1] is enabled by default with the Datadog Operator. If you disabled it, re-enable it by adding the following highlighted lines to `datadog-agent.yaml`:
@@ -109,7 +109,7 @@ kubectl apply -n $DD_NAMESPACE -f datadog-agent.yaml
 {{% /tab %}}
 {{% tab "Helm" %}}
 
-1. Ensure you are using Agent and Cluster Agent v7.66.1+. Add the following to your `datadog-values.yaml` configuration file:
+1. Ensure you are using Agent and Cluster Agent v7.67.0+. Add the following to your `datadog-values.yaml` configuration file:
 
 ```yaml
 datadog:
@@ -125,7 +125,7 @@ datadog:
 ...
 clusterAgent:
   image:
-    tag: 7.66.1
+    tag: 7.67.0
   admissionController:
     enabled: true
 ...
@@ -202,7 +202,7 @@ When you are ready to proceed with enabling Autoscaling for a workload, you have
    
    Use your existing deploy process to target and configure Autoscaling for your workload. 
 
-   {{% collapse-content title="Example DatadogPodAutoscaler CRD" level="h4" expanded=false id="id-for-anchoring" %}}
+   {{% collapse-content title="Example DatadogPodAutoscaler CR" level="h4" expanded=false id="id-for-anchoring" %}}
    ```yaml
    apiVersion: datadoghq.com/v1alpha2
    kind: DatadogPodAutoscaler


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Update the recommended agent version to be used for autoscaling to `7.67.0`. `7.67.0` was just released and contains some features that would be useful for customers using autoscaling.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
