### PR TITLE
Azure App Services - rename/reorder .NET tab

### DIFF
--- a/content/en/serverless/azure_app_services/azure_app_services_windows.md
+++ b/content/en/serverless/azure_app_services/azure_app_services_windows.md
@@ -46,18 +46,18 @@ The Datadog .NET, Java, and Node.js APM extensions support the following runtime
 ### Extension-specific notes
 
 {{< tabs >}}
-{{% tab "Java" %}}
-Support for Java Web Apps is in Preview for extension v2.4+.
-
-There are no billing implications for tracing Java Web Apps during this period.
-{{% /tab %}}
-{{% tab "Node.js" %}}
+{{% tab ".NET" %}}
 Datadog's automatic instrumentation relies on the .NET CLR Profiling API. This API allows only one subscriber (for example, Datadog's .NET Tracer with Profiler enabled). To ensure maximum visibility, run only one APM solution within your application environment.
 
 Additionally, if you are using the Azure Native integration, you can use the Datadog resource in Azure to add the extension to your .NET apps. For instructions, see the [App Service extension section][1] of Datadog's [Azure Portal guide][2].
 
 [1]: /integrations/guide/azure-portal/?tab=vmextension#app-service-extension
 [2]: /integrations/guide/azure-portal/
+{{% /tab %}}
+{{% tab "Java" %}}
+Support for Java Web Apps is in Preview for extension v2.4+.
+
+There are no billing implications for tracing Java Web Apps during this period.
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
@aniket-datadog noticed that we had an improperly labelled tab. I renamed the tab and switched the order for consistency with the rest of the doc.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
