### PR TITLE
[Serverless] Update Supported Languages for APIGW

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/apigateway.md
+++ b/content/en/tracing/trace_collection/proxy_setup/apigateway.md
@@ -65,7 +65,8 @@ Datadog APM can create **inferred spans** for requests that pass through Amazon 
 | Go | `dd-trace-go` | v[1.72.1][3]+ | chi, httptreemux, echo, go-restful, fiber, gin, gorilla mux, httprouter, fasthttp, goji |
 | Python | `dd-trace-py` | v[3.1.0][4]+ | aiohttp, asgi, bottle, cherrypy, django, djangorestframework, falcon, fastapi, flask, molten, pyramid, sanic, starlette, tornado, wsgi |
 | PHP | `dd-trace-php` | v[1.8.0][7]+ | CakePHP, CodeIgniter, Drupal, FuelPHP, Laminas, Laravel, Lumen, Magento, Neos Flow, Phalcon, Roadrunner, Slim, Symfony, WordPress, Zend Framework |
-| .NET | `dd-trace-dotnet` | v[3.15.0][8]+ | CakePHP, CodeIgniter, Drupal, FuelPHP, Laminas, Laravel, Lumen, Magento, Neos Flow, Phalcon, Roadrunner, Slim, Symfony, WordPress, Zend Framework |
+| .NET | `dd-trace-dotnet` | v[3.15.0][8]+ | ASP.NET, ASP.NET Core |
+| Java | `dd-trace-java` | v[1.56.0][9]+ | akka-http, axway-api, azure-functions, finatra, grizzly, jetty, liberty, micronaut, netty, pekko-http, play, ratpack, restlet, servlet, spring-web, spray, synapse, tomcat, undertow, vertx |
 
 ## Setup
 
@@ -206,3 +207,4 @@ Update the rule in one of the following ways:
 [6]: https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api.html
 [7]: https://github.com/DataDog/dd-trace-php/releases/tag/1.8.0
 [8]: https://github.com/DataDog/dd-trace-dotnet/releases/tag/v3.15.0
+[9]: https://github.com/DataDog/dd-trace-java/releases/tag/v1.56.0


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

We added support for [Java](https://github.com/DataDog/dd-trace-java/releases/tag/v1.56.0) for API Gateway in the latest release. Updating docs to support that

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
