### PR TITLE
Update usage constraints of Data Access Control

### DIFF
--- a/content/en/account_management/rbac/data_access.md
+++ b/content/en/account_management/rbac/data_access.md
@@ -96,7 +96,9 @@ Playlists are collections of Session Replays you can aggregate in a folder-like 
 Data Access Control is separate from the existing [Logs RBAC permissions][11] feature, also known as log restriction queries. Datadog recommends using a single solution to restrict logs data. If you limit user access using both Data Access Control and log restriction queries, both sets of restrictions apply.
 
 ### Monitors
-Users can create Monitors that query and alert on active telemetry. While the user will only be able to directly query data they’re allowed to access, the Monitor will operate as a System User with full access to data. This gap will be addressed in a future iteration. We encourage customers who are concerned about this to carefully monitor which Monitors are created by their users and restrict the ability to create these Monitors.
+Users can create monitors that query and alert on active telemetry. While the user can only directly query data they're allowed to access, the monitor operates as a system user with full access to data.
+
+If you are concerned about unauthorized data access through monitors, Datadog recommends that you track the monitors your users create. Then, restrict access to the creation of monitors that read sensitive data.
 
 ### Software Delivery repository info (CI Visibility pipelines)
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Updates Data Access Control documentation in preparation for GA. These updates:
- Reflect which telemetry types are part of GA vs still in preview
- Clarifies updated interaction between Logs RBAC and DAC
- Adds usage constraint for Monitors not being subject to DAC restrictions
- Updated RUM constraints -- Session Replay sub-features do not get turned off now unless RUM is in a dataset

### Merge instructions

Merge readiness:
- [ X] Ready for merge
