### PR TITLE
Update DAC docs for OTel exception

### DIFF
--- a/content/en/account_management/rbac/data_access.md
+++ b/content/en/account_management/rbac/data_access.md
@@ -71,7 +71,7 @@ Terraform support will be announced after Data Access Control is generally avail
 - Software Delivery repository info (CI Visibility pipelines)
 - Cloud costs
 - Custom metrics
-    - **Note:** Standard metrics and OpenTelemetry (OTel) metrics are not currently supported
+    - **Note:** Standard and OpenTelemetry (OTel) metrics are not supported
 - Error Tracking issues
 - Logs
 - RUM sessions


### PR DESCRIPTION
Update to flag that OTel metrics do not currently respect DAC

### What does this PR do? What is the motivation?

Corrects the DAC documentation to flag OTel metrics as an exception to supporting "Custom Metrics."

### Merge instructions

Merge readiness:
- [x] Ready for merge
