### PR TITLE
[CLOUDS_6404] feat(doc): add autosubscription limitation language

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -64,7 +64,9 @@ There are two options when configuring triggers on the Datadog Forwarder Lambda 
 
 ### Automatically set up triggers
 
-Datadog can automatically configure triggers on the Datadog Forwarder Lambda function to collect AWS logs from the following sources and locations:
+Datadog can automatically configure triggers on the Datadog Forwarder Lambda function to collect AWS logs. However, automatic subscription does not support creating triggers across different AWS accounts or regions. For scenarios where logs are published to S3 buckets in a separate account, we recommend manually creating a trigger in the same account as the bucket to work around this limitation.
+
+The following sources and locations are supported:
 
 | Source                      | Location       |
 | --------------------------- | -------------- |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR adds some language around limitations for AWS log autosubscription. More specifically, we've had a few support cases raising issues when logs are published in buckets in different accounts and the triggers aren't created.
This is due to a lambda limitation that makes it so that we can't trigger an AWS Lambda function from notifications emitted from a different account/region.

Merge readiness:
- [ X] Ready for merge
