### PR TITLE
fix: correct reference to Terraform 'module' w/ 'resource'

### DIFF
--- a/content/en/internal_developer_portal/software_catalog/entity_model/_index.md
+++ b/content/en/internal_developer_portal/software_catalog/entity_model/_index.md
@@ -20,7 +20,7 @@ aliases:
   - /service_catalog/service_definitions/v3-0
   - /software_catalog/service_definitions/v3-0
   - /software_catalog/apis   ## aliases for definitions/apis page
-  - /tracing/faq/service_definition_api/    
+  - /tracing/faq/service_definition_api/
   - /tracing/software_catalog/service_definition_api
   - /software_catalog/service_definition_api
   - /tracing/service_catalog/service_definition_api
@@ -55,7 +55,7 @@ algolia:
 
 ## Overview
 
-Software Catalog uses definition schemas to store and display relevant metadata about your services. The schemas have built-in validation rules to ensure that only valid values are accepted. You can view warnings in the **Definition** tab on the Software Catalog side panel for any selected services. 
+Software Catalog uses definition schemas to store and display relevant metadata about your services. The schemas have built-in validation rules to ensure that only valid values are accepted. You can view warnings in the **Definition** tab on the Software Catalog side panel for any selected services.
 
 {{< callout url="https://forms.gle/fwzarcSww6By7tn39" btn_hidden="true" header="false" >}}
 <a href="https://forms.gle/fwzarcSww6By7tn39">Share feedback</a> on new and upcoming Software Catalog features!
@@ -100,16 +100,16 @@ For detailed information about each version, including full schemas and example 
 - **Expanded data model**: v3.0 supports multiple kinds of entities. You can organize your systems using various components such as systems, services, queues, and datastores.
 - **Multi-ownership**: You can assign multiple owners to any objects defined through the v3.0 schema to specify multiple points of contact.
 - **Enhanced relationship mapping**: With APM and USM data, you can automatically detect dependencies among components. v3.0 supports manual declaration to augment auto-detected system topology to ensure a complete overview of how components interact within your systems.
-- **Inheritance of system metadata**: Components within a system automatically inherit the system's metadata. It's no longer necessary to declare metadata for all related components one-by-one as in v2.1 and v2.2. 
+- **Inheritance of system metadata**: Components within a system automatically inherit the system's metadata. It's no longer necessary to declare metadata for all related components one-by-one as in v2.1 and v2.2.
 - **Precise code location**: Add the mapping of your code location for your service. The `codeLocations` section in v3.0 specifies the locations of the code with the repository that contains the code and its associated `paths`. The `paths` attribute is a list of [globs][4] that should match paths in the repository.
-- **Filtered logs & events**: Declare saved logs and event queries for a `system` through the `logs` and `events` sections and view results on the System page.  
+- **Filtered logs & events**: Declare saved logs and event queries for a `system` through the `logs` and `events` sections and view results on the System page.
 - **Custom entities**: Define custom entity types beyond Service, System, Datastore, Queue, and API. Scope scorecards and actions to specific entity types.
 - **(Upcoming) Integrations**: Integrate with third-party tools to dynamically source information related to your components (for example, GitHub pull requests, PagerDuty incidents, and GitLab pipelines). Report on and write scorecard rules against any third-party source.
 - **(Upcoming) Group by product or domain**: Organize components by product, enabling multiple layers of hierarchical grouping.
 
 ### Schema structure
 
-You can see the [full schema definitions on Github][1]. 
+You can see the [full schema definitions on Github][1].
 
 V3.0 contains the following changes from v2.2:
 - `schema_version` is now `apiVersion`
@@ -290,9 +290,9 @@ V3.0 contains the following changes from v2.2:
   {{< /code-block >}}
 {{% /collapse-content %}}
 
-### Explicit and implicit metadata inheritance 
+### Explicit and implicit metadata inheritance
 
-#### Explicit inheritance 
+#### Explicit inheritance
 
 The `inheritFrom` field instructs the ingestion pipeline to inherit metadata from the entity's metadata referenced by `<entity_kind>:<name>`.
 
@@ -300,13 +300,13 @@ The `inheritFrom` field instructs the ingestion pipeline to inherit metadata fro
 inheritFrom:<entity_kind>:<name>
 {{< /code-block >}}
 
-#### Implicit inheritance 
+#### Implicit inheritance
 Components (`kind:service`, `kind:datastore`, `kind:queue`, `kind:ui`) inherit all metadata from the system that they belong to under the following conditions:
 - There is only one system defined in the YAML file.
 - The clause `inheritFrom:<entity_kind>:<name>` is absent in the YAML file.
 
 ### Migrating to v3.0
-v3.0 supports the same methods of creating metadata as previous versions, including Github, API, Terraform, Backstage, ServiceNow, and the UI. However, there are new [API endpoints][5] and a new [Terraform module][6] for v3.0.
+v3.0 supports the same methods of creating metadata as previous versions, including Github, API, Terraform, Backstage, ServiceNow, and the UI. However, there are new [API endpoints][5] and a new [Terraform resource][6] for v3.0.
 
 ### API reference documentation
 To create, get, and delete definitions for all entity types like endpoints, systems, datastores, and queues, see the [Software Catalog API reference][8].
@@ -526,7 +526,7 @@ integrations:
 
 <div class="alert alert-info">Custom extensions are in Limited Availability for all schema versions.</div>
 
-Custom extensions allow you to attach organization-specific metadata to entities, enabling support for custom tooling and workflows. For example, use the `extensions` field to include release notes, compliance tags, or ownership models in your entity definitions. 
+Custom extensions allow you to attach organization-specific metadata to entities, enabling support for custom tooling and workflows. For example, use the `extensions` field to include release notes, compliance tags, or ownership models in your entity definitions.
 
 Datadog also supports specific extension keys for certain features. These include:
 - `datadoghq.com/dora-metrics`: Define source code path patterns for filtering Git commits when calculating [DORA metrics][21].
@@ -570,7 +570,7 @@ extensions:
 {{< /code-block >}}
 
 
-## Schema validation through IDE plugin 
+## Schema validation through IDE plugin
 
 Datadog provides a [JSON Schema][18] for definitions so that when you are editing a definition in a [supporting IDE][19], features such as autocomplete and validation are provided.
 


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This corrects the IDP entity model documentation's reference to a corresponding Terraform _resource_; the link points to a Terraform resource, not a Terraform _module_.


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
