### PR TITLE
[SVLS-7119] add instructions to install Serverless monitoring for .NET Azure Functions

### DIFF
--- a/content/en/serverless/azure_functions/_index.md
+++ b/content/en/serverless/azure_functions/_index.md
@@ -3,11 +3,11 @@ title: Install Serverless Monitoring for Azure Functions
 ---
 
 ## Overview
-This page explains how to collect traces, trace metrics, runtime metrics, and custom metrics from your Azure Functions. To collect additional metrics, install the [Datadog Azure integration][6].
+This page explains how to collect traces, trace metrics, runtime metrics, and custom metrics from your Azure Functions. To collect additional metrics, install the [Datadog Azure integration][5].
 
 ## Setup
 
-{{< programming-lang-wrapper langs="nodejs,python,java" >}}
+{{< programming-lang-wrapper langs="nodejs,python,java,dotnet" >}}
 {{< programming-lang lang="nodejs" >}}
 1. **Install dependencies**. Run the following commands:
    ```shell
@@ -15,11 +15,9 @@ This page explains how to collect traces, trace metrics, runtime metrics, and cu
    npm install dd-trace
    ```
 
-   To use [automatic instrumentation][1], you must use `dd-trace` v5.25+.
-
    Datadog recommends pinning the package versions and regularly upgrading to the latest versions of both `@datadog/serverless-compat` and `dd-trace` to ensure you have access to enhancements and bug fixes.
 
-2. **Start the Datadog serverless compatibility layer and initialize the Node.js tracer**. Add the following lines to your main application entry point file (for example, `app.js`):
+2. **Start the Datadog Serverless Compatibility Layer and initialize the Datadog Node.js tracer**. Add the following lines to your main application entry point file (for example, `app.js`):
 
    ```js
    require('@datadog/serverless-compat').start();
@@ -28,13 +26,12 @@ This page explains how to collect traces, trace metrics, runtime metrics, and cu
    const tracer = require('dd-trace').init()
    ```
 
-3. (Optional) **Enable runtime metrics**. See [Node.js Runtime Metrics][2].
+3. (Optional) **Enable runtime metrics**. See [Node.js Runtime Metrics][1].
 
-4. (Optional) **Enable custom metrics**. See [Metric Submission: DogStatsD][3].
+4. (Optional) **Enable custom metrics**. See [Metric Submission: DogStatsD][2].
 
-[1]: /tracing/trace_collection/automatic_instrumentation/?tab=singlestepinstrumentation
-[2]: /tracing/metrics/runtime_metrics/nodejs/?tab=environmentvariables
-[3]: /metrics/custom_metrics/dogstatsd_metrics_submission/?code-lang=nodejs
+[1]: /tracing/metrics/runtime_metrics/?tab=nodejs#environment-variables
+[2]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=nodejs
 {{< /programming-lang >}}
 {{< programming-lang lang="python" >}}
 1. **Install dependencies**. Run the following commands:
@@ -43,11 +40,9 @@ This page explains how to collect traces, trace metrics, runtime metrics, and cu
    pip install ddtrace
    ```
 
-   To use [automatic instrumentation][1], you must use `dd-trace` v2.19+.
-
    Datadog recommends using the latest versions of both `datadog-serverless-compat` and `ddtrace` to ensure you have access to enhancements and bug fixes.
 
-2. **Initialize the Datadog Python tracer and serverless compatibility layer**. Add the following lines to your main application entry point file:
+2. **Start the Datadog Serverless Compatibility Layer and initialize the Datadog Python tracer**. Add the following lines to your main application entry point file:
 
    ```python
    from datadog_serverless_compat import start
