### PR TITLE
TCP remove legacy endoints

### DIFF
--- a/assets/scripts/config/regions.config.js
+++ b/assets/scripts/config/regions.config.js
@@ -70,6 +70,15 @@ export default {
     ap2: 'The AP2 endpoint is not supported.',
     gov: 'The GOV TCP endpoint port is not supported.'
   },
+  hipaa_logs_legacy: {
+    us: 'tcp-encrypted-intake.logs.datadoghq.com<br>lambda-tcp-encrypted-intake.logs.datadoghq.com<br>gcp-encrypted-intake.logs.datadoghq.com<br>http-encrypted-intake.logs.datadoghq.com',
+    us3: 'lambda-tcp-encrypted-intake.logs.us3.datadoghq.com<br>gcp-encrypted-intake.logs.us3.datadoghq.com<br>http-encrypted-intake.logs.us3.datadoghq.com',
+    us5: 'lambda-tcp-encrypted-intake.logs.us5.datadoghq.com<br>gcp-encrypted-intake.logs.us5.datadoghq.com<br>http-encrypted-intake.logs.us5.datadoghq.com',
+    eu: 'tcp-encrypted-intake.logs.datadoghq.eu<br>lambda-tcp-encrypted-intake.logs.datadoghq.eu<br>gcp-encrypted-intake.logs.datadoghq.eu<br>http-encrypted-intake.logs.datadoghq.eu',
+    ap1: 'N/A',
+    ap2: 'N/A',
+    gov: 'lambda-tcp-encrypted-intake.logs.ddog-gov.com<br>gcp-encrypted-intake.logs.ddog-gov.com<br>http-encrypted-intake.logs.ddog-gov.com'
+  },
   web_integrations_endpoint: {
     us: 'intake.logs.datadoghq.com',
     us3: 'intake.logs.us3.datadoghq.com',

--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -109,6 +109,9 @@ API test results for the Synthetics Worker < v0.1.5: `api.`{{< region-param key=
 HTTP: {{< region-param key=agent_http_endpoint code="true" >}}<br>
 Other: See [logs endpoints][32]
 
+[HIPAA logs legacy][31] (Deprecated, TCP not supported)
+: {{< region-param key=hipaa_logs_legacy code="true" >}}
+
 [Metrics][26], [Service Checks][27], [Events][28], and other Agent metadata
 : `<VERSION>-app.agent.`{{< region-param key="dd_site" code="true" >}}<br>
 For example, Agent v7.31.0 reports to `7-31-0-app.agent.`{{< region-param key="dd_site" code="true" >}}. You must add `*.agent.`{{< region-param key="dd_site" code="true" >}} to your inclusion list in your firewall(s).<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Remove deprecated TLS encryption endpoints from data security docs
- Add deprecated note for HIPAA logs legacy endpoints
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
