### PR TITLE
[NO-TICKET] Add note about precedence of Ruby configuration

### DIFF
--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -129,7 +129,7 @@ You can configure the profiler using the following environment variables:
 | `DD_VERSION`                                  | String  | The [version][10] of your service.                                                                                                      |
 | `DD_TAGS`                                     | String  | Tags to apply to an uploaded profile. Must be a list of `<key>:<value>` separated by commas such as: `layer:api, team:intake`.          |
 
-Alternatively, you can set profiler parameters in code with these functions, inside a `Datadog.configure` block. Note that parameters provided via code take precedence over those provided via environment variable.
+Alternatively, you can set profiler parameters in code with these functions, inside a `Datadog.configure` block. Note that parameters provided in code take precedence over those provided as environment variables.
 
 | Environment variable                                  | Type    | Description                                                                                                                             |
 | ----------------------------------------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR documents the precedence of Ruby profiler configuration. We've gotten feedback from a customer that it wasn't clear what happened when settings were provided via both environment variables and via code, so I decided to open a tiny PR to document the expected behavior.

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

N/A