### PR TITLE
[PROF-11936] Remove deprecated profiling routes

### DIFF
--- a/content/en/integrations/guide/source-code-integration.md
+++ b/content/en/integrations/guide/source-code-integration.md
@@ -518,7 +518,7 @@ You can also see links from profile frames to their source repository. This is s
 {{< img src="integrations/guide/source_code_integration/profiler-link-to-git.png" alt="Link to GitHub from the Continuous Profiler" style="width:100%;">}}
 
 [1]: /profiler/
-[2]: https://app.datadoghq.com/profiling/search
+[2]: https://app.datadoghq.com/profiling/explorer
 {{% /tab %}}
 {{% tab "Serverless Monitoring" %}}
 

--- a/content/en/profiler/profile_visualizations.md
+++ b/content/en/profiler/profile_visualizations.md
@@ -193,7 +193,7 @@ Timeline view is currently not supported for Full Host profiling
 
 [1]: /tracing/send_traces/#configure-your-environment
 [2]: /tracing/glossary/#services
-[3]: https://app.datadoghq.com/profiling/search?viz=timeseries
+[3]: https://app.datadoghq.com/profiling/explorer?viz=timeseries
 [4]: /profiler/profile_types/
 [5]: /dashboards/widgets/profiling_flame_graph
 [6]: /profiler/connect_traces_and_profiles/#span-execution-timeline-view

--- a/content/en/watchdog/insights.md
+++ b/content/en/watchdog/insights.md
@@ -163,7 +163,7 @@ In the banner card view, you can see:
   * The name of the impacted service
   * The number of threads impacted
   * The potential CPU savings (and estimated cost savings)
-    
+
 {{< img src="watchdog/small_card_profiling_lock_pressure.png" alt="Profiling insight on Lock Contention" style="width:50%;">}}
 
 In the full side panel, you can see instructions on how to resolve the lock contention:
@@ -212,7 +212,7 @@ Find the databases impacted by one or multiple outliers by using the Insight car
 
 {{< img src="watchdog/side_panel_dbm_insights.png" alt="Carousel to filter the Databases with Insights" style="width:100%;">}}
 
-An overlay is then set on the databases, with pink pills highlighting the different Insights and giving more information about what happened. 
+An overlay is then set on the databases, with pink pills highlighting the different Insights and giving more information about what happened.
 
 {{< img src="watchdog/overlay_database_insight.png" alt="Watchdog insight overlay on the database to highlight what is happening" style="width:100%;">}}
 
@@ -293,7 +293,7 @@ An overlay is then set on the function, with pink pills highlighting the differe
 {{% /tab %}}
 {{% tab "Processes" %}}
 
-For Process Explorer, the Watchdog Insight carousel reflects [all Process anomalies][1] for the current context of the Process Explorer. 
+For Process Explorer, the Watchdog Insight carousel reflects [all Process anomalies][1] for the current context of the Process Explorer.
 
 [1]: https://app.datadoghq.com/process
 {{% /tab %}}
