### PR TITLE
[K9VULN-6032] Fix catch-all glob

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -358,7 +358,7 @@ datadog:
       paths:
         - path/to/service/code/**
 {{< /code-block >}}
-If you want all the files in a repository to be associated with a service, you can use the glob `**/*` as follows:
+If you want all the files in a repository to be associated with a service, you can use the glob `**` as follows:
 {{< code-block lang="yaml" filename="entity.datadog.yaml" collapsible="true" >}}
 apiVersion: v3
 kind: service
@@ -368,7 +368,7 @@ datadog:
   codeLocations:
     - repositoryURL: https://github.com/myorganization/myrepo.git
       paths:
-        - "**/*"
+        - "**"
 {{< /code-block >}}
 {{% /collapse-content %}}
 

--- a/content/en/security/code_security/static_analysis/setup/_index.md
+++ b/content/en/security/code_security/static_analysis/setup/_index.md
@@ -476,7 +476,7 @@ datadog:
 {{< /code-block >}}
 
 
-If you want all the files in a repository to be associated with a service, you can use the glob `**/*` as follows:
+If you want all the files in a repository to be associated with a service, you can use the glob `**` as follows:
 
 {{< code-block lang="yaml" filename="entity.datadog.yaml" collapsible="true" >}}
 apiVersion: v3
@@ -487,7 +487,7 @@ datadog:
   codeLocations:
     - repositoryURL: https://github.com/myorganization/myrepo.git
       paths:
-        - "**/*"
+        - "**"
 {{< /code-block >}}
 
 #### Detecting file usage patterns


### PR DESCRIPTION
### What does this PR do? What is the motivation?

We suggest that customers use `**/*` as a catch-all glob, but this will catch files in the root directory. This is especially problematic for the SCA product because dependency files are typically located at the root.

### Merge instructions

Merge readiness:
- [X] Ready for merge