@@ -56,13 +51,12 @@ This page explains how to collect traces, trace metrics, runtime metrics, and cu
    start()
    ```
 
-3. (Optional) **Enable runtime metrics**. See [Python Runtime Metrics][2].
+3. (Optional) **Enable runtime metrics**. See [Python Runtime Metrics][1].
 
-4. (Optional) **Enable custom metrics**. See [Metric Submission: DogStatsD][3].
+4. (Optional) **Enable custom metrics**. See [Metric Submission: DogStatsD][2].
 
-[1]: /tracing/trace_collection/automatic_instrumentation/?tab=singlestepinstrumentation
-[2]: /tracing/metrics/runtime_metrics/python/
-[3]: /metrics/custom_metrics/dogstatsd_metrics_submission/?code-lang=python
+[1]: /tracing/metrics/runtime_metrics/?tab=python#code-based-configuration
+[2]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python
 {{< /programming-lang >}}
 {{< programming-lang lang="java" >}}
 1. **Install dependencies**. Download the Datadog JARs and deploy them with your function:
@@ -70,29 +64,104 @@ This page explains how to collect traces, trace metrics, runtime metrics, and cu
    wget -O dd-java-agent.jar 'https://dtdg.co/latest-java-tracer'
    wget -O dd-serverless-compat-java-agent.jar 'https://dtdg.co/latest-serverless-compat-java-agent'
    ```
-   See Datadog's [Maven Repository][4] for any specific version of the Datadog Serverless Compatibility Layer.
-
-   To use [automatic instrumentation][1], you must use `dd-java-agent` v1.48.0+.
+   See Datadog's [Maven Repository][3] for any specific version of the Datadog Serverless Compatibility Layer.
 
    Datadog recommends regularly upgrading to the latest versions of both `dd-serverless-compat-java-agent` and `dd-java-agent` to ensure you have access to enhancements and bug fixes.
 
-2. **Start the Datadog serverless compatibility layer and initialize the Java tracer**. Add the following `-javaagent` arguments to the JVM options.:
+2. **Start the Datadog Serverless Compatibility Layer and initialize the Datadog Java tracer**. Add the following `-javaagent` arguments to the JVM options.:
 
    ```bash
    -javaagent:/path/to/dd-serverless-compat-java-agent.jar -javaagent:/path/to/dd-java-agent.jar
    ```
 
-   **Note**: the environment variable to set JVM options depends on the hosting plan (example, Consumption, Elastic Premium, Dedicated). See [Azure Functions Java developer guide][5] for more details on the appropriate environment variable for your hosting plan.
+   **Note**: the environment variable to set JVM options depends on the hosting plan (example, Consumption, Elastic Premium, Dedicated). See [Azure Functions Java developer guide][4] for more details on the appropriate environment variable for your hosting plan.
 
-3. (Optional) **Enable runtime metrics**. See [Java Runtime Metrics][2].
+3. (Optional) **Enable runtime metrics**. See [Java Runtime Metrics][1].
 
-4. (Optional) **Enable custom metrics**. See [Metric Submission: DogStatsD][3].
+4. (Optional) **Enable custom metrics**. See [Metric Submission: DogStatsD][2].
 
