### PR TITLE
update dogstatsd origin detection section

### DIFF
--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -106,6 +106,10 @@ The following tags are added for [Docker][3]. It is important to note that [card
 
 Origin detection in non-Kubernetes environments is based on an extension of the DogStatsD protocol in [Datagram Format and Shell Usage][2]. To enable the feature in the Agent, set the `DD_DOGSTATSD_ORIGIN_DETECTION_CLIENT` environment variable to `true`.
 
+<div class="alert alert-warning">
+  By default, origin detection is enabled in all DogStatsD clients, but it is not enabled by default in the Datadog Agent. To disable origin detection in a client, refer to the documentation for the specific DogStatsD library you’re using.
+</div>
+
 **Note**: Origin detection is not supported for Fargate environments.
 
 [1]: /developers/dogstatsd/unix_socket/


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR calls out a behavior that a customer brought up here: [https://github.com/DataDog/dogstatsd-ruby/issues/314](https://github.com/DataDog/dogstatsd-ruby/issues/314).

It calls out specifically that origin detection is enabled on the client libraries, and this behavior can be disabled if the customer wants.

Merge readiness:
- [ ] Ready for merge