### PR TITLE
Scheduled CSV Reports: remove preview callout

### DIFF
--- a/content/en/logs/reports/_index.md
+++ b/content/en/logs/reports/_index.md
@@ -2,10 +2,6 @@
 title: Scheduled CSV Reports
 ---
 
-{{< callout url="#" btn_hidden="true" header="false">}}  
-Scheduled CSV Reports are in Preview.  
-{{< /callout >}}
-
 ## Overview
 
 Scheduled CSV Reports let you automatically receive recurring, structured data exports through email or Slack. This feature supports operational, compliance, and executive stakeholders by delivering periodic snapshots of key metrics, without needing to log into the Datadog platform.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Once Scheduled CSV reports go GA, the `Scheduled CSV Reports are in Preview` callout in our public docs will be stale.

### Merge instructions
Do not merge until the corresponding feature flag (`widget_log_list_reporting`) is GA in commercial DCs.

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
