### PR TITLE
Fix Ruby distribution example metric name

### DIFF
--- a/content/en/metrics/custom_metrics/dogstatsd_metrics_submission.md
+++ b/content/en/metrics/custom_metrics/dogstatsd_metrics_submission.md
@@ -873,7 +873,7 @@ require 'datadog/statsd'
 statsd = Datadog::Statsd.new('localhost', 8125)
 
 while true do
-    statsd.distribution('example_metric.gauge', rand 20, tags: ['environment:dev'])
+    statsd.distribution('example_metric.distribution', rand 20, tags: ['environment:dev'])
     sleep 2
 end
 ```

--- a/content/es/metrics/custom_metrics/dogstatsd_metrics_submission.md
+++ b/content/es/metrics/custom_metrics/dogstatsd_metrics_submission.md
@@ -873,7 +873,7 @@ require 'datadog/statsd'
 statsd = Datadog::Statsd.new('localhost', 8125)
 
 while true do
-    statsd.distribution('example_metric.gauge', rand 20, tags: ['environment:dev'])
+    statsd.distribution('example_metric.distribution', rand 20, tags: ['environment:dev'])
     sleep 2
 end
 ```

--- a/content/ja/metrics/custom_metrics/dogstatsd_metrics_submission.md
+++ b/content/ja/metrics/custom_metrics/dogstatsd_metrics_submission.md
@@ -872,7 +872,7 @@ require 'datadog/statsd'
 statsd = Datadog::Statsd.new('localhost', 8125)
 
 while true do
-    statsd.distribution('example_metric.gauge', rand 20, tags: ['environment:dev'])
+    statsd.distribution('example_metric.distribution', rand 20, tags: ['environment:dev'])
     sleep 2
 end
 ```

--- a/content/ko/metrics/custom_metrics/dogstatsd_metrics_submission.md
+++ b/content/ko/metrics/custom_metrics/dogstatsd_metrics_submission.md
@@ -873,7 +873,7 @@ require 'datadog/statsd'
 statsd = Datadog::Statsd.new('localhost', 8125)
 
 while true do
-    statsd.distribution('example_metric.gauge', rand 20, tags: ['environment:dev'])
+    statsd.distribution('example_metric.distribution', rand 20, tags: ['environment:dev'])
     sleep 2
 end
 ```


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The distribution metric example said `gauge` (which is a different type of metric entirely). It should instead say `distribution` (the other languages say `distribution`, not `gauge`). This fixes it

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
