### PR TITLE
Add App Builder identity information

### DIFF
--- a/content/en/actions/app_builder/auth.md
+++ b/content/en/actions/app_builder/auth.md
@@ -19,7 +19,7 @@ Actions can be authenticated in the following ways:
 - Credentials and permissions configured in the integration tile
 - Connection credentials
 
-By default, viewers of a published app do not need access to the app’s connections. Instead, actions use the identity of the app’s author. This simplifies sharing and improves security by preventing apps from performing sensitive operations using the identity of arbitrary viewers.
+By default, viewers of a published app do not need access to the app's connections. Instead, actions use the identity of the app's author. This simplifies sharing and improves security by preventing apps from performing sensitive operations using the identity of arbitrary viewers.
 For more information on configuring credentials, see [Connections][2]. App Builder shares the Action Catalog and the connection credentials for each integration with [Datadog Workflow Automation][3].
 
 ## App permissions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Apps currently “run as” end users during execution. This introduces a number of confusing authorization scenarios that we would like to solve by running apps as the author of the app.

Apps currently “run as” the viewing user, which means a malicious app creator can trick a large number of unsuspecting users into performing actions by putting a malicious app into a widely viewed dashboard. Additionally, even in the non-malicious case, each viewing user needs “resolve” permissions on the connections used in the app. This means that broad access sensitive information needs to be granted in order for an app to be useful.

To make this better we would like to switch App Builder actions from executing as the current authenticated user to the app creator. This conforms with Workflow Automation’s permission model. This will only apply in the app's published mode. Edit mode will continue to run as the editor.

Modeled after workflows docs: [Access and Authentication](https://docs.datadoghq.com/actions/workflows/access/)
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
