### PR TITLE
specify when releases move between support levels

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -25,8 +25,8 @@ Support levels are defined by the following:
 | Level                | Policy |
 |----------------------|--------|
 | General Availability | Bug fixes are released on the most recent General Availability minor release line. New features are released periodically as minor version changes. Critical fixes are backported to the three most recent minor release lines. |
-| Maintenance          | The most recent Maintenance minor release line receives critical fixes. Major versions become end of life 6 months after the new major version is GA. |
-| End of Life (EOL)    | Receives no updates or support. |
+| Maintenance          | The most recent Maintenance minor release line receives critical fixes. Releases "x.y.z" go from GA to Maintenance 12 months after the "x.0.0" release. |
+| End of Life (EOL)    | Receives no updates or support. Releases "x.y.z" go from Maintenance to EOL 18 months after the "x.0.0" release. |
 
 The Python APM Client library supports the following Python runtimes:
 

--- a/content/en/tracing/trace_collection/compatibility/python.md
+++ b/content/en/tracing/trace_collection/compatibility/python.md
@@ -22,11 +22,12 @@ The following Python APM Client library release branches are supported:
 {{< partial name="trace_collection/python/supported_versions.html" >}}
 
 Support levels are defined by the following:
-| Level                | Policy |
-|----------------------|--------|
-| General Availability | Bug fixes are released on the most recent General Availability minor release line. New features are released periodically as minor version changes. Critical fixes are backported to the three most recent minor release lines. |
-| Maintenance          | The most recent Maintenance minor release line receives critical fixes. Releases "x.y.z" go from GA to Maintenance 12 months after the "x.0.0" release. |
-| End of Life (EOL)    | Receives no updates or support. Releases "x.y.z" go from Maintenance to EOL 18 months after the "x.0.0" release. |
+
+| Support Level | Support Provided | Lifecycle Timeline |
+| :--- | :--- | :--- |
+| **General Availability (GA)** | <li>New features and enhancements</li><li>All bug and security fixes (on the latest minor release)</li><li>Critical fixes backported (to the 3 most recent minor releases)</li> | A major version is in GA for **12 months** following its initial `x.0.0` release. |
+| **Maintenance** | <li>Critical security and bug fixes only</li> | A major version enters Maintenance **12 months** after its initial release and remains for **6 months**. |
+| **End of Life (EOL)** | <li>No updates or support</li> | A major version becomes EOL **18 months** after its initial `x.0.0` release. |  
 
 The Python APM Client library supports the following Python runtimes:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Provides clear expectations to customers around when particular versions of dd-trace-py will move between support levels, from GA to Maintenance and from Maintenance to EOL

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
