### PR TITLE
Fix typo in logs pipeline array processor API doc

### DIFF
--- a/content/en/logs/log_configuration/processors.md
+++ b/content/en/logs/log_configuration/processors.md
@@ -873,7 +873,7 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following array processo
     "source": "httpRequest.headers",
     "target": "referrer",
     "filter": "name:Referrer",
-    "value_to_xtract": "value"
+    "value_to_extract": "value"
   }
 }
 ```


### PR DESCRIPTION
This is a follow up of https://github.com/DataDog/documentation/pull/31339 that contained a typo

- [X] Ready to be merged