### PR TITLE
[DOCSENG-208]Fix: Search indexing job shows false positives due to duplicate objectIDs in local build

### DIFF
--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -7,9 +7,12 @@
     {{ range (where (where (where .Site.AllPages "Kind" "!=" "home") "Type" "!=" "api") ".RelPermalink" "not in" $apiPagesWithoutTypeAPI) }}
         {{ $page := . }}
         {{ if and ($page.IsDescendant $section) (ne $page.Params.type "partners") (ne $page.Params.private true) (not (in $page.RelPermalink "/faq")) (not $page.Draft) (not (isset .Params "external_redirect")) }}
+            {{- /* Generate unique ID for each page. Use file path when available, fallback to RelPermalink for pages without files (e.g. virtual pages). This avoids duplicate IDs while preserving existing IDs for 300k+ items. */ -}}
             {{ $rel_path := "" }}
             {{ with $page.File }}
               {{ $rel_path = (print $page.Language.Lang "/" .Path) }}
+            {{ else }}
+              {{ $rel_path = $page.RelPermalink }}
             {{ end }}
             {{ $object_id := md5 $rel_path }}
             {{ $title := $page.Params.integration_title | default $page.Title }}

--- a/layouts/partials/algolia/api-page-index.json
+++ b/layouts/partials/algolia/api-page-index.json
@@ -40,10 +40,11 @@
 {{ end }}
 
 {{/* Add the resulting object to the index */}}
+{{ $object_id := print $full_url "_" $operationId }}
 {{
     $hugo_context.Scratch.Add "algoliaindex" (
-        dict "objectID" (md5 $full_url)
-        "id" (md5 $full_url)
+        dict "objectID" (md5 $object_id)
+        "id" (md5 $object_id)
         "title" $title
         "section_header" $section_header
         "content" $section_content

--- a/layouts/partials/algolia/standard-attributes.json
+++ b/layouts/partials/algolia/standard-attributes.json
@@ -1,8 +1,8 @@
 {{- $hugo_context := .context -}}
 {{- $page := $hugo_context.Site.GetPage "/standard-attributes/" -}}
 
-{{- range $attr := $page.Params.attributes -}}
-  {{- $object_id := (print $page.File.UniqueID "_" $page.Language.Lang "_" ($attr.name | anchorize)) -}}
+{{- range $index, $attr := $page.Params.attributes -}}
+  {{- $object_id := (print $page.File.UniqueID "_" $page.Language.Lang "_" ($attr.name | anchorize)) "_" $index -}}
   {{- $relpermalink := print $page.RelPermalink "?search=" $attr.name -}}
   {{
     $hugo_context.Scratch.Add "algoliaindex" (


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->



### What does this PR do? What is the motivation?
### Problem
The GitLab search indexing job consistently reports ~63 items needing updates on every run, even when no content has changed. Investigation revealed these are false positives caused by duplicate `objectID` values in the locally generated search index.
<img width="609" height="74" alt="image" src="https://github.com/user-attachments/assets/59800e66-4379-4476-b46f-1d6fe418ba74" />


### Root Cause
When the local build generates search.json with duplicate IDs, only the last occurrence is kept. However, Typesense remote collection contains different versions of these duplicates from previous syncs, causing the comparison to always detect differences.

**Two sources of duplicates:**
1. **API operations** (21+ duplicates): Multiple operations with the same translated section header generate identical IDs
2. **Virtual pages** (~30 duplicates): Pages without files all generate the empty string hash `d41d8cd98f00b204e9800998ecf8427e` = `md5('')`

### Impact
- Indexing job shows misleading "updated" count
- Difficult to detect actual content changes
- Potential for overwriting wrong documents in Typesense

### Solution
Fix ID generation to ensure uniqueness:
- API pages: Include `operationId` in hash
- Virtual pages: Use `RelPermalink` as fallback when file is `nil`

jira ticket: 
https://datadoghq.atlassian.net/browse/DOCSENG-208

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
