### PR TITLE
Remove security notification testing limitation

### DIFF
--- a/content/en/security/notifications/rules.md
+++ b/content/en/security/notifications/rules.md
@@ -50,7 +50,7 @@ To create a notification rule, specify the conditions under which the rule shoul
    - **Trigger immediately for each individual issue meeting the criteria**: Select this option to get one notification for each detection.<br />**Note**: Selecting this option can result in a large number of notifications.
 1. Click **Add Recipient**.
 1. Specify the recipients you want to notify when the notification rule is triggered. You can notify individuals, teams, create Jira issues, and more. See [Notification channels][2] for more information.
-1. If you chose **Signal** in step 3, to test notifications for this rule, click **Test Notifications**.</br >**Note**: Testing notifications isn't available for finding notifications.
+1. To send test notifications for this rule, click **Test Notifications**.
   1. In the modal, select the security products you want to test.
   1. Click **Run Test**.
 1. Click **Save**.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
You can now test finding notifications in Security! This is a very small PR to remove mention of the old limitation.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
