### PR TITLE
[Cloud Run] Fix .NET tracer install for sidecar instrumentation

### DIFF
--- a/content/en/serverless/google_cloud_run/containers/sidecar/dotnet.md
+++ b/content/en/serverless/google_cloud_run/containers/sidecar/dotnet.md
@@ -18,13 +18,12 @@ further_reading:
 
 1. **Install the Datadog .NET tracer** in your Dockerfile.
 
-   Because GitHub requests are rate limited, you must pass a GitHub token saved in the environment variable `GITHUB_TOKEN` as a [Docker build secret][1] `--secret id=github-token,env=GITHUB_TOKEN`.
-
    {{< tabs >}}
    {{% tab "Linux/AMD64" %}}
 {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
-RUN --mount=type=secret,id=github-token,env=GITHUB_TOKEN \
-    chmod +x /app/dotnet.sh && /app/dotnet.sh
+ARG TRACER_VERSION
+RUN curl -L -s "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb" --output datadog-dotnet-apm.deb && \
+   dpkg -i datadog-dotnet-apm.deb
 {{< /code-block >}}
    {{% /tab %}}
 
@@ -38,6 +37,8 @@ RUN mkdir -p /dd_tracer/dotnet/ && tar -xzvf /tmp/datadog-dotnet-apm.tar.gz -C /
 {{< /code-block >}}
    {{% /tab %}}
    {{< /tabs >}}
+
+   See the [dd-trace-dotnet releases][1] to view the latest tracer version.
 
    For more information, see [Tracing .NET applications][2].
 
@@ -105,7 +106,7 @@ logger.LogInformation("Hello World!");
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.docker.com/build/building/secrets/
+[1]: https://github.com/DataDog/dd-trace-dotnet/releases/
 [2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core/?tab=linux
 [3]: /tracing/other_telemetry/connect_logs_and_traces/dotnet/
 [4]: /developers/dogstatsd/?tab=dotnet#install-the-dogstatsd-client


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The docs referenced a `dotnet.sh` script which is included in the serverless-init agent, but sidecar instrumentation does not have the serverless-init agent installed in the Dockerfile. So we need to `curl` the tracer agent instead

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
