### PR TITLE
feat: datadog lambda extension supports timestamped metrics

### DIFF
--- a/content/en/serverless/aws_lambda/metrics.md
+++ b/content/en/serverless/aws_lambda/metrics.md
@@ -311,7 +311,7 @@ namespace Example
 
 ### Submit historical metrics
 
-To submit historical metrics, Datadog recommends using the Datadog Lambda Extension. Historical metrics can have timestamps within the last hour.
+Use the Datadog Lambda Extension to submit historical metrics. These metrics can have timestamps up to one hour in the past.
 
 Start by [installing Serverless Monitoring for AWS Lambda][1]. Ensure that you have installed the latest Datadog Lambda Extension.
 

--- a/content/en/serverless/aws_lambda/metrics.md
+++ b/content/en/serverless/aws_lambda/metrics.md
@@ -309,13 +309,11 @@ namespace Example
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
 
-### Submit historical metrics with the Datadog Forwarder
+### Submit historical metrics
 
-In most cases, Datadog recommends that you use the Datadog Lambda extension to submit custom metrics. However, the Lambda extension can only submit metrics with a current timestamp.
+To submit historical metrics, Datadog recommends using the Datadog Lambda Extension. Historical metrics can have timestamps within the last hour.
 
-To submit historical metrics, use the Datadog Forwarder. These metrics can have timestamps within the last one hour.
-
-Start by [installing Serverless Monitoring for AWS Lambda][1]. Ensure that you have installed the Datadog Lambda Forwarder.
+Start by [installing Serverless Monitoring for AWS Lambda][1]. Ensure that you have installed the latest Datadog Lambda Extension.
 
 Then, choose your runtime:
 
@@ -469,28 +467,6 @@ For example:
 
 {{< /programming-lang >}}
 {{< /programming-lang-wrapper >}}
-
-#### Submitting many data points
-
-Using the Forwarder to submit many data points for the same metric and the same set of tags (for example, inside a big `for`-loop) may impact Lambda performance and CloudWatch cost.
-
-You can aggregate the data points in your application to avoid the overhead.
-
-For example, in Python:
-
-```python
-def lambda_handler(event, context):
-
-    # Inefficient when event['Records'] contains many records
-    for record in event['Records']:
-      lambda_metric("record_count", 1)
-
-    # Improved implementation
-    record_count = 0
-    for record in event['Records']:
-      record_count += 1
-    lambda_metric("record_count", record_count)
-```
 
 ### Understanding distribution metrics
 

--- a/content/en/serverless/custom_metrics/_index.md
+++ b/content/en/serverless/custom_metrics/_index.md
@@ -21,10 +21,6 @@ A Lambda function may launch many concurrent execution environments when traffic
 
 Distributions provide `avg`, `sum`, `max`, `min`, `count` aggregations by default. On the Metric Summary page, you can enable percentile aggregations (p50, p75, p90, p95, p99) and also [manage tags][3]. To monitor a distribution for a gauge metric type, use `avg` for both the [time and space aggregations][4]. To monitor a distribution for a count metric type, use `sum` for both the [time and space aggregations][4]. Refer to the guide [Query to the Graph][5] for how time and space aggregations work.
 
-### Submitting historical metrics
-
-To submit historical metrics (only timestamps that are within the last 20 minutes are allowed), you must use the [Datadog Forwarder](#with-the-datadog-forwarder). The [Datadog Lambda Extension](#with-the-datadog-lambda-extension) can only submit metrics with the current timestamp due to the limitation of the StatsD protocol.
-
 ### Submitting many data points
 
 When using the Forwarder to submit many data points for the same metric and the same set of tags, for example, inside a big `for` loop, there may be noticeable performance impact to the Lambda and also CloudWatch cost impact. You can aggregate the data points in your application to avoid the overhead, see the following Python example:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The Datadog Lambda Extension has supported historical metrics for a long time, I was only made aware of this when a support person asked me to clarify these docs.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
