### PR TITLE
Add improvement on Github job correlation

### DIFF
--- a/content/en/continuous_delivery/deployments/ciproviders.md
+++ b/content/en/continuous_delivery/deployments/ciproviders.md
@@ -95,7 +95,7 @@ datadog-ci deployment mark --env prod --tags team:backend --tags reason:schedule
 Starting with `datadog-ci` version `4.1.1`, no additional action is required, even when using custom names or matrix strategies.
 
 <details>
-<summary><strong>For datadog-ci versions prior to 4.1.0</strong></summary>
+<summary><strong>For datadog-ci versions prior to 4.1.1</strong></summary>
 
 If you are using `datadog-ci` version `2.29.0` to `4.1.0` and the job name does not match the entry defined in the workflow configuration file (the GitHub [job ID][12]), the `DD_GITHUB_JOB_NAME` environment variable needs to be exposed, pointing to the job name. For example:
 

--- a/content/en/continuous_integration/pipelines/custom_commands.md
+++ b/content/en/continuous_integration/pipelines/custom_commands.md
@@ -185,7 +185,7 @@ Additionally, configure the Datadog site to use the selected one ({{< region-par
 Starting with `datadog-ci` version `4.1.1`, no additional action is required, even when using custom names or matrix strategies.
 
 <details>
-<summary><strong>For datadog-ci versions prior to 4.1.0</strong></summary>
+<summary><strong>For datadog-ci versions prior to 4.1.1</strong></summary>
 
 If you are using `datadog-ci` version `2.29.0` to `4.1.0` and the job name does not match the entry defined in the workflow configuration file (the GitHub [job ID][3]), the `DD_GITHUB_JOB_NAME` environment variable needs to be exposed, pointing to the job name. For example:
 

--- a/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
+++ b/content/en/continuous_integration/pipelines/custom_tags_and_measures.md
@@ -123,7 +123,7 @@ To create a measure, click the gear icon next to a measures name on the [Pipelin
 Starting with `datadog-ci` version `4.1.1`, no additional action is required, even when using custom names or matrix strategies.
 
 <details>
-<summary><strong>For datadog-ci versions prior to 4.1.0</strong></summary>
+<summary><strong>For datadog-ci versions prior to 4.1.1</strong></summary>
 
 If you are using `datadog-ci` version `2.29.0` to `4.1.0` and the job name does not match the entry defined in the workflow configuration file (the GitHub [job ID][7]), the `DD_GITHUB_JOB_NAME` environment variable needs to be exposed, pointing to the job name. For example:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Recent versions of the `datadog-ci` CLI do not require the user to manually expose the `DD_GITHUB_JOB_NAME` environment variable. Instead, the command will try to do determine the Github job name automatically. Customers can still pass that variable which takes more priority

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
