### PR TITLE
[DOCS-11638] Use HTML table for Socket source doc

### DIFF
--- a/layouts/shortcodes/observability_pipelines/source_settings/socket.md
+++ b/layouts/shortcodes/observability_pipelines/source_settings/socket.md
@@ -1,9 +1,36 @@
 1. In the **Mode** dropdown menu, select the socket type to use.
 1. In the **Framing** dropdown menu, select how to delimit the stream of events.
-    | Framing method      | Description                                             |
-    |---------------------|---------------------------------------------------------|
-    | `newline_delimited`   | Byte frames are delimited by a newline character. |
-    | `bytes`               | Byte frames are passed through as-is according to the underlying I/O boundaries (for example, split between messages or stream segments).                                     |
-    | `character_delimited` | Byte frames are delimited by a chosen character.  |
-    | `chunked_gelf`        | Byte frames are chunked GELF messages.            |
-    | `octet_counting`      | Byte frames are delimited according to the octet counting format.     |
+    <table>
+    <colgroup>
+        <col style="width:40%">
+        <col style="width:60%">
+    </colgroup>
+    <thead>
+        <tr>
+        <th>FRAMING METHOD</th>
+        <th>DESCRIPTION</th>
+        </tr>
+        <tr>
+            <td><code>newline_delimited</code></td>
+            <td>Byte frames are delimited by a newline character.</td>
+        </tr>
+        <tr>
+            <td><code>bytes</code></td>
+            <td>Byte frames are passed through as-is according to the underlying I/O boundaries (for example, split between messages or stream segments).</td>
+        </tr>
+        <tr>
+            <td><code>character_delimited</code></td>
+            <td>Byte frames are delimited by a chosen character.</td>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>chunked_gelf</code></td>
+            <td>Byte frames are chunked GELF messages.</td>
+        </tr>
+        <tr>
+            <td><code>octet_counting</code></td>
+            <td>Byte frames are delimited according to the octet counting format.</td>
+        </tr>
+    </tbody>
+    </table>

--- a/layouts/shortcodes/observability_pipelines/source_settings/socket.md
+++ b/layouts/shortcodes/observability_pipelines/source_settings/socket.md
@@ -1,15 +1,16 @@
 1. In the **Mode** dropdown menu, select the socket type to use.
 1. In the **Framing** dropdown menu, select how to delimit the stream of events.
     <table>
-    <colgroup>
-        <col style="width:40%">
-        <col style="width:60%">
-    </colgroup>
-    <thead>
-        <tr>
-        <th>FRAMING METHOD</th>
-        <th>DESCRIPTION</th>
-        </tr>
+        <colgroup>
+            <col style="width:40%">
+            <col style="width:60%">
+        </colgroup>
+        <thead>
+            <tr>
+                <th>FRAMING METHOD</th>
+                <th>DESCRIPTION</th>
+            </tr>
+        </thead>
         <tr>
             <td><code>newline_delimited</code></td>
             <td>Byte frames are delimited by a newline character.</td>
@@ -22,8 +23,6 @@
             <td><code>character_delimited</code></td>
             <td>Byte frames are delimited by a chosen character.</td>
         </tr>
-    </thead>
-    <tbody>
         <tr>
             <td><code>chunked_gelf</code></td>
             <td>Byte frames are chunked GELF messages.</td>
@@ -32,5 +31,4 @@
             <td><code>octet_counting</code></td>
             <td>Byte frames are delimited according to the octet counting format.</td>
         </tr>
-    </tbody>
     </table>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Use HTML tables for the Socket source doc because the Framing column is getting cut off. PM request.

### Merge instructions

- Replace markdown table with HTML table so that widths can be manually adjusted.

Preview: https://docs-staging.datadoghq.com/may/fix-table-widths-socket-source/observability_pipelines/sources/socket/
<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
