### PR TITLE
Add css fix for dash bug

### DIFF
--- a/assets/styles/components/_tab-toggle.scss
+++ b/assets/styles/components/_tab-toggle.scss
@@ -106,6 +106,16 @@ $tab-active-shadow: 0 -4px 12px rgba(99, 44, 166, 0.08);
   }
 }
 
+// Fix for nav-tabs being affected by .main ul li:before rule
+.nav-tabs.response-toggle {
+  .nav-item {
+    &::before {
+      content: none !important;
+      display: none !important;
+    }
+  }
+}
+
 // Common tab styles
 .code-tabs {
   position: relative;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- The Widget pages have an API section, there's a formatting bug that puts a dash before and after the Model tab
- Example: [Pie Chart widget docs](https://docs.datadoghq.com/dashboards/widgets/pie_chart/#api)
- 
<img width="726" height="235" alt="image" src="https://github.com/user-attachments/assets/6951a958-9255-4cc6-b208-56ff1e4257e1" />

I think the cause is this [scss](https://github.com/DataDog/documentation/blob/e50bc0b43e12e5a32ab323a83336c97eeed5508a/assets/styles/pages/_global.scss#L480), but I wasn't sure if changing this would affect other docs. 

This is the shortcode: https://github.com/DataDog/documentation/blob/master/layouts/shortcodes/dashboards-widgets-api.html

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:

**Pending websites review**