### PR TITLE
Update sdk.md

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -481,6 +481,7 @@ To finish a span, call `finish()` on a span object instance. If possible, wrap t
 {{< tabs >}}
 {{% tab "Python" %}}
 To trace an LLM span, use the function decorator `ddtrace.llmobs.decorators.llm()`.
+**Note**: To display the estimated cost in U.S. dollars, set modelProvider to one of the following values: `openai`, `azure_openai`, or `anthropic`.
 
 {{% collapse-content title="Arguments" level="h4" expanded=false id="llm-span-arguments" %}}
 
@@ -519,6 +520,7 @@ def llm_call():
 
 {{% tab "Node.js" %}}
 To trace an LLM span, specify the span kind as `llm`, and optionally specify the following arguments on the options object.
+**Note**: To display the estimated cost in U.S. dollars, set modelProvider to one of the following values: `openai`, `azure_openai`, or `anthropic`.
 
 {{% collapse-content title="Arguments" level="h4" expanded=false id="llm-span-arguments" %}}
 
@@ -557,6 +559,7 @@ llmCall = llmobs.wrap({ kind: 'llm', name: 'invokeLLM', modelName: 'claude', mod
 {{% /tab %}}
 {{% tab "Java" %}}
 To trace an LLM span, import and call the following method with the arguments listed below:
+**Note**: To display the estimated cost in U.S. dollars, set modelProvider to one of the following values: `openai`, `azure_openai`, or `anthropic`.
 
 ```
 import datadog.trace.api.llmobs.LLMObs;


### PR DESCRIPTION
When creating manual spans, either "openai", "azure_openai", or "anthropic" must be used for modelProvider to display the estimated cost in dollars.

Discussion in the slack channel:
https://dd.slack.com/archives/C065X379VG8/p1756442992780469

<img width="852" height="1062" alt="image" src="https://github.com/user-attachments/assets/79067f15-e020-44b7-b106-85b777aeb895" />