### PR TITLE
Update integrations.md

### DIFF
--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -417,7 +417,7 @@ metadata:
   annotations:
     ad.datadoghq.com/postgres.checks: |
       {
-        "postgresql": {
+        "postgres": {
           "instances": [
             {
               "host": "%%host%%",
@@ -450,7 +450,7 @@ kind: Pod
 metadata:
   name: postgres
   annotations:
-    ad.datadoghq.com/postgres.check_names: '["postgresql"]'
+    ad.datadoghq.com/postgres.check_names: '["postgres"]'
     ad.datadoghq.com/postgres.init_configs: '[{}]'
     ad.datadoghq.com/postgres.instances: |
       [
@@ -575,7 +575,7 @@ The following etcd commands create a Postgres integration template with a custom
 
 ```conf
 etcdctl mkdir /datadog/check_configs/postgres
-etcdctl set /datadog/check_configs/postgres/check_names '["postgresql"]'
+etcdctl set /datadog/check_configs/postgres/check_names '["postgres"]'
 etcdctl set /datadog/check_configs/postgres/init_configs '[{}]'
 etcdctl set /datadog/check_configs/postgres/instances '[{"host": "%%host%%","port":"5432","username":"datadog","password":"%%env_PG_PASSWORD%%"}]'
 ```


### PR DESCRIPTION
We were using postgresql as integration name, but according to our integration core page (https://github.com/DataDog/integrations-core/tree/master/postgres) it's only postgres

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
We were using postgresql as integration name, but according to our integration core [page](https://github.com/DataDog/integrations-core/tree/master/postgres)  it's only postgres

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
