### PR TITLE
Reflect per-project quota being GA in Google Cloud docs

### DIFF
--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -99,7 +99,7 @@ Organization-level monitoring is recommended for comprehensive coverage of all p
    - [Monitoring Viewer][403] provides **read-only** access to the monitoring data availabile in your Google Cloud environment
    - [Cloud Asset Viewer][404] provides **read-only** access to cloud assets metadata
    - [Browser][405] provides **read-only** access to browse the hierarchy of a project
-   - [Service Usage Consumer][406] (**optional**, for multi-project environments) provides [per-project cost and API quota attribution](#enable-per-project-cost-and-api-quota-attribution) after this feature has been enabled by Datadog support
+   - [Service Usage Consumer][406] (**optional**, for multi-project environments) provides [per-project cost and API quota attribution](#enable-per-project-cost-and-api-quota-attribution)
 6. Click **Save**.
 
 **Note**: The `Browser` role is only required in the default project of the service account. Other projects require only the other listed roles.


### PR DESCRIPTION

### What does this PR do? What is the motivation?
We have made the "Enable Per Project Quota" feature generally available, meaning that customers don't need to reach out to support to use the feature. This PR updates the Google Cloud integration setup instructions to reflect that.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
