### PR TITLE
Update AKS instructions for new certificate rotation format

### DIFF
--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -82,7 +82,7 @@ Your nodes have this feature enabled if they have the label `kubernetes.azure.co
 kubectl get nodes -L kubernetes.azure.com/kubelet-serving-ca
 ```
 
-If all your nodes show `cluster` do not provide any specific `kubelet` configuration as the Agent will connect automatically. If your nodes do not have this feature enabled use the [Kubelet configurations without certificate rotation](#without-kubernetes-certificate-rotation).
+If all your nodes show `cluster` do not provide any specific `kubelet` configuration as the Agent successfully connects by default. If your nodes do not have this feature enabled use the [Kubelet configurations without certificate rotation](#without-kubelet-serving-certificate-rotation).
 **Note:** This configuration should be removed once certificate rotation is enabled in your cluster.
 
 Lastly, the optional [Admission Controller][1] feature requires a specific configuration to prevent an error when reconciling the webhook.
@@ -137,7 +137,7 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 {{% /tab %}}
 {{< /tabs >}}
 
-### Without Kubernetes certificate rotation
+### Without Kubelet serving certificate rotation
 
 **Note:** When upgrading your AKS cluster you may see the [certificate rotation][13] feature enabled for you automatically which can negatively impact your Datadog Agent if you are using the below configuration to reference the certificate `/etc/kubernetes/certs/kubeletserver.crt`. This certificate file is removed once this feature enabled. Which can cause:
 
@@ -145,6 +145,8 @@ The `providers.aks.enabled` option sets the necessary environment variable `DD_A
 - In Helm: The Agent pod fails to start with the warning event `MountVolume.SetUp failed for volume "kubelet-ca" : hostPath type check failed: /etc/kubernetes/certs/kubeletserver.crt is not a file`
 
 In these cases remove the kubelet configurations and return to the defaults as seen above. Alternatively [connecting to the kubelet without TLS Verification](#without-tls-verification) is still supported on all AKS versions.
+
+When this feature is not enabled you can provide the Datadog Agent an updated kubelet configuration to allow it to properly connect.
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Update the instructions with respect to the changes in AKS certificates once kubelet serving certificate rotation is enabled. 
- https://learn.microsoft.com/en-us/azure/aks/certificate-rotation#kubelet-serving-certificate-rotation

As once this is enabled you do not need to provide any unique kubelet configuration anymore, the Datadog Agent can connect with the default configurations. As the default certificate is no longer self signed and the endpoint supports the IP Address in the Subject Alternative Name (SAN).

This feature is gradually being rolled out to nodes, with 2 regions in June and more in the next few days. So there isn't an *exact* node image version to point to. Which is why we recommend to check the node labels to validate which configuration to use. 

Additionally when upgrading your cluster you will encounter issues when using the old configuration. Which is why those disclaimers and the relative logs are shown. 

Minor note: fixed an issue in the old Operator config as it didn't need the `valueFrom` in the config.

Can see below for more details:
- https://datadoghq.atlassian.net/browse/TEEP-1181

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->
Can probably close
- https://datadoghq.atlassian.net/browse/DOCS-10757
- https://datadoghq.atlassian.net/browse/DOCS-11326

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
