### PR TITLE
Remove deprecated method to specify hostname for python

### DIFF
--- a/content/en/containers/amazon_ecs/apm.md
+++ b/content/en/containers/amazon_ecs/apm.md
@@ -129,21 +129,6 @@ Update the Task Definition's `entryPoint` with the following, substituting your 
 ```
 For Python the startup command is generally `ddtrace-run python my_app.py` but may vary depending on the framework used, for example, using [uWSGI][1] or instrumenting your [code manually with `patch_all`][2].
 
-#### Code
-You can alternatively update your code to have the tracer set the hostname explicitly:
-
-```python
-import requests
-from ddtrace import tracer
-
-
-def get_aws_ip():
-  r = requests.get('http://169.254.169.254/latest/meta-data/local-ipv4')
-  return r.text
-
-tracer.configure(hostname=get_aws_ip())
-```
-
 [1]: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#uwsgi
 [2]: https://ddtrace.readthedocs.io/en/stable/basic_usage.html#patch-all
 {{< /programming-lang >}}


### PR DESCRIPTION
Removed code snippet for setting tracer hostname in Python code. The method has been deprecated and is no longer available.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Remove deprecated `tracer.configure()` code samples.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->
* `tracer.configure()` has been deprecated and removed: https://docs.datadoghq.com/tracing/trace_collection/automatic_instrumentation/dd_libraries/python/#tracing
> `Tracer.configure()`: Deprecated parameters have been removed. Use environment variables to configure Agent connection details (hostname, port), sampling, and other settings.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
