### PR TITLE
Rename dd-trace-js master branch to main

### DIFF
--- a/content/en/security/application_security/troubleshooting.md
+++ b/content/en/security/application_security/troubleshooting.md
@@ -402,7 +402,7 @@ If you don't see AAP threat information in the [Trace and Signals Explorer][2] f
     DD_TRACE_LOG_LEVEL=info
     ```
 
-[1]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[1]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [2]: https://app.datadoghq.com/security/appsec/
 [3]: /tracing/troubleshooting/tracer_startup_logs/
 [5]: /tracing/troubleshooting/

--- a/content/en/security/code_security/iast/setup/_index.md
+++ b/content/en/security/code_security/iast/setup/_index.md
@@ -280,7 +280,7 @@ Update your ECS task definition JSON file, by adding this in the environment sec
 ]
 ```
 
-[1]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[1]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [2]: /security/code_security/iast/setup/nodejs/
 [3]: /security/code_security/iast/setup/
 [4]: /agent/versions/upgrade_between_agent_minor_versions/

--- a/content/en/security/code_security/iast/setup/nodejs.md
+++ b/content/en/security/code_security/iast/setup/nodejs.md
@@ -106,7 +106,7 @@ If you need additional assistance, contact [Datadog support][6].
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[1]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [2]: /security/code_security/iast/setup/nodejs/
 [3]: /security/code_security/iast/setup/
 [4]: /agent/versions/upgrade_between_agent_minor_versions/

--- a/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/en/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -269,7 +269,7 @@ Read [tracer settings][3] for a list of initialization options.
 [2]: https://app.datadoghq.com/apm/service-setup
 [3]: https://datadog.github.io/dd-trace-js/#tracer-settings
 [4]: /tracing/trace_collection/library_config/nodejs/
-[5]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[5]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [6]: /tracing/trace_collection/compatibility/nodejs/#complex-framework-usage
 [11]: /tracing/trace_collection/library_injection_local/
 [13]: /tracing/trace_collection/automatic_instrumentation/?tab=datadoglibraries#install-and-configure-the-agent

