### PR TITLE
[OTAGENT-643] Update configs on DDOT Gateway

### DIFF
--- a/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_gateway.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_gateway.md
@@ -51,12 +51,12 @@ Before you begin, ensure you have the following:
 * **Software**:
     * A Kubernetes cluster (v1.29+). EKS Fargate and GKE Autopilot are not supported.
     * [Helm][3] (v3+).
-    * Datadog Helm chart version 3.137.1 or higher.
+    * Datadog Helm chart version 3.143.0 or higher.
     * [kubectl][4].
 
 ## Installation and configuration
 
-This guide uses the Datadog Helm chart to configure the DDOT Collector gateway.
+This guide uses the Datadog Helm chart to configure the DDOT Collector gateway. Check out all the available configurations on the [Datadog Helm chart README][8].
 
 ### Deploying the gateway with a daemonset
 
@@ -353,21 +353,21 @@ To ensure APM Stats are calculated on 100% of your traces before sampling, the <
 
 ### Using a custom Collector image
 
-To use a custom-built Collector image for your gateway, specify the image repository and tag under `agents.image`. This follows the same process as the DaemonSet deployment. For more details, see [Use Custom OpenTelemetry Components][5].
+To use a custom-built Collector image for your gateway, specify the image repository and tag under `otelAgentGateway.image`. If you need instructions on how to build the custom images, see [Use Custom OpenTelemetry Components][5].
 
 ```yaml
 # values.yaml
 targetSystem: "linux"
 agents:
   enabled: false
-  image:
-    repository: <YOUR REPO>
-    tag: <IMAGE TAG>
-    doNotCheckTag: true
 clusterAgent:
   enabled: false
 otelAgentGateway:
   enabled: true
+  image:
+    repository: <YOUR REPO>
+    tag: <IMAGE TAG>
+    doNotCheckTag: true
   ports:
     - containerPort: "4317"
       name: "otel-grpc"
@@ -515,3 +515,4 @@ For advanced scenarios, you can deploy multiple gateway layers to create a proce
 [5]: /opentelemetry/setup/ddot_collector/custom_components
 [6]: https://opentelemetry.io/docs/collector/deployment/gateway/
 [7]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/configtls
+[8]: http://github.com/DataDog/helm-charts/blob/main/charts/datadog/README.md


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Update DDOT Gateway configs in helm chart from https://github.com/DataDog/helm-charts/pull/2132. 
The main change is the image of OTel Agent Gateway is now configured with `otelAgentGateway.image` rather than `agents.image` to avoid confusions and unexpected dependencies.
Also add a link to helm chart README for full list of configs.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
