### PR TITLE
[PROF-12448] Remove current symbol upload instructions and add manual symbol upload info

### DIFF
--- a/content/en/profiler/enabling/full_host.md
+++ b/content/en/profiler/enabling/full_host.md
@@ -61,9 +61,28 @@ For hosts without container runtimes, follow the instructions for [running direc
 For compiled languages (C/C++/Rust/Go), the profiler can upload local symbols to Datadog for symbolication when unstripped binaries are available. 
 The Full-Host Profiler handles this automatically.
 
-#### Symbol upload using datadog-ci
+To upload symbols using datadog-ci, see <a href="#symbol-upload-using-datadog-ci">Symbol upload</a>.
 
-1. Git clone the [Datadog CI][13] 
+### Build
+To build the Full-Host Profiler directly on your machine, run:
+
+   ```shell
+   make
+   ```
+
+## Service naming
+When using full-host profiling, Datadog captures profiles from all processes running on the host. The service name for each process depends on the `DD_SERVICE` environment variable.
+
+If `DD_SERVICE` is set, the profiler uses the value of `DD_SERVICE` as the service name. This is the recommended and most reliable approach.
+
+If `DD_SERVICE` is not set, Datadog infers a service name from the binary name. For interpreted languages, this is the name of the interpreter. For example, for a service written in Java, the full-host profiler sets the service name to `service:java`.
+{{< img src="profiler/inferred_service_example.png" alt="Example of an inferred services within Profiling" style="width:50%;">}}
+
+If multiple services are running under the same interpreter (for example, two separate Java applications on the same host), and neither sets `DD_SERVICE`, Datadog groups them together under the same service name. Datadog cannot distinguish between them unless you provide a unique service name.
+
+## Symbol upload using datadog-ci
+
+1. Git clone the [datadog-ci][13] command line tool 
 2. Install `datadog-ci`, run:
 
    ```shell
@@ -85,23 +104,6 @@ The Full-Host Profiler handles this automatically.
 ```
 DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload ~/your/build/bin/
 ```
-
-### Build
-To build the Full-Host Profiler directly on your machine, run:
-
-   ```shell
-   make
-   ```
-
-## Service naming
-When using full-host profiling, Datadog captures profiles from all processes running on the host. The service name for each process depends on the `DD_SERVICE` environment variable.
-
-If `DD_SERVICE` is set, the profiler uses the value of `DD_SERVICE` as the service name. This is the recommended and most reliable approach.
-
-If `DD_SERVICE` is not set, Datadog infers a service name from the binary name. For interpreted languages, this is the name of the interpreter. For example, for a service written in Java, the full-host profiler sets the service name to `service:java`.
-{{< img src="profiler/inferred_service_example.png" alt="Example of an inferred services within Profiling" style="width:50%;">}}
-
-If multiple services are running under the same interpreter (for example, two separate Java applications on the same host), and neither sets `DD_SERVICE`, Datadog groups them together under the same service name. Datadog cannot distinguish between them unless you provide a unique service name.
 
 
 ## What's next?

--- a/content/en/profiler/enabling/full_host.md
+++ b/content/en/profiler/enabling/full_host.md
@@ -57,20 +57,21 @@ For hosts running containerized workloads, Datadog recommends running the profil
 For hosts without container runtimes, follow the instructions for [running directly on the host][10].
 
 ### Configuration
-#### Local symbol upload (Experimental)
+#### Local symbol upload
 For compiled languages (C/C++/Rust/Go), the profiler can upload local symbols to Datadog for symbolication when unstripped binaries are available. 
 The Full-Host Profiler handles this automatically.
 
-To manually upload symbols or add debug information:
+#### Symbol upload using datadog-ci
 
-1. Git clone the [Datadog CI][14] 
+1. Git clone the [Datadog CI][13] 
 2. Install `datadog-ci`, run:
 
    ```shell
    npm install -g @datadog/datadog-ci
    ```
 3. Provide a [Datadog API key][11] through the `DD_API_KEY` environment variable.
-4. Set variables in an encrypted `datadog-ci.json` file at the root of your project:
+4. Set the `DD_SITE` environment variable to your [Datadog site][12]. Your site is: {{< region-param key="dd_site" code="true" >}}
+5. Set variables in an encrypted `datadog-ci.json` file at the root of your project:
 
    ```
    {
@@ -78,8 +79,8 @@ To manually upload symbols or add debug information:
       "datadogSite": "<SITE>"
    }
    ```
-5. Install `binutils` 
-6. Run:
+6. Install `binutils` 
+7. Run:
 
 ```
 DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload ~/your/build/bin/
@@ -122,5 +123,4 @@ After installing the Full-Host Profiler, see the [Getting Started with Profiler]
 [10]: https://github.com/DataDog/dd-otel-host-profiler/blob/main/doc/running-on-host.md
 [11]: https://app.datadoghq.com/organization-settings/api-keys
 [12]: /getting_started/site/
-[13]: https://app.datadoghq.com/access/application-keys
-[14]: https://github.com/DataDog/datadog-ci/tree/master
+[13]: https://github.com/DataDog/datadog-ci/tree/master

--- a/content/en/profiler/enabling/full_host.md
+++ b/content/en/profiler/enabling/full_host.md
@@ -58,14 +58,32 @@ For hosts without container runtimes, follow the instructions for [running direc
 
 ### Configuration
 #### Local symbol upload (Experimental)
-For compiled languages (C/C++/Rust/Go), the profiler can upload local symbols to Datadog for symbolication when unstripped binaries are available.
+For compiled languages (C/C++/Rust/Go), the profiler can upload local symbols to Datadog for symbolication when unstripped binaries are available. 
+The Full-Host Profiler handles this automatically.
 
-To enable local symbol upload:
+To manually upload symbols or add debug information:
 
-1. Set the `DD_HOST_PROFILING_EXPERIMENTAL_UPLOAD_SYMBOLS=true`.
-2. Provide a [Datadog API key][11] through the `DD_API_KEY` environment variable.
-3. Provide a [Datadog application key][13] through the `DD_APP_KEY` environment variable.
-4. Set the `DD_SITE` environment variable to your [Datadog site][12]. Your site is: {{< region-param key="dd_site" code="true" >}}
+1. Git clone the [Datadog CI][14] 
+2. Install `datadog-ci`, run:
+
+   ```shell
+   npm install -g @datadog/datadog-ci
+   ```
+3. Provide a [Datadog API key][11] through the `DD_API_KEY` environment variable.
+4. Set variables in an encrypted `datadog-ci.json` file at the root of your project:
+
+   ```
+   {
+      "apiKey": "<API_KEY>",
+      "datadogSite": "<SITE>"
+   }
+   ```
+5. Install `binutils` 
+6. Run:
+
+```
+DD_BETA_COMMANDS_ENABLED=1 datadog-ci elf-symbols upload ~/your/build/bin/
+```
 
 ### Build
 To build the Full-Host Profiler directly on your machine, run:
@@ -105,3 +123,4 @@ After installing the Full-Host Profiler, see the [Getting Started with Profiler]
 [11]: https://app.datadoghq.com/organization-settings/api-keys
 [12]: /getting_started/site/
 [13]: https://app.datadoghq.com/access/application-keys
+[14]: https://github.com/DataDog/datadog-ci/tree/master


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The current configuration information for local symbol upload is outdated as users will no longer need to upload local symbols manually. However, if the user wants to upload local symbols manually or add debug information, we provided the instructions to do so.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
