### PR TITLE
Update podman-support-with-docker-integration.md

### DIFF
--- a/content/en/containers/guide/podman-support-with-docker-integration.md
+++ b/content/en/containers/guide/podman-support-with-docker-integration.md
@@ -19,11 +19,11 @@ The Datadog Agent works with both rootless and rootful containers.
 
 To deploy the Agent as a rootless Podman container, the command to run is similar to the one used for [Docker][2].
 
-The main difference is that as the Agent does not have access to the runtime socket, it relies on the Podman DB to extract the container information that it needs. Instead of mounting the Docker socket and setting `DOCKER_HOST`, you need to mount the Podman DB (`<PODMAN_DB_PATH>` in the command below).
+The main difference is that as the Agent does not have access to the runtime socket, it relies on the Podman DB to extract the container information that it needs. Instead of mounting the Docker socket and setting `DOCKER_HOST`, you need to mount the Podman DB (`PODMAN_DB_PATH>` in the command below).
 In some systems the path of the Podman DB is `$HOME/.local/share/containers/storage/libpod/bolt_state.db` but it might be different in your system. Set `<PODMAN_DB_PATH>` in the command below accordingly.
 
 <div class="alert alert-info">
-<strong>Podman version 4.8+</strong> uses SQLite as the default database backend, and BoltDB is deprecated from v5. You may need to update the <code><PODMAN_DB_PATH></code> to your <code>db.sql</code> path. Generally, this path is <code>/var/lib/containers/storage/db.sql</code>, but it may differ in some systems.
+<strong>Podman version 4.8+</strong> uses SQLite as the default database backend, and BoltDB is deprecated from v5. You may need to update the <code>&lt;PODMAN_DB_PATH&gt;</code> to your <code>db.sql</code> path. Generally, this path is <code>/var/lib/containers/storage/db.sql</code>, but it may differ in some systems.
 </div>
 
 ```

--- a/content/en/containers/guide/podman-support-with-docker-integration.md
+++ b/content/en/containers/guide/podman-support-with-docker-integration.md
@@ -19,11 +19,11 @@ The Datadog Agent works with both rootless and rootful containers.
 
 To deploy the Agent as a rootless Podman container, the command to run is similar to the one used for [Docker][2].
 
-The main difference is that as the Agent does not have access to the runtime socket, it relies on the Podman DB to extract the container information that it needs. So, instead of mounting the Docker socket and setting `DOCKER_HOST` we need to mount the Podman DB (`<PODMAN_DB_PATH>` in the command below).
+The main difference is that as the Agent does not have access to the runtime socket, it relies on the Podman DB to extract the container information that it needs. Instead of mounting the Docker socket and setting `DOCKER_HOST`, you need to mount the Podman DB (`<PODMAN_DB_PATH>` in the command below).
 In some systems the path of the Podman DB is `$HOME/.local/share/containers/storage/libpod/bolt_state.db` but it might be different in your system. Set `<PODMAN_DB_PATH>` in the command below accordingly.
 
 <div class="alert alert-info">
-If you are using <strong> Podman verstion >=v4.8 </strong>, podman uses Sqlite as the default database backend and boltDB is deprecated from v5. If this is the case, please update the (`<PODMAN_DB_PATH>`) to the path of db.sql, this is generally `/var/lib/containers/storage/db.sql`. In some systems this path may differ so, please ensure to use the right db path.
+<strong>Podman version 4.8+</strong> uses SQLite as the default database backend, and BoltDB is deprecated from v5. You may need to update the <code><PODMAN_DB_PATH></code> to your <code>db.sql</code> path. Generally, this path is <code>/var/lib/containers/storage/db.sql</code>, but it may differ in some systems.
 </div>
 
 ```

--- a/content/en/containers/guide/podman-support-with-docker-integration.md
+++ b/content/en/containers/guide/podman-support-with-docker-integration.md
@@ -22,6 +22,10 @@ To deploy the Agent as a rootless Podman container, the command to run is simila
 The main difference is that as the Agent does not have access to the runtime socket, it relies on the Podman DB to extract the container information that it needs. So, instead of mounting the Docker socket and setting `DOCKER_HOST` we need to mount the Podman DB (`<PODMAN_DB_PATH>` in the command below).
 In some systems the path of the Podman DB is `$HOME/.local/share/containers/storage/libpod/bolt_state.db` but it might be different in your system. Set `<PODMAN_DB_PATH>` in the command below accordingly.
 
+<div class="alert alert-info">
+If you are using <strong> Podman verstion >=v4.8 </strong>, podman uses Sqlite as the default database backend and boltDB is deprecated from v5. If this is the case, please update the (`<PODMAN_DB_PATH>`) to the path of db.sql, this is generally `/var/lib/containers/storage/db.sql`. In some systems this path may differ so, please ensure to use the right db path.
+</div>
+
 ```
 $ podman run -d --name dd-agent \
     --cgroupns host --pid host \


### PR DESCRIPTION
Added the info about bold_db deprecation and support for sqlite in podman

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Added info on the Sqlite DB in podman. The Document was outdated and did not conform to the latest releases from Podman, which have deprecated boltDB.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
