### PR TITLE
Updated Datadog Agent binary location

### DIFF
--- a/content/en/network_monitoring/devices/troubleshooting.md
+++ b/content/en/network_monitoring/devices/troubleshooting.md
@@ -214,7 +214,7 @@ Check for any rules blocking UDP traffic on your configured ports. For example:`
    Add a net bind capability to the Agent binary, which allows the Agent to bind to reserved ports:
 
    ```
-   sudo setcap 'cap_net_bind_service=+ep' /opt/datadog-agent/bin/agent/agent
+   sudo setcap 'CAP_NET_BIND_SERVICE=+ep' /opt/datadog-packages/datadog-agent/stable/bin/agent/agent
    ```
 
 ### Traps incorrectly formatted


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Binding to ports below 1024 (like SNMP Trap port 162) requires elevated permissions. To enable this, the agent binary needs an additional capability set.

The existing instructions point to an outdated binary path:
`/opt/datadog-agent/bin/agent/agent`

Current path is:
`/opt/datadog-packages/datadog-agent/stable/bin/agent/agent`

This update fixes the path reference in the documentation. Verified the current path with v7.67.0

### _NOTE TO THE DOCS TEAM:_
This is the same issue as a previous PR I submitted: https://github.com/DataDog/documentation/pull/30265

There are four more docs where the same agent binary path update should be applied. I am unable to edit these page w/o the "EDIT" button on them. They are:

1. [Symantec Endpoint Protection](https://docs.datadoghq.com/integrations/symantec-endpoint-protection/#permission-denied-while-port-binding)
2. [Juniper SRX Firewall](https://docs.datadoghq.com/integrations/juniper-srx-firewall/#permission-denied-while-port-binding)
3. [Delinea Secret Server](https://docs.datadoghq.com/integrations/delinea-secret-server/#permission-denied-while-port-binding)
4. [Checkpoint Quantum Firewall](https://docs.datadoghq.com/integrations/checkpoint-quantum-firewall/#permission-denied-while-port-binding)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
