### PR TITLE
[Cloud Run] Add service label instructions to sidecar docs & other nits

### DIFF
--- a/content/en/serverless/google_cloud_run/containers/in_process/dotnet.md
+++ b/content/en/serverless/google_cloud_run/containers/in_process/dotnet.md
@@ -70,6 +70,8 @@ logger.LogInformation("Hello World!");
 
 {{% gcr-configure %}}
 
+5. {{% gcr-service-label %}}
+
 6. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].

--- a/content/en/serverless/google_cloud_run/containers/in_process/go.md
+++ b/content/en/serverless/google_cloud_run/containers/in_process/go.md
@@ -65,6 +65,8 @@ go get github.com/DataDog/dd-trace-go/contrib/net/http/v2
 
 {{% gcr-configure%}}
 
+5. {{% gcr-service-label %}}
+
 6. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].

--- a/content/en/serverless/google_cloud_run/containers/in_process/java.md
+++ b/content/en/serverless/google_cloud_run/containers/in_process/java.md
@@ -80,6 +80,8 @@ logger.info("Hello World!");
 
 {{% gcr-configure%}}
 
+5. {{% gcr-service-label %}}
+
 6. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].

--- a/content/en/serverless/google_cloud_run/containers/in_process/nodejs.md
+++ b/content/en/serverless/google_cloud_run/containers/in_process/nodejs.md
@@ -73,6 +73,8 @@ logger.info(`Hello world!`);
 
 {{% gcr-configure %}}
 
+5. {{% gcr-service-label %}}
+
 6. **Send custom metrics**.
 
    To send custom metrics, [view code examples][3].

--- a/content/en/serverless/google_cloud_run/containers/in_process/php.md
+++ b/content/en/serverless/google_cloud_run/containers/in_process/php.md
@@ -49,6 +49,8 @@ apk add libgcc
 
 {{% gcr-configure %}}
 
+5. {{% gcr-service-label %}}
+
 6. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].

--- a/content/en/serverless/google_cloud_run/containers/in_process/python.md
+++ b/content/en/serverless/google_cloud_run/containers/in_process/python.md
@@ -16,17 +16,23 @@ further_reading:
 
 <div class="alert alert-info">A sample application is <a href="https://github.com/DataDog/serverless-gcp-sample-apps/tree/main/cloud-run/in-process/python">available on GitHub</a>.</div>
 
-1. **Install the Datadog Python tracer** in your Dockerfile.
+1. **Install the Datadog Python tracer**.
 
-   {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
-RUN pip install --target /dd_tracer/python/ ddtrace
+   Add `ddtrace` to your `requirements.txt` or `pyproject.toml`. You can find the latest version on [PyPI][1]:
+   {{< code-block lang="text" filename="requirements.txt" disable_copy="false" collapsible="true" >}}
+ddtrace==<VERSION>
 {{< /code-block >}}
 
-   For more information, see [Tracing Python applications][1].
+   Alternatively, you can install the tracer in your Dockerfile:
+   {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
+RUN pip install ddtrace
+{{< /code-block >}}
+
+   For more information, see [Tracing Python applications][2].
 
 2. **Install serverless-init**.
 
-   {{% gcr-install-serverless-init cmd="\"/dd_tracer/python/bin/ddtrace-run\", \"python\", \"path/to/your/python/app.py\"" %}}
+   {{% gcr-install-serverless-init cmd="\"ddtrace-run\", \"python\", \"path/to/your/python/app.py\"" %}}
 
 3. **Set up logs**.
 
@@ -58,7 +64,7 @@ logger = structlog.get_logger()
 logger.info("Hello world!")
 {{< /code-block >}}
 
-   For more information, see [Correlating Python Logs and Traces][2].
+   For more information, see [Correlating Python Logs and Traces][3].
 
 4. **Configure your application**.
 
@@ -66,7 +72,7 @@ logger.info("Hello world!")
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
 
 {{% gcr-env-vars instrumentationMethod="in-process" language="python" %}}
 
@@ -78,7 +84,8 @@ logger.info("Hello world!")
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/python
-[2]: /tracing/other_telemetry/connect_logs_and_traces/python/
-[3]: /developers/dogstatsd/?tab=python#install-the-dogstatsd-client
-[4]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples
+[1]: https://pypi.org/project/ddtrace/
+[2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/python
+[3]: /tracing/other_telemetry/connect_logs_and_traces/python/
+[4]: /developers/dogstatsd/?tab=python#install-the-dogstatsd-client
+[5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples

--- a/content/en/serverless/google_cloud_run/containers/in_process/python.md
+++ b/content/en/serverless/google_cloud_run/containers/in_process/python.md
@@ -70,6 +70,8 @@ logger.info("Hello world!")
 
 {{% gcr-configure %}}
 
+5. {{% gcr-service-label %}}
+
 6. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].

--- a/content/en/serverless/google_cloud_run/containers/in_process/ruby.md
+++ b/content/en/serverless/google_cloud_run/containers/in_process/ruby.md
@@ -52,6 +52,8 @@ logger.info "Hello world!"
 
 {{% gcr-configure %}}
 
+5. {{% gcr-service-label %}}
+
 6. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].

--- a/content/en/serverless/google_cloud_run/containers/sidecar/dotnet.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/dotnet.md
@@ -85,7 +85,9 @@ logger.LogInformation("Hello World!");
 
    For more information, see [Correlating .NET Logs and Traces][3].
 
-4. **Send custom metrics**.
+4. {{% gcr-service-label %}}
+
+5. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/go.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/go.md
@@ -82,7 +82,9 @@ logrus.WithContext(ctx).Info("Hello World!")
 
    For more information, see [Correlating Go Logs and Traces][3].
 
-4. **Send custom metrics**.
+4. {{% gcr-service-label %}}
+
+5. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/java.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/java.md
@@ -93,7 +93,9 @@ logger.info("Hello World!");
 
    For more information, see [Correlating Java Logs and Traces][2].
 
-4. **Send custom metrics**.
+4. {{% gcr-service-label %}}
+
+5. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
@@ -86,7 +86,9 @@ logger.info(`Hello world!`);
 
    For more information, see [Correlating Node.js Logs and Traces][2].
 
-4. **Send custom metrics**.
+4. {{% gcr-service-label %}}
+
+5. **Send custom metrics**.
 
    To send custom metrics, [view code examples][3].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/php.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/php.md
@@ -74,7 +74,9 @@ logInfo('Hello World!');
 
    For more information, see [Correlating PHP Logs and Traces][2].
 
-4. **Send custom metrics**.
+4. {{% gcr-service-label %}}
+
+5. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/python.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/python.md
@@ -81,7 +81,9 @@ logger.info('Hello world!')
 
    For more information, see [Correlating Python Logs and Traces][3].
 
-4. **Send custom metrics**.
+4. {{% gcr-service-label %}}
+
+5. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/python.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/python.md
@@ -16,13 +16,19 @@ further_reading:
 
 ## Setup
 
-1. **Install the Datadog Python tracer** in your Dockerfile.
+1. **Install the Datadog Python tracer**.
 
-   {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
-RUN pip install --target /dd_tracer/python/ ddtrace
+   Add `ddtrace` to your `requirements.txt` or `pyproject.toml`. You can find the latest version on [PyPI][1]:
+   {{< code-block lang="text" filename="requirements.txt" disable_copy="false" collapsible="true" >}}
+ddtrace==<VERSION>
 {{< /code-block >}}
 
-   For more information, see [Tracing Python applications][1].
+   Alternatively, you can install the tracer in your Dockerfile:
+   {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
+RUN pip install ddtrace
+{{< /code-block >}}
+
+   For more information, see [Tracing Python applications][2].
 
 2. **Install serverless-init as a sidecar**.
 
@@ -73,11 +79,11 @@ logger.level = logging.INFO
 logger.info('Hello world!')
 {{< /code-block >}}
 
-   For more information, see [Correlating Python Logs and Traces][2].
+   For more information, see [Correlating Python Logs and Traces][3].
 
 4. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="python" %}}
 
@@ -89,7 +95,8 @@ logger.info('Hello world!')
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/python
-[2]: /tracing/other_telemetry/connect_logs_and_traces/python/
-[3]: /developers/dogstatsd/?tab=python#install-the-dogstatsd-client
-[4]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples
+[1]: https://pypi.org/project/ddtrace/
+[2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/python
+[3]: /tracing/other_telemetry/connect_logs_and_traces/python/
+[4]: /developers/dogstatsd/?tab=python#install-the-dogstatsd-client
+[5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=python#code-examples

--- a/content/en/serverless/google_cloud_run/containers/sidecar/ruby.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/ruby.md
@@ -65,7 +65,9 @@ logger.info "Hello World!"
 
    For more information, see [Correlating Ruby Logs and Traces][2].
 
-4. **Send custom metrics**.
+4. {{% gcr-service-label %}}
+
+5. **Send custom metrics**.
 
    To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
 

--- a/layouts/shortcodes/gcr-configure.html
+++ b/layouts/shortcodes/gcr-configure.html
@@ -15,12 +15,4 @@
      --update-env-vars=DD_SITE=$DD_SITE \
    ```
 
-5.  **Add a service label in Google Cloud**. In your Cloud Run service's info panel, add a label with the following key and value:
-
-   | Key      | Value                                                       |
-   |-----------|-------------------------------------------------------------|
-   | `service` | The name of your service. Matches the value provided as the `DD_SERVICE` environment variable. |
-
-   See [Configure labels for services][1006] in the Cloud Run documentation for instructions.
-
 [1001]: https://app.datadoghq.com/organization-settings/api-keys

--- a/layouts/shortcodes/gcr-env-vars.html
+++ b/layouts/shortcodes/gcr-env-vars.html
@@ -4,17 +4,18 @@
 Unless specified otherwise, all environment variables below should be set in the **sidecar** container. Only environment variables used to configure the tracer should be set in your main application container.
 {{ end }}
 
-| Variable            | Description |
-| ------------------- | ----------- |
-| `DD_API_KEY`        | [Datadog API key][1001] - **Required**|
-| `DD_SITE`           | [Datadog site][1002] - **Required** |{{ if eq (.Get "instrumentationMethod") "in-process" }}
-| `DD_LOGS_ENABLED`   | When true, send logs (stdout and stderr) to Datadog. Defaults to false. |{{ end }}
-| `DD_LOGS_INJECTION` | When true, enrich all logs with trace data for supported loggers. See [Correlate Logs and Traces][1003] for more information. {{ if eq (.Get "instrumentationMethod") "sidecar" }}Set in your *main* application container, not the sidecar container.{{ end }}|
-| `DD_SERVICE`       | See [Unified Service Tagging][1004]. Set in *all* containers. **Recommended** |
-| `DD_VERSION`       | See [Unified Service Tagging][1004]. **Recommended** |
-| `DD_ENV`           | See [Unified Service Tagging][1004]. **Recommended** |
-| `DD_SOURCE`        | Set the log source to enable a [Log Pipeline][1005] for advanced parsing. To automatically apply language-specific parsing rules, set to `{{ .Get "language" }}`, or use your custom pipeline. Defaults to `cloudrun`. |
-| `DD_TAGS`          | Add custom tags to your logs, metrics, and traces. Tags should be comma separated in key/value format (for example: `key1:value1,key2:value2`). |
+| Variable                 | Description |
+| ------------------------ | ----------- |
+| `DD_API_KEY`             | [Datadog API key][1001] - **Required**|
+| `DD_SITE`                | [Datadog site][1002] - **Required** |{{ if eq (.Get "instrumentationMethod") "in-process" }}
+| `DD_LOGS_ENABLED`        | When true, send logs (stdout and stderr) to Datadog. Defaults to false. |{{ end }}{{ if eq (.Get "instrumentationMethod") "sidecar" }}
+| `DD_SERVERLESS_LOG_PATH` | The path where the sidecar should tail logs from. Defaults to `/shared-volume/logs/app.log`. |{{ end }}
+| `DD_LOGS_INJECTION`      | When true, enrich all logs with trace data for supported loggers. See [Correlate Logs and Traces][1003] for more information. {{ if eq (.Get "instrumentationMethod") "sidecar" }}Set in your *main* application container, not the sidecar container.{{ end }}|
+| `DD_SERVICE`            | See [Unified Service Tagging][1004]. Set in *all* containers. **Recommended** |
+| `DD_VERSION`            | See [Unified Service Tagging][1004]. **Recommended** |
+| `DD_ENV`                | See [Unified Service Tagging][1004]. **Recommended** |
+| `DD_SOURCE`             | Set the log source to enable a [Log Pipeline][1005] for advanced parsing. To automatically apply language-specific parsing rules, set to `{{ .Get "language" }}`, or use your custom pipeline. Defaults to `cloudrun`. |
+| `DD_TAGS`               | Add custom tags to your logs, metrics, and traces. Tags should be comma separated in key/value format (for example: `key1:value1,key2:value2`). |
 
 [1001]: https://app.datadoghq.com/organization-settings/api-keys
 [1002]: /getting_started/site/

--- a/layouts/shortcodes/gcr-service-label.md
+++ b/layouts/shortcodes/gcr-service-label.md
@@ -1,0 +1,9 @@
+**Add a service label in Google Cloud**. In your Cloud Run service's info panel, add a label with the following key and value:
+
+   | Key      | Value                                                       |
+   |-----------|-------------------------------------------------------------|
+   | `service` | The name of your service. Matches the value provided as the `DD_SERVICE` environment variable. |
+
+   See [Configure labels for services][2001] in the Cloud Run documentation for instructions.
+
+[2001]: https://cloud.google.com/run/docs/configuring/services/labels


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Add service label instructions to sidecar docs
- Add `DD_SERVERLESS_LOG_PATH ` env var to the env vars table in sidecar docs
- Update python tracer installation instructions with better practice example

### Merge instructions

Merge readiness:
- [x] Ready for merge


### Additional notes

