### PR TITLE
AAP setup lambda: update serverless plugin enablement option

### DIFF
--- a/content/en/security/application_security/setup/aws/lambda/dotnet.md
+++ b/content/en/security/application_security/setup/aws/lambda/dotnet.md
@@ -52,7 +52,7 @@ To install and configure the Datadog Serverless Framework plugin:
    ```yaml
    custom:
      datadog:
-       enableASM: true
+       appSecMode: on
    ```
 
    Overall, your new `serverless.yml` file should contain at least:
@@ -60,8 +60,7 @@ To install and configure the Datadog Serverless Framework plugin:
    custom:
      datadog:
        apiKeySecretArn: "{Datadog_API_Key_Secret_ARN}" # or apiKey
-       enableDDTracing: true
-       enableASM: true
+       appSecMode: on
    ```
    See also the complete list of [plugin parameters][2] to further configure your Lambda settings.
 

--- a/content/en/security/application_security/setup/aws/lambda/go.md
+++ b/content/en/security/application_security/setup/aws/lambda/go.md
@@ -52,7 +52,7 @@ To install and configure the Datadog Serverless Framework plugin:
    ```yaml
    custom:
      datadog:
-       enableASM: true
+       appSecMode: on
    ```
 
    Overall, your new `serverless.yml` file should contain at least:
@@ -60,8 +60,7 @@ To install and configure the Datadog Serverless Framework plugin:
    custom:
      datadog:
        apiKeySecretArn: "{Datadog_API_Key_Secret_ARN}" # or apiKey
-       enableDDTracing: true
-       enableASM: true
+       appSecMode: on
    ```
    See also the complete list of [plugin parameters][2] to further configure your lambda settings.
 

--- a/content/en/security/application_security/setup/aws/lambda/java.md
+++ b/content/en/security/application_security/setup/aws/lambda/java.md
@@ -52,7 +52,7 @@ To install and configure the Datadog Serverless Framework plugin:
    ```yaml
    custom:
      datadog:
-       enableASM: true
+       appSecMode: on
    ```
 
    Overall, your new `serverless.yml` file should contain at least:
@@ -60,8 +60,7 @@ To install and configure the Datadog Serverless Framework plugin:
    custom:
      datadog:
        apiKeySecretArn: "{Datadog_API_Key_Secret_ARN}" # or apiKey
-       enableDDTracing: true
-       enableASM: true
+       appSecMode: on
    ```
    See also the complete list of [plugin parameters][2] to further configure your lambda settings.
 

--- a/content/en/security/application_security/setup/aws/lambda/nodejs.md
+++ b/content/en/security/application_security/setup/aws/lambda/nodejs.md
@@ -52,7 +52,7 @@ To install and configure the Datadog Serverless Framework plugin:
    ```yaml
    custom:
      datadog:
-       enableASM: true
+       appSecMode: on
    ```
 
    Overall, your new `serverless.yml` file should contain at least:
@@ -60,8 +60,7 @@ To install and configure the Datadog Serverless Framework plugin:
    custom:
      datadog:
        apiKeySecretArn: "{Datadog_API_Key_Secret_ARN}" # or apiKey
-       enableDDTracing: true
-       enableASM: true
+       appSecMode: on
    ```
    See also the complete list of [plugin parameters][2] to further configure your lambda settings.
 

--- a/content/en/security/application_security/setup/aws/lambda/python.md
+++ b/content/en/security/application_security/setup/aws/lambda/python.md
@@ -48,11 +48,11 @@ To install and configure the Datadog Serverless Framework plugin:
    serverless plugin install --name serverless-plugin-datadog
    ```
 
-2. Enable App and API protection by updating your `serverless.yml` with the `enableASM` configuration parameter:
+2. Enable App and API protection by updating your `serverless.yml` with the `appSecMode` configuration parameter:
    ```yaml
    custom:
      datadog:
-       enableASM: true
+       appSecMode: "on"
    ```
 
    Overall, your new `serverless.yml` file should contain at least:
@@ -60,8 +60,7 @@ To install and configure the Datadog Serverless Framework plugin:
    custom:
      datadog:
        apiKeySecretArn: "{Datadog_API_Key_Secret_ARN}" # or apiKey
-       enableDDTracing: true
-       enableASM: true
+       appSecMode: "on"
    ```
    See also the complete list of [plugin parameters][2] to further configure your lambda settings.
 

--- a/content/en/security/application_security/setup/aws/lambda/ruby.md
+++ b/content/en/security/application_security/setup/aws/lambda/ruby.md
@@ -51,7 +51,7 @@ To install and configure the Datadog Serverless Framework plugin:
    ```yaml
    custom:
      datadog:
-       enableASM: true
+       appSecMode: on
    ```
 
    Overall, your new `serverless.yml` file should contain at least:
@@ -59,8 +59,7 @@ To install and configure the Datadog Serverless Framework plugin:
    custom:
      datadog:
        apiKeySecretArn: "{Datadog_API_Key_Secret_ARN}" # or apiKey
-       enableDDTracing: true
-       enableASM: true
+       appSecMode: on
    ```
    See also the complete list of [plugin parameters][2] to further configure your lambda settings.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Update the setup instructions for App and API Protection on AWS Lambda using the Serverless Plugin.

With the release `5.110.0` of the Serverless Plugin Datadog, the configuration option for AAP has changed

see: https://github.com/DataDog/serverless-plugin-datadog/releases/tag/v5.110.0

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
