### PR TITLE
Use updated dockerhub link for synthetics FIPS PL 

### DIFF
--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -56,7 +56,7 @@ Private locations are Docker containers that you can install anywhere inside you
 
 If you require FIPS support, use the [FIPS compliant image][26] on Docker hub.
 
-[26]: https://hub.docker.com/repository/docker/datadog/synthetics-private-location-worker-fips/general
+[26]: https://hub.docker.com/r/datadog/synthetics-private-location-worker-fips
 
 {{< /site-region >}}
 
@@ -679,7 +679,7 @@ You can upload custom root certificates to your private locations to have your A
 {{< tabs >}}
 {{% tab "Linux container" %}}
 
-When spinning up your private location containers, mount the relevant certificate `.pem` files to `/etc/datadog/certs` in the same way you mount your private location configuration file. These certificates are considered trusted CA and are used at test runtime. 
+When spinning up your private location containers, mount the relevant certificate `.pem` files to `/etc/datadog/certs` in the same way you mount your private location configuration file. These certificates are considered trusted CA and are used at test runtime.
 
 <div class="alert alert-info"><strong>Note</strong>: If you combine all your <code>.pem</code> files into one file, the sequence of the certificates within the file is important. It is required that the intermediate certificate precedes the root certificate to successfully establish a chain of trust.</div>
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Updates the link for the synthetics FIPS PL. Some customers have run into issues with the current link requiring docker hub authentication.

### Merge instructions

Merge readiness:
- [x] Ready for merge

