### PR TITLE
Update GitHub links for datadog-ci sourcemaps

### DIFF
--- a/content/en/error_tracking/frontend/browser.md
+++ b/content/en/error_tracking/frontend/browser.md
@@ -4,7 +4,7 @@ aliases:
 - /real_user_monitoring/error_tracking/browser_errors
 - /error_tracking/standalone_frontend/browser
 further_reading:
-- link: "https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps"
+- link: "https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps"
   tag: "Source Code"
   text: "datadog-ci Source code"
 - link: "/real_user_monitoring/guide/upload-javascript-source-maps"
@@ -175,7 +175,7 @@ In addition to sending source maps, the [Datadog CLI][11] reports Git informatio
 
 Error Tracking can use this information to correlate errors with your [source code][15], allowing you to pivot from any stack trace frame to the related line of code in [GitHub][12], [GitLab][13] and [Bitbucket][14].
 
-<div class="alert alert-info">Linking from stack frames to source code is supported in the <a href="https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command">Datadog CLI</a> version <code>0.12.0</code> and later.</div>
+<div class="alert alert-info">Linking from stack frames to source code is supported in the <a href="https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command">Datadog CLI</a> version <code>0.12.0</code> and later.</div>
 
 For more information, see the [Datadog Source Code Integration][15].
 
@@ -224,7 +224,7 @@ You can monitor unhandled exceptions, unhandled promise rejections, handled exce
 [8]: /real_user_monitoring/platform/dashboards/errors/
 [9]: https://datadoghq.dev/browser-sdk/interfaces/_datadog_browser-rum.RumInitConfiguration.html
 [10]: /real_user_monitoring/session_replay/browser/privacy_options#mask-action-names
-[11]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command
+[11]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command
 [12]: https://github.com
 [13]: https://about.gitlab.com
 [14]: https://bitbucket.org/product

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -8,7 +8,7 @@ further_reading:
 - link: '/real_user_monitoring/error_tracking/explorer'
   tag: 'Documentation'
   text: 'Visualize your Error Tracking data in the Explorer'
-- link: 'https://github.com/DataDog/datadog-ci/tree/457d25821e838db9067dbe376d0f34fb1a197869/src/commands/sourcemaps'
+- link: 'https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command'
   tag: 'Source Code'
   text: 'Sourcemaps command reference'
 ---

--- a/content/es/error_tracking/frontend/browser.md
+++ b/content/es/error_tracking/frontend/browser.md
@@ -3,7 +3,7 @@ aliases:
 - /es/real_user_monitoring/error_tracking/browser_errors
 - /es/error_tracking/standalone_frontend/browser
 further_reading:
-- link: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+- link: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command
   tag: Código fuente
   text: Código fuente de datadog-ci
 - link: /real_user_monitoring/guide/upload-javascript-source-maps
@@ -33,7 +33,7 @@ Además de enviar mapas de fuente, la [CLI de Datadog][10] reporta información 
 
 Error Tracking puede utilizar esta información para correlacionar los errores con tu código fuente, lo que te permite pivotar desde cualquier marco del stack trace a la línea de código relacionada en [GitHub][11], [GitLab][12] y [Bitbucket][13].
 
-<div class="alert alert-info">La vinculación de los marcos de stack tecnológico con el código fuente es compatible con la versión <a href="https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command">0.12.0</a> y posteriores de la <code>CLI de Datadog</code>.</div>
+<div class="alert alert-info">La vinculación de los marcos de stack tecnológico con el código fuente es compatible con la versión <a href="https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command">0.12.0</a> y posteriores de la <code>CLI de Datadog</code>.</div>
 
 Para obtener más información, consulta [Integración de código fuente en Datadog][14].
 
@@ -63,7 +63,7 @@ Puedes monitorizar excepciones no gestionadas, rechazos de promesas no gestionad
 [7]: https://www.npmjs.com/package/@datadog/browser-rum
 [8]: /es/real_user_monitoring/browser/setup/#initialization-parameters
 [9]: /es/real_user_monitoring/guide/upload-javascript-source-maps
