### PR TITLE
Add further reading link for Kubernetes observability

### DIFF
--- a/content/en/containers/kubernetes/_index.md
+++ b/content/en/containers/kubernetes/_index.md
@@ -13,6 +13,9 @@ aliases:
     - /integrations/faq/why-is-the-kubernetes-check-failing-with-a-connecttimeout-error-to-port-10250/
     - /agent/kubernetes/
 further_reading:
+    - link: "https://learn.datadoghq.com/courses/getting-started-k8s"
+      tag: "Learning Center"
+      text: "Getting Started with Kubernetes Observability"
     - link: "https://app.datadoghq.com/release-notes?category=Container%20Monitoring"
       tag: "Release Notes"
       text: "Check out the latest Datadog Containers releases (App login required)."


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This pull request adds a new resource to the Kubernetes documentation to help users get started with Kubernetes observability.

Documentation improvements:

* Added a "Getting Started with Kubernetes Observability" link to the `further_reading` section in `content/en/containers/kubernetes/_index.md` to direct users to a relevant Learning Center course.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
