### PR TITLE
[DOCSENG-142]: Add a11y to Algolia search feature

### DIFF
--- a/assets/scripts/components/instantsearch.js
+++ b/assets/scripts/components/instantsearch.js
@@ -341,16 +341,14 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
     }
     
     const handleSearchbarKeydown = (e) => {
-        const code = e.code;
         // Only handle navigation and selection keys; exit early for all others
-        if (!['ArrowDown', 'ArrowUp', 'Enter'].includes(code)) return;
+        if (!['ArrowDown', 'ArrowUp', 'Enter'].includes(e.code)) return;
 
         e.preventDefault();
         const searchResultItems = getVisibleSearchResultItems();
         const currentSelectedIndex = Array.from(searchResultItems).findIndex((item) => item.classList.contains('selected-item'));
 
         if (e.code === 'Enter') {
-            console.log("debug: currentSelectedIndex",currentSelectedIndex);
             const link = searchResultItems[currentSelectedIndex]?.querySelector('a[href]');
             if (link?.href) {
                 return navigateToUrl(link.href);
@@ -362,8 +360,7 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
             setTimeout(() => {
                 window.location.pathname = searchPathname;
             }, 500);
-        }
-        if (e.code === 'ArrowDown') {
+        } else if (e.code === 'ArrowDown') {
             if (searchResultItems.length === 0) {
                 return;
             }
@@ -375,7 +372,7 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
                 searchResultItems[currentSelectedIndex + 1].classList.add('selected-item');
             }
         }
-        if (e.code === 'ArrowUp') {
+        else if (e.code === 'ArrowUp') {
             if (currentSelectedIndex > 0) {
                 searchResultItems[currentSelectedIndex].classList.remove('selected-item');
                 searchResultItems[currentSelectedIndex - 1].classList.add('selected-item');

--- a/assets/scripts/components/instantsearch.js
+++ b/assets/scripts/components/instantsearch.js
@@ -335,16 +335,55 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
             aisSearchBoxInput.blur();
         }
     };
+
+    const getVisibleSearchResultItems = () => {
+        return Array.from(document.querySelectorAll('#hits:not(.no-hits) .ais-Hits-item:not(.ais-Hits-category), #hits-partners:not(.no-hits) .ais-Hits-item:not(.ais-Hits-category)'));
+    }
     
     const handleSearchbarKeydown = (e) => {
+        const code = e.code;
+        // Only handle navigation and selection keys; exit early for all others
+        if (!['ArrowDown', 'ArrowUp', 'Enter'].includes(code)) return;
+
+        e.preventDefault();
+        const searchResultItems = getVisibleSearchResultItems();
+        const currentSelectedIndex = Array.from(searchResultItems).findIndex((item) => item.classList.contains('selected-item'));
+
         if (e.code === 'Enter') {
-            e.preventDefault();
+            console.log("debug: currentSelectedIndex",currentSelectedIndex);
+            const link = searchResultItems[currentSelectedIndex]?.querySelector('a[href]');
+            if (link?.href) {
+                return navigateToUrl(link.href);
+            }
+
             sendSearchRumAction(search.helper.state.query);
 
             // Give query-url sync 500ms to update
             setTimeout(() => {
                 window.location.pathname = searchPathname;
             }, 500);
+        }
+        if (e.code === 'ArrowDown') {
+            if (searchResultItems.length === 0) {
+                return;
+            }
+            if (currentSelectedIndex === -1) {
+                // No item is currently selected, select the first one
+                searchResultItems[0].classList.add('selected-item');
+            } else if (currentSelectedIndex < searchResultItems.length - 1) {
+                searchResultItems[currentSelectedIndex].classList.remove('selected-item');
+                searchResultItems[currentSelectedIndex + 1].classList.add('selected-item');
+            }
+        }
+        if (e.code === 'ArrowUp') {
+            if (currentSelectedIndex > 0) {
+                searchResultItems[currentSelectedIndex].classList.remove('selected-item');
+                searchResultItems[currentSelectedIndex - 1].classList.add('selected-item');
+            } else if (currentSelectedIndex === 0) {
+                // If it's the first item, move focus to input
+                searchResultItems[currentSelectedIndex].classList.remove('selected-item');
+                aisSearchBoxInput.focus();
+            }
         }
     };
 

--- a/assets/styles/instantsearch/searchbar-with-dropdown.scss
+++ b/assets/styles/instantsearch/searchbar-with-dropdown.scss
@@ -132,6 +132,8 @@
             & a {
                 outline: 2px solid #0196ed5c;
                 outline-radius: 3px;
+                background-color: rgba(69, 142, 225, 0.05);
+
             }
         }
 

--- a/assets/styles/instantsearch/searchbar-with-dropdown.scss
+++ b/assets/styles/instantsearch/searchbar-with-dropdown.scss
@@ -127,6 +127,13 @@
                 background-color: rgba(69, 142, 225, 0.05);
             }
         }
+        
+        &.selected-item {
+            & a {
+                outline: 2px solid #0196ed5c;
+                outline-radius: 3px;
+            }
+        }
 
         & .ais-Hits-subcategory {
             grid-column: span 1 / span 1;


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR add a11y to search bar, by allowing `up` and `down` + quick nav to targets .

https://datadoghq.atlassian.net/browse/DOCSENG-142
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->
### Preview : https://docs-staging.datadoghq.com/reda.elissati/docseng-142-improve-a11y/
