### PR TITLE
[RUMS-4743] Expo: added EAS updates documentation

### DIFF
--- a/content/en/real_user_monitoring/error_tracking/mobile/expo.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/expo.md
@@ -83,6 +83,57 @@ const config = getDatadogExpoConfig(__dirname);
 module.exports = config;
 ```
 
+### Uploading sourcemaps for EAS updates
+
+When creating an [EAS update](https://docs.expo.dev/eas-update/introduction/), you’ll also need to upload the corresponding sourcemaps to Datadog. This ensures accurate error tracking and symbolication.
+
+#### 1. Create the EAS update
+
+Run the update command as usual:
+
+```
+eas update --channel [channel-name] --message "[message]"
+```
+
+This will generate a `dist` folder at the root of your project.
+
+---
+
+#### 2. Locate the sourcemaps
+
+Inside the `dist` folder, you’ll find the generated bundles and sourcemaps:
+
+* Example paths:
+
+  * `./dist/_expo/static/js/ios`
+  * `./dist/_expo/static/js/android`
+
+* File pairs you may see:
+
+  * Hermes: `.hbc` (bundle) and `.hbc.map` (sourcemap)
+  * JSC: `.js` or `.jsbundle` (bundle) and `*.map` (sourcemap)
+
+---
+
+#### 3. Upload the sourcemaps
+
+Make sure you have the latest version of `datadog-ci` installed.
+For each platform (Android & iOS), upload the debug symbols using:
+
+```
+npx datadog-ci react-native upload \
+  --platform [ios OR android] \
+  --service com.example.service \
+  --bundle [BUNDLE_FILE] \
+  --sourcemap [SOURCEMAP_FILE] \
+  --release-version [YOUR_RELEASE_VERSION] \
+  --build-version [YOUR_BUILD_VERSION]
+```
+
+The sourcemaps include a unique debug ID generated from the bundle’s contents.
+This ID changes with every EAS update. As a result, **even if the service, release, and build version stay the same, Datadog will always receive a new sourcemap upload**.
+
+
 ### Use the `datadog-ci react-native inject-debug-id` command
 
 As an alternative to the Expo Configuration, starting from `@datadog/mobile-react-native@2.10.0` and `@datadog/datadog-ci@v3.13.0`, you can use the `datadog-ci react-native inject-debug-id` command to manually attach a unique Debug ID to your application bundle and sourcemap.


### PR DESCRIPTION
### What does this PR do?

Adds documentation for handling the upload of sourcemaps for EAS updates.

### Merge instructions
Merge readiness:
- [x] Ready for merge
