### PR TITLE
Update environment-variables.md using comma as a separator

### DIFF
--- a/content/en/agent/guide/environment-variables.md
+++ b/content/en/agent/guide/environment-variables.md
@@ -105,7 +105,7 @@ From Datadog Agent 7.45, the Datadog Agent service (`datadog-agent.service` unit
   ```
   GODEBUG=x509ignoreCN=0,x509sha1=1
   DD_HOSTNAME=myhost.local
-  DD_TAGS=env:dev service:foo
+  DD_TAGS=env:dev,service:foo
   ```
 3. Restart the service for changes to take effect
 


### PR DESCRIPTION
Our [documentation](https://docs.datadoghq.com/agent/guide/environment-variables/#using-environment-variables-in-systemd-units) explicitly states that the DD_TAGS environment variable should be defined with values separated by spaces. This guidance is reflected in the systemd units section.

However, upon reviewing both the Install-Datadog.ps1 script for Windows hosts and the install_script_agent7.sh for Linux-based systems, we found that both scripts expect the tags to be separated by commas, not spaces.

This inconsistency could lead to confusion or misconfigured tags depending on how users follow the documentation versus the install scripts.

Here is the snippet of the [install_script_agent7.sh](https://install.datadoghq.com/scripts/install_script_agent7.sh):

```
host_tags=  # A comma-separated list of tags, e.g. foo:bar,env:prod  
if [ -n "$DD_TAGS" ]; then
    host_tags=$DD_TAGS
```

Here is the snippet of the Windows installer [Install-Datadog.ps1](https://raw.githubusercontent.com/DataDog/datadog-agent/main/tools/windows/DatadogAgentInstallScript/Install-Datadog.ps1):

```
if ($env:DD_TAGS) {
        Write-Host "Writing DD_TAGS"

        $tags = $env:DD_TAGS -split ","
        $yamlTags = @("tags:") + ($tags | ForEach-Object { "  - $_" })
```

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
ZD case 2164773


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
