### PR TITLE
Add rate limit table to Bits AI SRE docs

### DIFF
--- a/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
+++ b/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
@@ -27,8 +27,8 @@ An investigation initiates when a monitor transitions to the alert state. Transi
 
 |  Type         | Description                                                                                   | Limit                                      |
 |--------------------|----------------------------------------------------------------------------------------------|--------------------------------------------|
-| Monitor limits     | Each individual monitor can execute investigations up to 2 times every 30 minutes.<br>A monitor is considered "noisy" if it triggers alerts on 12 or more of the last 14 days, or fires in more than 15% of an hour interval. Noisy monitors are automatically rate-limited. | 2 executions per 30 minutes per monitor     |
-| Organization limits| The total number of monitor investigations that can be executed across the organization.      | 5 executions per hour per organization     |
+| Monitor limit     | A monitor can trigger up to 2 investigations every 30 minutes.<br>If a monitor is "noisy"&mdash;  that is, if it triggers alerts on 12 or more of the last 14 days, or fires in more than 15% of an hour interval&mdash; it is automatically rate-limited. | 2 executions per 30 minutes per monitor     |
+| Organization limit| The total number of monitor investigations that can be executed across the organization.      | 5 executions per hour per organization     |
 
 ### Manually start an investigation
 

--- a/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
+++ b/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
@@ -21,7 +21,14 @@ There are a few ways to enable Bits for automated investigations:
 
 You can also add the tag to your desired monitors using the Datadog API or Terraform.
 
-An investigation initiates when a monitor transitions to the alert state. Transitions to the warn or no data state, [renotifications][12], and test notifications do not trigger investigations. Additionally, noisy monitors are automatically rate-limited to avoid unnecessary investigations and protect your budget.
+An investigation initiates when a monitor transitions to the alert state. Transitions to the warn or no data state, [renotifications][12], and test notifications do not trigger investigations.
+
+#### Rate limits
+
+|  Type         | Description                                                                                   | Limit                                      |
+|--------------------|----------------------------------------------------------------------------------------------|--------------------------------------------|
+| Monitor limits     | Each individual monitor can execute investigations up to 2 times every 30 minutes.<br>A monitor is considered "noisy" if it triggers alerts on 12 or more of the last 14 days, or fires in more than 15% of an hour interval. Noisy monitors are automatically rate-limited. | 2 executions per 30 minutes per monitor     |
+| Organization limits| The total number of monitor investigations that can be executed across the organization.      | 5 executions per hour per organization     |
 
 ### Manually start an investigation
 

--- a/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
+++ b/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
@@ -25,10 +25,10 @@ An investigation initiates when a monitor transitions to the alert state. Transi
 
 #### Rate limits
 
-|  Type         | Description                                                                                   | Limit                                      |
-|--------------------|----------------------------------------------------------------------------------------------|--------------------------------------------|
-| Monitor limit     | A monitor can trigger up to 2 investigations every 30 minutes.<br>If a monitor is "noisy"&mdash;  that is, if it triggers alerts on 12 or more of the last 14 days, or fires in more than 15% of an hour interval&mdash; it is automatically rate-limited. | 2 executions per 30 minutes per monitor     |
-| Organization limit| The total number of monitor investigations that can be executed across the organization.      | 5 executions per hour per organization     |
+| Type              | Description                                                                                                                                                                                                                  |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Monitor limit     | A monitor can trigger up to 2 investigations every 30 minutes.<br>Additionally, if a monitor is "noisy"&mdash;that is, if it triggers alerts on 12 or more of the last 14 days, or fires in more than 15% of an hour interval&mdash;it is automatically rate-limited. |
+| Organization limit| Five investigations per hour per organization.                                                                                                                                    |
 
 ### Manually start an investigation
 

--- a/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
+++ b/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
@@ -25,10 +25,10 @@ An investigation initiates when a monitor transitions to the alert state. Transi
 
 #### Rate limits
 
-| Type              | Description                                                                                                                                                                                                                  |
-|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Monitor limit     | A monitor can trigger up to 2 investigations every 30 minutes.<br>Additionally, if a monitor is "noisy"&mdash;that is, if it triggers alerts on 12 or more of the last 14 days, or fires in more than 15% of an hour interval&mdash;it is automatically rate-limited. |
-| Organization limit| Five investigations per hour per organization.                                                                                                                                    |
+| Type              | Description                                                                                   |
+|-------------------|-----------------------------------------------------------------------------------------------|
+| Monitor limit     | Up to two investigations every 30 minutes per monitor.<br><br>In addition, "noisy" monitors are automatically rate-limited. A monitor is considered noisy if it:<br>• Triggers alerts on 12+ of the last 14 days, OR<br>• Fires in more than 15% of an hour interval |
+| Organization limit| Up to five investigations per hour per organization.                                           |
 
 ### Manually start an investigation
 

--- a/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
+++ b/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
@@ -30,6 +30,8 @@ An investigation initiates when a monitor transitions to the alert state. Transi
 | Monitor limit     | Up to two investigations every 30 minutes per monitor.<br><br>In addition, "noisy" monitors are automatically rate-limited. A monitor is considered noisy if it:<br>• Triggers alerts on 12+ of the last 14 days, OR<br>• Stays in alert state for more than 15% of an hour interval |
 | Organization limit| Up to five investigations per hour per organization.                                           |
 
+Rate limits only apply to automatic investigations, not manually triggered ones.
+
 ### Manually start an investigation
 
 Alternatively, you can manually invoke Bits on an individual monitor alert or warn event.

--- a/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
+++ b/content/en/bits_ai/bits_ai_sre/investigate_alerts.md
@@ -27,7 +27,7 @@ An investigation initiates when a monitor transitions to the alert state. Transi
 
 | Type              | Description                                                                                   |
 |-------------------|-----------------------------------------------------------------------------------------------|
-| Monitor limit     | Up to two investigations every 30 minutes per monitor.<br><br>In addition, "noisy" monitors are automatically rate-limited. A monitor is considered noisy if it:<br>• Triggers alerts on 12+ of the last 14 days, OR<br>• Fires in more than 15% of an hour interval |
+| Monitor limit     | Up to two investigations every 30 minutes per monitor.<br><br>In addition, "noisy" monitors are automatically rate-limited. A monitor is considered noisy if it:<br>• Triggers alerts on 12+ of the last 14 days, OR<br>• Stays in alert state for more than 15% of an hour interval |
 | Organization limit| Up to five investigations per hour per organization.                                           |
 
 ### Manually start an investigation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
 
 Customers need more granular information about the specific rate limits for Bits AI SRE automatic investigations both from a per-org and per-monitor basis.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge


[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
