### PR TITLE
Added timestamp section to Live Tail troubleshooting public docs

### DIFF
--- a/content/en/logs/troubleshooting/live_tail.md
+++ b/content/en/logs/troubleshooting/live_tail.md
@@ -54,7 +54,7 @@ Determine whether an administrator configured a [logs restriction query (RBAC)][
 
 {{< img src="logs/explorer/live_tail/logs_rbac_page.png" alt="Logs RBAC page" style="width:100%;" >}}
 
-## Check Log Timestamps
+## Check log timestamps
 
 If you are expecting logs to appear in Live Tail which are not visible, verify whether the timestamps of the logs are within the 15 minute period of Live Tail's window.
 If log timestamps are aligned with UTC time, logs sent in real time should appear within the 15 minute period specified.
@@ -66,7 +66,7 @@ During processing, this may happen in two ways:
 - If logs are sent as JSON, automatic parsing will extract the date attribute if it is reflected by a listed attribute in [JSON Preprocessing][10].
 
 If the attribute used to reflect the timestamp of the log is in a different timezone to UTC, see [Parsing dates][9] with a Grok Parser to shift the timezone.
-- Note that this will not function for attributes parsed with JSON Preprocessing. These will need to be modified outside of Preprocessing.
+- This does not function for attributes parsed with JSON Preprocessing. These attributes must be modified outside of Preprocessing.
 
 ## Create a support ticket
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The TEE team responsible for Logs Management recently found that Live Tail is not an accurate picture of ingestion for customers to use.

After creating this document last year, we realized due to escalations that we received, that there was a gap in our public facing documentation where customers expected that Live Tail would be a picture of all incoming logs. Logs customers also use it as a source to troubleshoot their own ingestion failures, and as such, it would be ideal to notate this caveat in our documentation.

### Merge instructions

Merge readiness:
- [❌ ] Ready for merge _(needs review)_

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes

Possibly may need a rewrite to be more linguistically appropriate in line with Datadog documentation standards.