### PR TITLE
Fix bump version workflow

### DIFF
--- a/.github/chainguard/self.bump-versions.create-pr.sts.yaml
+++ b/.github/chainguard/self.bump-versions.create-pr.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/documentation:ref:refs/heads/master
+
+claim_pattern:
+  event_name: schedule
+  ref: refs/heads/master
+  ref_protected: "true"
+  job_workflow_ref: DataDog/documentation/\.github/workflows/bump_versions\.yml@refs/heads/master
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.github/workflows/bump_versions.yml
+++ b/.github/workflows/bump_versions.yml
@@ -16,7 +16,7 @@ jobs:
         id: octo-sts
         with:
           scope: DataDog/documentation
-          policy: self.bump-private-action-runner-version.create-pr
+          policy: self.bump-versions.create-pr
 
       - id: set-versions
         name: Load latest SDK versions


### PR DESCRIPTION
Add back the auth config for the bump_versions workflow. It was renamed in https://github.com/DataDog/documentation/pull/31632 and the workflow has been failing since: https://github.com/DataDog/documentation/actions/workflows/bump_versions.yml