### PR TITLE
[SVLS-5132] Add SST v3 deployment instructions to public documentation

### DIFF
--- a/content/en/serverless/aws_lambda/installation/go.md
+++ b/content/en/serverless/aws_lambda/installation/go.md
@@ -140,30 +140,30 @@ module "lambda-datadog" {
 
 To configure Datadog using SST v3, follow these steps:
 
-  ```ts
-  const app = new sst.aws.Function("MyApp", {
-    handler: "./src",
-    runtime: "go",
-    environment: {
-      DD_ENV: "<ENVIRONMENT>",
-      DD_SERVICE: "<SERVICE_NAME>",
-      DD_VERSION: "<VERSION>",
-      DATADOG_API_KEY_SECRET_ARN: "<DATADOG_API_KEY_SECRET_ARN>",
-      DD_SITE: "<DATADOG_SITE>",
-    },
-    layers: [
-      $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`,
-    ],
-  });
-  ```
+```ts
+const app = new sst.aws.Function("MyApp", {
+  handler: "./src",
+  runtime: "go",
+  environment: {
+    DD_ENV: "<ENVIRONMENT>",
+    DD_SERVICE: "<SERVICE_NAME>",
+    DD_VERSION: "<VERSION>",
+    DATADOG_API_KEY_SECRET_ARN: "<DATADOG_API_KEY_SECRET_ARN>",
+    DD_SITE: "<DATADOG_SITE>",
+  },
+  layers: [
+    $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`,
+  ],
+});
+```
 
-  Fill in the environment variable placeholders:
+Fill in the environment variable placeholders:
 
-     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
-     - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
-     - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
-     - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][1] is selected on this page).
-     - Replace `<VERSION>` with the version number of the Lambda function
+  - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+  - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+  - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+  - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][1] is selected on this page).
+  - Replace `<VERSION>` with the version number of the Lambda function
 
 [1]: /getting_started/site/
 

--- a/content/en/serverless/aws_lambda/installation/go.md
+++ b/content/en/serverless/aws_lambda/installation/go.md
@@ -152,15 +152,12 @@ To configure Datadog using SST v3, follow these steps:
       DD_SITE: "<DATADOG_SITE>",
     },
     layers: [
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}",
+      $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`,
     ],
   });
   ```
-  1. Configure the Datadog Lambda Extension layer
 
-     - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`.
-
-  2. Fill in the environment variable placeholders:
+  Fill in the environment variable placeholders:
 
      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
      - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`

--- a/content/en/serverless/aws_lambda/installation/go.md
+++ b/content/en/serverless/aws_lambda/installation/go.md
@@ -136,6 +136,39 @@ module "lambda-datadog" {
 [3]: https://github.com/DataDog/terraform-aws-lambda-datadog?tab=readme-ov-file#inputs
 [4]: /getting_started/site/
 {{% /tab %}}
+{{% tab "SST v3" %}}
+
+- [Apply the Datadog wrapper in your function code][1]
+- Update your function configuration in `sst.config.ts`:
+  ```ts
+  const app = new sst.aws.Function("MyApp", {
+    handler: "./src",
+    runtime: "go",
+    environment: {
+      DD_ENV: "<ENVIRONMENT>",
+      DD_SERVICE: "<SERVICE_NAME>",
+      DD_VERSION: "<VERSION>",
+      DATADOG_API_KEY_SECRET_ARN: "<DATADOG_API_KEY_SECRET_ARN>",
+      DD_SITE: "<DATADOG_SITE>",
+    },
+    layers: [
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:81",
+    ],
+  });
+  ```
+  1. Configure the Datadog Lambda Extension layer
+      - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`.
+  2. Fill in the environment variable placeholders:
+      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+      - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+      - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+      - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][2] is selected on this page).
+      - Replace `<VERSION>` with the version number of the Lambda function
+
+[1]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
+[2]: /getting_started/site/
+
+{{% /tab %}}
 {{% tab "Custom" %}}
 ### Install the Datadog Lambda Extension
 

--- a/content/en/serverless/aws_lambda/installation/go.md
+++ b/content/en/serverless/aws_lambda/installation/go.md
@@ -138,8 +138,8 @@ module "lambda-datadog" {
 {{% /tab %}}
 {{% tab "SST v3" %}}
 
-- [Apply the Datadog wrapper in your function code][1]
-- Update your function configuration in `sst.config.ts`:
+To configure Datadog using SST v3, follow these steps:
+
   ```ts
   const app = new sst.aws.Function("MyApp", {
     handler: "./src",
@@ -157,16 +157,18 @@ module "lambda-datadog" {
   });
   ```
   1. Configure the Datadog Lambda Extension layer
-      - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`.
-  2. Fill in the environment variable placeholders:
-      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
-      - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
-      - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
-      - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][2] is selected on this page).
-      - Replace `<VERSION>` with the version number of the Lambda function
 
