### PR TITLE
Fix white-space in example service.datadog.yaml file

### DIFF
--- a/content/en/internal_developer_portal/software_catalog/entity_model/_index.md
+++ b/content/en/internal_developer_portal/software_catalog/entity_model/_index.md
@@ -547,11 +547,10 @@ metadata:
     - name: Payment Team
       type: team
       contact: https://www.slack.com/archives/payments
-
-owner: payments-team
-additionalOwners:
-  - name: finance-team
-    type: stakeholder
+  owner: payments-team
+  additionalOwners:
+    - name: finance-team
+      type: stakeholder
 spec:
   components:
     - service:payment-api


### PR DESCRIPTION
### What does this PR do? What is the motivation?

In the `service.datadog.yaml` file modified, `owner` and `additionalOwners` belong under the `metadata` block.  The schema [here](https://github.com/DataDog/schema/blob/3542c9e9e3637f4ba404fa90b4c308d85a39b32f/service-catalog/v3/metadata.schema.json#L32) agrees.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
