### PR TITLE
OpenTelemetry: Update the HTTP path and headers for logs and traces

### DIFF
--- a/assets/scripts/config/regions.config.js
+++ b/assets/scripts/config/regions.config.js
@@ -340,10 +340,10 @@ export default {
     gov: 'https://ip-ranges.ddog-gov.com'
   },
   otlp_trace_endpoint: {
-    us: 'https://trace.agent.datadoghq.com/api/v0.2/traces',
-    us3: 'https://trace.agent.us3.datadoghq.com/api/v0.2/traces',
-    us5: 'https://trace.agent.us5.datadoghq.com/api/v0.2/traces',
-    eu: 'https://trace.agent.datadoghq.eu/api/v0.2/traces',
+    us: 'https://trace.agent.datadoghq.com/v1/traces',
+    us3: 'https://trace.agent.us3.datadoghq.com/v1/traces',
+    us5: 'https://trace.agent.us5.datadoghq.com/v1/traces',
+    eu: 'https://trace.agent.datadoghq.eu/v1/traces',
     ap1: 'Datadog OTLP traces intake endpoint is not supported for AP1',
     ap2: 'Datadog OTLP traces intake endpoint is not supported for AP2'
   },
@@ -356,10 +356,10 @@ export default {
     ap2: 'Datadog OTLP metrics intake endpoint is not supported for AP2'
   },
   otlp_logs_endpoint: {
-    us: 'https://http-intake.logs.datadoghq.com/api/v2/logs',
-    us3: 'https://http-intake.logs.us3.datadoghq.com/api/v2/logs',
-    us5: 'https://http-intake.logs.us5.datadoghq.com/api/v2/logs',
-    eu: 'https://http-intake.logs.datadoghq.eu/api/v2/logs',
+    us: 'https://http-intake.logs.datadoghq.com/v1/logs',
+    us3: 'https://http-intake.logs.us3.datadoghq.com/v1/logs',
+    us5: 'https://http-intake.logs.us5.datadoghq.com/v1/logs',
+    eu: 'https://http-intake.logs.datadoghq.eu/v1/logs',
     ap1: 'Datadog OTLP logs intake endpoint is not supported for AP1',
     ap2: 'Datadog OTLP logs intake endpoint is not supported for AP2'
   },

--- a/content/en/opentelemetry/setup/agentless/logs.md
+++ b/content/en/opentelemetry/setup/agentless/logs.md
@@ -38,7 +38,7 @@ If you are using [OpenTelemetry automatic instrumentation][3], set the following
 ```shell
 export OTEL_EXPORTER_OTLP_LOGS_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT="${YOUR_ENDPOINT}" // Replace this with the correct endpoint
-export OTEL_EXPORTER_OTLP_LOGS_HEADERS="dd-protocol=otlp,dd-api-key=${DD_API_KEY}"
+export OTEL_EXPORTER_OTLP_LOGS_HEADERS="dd-api-key=${DD_API_KEY}"
 ```
 
 #### Manual instrumentation
@@ -56,7 +56,6 @@ import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter;
 
 OtlpHttpLogRecordExporter exporter = OtlpHttpLogRecordExporter.builder()
     .setEndpoint("${YOUR_ENDPOINT}") // Replace this with the correct endpoint
-    .addHeader("dd-protocol", "otlp")
     .addHeader("dd-api-key", System.getenv("DD_API_KEY"))
     .build();
 ```
@@ -71,10 +70,9 @@ import "go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 logExporter, err := otlploghttp.New(
     ctx,
     otlploghttp.WithEndpointURL("${YOUR_ENDPOINT}"), // Replace this with the correct endpoint, minus the URL path
-    otlploghttp.WithURLPath("/api/v2/logs"),
+    otlploghttp.WithURLPath("/v1/logs"),
     otlploghttp.WithHeaders(
         map[string]string{
-            "dd-protocol": "otlp",
             "dd-api-key": os.Getenv("DD_API_KEY"),
         }),
 )
@@ -93,7 +91,6 @@ exporters:
   otlphttp:
     logs_endpoint: ${YOUR_ENDPOINT} // Replace this with the correct endpoint
     headers:
-      dd-protocol: "otlp"
       dd-api-key: ${env:DD_API_KEY}
 
 service:

--- a/content/en/opentelemetry/setup/agentless/traces.md
+++ b/content/en/opentelemetry/setup/agentless/traces.md
@@ -111,7 +111,7 @@ traceExporter, err := otlptracehttp.New(
 		map[string]string{
 			"dd-api-key": os.Getenv("DD_API_KEY"),
 			"dd-otel-span-mapping": "{span_name_as_resource_name: true}",
-      "dd-otlp-source": "${YOUR_SITE}", // Replace with the specific value provided by Datadog for your organization
+			"dd-otlp-source": "${YOUR_SITE}", // Replace with the specific value provided by Datadog for your organization
 		}),
 )
 ```

