### PR TITLE
`dogstatsd_non_local_traffic` is true by default

### DIFF
--- a/content/en/tracing/metrics/runtime_metrics/_index.md
+++ b/content/en/tracing/metrics/runtime_metrics/_index.md
@@ -125,7 +125,7 @@ Enable [DogStatsD for the Agent][2]. By default, the Datadog Agent is configured
 
 When running the Agent in containerized environments, additional configuration is required:
 
-1. Set `dogstatsd_non_local_traffic: true` in your main [`datadog.yaml` configuration file][8], or set the [environment variable][3] `DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true`. **Note**: DogStatsD non‑local traffic is enabled by default, so you typically don’t need to set this unless you’ve overridden the default.
+1. Set `dogstatsd_non_local_traffic: true` in your main [`datadog.yaml` configuration file][8], or set the [environment variable][3] `DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true`. **Note**: DogStatsD non‑local traffic is enabled by default, so you only need to set this if you've overridden it.
 2. Follow these container-specific setup instructions:
 
 {{< partial name="apm/apm-runtime-metrics-containers.html" >}}


### PR DESCRIPTION
`dogstatsd_non_local_traffic` is set to true by default. Just adding a note to inform users, since the current documentation requests this to be configured, which is not necessary. ZD: 2363535

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
