### PR TITLE
[DOCSENG-132]: Add Active attribute to collapse items & apply on OOTB rules

### DIFF
--- a/layouts/partials/grouped-item-listings.html
+++ b/layouts/partials/grouped-item-listings.html
@@ -2,6 +2,7 @@
 {{- $filters := .filters -}}
 {{- $listGroups := .listgroups -}}
 {{- $transformGroupTitle := .transformGroupTitle | default false -}}
+{{- $activeAttr := .activeAttr -}}
 
 {{ with $filters }}
 <div class="controls" data-ref="controls">
@@ -21,7 +22,7 @@
   <div class="js-empty-results d-none font-semibold"></div>
   {{ range $i, $v := $listGroups }}
   <div class="js-group js-group-{{ $i }}" id="{{ $v.Key | anchorize }}">
-    <div class="js-group-header mb-1 d-flex align-items-center" id="">
+    <div class="js-group-header mb-1 d-flex align-items-center {{$activeAttr}}" id="">
       <div class="js-group-header__icon d-inline font-semibold h-100 text-uppercase px-2">
         {{ range last 1 $v.Pages }}
           {{ $basename := .Params.integration_id | default .Params.icon.integration_id | default .Params.source }}

--- a/layouts/security_rules/list.html
+++ b/layouts/security_rules/list.html
@@ -28,6 +28,6 @@
 {{ .Content }}
 
 <form id="rules">
-    {{- partial "grouped-item-listings.html" ( dict "context" $dot "filters" (sort ($.Scratch.Get "filters")) "listgroups" ($list.GroupByParam "source") "transformGroupTitle" true ) -}}
+    {{- partial "grouped-item-listings.html" ( dict "context" $dot "filters" (sort ($.Scratch.Get "filters")) "listgroups" ($list.GroupByParam "source") "transformGroupTitle" true "activeAttr" "active" ) -}}
 </form>
 {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->
this PR adds optional expanding behavior on the collapses item, especially for the ootb rules page.

https://datadoghq.atlassian.net/browse/DOCSENG-132

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Security teams want their collapses to be expanding on initial load.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
