### PR TITLE
[docseng-37] copy sourced integrations earlier in the build process to generate placeholder pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,12 @@ update_websites_sources_module:
 	node_modules/hugo-bin/vendor/hugo mod clean
 	node_modules/hugo-bin/vendor/hugo mod tidy
 	cat go.mod
-	node_modules/hugo-bin/vendor/hugo mod vendor
-	cp -rpv _vendor/github.com/DataDog/websites-sources/content/en/integrations/. content/en/integrations/
-	rm -rf _vendor
+	@if [ -n "$(CI_COMMIT_REF_NAME)" ]; then \
+		echo "In ci, vendoring integrations pages for placeholder generation"; \
+		node_modules/hugo-bin/vendor/hugo mod vendor; \
+		cp -rpv _vendor/github.com/DataDog/websites-sources/content/en/integrations/. content/en/integrations/; \
+		rm -rf _vendor; \
+	fi
 
 #######################################################################################################################
 # API Code Examples

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ start-no-pre-build: node_modules  ## Build and run docs excluding external conte
 
 # Leave build scripts as is for local testing
 # This is useful for testing changes to the build scripts locally
+# We aren't generating placeholders locally so the order of dependencies and sources module doesn't matter
 start-preserve-build: dependencies
 	@make update_websites_sources_module
 	@make server

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ watch-cdocs:
 
 start:
 	@make setup-build-scripts ## Build and run docs including external content.
-	@make dependencies
 	@make update_websites_sources_module
+	@make dependencies
 	@make server
 
 # Skip downloading any dependencies and run the site (hugo needs at the least node)
@@ -153,6 +153,10 @@ update_websites_sources_module:
 	node_modules/hugo-bin/vendor/hugo mod clean
 	node_modules/hugo-bin/vendor/hugo mod tidy
 	cat go.mod
+	node_modules/hugo-bin/vendor/hugo mod vendor
+	cp -rpv _vendor/github.com/DataDog/websites-sources/content/en/integrations/. content/en/integrations/
+	rm -rf _vendor
+
 #######################################################################################################################
 # API Code Examples
 #######################################################################################################################

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,8 @@ watch-cdocs:
 
 start:
 	@make setup-build-scripts ## Build and run docs including external content.
-	@make update_websites_sources_module
 	@make dependencies
+	@make update_websites_sources_module
 	@make server
 
 # Skip downloading any dependencies and run the site (hugo needs at the least node)
@@ -86,7 +86,6 @@ start-no-pre-build: node_modules  ## Build and run docs excluding external conte
 
 # Leave build scripts as is for local testing
 # This is useful for testing changes to the build scripts locally
-# We aren't generating placeholders locally so the order of dependencies and sources module doesn't matter
 start-preserve-build: dependencies
 	@make update_websites_sources_module
 	@make server
@@ -117,7 +116,7 @@ node_modules: package.json yarn.lock
 
 # All the requirements for a full build
 dependencies: clean
-	make hugpython all-examples update_pre_build node_modules build-cdocs placeholders
+	make hugpython all-examples update_pre_build node_modules build-cdocs
 
 integrations_data/extracted/vector:
 	$(call source_repo,vector,https://github.com/vectordotdev/vector.git,master,true,website/)


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This aims to solve the missing placeholder pages from integrations problem.

- separates `placeholders` from the `make dependencies` chain so it can happen further down the line.   we don't generate placeholders locally, so there's no need to call on it in the Makefile.
- update `make update_websites_sources_module` to use `hugo mod vendor`, copy the sourced integrations markdown files from websites-sources into docs, and remove the vendor directory immediately.  this should only happen in the CI.  the `_vendor` folder is already gitignored and there is logic to prevent it from running locally anyway, so it would never be committed.

new order of operations would be:
- `dependencies`
- `update_websites_sources_module`
- `placeholders`
...
- `build_site`

now we have the integrations in the file system, we can generate placeholders for them.

https://datadoghq.atlassian.net/browse/DOCSENG-37

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
QA integrations page: https://docs-staging.datadoghq.com/brian.deutsch/docseng-37-placehold-apw-integrations/integrations/
QA integration details pages
pages that don't have placeholders in live have them in this preview for every language.   for example:
- https://docs-staging.datadoghq.com/brian.deutsch/docseng-37-placehold-apw-integrations/es/integrations/google-cloud-platform
- https://docs-staging.datadoghq.com/brian.deutsch/docseng-37-placehold-apw-integrations/ko/integrations/celery/
