### PR TITLE
docs(nginx): Version update and logging clarification

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/nginx.md
+++ b/content/en/tracing/trace_collection/proxy_setup/nginx.md
@@ -408,9 +408,7 @@ By default, logs capture `dd.trace_id` and `dd.span_id` in hexadecimal format:
 10.244.0.1 - - [12/Sep/2025:22:41:03 +0000] "GET /health HTTP/1.1" 200 87 0.002 "-" "kube-probe/1.32" "-" dd.trace_id="68c4a17f000000009aed12af2ccb1ead" dd.span_id="9aed12af2ccb1ead"
 ```
 
-This means you'll need to remap them as decimal for logs and trace correlation to work in Datadog. 
-
-To fix this, you'll need to create a pipeline to process the trace ID from your logs. These steps are the same for both instrumentation methods.
+To enable log and trace correlation in Datadog, configure a log processing pipeline to convert these IDs from hexadecimal to decimal. Follow the same steps regardless of the instrumentation method you use.
 
 1. In Datadog, navigate to the [**Log Configuration**][9] page.
 2. Hover over your active NGINX pipeline and click the **Clone** icon to create an editable version.


### PR DESCRIPTION
- Update NGINX version from 1.26.0 to 1.29.0 (1.26 is EOL per endoflife.date)
- Add example log showing hexadecimal format of trace and span IDs
- Reword pipeline configuration explanation for clarity

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
