### PR TITLE
[DDSQL] DDSQL type and type literal docs

### DIFF
--- a/content/en/ddsql_reference/_index.md
+++ b/content/en/ddsql_reference/_index.md
@@ -96,13 +96,13 @@ DDSQL supports the following data types:
 
 | Data Type | Description |
 |-----------|-------------|
-| `BIGINT` | 64-bit signed integers |
-| `BOOLEAN` | True or false values |
-| `DOUBLE` | Double-precision floating-point numbers |
-| `INTERVAL` | Time duration values |
-| `JSON` | JSON data |
-| `TIMESTAMP` | Date and time values |
-| `VARCHAR` | Variable-length character strings |
+| `BIGINT` | 64-bit signed integers. |
+| `BOOLEAN` | `true` or `false` values. |
+| `DOUBLE` | Double-precision floating-point numbers. |
+| `INTERVAL` | Time duration values. |
+| `JSON` | JSON data. |
+| `TIMESTAMP` | Date and time values. |
+| `VARCHAR` | Variable-length character strings. |
 
 ### Array types
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR adds docs for DDSQL types and type literals. It is based on a request in [this thread](https://dd.slack.com/archives/C05NJ9HNMEJ/p1755800387583369).

Preview link -> https://docs-staging.datadoghq.com/brad.besserman/ddsql-type-and-type-literal-docs/ddsql_reference/#data-types

### Merge instructions

Merge readiness:
- [x] Ready for merge
