### PR TITLE
Modify git provider sections on SAST/SCA setup pages

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/_index.md
@@ -30,7 +30,7 @@ SCA supports both static and runtime dependency detection:
 
 ## Search and filter results
 ### Vulnerabilities explorer
-The [Vulnerabilities][11] explorer provides a vulnerability-centric view of library vulnerabilities detected by SCA, alongside vulnerabilities detected by other Code Security capabilities (SAST and IAST). All vulnerabilities shown in this explorer are detected on the default branch and the last commit of a scanned repository and/or affecting a running service.
+The [Vulnerabilities][11] explorer provides a vulnerability-centric view of library vulnerabilities detected by SCA, alongside vulnerabilities detected by other Code Security capabilities (SAST and IAST). All vulnerabilities shown in this explorer are detected on the **default branch** and the last commit of a scanned repository and/or **affecting a running service**.
 
 ### Datadog severity score
 Each vulnerability has a defined base severity score. To assist in prioritizing remediation, Datadog modifies the base CVSS score into the Datadog Severity Score by considering evidence of suspicious requests or attacks, the business sensitivity or internet exposure of the environment, and the risk of a successful exploit.
@@ -72,7 +72,7 @@ SCA enriches the information Application Performance Monitoring (APM) is already
 - Software supply chain & Software Bill of Materials (SBOM) management
 
 
-### Vulnerabilities lifecycle
+### Vulnerability lifecycle
 Vulnerabilities detected in libraries by SCA **at runtime** are closed by Datadog after a certain period, depending on the service's usage of the vulnerable library.
 
 - **Hot Libraries:**

--- a/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -11,61 +11,13 @@ aliases:
 
 Datadog Software Composition Analysis (SCA) scans your repositories for open-source libraries and detects known security vulnerabilities before you ship to production.
 
