### PR TITLE
(synthetics) Rename recording steps page

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -7334,7 +7334,7 @@ menu:
       weight: 3
     - name: Recording Steps
       identifier: synthetics_browser_tests_recording_steps
-      url: synthetics/browser_tests/actions
+      url: synthetics/browser_tests/test_steps
       parent: synthetics_browser_tests
       weight: 301
     - name: Browser Testing Results

--- a/content/en/synthetics/browser_tests/_index.md
+++ b/content/en/synthetics/browser_tests/_index.md
@@ -151,7 +151,7 @@ When setting up a new Synthetic Monitoring browser test, use snippets to automat
 
    Enter one or more request patterns to block from loading while the test is run. Enter one request pattern per line using the [match pattern format][1]. Wildcards (for example, `*://*.example.com/*`) are supported.
 
-   Blocked requests are skipped during test execution but do not affect page rendering when [recording steps](/synthetics/browser_tests/actions). View blocked requests in the [Resources tab](/synthetics/browser_tests/test_results#resources) of test runs. Blocked requests have a status of `blocked`.
+   Blocked requests are skipped during test execution but do not affect page rendering when [recording steps](/synthetics/browser_tests/test_steps). View blocked requests in the [Resources tab](/synthetics/browser_tests/test_results#resources) of test runs. Blocked requests have a status of `blocked`.
 
 [1]: https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
 
@@ -360,16 +360,16 @@ Use [granular access control][17] to limit who has access to your test based on 
 [2]: /continuous_testing/environments/proxy_firewall_vpn
 [3]: /help/
 [4]: /synthetics/settings/#global-variables
-[5]: /synthetics/browser_tests/actions#variables
+[5]: /synthetics/browser_tests/test_steps#variables
 [6]: /api/latest/synthetics/#create-or-clone-a-test
 [7]: http://daringfireball.net/projects/markdown/syntax
 [8]: /monitors/notify/variables/?tab=is_alert#conditional-variables
 [9]: /synthetics/notifications/
 [10]: https://www.google.com/chrome
 [11]: https://chrome.google.com/webstore/detail/datadog-test-recorder/kkbncfpddhdmkfmalecgnphegacgejoa
-[12]: /synthetics/browser_tests/actions/#assertion
+[12]: /synthetics/browser_tests/test_steps/#assertion
 [13]: /synthetics/guide/explore-rum-through-synthetics/
-[14]: /synthetics/browser_tests/actions/
+[14]: /synthetics/browser_tests/test_steps/
 [15]: /account_management/rbac#custom-roles
 [16]: /account_management/rbac/#create-a-custom-role
 [17]: /account_management/rbac/granular_access

--- a/content/en/synthetics/browser_tests/advanced_options.md
+++ b/content/en/synthetics/browser_tests/advanced_options.md
@@ -8,7 +8,7 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/browser-tests/"
   tag: "Blog"
   text: "User experience monitoring with Synthetic browser tests"
-- link: "/synthetics/browser_tests/actions/"
+- link: "/synthetics/browser_tests/test_steps/"
   tag: "Documentation"
   text: "Learn more about Browser Test Steps"
 ---
@@ -121,8 +121,8 @@ For more information, see [Browser Test Steps][4].
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /synthetics/browser_tests/actions/
+[1]: /synthetics/browser_tests/test_steps/
 [2]: /data_security/synthetics/
 [3]: /synthetics/browser_tests/?tab=privacy#test-configuration
-[4]: /synthetics/browser_tests/actions/#subtests
-[5]: /synthetics/browser_tests/actions/#assertion
+[4]: /synthetics/browser_tests/test_steps/#subtests
+[5]: /synthetics/browser_tests/test_steps/#assertion

--- a/content/en/synthetics/browser_tests/app-that-requires-login.md
+++ b/content/en/synthetics/browser_tests/app-that-requires-login.md
@@ -14,7 +14,7 @@ further_reading:
   - link: '/synthetics/guide/browser-tests-passkeys'
     tag: 'Documentation'
     text: 'Learn about Passkeys in browser tests'
-  - link: '/synthetics/browser_tests/actions'
+  - link: '/synthetics/browser_tests/test_steps'
     tag: 'Documentation'
     text: 'Learn about browser test steps'
   - link: '/synthetics/guide/kerberos-authentication/'
@@ -108,13 +108,13 @@ For more information about account security, see [Synthetic Monitoring Data Secu
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /synthetics/browser_tests/actions/
-[2]: /synthetics/browser_tests/actions/#subtests
+[1]: /synthetics/browser_tests/test_steps/
+[2]: /synthetics/browser_tests/test_steps/#subtests
 [3]: /synthetics/guide/identify_synthetics_bots/
 [4]: /synthetics/guide/browser-tests-passkeys
 [5]: /synthetics/guide/browser-tests-totp
-[6]: /synthetics/browser_tests/actions/#test-your-ui-with-custom-javascript
+[6]: /synthetics/browser_tests/test_steps/#test-your-ui-with-custom-javascript
 [7]: /synthetics/settings/?tab=specifyvalue#global-variables
-[8]: /synthetics/browser_tests/actions#a-global-variable
+[8]: /synthetics/browser_tests/test_steps#a-global-variable
 [9]: /data_security/synthetics
 [10]: /synthetics/guide/authentication-protocols/?tab=basicaccess#authentication-methods

--- a/content/en/synthetics/browser_tests/test_steps.md
+++ b/content/en/synthetics/browser_tests/test_steps.md
@@ -1,6 +1,8 @@
 ---
 title: Browser Testing Steps
 description: Learn how to automatically record and manually set steps in a browser test recording.
+aliases:
+- /synthetics/browser_tests/actions
 further_reading:
 - link: "/synthetics/browser_tests/advanced_options/"
   tag: "Documentation"
@@ -160,7 +162,7 @@ Create this assertion step to have your browser test verify the downloaded files
 For more information about how to test downloads, see [Test File Upload and Download][3].
 
 [1]: /synthetics/guide/email-validation
-[2]: /synthetics/browser_tests/actions#use-variables
+[2]: /synthetics/browser_tests/test_steps#use-variables
 [3]: /synthetics/guide/testing-file-upload-and-download/#testing-a-file-download
 
 #### Test HTTP Request Count

--- a/content/en/synthetics/guide/browser-tests-using-shadow-dom.md
+++ b/content/en/synthetics/guide/browser-tests-using-shadow-dom.md
@@ -120,5 +120,5 @@ You can use the `Press Key` action to select the appropriate options. For exampl
 
 [1]: https://developers.google.com/web/fundamentals/web-components/shadowdom
 [2]: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM#basic_usage
-[3]: /synthetics/browser_tests/actions#type-text
+[3]: /synthetics/browser_tests/test_steps#type-text
 

--- a/content/en/synthetics/guide/custom-javascript-assertion.md
+++ b/content/en/synthetics/guide/custom-javascript-assertion.md
@@ -3,7 +3,7 @@ title: Use Custom JavaScript Assertions In Browser Tests
 
 description: Learn how to use custom JavaScript assertions in your Synthetic browser tests.
 further_reading:
-- link: '/synthetics/browser_tests/actions/'
+- link: '/synthetics/browser_tests/test_steps/'
   tag: 'Documentation'
   text: 'Learn about browser test steps'
 - link: '/synthetics/browser_tests/advanced_options/'
@@ -108,4 +108,4 @@ return await loadingTask.promise.then(function(pdf) {
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /synthetics/browser_tests/
-[2]: /synthetics/browser_tests/actions/?tab=testanelementontheactivepage#assertion
+[2]: /synthetics/browser_tests/test_steps/?tab=testanelementontheactivepage#assertion

--- a/content/en/synthetics/guide/email-validation.md
+++ b/content/en/synthetics/guide/email-validation.md
@@ -2,7 +2,7 @@
 title: Use Email Validation In Browser Tests
 description: Verify an email and its content with browser test steps.
 further_reading:
-- link: "/synthetics/browser_tests/actions"
+- link: "/synthetics/browser_tests/test_steps"
   tag: "Documentation"
   text: "Learn about steps for browser tests"
 - link: "/synthetics/browser_tests/advanced_options/"

--- a/content/en/synthetics/guide/otp-email-synthetics-test.md
+++ b/content/en/synthetics/guide/otp-email-synthetics-test.md
@@ -138,10 +138,10 @@ From here, you can continue [recording the rest of your Browser Test][9] and the
 [2]: https://app.datadoghq.com/synthetics/settings/variables
 [3]: https://app.datadoghq.com/synthetics/browser/create
 [4]: /synthetics/settings/?tab=specifyvalue#global-variables
-[5]: /synthetics/browser_tests/actions/?tab=testanelementontheactivepage#javascript
-[6]: /synthetics/browser_tests/actions/?tab=testanelementontheactivepage#assertion
-[7]: /synthetics/browser_tests/actions/?tab=testanelementontheactivepage#email
+[5]: /synthetics/browser_tests/test_steps/?tab=testanelementontheactivepage#javascript
+[6]: /synthetics/browser_tests/test_steps/?tab=testanelementontheactivepage#assertion
+[7]: /synthetics/browser_tests/test_steps/?tab=testanelementontheactivepage#email
 [8]: /synthetics/guide/email-validation/#create-an-email-variable
-[9]: /synthetics/browser_tests/actions?tab=testanelementontheactivepage
+[9]: /synthetics/browser_tests/test_steps?tab=testanelementontheactivepage
 [10]: /synthetics/browser_tests/test_results
-[11]: /synthetics/browser_tests/actions?tab=testanelementontheactivepage#automatically-recorded-steps
+[11]: /synthetics/browser_tests/test_steps?tab=testanelementontheactivepage#automatically-recorded-steps

--- a/content/en/synthetics/guide/popup.md
+++ b/content/en/synthetics/guide/popup.md
@@ -69,5 +69,5 @@ Alternatively, use one of these methods to ensure your pop-up is closed and your
 [1]: https://javascript.info/alert-prompt-confirm
 [2]: /synthetics/browser_tests/#test-configuration
 [3]: /synthetics/browser_tests/advanced_options/#optional-step
-[4]: /synthetics/browser_tests/actions#test-your-ui-with-custom-javascript
+[4]: /synthetics/browser_tests/test_steps#test-your-ui-with-custom-javascript
 [5]: /synthetics/browser_tests

--- a/content/en/synthetics/guide/recording-custom-user-agent.md
+++ b/content/en/synthetics/guide/recording-custom-user-agent.md
@@ -2,7 +2,7 @@
 title: Record Steps With A Custom User-Agent
 description: Record browser test steps with a custom User-Agent string 
 further_reading:
-- link: "/synthetics/browser_tests/actions"
+- link: "/synthetics/browser_tests/test_steps"
   tag: "Documentation"
   text: "Learn about steps for browser tests"
 - link: "/synthetics/browser_tests/advanced_options/"

--- a/content/en/synthetics/guide/reusing-browser-test-journeys.md
+++ b/content/en/synthetics/guide/reusing-browser-test-journeys.md
@@ -5,7 +5,7 @@ further_reading:
     - link: 'synthetics/browser_tests'
       tag: 'Documentation'
       text: 'Configure a Browser Test'
-    - link: '/synthetics/browser_tests/actions'
+    - link: '/synthetics/browser_tests/test_steps'
       tag: 'Documentation'
       text: 'Create Browser Test Steps'
     - link: 'https://www.datadoghq.com/blog/test-creation-best-practices/'

--- a/content/en/synthetics/guide/rum-to-synthetics.md
+++ b/content/en/synthetics/guide/rum-to-synthetics.md
@@ -44,5 +44,5 @@ Further customize your tests and test steps to suit your needs, just as you woul
 [2]: /synthetics/browser_tests
 [3]: https://app.datadoghq.com/rum/sessions
 [4]: /real_user_monitoring/session_replay/browser/
-[5]: /synthetics/browser_tests/actions
+[5]: /synthetics/browser_tests/test_steps
 [6]: /synthetics/browser_tests/?tab=requestoptions#test-configuration

--- a/content/en/synthetics/guide/testing-file-upload-and-download.md
+++ b/content/en/synthetics/guide/testing-file-upload-and-download.md
@@ -53,5 +53,5 @@ To setup a browser test with this assertion:
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: /synthetics/browser_tests/actions/#upload-file
-[2]: /synthetics/browser_tests/actions/#assertion
+[1]: /synthetics/browser_tests/test_steps/#upload-file
+[2]: /synthetics/browser_tests/test_steps/#assertion

--- a/content/en/synthetics/platform/settings/_index.md
+++ b/content/en/synthetics/platform/settings/_index.md
@@ -323,7 +323,7 @@ To allow Datadog to collect RUM data from your mobile application test runs, con
 [13]: /account_management/billing/usage_attribution
 [14]: /synthetics/guide/explore-rum-through-synthetics/
 [15]: /synthetics/apm/#prerequisites
-[16]: /synthetics/browser_tests/actions/#use-variables
+[16]: /synthetics/browser_tests/test_steps/#use-variables
 [17]: /synthetics/mobile_app_testing/
 [18]: /synthetics/mobile_app_testing/settings/
 [19]: /synthetics/mobile_app_testing/#use-global-variables


### PR DESCRIPTION
This page being named "actions" is causing it to pick up the site support config for the actions product. Renaming it is the easiest way to avoid this issue.

See DOCS-12707, DOCSENG-195

- [x] Ready to merge