-[10]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command
+[10]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command
 [11]: https://github.com
 [12]: https://about.gitlab.com
 [13]: https://bitbucket.org/product

--- a/content/es/real_user_monitoring/error_tracking/browser.md
+++ b/content/es/real_user_monitoring/error_tracking/browser.md
@@ -2,7 +2,7 @@
 aliases:
 - /es/real_user_monitoring/error_tracking/browser_errors
 further_reading:
-- link: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+- link: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps
   tag: Código fuente
   text: Código fuente datadog-ci
 - link: /real_user_monitoring/guide/upload-javascript-source-maps
@@ -32,7 +32,7 @@ Además de enviar mapas de origen, la [CLI de Datadog][10] proporciona informaci
 
 El Seguimiento de errores puede utilizar esta información para correlacionar los errores con tu código fuente. Esto te permite cambiar desde cualquier marco de traza de stack tecnológico a la línea de código relacionada en [GitHub][11], [GitLab][12] y [Bitbucket][13]. 
 
-<div class="alert alert-info">La vinculación de los marcos de stack tecnológico con el código fuente es compatible con la versión <a href="https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command">0.12.0</a> y posteriores de la <code>CLI de Datadog</code>.</div>
+<div class="alert alert-info">La vinculación de los marcos de stack tecnológico con el código fuente es compatible con la versión <a href="https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command">0.12.0</a> y posteriores de la <code>CLI de Datadog</code>.</div>
 
 Para obtener más información, consulta [Integración de código fuente en Datadog][14].
 
