### PR TITLE
Update search_syntax to include missing attributes for free text search

### DIFF
--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -52,7 +52,7 @@ Use the syntax `*:search_term` to perform a full-text search across all log attr
 | Search syntax | Search type | Description                                               |
 | ------------- | ----------- | --------------------------------------------------------- |
 | `*:hello`     | Full-text   | Searches all log attributes for the exact string `hello`. |
-| `hello`       | Free text   | Searches only the log message for the exact string `hello`.       |
+| `hello`       | Free text   | Searches only the `message`, `@title`, `@error.message`, and `@error.stack` attributes for the exact string `hello`.       |
 
 ### Search term with wildcard example
 


### PR DESCRIPTION
The public docs are out of sync with our internal docs.

https://datadoghq.atlassian.net/wiki/spaces/EP/pages/978223114/Query+Language+syntax+and+functionalities#Free-text-search
