### PR TITLE
Update Node Layer version from 127 to 130

### DIFF
--- a/layouts/shortcodes/latest-lambda-layer-version.html
+++ b/layouts/shortcodes/latest-lambda-layer-version.html
@@ -11,7 +11,7 @@
 
 <!-- Node Layer -->
 {{- if eq (.Get "layer") "node" -}}
-    127
+    130
 {{- end -}}
 
 <!-- Ruby Layer -->


### PR DESCRIPTION
Updating the latest lambda layer because 127 doesn't support DSM and it's not the latest version

Before
<img width="820" height="462" alt="image" src="https://github.com/user-attachments/assets/12660821-d3f7-469e-94b6-910577301326" />

After
<img width="743" height="432" alt="image" src="https://github.com/user-attachments/assets/1a4d6537-bc5e-4d2e-9a1c-262a8aeefb0e" />

To test: https://docs-staging.datadoghq.com/jj.botha/johannbotha-patch-2/serverless/aws_lambda/instrumentation/nodejs/?tab=awssam#setup