### PR TITLE
Update Java example with tags

### DIFF
--- a/content/en/service_management/events/guides/dogstatsd.md
+++ b/content/en/service_management/events/guides/dogstatsd.md
@@ -115,7 +115,7 @@ public class DogStatsdClient {
           .withTitle("An error occurred")
           .withText("Error message")
           .withAlertType(Event.AlertType.ERROR)
-          .withTags("env:prod", "tagkey:value")  // Tags added here
+          .withTags("env:prod", "tagkey:value")
           .build();
 
         Statsd.recordEvent(event);

--- a/content/en/service_management/events/guides/dogstatsd.md
+++ b/content/en/service_management/events/guides/dogstatsd.md
@@ -106,7 +106,7 @@ public class DogStatsdClient {
     public static void main(String[] args) throws Exception {
 
         StatsDClient Statsd = new NonBlockingStatsDClientBuilder()
-            .prefix("statsd").
+            .prefix("statsd")
             .hostname("localhost")
             .port(8125)
             .build();
@@ -115,6 +115,7 @@ public class DogStatsdClient {
           .withTitle("An error occurred")
           .withText("Error message")
           .withAlertType(Event.AlertType.ERROR)
+          .withTags("env:prod", "tagkey:value")  // Tags added here
           .build();
 
         Statsd.recordEvent(event);


### PR DESCRIPTION
- adding tags to Java example at customer request
- fixed syntax error where there was a `.` with no following method

### What does this PR do? What is the motivation?

From @binitapoudel1 : 

> However, customer raised a case where they stated that if we could include tags also in our java example config that would be helpful:

### Merge instructions

Merge readiness:
- [X] Ready for merge
