### PR TITLE
Including vertx v5 as supported version

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/java.md
+++ b/content/en/tracing/trace_collection/compatibility/java.md
@@ -88,30 +88,30 @@ Integrations in Preview are disabled by default but can be enabled individually:
 - error and stacktrace capturing
 - linking work created within a web request and Distributed Tracing
 
-| Server                  | Versions     | Support Type                                           | Instrumentation Names (used for configuration)           |
-|-------------------------|--------------|--------------------------------------------------------|----------------------------------------------------------|
-| Akka-Http Server        | 10.0+        | Fully Supported                                        | `akka-http`, `akka-http-server`                          |
-| Apache Pekko            | 1.0+         | Fully Supported                                        | `pekko-http`, `pekko-http-server`                        |
-| Finatra Web             | 2.9+         | Fully Supported                                        | `finatra`                                                |
-| Grizzly                 | 2.0+         | Fully Supported                                        | `grizzly`                                                |
-| Grizzly-HTTP            | 2.3.20+      | Fully Supported                                        | `grizzly-filterchain`                                    |
-| Java Servlet Compatible | 2.3+, 3.0+   | Fully Supported                                        | `servlet`, `servlet-2`, `servlet-3`                      |
-| Jax-RS Annotations      | JSR311-API   | Fully Supported                                        | `jax-rs`, `jaxrs`, `jax-rs-annotations`, `jax-rs-filter` |
-| Jetty                   | 7.0-12.x     | Fully Supported                                        | `jetty`                                                  |
-| Micronaut HTTP Server   | 2.x+         | Fully Supported                                        | `micronaut`                                              |
-| Mulesoft                | 4.5.0+       | Fully Supported                                        | `mule`                                                   |
-| Netty HTTP Server       | 3.8+         | Fully Supported                                        | `netty`, `netty-3.8`, `netty-4.0`, `netty-4.1`           |
-| Play                    | 2.3-2.8      | Fully Supported                                        | `play`, `play-action`                                    |
-| Ratpack                 | 1.5+         | Fully Supported                                        | `ratpack`                                                |
-| Restlet HTTP Server     | 2.2 - 2.4    | Fully Supported                                        | `restlet-http`.                                          |
-| Spark Java              | 2.3+         | [Preview](#framework-integrations-disabled-by-default) | `sparkjava` (requires `jetty`)                           |
-| Spring Boot             | 1.5+         | Fully Supported                                        | `spring-web` or `spring-webflux`                         |
-| Spring Web (MVC)        | 4.0+         | Fully Supported                                        | `spring-web`                                             |
-| Spring WebFlux          | 5.0+         | Fully Supported                                        | `spring-webflux`                                         |
-| Tomcat                  | 5.5+         | Fully Supported                                        | `tomcat`                                                 |
-| Undertow                | 2.0+         | Fully Supported                                        | `undertow`                                               |
-| Vert.x                  | 3.4 - 4.5.15 | Fully Supported                                        | `vertx`, `vertx-3.4`, `vertx-3.9`, `vertx-4.0`           |
-| Websocket (JSR356)      | 1.0+         | [Preview](#framework-integrations-disabled-by-default) | `websocket`                                              |
+| Server                  | Versions     | Support Type                                           | Instrumentation Names (used for configuration)             |
+|-------------------------|--------------|--------------------------------------------------------|------------------------------------------------------------|
+| Akka-Http Server        | 10.0+        | Fully Supported                                        | `akka-http`, `akka-http-server`                            |
+| Apache Pekko            | 1.0+         | Fully Supported                                        | `pekko-http`, `pekko-http-server`                          |
+| Finatra Web             | 2.9+         | Fully Supported                                        | `finatra`                                                  |
+| Grizzly                 | 2.0+         | Fully Supported                                        | `grizzly`                                                  |
+| Grizzly-HTTP            | 2.3.20+      | Fully Supported                                        | `grizzly-filterchain`                                      |
+| Java Servlet Compatible | 2.3+, 3.0+   | Fully Supported                                        | `servlet`, `servlet-2`, `servlet-3`                        |
+| Jax-RS Annotations      | JSR311-API   | Fully Supported                                        | `jax-rs`, `jaxrs`, `jax-rs-annotations`, `jax-rs-filter`   |
+| Jetty                   | 7.0-12.x     | Fully Supported                                        | `jetty`                                                    |
+| Micronaut HTTP Server   | 2.x+         | Fully Supported                                        | `micronaut`                                                |
+| Mulesoft                | 4.5.0+       | Fully Supported                                        | `mule`                                                     |
+| Netty HTTP Server       | 3.8+         | Fully Supported                                        | `netty`, `netty-3.8`, `netty-4.0`, `netty-4.1`             |
+| Play                    | 2.3-2.8      | Fully Supported                                        | `play`, `play-action`                                      |
+| Ratpack                 | 1.5+         | Fully Supported                                        | `ratpack`                                                  |
+| Restlet HTTP Server     | 2.2 - 2.4    | Fully Supported                                        | `restlet-http`.                                            |
+| Spark Java              | 2.3+         | [Preview](#framework-integrations-disabled-by-default) | `sparkjava` (requires `jetty`)                             |
+| Spring Boot             | 1.5+         | Fully Supported                                        | `spring-web` or `spring-webflux`                           |
+| Spring Web (MVC)        | 4.0+         | Fully Supported                                        | `spring-web`                                               |
+| Spring WebFlux          | 5.0+         | Fully Supported                                        | `spring-webflux`                                           |
+| Tomcat                  | 5.5+         | Fully Supported                                        | `tomcat`                                                   |
+| Undertow                | 2.0+         | Fully Supported                                        | `undertow`                                                 |
+| Vert.x                  | 3.4 - 5.x    | Fully Supported                                        | `vertx`, `vertx-3.4`, `vertx-3.9`, `vertx-4.0`, `vertx-5.0`|
+| Websocket (JSR356)      | 1.0+         | [Preview](#framework-integrations-disabled-by-default) | `websocket`                                                |
 
 **Note**: Many application servers are Servlet compatible and are automatically covered by that instrumentation, such as Websphere, Weblogic, and JBoss.
 Also, frameworks like Spring Boot (version 3) inherently work because they usually use a supported embedded application server, such as Tomcat, Jetty, or Netty.


### PR DESCRIPTION
Updating the vertx versions supported at the moment to include vertx v5

We support up to v5: https://github.com/DataDog/dd-trace-java/tree/master/dd-java-agent/instrumentation/vertx/vertx-web