### PR TITLE
[ACTP] use a placeholder for the custom PAR image in script

### DIFF
--- a/content/en/actions/private_actions/run_script.md
+++ b/content/en/actions/private_actions/run_script.md
@@ -104,8 +104,8 @@ You can mount complex scripts inside the runner:
 # docker-compose example
 services:
   runner:
-    image: gcr.io/datadoghq/private-action-runner:v{{< private-action-runner-version "private-action-runner" >}}
-    # build: . # if you are using a custom Dockerfile
+    build: . # if you are using a local Dockerfile
+    # image: <your_custom_published_image> # if you published your image to a registry
     volumes:
       - "./config:/etc/dd-action-runner/config"
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

@merchristK made the observation that this section explains how to use a custom image so customers should not use the default image in this context.
So using a placeholder as the image because customers would need to fill it with their own image

Also using the local `Dockerfile` as the default as it is easier to use

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
