### PR TITLE
Fix configuration example for Setting up Cloud Security on Linux

### DIFF
--- a/content/en/security/cloud_security_management/setup/agent/linux.md
+++ b/content/en/security/cloud_security_management/setup/agent/linux.md
@@ -28,8 +28,6 @@ compliance_config:
   ## Set to true to enable CIS benchmarks for Misconfigurations.
   #
   enabled: true
-  host_benchmarks:
-    enabled: true
 
 # Vulnerabilities are evaluated and scanned against your containers and hosts every hour.
 sbom:


### PR DESCRIPTION

### What does this PR do? What is the motivation?

The following block isn't listed as available configuration settings in the configuration template: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml

```yaml
  host_benchmarks:
    enabled: true
```

### Merge instructions

None.

Merge readiness:
- [x] Ready for merge


### Additional notes


