### PR TITLE
Removing "infra config" from supported rules in custom frameworks

### DIFF
--- a/content/en/security/cloud_security_management/misconfigurations/frameworks_and_benchmarks/custom_frameworks.md
+++ b/content/en/security/cloud_security_management/misconfigurations/frameworks_and_benchmarks/custom_frameworks.md
@@ -36,7 +36,7 @@ Next, add requirements to the framework:
     - **Requirement**: A requirement acts as a control family, enabling you to add controls and associate rules with each control. Can include lowercase letters, numbers, dashes, underscores, and periods.
     - **Control**: A control represents the criteria that the requirement must meet and includes the rules associated with these criteria. Multiple rules can be included in a control. Can include lowercase letters, numbers, dashes, underscores, and periods.
 1. Click **Add Rules**.
-1. Select the cloud or infrastructure rules you want to assign to the control, then click **Add to Control**.
+1. Select the cloud configuration rules you want to assign to the control, then click **Add to Control**.
 1. To add additional items:
     - For additional rules, click **Add Rules**.
     - For another control, click **Add Control**.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Docs incorrectly said that we support cloud config and infra config rules, when we just support cloud config (see [slack](https://dd.slack.com/archives/C02G5J4FB0E/p1750410520500859))

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
