### PR TITLE
Add blog to 2 Error Tracking pages

### DIFF
--- a/content/en/error_tracking/_index.md
+++ b/content/en/error_tracking/_index.md
@@ -1,6 +1,10 @@
 ---
 title: Error Tracking
 disable_toc: false
+further_reading:
+- link: 'https://www.datadoghq.com/blog/error-tracking-and-github/'
+  tag: 'Blog'
+  text: 'Troubleshoot root causes with GitHub commit and ownership data in Error Tracking'
 ---
 
 ## Overview
@@ -27,6 +31,10 @@ For details, see the product-specific Error Tracking documentation:
 - [APM][1]
 - [Log Management][2]
 - [Real User Monitoring][3]
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /tracing/error_tracking#setup
 [2]: /logs/error_tracking#setup

--- a/content/en/error_tracking/suspect_commits.md
+++ b/content/en/error_tracking/suspect_commits.md
@@ -1,6 +1,10 @@
 ---
 title: Suspect Commits
 disable_toc: false
+further_reading:
+- link: 'https://www.datadoghq.com/blog/error-tracking-and-github/'
+  tag: 'Blog'
+  text: 'Troubleshoot root causes with GitHub commit and ownership data in Error Tracking'
 ---
 ## Overview
 
@@ -37,6 +41,11 @@ The Suspect Commits feature requires [Source Code Integration][1]. To enable Sou
 ### Install the GitHub integration
 Install [the GitHub integration][2], enabling read permissions for pull requests and contents.
 
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
 [1]: /integrations/guide/source-code-integration
 [2]: /integrations/github/
 [3]: https://app.datadoghq.com/integrations
+


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Adds the [Troubleshoot root causes with GitHub commit and ownership data in Error Tracking](https://www.datadoghq.com/blog/error-tracking-and-github/) to the following Error Tracking pages:
  - https://docs.datadoghq.com/error_tracking/
  - https://docs.datadoghq.com/error_tracking/suspect_commits/

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
