### PR TITLE
[Cloud Run] Minor improvements to logging, metrics, and Java tracer install

### DIFF
--- a/content/en/serverless/google_cloud_run/containers/in_container/dotnet.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/dotnet.md
@@ -51,7 +51,7 @@ RUN mkdir -p /dd_tracer/dotnet/ && tar -xzvf /tmp/datadog-dotnet-apm.tar.gz -C /
 
    To enable logging, set the environment variable `DD_LOGS_ENABLED=true`. This allows `serverless-init` to read logs from stdout and stderr.
 
-   Datadog also recommends setting the environment variable `DD_SOURCE=csharp` to enable advanced Datadog log parsing.
+   Datadog also recommends setting the environment variables `DD_LOGS_INJECTION=true` and `DD_SOURCE=csharp` to enable advanced Datadog log parsing.
 
    If you want multiline logs to be preserved in a single log message, Datadog recommends writing your logs in JSON format. For example, you can use a third-party logging library such as `Serilog`:
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/dotnet.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/dotnet.md
@@ -76,7 +76,7 @@ logger.LogInformation("Hello World!");
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="in-container" language="csharp" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/go.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/go.md
@@ -71,7 +71,7 @@ go get github.com/DataDog/dd-trace-go/contrib/net/http/v2
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="in-container" language="go" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/java.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/java.md
@@ -88,7 +88,7 @@ logger.info("Hello World!");
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="in-container" language="java" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/java.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/java.md
@@ -60,7 +60,7 @@ implementation 'com.datadoghq:dd-trace-api:DD_TRACE_JAVA_VERSION_HERE'
 
    To enable logging, set the environment variable `DD_LOGS_ENABLED=true`. This allows `serverless-init` to read logs from stdout and stderr.
 
-   Datadog also recommends setting the environment variable `DD_SOURCE=java` to enable advanced Datadog log parsing.
+   Datadog also recommends setting the environment variable `DD_LOGS_INJECTION=true` and `DD_SOURCE=java` to enable advanced Datadog log parsing.
 
    If you want multiline logs to be preserved in a single log message, Datadog recommends writing your logs in *compact* JSON format. For example, you can use a third-party logging library such as `Log4j 2`:
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/java.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/java.md
@@ -46,7 +46,7 @@ implementation 'com.datadoghq:dd-trace-api:DD_TRACE_JAVA_VERSION_HERE'
       {{% /tab %}}
       {{< /tabs >}}
 
-   See [dd-trace-java releases][1] for the latest tracer version.
+      See [dd-trace-java releases][1] for the latest tracer version.
 
    3. Add the `@Trace` annotation to any method you want to trace.
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/java.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/java.md
@@ -46,9 +46,11 @@ implementation 'com.datadoghq:dd-trace-api:DD_TRACE_JAVA_VERSION_HERE'
       {{% /tab %}}
       {{< /tabs >}}
 
+   See [dd-trace-java releases][1] for the latest tracer version.
+
    3. Add the `@Trace` annotation to any method you want to trace.
 
-   For more information, see [Tracing Java Applications][1].
+   For more information, see [Tracing Java Applications][2].
 
 2. **Install serverless-init**.
 
@@ -76,7 +78,7 @@ logger.info("Hello World!");
 </Configuration>
 {{< /code-block >}}
 
-   For more information, see [Correlating Java Logs and Traces][2].
+   For more information, see [Correlating Java Logs and Traces][3].
 
 4. **Configure your application**.
 
@@ -86,7 +88,7 @@ logger.info("Hello World!");
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
 
 {{% gcr-env-vars instrumentationMethod="in-container" language="java" %}}
 
