### PR TITLE
Document the static analyzer's rule config 'severity' and 'category' fields

### DIFF
--- a/content/en/security/code_security/static_analysis/setup/_index.md
+++ b/content/en/security/code_security/static_analysis/setup/_index.md
@@ -340,6 +340,8 @@ rulesets:
         arguments:
           # Set the max-function-lines rule's threshold to 150 lines
           max-lines: 150
+        # Override this rule's severity
+        severity: NOTICE
       max-class-lines:
         arguments:
           # Set different thresholds for the max-class-lines rule in different subtrees
@@ -348,6 +350,12 @@ rulesets:
             /: 200
             # Set the rule's threshold to 100 lines in src/main/backend
             src/main/backend: 100
+        # Override this rule's severity with different values in different subtrees
+        severity:
+          # Set the rule's severity to INFO by default
+          /: INFO
+          # Set the rule's severity to NONE in tests/
+          tests: NONE
   - python-inclusive
   - python-django:
     # Only apply the python-django ruleset to the following paths
@@ -392,12 +400,21 @@ You can include the following **rule** options in the `static-analysis.datadog.y
 | ------------- | ------------------------------------------------------------------------------------------------------------------ | --------- |
 | `ignore`    | A list of path prefixes and glob patterns to ignore for this specific rule. Matching files will not be analyzed.   | `false` |
 | `only`      | A list of path prefixes and glob patterns to analyze for this specific rule. Only matching files will be analyzed. | `false` |
-| `arguments` | A map of values for rules that support customizable arguments.                                                     | `false` |
+| `arguments` | A map of values for rules that support customizable arguments. See the syntax below.                               | `false` |
+| `severity`  | Override the rule's severity. See the syntax below.                                                                | `false` |
+| `category`  | Override the rule's category. See the syntax below.                                                                | `false` |
 
 The map in the `arguments` field uses an argument's name as its key, and the values are either strings or maps:
 
 * To set a value for the whole repository, you can specify it as a string.
 * To set different values for different subtrees in the repository, you can specify them as a map from a subtree prefix to the value that the argument will have within that subtree.
+
+The `severity` field can take a string or a map:
+
+* To set the severity for the whole repository, specify it as one of the following strings: `ERROR`, `WARNING`, `NOTICE`, or `NONE`.
+* To set different severities for different subtrees in the repository, you can specify them as a map from a subtree prefix to the severity for that subtree.
+
+The `category` field can take a string with one of the following values: `BEST_PRACTICES`, `CODE_STYLE`, `ERROR_PRONE`, `PERFORMANCE`, or `SECURITY`. You can only specify one category for the whole repository.
 
 ### Ignoring violations
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Document these fields, which have existed for a while but were undocumented.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
