### PR TITLE
[RFC, DO NOT MERGE] Spec for generating plaintext .md files for AI agents

### DIFF
--- a/content/en/md_conversion_test_files/README.md
+++ b/content/en/md_conversion_test_files/README.md
@@ -1,0 +1,24 @@
+---
+title: Plaintext Markdown Spec
+---
+
+## What is this?
+
+This folder contains a listing of the components used on the docs site, and a description of their desired output format in the plaintext files generated for AI agents.
+
+The HTML compiled from these files will be used as the test input HTML for the Markdown generator job.
+
+## Where can I learn more?
+
+1. Read [Datadog Docs for AI Agents](https://docs.google.com/document/d/1t48N0uDJElMP_228n2bIYi_cUIj_xMOKjdHuh1Z4rMg), which attempts to summarize the problem space and why this is important.
+2. Ask Jen Gilbert.
+
+## Disclaimer
+
+Everything described here is *probably* possible based on the technical context and existing libraries we have so far, but it's not *guaranteed* to be possible until the docs are migrated to Markdoc.
+
+If you'd like to follow along with changes in the spec, Jen will keep this PR up to date, with clear commit messages about what changed.
+
+## Feedback is welcome!
+
+Jen took her best shot at these, but she's not attached to any of it. Comment away!

--- a/content/en/md_conversion_test_files/common_components/alert.md
+++ b/content/en/md_conversion_test_files/common_components/alert.md
@@ -1,0 +1,25 @@
+---
+title: Alert
+---
+
+## Expected .md output
+
+Each alert is bordered with `[BEGIN <ALERT_LEVEL> ALERT]` and `[END <ALERT_LEVEL> ALERT]`. For example, `[BEGIN INFO ALERT]`.
+
+### Info
+
+<div class="alert alert-info">This is an info alert.</div>
+
+This is a random sentence.
+
+### Warning
+
+<div class="alert alert-warning">This is a warning alert containing an <a href="https://google.com">HTML link.</a></div>
+
+This is a random sentence.
+
+### Danger
+
+<div class="alert alert-danger">This is a danger alert.</div>
+
+This is a random sentence.

--- a/content/en/md_conversion_test_files/common_components/callouts.md
+++ b/content/en/md_conversion_test_files/common_components/callouts.md
@@ -1,0 +1,24 @@
+---
+title: Callouts
+---
+
+## Expected .md output
+
+- Each callout is marked by `[BEGIN CALLOUT]` and `[END CALLOUT]`.
+- Any attributes, such as the title or the URL, are included in the box contents:
+    - The title is a heading at the top of the box.
+    - The URL is included with verbiage at the bottom like "Visit this URL: <URL>".
+
+## Example inputs
+
+### Callout (preview / beta)
+
+{{< callout url="https://www.datadoghq.com/">}}
+  Datadog Apps are in Preview. Request access by using this form. Once approved, you can start getting creative and develop your App for you, your organization, or for publishing to the entire Datadog community alongside our other great Datadog Apps!
+{{< /callout >}} 
+
+### Learning center callout
+
+{{< learning-center-callout header="Try Foundations in the Learning Center" btn_title="Enroll Now" btn_url="https://learn.datadoghq.com/courses/datadog-foundation">}}
+  The Datadog Learning Center is full of hands-on courses to help you learn about this topic. Enroll today to learn more about Datadog Foundations.
+{{< /learning-center-callout >}}

--- a/content/en/md_conversion_test_files/common_components/code_blocks.md
+++ b/content/en/md_conversion_test_files/common_components/code_blocks.md
@@ -1,0 +1,60 @@
+---
+title: Code Blocks
+---
+
+## Scope
+
+This covers the `code-block` and `highlight` shortcodes. Plain fences are already covered in the "plain markdown" examples.
+
+## Expected .md output
+
+Each code block is wrapped in a fence, with the language included when available:
+
+```lang
+Code contents here.
+```
+
+### Filenames
+
+When a filename is present, it appears above the code block, like this:
+
+In the `block.java` file:
+
+```lang
+Code contents here.
+```
+
+### Highlighted lines
+
+When a highlight is present, it appears above the code block, like this:
+
+See lines 2-3 below:
+
+```lang
+Code contents here.
+```
+
+## Example inputs
+
+### Code block
+
+{{< code-block lang="java" filename="block.java" disable_copy="true" collapsible="true" >}}
+import com.datadoge.docs.SweetCodeBlock;
+import com.datadoge.docs.TryItOut;
+public class CodeBlocksForLife {
+    ...
+    }
+{{< /code-block >}}
+
+### Highlighted code block
+
+{{< highlight yaml "hl_lines=6-8" >}}
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+    name: springfront
+    labels:
+        tags.datadoghq.com/env: "dev"
+        tags.datadoghq.com/service: "springfront"
+        tags.datadoghq.com/version: "12"
+    {{< /highlight >}}

--- a/content/en/md_conversion_test_files/common_components/collapsible_sections.md
+++ b/content/en/md_conversion_test_files/common_components/collapsible_sections.md
@@ -1,0 +1,30 @@
+---
+title: Collapsible Sections
+---
+
+## Expected .md output
+
+Each section begins and ends with a box marker: `[BEGIN BOX]` and `[END BOX]`.
+
+## Example inputs
+
+### Details
+
+This content is outside the `details` tag.
+
+<details>
+  <summary>Details</summary>
+  This content would be hidden inside the details panel.
+</details>
+
+This content is outside the `details` tag.
+
+### Collapse content
+
+This content is outside the `content-collapse` block.
+
+{{% collapse-content title="Datadog Operator" level="h4" expanded=false id="id-for-anchoring" %}}
+This content is inside the `content-collapse` block.
+{{% /collapse-content %}} 
+
+This content is outside the `content-collapse` block.

--- a/content/en/md_conversion_test_files/common_components/further_reading.md
+++ b/content/en/md_conversion_test_files/common_components/further_reading.md
@@ -1,0 +1,20 @@
+---
+title: Further Reading
+further_reading:
+  - link: "logs/processing/pipelines"
+    tag: "Documentation"
+    text: "Log processing pipelines"
+  - link: "some/blog/post"
+    tag: "Blog"
+    text: "Some blog post"
+---
+
+## Expected .md output
+
+A list of links, introduced by the text "Further reading:".
+
+## Example input
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/md_conversion_test_files/common_components/images_and_videos.md
+++ b/content/en/md_conversion_test_files/common_components/images_and_videos.md
@@ -1,0 +1,17 @@
+---
+title: Images and Videos
+---
+
+## Expected .md output
+
+A placeholder including relevant information about the asset, such as `[IMAGE src="some/src/path" alt="some alt text"]`.
+
+## Example inputs
+
+## Image
+
+{{< img src="path/to/your/image-name-here.png" alt="Your image description" caption="Your image description" style="width:100%;" >}}
+
+## Video
+
+{{< img src="path/to/your/video-name-here.mp4" alt="Your image description" video="true" width="100%" >}}

--- a/content/en/md_conversion_test_files/common_components/plain_markdown.md
+++ b/content/en/md_conversion_test_files/common_components/plain_markdown.md
@@ -1,0 +1,80 @@
+---
+title: Plain Markdown Elements
+---
+
+## Expected .md output
+
+- Most of this should remains unchanged, or uses a format that does not meaningfully differ from its original form. (Some spacing changes can be difficult to avoid.)
+- In some cases, content may be slightly optimized for agents (for example, links will become inline).
+
+## Headings
+
+### Heading level 3
+
+Some text.
+
+#### Heading level 4 {#heading-level-4}
+
+Some text, with a custom heading ID.
+
+##### Heading level 5
+
+Some text.
+
+###### Heading level 6
+
+Some text.
+
+## Inline text formatting
+
+You can *italicize* text, or **bold** it.
+
+Text can also be formatted as a [plain link][1], **[bold link][1]**, or *[italic link][1]*.
+
+## Lists
+
+### Ordered
+
+Here's an ordered list of steps:
+
+1. Figure out how to migrate to [Astro][2].
+2. Make some *incredible docs*.
+3. **Profit.**
+
+### Unordered
+
+Here's an unordered version of the same list, which doesn't make as much sense, but that's okay.
+
+- Figure out how to migrate to [Astro][2].
+- Make some *incredible docs*.
+- **Profit.**
+
+## Code
+
+### Inline code
+
+Here's some `inline code`.
+
+### Code fence
+
+```javascript
+console.log("Hello, world!");
+```
+
+## Description list
+
+Service
+: Services are the building blocks of modern microservice architectures - broadly a service groups together endpoints, queries, or jobs for the purposes of building your application.
+
+Resource
+: Resources represent a particular domain of a customer application - they are typically an instrumented web endpoint, database query, or background job.
+
+`clusterChecksRunner.affinity.podAffinity.preferredDuringSchedulingIgnoredDuringExecution`
+: Required. A list of node selector terms. The terms are ORed.
+
+`site`
+: Set the site of the Datadog intake for Agent data:  {{< region-param key="dd_site" code="true" >}}. Defaults to `datadoghq.com`.
+
+
+[1]: https://www.google.com
+[2]: https://astro.build/

--- a/content/en/md_conversion_test_files/common_components/programming_lang_wrapper.md
+++ b/content/en/md_conversion_test_files/common_components/programming_lang_wrapper.md
@@ -1,0 +1,39 @@
+---
+title: Programming lang wrapper
+---
+
+## Expected .md output
+
+These are treated as tabs:
+
+- Each section starts with `[BEGIN TAB]` and end with `[END TAB]`.
+- Each section includes its label at the top (for example, "Python"), formatted as a heading.
+
+## Example input
+
+{{< programming-lang-wrapper langs="python,ruby,PHP" >}}
+
+{{< programming-lang lang="python" >}}
+Info about how to do this with Python.
+ ```python
+from datadog import initialize, statsd
+```
+{{< /programming-lang >}}
+
+{{< programming-lang lang="ruby" >}}
+Info about how to do this with Ruby.
+ ```ruby
+require 'datadog/statsd'
+```
+{{< /programming-lang >}}
+
+{{< programming-lang lang="PHP" >}}
+Info about how to do this with PHP.
+ ```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+```
+{{< /programming-lang >}}
+
+{{< /programming-lang-wrapper >}}

--- a/content/en/md_conversion_test_files/common_components/region_shortcodes.md
+++ b/content/en/md_conversion_test_files/common_components/region_shortcodes.md
@@ -1,0 +1,36 @@
+---
+title: Region Shortcodes
+---
+
+## Site region shortcode
+
+### Expected .md output
+
+The contents are enclosed in `[BEGIN CONTENT FOR REGIONS "ap1", "gov"]` and `[END CONTENT FOR REGIONS "ap1", "gov"]`.
+
+### Example input
+
+{{< site-region region="us,ap1" >}}
+This paragraph only appears if the user has selected US or AP1 from the Site Selector dropdown.
+{{< /site-region >}}
+
+## Region parameter shortcode
+
+### Expected .md output
+
+A placeholder: 
+
+- `<YOUR_DATADOG_SITE>` in code.
+- `[USER'S DATADOG SITE]` in copy.
+
+### Example inputs
+
+#### In code
+
+```shell
+export DD_SITE={{< region-param key=dd_site code="true" >}}
+```
+
+#### In copy
+
+Your Datadog site is {{< region-param key=dd_site >}}.

--- a/content/en/md_conversion_test_files/common_components/tables.md
+++ b/content/en/md_conversion_test_files/common_components/tables.md
@@ -1,0 +1,72 @@
+---
+title: Tables
+---
+
+## Plain Markdown tables
+
+### Expected .md output
+
+A key-value list for each table row:
+
+- Name: Jen
+  Country: USA
+  Has dog?: Yes
+
+- Name: Kari
+  Country: Canada
+  Has dog?: No
+
+### Example input
+
+| Column 1     | Column 2     | Column 3     | Supported? |
+| ------------ | ------------ | ------------ | ---------- |
+| Row 1, Col 1 | Row 1, Col 2 | Row 1, Col 3 | {{< X >}}  |
+| Row 2, Col 1 | Row 2, Col 2 | Row 2, Col 3 |            |
+| Row 3, Col 1 | Row 3, Col 2 | Row 3, Col 3 | {{< X >}}  |
+| Row 4, Col 1 | Row 4, Col 2 | Row 4, Col 3 |            |
+
+## HTML tables
+
+### Expected .md output
+
+Both of these should be included:
+
+- Whatever the generator can safely derive from the table, in "key-value list" form, with a disclaimer that the data may be incomplete.
+- The raw HTML contents, for further reference.
+
+### Example input
+
+<table>
+  <colgroup>
+    <col style="width:20%">
+    <col style="width:20%">
+  </colgroup>
+  <tr>
+    <th>Icon</th>
+    <th>Description</th>
+  </tr>
+  <tr>
+    <td style="text-align:center;">{{<img src="/network_device_monitoring/network_topology_map/icons/access-point.png" alt="Access point icon" style="width:10%; border:none;" popup="false">}}</td>
+    <td>Access Point</td>
+  </tr>
+  <tr>
+    <td style="text-align:center;">{{<img src="/network_device_monitoring/network_topology_map/icons/firewall.png" alt="Firewall icon" style="width:10%; border:none;" popup="false">}}</td>
+    <td>Firewall</td>
+  </tr>
+  <tr>
+    <td style="text-align:center;">{{<img src="/network_device_monitoring/network_topology_map/icons/router.png" alt="Router icon" style="width:10%; border:none;" popup="false">}}</td>
+    <td>Router</td>
+  </tr>
+  <tr>
+   <td style="text-align:center;">{{<img src="/network_device_monitoring/network_topology_map/icons/server.png" alt="Server icon" style="width:10%; border:none;" popup="false">}}</td>
+    <td>Server</td>
+  </tr>
+  <tr>
+    <td style="text-align:center;">{{<img src="/network_device_monitoring/network_topology_map/icons/switch.png" alt="Switch icon" style="width:10%; border:none;" popup="false">}}</td>
+    <td>Switch</td>
+  </tr>
+  <tr>
+    <td style="text-align:center;">{{<img src="/network_device_monitoring/network_topology_map/icons/device.png" alt="Device icon" style="width:10%; border:none;" popup="false">}}</td>
+    <td>Device</td>
+  </tr>
+</table>

--- a/content/en/md_conversion_test_files/common_components/tabs.md
+++ b/content/en/md_conversion_test_files/common_components/tabs.md
@@ -1,0 +1,32 @@
+---
+title: Tabs
+---
+
+## Expected .md output
+
+- Each tab starts with `[BEGIN TAB]` and end with `[END TAB]`.
+- Each tab includes its label at the top (for example, "Python"), formatted as a heading.
+
+## Example input
+
+A random sentence goes here.
+
+{{< tabs >}}
+{{% tab "Python" %}}
+This tab is for Python. It has a code fence in it:
+
+```python
+print('Hello world')
+```
+{{% /tab %}}
+
+{{% tab "JavaScript" %}}
+This tab is for JavaScript. It has a code fence in it:
+
+```javascript
+console.log('Hello world');
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+A random sentence goes here.

--- a/content/en/md_conversion_test_files/common_components/tile_partial.md
+++ b/content/en/md_conversion_test_files/common_components/tile_partial.md
@@ -1,0 +1,43 @@
+---
+title: Tile partial
+---
+
+## Expected .md output
+
+A list of links that uses the image alt text as the link text.
+
+## Input example
+
+Here's a sentence before the tile partial.
+
+{{ $dot := . }}
+<div class="logs-containers">
+    <div class="container cards-dd col-num-3">
+        <div class="row row-cols-2 row-cols-sm-3 g-2 g-xl-3 justify-content-sm-center">
+            <div class="col">
+                <a class="card h-100" href="/serverless/installation/python/">
+                    <div class="card-body text-center py-2 px-1">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col">
+                <a class="card h-100" href="/serverless/installation/nodejs/">
+                    <div class="card-body text-center py-2 px-1">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col">
+                <a class="card h-100" href="/serverless/installation/ruby/">
+                    <div class="card-body text-center py-2 px-1">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
+                    </div>
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+<br>
+
+Here's a sentence after the tile partial.

--- a/content/en/md_conversion_test_files/common_components/tooltip.md
+++ b/content/en/md_conversion_test_files/common_components/tooltip.md
@@ -1,0 +1,17 @@
+---
+title: Tooltip
+---
+
+## Expected .md output
+
+The hidden contents of the tooltip are added as parenthetical text next to the display text of the tooltip, like this: Jen loves boba (a popular drink made of tea, milk, and tapioca pearls).
+
+## Example inputs
+
+### Custom tooltip
+
+Here's an example of a {{< tooltip text="tooltip" tooltip="This is additional information that appears in the tooltip" >}} in action.
+
+### Glossary tooltip
+
+Define the retention query by adding any span tag. Choose to retain all spans with the defined tags, only service entry spans (selected by default), or only a {{< tooltip glossary="trace root span" >}}.

--- a/content/en/md_conversion_test_files/do_not_process/private_page.md
+++ b/content/en/md_conversion_test_files/do_not_process/private_page.md
@@ -1,0 +1,8 @@
+---
+title: A Private Page
+private: true
+---
+
+## Overview
+
+This is a private page. The Markdown generator should not process it at all, and we should verify that it does not exist in the generated output.

--- a/content/en/md_conversion_test_files/uncommon_components/agent_config.md
+++ b/content/en/md_conversion_test_files/uncommon_components/agent_config.md
@@ -1,0 +1,15 @@
+---
+title: Agent config
+---
+
+## Expected .md output
+
+A yaml code fence:
+
+```yaml
+Some config goes here.
+```
+
+## Example input
+
+{{< agent-config type="log collection configuration" filename="datadog.yaml" collapsible="true">}}

--- a/content/en/md_conversion_test_files/uncommon_components/dashboard_widgets_api.md
+++ b/content/en/md_conversion_test_files/uncommon_components/dashboard_widgets_api.md
@@ -1,0 +1,12 @@
+---
+title: Dashboard Widgets API
+widget_type: alert_value
+---
+
+## Expected .md output
+
+This shortcode generates tabs and tables, which can be processed the same as any other tabs and tables.
+
+## Example input
+
+{{< dashboards-widgets-api >}}

--- a/content/en/md_conversion_test_files/uncommon_components/expression_language_evaluator.md
+++ b/content/en/md_conversion_test_files/uncommon_components/expression_language_evaluator.md
@@ -1,0 +1,15 @@
+---
+title: Expression Language Evaluator
+---
+
+## Expected .md output
+
+A placeholder is inserted, like this:
+
+[INTERACTIVE DEMO OF `matches(\"Hello\", \"^H.*o$\")`]
+
+## Example input
+
+This is a test of the expression language evaluator:
+
+{{< expression-language-evaluator expression="matches(\"Hello\", \"^H.*o$\")" >}}

--- a/content/en/md_conversion_test_files/uncommon_components/header_list.md
+++ b/content/en/md_conversion_test_files/uncommon_components/header_list.md
@@ -1,0 +1,18 @@
+---
+title: Header List
+---
+
+## Expected .md output
+
+A list of links. If the header is present, it introduces the list:
+
+Some header:
+- Link one
+- Link two
+
+## Example input
+
+{{< header-list header="Section title" >}}
+    {{< nextlink href="link/here" >}}Link one{{< /nextlink >}}
+    {{< nextlink href="link/here" >}}Link two{{< /nextlink >}}
+{{< /header-list >}}

--- a/content/en/md_conversion_test_files/uncommon_components/icon.md
+++ b/content/en/md_conversion_test_files/uncommon_components/icon.md
@@ -1,0 +1,11 @@
+---
+title: Icon
+---
+
+## Expected .md output
+
+A placeholder: `[ICON: some-icon-name]`
+
+## Example input
+
+<i class="some-icon-name"></i>

--- a/content/en/md_conversion_test_files/uncommon_components/integration_count.md
+++ b/content/en/md_conversion_test_files/uncommon_components/integration_count.md
@@ -1,0 +1,11 @@
+---
+title: Integration count
+---
+
+## Expected .md output
+
+A placeholder is used: `[INTEGRATION COUNT PLACEHOLDER]`.
+
+## Integration count
+
+Datadog has over {{< translate key="integration_count" >}} integrations.

--- a/content/en/md_conversion_test_files/uncommon_components/kbd.md
+++ b/content/en/md_conversion_test_files/uncommon_components/kbd.md
@@ -1,0 +1,11 @@
+---
+title: kbd
+---
+
+## Expected .md output
+
+The `kbd` is replaced with **bold** markers.
+
+## Example
+
+To open the Event Management page from Datadog's global search, press <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> + <kbd>K</kbd> and search for `event explorer`.

--- a/content/en/md_conversion_test_files/uncommon_components/math.md
+++ b/content/en/md_conversion_test_files/uncommon_components/math.md
@@ -1,0 +1,12 @@
+---
+title: Math
+---
+{{< jqmath-vanilla >}}
+
+## Expected .md output
+
+The literal contents are wrapped in a code fence labeled `jqmath`.
+
+## Example input
+
+$$(\text"long window error rate" / {1 - \text"SLO target"} ≥ \text"burn rate threshold") ∧ (\text"short window error rate" / {1 - \text"SLO target"} ≥ \text"burn rate threshold") = \text"ALERT"$$

--- a/content/en/md_conversion_test_files/uncommon_components/permissions.md
+++ b/content/en/md_conversion_test_files/uncommon_components/permissions.md
@@ -1,0 +1,11 @@
+---
+title: Permissions
+---
+
+## Expected .md output
+
+This generates tables, so it can be processed the same as any other set of tables.
+
+## Example input
+
+{{% permissions %}}


### PR DESCRIPTION
# Spec for generating plaintext .md files for AI agents

## What is this?

This folder contains a listing of the components used on the docs site, and a description of their desired output format in the plaintext files generated for AI agents.

The HTML compiled from these files will be used as the test input HTML for the Markdown generator job.

## Where can I learn more?

1. Read [Datadog Docs for AI Agents](https://docs.google.com/document/d/1t48N0uDJElMP_228n2bIYi_cUIj_xMOKjdHuh1Z4rMg), which attempts to summarize the problem space and why this is important.
2. Ask Jen Gilbert.

## Disclaimer

Everything described here is *probably* possible based on the technical context and existing libraries we have so far, but it's not *guaranteed* to be possible until the docs are migrated to Markdoc.

If you'd like to follow along with changes in the spec, Jen will keep this PR up to date, with clear commit messages about what changed.

## Feedback is welcome!

Jen took her best shot at these, but she's not attached to any of it. Comment away!