### PR TITLE
Bump terraform module version to 3.2.0 and make all layer versions use shortcuts

### DIFF
--- a/content/en/serverless/aws_lambda/installation/dotnet.md
+++ b/content/en/serverless/aws_lambda/installation/dotnet.md
@@ -206,7 +206,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -216,8 +216,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 81
-  datadog_dotnet_layer_version = 20
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_dotnet_layer_version = {{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}
 
   # aws_lambda_function arguments
 }
@@ -242,8 +242,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog .NET Lambda layer to use. Defaults to the latest layer versions.
 
 ```
-  datadog_extension_layer_version = 81
-  datadog_dotnet_layer_version = 20
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_dotnet_layer_version = {{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/go.md
+++ b/content/en/serverless/aws_lambda/installation/go.md
@@ -93,7 +93,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -103,7 +103,7 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 81
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
 
   # aws_lambda_function arguments
 }
@@ -128,7 +128,7 @@ module "lambda-datadog" {
 4. Select the version of the Datadog Extension Lambda layer to use. If left blank the latest layer version will be used.
 
 ```
-  datadog_extension_layer_version = 81
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/java.md
+++ b/content/en/serverless/aws_lambda/installation/java.md
@@ -279,7 +279,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -289,8 +289,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 81
-  datadog_java_layer_version = 21
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_java_layer_version = {{< latest-lambda-layer-version layer="dd-trace-java" >}}
 
   # aws_lambda_function arguments
 }
@@ -315,8 +315,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Java Lambda layer to use. If left blank the latest layer versions will be used.
 
 ```
-  datadog_extension_layer_version = 81
-  datadog_java_layer_version = 21
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_java_layer_version = {{< latest-lambda-layer-version layer="dd-trace-java" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -277,7 +277,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -287,8 +287,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 81
-  datadog_node_layer_version = 125
+  datadog_extension_layer_version = 83
+  datadog_node_layer_version = 126
 
   # aws_lambda_function arguments
 }
@@ -313,8 +313,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Node.js Lambda layer to use. Defaults to the latest layer versions.
 
 ```
-  datadog_extension_layer_version = 81
-  datadog_node_layer_version = 125
+  datadog_extension_layer_version = 83
+  datadog_node_layer_version = 126
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/nodejs.md
+++ b/content/en/serverless/aws_lambda/installation/nodejs.md
@@ -287,8 +287,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 83
-  datadog_node_layer_version = 126
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_node_layer_version = {{< latest-lambda-layer-version layer="node" >}}
 
   # aws_lambda_function arguments
 }
@@ -313,8 +313,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Node.js Lambda layer to use. Defaults to the latest layer versions.
 
 ```
-  datadog_extension_layer_version = 83
-  datadog_node_layer_version = 126
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_node_layer_version = {{< latest-lambda-layer-version layer="node" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -264,7 +264,7 @@ The [`lambda-datadog`][1] Terraform module wraps the [`aws_lambda_function`][2] 
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "3.1.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -274,8 +274,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 81
-  datadog_python_layer_version = 110
+  datadog_extension_layer_version = 83
+  datadog_python_layer_version = 112
 
   # aws_lambda_function arguments
 }
@@ -300,8 +300,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Python Lambda layer to use. If left blank the latest layer versions will be used.
 
 ```
-  datadog_extension_layer_version = 81
-  datadog_python_layer_version = 110
+  datadog_extension_layer_version = 83
+  datadog_python_layer_version = 112
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/en/serverless/aws_lambda/installation/python.md
+++ b/content/en/serverless/aws_lambda/installation/python.md
@@ -274,8 +274,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 83
-  datadog_python_layer_version = 112
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_python_layer_version = {{< latest-lambda-layer-version layer="python" >}}
 
   # aws_lambda_function arguments
 }
