### PR TITLE
[DOCS-11746] Add missing navigation links

### DIFF
--- a/content/en/getting_started/application/_index.md
+++ b/content/en/getting_started/application/_index.md
@@ -145,6 +145,8 @@ Navigate to the [Dashboard List][21] in the app to get started. To learn more, r
 - Send alerts to Slack, email, PagerDuty, and more, by adding`@` in alert messages to direct notifications to the right people.
 - Schedule downtimes to suppress notifications for system shutdowns, offline maintenance, and more.
 
+Navigate to the [Monitors List][23] in the app to get started. To learn more, read the [Monitors documentation][22].
+
 ## Further Reading
 {{< partial name="whats-next/whats-next.html" >}}
 
@@ -170,3 +172,4 @@ Navigate to the [Dashboard List][21] in the app to get started. To learn more, r
 [20]: /dashboards/
 [21]: https://app.datadoghq.com/dashboard/lists
 [22]: /monitors/
+[23]: https://app.datadoghq.com/monitors/manage


### PR DESCRIPTION
### What does this PR do? What is the motivation?
After merging https://github.com/DataDog/documentation/pull/32238 and checking it out on prod, I realized I forgot the app/docs links at the bottom of the very last section of this guide (Monitors). Adding those links now.

### Merge instructions

Merge readiness:
- [x] Ready for merge
