### PR TITLE
fixes to glossary scrolling

### DIFF
--- a/assets/scripts/components/instantsearch.js
+++ b/assets/scripts/components/instantsearch.js
@@ -7,6 +7,56 @@ import { searchpageHits } from './instantsearch/searchpageHits';
 import { customPagination } from './instantsearch/customPagination';
 import { debounce } from '../utils/debounce';
 
+// Helper function to handle navigation with proper anchor scrolling
+function navigateToUrl(url) {
+    const urlObj = new URL(url, window.location.origin);
+    
+    // Check if we're navigating to the same page
+    if (window.location.pathname === urlObj.pathname) {
+        window.history.pushState({}, '', url);
+        
+        // Close search dropdown since we're staying on the same page
+        const hitsContainer = document.querySelector('.search-searchbar-hits-container');
+        if (hitsContainer) {
+            hitsContainer.classList.add('d-none');
+        }
+        
+        // If there's an anchor, scroll to it
+        if (urlObj.hash) {
+            setTimeout(() => {
+                const targetElement = document.getElementById(urlObj.hash.substring(1));
+                if (targetElement) {
+                    // Calculate offset from fixed header and any page-specific nav
+                    const header = document.querySelector('.navbar');
+                    const glossaryNav = document.querySelector('.glossary-nav');
+                    let offset = 20; // Base padding
+                    
+                    if (header) offset += header.offsetHeight;
+                    if (glossaryNav) offset += glossaryNav.offsetHeight;
+                    
+                    const elementTop = targetElement.getBoundingClientRect().top + window.pageYOffset;
+                    window.scrollTo({
+                        top: elementTop - offset,
+                        behavior: 'smooth'
+                    });
+                }
+            }, 50);
+        }
+        return;
+    }
+    
+    // Check if this is a glossary page with an anchor for cross-page navigation
+    if (urlObj.pathname.includes('/glossary/') && urlObj.hash) {
+        // For cross-page navigation, store the anchor in sessionStorage and navigate
+        sessionStorage.setItem('glossaryScrollTarget', urlObj.hash.substring(1));
+        window.location.href = url;
+    } else {
+        // For other cross-page navigation, use normal navigation
+        window.history.pushState({}, '', url);
+        window.location.reload();
+    }
+}
+
 const { env } = document.documentElement.dataset;
 const pageLanguage = getPageLanguage();
 const typesenseConfig = getConfig(env).typesense;
@@ -294,8 +344,7 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
 
                     if (target && target.href && targetIsDescendant) {
                         sendSearchRumAction(search.helper.state.query, target.href);
-                        window.history.pushState({}, '', target.href);
-                        window.location.reload();
+                        navigateToUrl(target.href);
                     }
 
                     target = target.parentNode;
@@ -319,12 +368,11 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
                         const page = search.helper.state.page;
                         const clickPosition = getSearchResultClickPosition(target.href, hitsArray, numHits, page);
                         sendSearchRumAction(search.helper.state.query, target.href, clickPosition);
-                        window.history.pushState({}, '', target.href);
 
                         if (e.metaKey || e.ctrlKey) {
                             window.open(target.href, '_blank');
                         } else {
-                            window.location.reload();
+                            navigateToUrl(target.href);
                         }
                     }
 

--- a/assets/scripts/components/instantsearch.js
+++ b/assets/scripts/components/instantsearch.js
@@ -16,9 +16,9 @@ function navigateToUrl(url) {
         window.history.pushState({}, '', url);
         
         // Close search dropdown since we're staying on the same page
-        const hitsContainer = document.querySelector('.search-searchbar-hits-container');
-        if (hitsContainer) {
-            hitsContainer.classList.add('d-none');
+        const hitsContainerContainer = document.querySelector('.hits-container');
+        if (hitsContainerContainer) {
+            hitsContainerContainer.classList.add('d-none');
         }
         
         // If there's an anchor, scroll to it

--- a/assets/scripts/datadog-docs.js
+++ b/assets/scripts/datadog-docs.js
@@ -407,6 +407,55 @@ window.addEventListener('click', (event) => {
 window.onload = function () {
     getPathElement();
     setMobileNav();
+    
+    // Handle glossary anchor scrolling from search results
+    if (window.location.pathname.includes('/glossary/')) {
+        const scrollTarget = sessionStorage.getItem('glossaryScrollTarget');
+        if (scrollTarget) {
+            sessionStorage.removeItem('glossaryScrollTarget');
+            // Use requestAnimationFrame to ensure DOM is fully rendered
+            requestAnimationFrame(() => {
+                setTimeout(() => {
+                    const targetElement = document.getElementById(scrollTarget);
+                    if (targetElement) {
+                        const header = document.querySelector('.navbar');
+                        const glossaryNav = document.querySelector('.glossary-nav');
+                        let offset = 20;
+                        
+                        if (header) offset += header.offsetHeight;
+                        if (glossaryNav) offset += glossaryNav.offsetHeight;
+                        
+                        const elementTop = targetElement.getBoundingClientRect().top + window.pageYOffset;
+                        window.scrollTo({
+                            top: elementTop - offset,
+                            behavior: 'smooth'
+                        });
+                    }
+                }, 300); // Longer delay for Chrome's rendering
+            });
+        } else if (window.location.hash) {
+            // Handle direct hash navigation with Chrome-compatible timing
+            requestAnimationFrame(() => {
+                setTimeout(() => {
+                    const targetElement = document.getElementById(window.location.hash.substring(1));
+                    if (targetElement) {
+                        const header = document.querySelector('.navbar');
+                        const glossaryNav = document.querySelector('.glossary-nav');
+                        let offset = 20;
+                        
+                        if (header) offset += header.offsetHeight;
+                        if (glossaryNav) offset += glossaryNav.offsetHeight;
+                        
+                        const elementTop = targetElement.getBoundingClientRect().top + window.pageYOffset;
+                        window.scrollTo({
+                            top: elementTop - offset,
+                            behavior: 'smooth'
+                        });
+                    }
+                }, 300);
+            });
+        }
+    }
 };
 
 function replaceURL(inputUrl) {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
https://datadoghq.atlassian.net/browse/WEB-5827

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

https://docs-staging.datadoghq.com/fitzage/gallery-scrolling/glossary/

There are a number of search terms you can test, but scope is a useful example. Each of these should result in the glossary page scrolling to the correct spot, unlike the production site.

1. Search from a different page and select the glossary result
2. Search when already on the glossary page and select the result
3. Search when already on the glossary page with a pre-existing hash or without, and select the glossary result
4. Search in the homepage search field and select the glossary result

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
