### PR TITLE
Note lack of vulnerabilities support for non-official OS packages

### DIFF
--- a/content/en/security/cloud_security_management/vulnerabilities/hosts_containers_compatibility.md
+++ b/content/en/security/cloud_security_management/vulnerabilities/hosts_containers_compatibility.md
@@ -26,7 +26,7 @@ Cloud Security Vulnerabilities supports vulnerability scanning for hosts and con
 | Windows                  | Windows Server 2016/2019/2022, Windows 10 and later | Windows OS                | {{< X >}}         | {{< X >}}         |
 
 <div class="alert alert-info">
-Third-party or self-compiled OS packages are not supported, only official packages provided by the vendors listed above.
+Datadog supports only the official OS packages provided by the vendors listed above. Third-party or self-compiled packages are not supported.
 </div>
 
 {{% collapse-content title="Windows limitations" level="h4" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Cloud Security Vulnerabilities does not support packages from 3rd party repositories nor self-compiled ones.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
