### PR TITLE
APM: Document trace context propagation configuration `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT`

### DIFF
--- a/content/en/tracing/trace_collection/trace_context_propagation/_index.md
+++ b/content/en/tracing/trace_collection/trace_context_propagation/_index.md
@@ -51,6 +51,14 @@ Use the following environment variables to configure formats for reading and wri
 : Specifies trace context propagation formats for both extraction and injection (comma-separated list). Lowest precedence; ignored if any other Datadog trace context propagation environment variable is set.<br>
 **Note**: Only use this configuration when migrating an application from the OpenTelemetry SDK to the Datadog SDK. For more information on this configuration and other OpenTelemetry environment variables, see [Using OpenTelemetry Environment Variables with Datadog SDKs][9].
 
+`DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT`
+: Specifies how incoming distributed tracing headers should be handled at a service level. Accepted values are:<br>
+`continue`: The SDK will continue the distributed trace if the incoming distributed tracing headers represent a valid trace context.<br>
+`restart`: The SDK will always start a new trace. If the incoming distributed tracing headers represent a valid trace context, that trace context will be represented as a span link on service entry spans (as opposed to the parent span in the `continue` configuration).<br>
+`ignore`: The SDK will always start a new trace and all incoming distributed tracing headers are ignored.<br>
+**Default**: `continue` <br>
+**Note**: This is only implemented in the .NET, Node.js, Python, and Java libraries.
+
 ### Advanced configuration
 
 Most services send and receive trace context headers using the same format. However, if your service needs to accept trace context headers in one format and send them in another, use these configurations:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR documents a configuration that has been implemented across several APM SDKs. This allows users to customize the trace context extraction behavior of their tracing libraries.

### Merge instructions
Let's ensure that @mervebolatdd signs off before merging

Merge readiness:
- [ ] Ready for merge

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
