### PR TITLE
[ABLD-27] Document Agent 7.70+ supports macOS on ARM64

### DIFF
--- a/content/en/agent/supported_platforms/_index.md
+++ b/content/en/agent/supported_platforms/_index.md
@@ -305,9 +305,9 @@ To install a specific version of the Windows Agent, see the [installer list][8].
 
 | macOS version | Agent 7               |
 |---------------|-----------------------|
-| >= 11.0       | >= 7.70.0<sup>*</sup> |
+| >= 11.0       | >= 7.70.0*            |
 
-<sup>*</sup>Earlier versions for 64-BIT X86 may be used on Apple ARM64 through [Rosetta 2](https://support.apple.com/en-us/102527) emulation.
+*Earlier versions for 64-BIT X86 may be used on Apple ARM64 through [Rosetta 2](https://support.apple.com/en-us/102527) emulation.
 
 {{% /tab %}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Given Agent 7.70.0 was released on [September 3](https://github.com/DataDog/datadog-agent/releases/tag/7.70.0), the present change aims at documenting the fact it now supports [macOS on AArch64/ARM64](https://github.com/DataDog/datadog-agent/releases/tag/7.70.0#:~:text=Add%20macOS%20build%20for%20AArch64/ARM64) "natively" - that is, without Rosetta 2 emulation.

### Merge instructions
Merge readiness:
- [x] Ready for merge

### Additional notes
See also:
- #29695

| <img alt="before" width="42%" src="https://github.com/user-attachments/assets/ebe8d119-3835-4573-8567-cfc5c0f9327a" /> | <img alt="after" width="42%" src="https://github.com/user-attachments/assets/b468368a-1e45-4c60-9606-20120b48d2f7" /> |