### PR TITLE
[AWSX-1243] feat(redshift-serverless): update doc

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -53,6 +53,8 @@ Any AWS service that generates logs into a S3 bucket or a CloudWatch Log Group i
 | [Web Application Firewall][49]     | [Enable Amazon WAF logs][50]                                                                                   | [Manual][51] and [automatic](#automatically-set-up-triggers) log collection.                                                                                               |
 | [MWAA][55]                         | [Enable Amazon MWAA logs][56]                                                                                  | [Manual][56] and [automatic](#automatically-set-up-triggers) log collection.                                                                                                 |
 | [Network Firewall][57]             | [Enable AWS Network Firewall logs][58]                                                                      | [Manual][58] and [automatic](#automatically-set-up-triggers) log collection.                                                                                                 |
+| Redshift Serverless             | -                                                                      | [Automatic](#automatically-set-up-triggers) log collection.                                                                                                 |
+
 
 
 ## Set up triggers
@@ -80,7 +82,8 @@ The following sources and locations are supported:
 | Lambda Logs                 | CloudWatch     |
 | Lambda@Edge Logs            | Cloudwatch     |
 | Network Firewall Logs       | S3, CloudWatch |
-| Redshift Logs               | S3             |
+| Redshift Logs               | S3, Cloudwatch |
+| Redshift Serverless Logs    | Cloudwatch     |
 | S3 Access Logs              | S3             |
 | SSM Command Logs            | Cloudwatch     |
 | Step Functions              | CloudWatch     |
@@ -107,6 +110,7 @@ The following sources and locations are supported:
     "network-firewall:ListFirewalls",
     "redshift:DescribeClusters",
     "redshift:DescribeLoggingStatus",
+    "redshift-serverless:ListNamespaces",
     "s3:GetBucketLogging",
     "s3:GetBucketLocation",
     "s3:GetBucketNotification",
@@ -136,9 +140,10 @@ The following sources and locations are supported:
     | `lambda:List*`                                              | List all Lambda functions.                                                   |
     | `lambda:GetPolicy`                                          | Get the Lambda policy when triggers are to be removed.                       |
     | `network-firewall:DescribeLoggingConfiguration`             | Get the logging configuration of a firewall                                  |
-    | `network-firewall:ListFirewalls`                            | List all Network Firewall firewalls                                                           |
+    | `network-firewall:ListFirewalls`                            | List all Network Firewall firewalls                                          |
     | `redshift:DescribeClusters`                                 | List all Redshift clusters.                                                  |
     | `redshift:DescribeLoggingStatus`                            | Get the name of the S3 bucket containing Redshift Logs.                      |
+    | `redshift-serverless:ListNamespaces`                        | List all Redshift Serverless namespaces                                      |
     | `s3:GetBucketLogging`                                       | Get the name of the S3 bucket containing S3 access logs.                     |
     | `s3:GetBucketLocation`                                      | Get the region of the S3 bucket containing S3 access logs.                   |
     | `s3:GetBucketNotification`                                  | Get existing Lambda trigger configurations.                                  |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Update documentation to add information about AWS Redshift Serverless log support


Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:
