### PR TITLE
CASCL-718: Add Autoscaling to Remote Config

### DIFF
--- a/content/en/remote_configuration/_index.md
+++ b/content/en/remote_configuration/_index.md
@@ -80,7 +80,7 @@ Workload Protection
 Observability Pipelines
 : - Remotely deploy and update [Observability Pipelines Workers][4] (OPW): Build and edit pipelines in the Datadog UI, rolling out your configuration changes to OPW instances running in your environment.
 
-Autoscaling
+[Autoscaling][47]
 : - Remotely manage autoscaling cluster and workload scaling configurations for your containerized environments. See [Autoscaling][47] for more information.
 
 Private action runner


### PR DESCRIPTION
<!-- dd-meta {"pullId":"4a6cab88-7933-42c9-a2a2-ceb57174d60d","source":"chat","resourceId":"57f6c4ac-7f28-496b-921c-330d80d6c66c","workflowId":"38291e4e-6922-4b55-95d8-1b4d8de10504","codeChangeId":"38291e4e-6922-4b55-95d8-1b4d8de10504","sourceType":"chat"} -->
[![Open Bits Dev Session](https://img.shields.io/badge/Open%20Bits%20Dev%20Session-%20?logo=datadog&logoColor=%23632CA6&labelColor=white&color=%23632CA6)](https://app.datadoghq.com/code/57f6c4ac-7f28-496b-921c-330d80d6c66c)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do? What is the motivation?
Adds Autoscaling to the "Supported products and features" section on the Remote Configuration index page and links to the Autoscaling docs, clarifying that Autoscaling depends on Remote Configuration (CASCL-718).

### Merge instructions
None.

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
N/A