### PR TITLE
FIX: Added RN error tracking docs to correct file

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/error_tracking.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/error_tracking.md
@@ -67,6 +67,28 @@ To set your project up to send the symbolication files automatically, run `npx d
 
 See the wizard [official documentation][13] for options.
 
+### Use Datadog Metro Configuration
+
+Starting from `@datadog/mobile-react-native@2.9.0` and `@datadog/datadog-ci@v3.10.0`, the SDK exports a Datadog Metro Plugin, which attaches a unique Debug ID to your application bundle and sourcemap.
+
+Add it to your `metro.config.js` to allow for accurate symbolication of stacktraces on Datadog:
+
+```js
+const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+const {withDatadogMetroConfig} = require('@datadog/mobile-react-native/metro');
+
+// Your configuration
+const config = mergeConfig(getDefaultConfig(__dirname), {});
+
+module.exports = withDatadogMetroConfig(config);
+```
+
+### Use the `datadog-ci react-native inject-debug-id` command
+
+As an alternative to the Metro Configuration, starting from `@datadog/mobile-react-native@2.9.0` and `@datadog/datadog-ci@v3.10.0`, you can use the `datadog-ci react-native inject-debug-id` command to manually attach a unique Debug ID to your application bundle and sourcemap.
+
+Usage instructions are available on the [command documentation page][17].
+
 ### Passing options for your uploads
 
 #### Using the `datadog-sourcemaps.gradle` script
@@ -481,3 +503,4 @@ Inside the loop, add the following snippet:
 [14]: https://github.com/DataDog/react-native-performance-limiter
 [15]: https://plugins.gradle.org/plugin/com.datadoghq.dd-sdk-android-gradle-plugin
 [16]: https://app.datadoghq.com/source-code/setup/rum
+[17]: https://github.com/DataDog/datadog-ci/blob/master/src/commands/react-native/README.md#inject-debug-id


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?
Adds new error tracking paragraphs to the correct file, as the changes have not been deployed for `content/en/real_user_monitoring/error_tracking/mobile/reactnative.md` in https://github.com/DataDog/documentation/pull/30025