### PR TITLE
One word change - fix a typo in docs

### DIFF
--- a/content/en/ddsql_reference/ddsql_default.md
+++ b/content/en/ddsql_reference/ddsql_default.md
@@ -428,7 +428,7 @@ FROM
 
 ## Window functions
 
-This table provides an overview of the supprted window functions. For comprehensive details and examples, see the [PostgreSQL documentation][2].
+This table provides an overview of the supported window functions. For comprehensive details and examples, see the [PostgreSQL documentation][2].
 
 | Function                | Return Type       | Description                                                            |
 |-------------------------|-------------------|------------------------------------------------------------------------|


### PR DESCRIPTION
Just a one-word change to fix a typo I noticed while referencing up DDSQL documentation

### Merge instructions
NA

Merge readiness:
- [x] Ready for merge

### Additional notes
