### PR TITLE
[WP] Remove Kubernetes User session preview

### DIFF
--- a/content/en/security/workload_protection/setup/agent/kubernetes.md
+++ b/content/en/security/workload_protection/setup/agent/kubernetes.md
@@ -17,12 +17,6 @@ Use the following instructions to enable Workload Protection.
 
 ## Installation
 
-{{< beta-callout url="" header="Enrich events with Kubernetes user identities." btn_hidden="true">}}
-Enrich your events with Kubernetes user identities to help you investigate signals.
-
-Join the preview by enabling the admission controller and cws instrumentation variables (see instructions below)
-{{< /beta-callout >}}
-
 {{< tabs >}}
 
 {{% tab "Datadog Operator" %}}
@@ -37,12 +31,12 @@ Join the preview by enabling the admission controller and cws instrumentation va
       name: datadog
     spec:
       features:
-        # PREVIEW Configuration - Integrate with Kubernetes to enrich Workload Protection events with Kubernetes user identities
+        # (Optional) Integrate with Kubernetes to enrich Workload Protection events with Kubernetes user identities
         admissionController:
           enabled: true
           cwsInstrumentation:
             enabled: true
-        # END OF PREVIEW Configuration
+
         remoteConfiguration:
           enabled: true
         # Enables Threat Detection
@@ -82,13 +76,13 @@ Join the preview by enabling the admission controller and cws instrumentation va
     ```yaml
     # datadog-values.yaml file
 
-    # PREVIEW Configuration - Integrate with Kubernetes to enrich Workload Protection events with Kubernetes user identities
+    # (Optional) Integrate with Kubernetes to enrich Workload Protection events with Kubernetes user identities
     clusterAgent:
       admissionController:
         enabled: true
         cwsInstrumentation:
           enabled: true
-    # END OF PREVIEW Configuration
+
     datadog:
       remoteConfiguration:
         enabled: true
@@ -130,7 +124,7 @@ helm install datadog-operator datadog/datadog-operator --set clusterRole.allowCr
 
 {{% tab "DaemonSet" %}}
 
-1. Add the following settings to the `env` section of `security-agent` and `system-probe` in the `daemonset.yaml` file. Note that `DD_ADMISSION_CONTROLLER_ENABLED` and `DD_RUNTIME_ADMISSION_CONTROLLER_CWS_INSTRUMENTATION_ENABLED` variables in the `cluster-agent-deployment.yaml` enables event enrichment with Kubernetes user identities (in preview).
+1. Add the following settings to the `env` section of `security-agent` and `system-probe` in the `daemonset.yaml` file. Note that the `DD_ADMISSION_CONTROLLER_ENABLED` and `DD_RUNTIME_ADMISSION_CONTROLLER_CWS_INSTRUMENTATION_ENABLED` variables in the `cluster-agent-deployment.yaml` enable event enrichment with Kubernetes user identities (optional).
 
     ```bash
       # Source: datadog/templates/daemonset.yaml


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR removes the preview banners / warning for Kubernetes User session monitoring in Workload Protection. This feature is no longer in preview.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
