### PR TITLE
move to using OPENLINEAGE_NAMESPACE as default for Airflow

### DIFF
--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -50,8 +50,8 @@ To get started, follow the instructions below.
    ```shell
    export OPENLINEAGE_URL=<DD_DATA_OBSERVABILITY_INTAKE>
    export OPENLINEAGE_API_KEY=<DD_API_KEY>
-   # AIRFLOW__OPENLINEAGE__NAMESPACE sets the 'env' tag value in Datadog. You can hardcode this to a different value
-   export AIRFLOW__OPENLINEAGE__NAMESPACE=${AIRFLOW_ENV_NAME}
+   # OPENLINEAGE_NAMESPACE sets the 'env' tag value in Datadog. You can hardcode this to a different value
+   export OPENLINEAGE_NAMESPACE=${AIRFLOW_ENV_NAME}
    ```
    * Replace `<DD_DATA_OBSERVABILITY_INTAKE>` with `https://data-obs-intake.`{{< region-param key="dd_site" code="true" >}}.
    * Replace `<DD_API_KEY>` with your valid [Datadog API key][4].


### PR DESCRIPTION
### What does this PR do? What is the motivation?

OPENLINEAGE_NAMESPACE is compatible with all Airflow flavors, and works better with Cloud Composer because they disable the option to override config via env variables

### Merge instructions

Merge readiness:
- [ ] Ready for merge
