### PR TITLE
Update java.md dd.jdk.socket.enabled default value to true

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -487,8 +487,8 @@ When set to `true`, the websocket spans have the tag `websocket.session.id` cont
 
 `dd.jdk.socket.enabled`
 : **Environment Variable**: `DD_JDK_SOCKET_ENABLED` <br>
-**Default**: `false`<br>
-Enable native JDK support for unix domain sockets.
+**Default**: `true`<br>
+Enable native JDK support for Unix Domain Sockets.
 
 ### Examples
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The default value for dd.jdk.socket.enabled is now set to true after the dd-trace-java 1.50.0 release ([notes reference](https://github.com/DataDog/dd-trace-java/releases/tag/v1.50.0#:~:text=%F0%9F%90%9B%20Turn%20JDK%20socket%20support%20on%20by%20default%20(%238752%20%2D%20%40sarahchen6))).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