--- a/content/en/opentelemetry/setup/agentless/traces.md
+++ b/content/en/opentelemetry/setup/agentless/traces.md
@@ -46,7 +46,7 @@ If you are using [OpenTelemetry automatic instrumentation][3], set the following
 ```shell
 export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="{{< region-param key="otlp_trace_endpoint" >}}"
-export OTEL_EXPORTER_OTLP_TRACES_HEADERS="dd-protocol=otlp,dd-api-key=${DD_API_KEY},dd-otlp-source=${YOUR_SITE}"
+export OTEL_EXPORTER_OTLP_TRACES_HEADERS="dd-api-key=${DD_API_KEY},dd-otlp-source=${YOUR_SITE}"
 ```
 
 <div class="alert alert-info">The value for <code>dd-otlp-source</code> should be provided to you by Datadog after being allowlisted for the intake endpoint. This is a specific identifier assigned to your organization.</div>
@@ -68,7 +68,6 @@ const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-proto'
 const exporter = new OTLPTraceExporter({
   url: '${YOUR_ENDPOINT}', // Replace this with the correct endpoint
   headers: {
-    'dd-protocol': 'otlp',
     'dd-api-key': process.env.DD_API_KEY,
     'dd-otel-span-mapping': '{span_name_as_resource_name: true}',
     'dd-otlp-source': '${YOUR_SITE}', // Replace with the specific value provided by Datadog for your organization
@@ -88,7 +87,6 @@ import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 
 OtlpHttpSpanExporter exporter = OtlpHttpSpanExporter.builder()
     .setEndpoint("${YOUR_ENDPOINT}") // Replace this with the correct endpoint
-    .addHeader("dd-protocol", "otlp")
     .addHeader("dd-api-key", System.getenv("DD_API_KEY"))
     .addHeader("dd-otel-span-mapping", "{span_name_as_resource_name: true}")
     .addHeader("dd-otlp-source", "${YOUR_SITE}") // Replace with the specific value provided by Datadog for your organization
@@ -108,10 +106,9 @@ import "go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 traceExporter, err := otlptracehttp.New(
 	ctx,
 	otlptracehttp.WithEndpoint("${YOUR_ENDPOINT}"), // Replace this with the correct endpoint
-	otlptracehttp.WithURLPath("/api/v0.2/traces"),
+	otlptracehttp.WithURLPath("/v1/traces"),
 	otlptracehttp.WithHeaders(
 		map[string]string{
-			"dd-protocol": "otlp",
 			"dd-api-key": os.Getenv("DD_API_KEY"),
 			"dd-otel-span-mapping": "{span_name_as_resource_name: true}",
       "dd-otlp-source": "${YOUR_SITE}", // Replace with the specific value provided by Datadog for your organization
@@ -132,7 +129,6 @@ from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExport
 exporter = OTLPSpanExporter(
     endpoint="${YOUR_ENDPOINT}", # Replace this with the correct endpoint
     headers={
-        "dd-protocol": "otlp",
         "dd-api-key": os.environ.get("DD_API_KEY"),
         "dd-otel-span-mapping": "{span_name_as_resource_name: true}",
         "dd-otlp-source": "${YOUR_SITE}" # Replace with the specific value provided by Datadog for your organization
@@ -179,7 +175,6 @@ exporters:
   otlphttp:
     traces_endpoint: {{< region-param key="otlp_trace_endpoint" >}}
     headers:
-      dd-protocol: "otlp"
       dd-api-key: ${env:DD_API_KEY}
       dd-otel-span-mapping: "{span_name_as_resource_name: false}"
       dd-otlp-source: "${YOUR_SITE}", # Replace with the specific value provided by Datadog for your organization


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The intake now handles the standard OpenTelemetry HTTP paths without the need of additional header.

https://opentelemetry.io/docs/specs/otlp/#otlphttp-request

Simplify the documentation by:

- using the standard OTLP path (`/v1/logs` and `/v1/traces`)
- removing the need of `dd-protocol=otlp` HTTP header

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
