### PR TITLE
Update Kubernetes Airflow section to use Datadog Transport and add composite transport option

### DIFF
--- a/content/en/data_jobs/airflow.md
+++ b/content/en/data_jobs/airflow.md
@@ -68,7 +68,7 @@ To get started, follow the instructions below.
 
    Use this option if you're already using OpenLineage with another system and want to add Datadog as an additional destination. The composite transport sends events to all configured transports.
 
-   For example, if you're currently using an HTTP transport to send events to another system:
+   For example, if you're using an HTTP transport to send events to another system:
 
    ```shell
    # Your existing HTTP transport configuration


### PR DESCRIPTION
## Summary
This PR updates the Kubernetes section of the Airflow documentation to:
- Add Option 1: Datadog Transport (recommended) with proper version requirements
- Add Option 2: Composite Transport for users who need multiple destinations
- Add Option 3: Simple Configuration (backward compatible with all versions)

## Changes
- Updated Kubernetes section to use Datadog Transport configuration
- Added version requirements: `apache-airflow-providers-openlineage` >= 1.11.0 and `openlineage-python` >= 1.37.0 for transport options
- Added composite transport option similar to Astronomer section
- Preserved original simple configuration as Option 3 for backward compatibility

## References
- Datadog Transport instructions: https://docs.google.com/document/d/1TM_CI1qa2NpoEmoVhE-OK1gnk2KVHGqkSC46fIBDVcY/edit?tab=t.0
- Based on composite transport pattern from Astronomer section