### PR TITLE
[docseng-52] exclude headers from resource catalog pages from search

### DIFF
--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -1,4 +1,4 @@
-{{- if (or (eq hugo.Environment "live") (in (slice "typesense_sync_preview:manual" "algolia_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
+{{- if (or (eq "hugo.Environment" "live") (in (slice "typesense_sync_preview:manual" "algolia_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}

--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -1,4 +1,4 @@
-{{- if (or (eq "hugo.Environment" "live") (in (slice "typesense_sync_preview:manual" "algolia_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
+{{- if (or (eq hugo.Environment "live") (in (slice "typesense_sync_preview:manual" "algolia_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}

--- a/layouts/partials/algolia/page-sections.json
+++ b/layouts/partials/algolia/page-sections.json
@@ -48,7 +48,7 @@
                   {{- $relpermalink := print $page.RelPermalink "#" ($section_header | anchorize) -}}
                   {{- $object_id := (print $page.File.UniqueID "_" $page.Language.Lang "_" ($section_header | anchorize) "_" $i "_" $order) -}}
 
-                  {{- if eq $page.Params.exclude_headers_from_search "true" -}}
+                  {{- if $page.Params.exclude_headers_from_search -}}
                     {{- $section_header = "" -}}
                   {{- end -}}
                   

--- a/layouts/partials/algolia/page-sections.json
+++ b/layouts/partials/algolia/page-sections.json
@@ -47,6 +47,11 @@
                   {{- $full_url := print $page.Permalink "#" ($section_header | anchorize) -}}
                   {{- $relpermalink := print $page.RelPermalink "#" ($section_header | anchorize) -}}
                   {{- $object_id := (print $page.File.UniqueID "_" $page.Language.Lang "_" ($section_header | anchorize) "_" $i "_" $order) -}}
+
+                  {{- if $page.Params.exclude_headers_from_search -}}
+                    {{- $section_header = "" -}}
+                  {{- end -}}
+                  
                   {{- $hugo_context.Scratch.Add "algoliaindex" (
                       dict "objectID" $object_id
                       "id" $object_id

--- a/layouts/partials/algolia/page-sections.json
+++ b/layouts/partials/algolia/page-sections.json
@@ -48,7 +48,7 @@
                   {{- $relpermalink := print $page.RelPermalink "#" ($section_header | anchorize) -}}
                   {{- $object_id := (print $page.File.UniqueID "_" $page.Language.Lang "_" ($section_header | anchorize) "_" $i "_" $order) -}}
 
-                  {{- if $page.Params.exclude_headers_from_search -}}
+                  {{- if eq $page.Params.exclude_headers_from_search "true" -}}
                     {{- $section_header = "" -}}
                   {{- end -}}
                   

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -403,6 +403,7 @@
             path_to_remove: 'generated/md/external/'
             front_matters:
               disable_edit: true
+              exclude_headers_from_search: true
 
       - repo_name: datadog-agent
         contents:

--- a/local/bin/py/build/configurations/pull_config_preview.yaml
+++ b/local/bin/py/build/configurations/pull_config_preview.yaml
@@ -404,6 +404,7 @@
             path_to_remove: 'generated/md/external/'
             front_matters:
               disable_edit: true
+              exclude_headers_from_search: true
 
       - repo_name: datadog-agent
         contents:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
exclude section headers (i.e. `h2`) from search on the auto-generated resource catalog pages.

https://datadoghq.atlassian.net/browse/DOCSENG-52

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
hard to confirm in staging without running pipelines manually , without cache etc.   i built the search index locally and you can confirm in the screen shot the `section_header` is blank which should exclude from search

<img width="839" height="258" alt="Screenshot 2025-10-01 at 10 31 19 AM" src="https://github.com/user-attachments/assets/7104e9ac-0462-448d-8dac-b9d7d28b0a89" />

