### PR TITLE
[DOCS-11310] RUM actions limit

### DIFF
--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -27,6 +27,8 @@ You can accomplish the following objectives:
 * Quantify feature adoption
 * Identify the steps that led to a specific browser error
 
+While there is no explicit cap on the total number of actions that can be collected by the RUM Browser SDK during a session, there are technical limitations on individual event sizes and the payload sent. For further details about limitations on actions, see [RUM Browser Troubleshooting documentation][8].
+
 ## Manage information being collected
 
 The `trackUserInteractions` initialization parameter enables the collection of user clicks in your application, which means sensitive and private data contained in your pages may be included to identify elements that a user interacted with.
@@ -121,3 +123,4 @@ For more information, see [Send Custom Actions][5].
 [5]: /real_user_monitoring/guide/send-rum-custom-actions
 [6]: /data_security/real_user_monitoring/#mask-action-names
 [7]: /real_user_monitoring/browser/frustration_signals/
+[8]: /real_user_monitoring/browser/troubleshooting/

--- a/content/en/real_user_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/browser/tracking_user_actions.md
@@ -27,21 +27,21 @@ You can accomplish the following objectives:
 * Quantify feature adoption
 * Identify the steps that led to a specific browser error
 
-While there is no explicit cap on the total number of actions that can be collected by the RUM Browser SDK during a session, there are technical limitations on individual event sizes and the payload sent. For further details about limitations on actions, see [RUM Browser Troubleshooting documentation][8].
+While there is no explicit cap on the total number of actions that can be collected by the RUM Browser SDK during a session, there are technical limitations on individual event sizes and the payload sent. For further details about limitations on actions, see [RUM Browser Troubleshooting documentation][1].
 
 ## Manage information being collected
 
 The `trackUserInteractions` initialization parameter enables the collection of user clicks in your application, which means sensitive and private data contained in your pages may be included to identify elements that a user interacted with.
 
-To control which information is sent to Datadog, you can [mask action names with privacy options][6], [manually set an action name](#declare-a-name-for-click-actions), or [implement a global scrubbing rule in the Datadog Browser SDK for RUM][1].
+To control which information is sent to Datadog, you can [mask action names with privacy options][2], [manually set an action name](#declare-a-name-for-click-actions), or [implement a global scrubbing rule in the Datadog Browser SDK for RUM][3].
 
 ## Track user interactions
 
-The RUM Browser SDK automatically tracks clicks to generate click actions. A one-click action generally represents one user click, except when the same element is clicked multiple times in a row, which is considered a single action (see [Frustration Signals "rage clicks"][7]).
+The RUM Browser SDK automatically tracks clicks to generate click actions. A one-click action generally represents one user click, except when the same element is clicked multiple times in a row, which is considered a single action (see [Frustration Signals "rage clicks"][4]).
 
 ## Action timing metrics
 
-For information about the default attributes for all RUM event types, see [RUM Browser Data Collected][3].
+For information about the default attributes for all RUM event types, see [RUM Browser Data Collected][5].
 
 | Metric    | Type   | Description              |
 |--------------|--------|--------------------------|
@@ -50,9 +50,9 @@ For information about the default attributes for all RUM event types, see [RUM B
 | `action.resource.count`         | number      | Count of all resources collected for this action. |
 | `action.error.count`      | number      | Count of all errors collected for this action.|
 
-The Datadog Browser SDK for RUM calculates action loading time by monitoring page activity following every click. An action is considered complete when the page has no more activity. See [How page activity is calculated][2] for details.
+The Datadog Browser SDK for RUM calculates action loading time by monitoring page activity following every click. An action is considered complete when the page has no more activity. See [How page activity is calculated][6] for details.
 
-For more information about configuring for sampling or global context, see [Modifying RUM Data and Context][1].
+For more information about configuring for sampling or global context, see [Modifying RUM Data and Context][3].
 
 ## Action attributes
 
@@ -79,7 +79,7 @@ For example:
 </div>
 ```
 
-Starting with [version 2.16.0][4], with the `actionNameAttribute` initialization parameter, you can specify a custom attribute that is used to name the action.
+Starting with [version 2.16.0][7], with the `actionNameAttribute` initialization parameter, you can specify a custom attribute that is used to name the action.
 
 For example:
 
@@ -110,17 +110,17 @@ The Datadog Browser SDK uses different strategies to compute click action names:
 
 To extend the collection of user interactions, send your custom actions using the `addAction` API. These custom actions send information relative to an event that occurs during a user journey.
 
-For more information, see [Send Custom Actions][5].
+For more information, see [Send Custom Actions][8].
 
-## Further Reading
+## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /real_user_monitoring/browser/advanced_configuration/
-[2]: /real_user_monitoring/browser/monitoring_page_performance/#how-page-activity-is-calculated
-[3]: /real_user_monitoring/browser/data_collected/#default-attributes
-[4]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v2160
-[5]: /real_user_monitoring/guide/send-rum-custom-actions
-[6]: /data_security/real_user_monitoring/#mask-action-names
-[7]: /real_user_monitoring/browser/frustration_signals/
-[8]: /real_user_monitoring/browser/troubleshooting/
+[1]: /real_user_monitoring/browser/troubleshooting/
+[2]: /data_security/real_user_monitoring/#mask-action-names
+[3]: /real_user_monitoring/browser/advanced_configuration/
+[4]: /real_user_monitoring/browser/frustration_signals/
+[5]: /real_user_monitoring/browser/data_collected/#default-attributes
+[6]: /real_user_monitoring/browser/monitoring_page_performance/#how-page-activity-is-calculated
+[7]: https://github.com/DataDog/browser-sdk/blob/main/CHANGELOG.md#v2160
+[8]: /real_user_monitoring/guide/send-rum-custom-actions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Received external feedback (more of a question) about what limits there are on actions. This PR answers the question, and reorders links.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
