### PR TITLE
Update docs on new AKS certificate changes and relative agent configuration changes that are necessary

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -141,7 +141,11 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 
 The AKS Kubelet certificate requires changing the Kubelet host to the `spec.nodeName` and the `hostCAPath` location of the certificate, as seen in the previous snippets. This enables TLS verification. Without these changes, the Agent cannot connect to the Kubelet.
 
-However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13], which is rolled out for East US and UK South. You can read more about this [in the Azure documentation here][14]. If your AKS cluster is in any of those aformentioned regions you are upgrading your existing AKS cluster nodes from 1.27+ to a higher version or the node image `202501.12.0` to a newer image, make the following changes to the agent configuration:
+However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13], which is rolled out for East US and UK South. You can read more about this [in the Azure documentation here][14]. If your AKS cluster is located in one of the aforementioned regions and you are upgrading either:
+  - Your AKS node pool from version 1.27 or later to a newer version.
+  - The node image from `202501.12.0` to a more recent version.
+
+Make the following changes to the agent configuration:
   - Change the `hostCAPath` to `/var/lib/kubelet/pki/kubelet-server-current.pem`.
   - Optionally, you can remove the `spec.nodeName` configuration entirely since this new certificate path does not require changing the Kubelet host to `spec.nodeName` anymore.
 

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -141,7 +141,11 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 
 The AKS Kubelet certificate requires changing the Kubelet host to the `spec.nodeName` and the `hostCAPath` location of the certificate, as seen in the previous snippets. This enables TLS verification. Without these changes, the Agent cannot connect to the Kubelet.
 
-However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13], which is currently rolled out for East US and UK South. You can read more about this [in the Azure documentation here][14]. If your AKS cluster is in any of those aformentioned regions and you are upgrading your existing AKS cluster nodes from 1.27+ to a higher version or node image `202501.12.0` to a newer image, change the `hostCAPath` to `/var/lib/kubelet/pki/kubelet-server-current.pem`. Optionally, you can remove the `spec.nodeName` configuration entirely since this new certificate path does not require changing the Kubelet host to `spec.nodeName` anymore.
+However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13], which is currently rolled out for East US and UK South. You can read more about this [in the Azure documentation here][14]. If your AKS cluster is in any of those aformentioned regions and you are upgrading your existing AKS cluster nodes from 1.27+ to a higher version or node image `202501.12.0` to a newer image:
+  - Change the `hostCAPath` to `/var/lib/kubelet/pki/kubelet-server-current.pem`.
+  - Optionally, you can remove the `spec.nodeName` configuration entirely since this new certificate path does not require changing the Kubelet host to `spec.nodeName` anymore.
+
+If you choose to upgrade and disable [Kubelet serving certificate rotation][15] then you can keep the previous configurations.
 
 ### Without TLS verification
 
@@ -611,3 +615,4 @@ agents:
 [12]: https://cloud.google.com/kubernetes-engine/docs/how-to/disable-kubelet-readonly-port
 [13]: https://github.com/Azure/AKS/releases/tag/2025-06-17
 [14]: https://learn.microsoft.com/en-us/azure/aks/certificate-rotation
+[15]: https://learn.microsoft.com/en-us/azure/aks/certificate-rotation#disable-kubelet-serving-certificate-rotation

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -141,7 +141,7 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 
 The AKS Kubelet certificate requires changing the Kubelet host to the `spec.nodeName` and the `hostCAPath` location of the certificate, as seen in the previous snippets. This enables TLS verification. Without these changes, the Agent cannot connect to the Kubelet.
 
