### PR TITLE
Fix links to OTel config examples

### DIFF
--- a/content/en/opentelemetry/config/collector_batch_memory.md
+++ b/content/en/opentelemetry/config/collector_batch_memory.md
@@ -81,4 +81,4 @@ Memory usage after GC.
 
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/batch-memory.yaml
+[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/batch-memory.yaml

--- a/content/en/opentelemetry/config/hostname_tagging.md
+++ b/content/en/opentelemetry/config/hostname_tagging.md
@@ -496,7 +496,7 @@ processors:
 [1]: https://opentelemetry.io/docs/specs/semconv/resource/
 [2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/resourcedetectionprocessor/README.md
 [3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md
-[4]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/k8s-chart/k8s-values.yaml
+[4]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/k8s-chart/k8s-values.yaml
 [5]: https://opentelemetry.io/docs/languages/js/resources/
-[6]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/collector.yaml
+[6]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml
 [7]: https://docs.datadoghq.com/opentelemetry/schema_semantics/host_metadata/  

--- a/content/en/opentelemetry/config/log_collection.md
+++ b/content/en/opentelemetry/config/log_collection.md
@@ -163,5 +163,5 @@ Flags: 0
 
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/logs.yaml
+[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/logs.yaml
 [3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor

--- a/content/en/opentelemetry/config/otlp_receiver.md
+++ b/content/en/opentelemetry/config/otlp_receiver.md
@@ -198,4 +198,4 @@ Flags: 0
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/otlpreceiver/README.md
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/otlp.yaml
+[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/otlp.yaml

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -129,5 +129,5 @@ Descriptor:
 
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/collector-metrics.yaml
+[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector-metrics.yaml
 [3]: https://pkg.go.dev/runtime#MemStats.Sys

--- a/content/en/opentelemetry/integrations/docker_metrics.md
+++ b/content/en/opentelemetry/integrations/docker_metrics.md
@@ -188,7 +188,7 @@ Value: 0.170933
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/dockerstatsreceiver
 [2]: /opentelemetry/guide/metrics_mapping/
-[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/docker-stats.yaml
+[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/docker-stats.yaml
 [4]: /universal_service_monitoring/setup/
 [5]: /opentelemetry/guide/semantic_mapping/
 [6]: /opentelemetry/otel_collector_datadog_exporter/?tab=onahost#containers-overview-dashboard

--- a/content/en/opentelemetry/integrations/host_metrics.md
+++ b/content/en/opentelemetry/integrations/host_metrics.md
@@ -174,7 +174,7 @@ Value: 1153183744
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/hostmetricsreceiver/README.md
 [2]: /opentelemetry/guide/metrics_mapping/#host-metrics
-[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/host-metrics.yaml
+[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/host-metrics.yaml
 [4]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/hostmetricsreceiver
 [5]: /opentelemetry/otel_collector_datadog_exporter/
 [6]: https://app.datadoghq.com/infrastructure/map?fillby=avg%3Acpuutilization&groupby=availability-zone

--- a/content/en/opentelemetry/integrations/kafka_metrics.md
+++ b/content/en/opentelemetry/integrations/kafka_metrics.md
@@ -296,7 +296,7 @@ Please see the following [example application][6] which demonstrates the configu
 [2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/jmxreceiver
 [3]: https://github.com/open-telemetry/opentelemetry-java-contrib/blob/main/jmx-metrics 
 [4]: /opentelemetry/collector_exporter/log_collection
-[5]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/kafka.yaml
+[5]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/kafka.yaml
 [6]: https://github.com/DataDog/opentelemetry-examples/tree/main/apps/kafka-metrics
 [7]: https://app.datadoghq.com/dash/integration/50/kafka-zookeeper-and-kafka-consumer-overview
 [8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/attributesprocessor/README.md#includeexclude-filtering

--- a/content/en/opentelemetry/integrations/trace_metrics.md
+++ b/content/en/opentelemetry/integrations/trace_metrics.md
@@ -65,4 +65,4 @@ For a full working example configuration with the Datadog exporter, see [`trace-
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/datadogconnector
 [2]: /tracing/metrics/metrics_namespace/
-[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/trace-metrics.yaml
+[3]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/trace-metrics.yaml

--- a/content/en/opentelemetry/setup/collector_exporter/install.md
+++ b/content/en/opentelemetry/setup/collector_exporter/install.md
@@ -284,7 +284,7 @@ Configure each of the following components to suit your needs:
 [5]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
 [6]: /api/latest/logs/
 [7]: /api/latest/metrics/#submit-metrics
-[8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/collector.yaml
+[8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml
 [9]: https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#WithContainer
 [10]: /getting_started/tagging/unified_service_tagging/
 [11]: https://opentelemetry.io/docs/instrumentation/

--- a/content/en/tracing/services/inferred_services.md
+++ b/content/en/tracing/services/inferred_services.md
@@ -114,7 +114,7 @@ exporters:
 **Example**: [collector.yaml][2].
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.95.0
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/collector.yaml#L375-L395
+[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml#L375-L395
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/es/tracing/services/inferred_services.md
+++ b/content/es/tracing/services/inferred_services.md
@@ -115,7 +115,7 @@ exporters:
 **Ejemplo**: [collector.yaml][2].
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.95.0
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/collector.yaml#L375-L395
+[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml#L375-L395
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/fr/tracing/services/inferred_services.md
+++ b/content/fr/tracing/services/inferred_services.md
@@ -113,7 +113,7 @@ exportateurs :
 **Exemple** : [collector.yaml][2].
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.95.0
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/collector.yaml#L375-L395
+[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml#L375-L395
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/ja/opentelemetry/setup/collector_exporter/_index.md
+++ b/content/ja/opentelemetry/setup/collector_exporter/_index.md
@@ -278,7 +278,7 @@ OpenTelemetry Collector Contrib プロジェクトの [`exporter/datadogexporter
 [5]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md
 [6]: /ja/api/latest/logs/
 [7]: /ja/api/latest/metrics/#submit-metrics
-[8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/e2e/examples/collector.yaml
+[8]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector.yaml
 [9]: https://pkg.go.dev/go.opentelemetry.io/otel/sdk/resource#WithContainer
 [10]: /ja/getting_started/tagging/unified_service_tagging/
 [11]: https://opentelemetry.io/docs/instrumentation/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The example configs in the opentelemetry-collector-contrib repository were [moved into a different location](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/42805) by mistake. The links to the examples in our docs were updated (#32165 and #32192), but I recently [moved the examples back to their original location](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/43629). This PR updates the links again to point to the correct location.
