### PR TITLE
Update ring buffer size recommendation and filter datadog queries

### DIFF
--- a/content/en/database_monitoring/guide/sql_extended_events.md
+++ b/content/en/database_monitoring/guide/sql_extended_events.md
@@ -101,7 +101,7 @@ ADD EVENT sqlserver.module_end( -- capture stored procedure completions
 )
 ADD TARGET package0.ring_buffer -- do not change, datadog is only configured to read from ring buffer at this time
 WITH (
-    MAX_MEMORY = 2048 KB, -- do not exceed 2048, values above 2 MB may result in data loss due to SQLServer internals
+    MAX_MEMORY = 1024 KB, -- do not exceed 1024, values above 1 MB may result in data loss due to SQLServer internals
     TRACK_CAUSALITY = ON, -- allows datadog to correlate related events across activity ID
     EVENT_RETENTION_MODE = ALLOW_SINGLE_EVENT_LOSS,
     MAX_DISPATCH_LATENCY = 30 SECONDS,
@@ -147,7 +147,7 @@ ADD EVENT sqlserver.attention(
 )
 ADD TARGET package0.ring_buffer -- do not change, datadog is only configured to read from ring buffer at this time
 WITH (
-    MAX_MEMORY = 2048 KB, -- do not change, setting this larger than 2 MB may result in data loss due to SQLServer internals
+    MAX_MEMORY = 1024 KB, -- do not change, setting this larger than 1 MB may result in data loss due to SQLServer internals
     EVENT_RETENTION_MODE = ALLOW_SINGLE_EVENT_LOSS,
     MAX_DISPATCH_LATENCY = 30 SECONDS,
     STARTUP_STATE = ON
@@ -243,7 +243,7 @@ ADD EVENT sqlserver.module_end( -- capture stored procedure completions
 )
 ADD TARGET package0.ring_buffer -- do not change, datadog is only configured to read from ring buffer at this time
 WITH (
-    MAX_MEMORY = 2048 KB, -- do not exceed 2048, values above 2 MB may result in data loss due to SQLServer internals
+    MAX_MEMORY = 1024 KB, -- do not exceed 1024, values above 1 MB may result in data loss due to SQLServer internals
     TRACK_CAUSALITY = ON, -- allows datadog to correlate related events across activity ID
     EVENT_RETENTION_MODE = ALLOW_SINGLE_EVENT_LOSS,
     MAX_DISPATCH_LATENCY = 30 SECONDS,
@@ -289,7 +289,7 @@ ADD EVENT sqlserver.attention(
 )
 ADD TARGET package0.ring_buffer -- do not change, datadog is only configured to read from ring buffer at this time
 WITH (
-    MAX_MEMORY = 2048 KB, -- do not change, setting this larger than 2 MB may result in data loss due to SQLServer internals
+    MAX_MEMORY = 1024 KB, -- do not change, setting this larger than 1 MB may result in data loss due to SQLServer internals
     EVENT_RETENTION_MODE = ALLOW_SINGLE_EVENT_LOSS,
     MAX_DISPATCH_LATENCY = 30 SECONDS,
     STARTUP_STATE = ON
@@ -337,10 +337,10 @@ The default query duration threshold is `duration > 1000000` (1 second). Adjust 
 <div class="alert alert-warning">Setting thresholds too low can result in excessive event collection that affects server performance, event loss due to buffer overflow, and incomplete data, as Datadog only collects the most recent 1000 events per collection interval.</div>
 
 ### Memory allocation
-- The default value is `MAX_MEMORY = 2048 KB`.
-- Do not exceed 2048 KB, as higher values may cause data loss due to [SQL Server internal limitations][3].
-- For high-volume servers, keeping this at a maximum of 2048 KB is recommended.
-- For lower-traffic servers, a setting of 1024 KB may be sufficient.
+- The default value is `MAX_MEMORY = 1024 KB`.
+- Do not exceed 1024 KB, as higher values may cause data loss due to [SQL Server internal limitations][3].
+- For high-volume servers, keeping this at a maximum of 1024 KB is recommended.
+- For lower-traffic servers, a setting of 512 KB may be sufficient.
 
 ### Event filtering {#event-filtering}
 
@@ -351,9 +351,8 @@ To reduce event volume, you can add filters to the `WHERE` clause. For example:
       sql_text <> '' AND
       duration > 1000000 AND
       -- Add custom filters here
-      database_name = 'YourImportantDB' -- Only track specific databases
-      -- OR --
-      username <> 'ReportUser' -- Exclude specific users
+      database_name = 'YourImportantDB' AND -- Only track specific databases
+      username <> 'datadog' -- Exclude Datadog Agent queries or specific users
   )
   ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Update XE documentation based off of feedback from Rockstar trial. 2 MB max memory buffer was still hitting the 4 MB overflow issue, so suggesting 1 MB now. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
