### PR TITLE
Update minimum Node.js version requirement for profiler

### DIFF
--- a/content/en/profiler/enabling/nodejs.md
+++ b/content/en/profiler/enabling/nodejs.md
@@ -23,7 +23,7 @@ The profiler is shipped within Datadog tracing libraries. If you are already usi
 
 For a summary of the minimum and recommended runtime and tracer versions across all languages, read [Supported Language and Tracer Versions][7].
 
-The Datadog Profiler requires at least Node.js 14, but Node.js 16 or higher is recommended. If you use a version of Node.js earlier than 16, some applications see tail latency spikes every minute when starting the next profile.
+The Datadog Profiler requires at least Node.js 18.
 
 Continuous Profiler support is in Preview for some serverless platforms, such as [AWS Lambda][8].
 
@@ -81,10 +81,6 @@ const tracer = require('dd-trace/init')
 ## Not sure what to do next?
 
 The [Getting Started with Profiler][6] guide takes a sample service with a performance problem and shows you how to use Continuous Profiler to understand and fix the problem.
-
-## Experiencing high overhead?
-
-Node.js 16 or higher is recommended. On earlier versions, some applications see tail latency spikes every minute while starting the next profile.
 
 ## Further Reading
 

--- a/content/en/profiler/enabling/supported_versions.md
+++ b/content/en/profiler/enabling/supported_versions.md
@@ -19,8 +19,8 @@ To use the Datadog Profiler, use at least the minimum versions summarized in the
 
 |                                   |  [Java][1]   |   [Python][2]    |    [Go][3]    |   [Ruby][4]    | [Node.js][5]  |  [.NET][6]  |   [PHP][7]    | [Rust/C/C++][8] |
 |-----------------------------------|:------------:|:----------------:|:-------------:|:--------------:|:-------------:|:-----------------------------------------------------------------------:|:-------------:|:---------------:|
-| <strong>Minimum&nbsp;runtime&nbsp;version</strong> | [JDK&nbsp;8+][17]  | Python&nbsp;2.7+ | [previous major Go release][21] | Ruby&nbsp;2.5+ | Node&nbsp;14+ | .NET&nbsp;Core&nbsp;2.1+, .NET&nbsp;5+, .NET&nbsp;Framework&nbsp;4.6.1+ | PHP&nbsp;7.1+ |                 |
-| <strong>Feature-complete runtime version</strong>       | [JDK&nbsp;11+][17] | Python&nbsp;3.6+ | [latest major Go release][21] | Ruby&nbsp;3.2+ | Node&nbsp;18+ |                              .NET&nbsp;7+                               | PHP&nbsp;8.0+ |                 |
+| <strong>Minimum&nbsp;runtime&nbsp;version</strong> | [JDK&nbsp;8+][17]  | Python&nbsp;2.7+ | [previous major Go release][21] | Ruby&nbsp;2.5+ | Node.js&nbsp;18+ | .NET&nbsp;Core&nbsp;2.1+, .NET&nbsp;5+, .NET&nbsp;Framework&nbsp;4.6.1+ | PHP&nbsp;7.1+ |                 |
+| <strong>Feature-complete runtime version</strong>       | [JDK&nbsp;11+][17] | Python&nbsp;3.6+ | [latest major Go release][21] | Ruby&nbsp;3.2+ | Node.js&nbsp;18+ |                              .NET&nbsp;7+                               | PHP&nbsp;8.0+ |                 |
 | <strong>Feature-complete tracing library version</strong>        | [latest][9]  |   [latest][10]   | [latest][11]  |  [latest][12]  | [latest][13]  |                              [latest][14]                               | [latest][15]  |  [latest][16]   |
 
 ## Profile types


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates the minimum Node.js version requirement for profiler. It's been the case for a while that Node.js profiler minimum requirement is version 18.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
