### PR TITLE
Remove intake-v2.synthetics.datadoghq.com from PL docs

### DIFF
--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -114,7 +114,6 @@ To pull test configurations and push test results, the private location worker n
 | Port | Endpoint                               | Description                                                   |
 | ---- | -------------------------------------- | ------------------------------------------------------------- |
 | 443  | `intake.synthetics.datadoghq.com`      | Used by the private location to pull test configurations and push test results to Datadog using an in-house protocol based on [AWS Signature Version 4 protocol][1]. |
-| 443  | `intake-v2.synthetics.datadoghq.com` for versions >=0.2.0 and <=1.4.0   | Used by the private location to push browser test artifacts such as screenshots, errors, and resources.       |
 
 [1]: https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html
 


### PR DESCRIPTION
Remove intake-v2.synthetics.datadoghq.com for versions >=0.2.0 and <=1.4.0 from synthetics documentation.

The intake is no longer valid as-of Nov 2020, per PL changelog:
"Use a single endpoint for all requests to Datadog (deprecate https://intake-v2.synthetics.${site})"