### PR TITLE
fix doc error around argument of function

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -1855,7 +1855,7 @@ def llm_call():
     # joining an evaluation to a span via span ID and trace ID
     span_context = LLMObs.export_span(span=None)
     LLMObs.submit_evaluation(
-        span = span_context,
+        span_context = span_context,
         ml_app = "chatbot",
         label="harmfulness",
         metric_type="score",


### PR DESCRIPTION

### What does this PR do? What is the motivation?
https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/llmobs/_llmobs.py#L1644-L1647

it takes in `span_context` and not `span`, fix this

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
