### PR TITLE
Add event correlation to unsupported sites

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -262,6 +262,7 @@ unsupported_sites:
   ci_visibility: [gov]
   continuous_delivery: [gov]
   continuous_integration: [gov]
+  correlation: [gov]
   data_jobs: [gov]
   datadog_cloudcraft: [gov]
   dora_metrics: [gov]

--- a/content/en/service_management/events/correlation/_index.md
+++ b/content/en/service_management/events/correlation/_index.md
@@ -11,16 +11,12 @@ further_reading:
 algolia:
   tags: ["event correlation", "event grouping", "correlation pattern"]
 ---
-{{% site-region region="gov" %}}
-<div class="alert alert-warning">
-Event Correlation is not available in the {{< region-param key=dd_datacenter code="true" >}} site.
-</div>
-{{% /site-region %}}
+
 ## Overview
 
-Event Correlation groups events based on their relationships or on user-defined configurations to reduce the number of notifications and issues identified from the environment. Use correlation and cases to: 
-* Reduce alert fatigue 
-* Reduce the number of tickets and notifications you receive 
+Event Correlation groups events based on their relationships or on user-defined configurations to reduce the number of notifications and issues identified from the environment. Use correlation and cases to:
+* Reduce alert fatigue
+* Reduce the number of tickets and notifications you receive
 * Have all affected teams to be aware of a single issue instead of working in silos
 
 {{< whatsnext desc="Get Started:">}}

--- a/content/en/service_management/events/correlation/analytics.md
+++ b/content/en/service_management/events/correlation/analytics.md
@@ -8,7 +8,7 @@ further_reading:
 
 ## Overview
 
-Keep track of your teams' workload by charting and creating dashboards for events, alerts, and cases. 
+Keep track of your teams' workload by charting and creating dashboards for events, alerts, and cases.
 
 
 ## Case Metrics
@@ -16,16 +16,16 @@ Keep track of your teams' workload by charting and creating dashboards for event
 {{< img src="service_management/events/correlation/case_analytics.png" alt="Configure case analytics" style="width:100%;" >}}
 
 
-You can query Case analytics in a variety of graph widgets to analyze team productivity and identify patterns in issues. Display analytic graphs on both Dashboards and Notebooks. To get started, in the widget configuration, select **Cases** in the data source dropdown under the *Graph your data* section. 
+You can query Case analytics in a variety of graph widgets to analyze team productivity and identify patterns in issues. Display analytic graphs on both Dashboards and Notebooks. To get started, in the widget configuration, select **Cases** in the data source dropdown under the *Graph your data* section.
 
 The following widgets support Case Analytics:
 
 - timeseries
 - top list
-- query value 
+- query value
 - table
-- tree map 
-- pie chart 
+- tree map
+- pie chart
 - change
 - list
 
@@ -36,7 +36,7 @@ Break down event metrics by source, host, service, and more. Find out where your
 
 {{< img src="service_management/events/correlation/event_analytics.png" alt="Configure event analytics" style="width:100%;" >}}
 
-To get started, in the widget configuration, select **Events** in the data source dropdown under the *Graph your data* section. 
+To get started, in the widget configuration, select **Events** in the data source dropdown under the *Graph your data* section.
 
 ## Further Reading
 

--- a/content/en/service_management/events/correlation/configuration.md
+++ b/content/en/service_management/events/correlation/configuration.md
@@ -9,12 +9,6 @@ further_reading:
   text: "Analytics on cases"
 ---
 
-{{% site-region region="gov" %}}
-<div class="alert alert-warning">
-Event Correlation is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).
-</div>
-{{% /site-region %}}
-
 ## Overview
 
 There are two types of correlations: 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Use site support automation to add banner for Event Correlation docs
- Remove hard coded banners
- Correlation and child pages now show the Unsupported for US-FED1 banner

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

