### PR TITLE
Adding additional configuration option; making php instructions clearer

### DIFF
--- a/content/en/serverless/azure_app_services/azure_app_services_linux.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_linux.md
@@ -62,7 +62,7 @@ dotnet add package Datadog.Trace.Bundle --version 3.21.0
 {{% tab "PHP" %}}
 
 Run the following script to install Datadog's PHP tracing library:
-
+startup.sh:
 ```bash
 #!/usr/bin/env bash
 
@@ -78,10 +78,13 @@ else
     return
 fi
 
-cp /home/site/wwwroot/default /etc/nginx/sites-available/default && service nginx reload
+# This line is can be uncommented if the project contains an nginx configuration in the project root
+# cp /home/site/wwwroot/default /etc/nginx/sites-available/default && service nginx reload
+
+service nginx reload
 ```
 
-This script is intended to run as the startup command, which installs the tracing module into PHP and then restarts the application. 
+This bash script is intended to run as the startup command, which installs the tracing module into PHP and then restarts the nginx service. 
 
 {{% /tab %}}
 {{% tab "Python" %}}
@@ -164,6 +167,12 @@ Where you write your logs. For example, `/home/LogFiles/*.log` or `/home/LogFile
 : **Value**: `true`<br>
 Setting this environment variable to `true` allows the `/home/` mount to persist and be shared with the sidecar.<br>
 
+`DD_AAS_INSTANCE_LOGGING_ENABLED`
+: **Value**: false <br>
+When `true`, log collection is automatically configured for an additional file path: `/home/LogFiles/*$COMPUTERNAME*.log`
+
+<div class="alert alert-info">If your application has multiple instances, make sure that your application's log filename includes the <code>$COMPUTERNAME</code> variable. This ensures that log tailing does not create duplicated logs from multiple instances reading the same file.</div>
+    
 {{% collapse-content title=".NET: Additional required environment variables" level="h4" id="dotnet-additional-settings" %}}
 
 For .NET applications, the following environment variables are **required**. See the `Datadog.Tracer.Bundle` [Nuget package README file][1] for more details.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

 * Adding a missing configuration option on the manual tab
 * Making changes to the php script for customers that do not use a custom nginx configuration. 

### Merge instructions
Follow the typical merge process

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
