### PR TITLE
Add cloudprem to unsupported gov param

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -277,6 +277,7 @@ unsupported_sites:
   continuous_delivery: [gov]
   continuous_integration: [gov]
   correlation: [gov] #Event management correlation
+  cloudprem: [gov]
   data_jobs: [gov]
   datadog_cloudcraft: [gov]
   ddot_collector: [gov]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- CloudPrem is not supported on US1-FED
- Add `cloudprem` to params for unsupported_sites to apply banner to all pages
[DOCS-12597](https://datadoghq.atlassian.net/browse/DOCS-12597)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


[DOCS-12597]: https://datadoghq.atlassian.net/browse/DOCS-12597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