### PR TITLE
add how to use templateVariables 

### DIFF
--- a/content/en/actions/app_builder/embedded_apps.md
+++ b/content/en/actions/app_builder/embedded_apps.md
@@ -44,6 +44,12 @@ To list all of the available values of a specific template variable, use the fol
 ${global?.dashboard?.templateVariables?.find(v => v.name === '<TEMPLATE_VARIABLE_NAME>')?.availableValues}
 {{< /code-block >}}
 
+To list all of the available values when using a select component, use the following template expression:
+
+{{< code-block lang="json" disable_copy="false">}}
+${global?.dashboard?.templateVariables?.find(v => v.name === '<TEMPLATE_VARIABLE_NAME>')?.availableValues.map(availableValue => {return {label: availableValue, value:availableValue}})}
+{{< /code-block >}}
+
 To get the selected value of a template variable, use the following template expressions:
 
 - For a single-select template variable:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR adds a few lines to the page for Embedded Apps so that users can use templateVariables within App Builder's select. [This Jira ticket](https://datadoghq.atlassian.net/browse/DOCS-11971) provides more context about the history of the feature. 

Merge readiness:
- [x] Ready for merge
