### PR TITLE
Add prerequisites and cross-references to AWS Lambda .NET docs

### DIFF
--- a/content/en/serverless/aws_lambda/instrumentation/dotnet.md
+++ b/content/en/serverless/aws_lambda/instrumentation/dotnet.md
@@ -19,17 +19,17 @@ further_reading:
 
 ## Prerequisites
 
-Before instrumenting your Lambda function:
+Before you begin, complete these prerequisites:
 
 1. **Review compatibility requirements:** See [.NET Core Compatibility](/tracing/trace_collection/compatibility/dotnet-core) for supported .NET versions and integrations.
 2. **Understand Lambda-specific differences:**
    - Uses Lambda layers instead of MSI/system installation
-   - Custom instrumentation requires matching layer and NuGet package versions
+   - Custom instrumentation requires the NuGet package version to match the Lambda layer version
    - Environment variables are set in Lambda configuration, not system-wide
-3. **Learn about .NET tracing:** If you're new to Datadog .NET tracing, read [Tracing .NET Core Applications](/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core) for background concepts.
+3. **Learn about .NET tracing:** If new to Datadog .NET tracing, read [Tracing .NET Core Applications](/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core) for background concepts.
 
 <div class="alert alert-info">
-Looking for traditional host-based setup instead? See <a href="/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core">Tracing .NET Core Applications</a>.
+Looking for setup on hosts, containers, or Kubernetes instead? See <a href="/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core">Tracing .NET Core Applications</a>.
 </div>
 
 ## Setup
@@ -334,7 +334,7 @@ You can then add custom spans and span tags using the .NET tracer. For instructi
 Lambda functions support most standard .NET tracer configuration options. See [.NET Core Library Configuration](/tracing/trace_collection/library_config/dotnet-core/) for the full list of environment variables.
 
 **Lambda-specific configuration notes:**
-- Set environment variables in Lambda function configuration, not in code
+- Set environment variables in Lambda function configuration (not through IConfiguration or System.Environment.SetEnvironmentVariable)
 - Some Agent-related settings (like `DD_AGENT_HOST`) are managed by the Datadog Extension
 - Tracer version is determined by the Lambda layer version
 

--- a/content/en/serverless/aws_lambda/instrumentation/dotnet.md
+++ b/content/en/serverless/aws_lambda/instrumentation/dotnet.md
@@ -17,6 +17,21 @@ further_reading:
 
 <div class="alert alert-info">Version 67+ of the Datadog Lambda Extension is optimized to significantly reduce cold start duration. <a href="/serverless/aws_lambda/configuration/?tab=datadogcli#using-datadog-lambda-extension-v67">Read more</a>.</div>
 
+## Prerequisites
+
+Before instrumenting your Lambda function:
+
+1. **Review compatibility requirements:** See [.NET Core Compatibility](/tracing/trace_collection/compatibility/dotnet-core) for supported .NET versions and integrations.
+2. **Understand Lambda-specific differences:**
+   - Uses Lambda layers instead of MSI/system installation
+   - Custom instrumentation requires matching layer and NuGet package versions
+   - Environment variables are set in Lambda configuration, not system-wide
+3. **Learn about .NET tracing:** If you're new to Datadog .NET tracing, read [Tracing .NET Core Applications](/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core) for background concepts.
+
+<div class="alert alert-info">
+Looking for traditional host-based setup instead? See <a href="/tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core">Tracing .NET Core Applications</a>.
+</div>
+
 ## Setup
 
 If your application is deployed as a container image, use the _Container Image_ method.
@@ -313,6 +328,21 @@ When using the [Datadog Lambda tracing layer for .NET][9], ensure that a second 
 ```
 
 You can then add custom spans and span tags using the .NET tracer. For instructions on how to add spans, see [.NET custom instrumentation][10].
+
+## Configuration
+
+Lambda functions support most standard .NET tracer configuration options. See [.NET Core Library Configuration](/tracing/trace_collection/library_config/dotnet-core/) for the full list of environment variables.
+
+**Lambda-specific configuration notes:**
+- Set environment variables in Lambda function configuration, not in code
+- Some Agent-related settings (like `DD_AGENT_HOST`) are managed by the Datadog Extension
+- Tracer version is determined by the Lambda layer version
+
+## Troubleshooting
+
+For common issues and debugging steps, see:
+- [.NET Diagnostic Tool](/tracing/troubleshooting/dotnet_diagnostic_tool)
+- [Troubleshoot Serverless Monitoring](/serverless/guide/troubleshoot_serverless_monitoring)
 
 ## FIPS compliance
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a Prerequisites section and improves cross-referencing between the AWS Lambda .NET documentation and the main .NET Core APM docs.

**Changes:**
- Adds Prerequisites section at the beginning of the Lambda .NET instrumentation page
- Links to .NET Core compatibility requirements and main tracing documentation
- Clarifies Lambda-specific differences (layers vs MSI, version matching, environment variable configuration)
- Adds bidirectional link from Lambda docs back to traditional host setup
- Adds Configuration section explaining Lambda-specific configuration notes
- Adds Troubleshooting section with links to diagnostic tools

**Motivation:**
Users coming to the Lambda documentation often lack context about .NET tracing in general or miss important Lambda-specific configuration differences. Similarly, users who land on the main .NET Core docs might be deploying to Lambda but not realize they need different setup instructions. This PR creates better navigation between these related docs and sets proper expectations upfront.

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes

This PR complements the decision tree changes in #32476 by ensuring users who reach the Lambda docs understand the prerequisites and can easily navigate back to general .NET tracing docs for conceptual understanding.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->