-[1]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
-[2]: /getting_started/site/
+     - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`.
+
+  2. Fill in the environment variable placeholders:
+
+     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+     - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+     - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+     - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][1] is selected on this page).
+     - Replace `<VERSION>` with the version number of the Lambda function
+
+[1]: /getting_started/site/
 
 {{% /tab %}}
 {{% tab "Custom" %}}

--- a/content/en/serverless/aws_lambda/installation/go.md
+++ b/content/en/serverless/aws_lambda/installation/go.md
@@ -152,7 +152,7 @@ To configure Datadog using SST v3, follow these steps:
       DD_SITE: "<DATADOG_SITE>",
     },
     layers: [
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:81",
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}",
     ],
   });
   ```

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -343,15 +343,15 @@ To configure Datadog using SST v3, follow these steps:
       DD_SITE: "<DATADOG_SITE>",
     },
     layers: [
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}",
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="node" >}}",
+      $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`,
+      $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="node" >}}`,
     ],
   });
   ```
 
   1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
 
-     - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="node-versions" >}}. 
+     - The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="node-versions" >}}.
   
   2. Add `dd-trace` and `datadog-lambda-js` to the `nodejs.install` list
 

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -343,8 +343,8 @@ To configure Datadog using SST v3, follow these steps:
       DD_SITE: "<DATADOG_SITE>",
     },
     layers: [
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:81",        
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:125",
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}",
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="node" >}}",
     ],
   });
   ```

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -322,6 +322,45 @@ module "lambda-datadog" {
 [3]: https://github.com/DataDog/terraform-aws-lambda-datadog?tab=readme-ov-file#inputs
 [4]: /getting_started/site/
 {{% /tab %}}
+{{% tab "SST v3" %}}
+
+- [Apply the Datadog wrapper in your function code][1]
+- Update your function configuration in `sst.config.ts`:
+  ```ts
+  const app = new sst.aws.Function("MyApp", {
+    handler: "index.handler",
+    nodejs : {
+      install: [
+        "datadog-lambda-js",
+        "dd-trace",
+      ]
+    },
+    environment: {
+      DD_ENV: "<ENVIRONMENT>",
+      DD_SERVICE: "<SERVICE_NAME>",
+      DD_VERSION: "<VERSION>",
+      DATADOG_API_KEY_SECRET_ARN: "<DATADOG_API_KEY_SECRET_ARN>",
+      DD_SITE: "<DATADOG_SITE>",
+    },
+    layers: [
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:81",        
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:125",
+    ],
+  });
+  ```
+  1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
+      - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="node-versions" >}}. 
+  2. Add `dd-trace` and `datadog-lambda-js` to the `nodejs.install` list
+  3. Fill in the environment variable placeholders:
+      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+      - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+      - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+      - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][2] is selected on this page).
+      - Replace `<VERSION>` with the version number of the Lambda function
+
+[1]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
+[2]: /getting_started/site/
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 <div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -324,8 +324,8 @@ module "lambda-datadog" {
 {{% /tab %}}
 {{% tab "SST v3" %}}
 
-- [Apply the Datadog wrapper in your function code][1]
-- Update your function configuration in `sst.config.ts`:
+To configure Datadog using SST v3, follow these steps:
+
   ```ts
   const app = new sst.aws.Function("MyApp", {
     handler: "index.handler",
@@ -348,18 +348,25 @@ module "lambda-datadog" {
     ],
   });
   ```
-  1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
-      - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="node-versions" >}}. 
-  2. Add `dd-trace` and `datadog-lambda-js` to the `nodejs.install` list
-  3. Fill in the environment variable placeholders:
-      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
-      - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
-      - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
-      - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][2] is selected on this page).
-      - Replace `<VERSION>` with the version number of the Lambda function
 
-[1]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
-[2]: /getting_started/site/
+  1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
+
+     - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="node-versions" >}}. 
+  
+  2. Add `dd-trace` and `datadog-lambda-js` to the `nodejs.install` list
+
+  3. Fill in the environment variable placeholders:
+
+     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+     - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+     - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+     - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][1] is selected on this page)
+     - Replace `<VERSION>` with the version number of the Lambda function
+    
+  4. [Apply the Datadog wrapper in your function code][2]
+
+[1]: /getting_started/site/
+[2]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
 {{% /tab %}}
 {{% tab "Custom" %}}
 

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -316,7 +316,7 @@ To configure Datadog using SST v3, follow these steps:
   ```ts
   const app = new sst.aws.Function("MyApp", {
     handler: "lambda_function.lambda_handler",
-    runtime: "python3.12",
+    runtime: "python3.13",
     environment: {
       DD_ENV: "<ENVIRONMENT>",
       DD_SERVICE: "<SERVICE_NAME>",
@@ -325,15 +325,15 @@ To configure Datadog using SST v3, follow these steps:
       DD_SITE: "<DATADOG_SITE>",
     },
     layers: [
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:81",        
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:110",
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}",
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="python" >}}",
     ],
   });
   ```
 
   1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
