### PR TITLE
Updated DDOT BYOC instructions to reflect changes made to Dockerfile

### DIFF
--- a/content/en/opentelemetry/setup/ddot_collector/custom_components.md
+++ b/content/en/opentelemetry/setup/ddot_collector/custom_components.md
@@ -25,7 +25,7 @@ To complete this guide, you need the following:
 
 ## Store the desired Datadog Agent version in a shell variable
 
-This ensures all files are compatible
+This ensures all files are compatible:
 
 ```shell
 DD_AGENT_VERSION="{{< version key="agent_version" >}}"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This change relates to [this PR](https://github.com/DataDog/datadog-agent/pull/42614) about the DDOT Dockerfile, which simplify invocation by requiring a single argument.

A notable change is the use of a shell variable to ensure all downloaded files and docker images match the same version.
**Is that an accepted practice in public documentation ?**

### Merge instructions

1. Validate the general principle of this PR here
2. merge the referenced PR in the agent
3. wait for the associated release
4. merge this PR

Merge readiness:
- [ ] Ready for merge