-However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13]. You can read more about this [in the Azure documentation here][14]. If you are upgrading your existing AKS cluster nodes from 1.27+ to a higher version or node image `202501.12.0` to a newer image, change the `hostCAPath` to `/var/lib/kubelet/pki/kubelet-server-current.pem`. Optionally, you can remove the `spec.nodeName` configuration entirely since this new certificate path does not require changing the Kubelet host to `spec.nodeName` anymore.
+However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13], which is currently rolled out for East US and UK South. You can read more about this [in the Azure documentation here][14]. If your AKS cluster is in any of those aformentioned regions and you are upgrading your existing AKS cluster nodes from 1.27+ to a higher version or node image `202501.12.0` to a newer image, change the `hostCAPath` to `/var/lib/kubelet/pki/kubelet-server-current.pem`. Optionally, you can remove the `spec.nodeName` configuration entirely since this new certificate path does not require changing the Kubelet host to `spec.nodeName` anymore.
 
 ### Without TLS verification
 

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -141,7 +141,7 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 
 The AKS Kubelet certificate requires changing the Kubelet host to the `spec.nodeName` and the `hostCAPath` location of the certificate, as seen in the previous snippets. This enables TLS verification. Without these changes, the Agent cannot connect to the Kubelet.
 
-However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13], which is currently rolled out for East US and UK South. You can read more about this [in the Azure documentation here][14]. If your AKS cluster is in any of those aformentioned regions and you are upgrading your existing AKS cluster nodes from 1.27+ to a higher version or node image `202501.12.0` to a newer image:
+However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13], which is rolled out for East US and UK South. You can read more about this [in the Azure documentation here][14]. If your AKS cluster is in any of those aformentioned regions you are upgrading your existing AKS cluster nodes from 1.27+ to a higher version or the node image `202501.12.0` to a newer image, make the following changes to the agent configuration:
   - Change the `hostCAPath` to `/var/lib/kubelet/pki/kubelet-server-current.pem`.
   - Optionally, you can remove the `spec.nodeName` configuration entirely since this new certificate path does not require changing the Kubelet host to `spec.nodeName` anymore.
 

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -141,6 +141,8 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 
 The AKS Kubelet certificate requires changing the Kubelet host to the `spec.nodeName` and the `hostCAPath` location of the certificate, as seen in the previous snippets. This enables TLS verification. Without these changes, the Agent cannot connect to the Kubelet.
 
+However, AKS has changed how they structure their certificates relative to the [June 17th 2025 release][13]. You can read more about this [in the Azure documentation here][14]. If you are upgrading your existing AKS cluster nodes from 1.27+ to a higher version or node image `202501.12.0` to a newer image, change the `hostCAPath` to `/var/lib/kubelet/pki/kubelet-server-current.pem`. Optionally, you can remove the `spec.nodeName` configuration entirely since this new certificate path does not require changing the Kubelet host to `spec.nodeName` anymore.
+
 ### Without TLS verification
 
 In some clusters, DNS resolution for `spec.nodeName` inside Pods does not work in AKS. This affects:
@@ -607,3 +609,5 @@ agents:
 [10]: https://cloud.google.com/kubernetes-engine/docs/how-to/autopilot-spot-pods
 [11]: https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-compute-classes
 [12]: https://cloud.google.com/kubernetes-engine/docs/how-to/disable-kubelet-readonly-port
+[13]: https://github.com/Azure/AKS/releases/tag/2025-06-17
+[14]: https://learn.microsoft.com/en-us/azure/aks/certificate-rotation


### PR DESCRIPTION
AKS may have changed how they structure their certificates again. Relative to the June 17th release: https://github.com/Azure/AKS/releases/tag/2025-06-17

- Kubelet Service Certificate Rotation has now been rolled out to East US and UK South. Existing node pools will have kubelet serving certificate rotation enabled by default when they perform their first upgrade to any kubernetes version 1.27 or greater. New node pools on kubernetes version 1.27 or greater will have kubelet serving certificate rotation enabled by default. For more information on kubelet serving certificate rotation and disablement, see [certificate rotation in Azure Kubernetes Service](https://learn.microsoft.com/azure/aks/certificate-rotation).
- The cert path will be switched from `/etc/kubernetes/certs/kubeletserver.crt` to `/var/lib/kubelet/pki/kubelet-server-current.pem` once they upgrade their 1.27+ nodes to a higher version

This may impact customers that don't use  tlsVerify set to false but opt to give the agent the SSL cert following the docs: https://docs.datadoghq.com/containers/kubernetes/distributions/?tab=helm#AKS

This documentation update is to cover this in the event the customers run into issues with the agent when they upgrade their AKS nodes.