### PR TITLE
SDCD-1644: adding limitation warning around DORA failure enrichment from PagerDuty incidents created by Datadog monitors

### DIFF
--- a/content/en/dora_metrics/setup/failures.md
+++ b/content/en/dora_metrics/setup/failures.md
@@ -135,7 +135,7 @@ The matching algorithm works in the following steps:
 6. If there have been no matches up to this point, the incident metrics and events are emitted with the PagerDuty service and PagerDuty team provided in the incident.
 
 <div class="alert alert-warning">
-If an incident is resolved manually in PagerDuty instead of from a monitor notification, the incident resolution event will not contain monitor information and the first step of the matching algorithm will be skipped.
+If an incident is resolved manually in PagerDuty instead of from a monitor notification, the incident resolution event does not contain monitor information and the first step of the matching algorithm is skipped.
 </div>
 
 [101]: https://support.pagerduty.com/docs/services-and-integrations


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds clarifying warning around a limitation in the Datadog monitors -> PagerDuty incident enrichment for DORA metrics. In order for the incident to be properly enriched from a Datadog monitor, the incident needs to be resolved by the monitor. If the incident is resolved manually in PagerDuty, the associated monitor information is not sent to us, and we skip the first step in our matching algorithm.

### Merge instructions
This can be merged as soon as it is approved, and this is clarifying existing limitations. :) 

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
