### PR TITLE
[CAP-2694] CRD filtering/sorting

### DIFF
--- a/content/en/infrastructure/containers/configuration.md
+++ b/content/en/infrastructure/containers/configuration.md
@@ -272,7 +272,7 @@ Follow these steps to collect the custom resources that these CRDs define:
 
 1.  Select **Enable Indexing** to save.
 
-After the fields are indexed, you can add them as columns in the explorer or as part of Saved Views.
+After the fields are indexed, you can add them as columns in the explorer and sort them, or include them in Saved Views. You can also filter on indexed fields using the prefix `field#`.
 
 ### Indexing complex types
 

--- a/content/en/infrastructure/containers/orchestrator_explorer.md
+++ b/content/en/infrastructure/containers/orchestrator_explorer.md
@@ -158,12 +158,12 @@ There are multiple types of terms available:
 
 | Type | Examples |
 |---|---|
-| **Tags**: Attached to resources by [the agent collecting them][20]. There are also additional tags that Datadog generates for Kubernetes resources. | `datacenter:staging`<br>`tag#datacenter:staging`<br>*(the `tag#` is optional)* |
+| **Tags**: Attached to resources by [the agent collecting them][20]. There are also additional tags that Datadog generates for Kubernetes resources. | `datacenter:staging`, `tag#datacenter:staging`<br>_(the `tag#` is optional)_ |
 | **Labels**: Extracted from [a resource's metadata][25]. They are typically used to organize your cluster and target specific resources with selectors. | `label#chart_version:2.1.0` |
 | **Annotations**: Extracted from [a resource's metadata][26]. They are generally used to support tooling that aid in cluster management. | `annotation#checksum/configmap:a1bc23d4` |
 | **Metrics**: Added to workload resources (pods, deployments, etc.). You can find resources based on their utilization. To see what metrics are supported, see [Resource Utilization Filters](#resource-utilization-filters). | `metric#cpu_usage_pct_limits_avg15:>80%` |
-| **String matching**: Supported by some specific resource attributes, see below.<br>*Note: string matching does not use the key-value format, and you cannot specify the attribute to match on.* | `"10.132.6.23"` (IP)<br>`"9cb4b43f-8dc1-4a0e"` (UID)<br>`web-api-3` (Name) |
-| **Fields**: Extracted from [a resource's metadata][27]. | `field#metadata.creationTimestamp:>=4wk`<br>`field#metadata.deletionTimestamp:<=1hr` |
+| **String matching**: Supported by some specific resource attributes, see below.<br>_Note: string matching does not use the key-value format, and you cannot specify the attribute to match on._ | `"10.132.6.23"` (IP),<br>`"9cb4b43f-8dc1-4a0e"` (UID),<br>`web-api-3` (Name) |
+| **Fields**: Extracted from [a resource's metadata][27] or from custom resources' indexed fields. | `field#metadata.creationTimestamp:>=4wk`, `field#metadata.deletionTimestamp:<=1hr`, `field#status.currentReplicas:3`, `field#status.conditions.Active.status:True` |
 
 >  ***Note**: You might find the same key-value pairs as both a tag and label (or annotation) - this is dependent on how your cluster is configured.*
 
@@ -294,7 +294,7 @@ Some resources have specific tags that are extracted based on your cluster's env
 | Resource | Extracted Tags |
 |---|---|
 | **Cluster** | `api_server_version`<br>`kubelet_version` |
-| **Custom Resource Definitions** &<br>**Custom Resources** | `kube_crd_kind`<br>`kube_crd_group`<br>`kube_crd_version`<br>`kube_crd_scope` |
+| **Custom Resource Definitions** &<br>**Custom Resources** | `kube_crd_kind`<br>`kube_crd_group`<br>`kube_crd_version`<br>`kube_crd_scope`<br>`kube_crd_resource` |
 | **Namespace** | `phase` |
 | **Node** | `kube_node_unschedulable`<br>`kube_node_kubelet_version`<br>`kube_node_kernel_version`<br>`kube_node_runtime_version`<br>`eks_fargate_node`<br>`node_schedulable`<br>`node_status` |
 | **Persistent Volume** | `kube_reclaim_policy`<br>`kube_storage_class_name`<br>`pv_type`<br>`pv_phase` |


### PR DESCRIPTION
### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Here’s a quick summary of what’s new: CRD Filtering / Sorting: [before](https://app.datadoghq.com/orchestration/explorer/cr?cr-explorer-cols=name%2Ccluster%2C%40spec.maxReplicas%2C%40status.desiredReplicas&explorer-na-groups=false&ptfu=false)/[after](https://dd.datad0g.com/orchestration/explorer/cr?query=field%23status.agentList.available%3A1&cr-explorer-cols=name%2Cage%2Cfield%23apiVersion%2Cfield%23status.agentList.available%2Cfield%23status.agent.ready%2Cfield%23status.agentList.daemonsetName&crd_resource=datadogagent%2Fdatadoghq.com%2Fv2alpha1&explorer-na-groups=false)

- CR fields as columns using TagPopover: previously only partial data was shown, and CR field columns now support filtering, grouping, and column management — not just plain string values

- Filtering on CR fields is now fully supported: via the search bar (autocompletion and suggestions), facets, and TagPopover, etc.

- Sorting now works on CR field columns

> [!IMPORTANT]
>  Old CR columns don’t use the same field IDs, so features like sorting, TagPopover actions, etc. won’t work with them.
Since columns are stored in local storage, users may need to reset their columns and re-add CR fields in order to access the new functionality. Might be worth calling this out explicitly in the announcement as well.

Preview [here](https://docs-staging.datadoghq.com/christine.chun/update-crd-filtering-sorting/infrastructure/containers/configuration/?tab=datadogoperator#collect-custom-resources) and [here](https://docs-staging.datadoghq.com/christine.chun/update-crd-filtering-sorting/infrastructure/containers/orchestrator_explorer/?tab=datadogoperator#terms)


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->


Merge readiness:
- [x] Ready for merge