@@ -315,7 +315,7 @@ For Kubernetes Explorer, the Watchdog Insight carousel reflects [all the Kuberne
 [3]: /tracing/services/service_page/
 [4]: /tracing/services/resource_page/
 [5]: https://app.datadoghq.com/databases/list
-[6]: https://app.datadoghq.com/profiling/search
+[6]: https://app.datadoghq.com/profiling/explorer
 [7]: https://app.datadoghq.com/process
 [8]: https://app.datadoghq.com/functions
 [9]: https://app.datadoghq.com/orchestration/overview/pod

--- a/content/es/integrations/guide/source-code-integration.md
+++ b/content/es/integrations/guide/source-code-integration.md
@@ -227,7 +227,7 @@ Si utilizas un host, tienes dos opciones: utilizar Microsoft SourceLink o config
 <div class="alert alert-info">Se requiere la biblioteca cliente Node.js versión 3.21.0 o posterior.
 </br>
 </br>
-La visualización de enlaces y fragmentos de código para aplicaciones TypeScript requiere que tu aplicación Node se ejecute con: 
+La visualización de enlaces y fragmentos de código para aplicaciones TypeScript requiere que tu aplicación Node se ejecute con:
 </br>
 <a href="https://nodejs.org/dist/v12.22.12/docs/api/cli.html#cli_enable_source_maps"><code>--enable-source-maps</code></a>.
 </div>
@@ -522,7 +522,7 @@ También puedes ver los enlaces de los marcos de perfiles hasta su repositorio d
 {{< img src="integrations/guide/source_code_integration/profiler-link-to-git.png" alt="Enlace a GitHub desde Continuous Profiler" style="width:100%;">}}
 
 [1]: /es/profiler/
-[2]: https://app.datadoghq.com/profiling/search
+[2]: https://app.datadoghq.com/profiling/explorer
 {{% /tab %}}
 {{% tab "Serverless Monitoring" %}}
 

--- a/content/es/watchdog/insights.md
+++ b/content/es/watchdog/insights.md
@@ -203,7 +203,7 @@ Encuentra las bases de datos afectadas por uno o varios outliers utilizando el c
 
 {{< img src="watchdog/side_panel_dbm_insights.png" alt="Carrusel para filtrar bases de datos con información" style="width:100%;">}}
 
-A continuación, se establece un recubrimiento de las bases de datos, con píldoras rosas que resaltan las distintas informaciones y ofrecen más información sobre lo ocurrido. 
+A continuación, se establece un recubrimiento de las bases de datos, con píldoras rosas que resaltan las distintas informaciones y ofrecen más información sobre lo ocurrido.
 
 {{< img src="watchdog/overlay_database_insight.png" alt="Recubrimiento de información de Watchdog en bases de datos para resaltar lo que ocurre" style="width:100%;">}}
 
@@ -289,7 +289,7 @@ Para el explorador de Kubernetes, el carrusel de Watchdog Insights refleja [toda
 [3]: /es/tracing/services/service_page/
 [4]: /es/tracing/services/resource_page/
 [5]: https://app.datadoghq.com/databases/list
-[6]: https://app.datadoghq.com/profiling/search
+[6]: https://app.datadoghq.com/profiling/explorer
 [7]: https://app.datadoghq.com/process
 [8]: https://app.datadoghq.com/functions
 [9]: https://app.datadoghq.com/orchestration/overview/pod

--- a/content/fr/watchdog/insights.md
+++ b/content/fr/watchdog/insights.md
@@ -289,7 +289,7 @@ Pour le Kubernetes Explorer, le carrousel d'insights Watchdog affiche [toutes l
 [3]: /fr/tracing/services/service_page/
 [4]: /fr/tracing/services/resource_page/
 [5]: https://app.datadoghq.com/databases/list
-[6]: https://app.datadoghq.com/profiling/search
+[6]: https://app.datadoghq.com/profiling/explorer
 [7]: https://app.datadoghq.com/process
 [8]: https://app.datadoghq.com/functions
 [9]: https://app.datadoghq.com/orchestration/overview/pod

--- a/content/ja/integrations/guide/source-code-integration.md
+++ b/content/ja/integrations/guide/source-code-integration.md
@@ -520,7 +520,7 @@ GitHub インテグレーションを使用している場合、または GitLab
 {{< img src="integrations/guide/source_code_integration/profiler-link-to-git.png" alt="Continuous Profiler から GitHub へのリンク" style="width:100%;">}}
 
 [1]: /ja/profiler/
-[2]: https://app.datadoghq.com/profiling/search
+[2]: https://app.datadoghq.com/profiling/explorer
 {{% /tab %}}
 {{% tab "Serverless Monitoring" %}}
 

--- a/content/ja/watchdog/insights.md
+++ b/content/ja/watchdog/insights.md
@@ -274,7 +274,7 @@ An overlay is then set on the function, with pink pills highlighting the differe
 {{% /tab %}}
 {{% tab "Processes" %}}
 
-For Process Explorer, the Watchdog Insight carousel reflects [all Process anomalies][1] for the current context of the Process Explorer. 
+For Process Explorer, the Watchdog Insight carousel reflects [all Process anomalies][1] for the current context of the Process Explorer.
 
 [1]: https://app.datadoghq.com/process
 {{% /tab %}}
@@ -296,7 +296,7 @@ Kubernetes エクスプローラーの場合、Watchdog インサイトカルー
 [3]: /ja/tracing/services/service_page/
 [4]: /ja/tracing/services/resource_page/
 [5]: https://app.datadoghq.com/databases/list
-[6]: https://app.datadoghq.com/profiling/search
+[6]: https://app.datadoghq.com/profiling/explorer
 [7]: https://app.datadoghq.com/process
 [8]: https://app.datadoghq.com/functions
 [9]: https://app.datadoghq.com/orchestration/overview/pod

--- a/content/ko/integrations/guide/source-code-integration.md
+++ b/content/ko/integrations/guide/source-code-integration.md
@@ -225,7 +225,7 @@ Docker 컨테이너를 사용하는 경우 세 가지 옵션이 있습니다. Do
   Node.js 클라이언트 라이브러리 버전 3.21.0 이상이 필요합니다.
  </br>
   </br>
-  TypeScript 애플리케이션에 대한 코드 링크 및 스니펫을 표시하려면 Node 애플리케이션을 실행해야 합니다: 
+  TypeScript 애플리케이션에 대한 코드 링크 및 스니펫을 표시하려면 Node 애플리케이션을 실행해야 합니다:
  </br>
   <a href="https://NodeJS.org/dist/v12.22.12/docs/API/cli.html#cli_enable_source_maps"><code>--enable-source-maps</code></a>.
 </div>
@@ -520,7 +520,7 @@ GitHub(통합)를 사용 중이거나 GitLab SaaS 인스턴스(gitlab.com)에서
 {{< img src="integrations/guide/source_code_integration/profiler-link-to-git.png" alt="연속 프로파일러에서 GitHub 연결" style="width:100%;">}}
 
 [1]: /ko/profiler/
-[2]: https://app.datadoghq.com/profiling/search
+[2]: https://app.datadoghq.com/profiling/explorer
 {{% /tab %}}
 {{% tab "Serverless Monitoring" %}}
 

--- a/content/ko/watchdog/insights.md
+++ b/content/ko/watchdog/insights.md
@@ -287,7 +287,7 @@ First Contentful Paint, First Input Delay, Cumulative Layout Shift 및 [로딩 �
 [3]: /ko/tracing/services/service_page/
 [4]: /ko/tracing/services/resource_page/
 [5]: https://app.datadoghq.com/databases/list
-[6]: https://app.datadoghq.com/profiling/search
+[6]: https://app.datadoghq.com/profiling/explorer
 [7]: https://app.datadoghq.com/process
 [8]: https://app.datadoghq.com/functions
 [9]: https://app.datadoghq.com/orchestration/overview/pod


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The routes for the profiling view where updated with [web-ui/pull/123038](https://github.com/DataDog/web-ui/pull/123038) but the documentation was not updated.

PR aims to update all mentions of "/profiling/search" to "/profiling/explorer" in order to have the correct routing to Profile > Explorer.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
