### PR TITLE
remove trace metrics configuration from google cloud run functions 1st gen docs

### DIFF
--- a/content/en/serverless/google_cloud_run/functions_1st_gen.md
+++ b/content/en/serverless/google_cloud_run/functions_1st_gen.md
@@ -370,15 +370,6 @@ func helloHTTP(w http.ResponseWriter, r *http.Request) {
 - You can view your Cloud Run Functions traces in [Trace Explorer][4]. Search for the service name you set in the `DD_SERVICE` environment variable to see your traces.
 - You can use the [Serverless > Cloud Run Functions][5] page to see your traces enriched with telemetry collected by the [Google Cloud integration][6].
 
-### Enable/disable trace metrics
-
-[Trace metrics][3] are enabled by default. To configure trace metrics, use the following environment variable:
-
-`DD_TRACE_STATS_COMPUTATION_ENABLED`
-: Enables (`true`) or disables (`false`) trace metrics. Defaults to `true`.
-
-  **Values**: `true`, `false`
-
 ## Troubleshooting
 
 ### Enable debug logs


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Removes the setting `DD_TRACE_STATS_COMPUTATION_ENABLED` from Google Cloud Run Functions 1st gen docs. This setting enables a configuration that is no longer maintained by the APM teams. We're actively working on another supported approach for trace stats in this environment.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes

Handling for Azure Functions in https://github.com/DataDog/documentation/pull/30608

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
