### PR TITLE
[SEC-25486] Update SIEM Rule Case doc with Less Than

### DIFF
--- a/layouts/shortcodes/cloud_siem/set_conditions_then_operator.en.md
+++ b/layouts/shortcodes/cloud_siem/set_conditions_then_operator.en.md
@@ -5,7 +5,7 @@
 1. In the **Set severity to** dropdown menu, select the appropriate severity level (`INFO`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`).
 1. If you are creating a **Simple condition**, enter the condition when a signal should be created. If you are creating a **Then condition**, enter the conditions required for a signal to be generated.
     - All rule conditions are evaluated as conditional statements. Thus, the order of the conditions affects which notifications are sent because the first condition to match generates the signal. Click and drag your rule conditions to change their order.
-    - A rule condition contains logical operations (`>`, `>=`, `&&`, `||`) to determine if a signal should be generated based on the event counts in the previously defined queries.
+    - A rule condition contains logical operations (`>`, `>=`, `<`, `&&`, `||`) to determine if a signal should be generated based on the event counts in the previously defined queries.
     - The ASCII lowercase query labels are referenced in this section. An example rule condition for query `a` is `a > 3`.
     - **Note**: The query label must precede the operator. For example, `a > 3` is allowed; `3 < a` is not allowed.
 1. In the **Add notify** section, click **Add Recipient** to optionally configure [notification targets][101].

--- a/layouts/shortcodes/cloud_siem/set_conditions_threshold.en.md
+++ b/layouts/shortcodes/cloud_siem/set_conditions_threshold.en.md
@@ -7,7 +7,7 @@
 1. In the **Set severity to** dropdown menu, select the appropriate severity level (`INFO`, `LOW`, `MEDIUM`, `HIGH`, `CRITICAL`).
 1. If you are creating a **Simple condition**, enter the condition when a signal should be created. If you are creating a **Then condition**, enter the conditions required for a signal to be generated.
     - All rule conditions are evaluated as condition statements. Thus, the order of the conditions affects which notifications are sent because the first condition to match generates the signal. Click and drag your rule conditions to change their order.
-    - A rule condition contains logical operations (`>`, `>=`, `&&`, `||`) to determine if a signal should be generated based on the event counts in the previously defined queries.
+    - A rule condition contains logical operations (`>`, `>=`, `<`, `&&`, `||`) to determine if a signal should be generated based on the event counts in the previously defined queries.
     - The ASCII lowercase query labels are referenced in this section. An example rule condition for query `a` is `a > 3`.
     - **Note**: The query label must precede the operator. For example, `a > 3` is allowed; `3 < a` is not allowed.
 1. (Optional) In the **Add notify** section, click **Add Recipient** to configure [notification targets][101].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Cloud SIEM supports Less Than operator in Threshold rules (not Content Anomaly Detection).
The feature was made GA and t he description was updated in the rule editor, so we should update the doc.
In the rule editor:
<img width="825" height="316" alt="image" src="https://github.com/user-attachments/assets/f10ca1bd-3d12-42e5-8036-85ede4742942" />


### Merge instructions
Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

Check: https://docs-staging.datadoghq.com/cgc/SEC-25486-less-than-doc/security/cloud_siem/detect_and_monitor/custom_detection_rules/create_rule/real_time_rule?tab=threshold for the rendering.
It works as expected:
<img width="630" height="293" alt="image" src="https://github.com/user-attachments/assets/442a1350-806d-4ca8-af69-863edd72338f" />
