### PR TITLE
(maint) Fix policy links

### DIFF
--- a/.github/workflows/bump-private-action-runner-version.yml
+++ b/.github/workflows/bump-private-action-runner-version.yml
@@ -17,7 +17,7 @@ jobs:
         id: octo-sts
         with:
           scope: DataDog/documentation
-          policy: self.bump-private-action-runner-version.create-pr.sts.yaml
+          policy: self.bump-private-action-runner-version.create-pr
         
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:

--- a/.github/workflows/bump_synthetics_worker_version.yml
+++ b/.github/workflows/bump_synthetics_worker_version.yml
@@ -17,7 +17,7 @@ jobs:
         id: octo-sts
         with:
           scope: DataDog/documentation
-          policy: self.bump-synthetics-worker-version.create-pr.sts.yaml
+          policy: self.bump-synthetics-worker-version.create-pr
         
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:


### PR DESCRIPTION
It looks like the links to the policies shouldn't include the suffixes 
