### PR TITLE
adding menu link for PR Gates to Code Security docs' menu items

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -6875,7 +6875,7 @@ menu:
       weight: 6
     - name: Pull Request Comments
       identifier: dev_tool_int_github_pull_requests
-      url: /security/code_security/dev_tool_int/github_pull_requests/
+      url: /security/code_security/dev_tool_int/pull_request_comments/
       parent: dev_tool_int
       weight: 1
     - name: PR Gates


### PR DESCRIPTION
- PR Gates applies to Code Security, though it is located in a different part of the Datadog UI.
- Adding a menu item for PR Gates in the Code Security docs helps users easily find this feature when reading about Code Security

### Merge instructions

Merge readiness:
- [X] Ready for merge
