### PR TITLE
Fix formatting of custom metrics section links

### DIFF
--- a/content/fr/metrics/custom_metrics/_index.md
+++ b/content/fr/metrics/custom_metrics/_index.md
@@ -83,12 +83,12 @@ Définissez les unités des métriques via le [Résumé des métriques][12] ou d
 
 ## Envoi de métriques custom
 
-{{< whatsnext desc="Il existe plusieurs façons d'envoyer des métriques à Datadog :">}}
-    {{< nextlink href="/metrics/custom_metrics/agent_metrics_submission" >}}Check d'Agent custom{{{< /nextlink >}}
+{{< whatsnext desc="Il existe plusieurs façons d'envoyer des métriques à Datadog :" >}}
+    {{< nextlink href="/metrics/custom_metrics/agent_metrics_submission" >}}Check d'Agent custom{{< /nextlink >}}
     {{< nextlink href="/metrics/custom_metrics/dogstatsd_metrics_submission" >}}DogStatsD{{< /nextlink >}}
     {{< nextlink href="/metrics/custom_metrics/powershell_metrics_submission" >}}PowerShell{{< /nextlink >}}
     {{< nextlink href="/serverless/custom_metrics" >}}AWS Lambda{{< /nextlink >}}
-    {{< nextlink href="/api/v1/metrics/#submit-metrics" >}}API HTTP Datadog{{{< /nextlink >}}
+    {{< nextlink href="/api/v1/metrics/#submit-metrics" >}}API HTTP Datadog{{< /nextlink >}}
     {{< nextlink href="/logs/log_configuration/logs_to_metrics/#generate-a-log-based-metric" >}}Générer des métriques basées sur des logs{{< /nextlink >}}
     {{< nextlink href="/tracing/generate_metrics/" >}}Générer des métriques basées sur des spans APM{{< /nextlink >}}
     {{< nextlink href="/real_user_monitoring/platform/generate_metrics/" >}}Générer des métriques basées sur les événements du RUM{{< /nextlink >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Fix incorrect formatting in translated documentation.

**Note**: I've created an associated work item internally to follow up about correcting this at the source

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