@@ -98,8 +100,9 @@ logger.info("Hello World!");
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
-[2]: /tracing/other_telemetry/connect_logs_and_traces/java/
-[3]: /developers/dogstatsd/?tab=java#install-the-dogstatsd-client
-[4]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=java#code-examples
+[1]: https://github.com/DataDog/dd-trace-java/releases
+[2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
+[3]: /tracing/other_telemetry/connect_logs_and_traces/java/
+[4]: /developers/dogstatsd/?tab=java#install-the-dogstatsd-client
+[5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=java#code-examples
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
@@ -48,7 +48,7 @@ ENV NODE_OPTIONS="--require dd-trace/init"
 
    To enable logging, set the environment variable `DD_LOGS_ENABLED=true`. This allows `serverless-init` to read logs from stdout and stderr.
 
-   Datadog also recommends setting the environment variable `DD_SOURCE=nodejs` to enable advanced Datadog log parsing.
+   Datadog also recommends setting the environment variable `DD_LOGS_INJECTION=true` and `DD_SOURCE=nodejs` to enable advanced Datadog log parsing.
 
    If you want multiline logs to be preserved in a single log message, Datadog recommends writing your logs in JSON format. For example, you can use a third-party logging library such as `winston`:
    {{< code-block lang="javascript" disable_copy="false" >}}

--- a/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/nodejs.md
@@ -79,7 +79,7 @@ logger.info(`Hello world!`);
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [view code examples][3].
+   To send custom metrics, [view code examples][3]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="in-container" language="nodejs" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/php.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/php.md
@@ -43,7 +43,7 @@ apk add libgcc
 
    To enable logging, set the environment variable `DD_LOGS_ENABLED=true`. This allows `serverless-init` to read logs from stdout and stderr.
 
-   Datadog also recommends setting the environment variable `DD_SOURCE=php` to enable advanced Datadog log parsing.
+   Datadog also recommends setting the environment variable `DD_LOGS_INJECTION=true` and `DD_SOURCE=php` to enable advanced Datadog log parsing.
 
    For more information, see [Correlating PHP Logs and Traces][2].
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/php.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/php.md
@@ -55,7 +55,7 @@ apk add libgcc
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
+   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="in-container" language="php" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/python.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/python.md
@@ -42,6 +42,7 @@ RUN pip install ddtrace
 
    Datadog also recommends the following environment variables:
    - `ENV PYTHONUNBUFFERED=1`: Ensure Python outputs appear immediately in container logs instead of being buffered.
+   - `ENV DD_LOGS_INJECTION=true`: Enable log/trace correlation for supported loggers.
    - `ENV DD_SOURCE=python`: Enable advanced Datadog log parsing.
 
    If you want multiline logs to be preserved in a single log message, Datadog recommends writing your logs in JSON format. For example, you can use a third-party logging library such as `structlog`:

--- a/content/en/serverless/google_cloud_run/containers/in_container/python.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/python.md
@@ -77,7 +77,7 @@ logger.info("Hello world!")
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="in-container" language="python" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/in_container/ruby.md
+++ b/content/en/serverless/google_cloud_run/containers/in_container/ruby.md
@@ -58,7 +58,7 @@ logger.info "Hello world!"
 
 6. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
+   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="in-container" language="ruby" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/dotnet.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/dotnet.md
@@ -81,7 +81,7 @@ builder.Host.UseSerilog((context, config) =>
 logger.LogInformation("Hello World!");
 {{< /code-block >}}
 
-   Datadog recommends setting the environment variable `DD_SOURCE=csharp` in your sidecar container to enable advanced Datadog log parsing.
+   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=csharp` (in your sidecar container) to enable advanced Datadog log parsing.
 
    For more information, see [Correlating .NET Logs and Traces][3].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/dotnet.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/dotnet.md
@@ -89,7 +89,7 @@ logger.LogInformation("Hello World!");
 
 5. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="csharp" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/go.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/go.md
@@ -86,7 +86,7 @@ logrus.WithContext(ctx).Info("Hello World!")
 
 5. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="go" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/java.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/java.md
@@ -44,7 +44,7 @@ implementation 'com.datadoghq:dd-trace-api:DD_TRACE_JAVA_VERSION_HERE'
       {{% /tab %}}
       {{< /tabs >}}
 
-   See [dd-trace-java releases][1] for the latest tracer version.
+      See [dd-trace-java releases][1] for the latest tracer version.
 
    3. Add the `@Trace` annotation to any method you want to trace.
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/java.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/java.md
@@ -91,7 +91,7 @@ logger.info("Hello World!");
 </Configuration>
 {{< /code-block >}}
 
-   Datadog recommends setting the environment variable `DD_SOURCE=java` in your sidecar container to enable advanced Datadog log parsing.
+   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=java` (in your sidecar container) to enable advanced Datadog log parsing.
 
    For more information, see [Correlating Java Logs and Traces][3].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/java.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/java.md
@@ -44,9 +44,11 @@ implementation 'com.datadoghq:dd-trace-api:DD_TRACE_JAVA_VERSION_HERE'
       {{% /tab %}}
       {{< /tabs >}}
 
+   See [dd-trace-java releases][1] for the latest tracer version.
+
    3. Add the `@Trace` annotation to any method you want to trace.
 
-   For more information, see [Tracing Java Applications][1].
+   For more information, see [Tracing Java Applications][2].
 
 2. **Install serverless-init as a sidecar**.
 
@@ -91,13 +93,13 @@ logger.info("Hello World!");
 
    Datadog recommends setting the environment variable `DD_SOURCE=java` in your sidecar container to enable advanced Datadog log parsing.
 
-   For more information, see [Correlating Java Logs and Traces][2].
+   For more information, see [Correlating Java Logs and Traces][3].
 
 4. {{% gcr-service-label %}}
 
 5. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="java" %}}
 
@@ -109,7 +111,8 @@ logger.info("Hello World!");
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
-[2]: /tracing/other_telemetry/connect_logs_and_traces/java/
-[3]: /developers/dogstatsd/?tab=java#install-the-dogstatsd-client
-[4]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=java#code-examples
+[1]: https://github.com/DataDog/dd-trace-java/releases
+[2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
+[3]: /tracing/other_telemetry/connect_logs_and_traces/java/
+[4]: /developers/dogstatsd/?tab=java#install-the-dogstatsd-client
+[5]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=java#code-examples

--- a/content/en/serverless/google_cloud_run/containers/sidecar/java.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/java.md
@@ -99,7 +99,7 @@ logger.info("Hello World!");
 
 5. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="java" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
@@ -90,7 +90,7 @@ logger.info(`Hello world!`);
 
 5. **Send custom metrics**.
 
-   To send custom metrics, [view code examples][3].
+   To send custom metrics, [view code examples][3]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="nodejs" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/nodejs.md
@@ -82,7 +82,7 @@ const logger = createLogger({
 logger.info(`Hello world!`);
 {{< /code-block >}}
 
-   Datadog recommends setting the environment variable `DD_SOURCE=nodejs` in your sidecar container to enable advanced Datadog log parsing.
+   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=nodejs` (in your sidecar container) to enable advanced Datadog log parsing.
 
    For more information, see [Correlating Node.js Logs and Traces][2].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/php.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/php.md
@@ -78,7 +78,7 @@ logInfo('Hello World!');
 
 5. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
+   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="php" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/php.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/php.md
@@ -70,7 +70,7 @@ function logInfo($message) {
 logInfo('Hello World!');
 {{< /code-block >}}
 
-   Datadog recommends setting the environment variable `DD_SOURCE=php` in your sidecar container to enable advanced Datadog log parsing.
+   Datadog recommends setting the environment variable `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=php` (in your sidecar container) to enable advanced Datadog log parsing.
 
    For more information, see [Correlating PHP Logs and Traces][2].
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/python.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/python.md
@@ -86,7 +86,7 @@ logger.info('Hello world!')
 
 5. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5].
+   To send custom metrics, [install the DogStatsD client][4] and [view code examples][5]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="python" %}}
 

--- a/content/en/serverless/google_cloud_run/containers/sidecar/python.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/python.md
@@ -53,8 +53,9 @@ RUN pip install ddtrace
    In the previous step, you created a shared volume. Additionally, you set the `DD_SERVERLESS_LOG_PATH` env var, or it was defaulted to `/shared-volume/logs/app.log`.
 
    Now, you will need to configure your logging library to write logs to that file. You can also set a custom format for log/trace correlation and other features. Datadog recommends setting the following environment variables:
-   - `ENV PYTHONUNBUFFERED=1`: Ensure Python outputs appear immediately in container logs instead of being buffered.
-   - `ENV DD_SOURCE=python`: Enable advanced Datadog log parsing.
+   - `ENV PYTHONUNBUFFERED=1`: In your main container. Ensure Python outputs appear immediately in container logs instead of being buffered.
+   - `ENV DD_LOGS_INJECTION=true`: In your main container. Enable log/trace correlation for supported loggers.
+   - `DD_SOURCE=python`: In your sidecar container. Enable advanced Datadog log parsing.
 
    Then, update your logging library. For example, you can use Python's native `logging` library:
    {{< code-block lang="python" disable_copy="false" >}}

--- a/content/en/serverless/google_cloud_run/containers/sidecar/ruby.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/ruby.md
@@ -48,7 +48,7 @@ gem 'datadog'
 
    In the previous step, you created a shared volume. Additionally, you set the `DD_SERVERLESS_LOG_PATH` env var, or it was defaulted to `/shared-volume/logs/app.log`.
 
-   Now, you will need to configure your logging library to write logs to that file. You can also set a custom format for log/trace correlation and other features. Datadog recommends setting the environment variable `DD_SOURCE=ruby` to parse your log format.
+   Now, you will need to configure your logging library to write logs to that file. You can also set a custom format for log/trace correlation and other features. Datadog recommends setting the environment variable `DD_SOURCE=go` in your sidecar container to enable advanced Datadog log parsing.
 
    Then, update your logging library. For example, you can use Ruby's native `logger` library:
    {{< code-block lang="ruby" disable_copy="false" >}}

--- a/content/en/serverless/google_cloud_run/containers/sidecar/ruby.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/ruby.md
@@ -69,7 +69,7 @@ logger.info "Hello World!"
 
 5. **Send custom metrics**.
 
-   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4].
+   To send custom metrics, [install the DogStatsD client][3] and [view code examples][4]. In serverless, only the *distribution* metric type is supported.
 
 {{% gcr-env-vars instrumentationMethod="sidecar" language="ruby" %}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Explain where to find the latest dd-trace-java version
- Recommend `DD_LOGS_INJECTION=true` for supported runtimes
- Clarify that only *distribution* metric type is supported in serverless

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
