### PR TITLE
Group by any facet in CloudSec Misconfigurations

### DIFF
--- a/content/en/security/cloud_security_management/misconfigurations/findings/_index.md
+++ b/content/en/security/cloud_security_management/misconfigurations/findings/_index.md
@@ -32,7 +32,7 @@ A misconfiguration is the primary primitive for a rule evaluation against a reso
 
 Misconfigurations are displayed on the [Misconfigurations Findings page][1].
 - Aggregate misconfigurations by rule using the **Group by** filters and query search bar. For example, filtering by `evaluation:fail` narrows the list to all compliance rules that have issues that need to be addressed.
-  - Group misconfigurations by **Resources** or **Teams** (or **None** to view misconfigurations individually), so you can find the resources or teams that have the most failed misconfigurations, and prioritize your remediation efforts accordingly.
+  - Group misconfigurations by any facet, custom property, or tag (or **None** to view misconfigurations individually), so you can find patterns of failed misconfigurations and prioritize your remediation efforts accordingly.
 - Hover over **Views**, then select an existing view to apply, or click **Save as new view** to use your explorer settings again in the future.
 
 {{< img src="security/csm/findings_page_2.png" alt="Cloud Security Misconfigurations Findings page" style="width:100%;">}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Small docs update for a feature that just hit GA - in Cloud Security, on the Misconfigurations page, you can now group misconfigs by any facet (or custom property or tag) 🙂 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
