### PR TITLE
Add GKE Autopilot support for Datadog CSI Driver

### DIFF
--- a/content/en/containers/csi_driver/_index.md
+++ b/content/en/containers/csi_driver/_index.md
@@ -81,7 +81,6 @@ If the Datadog Agent is deployed using the Datadog Operator, you must install th
    helm install datadog-csi-driver datadog/datadog-csi-driver
    ```
 
-
 3. **Activate Datadog CSI in your `DatadogAgent` resource.**
 
    ```
@@ -121,6 +120,7 @@ If the Datadog Agent is deployed using a DaemonSet, you must install the Datadog
    ```shell
    helm install datadog-csi-driver datadog/datadog-csi-driver
    ```
+
 3. **Activate Datadog CSI**.
 
    To activate the Datadog CSI driver, set the following environment variable in the Datadog Cluster Agent container:


### PR DESCRIPTION
Added GKE Autopilot support information for Datadog CSI Driver installation via Helm chart, including a note on manual installation and AllowlistSynchronizer resource.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR updates the Datadog CSI Driver documentation to include instructions for installing the driver on GKE Autopilot clusters

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
