### PR TITLE
Document OTR mode toggle for existing organizations

### DIFF
--- a/content/en/account_management/api-app-keys.md
+++ b/content/en/account_management/api-app-keys.md
@@ -19,7 +19,20 @@ API keys are unique to your organization. An [API key][1] is required by the Dat
 
 ### One-Time Read mode
 
-All application keys for new parent organizations (and their child organizations) created after August 20th, 2025 are in One-Time Read (OTR) mode. OTR mode is a security feature that limits the visibility of application key secrets to creation time only. All application key secrets are only displayed once during creation and cannot be retrieved later for security purposes.
+One-Time Read (OTR) mode is a security feature that limits the visibility of application key secrets to creation time only. When OTR mode is enabled, application key secrets are only displayed once during creation and cannot be retrieved later for security purposes.
+
+#### For new organizations
+
+All application keys for new parent organizations (and their child organizations) created after August 20th, 2025 have OTR mode enabled by default. This setting is permanent and cannot be changed.
+
+#### For existing organizations
+
+Organization administrators can enable or disable OTR mode from [**Organization Settings** > **Application Keys**][2]. Once enabled:
+
+- Application key secrets are visible only once, at the time of creation
+- They are no longer retrievable via the UI or API afterward
+- The setting can be toggled on or off by organization administrators for 3 months after enabling
+- After 3 months of being continuously enabled, OTR mode becomes permanent and the toggle is removed
 
 ### Scopes 
 
@@ -87,6 +100,8 @@ To add a Datadog application key, navigate to [**Organization Settings** > **App
 {{< site-region region="ap2,gov" >}}
 <div class="alert alert-warning">Make sure to securely store your application key immediately after creation, as the key secret cannot be retrieved later.</div>
 {{< /site-region >}}
+
+<div class="alert alert-info">If your organization has One-Time Read (OTR) mode enabled, make sure to securely store your application key immediately after creation, as the key secret cannot be retrieved later.</div>
 
 **Notes:**
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Update Application Keys documentation to reflect GA release where existing organizations can enable/disable One-Time Read mode with 3-month reversibility period. New organizations continue to have OTR permanently enabled by default.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
