### PR TITLE
Add Datastore Automation Rules

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -2853,6 +2853,21 @@ menu:
       parent: actions_heading
       identifier: datastore
       weight: 40000
+    - name: Create and Manage Datastores
+      url: actions/datastore/create/
+      parent: datastore
+      identifier: create
+      weight: 1
+    - name: Use Datastores with Apps and Workflows
+      url: actions/datastore/use
+      parent: datastore
+      identifier: use
+      weight: 2
+    - name: Access and Authentication
+      url: actions/datastore/auth
+      parent: datastore
+      identifier: auth
+      weight: 3
     - name: Action Catalog
       url: actions/actions_catalog/
       pre: books

--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -2863,11 +2863,16 @@ menu:
       parent: datastore
       identifier: use
       weight: 2
+    - name: Use Automation Rules
+      url: actions/datastore/trigger
+      parent: datastore
+      identifier: trigger
+      weight: 3
     - name: Access and Authentication
       url: actions/datastore/auth
       parent: datastore
       identifier: auth
-      weight: 3
+      weight: 4
     - name: Action Catalog
       url: actions/actions_catalog/
       pre: books

--- a/content/en/actions/datastore/auth.md
+++ b/content/en/actions/datastore/auth.md
@@ -13,12 +13,12 @@ further_reading:
 
 ## Required Datadog role permissions
 
-To interact with the Actions Datastore, your Datadog account must have the following [permissions][1], which are included in the Datadog Standard Role:
+To interact with Datastores, your Datadog account must have the following [permissions][1], which are included in the Datadog Standard Role:
 
 * `actions_datastore_read` - Allows read access to the data within the Actions Datastore.
 * `actions_datastore_write` - Allows modification of data within the Actions Datastore, including adding, editing, and deleting records.
 
-To use the [Actions Datastore UI][2], you also need the following permission, which is also included in the Datadog Standard Role:
+To use the [Datastores UI][2], you also need the following permission, which is also included in the Datadog Standard Role:
 
 * `actions_datastore_manage` - Allows management of the Actions Datastore, including creating, updating, and deleting the datastore itself.
 

--- a/content/en/actions/datastore/auth.md
+++ b/content/en/actions/datastore/auth.md
@@ -47,7 +47,7 @@ None
 During the datastore creation process, you're asked to set the organization access level for the datastore. You can choose either `Contributor`, `Viewer`, or `None`. Contributor is the default access level.
 
 To restrict access to an existing datastore for either an organization or individual:
-1. Hover over the datastore on the [Datastore page][6] and click the padlock (**Permissions**) icon.
+1. Hover over the datastore on the [Datastores page][6] and click the padlock (**Permissions**) icon.
 1. Use the drop-down menus to edit the permissions for a user or organization.
 1. Click **Save**.
 
@@ -56,7 +56,7 @@ To restrict access to an existing datastore for either an organization or indivi
 The `user_access_manage` [permission][1] is required to elevate your access to datastores.
 
 To elevate your access:
-1. Hover over the datastore on the [Datastore page][6] and click the padlock (**Permissions**) icon.
+1. Hover over the datastore on the [Datastores page][6] and click the padlock (**Permissions**) icon.
 1. Click **Elevate Access**.
 1. Click **Save**.
 
@@ -65,8 +65,8 @@ To elevate your access:
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /account_management/rbac/permissions/?tab=ui#app-builder--workflow-automation
-[2]: https://app.datadoghq.com/app-builder/datastore
+[2]: https://app.datadoghq.com/actions/datastores
 [3]: /actions/workflows
 [4]: /actions/app_builder
 [5]: /service_management/app_builder/connections/
-[6]: https://app.datadoghq.com/app-builder/datastore
+[6]: https://app.datadoghq.com/actions/datastores

--- a/content/en/actions/datastore/create.md
+++ b/content/en/actions/datastore/create.md
@@ -51,7 +51,7 @@ You can create a datastore from an app or workflow by clicking the **Datastore I
 
 To manually edit a row in your datastore:
 1. On the [Datastores page][1], locate your datastore and click to open it.
-1. Hover over the row you want to change and click the pencil (**Edit**) icon.
+1. Hover over the row you want to change and click the **Edit** {{< img src="icons/pencil.png" inline="true" style="width:14px;">}} icon.
 1. Use the **JSON** or **Raw text** tabs to edit keys in the row.
 
 **Note:** You cannot manually edit the primary key in a row. If you need to edit a primary key, delete the row and re-add it or re-upload the data from a file.

