### PR TITLE
Clarify cross-org connection limits

### DIFF
--- a/content/en/account_management/org_settings/cross_org_visibility.md
+++ b/content/en/account_management/org_settings/cross_org_visibility.md
@@ -25,7 +25,7 @@ A _source_ organization exposes data to a _destination_ organization through an 
 The following limitations apply to organization connections:
 - The source and destination organizations must be in the same [account][1]
 - The source and destination organizations must be in the same [site][11].
-- One organization can share with up to 5 other organizations.
+- Non-Enterprise organizations can share with a maximum of 5 other organizations.
 
 **Note**: After the connection is established, the destination organization can query the source organization's data in the same ways it can query its own data. This means that the source organization's data—including sensitive data—may be queried and displayed as permitted by the _destination organization's_ access-control and other settings. This may include, for example, the destination organization's ability to create [public Dashboards][10] using the source organization's data even if the source organization's own settings do not permit the creation of public Dashboards.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Cross-org docs previously stated that orgs can share with up to 5 other orgs. This change clarifies that the limit only applies to non-Enterprise customers.

### Merge instructions

Merge readiness:
- [X] Ready for merge