### PR TITLE
Ian.bucad/fix 404 google cloud run in process

### DIFF
--- a/content/en/serverless/google_cloud_run/containers_sidecar.md
+++ b/content/en/serverless/google_cloud_run/containers_sidecar.md
@@ -873,5 +873,5 @@ $statsd->increment('page.views', 1, array('environment'=>'dev'));
 [11]: /tracing/other_telemetry/connect_logs_and_traces/go
 [12]: /tracing/other_telemetry/connect_logs_and_traces/ruby
 [13]: /getting_started/tagging/unified_service_tagging/
-[14]: /serverless/google_cloud/google_cloud_run_in_process
+[14]: /serverless/google_cloud_run/containers_in_process
 [15]: https://cloud.google.com/run/docs/configuring/services/labels

--- a/content/en/serverless/google_cloud_run/functions.md
+++ b/content/en/serverless/google_cloud_run/functions.md
@@ -757,6 +757,6 @@ public class Function : IHttpFunction
 [11]: /tracing/other_telemetry/connect_logs_and_traces/go
 [12]: /tracing/other_telemetry/connect_logs_and_traces/ruby
 [13]: /getting_started/tagging/unified_service_tagging/
-[14]: /serverless/google_cloud/google_cloud_run_in_process
+[14]: /serverless/google_cloud_run/containers_in_process
 [15]: https://cloud.google.com/run/docs/configuring/services/labels
 [16]: https://cloud.google.com/blog/products/serverless/google-cloud-functions-is-now-cloud-run-functions


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Fix broken link to serverless/google_cloud_run/containers_in_process

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
