### PR TITLE
Extend AAS Linux Wrapper Retirement Date

### DIFF
--- a/content/en/serverless/guide/azure_app_service_linux_code_wrapper_script.md
+++ b/content/en/serverless/guide/azure_app_service_linux_code_wrapper_script.md
@@ -9,7 +9,7 @@ further_reading:
 <div class="alert alert-danger">
 The AAS Linux Wrapper is now deprecated. It will continue to receive layer bumps but no new features.
 It will be retired on March 1, 2026, at which point no further updates will be provided.
-You can continue to use the wrapper after March 1, 2026. However, no further updates, fixes, or support will be provided beyond that point.
+You can continue to use the wrapper after March 1, 2026, but its use will not be supported.
 Datadog strongly recommends switching to the <a href="https://docs.datadoghq.com/serverless/azure_app_service/linux_code">sidecar instrumentation method</a> as soon as possible.
 </div>
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

As discussed by our team, we are extending the AAS Linux Wrapper retirement date from Jan 1 to March 1.

We are extending the deadline by 2 months to allow our customers more time to migrate.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
