### PR TITLE
[DOCSENG-208] Fix build failure in `standard-attributes.json`

### DIFF
--- a/layouts/partials/algolia/standard-attributes.json
+++ b/layouts/partials/algolia/standard-attributes.json
@@ -2,7 +2,7 @@
 {{- $page := $hugo_context.Site.GetPage "/standard-attributes/" -}}
 
 {{- range $index, $attr := $page.Params.attributes -}}
-  {{- $object_id := (print $page.File.UniqueID "_" $page.Language.Lang "_" ($attr.name | anchorize)) "_" $index -}}
+  {{- $object_id := (print $page.File.UniqueID "_" $page.Language.Lang "_" ($attr.name | anchorize) "_" $index) -}}
   {{- $relpermalink := print $page.RelPermalink "?search=" $attr.name -}}
   {{
     $hugo_context.Scratch.Add "algoliaindex" (


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Fixes missing closing parenthesis in `print`  function at `standard-attributes.json` that was causing build to fail.

Error: `can't give argument to non-function print`

Full Error:
```
Error: error building site: render: failed to render pages: render of "/go/src/github.com/DataDog/documentation/content/en/_index.md" failed: "/go/src/github.com/DataDog/documentation/layouts/_default/list.search.json:76:7": execute of template failed: template: list.search.json:76:7: executing "list.search.json" at <partial "algolia/standard-attributes.json" (dict "context" $hugo_context)>: error calling partial: "/go/src/github.com/DataDog/documentation/layouts/partials/algolia/standard-attributes.json:5:6": execute of template failed: template: _partials/algolia/standard-attributes.json:5:6: executing "_partials/algolia/standard-attributes.json" at <$object_id := (print $page.File.UniqueID "_" $page.Language.Lang "_" ($attr.name | anchorize)) "_" $index>: can't give argument to non-function print $page.File.UniqueID "_" $page.Language.Lang "_" ($attr.name | anchorize)
```

related to : 
https://datadoghq.atlassian.net/browse/DOCSENG-208
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
