### PR TITLE
[DOCS-11654] Correct Jetpack Compose language

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/android/jetpack_compose_instrumentation.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/android/jetpack_compose_instrumentation.md
@@ -122,7 +122,7 @@ datadog {
 	//(...)
 
 	// Jetpack Compose instrumentation mode option.
-	composeInstrumentation = InstrumentationMode.AUTO
+	composeInstrumentation = "AUTO"
 }
 ```
 {{% /tab %}}
@@ -140,9 +140,22 @@ datadog {
 {{< /tabs >}}
 
 Available instrumentation modes:
--   `InstrumentationMode.AUTO`: Instruments all `@Composable` functions.
--   `InstrumentationMode.ANNOTATION`: Only instruments `@Composable` functions annotated with `@ComposeInstrumentation`. You can define the scope of auto-instrumentation by using this annotation.
--   `InstrumentationMode.DISABLE`: Disables instrumentation completely.
+
+{{< tabs >}}
+{{% tab "Groovy" %}}
+- `"AUTO"`: Instruments all `@Composable` functions.
+- `"ANNOTATION"`: Only instruments `@Composable` functions annotated with `@ComposeInstrumentation`. You can define the scope of auto-instrumentation by using this annotation.
+- `"DISABLE"`: Disables instrumentation completely.
+{{% /tab %}}
+
+{{% tab "Kotlin" %}}
+
+- `InstrumentationMode.AUTO`: Instruments all `@Composable` functions.
+- `InstrumentationMode.ANNOTATION`: Only instruments `@Composable` functions annotated with `@ComposeInstrumentation`. You can define the scope of auto-instrumentation by using this annotation.
+- `InstrumentationMode.DISABLE`: Disables instrumentation completely.
+
+{{% /tab %}}
+{{< /tabs >}}
 
 **Note**: if you don't declare `composeInstrumentation` in `datadog` block, the auto-instrumentation is disabled by default.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Per user feedback, this PR corrects the syntax for Jetpack Compose settings described on the page. The example is supposed to be for Groovy, but it was actually written in Kotlin.

I also added separate instrumentation modes for Groovy and Kotlin.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
