### PR TITLE
[DDSQL] data type and type literal doc updates

### DIFF
--- a/content/en/ddsql_reference/_index.md
+++ b/content/en/ddsql_reference/_index.md
@@ -123,7 +123,7 @@ DDSQL supports explicit type literals using the syntax `[TYPE] [value]`.
 | `TIMESTAMP` | `TIMESTAMP 'value'` | `TIMESTAMP '2023-12-25 10:30:00'` |
 | `VARCHAR` | `VARCHAR 'value'` | `VARCHAR 'hello world'` |
 
-The type prefix can be omitted and the type is automatically inferred from the value. For example, `'hello world'` is inferred as `VARCHAR`, `123` as `BIGINT`, and `true` as `BOOLEAN`. Use explicit type prefixes when values could be ambiguous, for instance `TIMESTAMP '2025-01-01'` which would be inferred as `VARCHAR` without the prefix.
+The type prefix can be omitted and the type is automatically inferred from the value. For example, `'hello world'` is inferred as `VARCHAR`, `123` as `BIGINT`, and `true` as `BOOLEAN`. Use explicit type prefixes when values could be ambiguous; for example,`TIMESTAMP '2025-01-01'` would be inferred as `VARCHAR` without the prefix.
 
 ### Array literals
 

--- a/content/en/ddsql_reference/_index.md
+++ b/content/en/ddsql_reference/_index.md
@@ -107,7 +107,7 @@ DDSQL supports the following data types:
 
 ### Array types
 
-All data types except `JSON` support array types. Arrays can contain multiple values of the same data type.
+All data types support array types. Arrays can contain multiple values of the same data type.
 
 ## Type literals
 
@@ -123,7 +123,7 @@ DDSQL supports explicit type literals using the syntax `[TYPE] [value]`.
 | `TIMESTAMP` | `TIMESTAMP 'value'` | `TIMESTAMP '2023-12-25 10:30:00'` |
 | `VARCHAR` | `VARCHAR 'value'` | `VARCHAR 'hello world'` |
 
-The type prefix can be omitted and the type is automatically inferred from the value. For example, `'hello world'` is inferred as `VARCHAR`, `123` as `BIGINT`, and `true` as `BOOLEAN`.
+The type prefix can be omitted and the type is automatically inferred from the value. For example, `'hello world'` is inferred as `VARCHAR`, `123` as `BIGINT`, and `true` as `BOOLEAN`. Use explicit type prefixes when values could be ambiguous, for instance `TIMESTAMP '2025-01-01'` which would be inferred as `VARCHAR` without the prefix.
 
 ### Array literals
 
@@ -145,7 +145,7 @@ SELECT
     price * DOUBLE 1.08 AS price_with_tax,
     created_at + INTERVAL '7 days' AS expiry_date
 FROM products
-WHERE active = BOOLEAN true;
+WHERE created_at > TIMESTAMP '2025-01-01';
 {{< /code-block >}}
 
 ## Functions


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR updates the DDSQL data type and type literal docs to resolve three post-merge comments from https://github.com/DataDog/documentation/pull/31252.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

N/A