### PR TITLE
Clarify behavior without resource collection enabled

### DIFF
--- a/content/en/infrastructure/containers/amazon_elastic_container_explorer.md
+++ b/content/en/infrastructure/containers/amazon_elastic_container_explorer.md
@@ -25,7 +25,7 @@ The Datadog Agent and Datadog Amazon ECS integration can retrieve ECS resources 
 
 Ensure you have enabled [AWS resource collection][10], the [ECS on EC2 integration][2], and the [ECS on Fargate integration][3].
 
-**Note**: The collection interval for these integrations is approximately 15 minutes. To achieve a shorter collection interval of 15 seconds, it is recommended to install the Datadog Agent in your ECS cluster.
+**Note**: The collection interval for these integrations is approximately 15 minutes. Datadog recommends installing the Datadog Agent in your ECS cluster to achieve a shorter collection interval of 15 seconds.
 
 {{< tabs >}}
 {{% tab "Task Definition" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Updates the ECS Explorer documentation with the following:
- clarifies the responsibility of the Datadog Agent vs AWS Resource Collection along with the update frequency depending on the setup
- fixes incorrect references to 24 hour collection frequency.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
