### PR TITLE
Add `corp_vpn` as a Threat Intelligence Category

### DIFF
--- a/content/en/security/threat_intelligence.md
+++ b/content/en/security/threat_intelligence.md
@@ -97,6 +97,7 @@ Sources, categories, and intents are available as facets and filters on relevant
 | hosting_proxy | suspicious | IP addresses | Datacenter IPs with a reputation of abuse, such as for distributed credential stuffing attacks | AAP and Cloud SIEM |
 | tor | suspicious | IP addresses  | Corporate policy violations for user activity | AAP and Cloud SIEM |
 | disposable_email | suspicious | Domain  | Detect product usage from disposable email addresses | AAP |
+| corp_vpn | benign | IP addresses | IPs associated to Corperate VPNs | AAP and Client SIEM |
 
 ### Threat Intelligence Intents
 | Intent | Use Case |


### PR DESCRIPTION
Update external docs to match `corp_vpn` Threat Intel Category that we are already using