### PR TITLE
[Cloud Run] Fix .NET Function tracer path & add link to Terraform module

### DIFF
--- a/content/en/serverless/google_cloud_run/functions/dotnet.md
+++ b/content/en/serverless/google_cloud_run/functions/dotnet.md
@@ -24,8 +24,8 @@ further_reading:
    {{< code-block lang="text" disable_copy="false" >}}
 CORECLR_ENABLE_PROFILING=1
 CORECLR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-CORECLR_PROFILER_PATH=/workspace/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
-DD_DOTNET_TRACER_HOME=/workspace/datadog
+CORECLR_PROFILER_PATH=/layers/google.dotnet.publish/publish/bin/datadog/linux-x64/Datadog.Trace.ClrProfiler.Native.so
+DD_DOTNET_TRACER_HOME=/layers/google.dotnet.publish/publish/bin/datadog
 {{< /code-block >}}
 
    For more information, see [Tracing .NET applications][2].

--- a/layouts/shortcodes/gcr-install-sidecar-terraform.md
+++ b/layouts/shortcodes/gcr-install-sidecar-terraform.md
@@ -1,4 +1,4 @@
-The [Datadog Terraform module for Google Cloud Run][1] wraps the [google_cloud_run_v2_service][2] resource and automatically configures your Cloud Run service for Datadog Serverless Monitoring by adding required environment variables and the serverless-init sidecar.
+The [Datadog Terraform module for Google Cloud Run][1001] wraps the [google_cloud_run_v2_service][1002] resource and automatically configures your Cloud Run service for Datadog Serverless Monitoring by adding required environment variables and the serverless-init sidecar.
 
 Create a `.tf` file that contains your configuration. You can use the following example and adapt it to your needs:
 

--- a/layouts/shortcodes/gcr-install-sidecar-terraform.md
+++ b/layouts/shortcodes/gcr-install-sidecar-terraform.md
@@ -1,3 +1,5 @@
+The [Datadog Terraform module for Google Cloud Run][1] wraps the [google_cloud_run_v2_service][2] resource and automatically configures your Cloud Run service for Datadog Serverless Monitoring by adding required environment variables and the serverless-init sidecar.
+
 Create a `.tf` file that contains your configuration. You can use the following example and adapt it to your needs:
 
 ```tf
@@ -61,3 +63,5 @@ To deploy your app, run:
 terraform apply
 ```
 
+[1001]: https://github.com/DataDog/terraform-google-cloud-run-datadog
+[1002]: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/cloud_run_v2_service


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- The .NET Function tracer path changed in v3 of dd-trace-dotnet, so the docs need to be fixed
- Add a link to the Terraform module in Container sidecar instrumentation

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
