### PR TITLE
Change preview message from warning to info for Flutter SR

### DIFF
--- a/layouts/shortcodes/mdoc/en/real_user_monitoring/session_replay/setup_and_configuration.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/real_user_monitoring/session_replay/setup_and_configuration.mdoc.md
@@ -227,7 +227,7 @@ To set up Mobile Session Replay for React Native:
 <!-- Flutter -->
 {% if equals($platform, "flutter") %}
 
-{% alert level="warning" %}
+{% alert level="info" %}
 Datadog Session Replay for Flutter is currently in Preview.
 {% /alert %}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The message announcing Flutter Session Replay being in preview was labeled as a warning. It should be "info."

### Merge instructions

Merge readiness:
- [x] Ready for merge
