### PR TITLE
SVL: moving remote instrumentation to tabs

### DIFF
--- a/content/en/serverless/aws_lambda/instrumentation/nodejs.md
+++ b/content/en/serverless/aws_lambda/instrumentation/nodejs.md
@@ -24,15 +24,17 @@ aliases:
 
 ## Setup
 
-### Remote instrumentation
-
-If you are instrumenting your Node.js AWS Lambda application for the first time, Datadog recommends that you use remote instrumentation. See [Remote instrumentation for AWS Lambda][11].
-
-### Other instrumentation methods
-
 If your application is deployed as a container image, use the _Container Image_ method.
 
 {{< tabs >}}
+{{% tab "Datadog UI" %}}
+If [remote instrumentation][1] is enabled, you can instrument your Node.js AWS Lambda application directly within Datadog. Navigate to the [Serverless > AWS Lambda][2] page and select **Instrument Functions**.
+
+For more information, see [Remote instrumentation for AWS Lambda][1].
+
+[1]: /serverless/aws_lambda/remote_instrumentation
+[2]: https://app.datadoghq.com/functions?cloud=aws
+{{% /tab %}}
 {{% tab "Datadog CLI" %}}
 
 The Datadog CLI modifies existing Lambda functions' configurations to enable instrumentation without requiring a new deployment. It is the quickest way to get started with Datadog's serverless monitoring.

--- a/content/en/serverless/aws_lambda/instrumentation/python.md
+++ b/content/en/serverless/aws_lambda/instrumentation/python.md
@@ -23,15 +23,17 @@ algolia:
 
 ## Setup
 
-### Remote instrumentation
-
-If you are instrumenting your Python AWS Lambda application for the first time, Datadog recommends that you use remote instrumentation. See [Remote instrumentation for AWS Lambda][11].
-
-### Other instrumentation methods
-
 If your application is deployed as a container image, use the _Container Image_ method.
 
 {{< tabs >}}
+{{% tab "Datadog UI" %}}
+If [remote instrumentation][1] is enabled, you can instrument your Python AWS Lambda application directly within Datadog. Navigate to the [Serverless > AWS Lambda][2] page and select **Instrument Functions**.
+
+For more information, see [Remote instrumentation for AWS Lambda][1].
+
+[1]: /serverless/aws_lambda/remote_instrumentation
+[2]: https://app.datadoghq.com/functions?cloud=aws
+{{% /tab %}}
 {{% tab "Datadog CLI" %}}
 
 The Datadog CLI modifies existing Lambda functions' configurations to enable instrumentation without requiring a new deployment. It is the quickest way to get started with Datadog's serverless monitoring.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Moves remote instrumentation to a "Datadog UI" tab for the Python and Node.js Lambda instrumentation pages.
cc @sumedham 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
