### PR TITLE
CCR add information on tag pipeline support

### DIFF
--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -588,6 +588,8 @@ Recommendations are run on a daily basis and are automatically refreshed in your
 
 You can see the detailed logic for each recommendation type, along with observability metrics or cost data shown on this page.
 
+Recommendations support [Tag Pipelines][11], allowing you to filter, group, and analyze recommendations using your organization's standardized tags. Any tag rules configured in Tag Pipelines are automatically applied to recommendations.
+
 ## Recommendation categories
 
 Below are the available cloud cost recommendation categories and their descriptions.
@@ -646,3 +648,4 @@ You can act on recommendations to save money and optimize costs. Cloud Cost Reco
 [8]: https://app.datadoghq.com/integrations/azure
 [9]: /integrations/azure/
 [10]: https://app.datadoghq.com/integrations/gcp
+[11]: /cloud_cost_management/tags/tag_pipelines/

--- a/content/en/cloud_cost_management/tags/_index.md
+++ b/content/en/cloud_cost_management/tags/_index.md
@@ -83,6 +83,9 @@ Cloud Cost Management normalizes tag **values** as well, while maintaining human
 - Replace any other characters with an underscore `_`
 - Tag values up to 5000 characters are supported
 
+Cloud Cost Recommendations use [standard Datadog metrics normalization rules][14]. Tag values in recommendations are converted to lowercase and limited to 200 characters.
+For example, a tag `Team:Engineering-Services` would appear as `team:engineering-services` in recommendations, but as `team:Engineering-Services` in cost data.
+
 ## How tags are prioritized
 
 A cost data row can have multiple values for the same tag key when tag values from two or more sources are combined and one is not prioritized over the other.
@@ -128,3 +131,4 @@ Other tag sources (such as AWS Organization tags, integration tile tags, and sim
 [11]: /cloud_cost_management/cost_allocation/container_cost_allocation/
 [12]: /network_monitoring/cloud_network_monitoring/
 [13]: /cloud_cost_management/cost_allocation/container_cost_allocation/?tab=aws#data-transfer
+[14]: /getting_started/tagging/#define-tags


### PR DESCRIPTION

### What does this PR do? What is the motivation?

Adds some basic information on the new tag pipeline support for CCM Recommendations. Adjust the CCM tag normalization content to cover Recommendations normalization rules.

### Merge instructions
- [x] Have CCM pm review language


Merge readiness:
- [x] Ready for merge

### Additional notes
