### PR TITLE
Move API instructions to a separate tab

### DIFF
--- a/content/en/deployment_gates/setup.md
+++ b/content/en/deployment_gates/setup.md
@@ -373,7 +373,7 @@ This is a general behavior, and you should change it based on your personal use 
 {{% /tab %}}
 {{% tab "Direct API calls" %}}
 
-After a gate is configured with at least one rule, you can request a gate evaluation while deploying the related service. Deployment Gate evaluations are asynchronous, as the evaluation process can take some time to complete. When you trigger an evaluation, it's started in the background, and the API returns an evaluation ID that can be used to track its progress. The high-level interaction with the Deployment Gates API is the following:
+Deployment Gate evaluations are asynchronous, as the evaluation process can take some time to complete. When you trigger an evaluation, it's started in the background, and the API returns an evaluation ID that can be used to track its progress. The high-level interaction with the Deployment Gates API is the following:
 
 - First, request a Deployment Gate evaluation, which initiates the process and returns an evaluation ID.
 - Then, periodically poll the evaluation status endpoint using the evaluation ID to retrieve the result when the evaluation is complete. Polling every 10-20 seconds is recommended.


### PR DESCRIPTION
This is just an alternative proposed by @gturbat to move the API instructions into a separate tab