### PR TITLE
[MLOB] add DeepSeek auto-instrumentation support alongside OpenAI auto-instrumentation support

### DIFF
--- a/content/en/llm_observability/instrumentation/auto_instrumentation.md
+++ b/content/en/llm_observability/instrumentation/auto_instrumentation.md
@@ -75,6 +75,7 @@ The OpenAI integration instruments the following methods, including streamed cal
 - [Responses][50]:
    - `OpenAI().responses.create()`
    - `AsyncOpenAI().responses.create()`
+-  [Calls made to DeepSeek through the OpenAI Python SDK][54] (as of `ddtrace==3.1.0`)
 
 ## LangChain
 
@@ -322,6 +323,7 @@ The LiteLLM integration instruments the following methods:
 [51]: https://ai.google.dev/api/embeddings#method:-models.embedcontent
 [52]: https://github.com/google-gemini/deprecated-generative-ai-python
 [53]: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_agent-runtime_InvokeAgent.html
+[54]: https://api-docs.deepseek.com/
 
 {{% /tab %}}
 {{% tab "Node.js" %}}
@@ -392,6 +394,7 @@ The OpenAI integration instruments the following methods, including streamed cal
   - `openai.chat.completions.create()`
 - [Embeddings][5]:
   - `openai.embeddings.create()`
+- [Calls made to DeepSeek through the OpenAI Node.js SDK][21] (as of `dd-trace@5.42.0`)
 
 ## LangChain
 
@@ -535,6 +538,7 @@ module.exports = {
 [18]: https://cloud.google.com/vertex-ai/generative-ai/docs/reference/nodejs/latest#send-text-prompt-requests
 [19]: https://cloud.google.com/vertex-ai/generative-ai/docs/reference/nodejs/latest#send-multiturn-chat-requests
 [20]: https://www.npmjs.com/package/@aws-sdk/client-bedrock-runtime
+[21]: https://api-docs.deepseek.com/
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds notes for DeepSeek auto-instrumentation under our OpenAI auto-instrumentation docs. Because DeepSeek is sorta a "subset" because using it programmatically requires using the `openai` SDKs, I've decided to put it there, along with the versions of the tracers/LLMOBs SDKs that support them.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
