### PR TITLE
Remove note implying RATE metrics can be submitted via dogstatsd

### DIFF
--- a/content/en/metrics/types.md
+++ b/content/en/metrics/types.md
@@ -263,8 +263,6 @@ Submit your RATE type metrics from one of the following sources:
 | [Agent check][1]  | `self.rate(...)`                    | RATE            | GAUGE               |
 | [API][2]          | `api.Metric.send(type="rate", ...)` | RATE            | RATE                |
 
-**Note**: When submitting a RATE metric type through DogStatsD, the metric appears as a GAUGE in-app to ensure relevant comparison across different Agents.
-
 
 [1]: /metrics/custom_metrics/agent_metrics_submission/?tab=rate
 [2]: /api/v1/metrics/#submit-metrics


### PR DESCRIPTION


<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->


### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Removed note about dogstatsd RATE metric type submission appearing as GAUGE in-app.

Dogstatsd does not support sending RATE metrics, only count metrics, which are covered by the note above

### Merge instructions


Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
