### PR TITLE
feat(debugger): bump minimum agent version from v7.44/45 to v7.49

### DIFF
--- a/content/en/error_tracking/backend/exception_replay.md
+++ b/content/en/error_tracking/backend/exception_replay.md
@@ -45,7 +45,7 @@ Exception Replay is only available in APM Error Tracking. It is not available fo
 
 ## Setup
 
-1. Upgrade the Datadog Agent to version `7.44.0` or higher.
+1. Upgrade the Datadog Agent to version `7.49.0` or higher.
 1. Upgrade the APM tracer library to the minimum required version or higher:
    * `ddtrace` version `2.21.9+`
    * `dd-trace-java` version `1.49.0+`

--- a/content/en/tracing/dynamic_instrumentation/_index.md
+++ b/content/en/tracing/dynamic_instrumentation/_index.md
@@ -42,7 +42,7 @@ If you are interested in trying out the latest user experience improvements for 
 
 Dynamic Instrumentation requires the following:
 
-- [Datadog Agent][1] 7.45.0 or higher is installed alongside your service.
+- [Datadog Agent][1] 7.49.0 or higher is installed alongside your service.
 - [Remote Configuration][2] is enabled in that Agent.
 - For Java applications, tracing library [`dd-trace-java`][3] 1.34.0 or higher.
 - For Python applications, tracing library [`dd-trace-py`][4] 2.2.0 or higher.

