### PR TITLE
Fixing some missing environment variables from documentation

### DIFF
--- a/content/en/serverless/azure_app_services/azure_app_services_linux.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_linux.md
@@ -128,6 +128,9 @@ Additional flags, like `--service` and `--env`, can be used to set the service a
 | `DD_API_KEY` | Your Datadog API key. | See [Organization Settings > API Keys][301] in Datadog. |
 | `DD_SITE` | {{< region-param key="dd_site" code="true" >}} | Your [Datadog site][302]. Defaults to `datadoghq.com`. |
 | `DD_SERVICE` | Your application's service name. | Defaults to the name field value in `package.json`. |
+| `DD_ENV` | Your application's environment name. | There is no default value for this field. |
+| `DD_SERVERLESS_LOG_PATH` | The Logpath the sidecar uses to collect logs. | Where you write your logs. For example, `/home/LogFiles/*.log` or `/home/LogFiles/myapp/*.log` |
+| `WEBSITES_ENABLE_APP_SERVICE_STORAGE` | `true` | Setting this environment variable to `true` allows the `/home/` mount to persist and share with the sidecar |
 
 {{% collapse-content title=".NET: Additional required environment variables" level="h4" id="dotnet-additional-settings" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
There were a few key environment variables missing from the first publishing of the document. 
This PR addresses the miss environment variables.

### Merge instructions


Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
