### PR TITLE
fix link to inline-javascript-expression page

### DIFF
--- a/content/en/actions/workflows/variables.md
+++ b/content/en/actions/workflows/variables.md
@@ -149,3 +149,4 @@ To avoid a type error resulting from an undefined variable, assign a custom vari
 [5]: /service_management/workflows/trigger
 [6]: /service_management/app_builder/queries/#return-workflow-results-to-an-app
 [7]: /service_management/workflows/trigger/#access-the-result-of-a-child-workflow
+[8]: /service_management/workflows/expressions/#inline-javascript-expressions


### PR DESCRIPTION
### What does this PR do? What is the motivation?
I noticed that this link was broken on [this page](https://docs.datadoghq.com/actions/workflows/variables/)
<img width="719" height="92" alt="image" src="https://github.com/user-attachments/assets/4e79b4ce-a9f8-42fb-b9ea-67074b4e3b1b" />


### Merge instructions
Merge readiness:
- [X] Ready for merge