-[1]: /tracing/trace_collection/automatic_instrumentation/?tab=singlestepinstrumentation
-[2]: /tracing/metrics/runtime_metrics/?tab=java#environment-variables
-[3]: /metrics/custom_metrics/dogstatsd_metrics_submission/?code-lang=java
-[4]: https://repo1.maven.org/maven2/com/datadoghq/dd-serverless-compat-java-agent/
-[5]: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java?tabs=bash%2Cconsumption#customize-jvm
+[1]: /tracing/metrics/runtime_metrics/?tab=java#environment-variables
+[2]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=java
+[3]: https://repo1.maven.org/maven2/com/datadoghq/dd-serverless-compat-java-agent/
+[4]: https://learn.microsoft.com/en-us/azure/azure-functions/functions-reference-java?tabs=bash%2Cconsumption#customize-jvm
+{{< /programming-lang >}}
+{{< programming-lang lang="dotnet" >}}
+1. **Install dependencies**. Run the following commands:
+   ```shell
+   dotnet package add Datadog.Azure.Functions
+   ```
+
+   Datadog recommends regularly upgrading to the latest version of `Datadog.AzureFunctions` to ensure you have access to enhancements and bug fixes.
+
+2. **Start the Datadog Serverless Compatibility Layer**. Add the following lines to your main application entry point file:
+   If your Azure Function app uses the Isolated Worker model
+   ```csharp
+   using Datadog.Serverless;
+   ...
+   Datadog.Serverless.CompatibilityLayer.Start();
+   ```
+
+   If your Azure Function app uses the In-Process model
+   ```shell
+   dotnet package add Microsoft.Azure.Functions.Extensions
+   ```
+
+   ```csharp
+   using Datadog.Serverless;
+   using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+
+   [assembly: FunctionsStartup(typeof(MyFunctionApp.Startup))]
+
+   namespace MyFunctionApp
+   {
+      public class Startup : FunctionsStartup
+      {
+         public override void Configure(IFunctionsHostBuilder builder)
+         {
+               Datadog.Serverless.CompatibilityLayer.Start();
+         }
+      }
+   }
+   ```
+
+3. Configure Automatic Instrumentation
+   If your Azure Function app runs on Windows
+   ```
+   CORECLR_ENABLE_PROFILING=1
+
+   CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+
+   CORECLR_PROFILER_PATH_64=
+   C:\home\site\wwwroot\datadog\win-x64\Datadog.Trace.ClrProfiler.Native.dll
+
+   CORECLR_PROFILER_PATH_32=
+   C:\home\site\wwwroot\datadog\win-x86\Datadog.Trace.ClrProfiler.Native.dll
+
+   DD_DOTNET_TRACER_HOME=C:\home\site\wwwroot\datadog
+
+   DD_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS=monitor.azure, applicationinsights.azure, metadata/instance/compute, admin/host, AzureFunctionsRpcMessages.FunctionRpc
+   ```
+
+   If your Azure Function app runs on Linux
+   ```
+   CORECLR_ENABLE_PROFILING=1
+
+   CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+
+   CORECLR_PROFILER_PATH=
+      /home/site/wwwroot/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
+
+   DD_DOTNET_TRACER_HOME=/home/site/wwwroot/datadog
+
+   DD_TRACE_HTTP_CLIENT_EXCLUDED_URL_SUBSTRINGS=monitor.azure, applicationinsights.azure, metadata/instance/compute, admin/host, AzureFunctionsRpcMessages.FunctionRpc
+   ```
+
+4. (Optional) **Enable runtime metrics**. See [.NET Runtime Metrics][1].
+
+5. (Optional) **Enable custom metrics**. See [Metric Submission: DogStatsD][2].
+   
+[1]: /tracing/metrics/runtime_metrics/?tab=net#environment-variables
+[2]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=dotnet
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
@@ -105,50 +174,25 @@ This page explains how to collect traces, trace metrics, runtime metrics, and cu
    | `DD_API_KEY` | Your [Datadog API key][1]. |
    | `DD_SITE` | Your [Datadog site][2]. For example, {{< region-param key=dd_site code="true" >}}. |
 
-7. **Configure Unified Service Tagging**. You can collect metrics from your Azure Functions by installing the [Datadog Azure integration][6]. To correlate these metrics with your traces, first set the `env`, `service`, and `version` tags on your resource in Azure. Then, configure the following environment variables. You can add custom tags as `DD_TAGS`.
+7. **Configure Unified Service Tagging**. You can collect metrics from your Azure Functions by installing the [Datadog Azure integration][5]. To correlate these metrics with your traces, first set the `env`, `service`, and `version` tags on your resource in Azure. Then, configure the following environment variables. You can add custom tags as `DD_TAGS`.
 
    | Name | Value |
    | ---- | ----- |
-   | `DD_ENV` | How you want to tag your env for [Unified Service Tagging][9]. For example, `prod`. |
-   | `DD_SERVICE` | How you want to tag your service for [Unified Service Tagging][9].  |
-   | `DD_VERSION` | How you want to tag your version for [Unified Service Tagging][9]. |
+   | `DD_ENV` | How you want to tag your env for [Unified Service Tagging][7]. For example, `prod`. |
+   | `DD_SERVICE` | How you want to tag your service for [Unified Service Tagging][7].  |
+   | `DD_VERSION` | How you want to tag your version for [Unified Service Tagging][7]. |
    | `DD_TAGS` | Your comma-separated custom tags. For example, `key1:value1,key2:value2`.  |
 
 ## What's next?
 
