### PR TITLE
Fix capitalization in ping.md autodiscovery section

### DIFF
--- a/content/en/network_monitoring/devices/ping.md
+++ b/content/en/network_monitoring/devices/ping.md
@@ -65,7 +65,7 @@ instances:
 
 {{% tab "Autodiscovery" %}}
 
-Configure ping settings in the `network_devices` section under the autodiscovery parameter to apply them to _all_ autodiscovery subnets.
+Configure ping settings in the `network_devices` section under the Autodiscovery parameter to apply them to _all_ Autodiscovery subnets.
 
 ```yaml
 network_devices:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Yesterday I pushed a PR to change the wording on this but I read the vale rule incorrectly, this capitalizes Autodiscovery as it should be :) 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
