### PR TITLE
Update relative time description

### DIFF
--- a/content/en/synthetics/browser_tests/test_results.md
+++ b/content/en/synthetics/browser_tests/test_results.md
@@ -112,7 +112,7 @@ You can filter resources by type and search by name in the search bar. The maxim
 {{< img src="synthetics/browser_tests/resources_panel.png" alt="Resources Panel" style="width:100%" >}}
 
 Relative Time 
-: The time point when resource began to load during the test step.
+: The point in time when the resource began to load during the test step.
 
 CDN
 : The CDN provider that served the resource. Hover over a CDN provider's icon to see the raw cache status.  

--- a/content/en/synthetics/browser_tests/test_results.md
+++ b/content/en/synthetics/browser_tests/test_results.md
@@ -112,7 +112,7 @@ You can filter resources by type and search by name in the search bar. The maxim
 {{< img src="synthetics/browser_tests/resources_panel.png" alt="Resources Panel" style="width:100%" >}}
 
 Relative Time 
-: The resource duration over the total interaction time.
+: The time point when resource began to load during the test step.
 
 CDN
 : The CDN provider that served the resource. Hover over a CDN provider's icon to see the raw cache status.  


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Making the description of Relative Time clearer that it refers to specific time point, not duration or ratio which current description sounds like.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
