### PR TITLE
Clarify OTel Metric Pricing 

### DIFF
--- a/content/en/opentelemetry/integrations/_index.md
+++ b/content/en/opentelemetry/integrations/_index.md
@@ -22,7 +22,7 @@ Datadog collects metrics from supported OpenTelemetry receivers at no extra cost
 
 For example, the [`dockerstatsreceiver`][15] `metadata.yaml` file lists metrics that you can collect at no extra cost.
 
-<div class="alert alert-warning">Ensure you configure receivers according to OpenTelemetry receiver documentation. Incorrectly configured receivers may cause metrics to be classified as custom, resulting in additional charges.</div>
+<div class="alert alert-warning">Ensure that you configure receivers according to OpenTelemetry receiver documentation. Incorrectly configured receivers may cause metrics to be classified as custom, resulting in additional charges.</div>
 
 ## Datadog-supported OpenTelemetry integrations
 

--- a/content/en/opentelemetry/integrations/_index.md
+++ b/content/en/opentelemetry/integrations/_index.md
@@ -8,19 +8,21 @@ further_reading:
 
 This page covers Datadog-supported OpenTelemetry (OTel) integrations. These integrations allow you to collect and monitor your observability data using OpenTelemetry in Datadog.
 
-<div class="alert alert-info">
-  <strong>Metric Pricing</strong><br>
-  <i>Standard</i> metrics are collected at no extra cost. These are:<br>
-  &hyphen; Documented in the <strong>Data collected</strong> table for each integration.<br>
-  &hyphen; Defined in the <code>metadata.yaml</code> file of the <a href="https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver">corresponding OpenTelemetry receiver.</a><br><br>
-  Ensure you configure receivers according to OpenTelemetry receiver documentation. Incorrectly configured receivers may cause metrics to be classified as custom, resulting in additional charges.
-</div>
-
 ## Overview
 
 OpenTelemetry (OTel) integrations are components that enable the collection of observability data (metrics, traces, and logs) from various sources using the OpenTelemetry standard. These integrations are designed to work with the OpenTelemetry Collector, which receives, processes, and exports telemetry data to observability backends like Datadog.
 
 For a comprehensive list of all OpenTelemetry integrations, see the [OpenTelemetry Registry][1]. This registry provides information on receivers, exporters, and other components in the OpenTelemetry ecosystem.
+
+## Metric pricing
+
+Datadog collects metrics from supported OpenTelemetry receivers at no extra cost. These no-cost metrics are:
+- Defined in the `metadata.yaml` file for each receiver.
+- Listed in the [Metrics Mappings][14] table.
+
+For example, the [`dockerstatsreceiver`][15] `metadata.yaml` file lists metrics that you can collect at no extra cost.
+
+<div class="alert alert-warning">Ensure you configure receivers according to OpenTelemetry receiver documentation. Incorrectly configured receivers may cause metrics to be classified as custom, resulting in additional charges.</div>
 
 ## Datadog-supported OpenTelemetry integrations
 
@@ -85,3 +87,5 @@ Monitor big data processing frameworks:
 [11]: /opentelemetry/integrations/mysql_metrics/
 [12]: /opentelemetry/integrations/kafka_metrics/
 [13]: /opentelemetry/integrations/spark_metrics/
+[14]: /opentelemetry/mapping/metrics_mapping/#metrics-mappings
+[15]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/dockerstatsreceiver/metadata.yaml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Our current note on metric pricing for OTel integrations is causing confusion.
- Revise and clarify content + move to dedicated section.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
