### PR TITLE
Update database_hosts.md regarding grouping

### DIFF
--- a/content/en/database_monitoring/database_hosts.md
+++ b/content/en/database_monitoring/database_hosts.md
@@ -7,7 +7,7 @@ description: Explore and dig into your database host health and configuration
 {{< img src="database_monitoring/databases-list-3.png" alt="The Databases page in Datadog" style="width:100%;" >}}
 
 <div class="alert alert-info">
-If you are using Amazon RDS with the <a href="https://docs.datadoghq.com/integrations/amazon_rds/?tab=standard">RDS integration</a> enabled, Datadog automatically receives the <code>dbclusteridentifier</code> tag from AWS. When this tag is present, a <strong>Group my RDS clusters</strong> toggle appears, grouping related RDS instances into clusters based on the identifier. No additional setup or manual tagging is required.</div>
+If you are using Amazon RDS with the <a href="https://docs.datadoghq.com/integrations/amazon_rds/?tab=standard">RDS integration</a> enabled, Datadog automatically receives the <code>dbclusteridentifier</code> tag from AWS. When this tag is present, a <strong>Group my RDS clusters</strong> toggle appears, grouping related RDS instances into clusters based on the <code>dbclusteridentifier</code> and <code>region</code> tags. No additional setup or manual tagging is required.</div>
 
 On the [Databases page][1], you can assess the health and activity of your database hosts. Sort and filter the list to prioritize hosts with triggered alerts, high query volume, and other criteria. Click on any host in the list to open a details panel:
 


### PR DESCRIPTION
Database cluster grouping has been updated which we can see here:
https://github.com/DataDog/web-ui/pull/211279

It uses both `dbclusteridentifier` and `region` now, so this doc will reflect that

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
