### PR TITLE
Update OTLP metrics endpoint to new URL

### DIFF
--- a/assets/scripts/config/regions.config.js
+++ b/assets/scripts/config/regions.config.js
@@ -348,12 +348,12 @@ export default {
     ap2: 'https://trace.agent.ap2.datadoghq.com/v1/traces'
   },
   otlp_metrics_endpoint: {
-    us: 'https://api.datadoghq.com/api/intake/otlp/v1/metrics',
-    us3: 'https://api.us3.datadoghq.com/api/intake/otlp/v1/metrics',
-    us5: 'https://api.us5.datadoghq.com/api/intake/otlp/v1/metrics',
-    eu: 'https://api.datadoghq.eu/api/intake/otlp/v1/metrics',
-    ap1: 'https://api.ap1.datadoghq.com/api/intake/otlp/v1/metrics',
-    ap2: 'https://api.ap2.datadoghq.com/api/intake/otlp/v1/metrics'
+    us: 'https://otlp.datadoghq.com/v1/metrics',
+    us3: 'https://otlp.us3.datadoghq.com/v1/metrics',
+    us5: 'https://otlp.us5.datadoghq.com/v1/metrics',
+    eu: 'https://otlp.datadoghq.eu/v1/metrics',
+    ap1: 'https://otlp.ap1.datadoghq.com/v1/metrics',
+    ap2: 'https://otlp.ap2.datadoghq.com/v1/metrics'
   },
   otlp_logs_endpoint: {
     us: 'https://http-intake.logs.datadoghq.com/v1/logs',

--- a/content/en/opentelemetry/setup/agentless/metrics.md
+++ b/content/en/opentelemetry/setup/agentless/metrics.md
@@ -25,10 +25,6 @@ further_reading:
 site_support_id: otlp_agentless
 ---
 
-{{< callout header="false" btn_hidden="true">}}
-  The Datadog OTLP metrics intake endpoint is in Preview. To request access, contact your account representative.
-{{< /callout >}}
-
 ## Overview
 
 Datadog's OpenTelemetry Protocol (OTLP) metrics intake API endpoint allows you to send metrics directly to Datadog. With this feature, you don't need to run the [Datadog Agent][2] or [OpenTelemetry Collector + Datadog Exporter][1].
@@ -73,15 +69,9 @@ If you are using [OpenTelemetry automatic instrumentation][3], set the following
 ```shell
 export OTEL_EXPORTER_OTLP_METRICS_PROTOCOL="http/protobuf"
 export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT="{{< region-param key="otlp_metrics_endpoint" >}}"
-export OTEL_EXPORTER_OTLP_METRICS_HEADERS="dd-api-key=${DD_API_KEY},dd-otlp-source=${PARTNER_ID}"
+export OTEL_EXPORTER_OTLP_METRICS_HEADERS="dd-api-key=${DD_API_KEY}"
 export OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE="delta"
 ```
-
-<div class="alert alert-info">
-  The <code>dd-otlp-source</code> header is <strong>only required for Datadog platform partners</strong> who receive a specific identifier from Datadog for multi-tenant data ingestion.
-  <br>
-  <strong>Datadog customers</strong> whose organizations are allowlisted for OTLP metrics intake should <strong>omit this header</strong>. Contact your Datadog representative if unsure.
-</div>
 
 #### Manual instrumentation
 
@@ -96,12 +86,11 @@ The JavaScript exporter is [`@opentelemetry/exporter-metrics-otlp-proto`][100]. 
 const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-proto');
 
 const exporter = new OTLPMetricExporter({
-  url: 'https://api.datadoghq.com/api/intake/otlp/v1/metrics',
+  url: 'https://otlp.datadoghq.com/v1/metrics',
   temporalityPreference: AggregationTemporalityPreference.DELTA, // Ensure delta temporality
   headers: {
     'dd-api-key': process.env.DD_API_KEY,
     'dd-otel-metric-config': '{"resource_attributes_as_tags": true}',
-    'dd-otlp-source': '${PARTNER_ID}', // For Datadog platform partners only. Use the ID provided by Datadog.
   },
 });
 ```
@@ -118,12 +107,11 @@ The Java exporter is [`OtlpHttpMetricExporter`][200]. To configure the exporter,
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 
 OtlpHttpMetricExporter exporter = OtlpHttpMetricExporter.builder()
-    .setEndpoint("https://api.datadoghq.com/api/intake/otlp/v1/metrics")
+    .setEndpoint("https://otlp.datadoghq.com/v1/metrics")
     .setAggregationTemporalitySelector(
 			AggregationTemporalitySelector.deltaPreferred()) // Ensure delta temporality
     .addHeader("dd-api-key", System.getenv("DD_API_KEY"))
     .addHeader("dd-otel-metric-config", "{\"resource_attributes_as_tags\": true}")
-    .addHeader("dd-otlp-source", "${PARTNER_ID}") // For Datadog platform partners only. Use the ID provided by Datadog.
     .build();
 ```
 
@@ -140,14 +128,13 @@ import "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 
 metricExporter, err := otlpmetrichttp.New(
 	ctx,
-	otlpmetrichttp.WithEndpoint("api.datadoghq.com"),
-	otlpmetrichttp.WithURLPath("/api/intake/otlp/v1/metrics"),
+	otlpmetrichttp.WithEndpoint("otlp.datadoghq.com"),
+	otlpmetrichttp.WithURLPath("/v1/metrics"),
       otlpmetrichttp.WithTemporalitySelector(deltaSelector), // Ensure delta temporality
 	otlpmetrichttp.WithHeaders(
 		map[string]string{
 			"dd-api-key": os.Getenv("DD_API_KEY"),
 			"dd-otel-metric-config": "{\"resource_attributes_as_tags\": true}",
-      "dd-otlp-source": "${PARTNER_ID}", // For Datadog platform partners only. Use the ID provided by Datadog.
 		}),
 )
 ```
@@ -164,12 +151,11 @@ The Python exporter is [`OTLPMetricExporter`][400]. To configure the exporter, u
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
 
 exporter = OTLPMetricExporter(
-    endpoint="https://api.datadoghq.com/api/intake/otlp/v1/metrics",
+    endpoint="https://otlp.datadoghq.com/v1/metrics",
     preferred_temporality=deltaTemporality, # Ensure delta temporality
     headers={
         "dd-api-key": os.environ.get("DD_API_KEY"),
         "dd-otel-metric-config": '{"resource_attributes_as_tags": true}',
-        "dd-otlp-source": "${PARTNER_ID}" # Replace with the specific value provided by Datadog for your organization
     },
 )
 ```
@@ -240,7 +226,6 @@ exporters:
     headers:
       dd-api-key: ${env:DD_API_KEY}
       dd-otel-metric-config: '{"resource_attributes_as_tags": true}'
-      dd-otlp-source: "${PARTNER_ID}", # For Datadog platform partners only. Use the ID provided by Datadog.
 ...
 
 service:
@@ -257,15 +242,6 @@ service:
 ### Error: 403 Forbidden
 
 If you receive a `403 Forbidden` error when sending metrics to the Datadog OTLP metrics intake endpoint, it indicates one of the following issues:
-
-- The API key belongs to an organization that is not allowed to access the Datadog OTLP metrics intake endpoint.  
-   **Solution**: To request access, contact your account representative.
-
-- The `dd-otlp-source` header is missing or has an incorrect value.  
-   **Solution**: This error can relate to the <code>dd-otlp-source</code> header:
-    - <i>Datadog Platform Partners</i>: Verify <code>dd-otlp-source</code> is set to the unique identifier provided by Datadog.
-    - <i>Individual Datadog Customers</i>: If your organization is allowlisted, this header should be omitted. Remove <code>dd-otlp-source</code> from your configuration.
-    - If the error persists, contact your Datadog representative to confirm if <code>dd-otlp-source</code> is required for your organization and, if so, its correct value.
 
 - The endpoint URL is incorrect for your organization.  
    **Solution**: Use the correct endpoint URL for your organization. Your site is {{< region-param key=dd_datacenter code="true" >}}, so you need to use the {{< region-param key="otlp_metrics_endpoint" code="true" >}} endpoint.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Update OTLP metrics endpoint to new URL. See https://datadoghq.atlassian.net/wiki/spaces/FEG/pages/5374215320/Open+telemetry+unique+FQDN for context.

The new URL does not need allowlist. So as part of this change, the followings are removed:
- The banner saying this endpoint is in preview
- The `dd-otlp-source` header which is used to allowlist platform partners
- Troubleshooting section that mentions allowlists

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
