### PR TITLE
Add link to application security setup

### DIFF
--- a/content/en/security/application_security/_index.md
+++ b/content/en/security/application_security/_index.md
@@ -75,7 +75,7 @@ If you're curious how App and API Protection is structured and how it uses traci
 
 ## Configure your environment
 
-Powered by provided [out-of-the-box rules][4], AAP detects threats without manual configuration. If you already have Datadog [APM][1] configured on a physical or virtual host, setup only requires setting one environment variable to get started.
+Powered by provided [out-of-the-box rules][4], AAP detects threats without manual configuration. If you already have Datadog [APM][1] configured on a physical or virtual host, [setup][16] only requires setting one environment variable to get started.
 
 To start configuring your environment to detect and protect threats with AAP, follow the enabling documentation for each product. Once AAP is configured, you can begin investigating and remediating security signals in the [Security Signals Explorer][6].
 
@@ -126,4 +126,5 @@ For information on disabling AAP or its features, see the following:
 [13]: /security/application_security/exploit-prevention/#library-compatibility
 [14]: /security/application_security/exploit-prevention/
 [15]: /security/application_security/waf-integration/
+[16]: /security/application_security/setup/
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
This PR adds a link to the setup page from the main application security page.

I was looking into the docs and found it a bit confusing that we claim setup is so easy... but that I needed to figure out I was supposed to look on the docs tree on the left to figure out where that easiness was located ;)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
N/A