### PR TITLE
Add page on init container resource calc

### DIFF
--- a/content/en/tracing/guide/init_resource_calc.md
+++ b/content/en/tracing/guide/init_resource_calc.md
@@ -8,7 +8,7 @@ disable_toc: false
 
 Starting in Agent [v7.60+][1], Datadog uses dynamic resource calculation for init containers that inject tracing libraries. Instead of using fixed values, the init containers temporarily request all available CPU and memory for the pod, without affecting how the pod is scheduled. (Prior to v7.60, init containers used conservative defaults: `50m` for CPU and `20Mi` for memory.)
 
-This behavior improves tracer startup reliability while respecting Kubernetes scheduling rules. Init containers run sequentially and exit before application containers start, so they don't compete for runtime resources.
+This behavior improves tracer startup reliability while respecting Kubernetes scheduling rules. Since init containers run sequentially and exit before application containers start, they don't compete for runtime resources.
 
 ### Pod scheduling
 

--- a/content/en/tracing/guide/init_resource_calc.md
+++ b/content/en/tracing/guide/init_resource_calc.md
@@ -1,6 +1,6 @@
 ---
 title: Init Container Resource Usage
-Learn how Datadog Agent v7.60+ automatically manages resource allocation for init containers that set up tracing, ensuring reliable tracer startup without impacting pod scheduling.
+description: Learn how Datadog Agent v7.60+ automatically manages resource allocation for init containers that set up tracing, ensuring reliable tracer startup without impacting pod scheduling.
 disable_toc: false
 ---
 

--- a/content/en/tracing/guide/init_resource_calc.md
+++ b/content/en/tracing/guide/init_resource_calc.md
@@ -26,7 +26,7 @@ Since init containers run before application containers (and don't overlap with 
 
 ### Override default behavior
 
-If needed, you can override init container resource usage by setting the following environment variables in the Cluster Agent configuration:
+If needed, you can override the default init container resource usage by setting the following environment variables in the Cluster Agent configuration:
   - `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU`
   - `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY`
 

--- a/content/en/tracing/guide/init_resource_calc.md
+++ b/content/en/tracing/guide/init_resource_calc.md
@@ -22,7 +22,7 @@ Effective CPU/Memory request =
 </code></pre>
 </div>
 
-Because init containers run before application containers (and don't overlap), they can temporarily use more resources without increasing the pod's effective request, as long as no single init container requests more than the pod can tolerate.
+Since init containers run before application containers (and don't overlap with them), they can temporarily use more resources without increasing the pod's effective request. This works as long as no single init container requests more resources than the pod can tolerate.
 
 ### Override default behavior
 

--- a/content/en/tracing/guide/init_resource_calc.md
+++ b/content/en/tracing/guide/init_resource_calc.md
@@ -1,0 +1,32 @@
+---
+title: Init container resource usage
+disable_toc: false
+---
+
+### Overview
+
+Starting in Agent [v7.60+][1], Datadog uses dynamic resource calculation for init containers that inject tracing libraries. Instead of fixed values, the init containers temporarily request all available CPU and memory for the pod, without affecting how the pod is scheduled. (Prior v7.60, init containers used conservative defaults: `50m` for CPU and `20Mi` for memory.)
+
+This behavior improves tracer startup reliability while respecting Kubernetes scheduling rules. Init containers run sequentially and exit before application containers start, so they don't compete for runtime resources.
+
+### Pod scheduling
+
+Kubernetes schedules pods using a formula that accounts for init containers:
+
+<div style="text-align:center">
+<pre><code>
+Effective CPU/Memory request =
+  max(sum of requests from all regular containers,
+      max request of any single init container)
+</code></pre>
+</div>
+
+Because init containers run before application containers (and don't overlap), they can temporarily use more resources without increasing the pod's effective request, as long as no single init container requests more than the pod can tolerate.
+
+### Override default behavior
+
+If needed, you can override init container resource usage by setting the following environment variables in the Cluster Agent configuration:
+  - `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_CPU`
+  - `DD_ADMISSION_CONTROLLER_AUTO_INSTRUMENTATION_INIT_RESOURCES_MEMORY`
+
+[1]: https://github.com/DataDog/datadog-agent/blob/40f0be0645ae309a07031bd7954fd58a8eb79853/pkg/clusteragent/admission/mutate/autoinstrumentation/auto_instrumentation.go#L611-L626

--- a/content/en/tracing/guide/init_resource_calc.md
+++ b/content/en/tracing/guide/init_resource_calc.md
@@ -6,7 +6,7 @@ disable_toc: false
 
 ### Overview
 
-Starting in Agent [v7.60+][1], Datadog uses dynamic resource calculation for init containers that inject tracing libraries. Instead of fixed values, the init containers temporarily request all available CPU and memory for the pod, without affecting how the pod is scheduled. (Prior v7.60, init containers used conservative defaults: `50m` for CPU and `20Mi` for memory.)
+Starting in Agent [v7.60+][1], Datadog uses dynamic resource calculation for init containers that inject tracing libraries. Instead of using fixed values, the init containers temporarily request all available CPU and memory for the pod, without affecting how the pod is scheduled. (Prior to v7.60, init containers used conservative defaults: `50m` for CPU and `20Mi` for memory.)
 
 This behavior improves tracer startup reliability while respecting Kubernetes scheduling rules. Init containers run sequentially and exit before application containers start, so they don't compete for runtime resources.
 

--- a/content/en/tracing/guide/init_resource_calc.md
+++ b/content/en/tracing/guide/init_resource_calc.md
@@ -1,5 +1,6 @@
 ---
-title: Init container resource usage
+title: Init Container Resource Usage
+Learn how Datadog Agent v7.60+ automatically manages resource allocation for init containers that set up tracing, ensuring reliable tracer startup without impacting pod scheduling.
 disable_toc: false
 ---
 

--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm/kubernetes.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm/kubernetes.md
@@ -7,6 +7,9 @@ further_reading:
   - link: /tracing/metrics/runtime_metrics/
     tag: Documentation
     text: Enable Runtime Metrics
+  - link: /tracing/guide/init_resource_calc/
+    tag: Documentation
+    text: Learn about init container resource usage
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/DOCS-10936

Create a page that describes how init container resources are calculated. This is information that only a small subset of users want/need to know, so we want a page to point them to, but we don't need the content to be super visible. I've added a link to it from the Further Reading section of the K8s SSI home page. We can reconsider placement if/when we get feedback to warrant that. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
