### PR TITLE
Add troubleshooting case for workflows:write issue with GH

### DIFF
--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -80,6 +80,14 @@ When you launch the Dev Agent, it runs the setup command at startup and can use 
 
 **Note**: For best results, add a [custom instructions file](#configure-custom-instructions) (like `claude.md`) to your repository with instructions on how to build and test your code.
 
+## Troubleshooting
+
+### Problems Creating Pull Requests
+
+#### Missing Permissions Errors with GitHub
+
+In some cases GitHub requires the `workflows:write` permission to be granted to the App to be able to create/update Pull Requests via API for repositories with many branches. Please add the `workflows:write` permission to your GitHub App in [Source Code Integration][5].
+
 [1]: /error_tracking
 [2]: /security/code_security  
 [3]: /profiler/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

People often run into the undocumented GH Api behavior of a repo with too many branches causing PR creation/update to fail due to missing workflows:write permission. A customer ran into it this week.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