@@ -300,8 +300,8 @@ module "lambda-datadog" {
 4. Select the versions of the Datadog Extension Lambda layer and Datadog Python Lambda layer to use. If left blank the latest layer versions will be used.
 
 ```
-  datadog_extension_layer_version = 83
-  datadog_python_layer_version = 112
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_python_layer_version = {{< latest-lambda-layer-version layer="python" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/es/serverless/aws_lambda/installation/dotnet.md
+++ b/content/es/serverless/aws_lambda/installation/dotnet.md
@@ -200,7 +200,7 @@ El módulo de Terraform [`lambda-datadog`][1] envuelve el recurso [`aws_lambda_f
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -210,8 +210,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_dotnet_layer_version = 16
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_dotnet_layer_version = {{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}
 
   # los argumentos de aws_lambda_function
 }
@@ -236,8 +236,8 @@ module "lambda-datadog" {
 4. Selecciona las versiones de la capa de Lambda de la Datadog Extension y de la capa de Lambda de Datadog para .NET que quieres usar. Por defecto, se utilizan las últimas versiones de las capas.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_dotnet_layer_version = 16
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_dotnet_layer_version = {{< latest-lambda-layer-version layer="dd-trace-dotnet" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/es/serverless/aws_lambda/installation/java.md
+++ b/content/es/serverless/aws_lambda/installation/java.md
@@ -273,7 +273,7 @@ El módulo de Terraform [`lambda-datadog`][1] envuelve el recurso [`aws_lambda_f
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -283,8 +283,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_java_layer_version = 15
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_java_layer_version = {{< latest-lambda-layer-version layer="dd-trace-java" >}}
 
   # los argumentos de aws_lambda_function
 }
@@ -309,8 +309,8 @@ module "lambda-datadog" {
 4. Selecciona las versiones de la capa de Lambda de la Datadog Extension y de la capa de Lambda de Datadog para Java que quieres usar. Si las dejas en blanco, se utilizarán las últimas versiones de las capas.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_java_layer_version = 15
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_java_layer_version = {{< latest-lambda-layer-version layer="dd-trace-java" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/es/serverless/aws_lambda/installation/nodejs.md
+++ b/content/es/serverless/aws_lambda/installation/nodejs.md
@@ -266,7 +266,7 @@ El módulo de Terraform [`lambda-datadog`][1] envuelve el recurso [`aws_lambda_f
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -276,8 +276,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_node_layer_version = 117
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_node_layer_version = {{< latest-lambda-layer-version layer="node" >}}
 
   # los argumentos de aws_lambda_function
 }
@@ -302,8 +302,8 @@ module "lambda-datadog" {
 4. Selecciona las versiones de la capa de Lambda de la Datadog Extension y de la capa de Lambda de Datadog para .NET que quieres usar. Por defecto, se utilizan las últimas versiones de las capas.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_node_layer_version = 117
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_node_layer_version = {{< latest-lambda-layer-version layer="node" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/es/serverless/aws_lambda/installation/python.md
+++ b/content/es/serverless/aws_lambda/installation/python.md
@@ -258,7 +258,7 @@ El módulo de Terraform [`lambda-datadog`][1] envuelve el recurso [`aws_lambda_f
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -268,8 +268,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_python_layer_version = 104
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_python_layer_version = {{< latest-lambda-layer-version layer="python" >}}
 
   # los argumentos de aws_lambda_function
 }
@@ -294,8 +294,8 @@ module "lambda-datadog" {
 4. Selecciona las versiones de la capa de Lambda de la Datadog Extension y de la capa de Lambda de Datadog para Python que quieres usar. Si las dejas en blanco, se utilizarán las últimas versiones de las capas.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_python_layer_version = 104
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_python_layer_version = {{< latest-lambda-layer-version layer="python" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/fr/serverless/aws_lambda/installation/java.md
+++ b/content/fr/serverless/aws_lambda/installation/java.md
@@ -273,7 +273,7 @@ Le module Terraform [`lambda-datadog`][1] enveloppe la ressource [`aws_lambda_fu
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<ARN_SECRET_CLÉ_API_DATADOG>"
@@ -283,8 +283,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_java_layer_version = 15
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_java_layer_version = {{< latest-lambda-layer-version layer="dd-trace-java" >}}
 
   # aws_lambda_function arguments
 }
@@ -309,8 +309,8 @@ module "lambda-datadog" {
 4. Sélectionnez les versions de la couche de l'extension Lambda Datadog et de la couche Datadog Lambda Java à utiliser. Si rien n'est indiqué, les dernières versions de la couche seront utilisées.
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_java_layer_version = 15
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_java_layer_version = {{< latest-lambda-layer-version layer="dd-trace-java" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/ja/serverless/aws_lambda/installation/nodejs.md
+++ b/content/ja/serverless/aws_lambda/installation/nodejs.md
@@ -266,7 +266,7 @@ Datadog サーバーレスプラグインをインストールして構成する
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -276,8 +276,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_node_layer_version = 117
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_node_layer_version = {{< latest-lambda-layer-version layer="node" >}}
 
   # aws_lambda_function arguments
 }
@@ -302,8 +302,8 @@ module "lambda-datadog" {
 4. 使用する Datadog 拡張機能 Lambda レイヤーと Datadog Node.js Lambda レイヤーのバージョンを選択します。デフォルトは、レイヤーの最新バージョンになります。
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_node_layer_version = 117
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_node_layer_version = {{< latest-lambda-layer-version layer="node" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/content/ja/serverless/aws_lambda/installation/python.md
+++ b/content/ja/serverless/aws_lambda/installation/python.md
@@ -258,7 +258,7 @@ Datadog サーバーレスプラグインをインストールして構成する
 ```tf
 module "lambda-datadog" {
   source  = "DataDog/lambda-datadog/aws"
-  version = "2.0.0"
+  version = "3.2.0"
 
   environment_variables = {
     "DD_API_KEY_SECRET_ARN" : "<DATADOG_API_KEY_SECRET_ARN>"
@@ -268,8 +268,8 @@ module "lambda-datadog" {
     "DD_VERSION" : "<VERSION>"
   }
 
-  datadog_extension_layer_version = 67
-  datadog_python_layer_version = 104
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_python_layer_version = {{< latest-lambda-layer-version layer="python" >}}
 
   # aws_lambda_function arguments
 }
@@ -294,8 +294,8 @@ module "lambda-datadog" {
 4. 使用する Datadog 拡張機能 Lambda レイヤーと Datadog Python Lambda レイヤーのバージョンを選択します。空白の場合、最新のレイヤーが使用されます。
 
 ```
-  datadog_extension_layer_version = 67
-  datadog_python_layer_version = 104
+  datadog_extension_layer_version = {{< latest-lambda-layer-version layer="extension" >}}
+  datadog_python_layer_version = {{< latest-lambda-layer-version layer="python" >}}
 ```
 
 [1]: https://registry.terraform.io/modules/DataDog/lambda-datadog/aws/latest

--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -6,12 +6,12 @@
 
 <!-- Python Layer -->
 {{- if eq (.Get "layer") "python" -}}
-    111
+    112
 {{- end -}}
 
 <!-- Node Layer -->
 {{- if eq (.Get "layer") "node" -}}
-    125
+    126
 {{- end -}}
 
 <!-- Ruby Layer -->
@@ -21,12 +21,12 @@
 
 <!-- Lambda Extension -->
 {{- if eq (.Get "layer") "extension" -}}
-    81
+    83
 {{- end -}}
 
 <!-- dd-trace-java Layer -->
 {{- if eq (.Get "layer") "dd-trace-java" -}}
-    21
+    23
 {{- end -}}
 
 <!-- dd-trace-dotnet Layer -->


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR:
- bumps the terraform lambda module version in the docs from 3.1.0 to 3.2.0
- bumps the node layer, python layer, and extension layer versions used in the examples to latest versions

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
