### PR TITLE
Fix left navigation for Log Agent Tags

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -426,8 +426,8 @@ menu:
       weight: 5
     - name: Log Agent tags
       url: agent/logs/agent_tags/
-      parent: agent
-      identifier: agent_tags
+      parent: agent_logs
+      identifier: agent_logs_tags
       weight: 501
     - name: Advanced Configurations
       identifier: agent_logs_advanced_log_collection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Quick fix to move the Logs Agent tags under Log Collection, not under Agent
Original PR: https://github.com/DataDog/documentation/pull/30375/files

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
