### PR TITLE
Reordered the Agent tiles

### DIFF
--- a/data/partials/platforms.yaml
+++ b/data/partials/platforms.yaml
@@ -11,25 +11,25 @@ platforms:
     link: "agent/basic_agent_usage/windows/"
     image: "platform_windows.png"
     category: "Host-based"
-  - name: sccm
-    link: "agent/basic_agent_usage/sccm/"
-    image: "platform_sccm.png"
-    category: "configuration_management"
   - name: osx
     link: "agent/basic_agent_usage/osx/"
     image: "platform_macos.png"
     category: "Host-based"
-  - name: ansible
-    link: "agent/basic_agent_usage/ansible/"
-    image: "platform_ansible.png"
-    category: "configuration_management"
-  - name: chef
-    link: "agent/basic_agent_usage/chef/"
-    image: "platform_chef.png"
-    category: "configuration_management"
   - name: docker
     link: "agent/docker/"
     image: "platform_docker.png"
+    category: "Container platforms"
+  - name: kubernetes
+    link: "agent/kubernetes/"
+    image: "platform_kubernetes.png"
+    category: "Container platforms"
+  - name: Google Cloud Run
+    link: "serverless/google_cloud_run/containers/sidecar/"
+    image: "platform_gcr.png" 
+    category: "Container platforms"
+  - name: Amazon ECS
+    link: "/containers/amazon_ecs/"
+    image: "platform_ecs.png" 
     category: "Container platforms"
   - name: heroku
     link: "agent/basic_agent_usage/heroku/"
@@ -39,14 +39,18 @@ platforms:
     link: "serverless/aws_lambda/instrumentation/"
     image: "platform_awslambda.png"
     category: "Cloud platforms"
-  - name: kubernetes
-    link: "agent/kubernetes/"
-    image: "platform_kubernetes.png"
-    category: "Container platforms"
-  - name: Google Cloud Run
-    link: "serverless/google_cloud_run/containers/sidecar/"
-    image: "platform_gcr.png" 
-    category: "Container platforms"
+  - name: foundry
+    link: "integrations/guide/cloud-foundry-setup/"
+    image: "platform_cloud_foundry.png"
+    category: "Cloud platforms"
+  - name: ansible
+    link: "agent/basic_agent_usage/ansible/"
+    image: "platform_ansible.png"
+    category: "configuration_management"
+  - name: chef
+    link: "agent/basic_agent_usage/chef/"
+    image: "platform_chef.png"
+    category: "configuration_management"
   - name: puppet
     link: "agent/basic_agent_usage/puppet/"
     image: "platform_puppet.png"
@@ -55,14 +59,10 @@ platforms:
     link: "agent/basic_agent_usage/saltstack/"
     image: "platform_saltstack.png"
     category: "configuration_management"
-  - name: foundry
-    link: "integrations/guide/cloud-foundry-setup/"
-    image: "platform_cloud_foundry.png"
-    category: "Cloud platforms"
-  - name: Amazon ECS
-    link: "/containers/amazon_ecs/"
-    image: "platform_ecs.png" 
-    category: "Container platforms"
+  - name: sccm
+    link: "agent/basic_agent_usage/sccm/"
+    image: "platform_sccm.png"
+    category: "configuration_management"
   # - name: source
   #   link: "agent/basic_agent_usage/source/"
   #   image: "platform_fromsource.png"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR reorders the Agent tiles to be in the following order: 
`Host-based > Container > Cloud > Config management `
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
