### PR TITLE
Update the list of iOS SDK v3 modules for KMP SDK integration

### DIFF
--- a/content/en/logs/log_collection/kotlin_multiplatform.md
+++ b/content/en/logs/log_collection/kotlin_multiplatform.md
@@ -45,7 +45,7 @@ kotlin {
     * `DatadogLogs`
     * `DatadogCrashReporting`
 
-    **Note**: Versions of these dependencies should be aligned with the version used by the Datadog Kotlin Multiplatform SDK itself. You can find the complete mapping of iOS SDK versions for each Kotlin Multiplatform SDK release in the [version compatibility guide][6]. If you are using Kotlin Multiplatform SDK version 1.3.0 or below, you should add `DatadogObjc` dependency instead of `DatadogCore` and `DatadogLogs`.
+    **Note**: Versions of these dependencies should be aligned with the version used by the Datadog Kotlin Multiplatform SDK itself. You can find the complete mapping of iOS SDK versions for each Kotlin Multiplatform SDK release in the [version compatibility guide][6]. If you are using Kotlin Multiplatform SDK version 1.3.0 or below, add `DatadogObjc` dependency instead of `DatadogCore` and `DatadogLogs`.
 
     #### Adding native iOS dependencies using the CocoaPods plugin
 

--- a/content/en/real_user_monitoring/application_monitoring/kotlin_multiplatform/setup.md
+++ b/content/en/real_user_monitoring/application_monitoring/kotlin_multiplatform/setup.md
@@ -61,7 +61,7 @@ Add the following Datadog iOS SDK dependencies, which are needed for the linking
 * `DatadogRUM`
 * `DatadogCrashReporting`
 
-**Note**: Versions of these dependencies should be aligned with the version used by the Datadog Kotlin Multiplatform SDK itself. You can find the complete mapping of iOS SDK versions for each Kotlin Multiplatform SDK release in the [version compatibility guide][14]. If you are using Kotlin Multiplatform SDK version 1.3.0 or below, you should add `DatadogObjc` dependency instead of `DatadogCore` and `DatadogRUM`.
+**Note**: Versions of these dependencies should be aligned with the version used by the Datadog Kotlin Multiplatform SDK itself. You can find the complete mapping of iOS SDK versions for each Kotlin Multiplatform SDK release in the [version compatibility guide][14]. If you are using Kotlin Multiplatform SDK version 1.3.0 or below, add `DatadogObjc` dependency instead of `DatadogCore` and `DatadogRUM`.
 
 #### Adding native iOS dependencies using the CocoaPods plugin
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

iOS SDK v3 got `DatadogObjc` module removed (see [migration guide](https://github.com/DataDog/dd-sdk-ios/blob/develop/MIGRATION.md#migration-from-2x-to-30)), so we need to update KMP SDK documentation.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
