### PR TITLE
Update note reference from Quality Gates to PR Gates

### DIFF
--- a/content/en/security/code_security/dev_tool_int/pull_request_comments/_index.md
+++ b/content/en/security/code_security/dev_tool_int/pull_request_comments/_index.md
@@ -23,7 +23,7 @@ You can configure PR comments at the organization or repository level in [Reposi
 - Setting severity thresholds for each scan type
 - Excluding findings from test files or dev/test dependencies
 
-**Note**: PR comments are not PR checks. To set up checks, see [Quality Gates][10].
+**Note**: PR comments are not PR checks. To set up checks, see [PR Gates][10].
 
 ## Prerequisites
 - You must have the Datadog source code integration for your provider enabled. PR comments are supported for [GitHub][2], [GitLab][8], and [Azure DevOps][9] repositories.  


### PR DESCRIPTION

### What does this PR do? What is the motivation?
Following PR Gates GA, Quality Gates have been re-branded and updated as **PR Gates** see https://datadoghq.atlassian.net/wiki/spaces/Vulnerabil/pages/5522165751/Quality+Gates+vs+PR+Gates 

| [NOW](https://docs-staging.datadoghq.com/deforest/docs-12290-iac-security-version-control-providers/security/code_security/dev_tool_int/pull_request_comments/?tab=github) | AFTER |
|--------|--------|
| <img width="582" height="147" alt="image" src="https://github.com/user-attachments/assets/ecf751df-eb39-4018-b6b3-41bfe6df6c8c" /> | <img width="519" height="68" alt="image" src="https://github.com/user-attachments/assets/a5e69c98-d024-4026-8ac6-7c1533af5833" /> |

### Merge instructions

Merge readiness:
- [x] Validate with Code Security PMs

### Additional notes

