### PR TITLE
CCR add documentation for 4 more GCP recommendations

### DIFF
--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -458,13 +458,13 @@ multifiltersearch:
       cloud_provider: GCP
       resource_type: CloudSQL Instance
       recommendation_type: Purchase CUD for Cloud SQL
-      recommendation_description: CloudSQL instances that would benefit from committed use discounts.
+      recommendation_description: CloudSQL instances that benefit from committed use discounts.
       recommendation_prerequisites: ""
     - category: Rate optimization
       cloud_provider: GCP
       resource_type: Cloud Run Job
       recommendation_type: Purchase Flexible CUD for Cloud Run Job
-      recommendation_description: Cloud Run Jobs that would benefit from flexible committed use discounts.
+      recommendation_description: Cloud Run Jobs that benefit from flexible committed use discounts.
       recommendation_prerequisites: ""
     - category: Rate optimization
       cloud_provider: GCP
@@ -483,6 +483,23 @@ multifiltersearch:
       resource_type: Compute Global Address
       recommendation_type: Delete Unused Compute Global IP Address
       recommendation_description: Unused compute global IP address can be deleted.
+    - category: Unused resource
+      cloud_provider: GCP
+      resource_type: Compute Disk
+      recommendation_type: Delete Unattached Compute Disk
+      recommendation_description: Compute disks that are unattached and can be deleted.
+      recommendation_prerequisites: ""
+    - category: Unused resource
+      cloud_provider: GCP
+      resource_type: Compute Disk
+      recommendation_type: Delete Unused Compute Disk
+      recommendation_description: Compute disks that are unused and can be deleted.
+      recommendation_prerequisites: ""
+    - category: Rate optimization
+      cloud_provider: GCP
+      resource_type: Storage Bucket
+      recommendation_type: Delete Non-Current Cloud Storage objects
+      recommendation_description: Cloud Storage buckets that benefit from lifecycle rules to automatically delete non-current object versions.
       recommendation_prerequisites: ""
 ---
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds entries in the CCM recommendations table for 4 released GCP recommendations. I've confirmed that all 4 of these are fully released and are generating recommendations. See [this widget](https://app.datadoghq.com/s/yB5yjZ/f4f-yu3-y3y)

### Merge instructions

Merge readiness:
- [x] Ready for merge
