### PR TITLE
Update auto_instrumentation.md add openai responses nodejs

### DIFF
--- a/content/en/llm_observability/instrumentation/auto_instrumentation.md
+++ b/content/en/llm_observability/instrumentation/auto_instrumentation.md
@@ -459,6 +459,7 @@ The OpenAI integration instruments the following methods, including streamed cal
 - [Embeddings][5]:
   - `openai.embeddings.create()` and `azureopenai.embeddings.create()`
 - [Calls made to DeepSeek through the OpenAI Node.js SDK][21] (as of `dd-trace@5.42.0`)
+- [Responses][32] (as of `dd-trace@5.76.0`)
 
 ## LangChain
 
@@ -676,6 +677,7 @@ module.exports = {
 [29]: https://docs.claude.com/en/api/client-sdks#typescript
 [30]: https://docs.anthropic.com/en/api/messages
 [31]: https://docs.anthropic.com/en/api/messages-streaming
+[32]: https://platform.openai.com/docs/api-reference/responses/create
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adds a documentation bullet point for OpenAI responses instrumentation for the Node.js tracer https://github.com/DataDog/dd-trace-js/pull/6583

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
