### PR TITLE
[K9VULN-8923] Add not supported notice that SCA CI uploads using PR event triggers

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -172,7 +172,7 @@ There are two ways to run SCA scans from within your CI Pipelines:
 You can run SCA scans automatically as part of your CI/CD workflows using built-in integrations for popular CI providers.
 
 <div class="alert alert-danger">
-Datadog Software Composition Analysis CI jobs are only supported on <code>push</code> event trigger. Other event triggers (<code>pull_request</code>, etc.) are not supported and can cause issues with the product.
+Datadog Software Composition Analysis CI jobs are only supported on <code>push</code> event trigger. Other event triggers (<code>pull_request</code>, for example) are not supported and can cause issues with the product.
 </div>
 
 {{< tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
1. Removed a snippet from Azure CI job example that's not supported anymore
2. Added a notice that explains that SCA CI jobs should not be on PR triggers

### Merge instructions

Merge readiness:
- [X] Ready for merge