### PR TITLE
Update Java tracer configuration keys

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -342,15 +342,15 @@ For more information, see [Enabling AAP for Java][19].
 **Default**: `true`<br>
 By default, query string parameters and fragments are added to the `http.url` tag on web client spans. Set to `false` to prevent the collection of this data. 
 
-`dd.http.client.error.statuses`
-: **Environment Variable**: `DD_HTTP_CLIENT_ERROR_STATUSES`<br>
+`dd.trace.http.client.error.statuses`
+: **Environment Variable**: `DD_TRACE_HTTP_CLIENT_ERROR_STATUSES`<br>
 **Default**: `400-499`<br>
-A range of errors can be accepted. By default 4xx errors are reported as errors for http clients. This configuration overrides that. Ex. `dd.http.client.error.statuses=400-403,405,410-499`
+A range of errors can be accepted. By default 4xx errors are reported as errors for http clients. This configuration overrides that. Ex. `dd.trace.http.client.error.statuses=400-403,405,410-499`
 
-`dd.http.server.error.statuses`
-: **Environment Variable**: `DD_HTTP_SERVER_ERROR_STATUSES`<br>
+`dd.trace.http.server.error.statuses`
+: **Environment Variable**: `DD_TRACE_HTTP_SERVER_ERROR_STATUSES`<br>
 **Default**: `500-599`<br>
-A range of errors can be accepted. By default 5xx status codes are reported as errors for http servers. This configuration overrides that. Ex. `dd.http.server.error.statuses=500,502-599`
+A range of errors can be accepted. By default 5xx status codes are reported as errors for http servers. This configuration overrides that. Ex. `dd.trace.http.server.error.statuses=500,502-599`
 
 `dd.grpc.client.error.statuses`
 : **Environment Variable**: `DD_GRPC_CLIENT_ERROR_STATUSES`<br>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Update the names of the following configuration keys:

- `DD_HTTP_SERVER_ERROR_STATUSES` -->  `DD_TRACE_HTTP_SERVER_ERROR_STATUSES` 
- `DD_HTTP_CLIENT_ERROR_STATUSES` --> ` DD_TRACE_HTTP_CLIENT_ERROR_STATUSES `

This new names were introduced in PRs [#7694](https://github.com/DataDog/dd-trace-java/pull/7694) and [ #7716](https://github.com/DataDog/dd-trace-java/pull/7716) in dd-trace-java tracer release [v1.41.0](https://github.com/DataDog/dd-trace-java/releases/tag/v1.41.0).
Older configuration keys names have been deprecated.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge
