### PR TITLE
[SAASINT-4692] Velocloud: Remove 'VMware' from integration copy/docs/references

### DIFF
--- a/content/en/network_monitoring/devices/sd-wan.md
+++ b/content/en/network_monitoring/devices/sd-wan.md
@@ -1,5 +1,5 @@
 ---
-title: SD-WAN 
+title: SD-WAN
 description: Get started with your SD-WAN devices
 further_reading:
     - link: '/network_monitoring/devices/supported_devices'
@@ -28,9 +28,9 @@ SD-WAN is a type of networking technology that uses software-defined networking 
 
 Datadog supports the following vendors for SD-WAN network monitoring:
 
-  - [Meraki SD-WAN][2] 
-  - [Cisco SD-WAN][3] 
-  - [VmWare VeloCloud][4] (In Preview)
+  - [Meraki SD-WAN][2]
+  - [Cisco SD-WAN][3]
+  - [VeloCloud][4] (In Preview)
 
 ## Further Reading
 

--- a/content/es/network_monitoring/devices/sd-wan.md
+++ b/content/es/network_monitoring/devices/sd-wan.md
@@ -25,9 +25,9 @@ SD-WAN es un tipo de tecnología de red que utiliza principios de redes definida
 
 Datadog admite los siguientes proveedores para la monitorización de redes SD-WAN:
 
-  - [Meraki SD-WAN][2] 
-  - [Cisco SD-WAN][3] 
-  - [VmWare VeloCloud][4] (En vista previa)
+  - [Meraki SD-WAN][2]
+  - [Cisco SD-WAN][3]
+  - [VeloCloud][4] (En vista previa)
 
 ## Referencias adicionales
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

For the Velocloud integration, we want to update "VMware Velocloud" references to just "Velocloud" (due to changes in ownership as a company). This includes all consumer-facing assets and documentation.

Corresponding web UI PR: https://github.com/DataDog/web-ui/pull/234761
Corresponding ICS PR: https://github.com/DataDog/integrations-internal-core/pull/2192

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
