### PR TITLE
Improve Python Log/Trace Correlation Docs

### DIFF
--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/python.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/python.md
@@ -118,7 +118,7 @@ Once the logger is configured, executing a traced function that logs an event yi
 {"event": "In tracer context", "dd.trace_id": 9982398928418628468, "dd.span_id": 10130028953923355146, "dd.env": "dev", "dd.service": "hello", "dd.version": "abc123"}
 ```
 
-**Note**: If you are not using a [Datadog Log Integration][2] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped using the [Trace Remapper][3]. For more information, see [Correlated Logs Not Showing Up in the Trace ID Panel][4].
+**Note**: If you are not using a [Datadog Log Integration][7] to parse your logs, custom log parsing rules need to ensure that `dd.trace_id` and `dd.span_id` are being parsed as strings and remapped using the [Trace Remapper][3]. For more information, see [Correlated Logs Not Showing Up in the Trace ID Panel][4].
 
 [See the Python logging documentation][2] to ensure that the Python Log Integration is properly configured so that your Python logs are automatically parsed.
 
@@ -132,3 +132,4 @@ Once the logger is configured, executing a traced function that logs an event yi
 [4]: /tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel/?tab=custom
 [5]: /tracing/trace_collection/library_injection_local/
 [6]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#logs-injection
+[7]: https://docs.datadoghq.com/logs/log_collection/?tab=cloudintegration

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/python.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/python.md
@@ -32,6 +32,7 @@ To correlate your [traces][1] with your logs, complete the following steps:
 
   1. [Activate automatic instrumentation](#step-1---activate-automatic-instrumentation).
   2. [Include required attributes from the log record](#step-2---include-required-attributes).
+  3. [Configure log collection](#step-3---configure-log-collection).
 
 #### Step 1 - Activate automatic instrumentation
 
@@ -77,6 +78,10 @@ def hello():
 
 hello()
 ```
+
+#### Step 3 - Configure log collection
+
+Ensure that log collection is configured in the Datadog Agent and that the [Logs Agent configuration][2] for the specified files to tail is set to `source: python` so log pipelines can parse the log files. If the `source` is set to a value other than `python`, you may need to add a [trace remapper][3] to the appropriate log processing pipeline for the correlation to work correctly.
 
 To learn more about logs injection, read the [ddtrace documentation][6].
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

In [these docs](https://docs.datadoghq.com/tracing/other_telemetry/connect_logs_and_traces/python/) for correlation logs/traces, there is nothing that tells users to set the source in their datadog.yaml file to `source: python`.
In contrast, the dotnet tab makes it very clear. I think we should update the docs to clarify this.

This updates the instructions for the Python standard logging library to include this information. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
