### PR TITLE
Add google-hangouts-chat to unsupported gov site

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -286,6 +286,7 @@ unsupported_sites:
   events_from_sns_emails: [gov]
   feature_flags: [gov]
   getting_started_feature_flags: [gov]
+  google-hangouts-chat: [gov]
   fips-compliance: [us,us3,us5,eu,ap1,ap2]
   fips-integrations: [us,us3,us5,eu,ap1,ap2]
   fips-proxy: [us,us3,us5,eu,ap1,ap2]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Google chat integration is not supported on US-FED1
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge