### PR TITLE
DSMON-988  Improve DSM Messages role creation guide clarity

### DIFF
--- a/content/en/data_streams/messages.md
+++ b/content/en/data_streams/messages.md
@@ -73,7 +73,7 @@ Follow these steps to create a new role with the required permissions and assign
 6. Click **Save**.
 7. Confirm your role was created successfully by searching for it in the roles list.
 
-##### Step 2: Assign the role to users
+##### 2. Assign the role to users
 
 1. Go to the [Users page][9] in Datadog.
 2. Find and click on the user you want to assign the role to.


### PR DESCRIPTION
https://docs-staging.datadoghq.com/steven.pham/dsm/dsm-messages-permission-setup/data_streams/messages/#creating-a-new-role-with-permissions

### What does this PR do? What is the motivation?

#### What changed
Improved the user experience of the role creation documentation in the Data Streams Monitoring Messages setup guide. The changes make the permission setup process more accessible and easier to follow.

#### Why it changed
The original role creation instructions were technical and difficult to follow, especially for users who may not be familiar with Datadog's permission system. Users needed clearer, step-by-step guidance to successfully create roles and assign permissions for the Messages feature.

#### Where the changes occurred
- `content/en/data_streams/messages.md` - Enhanced the "Creating a new role with permissions" section

#### How it affects the system
This is purely a documentation improvement that doesn't affect any system behavior. It provides:
- Better structured step-by-step instructions
- Clear visual formatting with bold UI elements
- Helpful callout boxes warning users about permission requirements
- More descriptive language and examples
- Fixed duplicate link references

The changes make it easier for users to set up the required permissions for Data Streams Monitoring Messages feature.

### Merge instructions

Merge readiness:
- [x] Ready for merge
