### PR TITLE
MITRE ATT&CK map content updated for new product support

### DIFF
--- a/content/en/security/detection_rules/_index.md
+++ b/content/en/security/detection_rules/_index.md
@@ -63,14 +63,14 @@ By mapping tactics and techniques, MITRE ATT&CK provides security teams with a c
 
 To use the MITRE ATT&CK map, do the following:
 
-1. Open Detection Rules in [SIEM][16] or [Workload Protection][17]. The MITRE ATT&CK map can be used for Application and API Protection also, but the map is only available in SIEM or Workload Protection. Application and API Protection users typically focus on OWASP concerns, but it is included in the MITRE ATT&CK map for all-inclusive security coverage.
+1. Open Detection Rules in [SIEM][16] or [Workload Protection][17].
 2. Select **MITRE ATT&CK map**.
 3. Select one of more products in the filter <i class="icon-filter"></i>.
 4. Review the map for the following:
    - Assessing Coverage: Determine which attack techniques are well-covered and which are under-monitored.
    - Prioritizing Rule Creation: Focus on creating detection rules for techniques with low or no coverage.
    - Streamlining Rule Management: Manage and update detection rules, ensuring they align with the latest threat intelligence.
-
+The MITRE ATT&CK map available in SIEM or Workload Protection, but you can select Application and API Protection in the filter. Application and API Protection is included in the MITRE ATT&CK map for all-inclusive security coverage.
 ## Beta detection rules
 
 Datadog's Security Research team continually adds new OOTB security detection rules. While the aim is to deliver high quality detections with the release of integrations or other new features, the performance of the detection at scale often needs to be observed before making the rule generally available. This gives Datadog's Security Research the time to either refine or deprecate detection opportunities that do not meet our standards.

--- a/content/en/security/detection_rules/_index.md
+++ b/content/en/security/detection_rules/_index.md
@@ -63,7 +63,7 @@ By mapping tactics and techniques, MITRE ATT&CK provides security teams with a c
 
 To use the MITRE ATT&CK map, do the following:
 
-1. Open Detection Rules in [SIEM][16] or [Workload Protection][17]. The MITRE ATT&CK map can be used for Application and API Protection also, but the map is onlu available in SIEM or Workload Protection. Application and API Protection users typically focus on OWASP concerns, but it is included in the MITRE ATT&CK map for all-inclusive security coverage.
+1. Open Detection Rules in [SIEM][16] or [Workload Protection][17]. The MITRE ATT&CK map can be used for Application and API Protection also, but the map is only available in SIEM or Workload Protection. Application and API Protection users typically focus on OWASP concerns, but it is included in the MITRE ATT&CK map for all-inclusive security coverage.
 2. Select **MITRE ATT&CK map**.
 3. Select one of more products in the filter <i class="icon-filter"></i>.
 4. Review the map for the following:

--- a/content/en/security/detection_rules/_index.md
+++ b/content/en/security/detection_rules/_index.md
@@ -67,9 +67,9 @@ To use the MITRE ATT&CK map, do the following:
 2. Select **MITRE ATT&CK map**.
 3. Select one of more products in the filter <i class="icon-filter"></i>.
 4. Review the map for the following:
-   - Assessing Coverage: Quickly determine which attack techniques are well-covered and which are under-monitored.
+   - Assessing Coverage: Determine which attack techniques are well-covered and which are under-monitored.
    - Prioritizing Rule Creation: Focus on creating detection rules for techniques with low or no coverage.
-   - Streamlining Rule Management: Easily manage and update detection rules, ensuring they align with the latest threat intelligence.
+   - Streamlining Rule Management: Manage and update detection rules, ensuring they align with the latest threat intelligence.
 
 ## Beta detection rules
 

--- a/content/en/security/detection_rules/_index.md
+++ b/content/en/security/detection_rules/_index.md
@@ -28,6 +28,9 @@ products:
 - name: App and API Protection
   url: /security/application_security/
   icon: app-sec
+- name: Workload Protection
+  url: /security/workload_protection/
+  icon: cloud-security-management
 ---
 
 {{< product-availability >}}
@@ -43,9 +46,30 @@ Out-of-the box rules are available for the following security products:
 - [Cloud SIEM][3] uses log detection to analyze ingested logs in real-time.
 - Cloud Security:
     - [Cloud Security Misconfigurations][4] uses cloud configuration and infrastructure configuration detection rules to scan the state of your cloud environment.
-    - [Workload Protection][5] uses the Datadog Agent and detection rules to actively monitor and evaluate system activity.
     - [Cloud Security Identity Risks][6] uses detection rules to detect IAM-based risks in your cloud infrastructure.
+- [Workload Protection][5] uses the Datadog Agent and detection rules to actively monitor and evaluate system activity.
 - [App and API Protection][7] (AAP) leverages Datadog [APM][8], the [Datadog Agent][9], and detection rules to detect threats in your application environment.
+
+## MITRE ATT&CK map
+
+{{< product-availability names="Cloud SIEM,App and API Protection,Workload Protection" >}}
+
+MITRE ATT&CK is a framework that helps organizations understand how cyber attackers operate. It maps the following:
+
+- **Tactics:** The "why" of an attack. These are the high-level goals, like gaining initial access, executing malicious code, or stealing data.
+- **Techniques:** The "how" of an attack. These are the specific actions an attacker takes to achieve a tactic, like using phishing to get into a system or exploiting a vulnerability in software.
+
+By mapping tactics and techniques, MITRE ATT&CK provides security teams with a common language to communicate threats and better prepare defenses.
+
+To use the MITRE ATT&CK map, do the following:
+
+1. Open Detection Rules in [SIEM][16] or [Workload Protection][17]. The MITRE ATT&CK map can be used for Application and API Protection also, but the map is onlu available in SIEM or Workload Protection. Application and API Protection users typically focus on OWASP concerns, but it is included in the MITRE ATT&CK map for all-inclusive security coverage.
+2. Select **MITRE ATT&CK map**.
+3. Select one of more products in the filter <i class="icon-filter"></i>.
+4. Review the map for the following:
+   - Assessing Coverage: Quickly determine which attack techniques are well-covered and which are under-monitored.
+   - Prioritizing Rule Creation: Focus on creating detection rules for techniques with low or no coverage.
+   - Streamlining Rule Management: Easily manage and update detection rules, ensuring they align with the latest threat intelligence.
 
 ## Beta detection rules
 
@@ -175,3 +199,6 @@ The rule deprecation process is as follows:
 [13]: /security/cloud_security_management/misconfigurations/custom_rules
 [14]: /security/workload_protection/workload_security_rules?tab=host#create-custom-rules
 [15]: https://app.datadoghq.com/security/configuration/
+[16]: https://app.datadoghq.com/security/rules
+[17]: https://app.datadoghq.com/security/workload-protection/detection-rules
+


### PR DESCRIPTION
DOCS-11462

### What does this PR do? What is the motivation?
Adds a section on the MITRE ATT&CK map feature to the main Security detection rules page. MITRE ATT&CK map now supports 3 products, instead of just one, so it needs to be covered in the overview section.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

