### PR TITLE
[RUM-8832] Clarify SDK and RUM initialization timing requirements in `setup.md`

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
@@ -135,7 +135,7 @@ In the initialization snippet, set an environment name, service name, and client
 
 The SDK should be initialized as early as possible in the app lifecycle, specifically in the `AppDelegate`'s `application(_:didFinishLaunchingWithOptions:)` callback.  This ensures all measurements, including application startup duration, are captured correctly. For apps built with SwiftUI, you can use `@UIApplicationDelegateAdaptor` to hook into the `AppDelegate`.
 
-<div class="alert alert-warning">Initializing the SDK elsewhere (e.g., later during view loading) may result in inaccurate or missing telemetry, especially around app startup performance.</div>
+<div class="alert alert-warning">Initializing the SDK elsewhere (for example later during view loading) may result in inaccurate or missing telemetry, especially around app startup performance.</div>
 
 For more information, see [Using Tags][5].
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
@@ -133,7 +133,7 @@ For more information about setting up a client token, see the [Client token docu
 
 In the initialization snippet, set an environment name, service name, and client token.
 
-The SDK should be initialized as early as possible in the app lifecycle, specifically in the `AppDelegate`'s `application(_:didFinishLaunchingWithOptions:)` callback.  This ensures all measurements, including application startup duration, are captured correctly. For apps built with SwiftUI, you can use `@UIApplicationDelegateAdaptor` to hook into the `AppDelegate`.
+The SDK should be initialized as early as possible in the app lifecycle, specifically in the `AppDelegate`'s `application(_:didFinishLaunchingWithOptions:)` callback. This ensures all measurements, including application startup duration, are captured correctly. For apps built with SwiftUI, you can use `@UIApplicationDelegateAdaptor` to hook into the `AppDelegate`.
 
 <div class="alert alert-warning">Initializing the SDK elsewhere (for example later during view loading) may result in inaccurate or missing telemetry, especially around app startup performance.</div>
 

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
@@ -131,7 +131,11 @@ For more information about setting up a client token, see the [Client token docu
 
 ### Step 3 - Initialize the library
 
-In the initialization snippet, set an environment name, service name, and version number. In the examples below, `app-name` specifies the variant of the application that generates data.
+In the initialization snippet, set an environment name, service name, and client token.
+
+The SDK should be initialized as early as possible in the app lifecycle, specifically in the `AppDelegate`. This ensures all measurements, including application startup duration, are captured correctly. For apps built with SwiftUI, you can use `@UIApplicationDelegateAdaptor` to hook into the `AppDelegate`.
+
+<div class="alert alert-warning">Initializing the SDK elsewhere (e.g., later during view loading) may result in inaccurate or missing telemetry, especially around app startup performance.</div>
 
 For more information, see [Using Tags][5].
 
@@ -402,8 +406,8 @@ For example, if the current tracking consent is `.pending`:
 
 ### Step 4 - Start sending data
 
-#### Initialize the Datadog Monitor
-Configure and register the Datadog Monitor. You only need to do it once, usually in your `AppDelegate` code:
+#### Enable RUM
+Configure and start RUM. This should be done once and as early as possible, specifically in your `AppDelegate`:
 
 {{< tabs >}}
 {{% tab "Swift" %}}

--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/ios/setup.md
@@ -133,7 +133,7 @@ For more information about setting up a client token, see the [Client token docu
 
 In the initialization snippet, set an environment name, service name, and client token.
 
-The SDK should be initialized as early as possible in the app lifecycle, specifically in the `AppDelegate`. This ensures all measurements, including application startup duration, are captured correctly. For apps built with SwiftUI, you can use `@UIApplicationDelegateAdaptor` to hook into the `AppDelegate`.
+The SDK should be initialized as early as possible in the app lifecycle, specifically in the `AppDelegate`'s `application(_:didFinishLaunchingWithOptions:)` callback.  This ensures all measurements, including application startup duration, are captured correctly. For apps built with SwiftUI, you can use `@UIApplicationDelegateAdaptor` to hook into the `AppDelegate`.
 
 <div class="alert alert-warning">Initializing the SDK elsewhere (e.g., later during view loading) may result in inaccurate or missing telemetry, especially around app startup performance.</div>
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updated the public documentation to clearly state that the Datadog SDK and RUM should be initialized in `AppDelegate` to ensure accurate telemetry (e.g., application startup duration). 

Also added guidance for SwiftUI apps using [`@UIApplicationDelegateAdaptor`](https://developer.apple.com/documentation/swiftui/uiapplicationdelegateadaptor).

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes

This can be merged without waiting for upcoming `3.0.0` release.