--- a/content/en/actions/datastore/create.md
+++ b/content/en/actions/datastore/create.md
@@ -18,13 +18,13 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-You can create and manage datastores from the [Datastore page][1].
+You can create and manage datastores from the [Datastores][1].
 
 ## Create a datastore
 
 To create a datastore:
 
-1. Navigate to the [Datastore page][1].
+1. Navigate to the [Datastores page][1].
 1. Click **+ New Datastore**.
 1. Enter a **Name** for your datastore.
 1. Enter a **Primary Key** or toggle the option to **Autogenerate a Primary Key** if a primary key is not essential to your use case.
@@ -50,7 +50,7 @@ You can create a datastore from an app or workflow by clicking the **Datastore I
 ### Manually edit your data
 
 To manually edit a row in your datastore:
-1. On the [Datastore page][1], locate your datastore and click to open it.
+1. On the [Datastores page][1], locate your datastore and click to open it.
 1. Hover over the row you want to change and click the pencil (**Edit**) icon.
 1. Use the **JSON** or **Raw text** tabs to edit keys in the row.
 
@@ -59,7 +59,7 @@ To manually edit a row in your datastore:
 ### Update using a file
 
 To update a datastore using a file:
-1. On the [Datastore page][1], locate your datastore and click to open it.
+1. On the [Datastores page][1], locate your datastore and click to open it.
 1. Click **Add Data**.
 1. Select an option for how your data should be handled.
    - **Overwrite** replaces existing rows in your table with the data for your file.
@@ -68,7 +68,7 @@ To update a datastore using a file:
 
 ## View a datastore
 
-To view a datastore, locate your datastore on the [Datastore page][1] and click to open it.
+To view a datastore, locate your datastore on the [Datastores page][1] and click to open it.
 
 After you've opened a datastore, you can:
 - Export the dataset to a JSON or CSV file.
@@ -98,7 +98,7 @@ Reach out to [support][5] if you have a use case that exceeds these limits.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/app-builder/datastore
+[1]: https://app.datadoghq.com/actions/datastores
 [2]: /actions/datastore/use#create-workflow-app
 [3]: /actions/datastore/auth/
 [4]: /actions/datastore/use#multiple-datastores

--- a/content/en/actions/datastore/create.md
+++ b/content/en/actions/datastore/create.md
@@ -18,7 +18,7 @@ further_reading:
 <div class="alert alert-warning">App Builder is not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
-You can create and manage datastores from the [Datastores][1].
+You can create and manage datastores from the [Datastores page][1].
 
 ## Create a datastore
 

--- a/content/en/actions/datastore/trigger.md
+++ b/content/en/actions/datastore/trigger.md
@@ -17,7 +17,7 @@ You can add workflows to your datastores that automatically trigger when records
 ## Create a new automation rule
 
 To create a new automation rule: 
-1. Navigate to [Datastores][1].
+1. Navigate to [Datastores page][1].
 1. Select a datastore. 
 1. Click **Automation Rules**, then **+ New Automation Rule**. 
 1. Configure your new automation rule: 

--- a/content/en/actions/datastore/trigger.md
+++ b/content/en/actions/datastore/trigger.md
@@ -1,0 +1,54 @@
+---
+title: Use Automation Rules 
+description: Reduce manual effort by triggering workflows automatically when datastore records are created, updated, or change status. 
+disable_toc: false
+further_reading:
+- link: "https://www.datadoghq.com/blog/datadog-datastore/"
+  tag: "Blog"
+  text: "Enhance your automated workflows and apps with Datastore"
+---
+
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Datastores are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+You can add workflows to your datastores that automatically trigger when records are created, updated, or change status.
+
+## Create a new automation rule
+
+To create a new automation rule: 
+1. Navigate to [Datastores][1].
+1. Select a datastore. 
+1. Click **Automation Rules**, then **+ New Automation Rule**. 
+1. Configure your new automation rule: 
+    1. Choose if the rule will be triggered when a new entry is added, a value has changed, or an entry is deleted.
+    1. Choose the workflow that will be triggered when the event occurs. 
+    1. Name your rule. 
+1. Click **Save**.
+
+## Edit an automation rule 
+
+To edit an automation rule: 
+1. Navigate to [Datastores][1].
+1. Select a datastore. 
+1. Click **Automation Rules**, then **+ New Automation Rule**. 
+1. Click the **Edit** {{< img src="icons/pencil.png" inline="true" style="width:14px;">}} icon.
+1. Make your changes. 
+1. Click **Save Changes**.
+
+## Delete an automation rule
+
+To delete an automation rule: 
+1. Navigate to [Datastores][1].
+1. Select a datastore. 
+1. Click **Automation Rules**, then **+ New Automation Rule**. 
+1. Click the **Delete** {{< img src="icons/delete.png" inline="true" style="width:14px;">}} icon. 
+1. _Are you sure?_ will appear in the Datadog UI.
+1. Click **Delete**.
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+
+[1]: https://app.datadoghq.com/actions/datastores

