### PR TITLE
DOCSENG-173 - add obvious ignoredirs

### DIFF
--- a/.htmltest.yml
+++ b/.htmltest.yml
@@ -29,6 +29,9 @@ IgnoreDirs:
   - ko
   - es
   - security/default_rules
+  - resources # files for download
+  - img # some images
+  - images # most images
 IgnoreURLs:
   - "/favicon.ico"
   - "/resources/*"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

We don't need htmltest to look at large trees that aren't needed so excluding image dirs
https://datadoghq.atlassian.net/browse/DOCSENG-173

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