--- a/content/en/tracing/dynamic_instrumentation/enabling/dotnet.md
+++ b/content/en/tracing/dynamic_instrumentation/enabling/dotnet.md
@@ -21,7 +21,7 @@ For a better experience, Datadog recommends enabling [autocomplete and search (i
 
 ## Installation
 
-1. Install or upgrade your Agent to version [7.45.0][7] or higher.
+1. Install or upgrade your Agent to version [7.49.0][7] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 3. Install or upgrade the .NET tracing libraries to version 2.54.0, by following the relevant instructions for [.NET Framework][2] or [.NET Core][3].
 4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.

--- a/content/en/tracing/dynamic_instrumentation/enabling/java.md
+++ b/content/en/tracing/dynamic_instrumentation/enabling/java.md
@@ -22,7 +22,7 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 
 ## Installation
 
-1. Install or upgrade your Agent to version [7.45.0][2] or higher.
+1. Install or upgrade your Agent to version [7.49.0][2] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 
 3. Download `dd-java-agent.jar`:

--- a/content/en/tracing/dynamic_instrumentation/enabling/nodejs.md
+++ b/content/en/tracing/dynamic_instrumentation/enabling/nodejs.md
@@ -23,7 +23,7 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 
 ## Installation
 
-1. Install or upgrade your Agent to version [7.45.0][6] or higher.
+1. Install or upgrade your Agent to version [7.49.0][6] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 3. Install or upgrade the Node.js tracing library to version 5.48.0 or higher, by following the [relevant instructions][2].
 4. If your source code is transpiled during deployment (for example, if using TypeScript), ensure that source maps are published along with the deployed Node.js application.

--- a/content/en/tracing/dynamic_instrumentation/enabling/php.md
+++ b/content/en/tracing/dynamic_instrumentation/enabling/php.md
@@ -14,7 +14,7 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 
 ## Installation
 
-1. Install or upgrade your Agent to version [7.45.0][7] or higher.
+1. Install or upgrade your Agent to version [7.49.0][7] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 3. Install or upgrade the PHP tracing libraries to version 1.5.0, by following the [relevant instructions][2].
 4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.
@@ -64,4 +64,3 @@ See [Dynamic Instrumentation][5] for information about adding instrumentations a
 [7]: https://app.datadoghq.com/account/settings/agent/latest?platform=overview
 [8]: /dynamic_instrumentation/sensitive-data-scrubbing/#custom-identifier-redaction
 [9]: /integrations/guide/source-code-integration/?tab=php
-

--- a/content/en/tracing/dynamic_instrumentation/enabling/python.md
+++ b/content/en/tracing/dynamic_instrumentation/enabling/python.md
@@ -21,7 +21,7 @@ Recommended, [autocomplete and search (in Preview)][6] is enabled.
 
 ## Installation
 
-1. Install or upgrade your Agent to version [7.45.0][2] or higher.
+1. Install or upgrade your Agent to version [7.49.0][2] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 
 3. Install `ddtrace`, which provides both tracing and Dynamic Instrumentation:

--- a/content/en/tracing/dynamic_instrumentation/enabling/ruby.md
+++ b/content/en/tracing/dynamic_instrumentation/enabling/ruby.md
@@ -25,7 +25,7 @@ Dynamic Instrumentation is a feature of supporting Datadog tracing libraries. If
 
 ## Installation
 
-1. Install or upgrade your Agent to version [7.45.0][7] or higher.
+1. Install or upgrade your Agent to version [7.49.0][7] or higher.
 2. If you don't already have APM enabled, in your Agent configuration, set the `DD_APM_ENABLED` environment variable to `true` and listening to the port `8126/TCP`.
 3. Install or upgrade the Ruby tracing library to version 2.9.0 or higher, by following the [relevant instructions][2].
 4. Run your service with Dynamic Instrumentation enabled by setting the `DD_DYNAMIC_INSTRUMENTATION_ENABLED` environment variable to `true`. Specify `DD_SERVICE`, `DD_ENV`, and `DD_VERSION` Unified Service Tags so you can filter and group your instrumentations and target active clients across these dimensions.

--- a/content/en/tracing/dynamic_instrumentation/symdb/_index.md
+++ b/content/en/tracing/dynamic_instrumentation/symdb/_index.md
@@ -29,7 +29,7 @@ To provide autocomplete and search, nonsensitive symbols and metadata are upload
 Autocomplete and search require the following:
 
 - [Dynamic Instrumentation][1] is enabled for your service.
-- [Datadog Agent][2] 7.45.0 or higher is installed alongside your service.
+- [Datadog Agent][2] 7.49.0 or higher is installed alongside your service.
 - [Remote Configuration][3] is enabled in the Agent.
 - The [Unified Service Tagging][4] tags `service`, `env`, and `version` are applied to your deployment.
 
@@ -61,4 +61,3 @@ Dynamic Instrumentation also provides autocomplete for log templates and other t
 [3]: /tracing/guide/remote_config
 [4]: /getting_started/tagging/unified_service_tagging/
 [5]: /dynamic_instrumentation/expression-language
-

--- a/content/es/tracing/dynamic_instrumentation/_index.md
+++ b/content/es/tracing/dynamic_instrumentation/_index.md
@@ -48,7 +48,7 @@ Si estás interesado en probar las últimas mejoras de la experiencia de usuario
 
 Dynamic Instrumentation requiere lo siguiente:
 
-- [Datadog Agent][1] 7.45.0 o superior esté instalado junto a su servicio.
+- [Datadog Agent][1] 7.49.0 o superior esté instalado junto a su servicio.
 - [Configuración remota][2] esté habilitada en ese Agent.
 - Para aplicaciones Java, la librería de seguimiento [`dd-trace (traza)-java`][3] 1.34.0 o superior.
 - Para aplicaciones Python, la librería de seguimiento [`dd-trace (traza)-py`][4] 2.2.0 o superior.

--- a/content/es/tracing/dynamic_instrumentation/enabling/java.md
+++ b/content/es/tracing/dynamic_instrumentation/enabling/java.md
@@ -21,7 +21,7 @@ Dynamic Instrumentation es una característica de apoyo para las bibliotecas de 
 
 ## Instalación
 
-1. Instala o actualiza tu Agent a la versión [7.45.0][2] o posterior.
+1. Instala o actualiza tu Agent a la versión [7.49.0][2] o posterior.
 2. Si aún no tienes APM habilitado, en tu configuración del Agent, establece la variable de entorno `DD_APM_ENABLED` en `true` y escuchando en el puerto `8126/TCP`.
 
 3. Descarga `dd-java-agent.jar`:

--- a/content/es/tracing/dynamic_instrumentation/enabling/ruby.md
+++ b/content/es/tracing/dynamic_instrumentation/enabling/ruby.md
@@ -24,7 +24,7 @@ Dynamic Instrumentation es una característica de apoyo para las bibliotecas de 
 
 ## Instalación
 
-1. Instala o actualiza tu Agent a la versión [7.45.0][7] o posterior.
+1. Instala o actualiza tu Agent a la versión [7.49.0][7] o posterior.
 2. Si aún no tienes APM habilitado, en tu configuración del Agent, establece la variable de entorno `DD_APM_ENABLED` en `true` y escuchando en el puerto `8126/TCP`.
 3. Instala o actualiza la librería de rastreo de Ruby a la versión 2.9.0 o posterior, siguiendo las [instrucciones pertinentes][2].
 4. Ejecuta tu servicio conDynamic Instrumentation habilitada, al configurar la variable de entorno `DD_DYNAMIC_INSTRUMENTATION_ENABLED` en `true`. Especifica las etiquetas de servicio unificado `DD_SERVICE`, `DD_ENV` y `DD_VERSION` para que puedas filtrar y agrupar tus instrumentaciones y dirigirte a los clientes activos a través de estas dimensiones.

--- a/content/es/tracing/dynamic_instrumentation/symdb/_index.md
+++ b/content/es/tracing/dynamic_instrumentation/symdb/_index.md
@@ -28,7 +28,7 @@ Para el autocompletado y la búsqueda, los símbolos y metadatos no sensibles se
 La función Autocompletar y buscar requiere lo siguiente:
 
 - [Dynamic Instrumentation][1] está activado para tu servicio.
-- [Datadog Agent][2] v7.45.0 o superior instalado junto a tu servicio.
+- [Datadog Agent][2] v7.49.0 o superior instalado junto a tu servicio.
 - [Configuración remota][3] activada en el Agent.
 - Las etiquetas (tags) `service` , `env` y `version` del [Etiquetado unificado de servicios][4] se aplican a tu despliegue.
 

--- a/content/es/tracing/error_tracking/exception_replay.md
+++ b/content/es/tracing/error_tracking/exception_replay.md
@@ -41,7 +41,7 @@ Exception Replay solo está disponible en el seguimiento de errores de APM. No s
 
 ## Configuración
 
-1. Instala o actualiza el Agent a la versión `7.44.0` o superior.
+1. Instala o actualiza el Agent a la versión `7.49.0` o superior.
 2. Asegúrate de estar utilizando:
   * `ddtrace` versión `1.16.0` o superior.
   * `dd-trace-java` versión `1.35.0` o superior.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Bumps to minimum agent version for Live Debugger, Dynamic Instrumentation, and Exception Replay to v7.49.0

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
