### PR TITLE
fix resource DD_TRACE_SAMPLING_RULES example

### DIFF
--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -16,7 +16,7 @@ If you want the span included in the trace metrics but don't want it ingested, u
 The recommended approach is to use sampling rules, which allow you to sample traces based on resource names, service names, tags, and operation names:
 
 ```shell
-DD_TRACE_SAMPLING_RULES='[{"resource": "GET healthcheck", "sample_rate": 0.0}]'
+DD_TRACE_SAMPLING_RULES='[{"resource": "GET /healthcheck", "sample_rate": 0.0}]'
 ```
 
 Or to sample based on HTTP URL tags:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Hey, I only got the exclusion to work with a `/` before the resource/path.

I am using FastAPI
