### PR TITLE
Update profiler features status for .NET 10

### DIFF
--- a/content/en/profiler/enabling/dotnet.md
+++ b/content/en/profiler/enabling/dotnet.md
@@ -45,7 +45,8 @@ Supported .NET runtimes (64-bit applications)
 .NET 6<br/>
 .NET 7<br/>
 .NET 8<br/>
-.NET 9
+.NET 9<br/>
+.NET 10
 
 <div class="alert alert-warning">
   <strong>Note:</strong> For containers, <strong>more than one core</strong> is required. Read the <a href="/profiler/profiler_troubleshooting/dotnet#linux-containers">Troubleshooting documentation</a> for more details.
@@ -62,16 +63,16 @@ The following profiling features are available in the following minimum versions
 | CPU profiling              | 2.15.0+                            | All supported runtime versions.                                                          |
 | GC CPU consumption         | 3.19.0+                            | .NET 5+                                                          |
 | Exceptions profiling       | 2.31.0+                            | All supported runtime versions.                                                          |
-| Allocations profiling beta | 3.12.0+ / 2.18.0+                  | .NET Framework (requires Datadog Agent 7.51+ and 3.12.0+) / .NET 6+ (requires 2.18.0+)   |
+| Allocations profiling      | 3.12.0+ / 3.28.0+                  | .NET Framework (requires Datadog Agent 7.51+ and 3.12.0+) / .NET 6+ (requires 2.18.0+ but .NET10 recommended with 3.28+)   |
 | Lock Contention profiling  | 2.49.0+                            | .NET Framework (requires Datadog Agent 7.51+) and .NET 5+                                |
-| Live heap profiling beta   | 2.22.0+                            | .NET 7+                                                                                  |
+| Live heap profiling        | 3.28.0+                            | .NET 7+ but .NET 10+ recommended                                                                                  |
 | [Trace to Profiling integration][12]         | 2.30.0+                            | All supported runtime versions.                                                          |
 | [Endpoint Profiling][13]  | 2.15.0+                            | All supported runtime versions.                                                          |
 | Timeline                  | 2.30.0+ (and 3.19.0+ for outgoing HTTP requests longer than 50 ms in beta and thread start/end events)     | All supported runtime versions (except .NET 5+ required for garbage collection details and .NET 7+ required for outgoing HTTP requests). |
 
 - Allocations and Lock Contention profiling for .NET Framework requires that the Datadog Agent and the profiled applications are running on the same machine.
 - Due to a limitation of the .NET Framework, Allocations profiling does not show the size of the allocations. Instead, it only shows the count.
-- Allocations and Live Heap profiling are in beta until .NET 10 ships with the required changes for better statistical allocations sampling.
+- Allocations and Live Heap profiling are GA in .NET 10. For the other previous versions of .NET, the statistical distribution of allocations sampling might not be accurate (i.e. expect larger objects to be more represented).
 - Continuous Profiler is not supported for AWS Lambda.
 - Continuous Profiler does not support ARM64.
  

--- a/content/en/profiler/profile_types.md
+++ b/content/en/profiler/profile_types.md
@@ -204,18 +204,18 @@ CPU (v2.15+)
 Thrown Exceptions (v2.31+)
 : The number of caught or uncaught exceptions raised by each method, as well as their type and message.
 
-Allocations (in beta, v2.18+)
+Allocations (v3.28+)
 : The number and size of allocated objects by each method, as well as their type.
 For .NET Framework, the size is not available.<br />
-_Requires: .NET Framework (with Datadog Agent 7.51+ and v3.2+) / .NET 6+_
+_Requires: .NET Framework (with Datadog Agent 7.51+ and v3.2+) / .NET 6+ but .NET 10+ is recommended for more accurate sampling_
 
 Lock (v2.49+)
 : The number of times threads are waiting for a lock and for how long.<br />
 _Requires: .NET Framework (requires Datadog Agent 7.51+) / .NET 5+_
 
-Live Heap (in beta, v2.22+)
+Live Heap (v3.28+)
 : A subset of the allocated objects (with their class name) that are still in memory.<br />
-_Requires: .NET 7+_
+_Requires: .NET 7+ but .NET 10+ is recommended for more accurate sampling_
 
 Outgoing HTTP requests (in Timeline) (in beta v3.19+)
 : Start and end of outgoing HTTP requests with the duration of the different phases (DNS, security handshake, socket, request/response) and possible unexpected redirections.<br />
@@ -229,7 +229,7 @@ Garbage Collector CPU consumption (v3.19+)
 : The time garbage collector's threads spent running on the CPU.<br />
 _Requires: .NET Framework (with Datadog Agent 7.51+ and v3.2+) / .NET 5+_
 
-Note: **Allocations** and **Live Heap** profiling are in beta until .NET 10, where required better statistical allocation sampling will be available.
+Note: Before .NET 10, **Allocations** and **Live Heap** profiling might show bigger objects more than smaller ones due to sampling algorithm used by the .NET runtime. It is recommended to use .NET 10+ for more statistically correct results. 
 
 
 [1]: /profiler/enabling/dotnet/#requirements


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The .NET allocation and live heap profilers provide more accurate results with .NET 10  so they could be considered as GA.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->
Waiting for 3.28 release in https://github.com/DataDog/dd-trace-dotnet/releases

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