-- You can view your Azure Functions traces in [Trace Explorer][4]. Search for the service name you set in the `DD_SERVICE` environment variable to see your traces.
-- You can use the [Serverless > Azure Functions][5] page to see your traces enriched with telemetry collected by the [Datadog Azure integration][6].
-
-### Enable/disable trace metrics
-
-[Trace metrics][3] are enabled by default. To configure trace metrics, use the following environment variable:
-
-{{< programming-lang-wrapper langs="nodejs,python,java" >}}
-{{< programming-lang lang="nodejs" >}}
-`DD_TRACE_STATS_COMPUTATION_ENABLED`
-: Enables (`true`) or disables (`false`) trace metrics. Defaults to `true`.
-
-  **Values**: `true`, `false`
-{{< /programming-lang >}}
-{{< programming-lang lang="python" >}}
-`DD_TRACE_STATS_COMPUTATION_ENABLED`
-: Enables (`true`) or disables (`false`) trace metrics. Defaults to `true`.
-
-  **Values**: `true`, `false`
-{{< /programming-lang >}}
-{{< programming-lang lang="java" >}}
-`DD_TRACE_TRACER_METRICS_ENABLED`
-: Enables (`true`) or disables (`false`) trace metrics. Defaults to `true`.
-
-  **Values**: `true`, `false`
-{{< /programming-lang >}}
-{{< /programming-lang-wrapper >}}
+- You can view your Azure Functions traces in [Trace Explorer][3]. Search for the service name you set in the `DD_SERVICE` environment variable to see your traces.
+- You can use the [Serverless > Azure Functions][4] page to see your traces enriched with telemetry collected by the [Datadog Azure integration][5].
 
 ## Troubleshooting
 
 ### Enable debug logs
 
-You can collect [debug logs][7] for troubleshooting. To configure debug logs, use the following environment variables:
+You can collect [debug logs][6] for troubleshooting. To configure debug logs, use the following environment variables:
 
 `DD_TRACE_DEBUG`
 : Enables (`true`) or disables (`false`) debug logging for the Datadog Tracing Library. Defaults to `false`.
@@ -160,17 +204,10 @@ You can collect [debug logs][7] for troubleshooting. To configure debug logs, us
 
   **Values**: `trace`, `debug`, `info`, `warn`, `error`, `critical`, `off`
 
-### Linux Consumption plans and GitHub Actions
-
-To use a GitHub Action to deploy to a Linux Consumption function, you must configure your workflow to use an Azure Service Principal for RBAC. See [Using Azure Service Principal for RBAC as Deployment Credential][8].
-
-
 [1]: /account_management/api-app-keys/#add-an-api-key-or-client-token
 [2]: /getting_started/site
-[3]: /tracing/metrics/metrics_namespace/
-[4]: https://app.datadoghq.com/apm/traces
-[5]: https://app.datadoghq.com/functions?cloud=azure&entity_view=function
-[6]: /integrations/azure/
-[7]: /tracing/troubleshooting/tracer_debug_logs/#enable-debug-mode
-[8]: https://github.com/Azure/functions-action?tab=readme-ov-file#using-azure-service-principal-for-rbac-as-deployment-credential
-[9]: /getting_started/tagging/unified_service_tagging/
+[3]: https://app.datadoghq.com/apm/traces
+[4]: https://app.datadoghq.com/functions?cloud=azure&entity_view=function
+[5]: /integrations/azure/
+[6]: /tracing/troubleshooting/tracer_debug_logs/#enable-debug-mode
+[7]: /getting_started/tagging/unified_service_tagging/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds instructions to install Serverless monitoring for .NET Azure Functions.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes

- Rewords installation instructions to be consistent across languages
  * `Start the Datadog Serverless Compatibility Layer and initialize the Datadog<language> tracer`
- Fixes links to runtime metrics and custom metrics documentation
- Removes references to specific tracer versions. Recommending the latest version is sufficient now that automatic instrumentation of http triggers has been available for several months
- Removes instructions for trace stats. `DD_TRACE_STATS_COMPUTATION_ENABLED` and `DD_TRACE_TRACER_METRICS_ENABLED` are for a configuration that is no longer maintained
- Removes note around `Linux Consumption plans and GitHub Actions` since recent fixes have remedied this issue

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
