### PR TITLE
[PROF-11898] Tweak Ruby stack truncation config documentation

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -119,6 +119,7 @@ You can configure the profiler using the following environment variables:
 | --------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `DD_PROFILING_ENABLED`                        | Boolean | If set to `true`, enables the profiler. Defaults to `false`.                                                                            |
 | `DD_PROFILING_ALLOCATION_ENABLED`             | Boolean | Set to `true` to enable allocation profiling. It requires the profiler to be enabled already. Defaults to `false`.                      |
+| `DD_PROFILING_MAX_FRAMES`                     | Integer | Maximum backtrace (stack) depth gathered by the profiler. Stacks deeper than this value get truncated. Defaults to `400`.               |
 | `DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
 | `DD_PROFILING_EXPERIMENTAL_HEAP_SIZE_ENABLED` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to the same value as `DD_PROFILING_EXPERIMENTAL_HEAP_ENABLED`. |
 | `DD_PROFILING_NO_SIGNALS_WORKAROUND_ENABLED`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |
@@ -134,6 +135,7 @@ Alternatively, you can set profiler parameters in code with these functions, ins
 | ----------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
 | `c.profiling.enabled`                                 | Boolean | If set to `true`, enables the profiler. Defaults to `false`.                                                                            |
 | `c.profiling.allocation_enabled`                      | Boolean | Set to `true` to enable allocation profiling. It requires the profiler to be enabled already. Defaults to `false`.                      |
+| `c.profiling.advanced.max_frames`                     | Integer | Maximum backtrace (stack) depth gathered by the profiler. Stacks deeper than this value get truncated. Defaults to `400`.               |
 | `c.profiling.advanced.experimental_heap_enabled`      | Boolean | Set to `true` to enable heap live objects profiling. It requires that allocation profiling is enabled as well. Defaults to `false`.     |
 | `c.profiling.advanced.experimental_heap_size_enabled` | Boolean | Set to `true` to enable heap live size profiling. It requires that heap live objects profiling is enabled as well. Defaults to the same value as `experimental_heap_size_enabled`. |
 | `c.profiling.advanced.no_signals_workaround_enabled`  | Boolean | Automatically enabled when needed, can be used to force enable or disable this feature. See [Profiler Troubleshooting][15] for details. |

--- a/content/en/profiler/profiler_troubleshooting/ruby.md
+++ b/content/en/profiler/profiler_troubleshooting/ruby.md
@@ -34,13 +34,13 @@ For further help with this issue, [contact support][2] and include the output of
 
 ## Frames omitted when backtraces are very deep
 
-The Ruby profiler truncates deep backtraces when collecting profiling data. Truncated backtraces are missing some of their caller functions, making it impossible to link them to the root call frame. As a result, truncated backtraces are grouped together under a `N frames omitted` frame.
+The Ruby profiler truncates deep backtraces when collecting profiling data. Truncated backtraces are missing some of their caller functions, making it impossible to link them to the root call frame. As a result, truncated backtraces are grouped together under a `Truncated Frames` (or `N frames omitted` in older versions) frame.
 
-You can increase the maximum depth with the `DD_PROFILING_MAX_FRAMES` environment variable, or in code:
+You can increase the maximum backtrace (stack) depth with the `DD_PROFILING_MAX_FRAMES` environment variable, or in code:
 
 ```ruby
 Datadog.configure do |c|
-  c.profiling.advanced.max_frames = 500
+  c.profiling.advanced.max_frames = 600
 end
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR tweaks the documentation around the "max frames" setting, used to control the stack truncation/limit config setting.

Specifically it:
* Mentions this configuration in the enabling page, not just the troubleshooting page
* Mentions that the grouped frames can be under `Truncated Frames`, as per another PR I'm preparing on the Ruby lib side
* Uses 600 as an example for raising, as 600 is the current maximum the frontend will show, and hopefully works for even the most complex applications

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

N/A