### PR TITLE
Add fastify to nodejs documentation - security

### DIFF
--- a/content/en/security/application_security/setup/compatibility/nodejs.md
+++ b/content/en/security/application_security/setup/compatibility/nodejs.md
@@ -78,9 +78,9 @@ Although Threat Protection is available for express >= 4 versions, the blocking 
 
 | Framework | Versions | Threat Detection supported? | Threat Protection supported? |
 |-----------|----------|-----------------------------|------------------------------|
-| express   | >=4      | {{< X >}}                   | {{< X >}}                    |
-| fastify   | >=2      | {{< X >}}                   | {{< X >}}                    |
-| nextjs    | >=11.1   | {{< X >}}                   |                              |
+| express   | `>=4`      | {{< X >}}                   | {{< X >}}                    |
+| fastify   | `>=2`      | {{< X >}}                   | {{< X >}}                    |
+| nextjs    | `>=11.1`   | {{< X >}}                   |                              |
 
 
 

--- a/content/en/security/application_security/setup/compatibility/nodejs.md
+++ b/content/en/security/application_security/setup/compatibility/nodejs.md
@@ -74,11 +74,12 @@ The following operating systems are officially supported by `dd-trace`. Any oper
 
 ##### App and API Protection Capability Notes
 
-Although Threat Protection is available for express >= 4 versions, the blocking of payloads on the body is only supported for applications using `body-parser` library.
+Although Threat Protection is available for express >= 4 versions, the blocking of payloads on the body is only supported for applications using either the [`body-parser`][45] or [`multer`][46] libraries.
 
 | Framework | Versions | Threat Detection supported? | Threat Protection supported? |
 |-----------|----------|-----------------------------|------------------------------|
 | express   | >=4      | {{< X >}}                   | {{< X >}}                    |
+| fastify   | >=2      | {{< X >}}                   | {{< X >}}                    |
 | nextjs    | >=11.1   | {{< X >}}                   |                              |
 
 
@@ -176,3 +177,5 @@ Although Threat Protection is available for express >= 4 versions, the blocking 
 [42]: https://github.com/sequelize/sequelize
 [43]: https://github.com/apollographql/apollo-server
 [44]: https://www.npmjs.com/package/apollo-server-core
+[45]: https://www.npmjs.com/package/body-parser
+[46]: https://www.npmjs.com/package/multer


### PR DESCRIPTION
### What does this PR do? What is the motivation?

After releasing dd-trace-js v5.57.0 we are officially supporting Fastify in AAP ASM, This PR aims to add doc for fastify in ASM