-**Supported languages:** C#, Go, Java, JavaScript, PHP, Python, Ruby
-
 To get started:
 1. Open [Code Security settings][2].
 2. In **Activate scanning for your repositories**, click **Manage Repositories**.
 3. Choose [where to run SCA scans](#select-where-to-run-static-sca-scans) (Datadog-hosted or CI pipelines).
 4. Follow the setup instructions for your source code provider.
 
-The sections below cover the different ways to configure SCA for your repositories.
-
-## Select where to run static SCA scans
-
-You can run SCA scans in two ways:
-
-- **Datadog-hosted:** For GitHub repositories (except those using [Git Large File Storage](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage)).
-- **CI Pipelines:** For other providers (GitHub, GitLab, Azure DevOps).
-
-{{< tabs >}}
-{{% tab "Datadog" %}}
-**Analyze code directly in Datadog**
-
-For GitHub repositories, you can run Datadog SCA scans directly on Datadog infrastructure. To get started, navigate to [Code Security settings][1].
-
-[1]: https://app.datadoghq.com/security/configuration/code-security/setup
-
-<div class="alert alert-info">
-Datadog-hosted SCA does not support repositories that:<br>
-- Use <a href="https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage">Git Large File Storage</a><br>
-- Contain file paths with parent directory traversal (<code>..</code>)<br>
-- Contain file names longer than 255 characters<br>
-Use CI Pipelines for these repositories.
-</div>
-
-{{% /tab %}}
-{{% tab "CI Pipelines" %}}
-**Analyze code in your CI Pipelines**
-
-Run SCA by following instructions for your chosen CI provider below. Datadog SCA offers native support for:
-- [Github][1]
-- [Azure DevOps][2]
-- [Gitlab][3]
-- [Others][4] (via CLI)
-
-You **must** scan your default branch at least once before results appear in Datadog **Code Security**.
-
-[1]: /security/code_security/software_composition_analysis/setup_static/?tab=github#select-your-source-code-management-provider
-[2]: /security/code_security/software_composition_analysis/setup_static/?tab=azuredevops#select-your-source-code-management-provider
-[3]: /security/code_security/software_composition_analysis/setup_static/?tab=gitlab#select-your-source-code-management-provider
-[4]: /security/code_security/software_composition_analysis/setup_static/?tab=other#select-your-source-code-management-provider
-
-{{% /tab %}}
-{{< /tabs >}}
-
-## Run SCA scans in your CI Pipelines
-
+### Supported languages and lockfiles
 Datadog SCA scans libraries in the following languages and **requires** a lockfile to report them:
 
 | Language   | Package Manager    | Lockfile                                |
@@ -85,15 +37,42 @@ Datadog SCA scans libraries in the following languages and **requires** a lockfi
 | Python     | poetry            | `poetry.lock`                            |
 | Python     | UV                | `uv.lock`                                |
 | Ruby       | bundler           | `Gemfile.lock`                           |
-| Rust       | Cargo             | `cargo.lock`                             |
 
-### Select your source code management provider
+The sections below cover the different ways to configure SCA for your repositories.
+
+## Select where to run static SCA scans
+
+### Scan with Datadog-hosted scanning
+
+You can run Datadog Static Code Analysis scans directly on Datadog's infrastructure. This is supported for:
+- [GitHub repositories](/security/code_security/software_composition_analysis/setup_static/?tab=github#select-your-source-code-management-provider)
+- [GitLab.com and Self-Managed repositories](/security/code_security/software_composition_analysis/setup_static/?tab=gitlab#select-your-source-code-management-provider)
+- [Azure DevOps repositories](/security/code_security/software_composition_analysis/setup_static/?tab=azuredevops#select-your-source-code-management-provider)
+
+To get started, navigate to the [**Code Security** page](https://app.datadoghq.com/security/configuration/code-security/setup).
+
+<div class="alert alert-info">
+Datadog-hosted scanning for SCA does not support repositories that:<br>
+- Use <a href="https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage">Git Large File Storage</a><br>
+- Contain file paths with parent directory traversal (<code>..</code>)<br>
+- Contain file names longer than 255 characters<br>
+Use CI Pipelines for these repositories.
+</div>
+
+### Scan in CI pipelines
+Datadog Static Code Analysis runs in your CI pipelines using the [`datadog-ci` CLI][8].
+
+First, configure your Datadog API and application keys. Add `DD_APP_KEY` and `DD_API_KEY` as secrets. Please ensure your Datadog application key has the `code_analysis_read` scope.
+
+You **must** scan your default branch at least once before results appear in Datadog **Code Security**.
+
+## Select your source code management provider
 Datadog SCA supports all source code management providers, with native support for GitHub, GitLab, and Azure DevOps.
 
 {{< tabs >}}
 {{% tab "GitHub" %}}
 
-If GitHub is your source code management provider, you must configure a GitHub App using the [GitHub integration tile][1] and set up the [source code integration][2] to see inline code snippets and enable [pull request comments][3].
+You must configure a GitHub App using the [GitHub integration tile][1] and set up the [source code integration][2] to see inline code snippets and enable [pull request comments][3].
 
 When installing a GitHub App, the following permissions are required to enable certain features:
 
@@ -106,13 +85,20 @@ When installing a GitHub App, the following permissions are required to enable c
 [3]: /security/code_security/dev_tool_int/github_pull_requests
 
 {{% /tab %}}
+{{% tab "GitLab" %}}
+
+See [these instructions][1] to complete the setup process to connect your GitLab instance to Datadog. Both GitLab.com and Self-Managed are supported.
+
+[1] https://docs.datadoghq.com/integrations/gitlab-source-code/#setup 
+
+{{% /tab %}}
 {{% tab "Azure DevOps" %}}
 
 <div class="alert alert-warning">
 Repositories from Azure DevOps are supported in closed Preview. Your Azure DevOps organizations must be connected to a Microsoft Entra tenant. <a href="https://www.datadoghq.com/product-preview/azure-devops-integration-code-security/">Join the Preview</a>.
 </div>
 
-If Azure DevOps is your source code management provider, before you can begin installation, you must request access to the closed Preview using the form above. After being granted access, follow the instructions below to complete the setup process.
+Before you can begin installation, you must request access to the closed Preview using the form above. After being granted access, follow the instructions below to complete the setup process.
 
 **Note:** Azure DevOps Server is not supported.
 
@@ -159,17 +145,6 @@ Click [here][4] to see our CLI that automates this process.
 [3]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: https://github.com/DataDog/azdevops-sci-hooks
 [5]: /getting_started/site/
-
-{{% /tab %}}
-{{% tab "GitLab" %}}
-
-<div class="alert alert-warning">
-Repositories from GitLab instances are supported in closed Preview. <a href="https://www.datadoghq.com/product-preview/gitlab-source-code-integration/">Join the Preview</a>.
-</div>
-
-If GitLab is your source code management provider, before you can begin installation, you must request access to the closed Preview using the form above. After being granted access, follow [these instructions][1] to complete the setup process.
-
-[1]: https://github.com/DataDog/gitlab-integration-setup
 
 {{% /tab %}}
 {{% tab "Other" %}}

--- a/content/en/security/code_security/static_analysis/setup/_index.md
+++ b/content/en/security/code_security/static_analysis/setup/_index.md
@@ -23,7 +23,12 @@ To set up Datadog SAST in-app, navigate to [**Security** > **Code Security**][1]
 
 ### Scan with Datadog-hosted scanning
 
-For GitHub repositories, you can run Datadog Static Code Analysis scans directly on Datadog's infrastructure. To get started, navigate to the [**Code Security** page][1].
+You can run Datadog Static Code Analysis scans directly on Datadog's infrastructure. This is supported for:
+- GitHub repositories (except those using [Git Large File Storage](https://docs.github.com/en/repositories/working-with-files/managing-large-files/about-git-large-file-storage))
+- GitLab.com and Self-Managed repositories
+- Azure DevOps repositories
+
+To get started, navigate to the [**Code Security** page][1].
 
 ### Scan in CI pipelines
 Datadog Static Code Analysis runs in your CI pipelines using the [`datadog-ci` CLI][8].
@@ -43,7 +48,7 @@ Datadog Static Code Analysis supports all source code management providers, with
 {{< tabs >}}
 {{% tab "GitHub" %}}
 
-If GitHub is your source code management provider, you must configure a GitHub App using the [GitHub integration tile][1] and set up the [source code integration][2] to see inline code snippets and enable [pull request comments][3].
+You must configure a GitHub App using the [GitHub integration tile][1] and set up the [source code integration][2] to see inline code snippets and enable [pull request comments][3].
 
 When installing a GitHub App, the following permissions are required to enable certain features:
 
@@ -59,13 +64,9 @@ When installing a GitHub App, the following permissions are required to enable c
 {{% /tab %}}
 {{% tab "GitLab" %}}
 
-<div class="alert alert-warning">
-Repositories from GitLab instances are supported in closed Preview. <a href="https://www.datadoghq.com/product-preview/gitlab-source-code-integration/">Join the Preview</a>.
-</div>
+See [these instructions][1] to complete the setup process to connect your GitLab instance to Datadog. Both GitLab.com and Self-Managed are supported.
 
-If GitLab is your source code management provider, before you can begin installation, you must request access to the closed Preview using the form above. After being granted access, follow [these instructions][1] to complete the setup process.
-
-[1]: https://github.com/DataDog/gitlab-integration-setup
+[1] https://docs.datadoghq.com/integrations/gitlab-source-code/#setup 
 
 {{% /tab %}}
 {{% tab "Azure DevOps" %}}
@@ -74,7 +75,7 @@ If GitLab is your source code management provider, before you can begin installa
 Repositories from Azure DevOps are supported in closed Preview. Your Azure DevOps organizations must be connected to a Microsoft Entra tenant. <a href="https://www.datadoghq.com/product-preview/azure-devops-integration-code-security/">Join the Preview</a>.
 </div>
 
-If Azure DevOps is your source code management provider, before you can begin installation, you must request access to the closed preview using the form above. After being granted access, follow the instructions below to complete the setup process.
+Before you can begin installation, you must request access to the closed preview using the form above. After being granted access, follow the instructions below to complete the setup process.
 
 **Note:** Azure DevOps Server is not supported.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
- Update docs on SAST and SCA setup pages on latest support for GitLab and Azure repositories
- Makes SAST and SCA setup sections consistent with each other

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