-  
-     - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="python" >}}.
+
+     - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="python-versions" >}}.
 
   2. Fill in the environment variable placeholders:
      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -325,15 +325,15 @@ To configure Datadog using SST v3, follow these steps:
       DD_SITE: "<DATADOG_SITE>",
     },
     layers: [
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}",
-      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="python" >}}",
+      $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:464622532012:layer:Datadog-Extension:{{< latest-lambda-layer-version layer="extension" >}}`,
+      $interpolate`arn:aws:lambda:${aws.getRegionOutput().name}:464622532012:layer:Datadog-<RUNTIME>:{{< latest-lambda-layer-version layer="python" >}}`,
     ],
   });
   ```
 
   1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
 
-     - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="python-versions" >}}.
+     - The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="python-versions" >}}.
 
   2. Fill in the environment variable placeholders:
      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -311,8 +311,8 @@ module "lambda-datadog" {
 {{% /tab %}}
 {{% tab "SST v3" %}}
 
-- [Apply the Datadog wrapper in your function code][1]
-- Update your function configuration in `sst.config.ts`:
+To configure Datadog using SST v3, follow these steps:
+
   ```ts
   const app = new sst.aws.Function("MyApp", {
     handler: "lambda_function.lambda_handler",
@@ -330,17 +330,22 @@ module "lambda-datadog" {
     ],
   });
   ```
-  1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
-      - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="python" >}}.
-  2. Fill in the environment variable placeholders:
-      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
-      - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
-      - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
-      - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][2] is selected on this page).
-      - Replace `<VERSION>` with the version number of the Lambda function
 
-[1]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
-[2]: /getting_started/site/
+  1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
+  
+     - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="python" >}}.
+
+  2. Fill in the environment variable placeholders:
+     - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+     - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+     - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+     - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][1] is selected on this page).
+     - Replace `<VERSION>` with the version number of the Lambda function
+
+  3. [Apply the Datadog wrapper in your function code][2]
+
+[1]: /getting_started/site/
+[2]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
 
 {{% /tab %}}
 {{% tab "Custom" %}}

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -309,6 +309,40 @@ module "lambda-datadog" {
 [3]: https://github.com/DataDog/terraform-aws-lambda-datadog?tab=readme-ov-file#inputs
 [4]: /getting_started/site/
 {{% /tab %}}
+{{% tab "SST v3" %}}
+
+- [Apply the Datadog wrapper in your function code][1]
+- Update your function configuration in `sst.config.ts`:
+  ```ts
+  const app = new sst.aws.Function("MyApp", {
+    handler: "lambda_function.lambda_handler",
+    runtime: "python3.12",
+    environment: {
+      DD_ENV: "<ENVIRONMENT>",
+      DD_SERVICE: "<SERVICE_NAME>",
+      DD_VERSION: "<VERSION>",
+      DATADOG_API_KEY_SECRET_ARN: "<DATADOG_API_KEY_SECRET_ARN>",
+      DD_SITE: "<DATADOG_SITE>",
+    },
+    layers: [
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-Extension:81",        
+      "arn:aws:lambda:<AWS_REGION>:464622532012:layer:Datadog-<RUNTIME>:110",
+    ],
+  });
+  ```
+  1. Configure the Datadog Lambda Library and Datadog Lambda Extension layers
+      - Replace `<AWS_REGION>` with a valid AWS region such as `us-east-1`. The available `<RUNTIME>` options are: {{< latest-lambda-layer-version layer="python" >}}.
+  2. Fill in the environment variable placeholders:
+      - Replace `<DATADOG_API_KEY_SECRET_ARN>` with the ARN of the AWS secret where your Datadog API key is securely stored. The key needs to be stored as a plaintext string (not a JSON blob). The `secretsmanager:GetSecretValue` permission is required. For quick testing, you can instead use the environment variable `DD_API_KEY` and set your Datadog API key in plaintext.
+      - Replace `<ENVIRONMENT>` with the Lambda function's environment, such as `prod` or `staging`
+      - Replace `<SERVICE_NAME>` with the name of the Lambda function's service
+      - Replace `<DATADOG_SITE>` with {{< region-param key="dd_site" code="true" >}}. (Ensure the correct [Datadog site][2] is selected on this page).
+      - Replace `<VERSION>` with the version number of the Lambda function
+
+[1]: https://docs.datadoghq.com/serverless/guide/handler_wrapper
+[2]: /getting_started/site/
+
+{{% /tab %}}
 {{% tab "Custom" %}}
 
 <div class="alert alert-info">If you are not using a serverless development tool that Datadog supports, such as the Serverless Framework or AWS CDK, Datadog strongly encourages you instrument your serverless applications with the <a href="./?tab=datadogcli">Datadog CLI</a>.</div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates the lambda installation instructions to include adding Datadog to a lambda function using [SST](https://sst.dev/) v3 for Node, Python, and Go. (Note: SST v3 supports Node, Python, Go, and Rust, but we don't have Rust installation instructions).

These instructions will help customers using SST v3 add Datadog to their lambda functions. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge
