### PR TITLE
remove aliases that exist already

### DIFF
--- a/content/en/integrations/_index.md
+++ b/content/en/integrations/_index.md
@@ -63,6 +63,8 @@ cascade:
 - _target:
     path: /integrations/event-viewer
     lang: en
+  aliases:
+    - /integrations/eventviewer/
   algolia:
     rank: 60
     category: Documentation
@@ -139,6 +141,11 @@ cascade:
     lang: en
   aliases:
     - /integrations/agentil_software_sap_hana/
+- _target:
+    path: /integrations/azure-virtual-network
+    lang: en
+  aliases:
+    - /integrations/azure_virtual_networks
 ---
 
 More than {{< translate key="integration_count" >}} built-in integrations. See across all your systems, apps, and services.

--- a/content/en/integrations/_index.md
+++ b/content/en/integrations/_index.md
@@ -11,7 +11,6 @@ aliases:
     - /integrations/shoreline/
     - /integrations/shoreline_license/
     - /integrations/shoreline_software_license/
-    - /integrations/pingdom_v3/
 description: Gather data from all of your systems, apps, & services
 algolia:
     tags: ['integration', 'integration setup']
@@ -64,18 +63,11 @@ cascade:
 - _target:
     path: /integrations/event-viewer
     lang: en
-  aliases:
-    - /integrations/eventviewer/
   algolia:
     rank: 60
     category: Documentation
     subcategory: Integrations
     tags: ['event viewer']
-- _target:
-    path: /integrations/lambdatest-software-license
-    lang: en
-  aliases:
-    - /integrations/lambdatest_software_license/
 - _target:
     path: /integrations/rapdev-validator
     lang: en
@@ -86,11 +78,6 @@ cascade:
     lang: en
   aliases:
     - /integrations/wmi/
-- _target:
-    path: /integrations/jfrog-platform
-    lang: en
-  aliases:
-    - /integrations/jfrog_platform/
 - _target:
     path: /integrations/komodor_license
     lang: en
@@ -152,16 +139,6 @@ cascade:
     lang: en
   aliases:
     - /integrations/agentil_software_sap_hana/
-- _target:
-    path: /integrations/azure-virtual-network
-    lang: en
-  aliases:
-    - /integrations/azure_virtual_networks
-- _target:
-    path: /integrations/amazon-event-bridge
-    lang: en
-  aliases:
-    - /integrations/amazon_event_bridge
 ---
 
 More than {{< translate key="integration_count" >}} built-in integrations. See across all your systems, apps, and services.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Remove the following definitions as these exist as part of automation now.
if an integration is `/integrations/foo-bar/` it will also have an alias of `/integrations/foo_bar/` by default

- /integrations/pingdom_v3/
- /integrations/lambdatest_software_license/
- /integrations/jfrog_platform/
- /integrations/amazon_event_bridge/

These urls should still work on this preview even though they are removed from the file

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
