### PR TITLE
[documentation] Remove fed note since scheduled dashboards is enabled in fed

### DIFF
--- a/content/en/dashboards/sharing/scheduled_reports.md
+++ b/content/en/dashboards/sharing/scheduled_reports.md
@@ -65,11 +65,6 @@ To see the report before saving the schedule, click **Send Test Email**. You can
 
 #### Slack recipients
 
-{{< site-region region="gov" >}}
-
-<div class="alert alert-warning">Slack recipients are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
-{{< /site-region >}}
-
 To add Slack recipients, select the Slack workspace and channel from the available dropdowns. If you do not see any Slack workspaces available, ensure you have the Datadog [Slack Integration][8] installed. All public channels within the Slack workspace should be listed automatically. To select a private Slack channel, make sure to invite the Datadog Slack bot to the channel in Slack. To send a test message to Slack, add a channel recipient and click **Send Test Message**.
 
 **{{< img src="dashboards/scheduled_reports/add_slack_recipients.png" alt="The configuration modal for editing scheduled report email recipients." style="width:90%;" >}}**


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Slack support in Fed has been built and Scheduled Dashboards has been enabled in fed:
https://sdp.ddbuild.io/#/feature-flags/reporting-slack-support
https://sdp.ddbuild.io/#/feature-flags/dashboard_report_scheduling_slack_recipients

Since Scheduled Dashboards is now working in fed, removing this warning from documentation.

Merge readiness:
- [ ] Ready for merge
