### PR TITLE
[DOCS-11603] Remove single tab and stray references to removed content

### DIFF
--- a/content/en/synthetics/platform/test_coverage/_index.md
+++ b/content/en/synthetics/platform/test_coverage/_index.md
@@ -17,17 +17,12 @@ further_reading:
 - link: '/real_user_monitoring/session_replay'
   tag: 'Documentation'
   text: 'Learn about Session Replay'
-- link: '/software_catalog/endpoints/'
-  tag: 'Documentation'
-  text: 'Learn about the Endpoints list'
 ---
 
 ## Overview
 
-Explore your testing suite's Synthetic test coverage of RUM browser actions or API endpoints on the [**Test Coverage** page][1], which you can find under **Digital Experience** > **Synthetic Monitoring & Testing**.
+Explore your testing suite's Synthetic test coverage of RUM browser actions on the [**Test Coverage** page][1], which you can find under **Digital Experience** > **Synthetic Monitoring & Testing**.
 
-{{< tabs >}}
-{{% tab "Browser Actions" %}}
 The [**Test Coverage** page][1] provides actionable insight into the overall testing coverage of your [RUM applications][2]. It uses [data collected from the Browser RUM SDK][3] and [results from Synthetic browser tests][4].
 
 {{< img src="synthetics/test_coverage/browser_actions.png" alt="Test Coverage page with an Overview section, Untested Actions section, and a Tested Actions section" style="width:100%" >}}
@@ -93,9 +88,6 @@ Add the most popular sections of your application to a new or existing browser t
 [7]: /real_user_monitoring/session_replay/browser/
 [8]: https://app.datadoghq.com/rum/explorer/
 [9]: /continuous_testing/
-
-{{% /tab %}}
-{{< /tabs >}}
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
https://github.com/DataDog/documentation/pull/30655 removed one of two tabs of content on this page; this PR removes the tab structure entirely because it doesn't make sense to have a single remaining tab. I also removed a couple places that still referred to the removed content (API endpoints testing).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
