### PR TITLE
bump required openlineage-dbt version in airflow docs

### DIFF
--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -312,7 +312,7 @@ To see the link between Airflow tasks and dbt jobs, follow those steps:
 1. Install `openlineage-dbt`. Reference [Using dbt with Amazon MWAA][7] to setup dbt in the virtual environment.
 
 ```shell
-pip3 install openlineage-dbt>=1.33.0
+pip3 install openlineage-dbt>=1.36.0
 ```
 
 2. Change the dbt invocation to `dbt-ol` (OpenLineage wrapper for dbt).


### PR DESCRIPTION
Bump the dbt version as there were a lot of crucial fixes in the last few versions