### PR TITLE
Remove 'Database Monitoring' from unsupported monitors

### DIFF
--- a/content/en/monitors/status/status_page.md
+++ b/content/en/monitors/status/status_page.md
@@ -73,7 +73,6 @@ For more information, see the [Monitor status events][3] documentation.
 The following monitor types are not supported by the provisional status page:
 
 - Anomaly
-- Database Monitoring
 - Forecast
 - Outlier
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
DBM montiors are now supported in the new status page

### Merge instructions

Merge readiness:
- [x] Ready for merge