--- a/content/en/actions/datastore/trigger.md
+++ b/content/en/actions/datastore/trigger.md
@@ -17,7 +17,7 @@ You can add workflows to your datastores that automatically trigger when records
 ## Create a new automation rule
 
 To create a new automation rule: 
-1. Navigate to [Datastores page][1].
+1. Navigate to the [Datastores page][1].
 1. Select a datastore. 
 1. Click **Automation Rules**, then **+ New Automation Rule**. 
 1. Configure your new automation rule: 
@@ -29,7 +29,7 @@ To create a new automation rule:
 ## Edit an automation rule 
 
 To edit an automation rule: 
-1. Navigate to [Datastores][1].
+1. Navigate to the [Datastores page][1].
 1. Select a datastore. 
 1. Click **Automation Rules**, then **+ New Automation Rule**. 
 1. Click the **Edit** {{< img src="icons/pencil.png" inline="true" style="width:14px;">}} icon.
@@ -39,7 +39,7 @@ To edit an automation rule:
 ## Delete an automation rule
 
 To delete an automation rule: 
-1. Navigate to [Datastores][1].
+1. Navigate to the [Datastores page][1].
 1. Select a datastore. 
 1. Click **Automation Rules**, then **+ New Automation Rule**. 
 1. Click the **Delete** {{< img src="icons/delete.png" inline="true" style="width:14px;">}} icon. 

--- a/content/en/actions/datastore/use.md
+++ b/content/en/actions/datastore/use.md
@@ -29,7 +29,7 @@ You can get started with a workflow or app directly from a datastore. Each time 
 ### Workflow Automation
 
 To create a workflow from a datastore:
-1. On the [Datastore page][1], locate your datastore in the list and click to open it.
+1. On the [Datastores page][1], locate your datastore in the list and click to open it.
 1. Click **Create** > **Workflow from Datastore**.
 
 Datadog creates a workflow with a **List items** workflow step prepopulated with your datastore ID. From here, follow the [Workflow Automation][2] documentation to build your workflow. For a list of available datastore actions, see the [Action Catalog][4].
@@ -37,7 +37,7 @@ Datadog creates a workflow with a **List items** workflow step prepopulated with
 ### App Builder
 
 To create an app from a datastore:
-1. On the [Datastore page][1], locate your datastore in the list and click to open it.
+1. On the [Datastores page][1], locate your datastore in the list and click to open it.
 1. Click **Create** > **App from Datastore**.
 
 Datadog creates an app prepopulated with your datastore ID. From here, follow the [App Builder][3] documentation to build your app. For a list of available datastore actions, see the [Action Catalog][4].
@@ -82,7 +82,7 @@ The table uses the output from the List Items action to display the data from th
 ### Retrieve a UUID
 
 To retrieve the UUID for a datastore:
-1. On the [Datastore page][1], locate your datastore in the list and click to open it.
+1. On the [Datastores page][1], locate your datastore in the list and click to open it.
 1. Click **Table Options** > **Copy datastore UUID**.
 
 ## Use a datastore in a workflow {#use-workflow}
@@ -106,7 +106,7 @@ You can use a workflow to update a Datastore with Terraform by following these s
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://app.datadoghq.com/app-builder/datastore
+[1]: https://app.datadoghq.com/actions/datastores
 [2]: /actions/workflows/build/
 [3]: /actions/app_builder/build/
 [4]: /actions/actions_catalog/#datadog-actions-datastore


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR: 
- creates a new page for Datastore Automation Rules under Datastores in the docs.
- in other Datastore pages, fixes broken links as a result of UI changes.
- makes existing Datastore pages visible in the side nav. 

### Merge instructions

Merge readiness:
- [ ] Ready for merge

