### PR TITLE
Update troubleshooting section for Fleet Automation

### DIFF
--- a/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm/troubleshooting.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/single-step-apm/troubleshooting.md
@@ -17,7 +17,7 @@ You can troubleshoot injection issues in two ways: by using Fleet Automation in 
 ### Troubleshoot injection in Datadog Fleet Automation
 
 {{< callout btn_hidden="true" header="false">}}
-Instrumentation insights in Fleet Automation is available in Preview.
+Troubleshooting in Fleet Automation is available in Preview.
 {{< /callout >}}
 
 Using Datadog, you can identify and troubleshoot instrumentation issues across your infrastructure. You can see information like:
@@ -28,15 +28,15 @@ Using Datadog, you can identify and troubleshoot instrumentation issues across y
 
 #### Prerequisites
 
-Instrumentation insights are available for:
+This functionality is available for:
 
-- **Languages**: Python, Java, Node.js, Ruby, PHP, .NET
+- **Languages**: Python, Java, Node.js, PHP, .NET
 - **Environments**: Linux hosts, containers, Kubernetes
 - Datadog Agent v7.68.2+
 
-#### View instrumentation insights 
+#### View SSI troubleshooting insights 
 
-To access instrumentation insights in Datadog:
+To explore instrumentation troubleshooting data in Datadog:
 
 1. Navigate to [Fleet Automation][9].
 1. Use facets to filter down to relevant hosts:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
1. Remove Ruby from supported languages list
2. Remove "instrumentation insights" as official feature name and instead refer to general functionality (we don't want to brand/advertise a specific DD feature/product whose purpose is troubleshooting DD)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
