### PR TITLE
Update links to new Code Coverage product docs [DOCS-11678]

### DIFF
--- a/content/en/tests/code_coverage.md
+++ b/content/en/tests/code_coverage.md
@@ -15,7 +15,7 @@ further_reading:
 ---
 
 {{< callout url="https://www.datadoghq.com/product-preview/code-coverage/" >}}
-This Test Optimization feature is being deprecated and replaced by a new dedicated <a href="https://www.datadoghq.com/product-preview/code-coverage/">Code Coverage</a> product. Sign up for the Preview!
+This Test Optimization feature is being deprecated and replaced by a new dedicated <a href="https://docs.datadoghq.com/code_coverage/">Code Coverage</a> product. Sign up for the Preview!
 {{< /callout >}}
 
 ## Overview

--- a/content/en/tests/setup/junit_xml.md
+++ b/content/en/tests/setup/junit_xml.md
@@ -543,7 +543,7 @@ The values that you send to Datadog are strings, so the facets are displayed in 
 
 {{< callout url="https://www.datadoghq.com/product-preview/code-coverage/" >}}
 This section covers the code coverage feature of the Test Optimization product.
-This feature is being deprecated and replaced by a new dedicated <a href="https://www.datadoghq.com/product-preview/code-coverage/">Code Coverage</a> product. Sign up for the Preview!
+This feature is being deprecated and replaced by a new dedicated <a href="https://docs.datadoghq.com/code_coverage/">Code Coverage</a> product. Sign up for the Preview!
 {{< /callout >}}
 
 It is possible to report code coverage for a given JUnit report via the `--report-measures` option, by setting the `test.code_coverage.lines_pct` measure:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Updates inline links in the Code Coverage callouts to point to the new product docs. We couldn't link to the docs until they were published via https://github.com/DataDog/documentation/pull/30798. Previously we linked to the Preview signup page, but the callout button takes care of that.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
