### PR TITLE
Add RBAC troubleshooting note for Kubernetes agent

### DIFF
--- a/content/en/security/workload_protection/setup/agent/kubernetes.md
+++ b/content/en/security/workload_protection/setup/agent/kubernetes.md
@@ -120,7 +120,8 @@ Join the preview by enabling the admission controller and cws instrumentation va
 
 2. Restart the Agent.
 
-If you experience RBAC issues, you can run the chart with the `clusterRole.allowCreatePodsExec` option enabled for the `clusterRole`: `helm install datadog-operator datadog/datadog-operator --set clusterRole.allowCreatePodsExec=true`.
+If you experience RBAC issues, you can run the chart with the `clusterRole.allowCreatePodsExec` option enabled for the `clusterRole`: 
+
 
 {{% /tab %}}
 

--- a/content/en/security/workload_protection/setup/agent/kubernetes.md
+++ b/content/en/security/workload_protection/setup/agent/kubernetes.md
@@ -122,7 +122,7 @@ Join the preview by enabling the admission controller and cws instrumentation va
 
 If you experience RBAC issues, you can run the chart with the `clusterRole.allowCreatePodsExec` option enabled for the `clusterRole`: 
 
-```
+```sh
 helm install datadog-operator datadog/datadog-operator --set clusterRole.allowCreatePodsExec=true
 ```
 

--- a/content/en/security/workload_protection/setup/agent/kubernetes.md
+++ b/content/en/security/workload_protection/setup/agent/kubernetes.md
@@ -120,6 +120,8 @@ Join the preview by enabling the admission controller and cws instrumentation va
 
 2. Restart the Agent.
 
+If you experience RBAC issues, you can run the chart with the `clusterRole.allowCreatePodsExec` option enabled for the `clusterRole`: `helm install datadog-operator datadog/datadog-operator --set clusterRole.allowCreatePodsExec=true`.
+
 {{% /tab %}}
 
 {{% tab "DaemonSet" %}}

--- a/content/en/security/workload_protection/setup/agent/kubernetes.md
+++ b/content/en/security/workload_protection/setup/agent/kubernetes.md
@@ -122,6 +122,9 @@ Join the preview by enabling the admission controller and cws instrumentation va
 
 If you experience RBAC issues, you can run the chart with the `clusterRole.allowCreatePodsExec` option enabled for the `clusterRole`: 
 
+```
+helm install datadog-operator datadog/datadog-operator --set clusterRole.allowCreatePodsExec=true
+```
 
 {{% /tab %}}
 


### PR DESCRIPTION
Added note about enabling `clusterRole.allowCreatePodsExec` for RBAC issues.

### Merge instructions

Merge readiness:
- [ ] Ready for merge
