### PR TITLE
Rename Execution Replay -> Exception Replay

### DIFF
--- a/content/en/error_tracking/_index.md
+++ b/content/en/error_tracking/_index.md
@@ -24,7 +24,7 @@ Additional features are available depending on the source of the error. See [sup
 
 Error Tracking captures and processes errors across your web, mobile, and backend applications. You can instrument your applications and services using the [Browser SDK][6], [Mobile SDK][7], or ingest errors from your Logs, Traces, and Real User Monitoring events. 
 
-Additional features are available depending on the source of the error. For example, in errors originating from an APM trace, the [Execution Replay][4] feature automatically captures production variable values. 
+Additional features are available depending on the source of the error. For example, in errors originating from an APM trace, the [Exception Replay][4] feature automatically captures production variable values. 
 
 For details, see the product-specific Error Tracking documentation:
 
@@ -39,7 +39,7 @@ For details, see the product-specific Error Tracking documentation:
 [1]: /tracing/error_tracking#setup
 [2]: /logs/error_tracking#setup
 [3]: /real_user_monitoring/error_tracking#setup
-[4]: /tracing/error_tracking/execution_replay
+[4]: /error_tracking/backend/exception_replay
 [5]: /error_tracking/explorer
 [6]: /error_tracking/frontend/browser
 [7]: /error_tracking/frontend/mobile

--- a/content/en/tracing/live_debugger/_index.md
+++ b/content/en/tracing/live_debugger/_index.md
@@ -16,9 +16,9 @@ further_reading:
 - link: "/dynamic_instrumentation/symdb/"
   tag: "Documentation"
   text: "Autocomplete and Search (Preview)"
-- link: "/tracing/error_tracking/execution_replay"
+- link: "/error_tracking/backend/exception_replay"
   tag: "Documentation"
-  text: "Execution Replay"
+  text: "Exception Replay"
 ---
 
 {{< beta-callout-private url="https://www.datadoghq.com/product-preview/live-debugger/" >}}


### PR DESCRIPTION
Tiny proposed fix: I just learned about this feature and it looks like this is a rebranding?

I see that https://docs.datadoghq.com/tracing/error_tracking/execution_replay automatically redirects to https://docs.datadoghq.com/error_tracking/backend/exception_replay/ already
