### PR TITLE
apm: add recently supported Node.js integrations

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -261,4 +261,4 @@ For additional information or to discuss [leave a comment on this github issue][
 [65]: https://github.com/dotansimha/graphql-yoga
 [66]: https://js.langchain.com/
 [67]: https://www.npmjs.com/package/@confluentinc/kafka-javascript
-[67]: https://www.npmjs.com/package/@azure/service-bus
+[68]: https://www.npmjs.com/package/@azure/service-bus

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -149,12 +149,12 @@ Or, modify the `package.json` file if you typically start an application with np
 | Module                               | Versions  | Support Type    | Notes                                                  |
 | --------------------------           | --------  | --------------- | ------------------------------------------------------ |
 | [@azure/service-bus][68]             | `>=7.9.2` | Fully supported |                                                        |
+| [@confluentinc/kafka-javascript][67] | `>=1`     | Fully supported |                                                        |
 | [@google-cloud/pubsub][42]           | `>=1.2`   | Fully supported |                                                        |
 | [amqp10][43]                         | `>=3`     | Fully supported | Supports AMQP 1.0 brokers (such as ActiveMQ, or Apache Qpid) |
 | [amqplib][44]                        | `>=0.5`   | Fully supported | Supports AMQP 0.9 brokers (such as RabbitMQ, or Apache Qpid) |
 | [generic-pool][45]                   | `>=2`     | Fully supported |                                                        |
 | [kafkajs][46]                        | `>=1.4`   | Fully supported |                                                        |
-| [@confluentinc/kafka-javascript][67] | `>=1`     | Fully supported |                                                        |
 | [rhea][48]                           | `>=1`     | Fully supported |                                                        |
 
 ### SDK compatibility

--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -146,14 +146,16 @@ Or, modify the `package.json` file if you typically start an application with np
 
 ### Worker compatibility
 
-| Module                     | Versions | Support Type    | Notes                                                  |
-| -------------------------- | -------- | --------------- | ------------------------------------------------------ |
-| [@google-cloud/pubsub][42] | `>=1.2`  | Fully supported |                                                        |
-| [amqp10][43]               | `>=3`    | Fully supported | Supports AMQP 1.0 brokers (such as ActiveMQ, or Apache Qpid) |
-| [amqplib][44]              | `>=0.5`  | Fully supported | Supports AMQP 0.9 brokers (such as RabbitMQ, or Apache Qpid) |
-| [generic-pool][45]         | `>=2`    | Fully supported |                                                        |
-| [kafkajs][46]         | `>=1.4`    | Fully supported |                                                        |
-| [rhea][48]                 | `>=1`    | Fully supported |                                                        |
+| Module                               | Versions  | Support Type    | Notes                                                  |
+| --------------------------           | --------  | --------------- | ------------------------------------------------------ |
+| [@azure/service-bus][68]             | `>=7.9.2` | Fully supported |                                                        |
+| [@google-cloud/pubsub][42]           | `>=1.2`   | Fully supported |                                                        |
+| [amqp10][43]                         | `>=3`     | Fully supported | Supports AMQP 1.0 brokers (such as ActiveMQ, or Apache Qpid) |
+| [amqplib][44]                        | `>=0.5`   | Fully supported | Supports AMQP 0.9 brokers (such as RabbitMQ, or Apache Qpid) |
+| [generic-pool][45]                   | `>=2`     | Fully supported |                                                        |
+| [kafkajs][46]                        | `>=1.4`   | Fully supported |                                                        |
+| [@confluentinc/kafka-javascript][67] | `>=1`     | Fully supported |                                                        |
+| [rhea][48]                           | `>=1`     | Fully supported |                                                        |
 
 ### SDK compatibility
 
@@ -258,3 +260,5 @@ For additional information or to discuss [leave a comment on this github issue][
 [64]: https://github.com/openai/openai-node
 [65]: https://github.com/dotansimha/graphql-yoga
 [66]: https://js.langchain.com/
+[67]: https://www.npmjs.com/package/@confluentinc/kafka-javascript
+[67]: https://www.npmjs.com/package/@azure/service-bus


### PR DESCRIPTION
### What does this PR do? What is the motivation?
- adds two recently supported node.js integrations

### Merge instructions

- no PR dependencies, the referenced integrations are already publicly available

Merge readiness:
- [x] Ready for merge