--- a/content/es/security/application_security/troubleshooting.md
+++ b/content/es/security/application_security/troubleshooting.md
@@ -402,7 +402,7 @@ Si no ves información sobre amenazas AAP en el [Explorador de trazas y señales
     DD_TRACE_LOG_LEVEL=info
     ```
 
-[1]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[1]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [2]: https://app.datadoghq.com/security/appsec/
 [3]: /es/tracing/troubleshooting/tracer_startup_logs/
 [5]: /es/tracing/troubleshooting/

--- a/content/es/security/code_security/iast/setup/_index.md
+++ b/content/es/security/code_security/iast/setup/_index.md
@@ -280,7 +280,7 @@ Actualiza tu archivo JSON de definición de tarea de ECS añadiendo esto en la s
 ]
 ```
 
-[1]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[1]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [2]: /es/security/code_security/iast/setup/nodejs/
 [3]: /es/security/code_security/iast/setup/
 [4]: /es/agent/versions/upgrade_between_agent_minor_versions/

--- a/content/es/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/es/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -87,7 +87,7 @@ Para correlacionar manualmente tus trazas con tus logs, parchea el módulo de re
 // ########## logger.js
 
 // convertir a dd con:
-// https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/id.js
+// https://github.com/DataDog/dd-trace-js/blob/main/packages/dd-trace/src/id.js
 const opentelemetry = require('@opentelemetry/api');
 const winston = require('winston')
 

--- a/content/es/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/es/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -269,7 +269,7 @@ Para ver lista de opciones de inicialización, lee los [parámetros del rastread
 [2]: https://app.datadoghq.com/apm/service-setup
 [3]: https://datadog.github.io/dd-trace-js/#tracer-settings
 [4]: /es/tracing/trace_collection/library_config/nodejs/
-[5]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[5]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [6]: /es/tracing/trace_collection/compatibility/nodejs/#complex-framework-usage
 [11]: /es/tracing/trace_collection/library_injection_local/
 [13]: /es/tracing/trace_collection/automatic_instrumentation/?tab=datadoglibraries#install-and-configure-the-agent

--- a/content/fr/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/fr/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -87,7 +87,7 @@ Pour mettre manuellement en corrélation vos traces et vos logs, ajoutez à votr
 // ########## logger.js
 
 // convertir au format dd avec :
-// https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/id.js
+// https://github.com/DataDog/dd-trace-js/blob/main/packages/dd-trace/src/id.js
 const opentelemetry = require('@opentelemetry/api');
 const winston = require('winston')
 const UINT_MAX = 4294967296

--- a/content/ja/security/application_security/troubleshooting.md
+++ b/content/ja/security/application_security/troubleshooting.md
@@ -393,7 +393,7 @@ Node.js アプリケーションの[トレースとシグナルエクスプロ�
     DD_TRACE_LOG_LEVEL=info
     ```
 
-[1]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[1]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [2]: https://app.datadoghq.com/security/appsec/
 [3]: /ja/tracing/troubleshooting/tracer_startup_logs/
 [5]: /ja/tracing/troubleshooting/

--- a/content/ja/security/code_security/iast/setup/_index.md
+++ b/content/ja/security/code_security/iast/setup/_index.md
@@ -280,7 +280,7 @@ spec:
 ]
 ```
 
-[1]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[1]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [2]: /ja/security/code_security/iast/setup/nodejs/
 [3]: /ja/security/code_security/iast/setup/
 [4]: /ja/agent/versions/upgrade_between_agent_minor_versions/

--- a/content/ja/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/ja/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -86,7 +86,7 @@ log.info("Example log line with trace correlation info")
 // ########## logger.js
 
 // 以下で dd に変換します。
-// https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/id.js
+// https://github.com/DataDog/dd-trace-js/blob/main/packages/dd-trace/src/id.js
 const opentelemetry = require('@opentelemetry/api');
 const winston = require('winston')
 

--- a/content/ja/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
+++ b/content/ja/tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs.md
@@ -266,7 +266,7 @@ cp -R ./node_modules path/to/bundle
 [2]: https://app.datadoghq.com/apm/service-setup
 [3]: https://datadog.github.io/dd-trace-js/#tracer-settings
 [4]: /ja/tracing/trace_collection/library_config/nodejs/
-[5]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[5]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [6]: /ja/tracing/trace_collection/compatibility/nodejs/#complex-framework-usage
 [11]: /ja/tracing/trace_collection/library_injection_local/
 [13]: /ja/tracing/trace_collection/automatic_instrumentation/?tab=datadoglibraries#install-and-configure-the-agent

--- a/content/ko/security/application_security/troubleshooting.md
+++ b/content/ko/security/application_security/troubleshooting.md
@@ -400,7 +400,7 @@ Node.js 애플리케이션의 [트레이스 및 신호 탐색기][2]에 ASM 위�
     DD_TRACE_LOG_LEVEL=info
     ```
 
-[1]: https://github.com/DataDog/dd-trace-js/blob/master/MIGRATING.md
+[1]: https://github.com/DataDog/dd-trace-js/blob/main/MIGRATING.md
 [2]: https://app.datadoghq.com/security/appsec/
 [3]: /ko/tracing/troubleshooting/tracer_startup_logs/
 [5]: /ko/tracing/troubleshooting/

--- a/content/ko/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
+++ b/content/ko/tracing/other_telemetry/connect_logs_and_traces/opentelemetry.md
@@ -86,7 +86,7 @@ log.info("Example log line with trace correlation info")
 // ########## logger.js
 
 // 아래 주소와 함께 dd로 변환합니다
-// https://github.com/DataDog/dd-trace-js/blob/master/packages/dd-trace/src/id.js
+// https://github.com/DataDog/dd-trace-js/blob/main/packages/dd-trace/src/id.js
 const opentelemetry = require('@opentelemetry/api');
 const winston = require('winston')
 


### PR DESCRIPTION
Refs https://github.com/DataDog/dd-trace-js/pull/6551

Ideally, this could be approved and I can merge it as soon as I merge the one in dd-trace-js to keep the diverging time window as small as possible.