### PR TITLE
[React Native] Added docs for v2.9.0

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/expo.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/expo.md
@@ -69,6 +69,26 @@ Run `eas secret:create` to set `DATADOG_SITE` to the host of your Datadog site, 
 
 ## Get deobfuscated stack traces
 
+### Use Datadog Expo Configuration
+
+Starting from `@datadog/mobile-react-native@2.9.0` and `@datadog/datadog-ci@v3.10.0`, the SDK exports a Datadog Metro Plugin, which attaches a unique Debug ID to your application bundle and sourcemap.
+
+Add it to your `metro.config.js` to allow for accurate symbolication of stacktraces on Datadog:
+
+```js
+// const { getDefaultConfig } = require("expo/metro-config");
+const { getDatadogExpoConfig } = require("@datadog/mobile-react-native/metro");
+// const config = getDefaultConfig(__dirname);
+const config = getDatadogExpoConfig(__dirname);
+module.exports = config;
+```
+
+### Use the `datadog-ci react-native inject-debug-id` command
+
+As an alternative to the Expo Configuration, starting from `@datadog/mobile-react-native@2.9.0` and `@datadog/datadog-ci@v3.10.0`, you can use the `datadog-ci react-native inject-debug-id` command to manually attach a unique Debug ID to your application bundle and sourcemap.
+
+Usage instructions are available on the [command documentation page][5].
+
 ### Add git repository data to your mapping files on Expo Application Services (EAS)
 
 If you are using EAS to build your Expo application, set `cli.requireCommit` to `true` in your `eas.json` file to add git repository data to your mapping files.
@@ -177,3 +197,4 @@ If you are using the `expo-dev-client` and already have the `expo-datadog` plugi
 [2]: https://github.com/DataDog/expo-datadog
 [3]: /real_user_monitoring/mobile_and_tv_monitoring/react_native/setup/expo/#usage
 [4]: https://app.datadoghq.com/source-code/setup/rum
+[5]: https://github.com/DataDog/datadog-ci/blob/master/src/commands/react-native/README.md#inject-debug-id

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -68,6 +68,28 @@ To set your project up to send the symbolication files automatically, run `npx d
 
 See the wizard [official documentation][13] for options.
 
+### Use Datadog Metro Configuration
+
+Starting from `@datadog/mobile-react-native@2.9.0` and `@datadog/datadog-ci@v3.10.0`, the SDK exports a Datadog Metro Plugin, which attaches a unique Debug ID to your application bundle and sourcemap.
+
+Add it to your `metro.config.js` to allow for accurate symbolication of stacktraces on Datadog:
+
+```js
+const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+const {withDatadogMetroConfig} = require('@datadog/mobile-react-native/metro');
+
+// Your configuration
+const config = mergeConfig(getDefaultConfig(__dirname), {});
+
+module.exports = withDatadogMetroConfig(config);
+```
+
+### Use the `datadog-ci react-native inject-debug-id` command
+
+As an alternative to the Metro Configuration, starting from `@datadog/mobile-react-native@2.9.0` and `@datadog/datadog-ci@v3.10.0`, you can use the `datadog-ci react-native inject-debug-id` command to manually attach a unique Debug ID to your application bundle and sourcemap.
+
+Usage instructions are available on the [command documentation page][17].
+
 ### Passing options for your uploads
 
 #### Using the `datadog-sourcemaps.gradle` script
@@ -482,3 +504,4 @@ Inside the loop, add the following snippet:
 [14]: https://github.com/DataDog/react-native-performance-limiter
 [15]: https://plugins.gradle.org/plugin/com.datadoghq.dd-sdk-android-gradle-plugin
 [16]: https://app.datadoghq.com/source-code/setup/rum
+[17]: https://github.com/DataDog/datadog-ci/blob/master/src/commands/react-native/README.md#inject-debug-id


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for the upcoming React Native release v2.9.0, describing how the Debug ID can be used for symbolication.