### PR TITLE
Remove preview label for Sentry SDK Error Tracking

### DIFF
--- a/content/en/error_tracking/guides/sentry_sdk.md
+++ b/content/en/error_tracking/guides/sentry_sdk.md
@@ -6,10 +6,6 @@ further_reading:
   tag: "Documentation"
   text: "Manage Data Collection"
 ---
-{{< callout url="#" btn_hidden="true" >}}
-Using the Sentry SDK with Error Tracking is in Preview.
-{{< /callout >}}
-
 <div class="alert alert-warning">
 Using the Sentry SDK with Error Tracking helps you migrate to Datadog. However, to get the most out of Error Tracking, it is recommended to use the Datadog SDKs. See <a href="/error_tracking/frontend">Frontend Error Tracking</a> and <a href="/error_tracking/backend">Backend Error Tracking</a>.
 </div>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Removes the "Preview" callout for the Sentry SDK feature for Error Tacking. Feature is GA.

Merge readiness:
- [x] Ready for merge