### PR TITLE
[React Native] Update minimum supported React Native version to v0.65

### DIFF
--- a/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/setup/reactnative.md
+++ b/content/en/real_user_monitoring/mobile_and_tv_monitoring/react_native/setup/reactnative.md
@@ -31,7 +31,7 @@ further_reading:
 
 This page describes how to instrument your applications for both [Real User Monitoring (RUM)][1] or [Error Tracking][2] with the React Native SDK. You can follow the steps below to instrument your applications for RUM (includes Error Tracking), or Error Tracking if you have purchased it as a standalone product.
 
-The minimum supported version for the React Native SDK is React Native v0.63.4+. Compatibility with older versions is not guaranteed out-of-the-box.
+The minimum supported version for the React Native SDK is React Native v0.65+. Compatibility with older versions is not guaranteed out-of-the-box.
 
 The React Native SDK supports the following services:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Our minimum supported React Native version has been 0.65 for a while now. This PR updates the documentation accordingly.

Merge readiness:
- [x] Ready for merge

