### PR TITLE
[DOCS-11285] Document new blocked requests option for Synthetics browser tests

### DIFF
--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -148,7 +148,7 @@ When setting up a new Synthetic Monitoring browser test, use snippets to automat
 
    Enter one or more request patterns to block from loading while the test is run.
 
-   Enter one request pattern per line using the [match pattern format][1]. Wildcards (e.g., `*://*.example.com/*`) are supported.
+   Enter one request pattern per line using the [match pattern format][1]. Wildcards (for example, `*://*.example.com/*`) are supported.
 
    Blocked requests are skipped during test execution but do not affect page rendering when [recording steps](/synthetics/browser_tests/actions).
 

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -143,6 +143,21 @@ When setting up a new Synthetic Monitoring browser test, use snippets to automat
 [1]: https://www.loc.gov/standards/iso639-2/php/code_list.php
 
    {{% /tab %}}
+
+   {{% tab "Blocked Requests" %}}
+
+   Enter one or more request patterns to block from loading while the test is run.
+
+   Enter one request pattern per line using the [match pattern format][1]. Wildcards (e.g., `*://*.example.com/*`) are supported.
+
+   Blocked requests are skipped during test execution but do not affect page rendering when [recording steps](/synthetics/browser_tests/actions).
+
+   View blocked requests in the [Resources tab](/synthetics/browser_tests/test_results#resources) of test runs. Blocked requests have a status of `blocked`.
+
+[1]: https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
+
+   {{% /tab %}}
+
    {{< /tabs >}}
 
 {{% synthetics-variables %}}

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -146,13 +146,9 @@ When setting up a new Synthetic Monitoring browser test, use snippets to automat
 
    {{% tab "Blocked Requests" %}}
 
-   Enter one or more request patterns to block from loading while the test is run.
+   Enter one or more request patterns to block from loading while the test is run. Enter one request pattern per line using the [match pattern format][1]. Wildcards (for example, `*://*.example.com/*`) are supported.
 
-   Enter one request pattern per line using the [match pattern format][1]. Wildcards (for example, `*://*.example.com/*`) are supported.
-
-   Blocked requests are skipped during test execution but do not affect page rendering when [recording steps](/synthetics/browser_tests/actions).
-
-   View blocked requests in the [Resources tab](/synthetics/browser_tests/test_results#resources) of test runs. Blocked requests have a status of `blocked`.
+   Blocked requests are skipped during test execution but do not affect page rendering when [recording steps](/synthetics/browser_tests/actions). View blocked requests in the [Resources tab](/synthetics/browser_tests/test_results#resources) of test runs. Blocked requests have a status of `blocked`.
 
 [1]: https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?

Synthetics has added a new advanced option called Blocked Requests. We’d like to add a new Blocked Requests tab to the existing [Advanced Options documentation](https://docs.datadoghq.com/synthetics/browser_tests/?tab=requestoptions#advanced-options), in the same way as other advanced options.

### Merge instructions

Merge readiness:
- [x] Ready for merge