### PR TITLE
Revert "[DOCS-12479] Add external redirect to latest"

### DIFF
--- a/content/es/api/v1/_index.md
+++ b/content/es/api/v1/_index.md
@@ -9,5 +9,4 @@ cascade:
     publishResources: false
     render: never
 title: Api V1
-external_redirect: /api/latest/
 ---

--- a/content/es/api/v2/_index.md
+++ b/content/es/api/v2/_index.md
@@ -9,5 +9,4 @@ cascade:
     publishResources: false
     render: never
 title: Api V2
-external_redirect: /api/latest/
 ---

--- a/content/ko/api/v1/_index.md
+++ b/content/ko/api/v1/_index.md
@@ -9,5 +9,4 @@ cascade:
     render: never
     list: always
     publishResources: false
-external_redirect: /api/latest/
 ---

--- a/content/ko/api/v2/_index.md
+++ b/content/ko/api/v2/_index.md
@@ -9,5 +9,4 @@ cascade:
     render: never
     list: always
     publishResources: false
-external_redirect: /api/latest/
 ---


### PR DESCRIPTION
Reverts DataDog/documentation#32513. This doesn't work as expected and should be removed. Following up with another team internally to properly configure redirects to `latest` for Korean- and Spanish-language API documentation.