### PR TITLE
Add necessary /opt/datadog-agent/run bind mount for Docker log collec…

### DIFF
--- a/content/en/containers/guide/compose-and-the-datadog-agent.md
+++ b/content/en/containers/guide/compose-and-the-datadog-agent.md
@@ -158,6 +158,7 @@ services:
      - /proc/:/host/proc/:ro
      - /sys/fs/cgroup:/host/sys/fs/cgroup:ro
      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+     - /opt/datadog-agent/run:/opt/datadog-agent/run:rw
 ```
 
 **Note**: This configuration collects only logs from the `Redis` container. You can collect logs from the Datadog Agent by adding a similar `com.datadoghq.ad.logs` label. You can also explicitly enable logs collection for all containers by setting the environment variable `DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL` to `true`. See [Docker log collection][5] for details.


### PR DESCRIPTION
This is needed to prevent the agent from reingesting logs when it restarts.

This is also to match what is provided in the general Docker log collection docs: https://docs.datadoghq.com/containers/docker/log/?tab=containerinstallation