### PR TITLE
RUM-11859: Updating migration guide for SDK v3 - adding missing configuration details for RUM, Tracing, Logs and Session Replay.

### DIFF
--- a/content/en/real_user_monitoring/guide/mobile-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/mobile-sdk-upgrade.md
@@ -194,11 +194,11 @@ Logs.enable(
 ### Trace
 
 The URL provided in the `useCustomEndpoint` method should be the full endpoint URL
-(e.g.: https://example.com/trace/upload), not just the hostname, i.e:
+(e.g.: `https://example.com/trace/upload`), not just the hostname, i.e:
 ```kotlin
 Trace.enable(
   TraceConfiguration.Builder()
-      .useCustomEndpoint("https://example.com/trace/upload")
+      .useCustomEndpoint(`https://example.com/trace/upload`)
       .build()
 )
 ```
@@ -324,7 +324,7 @@ API changes:
 ### Session Replay
 
 The URL provided in the `useCustomEndpoint` method should be the full endpoint URL
-(e.g.: https://example.com/session_replay/upload), not just the hostname, i.e:
+(e.g.: `https://example.com/session_replay/upload`), not just the hostname, i.e:
 
 ```kotlin
 SessionReplay.enable(


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds some missing notes regarding SDK v2 -> SDK v3 migration

### Merge instructions

Ready to merge any time

Merge readiness:
- [*] Ready for merge
