### PR TITLE
Update repo source file destination

### DIFF
--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -429,7 +429,7 @@
           - 'docs/cloud-workload-security/linux_expressions.md'
           - 'docs/cloud-workload-security/windows_expressions.md'
           options:
-            dest_dir: '/security/threats/'
+            dest_dir: '/security/workload_protection/'
             path_to_remove: 'docs/cloud-workload-security/'
 
       - repo_name: web-ui


### PR DESCRIPTION
This page in the docs https://docs.datadoghq.com/security/workload_protection/linux_expressions/ that is sourced from this repo file https://github.com/DataDog/datadog-agent/blob/main/docs/cloud-workload-security/linux_expressions.md, but it wasn't picking up recent changes. Same with the other expressions docs in that folder. 

The file https://docs.datadoghq.com/security/workload_protection/linux_expressions/ was recently moved as part of a reorg. It used to be under /security/threats.

I updating the dest_dir here https://github.com/DataDog/documentation/blob/master/local/bin/py/build/configurations/pull_config_preview.yaml#L432C13-L432C21 with the following: dest_dir: '/security/workload_protection/'

### Merge instructions

Merge readiness:
- [ ] Ready for merge

