### PR TITLE
get latest sources when running `start no-pre-build`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ start:
 # Skip downloading any dependencies and run the site (hugo needs at the least node)
 start-no-pre-build: node_modules  ## Build and run docs excluding external content.
 	@make setup-build-scripts
+	@make update_websites_sources_module
 	@make build-cdocs
 	@make server
 

--- a/layouts/shortcodes/multifilter-search.html
+++ b/layouts/shortcodes/multifilter-search.html
@@ -43,8 +43,12 @@
     {{ $data = (index $resource_data "multifiltersearch" "data")}}
   {{ else }}
     {{/*  Data source input given, but not valid  */}}
-    {{ errorf "No valid data source provided for multifilter-search component on %s" $.Page.RelPermalink }}
-  {{ end}}
+    {{ if eq hugo.Environment "development" -}}
+      {{ warnf "No valid data source provided for multifilter-search component on %s" $.Page.RelPermalink }}
+    {{ else }}
+      {{ errorf "No valid data source provided for multifilter-search component on %s" $.Page.RelPermalink }}
+    {{ end }}
+  {{ end }}
 {{ end }}
   
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
we get latest sources when running `make start` not `make start-no-pre-build`.   some data was missing locally from more recent commits to sources.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
