### PR TITLE
Fix conflicting markdown link references in Data Streams Monitoring setup docs

### DIFF
--- a/content/en/data_streams/setup/language/dotnet.md
+++ b/content/en/data_streams/setup/language/dotnet.md
@@ -10,7 +10,7 @@ aliases:
 
 ### Prerequisites
 
-* [Datadog Agent v7.34.0 or later][1]
+* [Datadog Agent v7.34.0 or later][10]
 
 ### Supported libraries
 
@@ -100,7 +100,7 @@ The following size thresholds apply when Data Streams Monitoring is enabled in d
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent
+[10]: /agent
 [3]: https://www.nuget.org/packages/Confluent.Kafka
 [4]: https://www.nuget.org/packages/RabbitMQ.Client
 [5]: https://www.nuget.org/packages/AWSSDK.SQS

--- a/content/en/data_streams/setup/language/java.md
+++ b/content/en/data_streams/setup/language/java.md
@@ -16,7 +16,7 @@ aliases:
 
 ### Prerequisites
 
-* [Datadog Agent v7.34.0 or later][1]
+* [Datadog Agent v7.34.0 or later][10]
 
 ### Supported libraries
 
@@ -90,9 +90,9 @@ To monitor a data pipeline where Amazon SNS talks directly to Amazon SQS, you mu
      - DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED: "true"
      - DD_TRACE_SQS_BODY_PROPAGATION_ENABLED: "true"
    ```
-- Ensure that you are using [Java tracer v1.44.0+][1].
+- Ensure that you are using [Java tracer v1.44.0+][11].
 
-[1]: https://github.com/DataDog/dd-trace-java/releases
+[11]: https://github.com/DataDog/dd-trace-java/releases
 {{% /tab %}}
 {{% tab "SQS v2" %}}
 Enable [Amazon SNS raw message delivery][1].
@@ -130,7 +130,7 @@ Data Streams Monitoring can collect information from your self-hosted Kafka conn
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent
+[10]: /agent
 [2]: /tracing/trace_collection/dd_libraries/java/
 [4]: /remote_configuration
 [5]: /data_streams/manual_instrumentation/?tab=java

--- a/content/en/data_streams/setup/language/nodejs.md
+++ b/content/en/data_streams/setup/language/nodejs.md
@@ -15,7 +15,7 @@ aliases:
 ---
 ### Prerequisites
 
-* [Datadog Agent v7.34.0 or later][1]
+* [Datadog Agent v7.34.0 or later][10]
 
 ### Supported libraries
 
@@ -62,7 +62,7 @@ Data Streams Monitoring propagates context through message headers. If you are u
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent
+[10]: /agent
 [2]: /tracing/trace_collection/dd_libraries/nodejs
 [3]: https://pypi.org/project/confluent-kafka/
 [5]: https://www.npmjs.com/package/amqplib

--- a/content/en/data_streams/setup/language/python.md
+++ b/content/en/data_streams/setup/language/python.md
@@ -16,7 +16,7 @@ aliases:
 
 ### Prerequisites
 
-* [Datadog Agent v7.34.0 or later][1]
+* [Datadog Agent v7.34.0 or later][10]
 
 ### Supported libraries
 
@@ -61,7 +61,7 @@ Data Streams Monitoring propagates context through message headers. If you are u
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /agent
+[10]: /agent
 [2]: /tracing/trace_collection/dd_libraries/python
 [3]: https://pypi.org/project/confluent-kafka/
 [5]: https://pypi.org/project/kombu/


### PR DESCRIPTION
**Problem:**
The "Datadog Agent" link in Data Streams Monitoring setup pages was incorrectly redirecting to AWS documentation instead of `/agent`. This occurred because shortcodes included in these pages (like `monitoring-sqs-pipelines`) contained `[1]` link references that overrode the main file's `[1]: /agent` reference.

**Solution:**
Changed the Datadog Agent link reference from `[1]` to `[10]` in all affected language setup files to avoid conflicts with shortcode references.

**Files Changed:**
- `content/en/data_streams/setup/language/python.md`
- `content/en/data_streams/setup/language/nodejs.md` 
- `content/en/data_streams/setup/language/java.md`
- `content/en/data_streams/setup/language/dotnet.md`

**Testing:**
Verified that the "Datadog Agent v7.34.0 or later" links now correctly navigate to the agent documentation page instead of AWS SQS documentation.