### PR TITLE
Update Windows supported platforms

### DIFF
--- a/content/en/agent/supported_platforms/_index.md
+++ b/content/en/agent/supported_platforms/_index.md
@@ -223,7 +223,7 @@ A check mark ({{< X >}}) indicates support for all minor and patch versions.
     <th>Notes</th>
   </thead>
   <tr>
-    <th rowspan=4><a href='/agent/basic_agent_usage/windows/'>Windows Server</a></th>
+    <th rowspan=3><a href='/agent/basic_agent_usage/windows/'>Windows Server</a></th>
     <td>2008 R2</td>
     <td><i class='icon-check-bold'></td>
     <td><= 6.45.1</td>


### PR DESCRIPTION
### What does this PR do? What is the motivation?
https://datadoghq.atlassian.net/browse/WINA-1977

In the code, we don't prevent users from installing the agent versions up to 6.49.x/7.49.x on Windows 2012/R2 hosts. However, we intentionally bumped down the supported agent versions in https://github.com/DataDog/documentation/pull/22642 to <= 6.46.0/7.46.0, because there is a security vulnerability (see that PR for more details) in agent versions 6.47.0 to 6.52.0 and 7.47.0 to 7.52.0. We want to keep it that way. There might have been some confusion separating Windows 2012 and 2012 R2 in https://github.com/DataDog/documentation/pull/24258 - they should be merged back together.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
