### PR TITLE
Fix available dimensions for rum.measure.session.action metric

### DIFF
--- a/content/en/real_user_monitoring/rum_without_limits/metrics.md
+++ b/content/en/real_user_monitoring/rum_without_limits/metrics.md
@@ -31,7 +31,7 @@ Datadog provides the below out-of-the-box metrics for a comprehensive overview o
 | `rum.measure.error.hang` | Count of hangs (an iOS freeze) | Default | Mobile only |
 | `rum.measure.error.hang.duration` | Duration of hangs (an iOS freeze) | Default, View Name | Mobile only |
 | `rum.measure.session` | Count of sessions | Default | Mobile & Browser |
-| `rum.measure.session.action` | Count of actions | Default, Action Type, View Name | Mobile & Browser |
+| `rum.measure.session.action` | Count of actions | Default | Mobile & Browser |
 | `rum.measure.session.crash_free` | Count of crash-free sessions | Default | Mobile only |
 | `rum.measure.session.error` | Count of errors per session (@session.error.count) | Default, Percentiles breakdown | Mobile & Browser |
 | `rum.measure.session.frustration` | Count of frustration signals | Default | Mobile & Browser |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR fixes the documentation for the `rum.measure.session.action` metric by removing dimensions that are not actually available in the metric data.

**Changes:**
- Removed "Action Type" from the available dimensions list
- Removed "View Name" from the available dimensions list

**Motivation:**
These dimensions are not available for this metric. The metric only supports the Default dimensions (application.id, application.name, browser.name, env, geo.country, os.name, os.version, service, version).

### Merge instructions

Merge readiness:
- [x] Ready for merge