### PR TITLE
fix: "intrumentation" typo

### DIFF
--- a/content/en/tests/setup/swift.md
+++ b/content/en/tests/setup/swift.md
@@ -208,7 +208,7 @@ Environment variables need to be set only in the test target, because the framew
 
 ### Test Optimisation SDK
 
-If you don't use RUM, you can link your application target with the Test SDK. The SDK adds auto-intrumentation to your application, gathers network requests and logs, and attaches them to the test traces.
+If you don't use RUM, you can link your application target with the Test SDK. The SDK adds auto-instrumentation to your application, gathers network requests and logs, and attaches them to the test traces.
 
 Environment variables need to be set only in the test target, because the framework automatically injects these values to the application.
 

--- a/content/en/tracing/trace_pipeline/_index.md
+++ b/content/en/tracing/trace_pipeline/_index.md
@@ -9,7 +9,7 @@ description: "Learn how to control span ingestion"
 
 {{< img src="tracing/apm_lifecycle/trace_pipeline.png" style="width:100%; background:none; border:none; box-shadow:none;" alt="Trace Pipeline" >}}
 
-Collect traces from your intrumented applications to gain end-to-end visibility into your applications. Query and visualize distributed traces from the [Trace Explorer][1], understand how requests flow through your microservices and easily investigate errors and performance issues.
+Collect traces from your instrumented applications to gain end-to-end visibility into your applications. Query and visualize distributed traces from the [Trace Explorer][1], understand how requests flow through your microservices and easily investigate errors and performance issues.
 
 With APM, both the **ingestion** and the **retention** of traces are fully customizable.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Fixes a typo on 2 pages. `intrumentation` -> `instrumentation`. (missing an '*s*')

This typo is also present on the [`es` localization of the `trace_pipeline` page](https://github.com/DataDog/documentation/blob/master/content/es/tracing/trace_pipeline/_index.md). 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
