### PR TITLE
[AAS Linux Code Wrapper Script] Add deprecation notice

### DIFF
--- a/content/en/serverless/guide/azure_app_service_linux_code_wrapper_script.md
+++ b/content/en/serverless/guide/azure_app_service_linux_code_wrapper_script.md
@@ -5,6 +5,14 @@ further_reading:
   tag: "Blog"
   text: "Monitor your Linux web apps on Azure App Service with Datadog"
 ---
+
+<div class="alert alert-warning">
+The AAS Linux Wrapper is now deprecated. It will continue to receive layer bumps but no new features.
+It will be retired on January 1, 2026, at which point no further updates will be provided.
+
+We strongly recommend switching to the [sidecar instrumentation method][15] as soon as possible.
+</div>
+
 ## Overview
 
 This instrumentation method provides the following additional monitoring capabilities for Linux Azure App Service workloads:
@@ -118,4 +126,4 @@ Share the content of the **Log stream** with [Datadog Support][14].
 [10]: https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent&code-lang=php
 [11]: https://docs.datadoghq.com/developers/dogstatsd/?tab=hostagent&code-lang=python
 [14]: /help
-
+[15]: https://docs.datadoghq.com/serverless/azure_app_service/linux_code


### PR DESCRIPTION
### What does this PR do? What is the motivation?

We are deprecating the [AAS Linux Code Wrapper](https://github.com/DataDog/datadog-aas-linux/) Script in favor of the [sidecar](https://docs.datadoghq.com/serverless/azure_app_service/linux_code) instrumentation method.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