@@ -155,7 +155,7 @@ probar {
 [7]: https://www.npmjs.com/package/@datadog/browser-rum
 [8]: /es/real_user_monitoring/browser/setup/#initialization-parameters
 [9]: /es/real_user_monitoring/guide/upload-javascript-source-maps
-[10]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command
+[10]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command
 [11]: https://github.com
 [12]: https://about.gitlab.com
 [13]: https://bitbucket.org/product

--- a/content/es/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/es/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -6,7 +6,7 @@ further_reading:
 - link: /real_user_monitoring/error_tracking/explorer
   tag: Documentación
   text: Visualización de tus datos de rastreo de errores en el Explorer
-- link: https://github.com/DataDog/datadog-ci/tree/457d25821e838db9067dbe376d0f34fb1a197869/src/commands/sourcemaps
+- link: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps
   tag: Código fuente
   text: Referencia del comando Sourcemaps
 title: Carga de mapas de fuente de JavaScript
@@ -157,7 +157,7 @@ Por otro lado, un stack trace sin minificar te proporciona todo el contexto que 
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+[1]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps
 [2]: https://docs.datadoghq.com/es/real_user_monitoring/browser/setup/#initialization-parameters
 [3]: https://docs.datadoghq.com/es/logs/log_collection/javascript/#initialization-parameters
-[4]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#link-errors-with-your-source-code
+[4]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#link-errors-with-your-source-code

--- a/content/fr/real_user_monitoring/error_tracking/browser.md
+++ b/content/fr/real_user_monitoring/error_tracking/browser.md
@@ -2,7 +2,7 @@
 aliases:
 - /fr/real_user_monitoring/error_tracking/browser_errors
 further_reading:
-- link: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+- link: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps
   tag: GitHub
   text: Code source datadog-ci
 - link: /real_user_monitoring/guide/upload-javascript-source-maps
@@ -36,7 +36,7 @@ Le suivi des erreurs et la solution RUM peuvent utiliser ces informations pour c
 
 {{< img src="real_user_monitoring/error_tracking/link_to_git_js_example.mp4" alt="Associer le frame d'une stack trace au code source" video=true >}}
 
-<div class="alert alert-info">L'association des frames de stack trace au code source est prise en charge par la version <code>0.12.0</code> et les versions ultérieurs de l'<a href="https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command">interface de ligne de commande Datadog</a>.</div>
+<div class="alert alert-info">L'association des frames de stack trace au code source est prise en charge par la version <code>0.12.0</code> et les versions ultérieurs de l'<a href="https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command">interface de ligne de commande Datadog</a>.</div>
 
 Pour en savoir plus, consultez la section [Datadog Source Code Integration][13] (en anglais).
 
@@ -52,7 +52,7 @@ Pour en savoir plus, consultez la section [Datadog Source Code Integration][13] 
 [6]: https://www.npmjs.com/package/@datadog/browser-rum
 [7]: /fr/real_user_monitoring/browser/#initialization-parameters
 [8]: /fr/real_user_monitoring/guide/upload-javascript-source-maps
-[9]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command
+[9]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command
 [10]: https://github.com
 [11]: https://about.gitlab.com
 [12]: https://bitbucket.org/product

--- a/content/fr/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/fr/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -166,7 +166,7 @@ L'exemple suivant représente une stack trace minifiée :
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+[1]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps
 [2]: https://docs.datadoghq.com/fr/real_user_monitoring/browser/#initialization-parameters
 [3]: https://docs.datadoghq.com/fr/logs/log_collection/javascript/#initialization-parameters
-[4]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#link-errors-with-your-source-code
+[4]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#link-errors-with-your-source-code

--- a/content/ja/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/ja/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -6,7 +6,7 @@ further_reading:
 - link: /real_user_monitoring/error_tracking/explorer
   tag: Documentation
   text: エクスプローラーでエラー追跡データを視覚化する
-- link: https://github.com/DataDog/datadog-ci/tree/457d25821e838db9067dbe376d0f34fb1a197869/src/commands/sourcemaps
+- link: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps
   tag: ソースコード
   text: ソースマップのコマンドリファレンス
 title: JavaScript ソースマップのアップロード

--- a/content/ja/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/ja/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -167,7 +167,7 @@ Datadog は、縮小化を解除されたスタックフレームにソースコ
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+[1]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps
 [2]: https://docs.datadoghq.com/ja/real_user_monitoring/browser/setup/#initialization-parameters
 [3]: https://docs.datadoghq.com/ja/logs/log_collection/javascript/#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#link-errors-with-your-source-code

--- a/content/ko/real_user_monitoring/error_tracking/browser.md
+++ b/content/ko/real_user_monitoring/error_tracking/browser.md
@@ -2,7 +2,7 @@
 aliases:
 - /ko/real_user_monitoring/error_tracking/browser_errors
 further_reading:
-- link: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps
+- link: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps
   tag: GitHub
   text: datadog-ci Source code
 - link: /real_user_monitoring/guide/upload-javascript-source-maps
@@ -36,7 +36,7 @@ Browser SDK를 아직 설정하지 않은 경우 [인앱 설정 지침][4]을 �
 
 {{< img src="real_user_monitoring/error_tracking/link_to_git_js_example.mp4" alt="스택 프레임에서 소스 코드에 링크하기" video=true >}}
 
-<div class="alert alert-info">스택 프레임에서 소스 코드로의 연결은 <a href="https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command">Datadog CLI</a> 버전 <code>0.12.0</code> 이상에서 지원됩니다.</div>
+<div class="alert alert-info">스택 프레임에서 소스 코드로의 연결은 <a href="https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command">Datadog CLI</a> 버전 <code>0.12.0</code> 이상에서 지원됩니다.</div>
 
 자세한 내용은 [Datadog 소스 코드 통합][13]을 참조하세요.
 
@@ -52,7 +52,7 @@ Browser SDK를 아직 설정하지 않은 경우 [인앱 설정 지침][4]을 �
 [6]: https://www.npmjs.com/package/@datadog/browser-rum
 [7]: /ko/real_user_monitoring/browser/#initialization-parameters
 [8]: /ko/real_user_monitoring/guide/upload-javascript-source-maps
-[9]: https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#sourcemaps-command
+[9]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#sourcemaps-command
 [10]: https://github.com
 [11]: https://about.gitlab.com
 [12]: https://bitbucket.org/product


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Changes to the datadog-ci repository have caused some links to become broken. This PR updates the path in the URL to be correct

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
