### PR TITLE
Update Java logback configuration

### DIFF
--- a/content/en/logs/log_collection/java.md
+++ b/content/en/logs/log_collection/java.md
@@ -436,7 +436,7 @@ Once [log collection is enabled][5], set up [custom log collection][6] to tail y
 
 If logs are in JSON format, Datadog automatically [parses the log messages][10] to extract log attributes. Use the [Log Explorer][11] to view and troubleshoot your logs.
 
-## Agentless logging
+## Stream logs directly to the Agent
 
 In the exceptional case where your application is running on a machine that cannot be accessed or cannot log to a file, it is possible to stream logs to Datadog or to the Datadog Agent directly. This is not the recommended setup, because it requires that your application handles connection issues.
 

--- a/content/en/serverless/azure_app_service/windows_code.md
+++ b/content/en/serverless/azure_app_service/windows_code.md
@@ -423,10 +423,9 @@ This setup automatically includes trace correlation when `DD_LOGS_INJECTION=true
 {{% /tab %}}
 {{% tab "Java" %}}
 
-See instructions for [Agentless logging with Java][1] to configure application logging for Java in Azure App Service.
+See [Stream logs directly to the Agent][1] to configure application logging for Java in Azure App Service.
 
-[1]: /logs/log_collection/java/#agentless-logging
-
+[1]: /logs/log_collection/java/##stream-logs-directly-to-the-agent
 {{% /tab %}}
 {{% tab "Node.js" %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- TCP is not supported for sending logs directly to Datadog intake.
- Logback configuration is updated to send logs to the Agent which can take TCP, and then sends to Datadog over HTTP
- Part of the larger initiative to [update Log Collection docs ](https://docs.google.com/document/d/1DGhqNc8t-ghOifqEcHv84M83sGMKJoXBpQRLjQdwkRA/edit?tab=t.c8wc53rrnng4) regarding TCP intake
- Cosmetic link fixes and white space removal

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready to merge
