### PR TITLE
Fix incorrect API urls in Deployment Gates code examples

### DIFF
--- a/content/en/deployment_gates/setup.md
+++ b/content/en/deployment_gates/setup.md
@@ -402,7 +402,10 @@ Deployment Gate evaluations are asynchronous, as the evaluation process can take
 
 A Deployment Gate evaluation can be requested with an API call.
 
-Replace `<YOUR_DD_SITE>` below with your [Datadog site name][1] (for example, {{< region-param key="dd_site" code="true" >}}), `<YOUR_API_KEY>` with your [API key][2] and `<YOUR_APP_KEY>` with your [application key][3].
+Be sure to replace the following:
+- `<YOUR_DD_SITE>`: Your [Datadog site name][1] (for example, {{< region-param key="dd_site" code="true" >}})
+- `<YOUR_API_KEY>`: Your [API key][2]
+- `<YOUR_APP_KEY>`: Your [application key][3]
 
 ```bash
 curl -X POST "https://api.<YOUR_DD_SITE>/api/unstable/deployments/gates/evaluation" \

--- a/content/en/deployment_gates/setup.md
+++ b/content/en/deployment_gates/setup.md
@@ -239,7 +239,11 @@ spec:
 {{% /tab %}}
 {{% tab "Generic script" %}}
 
-Use this script as a starting point. Be sure to replace `<YOUR_DD_SITE>` with your [Datadog site name][1] (for example, {{< region-param key="dd_site" code="true" >}}), `<YOUR_API_KEY>` with your [API key][2] and `<YOUR_APP_KEY>` with your [application key][3].
+Use this script as a starting point. Be sure to replace the following:
+
+- `<YOUR_DD_SITE>`: Your [Datadog site name][1] (for example, {{< region-param key="dd_site" code="true" >}})
+- `<YOUR_API_KEY>`: Your [API key][2]
+- `<YOUR_APP_KEY>`: Your [application key][3]
 
 ```bash
 #!/bin/sh

--- a/content/en/deployment_gates/setup.md
+++ b/content/en/deployment_gates/setup.md
@@ -239,8 +239,7 @@ spec:
 {{% /tab %}}
 {{% tab "Generic script" %}}
 
-
-Use this script as a starting point. For the API_URL variable, be sure to replace `<YOUR_DD_SITE>` with your [Datadog site name][1] (for example, {{< region-param key="dd_site" code="true" >}}).
+Use this script as a starting point. Be sure to replace `<YOUR_DD_SITE>` with your [Datadog site name][1] (for example, {{< region-param key="dd_site" code="true" >}}), `<YOUR_API_KEY>` with your [API key][2] and `<YOUR_APP_KEY>` with your [application key][3].
 
 ```bash
 #!/bin/sh
@@ -386,6 +385,8 @@ The script has the following characteristics:
 This is a general behavior, and you should change it based on your personal use case and preferences. The script uses `curl` (to perform the request) and `jq` (to process the returned JSON). If those commands are not available, install them at the beginning of the script (for example, by adding `apk add --no-cache curl jq`).
 
 [1]: /getting_started/site/
+[2]: https://app.datadoghq.com/organization-settings/api-keys
+[3]: https://app.datadoghq.com/organization-settings/application-keys
 
 {{% /tab %}}
 {{% tab "Direct API calls" %}}
@@ -395,10 +396,12 @@ Deployment Gate evaluations are asynchronous, as the evaluation process can take
 - First, request a Deployment Gate evaluation, which initiates the process and returns an evaluation ID.
 - Then, periodically poll the evaluation status endpoint using the evaluation ID to retrieve the result when the evaluation is complete. Polling every 10-20 seconds is recommended.
 
-A Deployment Gate evaluation can be requested with an API call:
+A Deployment Gate evaluation can be requested with an API call.
+
+Replace `<YOUR_DD_SITE>` below with your [Datadog site name][1] (for example, {{< region-param key="dd_site" code="true" >}}), `<YOUR_API_KEY>` with your [API key][2] and `<YOUR_APP_KEY>` with your [application key][3].
 
 ```bash
-curl -X POST "https://api.{{< region-param key="dd_site" >}}/api/unstable/deployments/gates/evaluation" \
+curl -X POST "https://api.<YOUR_DD_SITE>/api/unstable/deployments/gates/evaluation" \
 -H "Content-Type: application/json" \
 -H "DD-API-KEY: <YOUR_API_KEY>" \
 -H "DD-APPLICATION-KEY: <YOUR_APP_KEY>" \
@@ -438,7 +441,7 @@ The field `data.attributes.evaluation_id` contains the unique identifier for thi
 You can fetch the status of a gate evaluation by polling an additional API endpoint using the gate evaluation ID:
 
 ```bash
-curl -X GET "https://api.{{< region-param key="dd_site" >}}/api/unstable/deployments/gates/evaluation/<evaluation_id>" \
+curl -X GET "https://api.<YOUR_DD_SITE>/api/unstable/deployments/gates/evaluation/<evaluation_id>" \
 -H "DD-API-KEY: <YOUR_API_KEY>" \
 -H "DD-APPLICATION-KEY: <YOUR_APP_KEY>"
 ```
@@ -455,14 +458,14 @@ When a 200 HTTP response is returned, it has the following format:
        "attributes": {
            "dry_run": false,
            "evaluation_id": "e9d2f04f-4f4b-494b-86e5-52f03e10c8e9",
-           "evaluation_url": "https://app.{{< region-param key="dd_site" >}}/ci/deployment-gates/evaluations?index=cdgates&query=level%3Agate+%40evaluation_id%3Ae9d2f14f-4f4b-494b-86e5-52f03e10c8e9",
+           "evaluation_url": "https://app.datadoghq.com/ci/deployment-gates/evaluations?index=cdgates&query=level%3Agate+%40evaluation_id%3Ae9d2f14f-4f4b-494b-86e5-52f03e10c8e9",
            "gate_id": "e140302e-0cba-40d2-978c-6780647f8f1c",
            "gate_status": "pass",
            "rules": [
                {
                    "name": "Check service monitors",
                    "status": "fail",
-                   "reason": "One or more monitors in ALERT state: https://app.{{< region-param key="dd_site" >}}/monitors/34330981",
+                   "reason": "One or more monitors in ALERT state: https://app.datadoghq.com/monitors/34330981",
                    "dry_run": true
                }
            ]
@@ -478,6 +481,10 @@ The field `data.attributes.gate_status` contains the result of the evaluation. I
 * `fail`: The Deployment Gate evaluation failed.
 
 **Note**: If the field `data.attributes.dry_run` is `true`, the field `data.attributes.gate_status` is always `pass`.
+
+[1]: /getting_started/site/
+[2]: https://app.datadoghq.com/organization-settings/api-keys
+[3]: https://app.datadoghq.com/organization-settings/application-keys
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Variables do not render well in code blocks:

<img width="1352" height="288" alt="Image" src="https://github.com/user-attachments/assets/061f9f7b-eb38-4128-9e86-20e6aae897ea" />

This PR adds placeholders and instructions to repace the DD_SITE variable

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
