### PR TITLE
[Serverless-Init] Add log file instructions to sidecar troubleshooting

### DIFF
--- a/layouts/shortcodes/gcr-troubleshooting.en.md
+++ b/layouts/shortcodes/gcr-troubleshooting.en.md
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 To have your Cloud Run services appear in the [software catalog][2001], you must set the `DD_SERVICE`, `DD_VERSION`, and `DD_ENV` environment variables.
 
-{{ if eq (.Get "sidecar") "true" }}Some logging libraries automatically create your log file, while others expect the log file to already exist. If your container fails to startup, you may need to explicitly create the log file.
+{{ if eq (.Get "sidecar") "true" }}Some logging libraries automatically create your log file, while others expect the log file to already exist. If your container fails to start up, you may need to explicitly create the log file.
 
 If you are missing logs or traces during container shutdown, specify a container start up order to make your main container depend on the sidecar container.
 {{ end }}

--- a/layouts/shortcodes/gcr-troubleshooting.en.md
+++ b/layouts/shortcodes/gcr-troubleshooting.en.md
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -y ca-certificates
 
 To have your Cloud Run services appear in the [software catalog][2001], you must set the `DD_SERVICE`, `DD_VERSION`, and `DD_ENV` environment variables.
 
-{{ if eq (.Get "sidecar") "true" }}If you are missing logs or traces during container shutdown, specify a container start up order to make your main container depend on the sidecar container.
+{{ if eq (.Get "sidecar") "true" }}Some logging libraries automatically create your log file, while others expect the log file to already exist. If your container fails to startup, you may need to explicitly create the log file.
+
+If you are missing logs or traces during container shutdown, specify a container start up order to make your main container depend on the sidecar container.
 {{ end }}
 [2001]: /internal_developer_portal/software_catalog/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

We give examples for logging setup in some logging libraries, but realistically we can't do that for every logging library.

Some logging libraries will create the specified file if it does not already exist; others will error and fail to startup the container if the file does not exist yet. We clarify that here.

Example URL: https://docs-staging.datadoghq.com/nicholas.hulston/serverless-init-sidecar-log-file-troubleshooting/serverless/google_cloud_run/containers/sidecar/python/?tab=datadogcli#troubleshooting

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

