### PR TITLE
updating title to improve search ranking

### DIFF
--- a/content/en/security/automation_pipelines/_index.md
+++ b/content/en/security/automation_pipelines/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Automation Pipelines
+title: Findings Automation Pipelines
 aliases:
   - /security/vulnerability_pipeline
 further_reading:
@@ -12,6 +12,8 @@ further_reading:
   - link: "/security/automation_pipelines/set_due_date"
     tag: "Documentation"
     text: "Set Due Date Rules"
+algolia:
+  tags: ["automation pipelines", "findings automation", "findings pipelines", "finding automation"]
 ---
 
 Automation Pipelines allows you to set up automated rules for newly discovered findings, thus accelerating triage and remediation efforts at scale.


### PR DESCRIPTION
When users search for `findings automation` they do not get the Automation Pipelines topic.

Users search for `findings automation` because the UI uses **Findings Automation Pipelines**.

I changed the doc topic title to **Findings Automation Pipelines** to help users find this content.

I also updated the search terms on the page:

```
algolia:
  tags: ["automation pipelines", "findings automation", "findings pipelines", "finding automation"]
```


### Merge instructions

Merge readiness:
- [X] Ready for merge

