### PR TITLE
DOCS-12225: add comprehensive config options to monitor crd

### DIFF
--- a/content/en/containers/datadog_operator/crd_monitor.md
+++ b/content/en/containers/datadog_operator/crd_monitor.md
@@ -187,8 +187,10 @@ spec:
 <br/>The number of minutes before a monitor notifies after data stops reporting. Datadog recommends at least 2x the monitor timeframe for metric alerts or 2 minutes for service checks. If omitted, 2x the evaluation timeframe is used for metric alerts, and 24 hours is used for service checks.
 
 `notificationPresetName`
-: _string_
-<br/>An enum that toggles the display of additional content sent in the monitor notification.
+: _enum_
+<br/>Toggles the display of additional content sent in the monitor notification. 
+<br/>Allowed enum values: `show_all`, `hide_query`, `hide_handles`, `hide_all`
+<br/>Default: `show_all`
 
 `notifyAudit`
 : _boolean_


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Customer asked for comprehensive reference. Information pulled from [DatadogMonitor CRD](https://github.com/DataDog/helm-charts/blob/main/crds/datadoghq.com_datadogmonitors.yaml) and [Create a monitor API](https://docs.datadoghq.com/api/latest/monitors/#create-a-monitor).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
