### PR TITLE
DOCSENG-192 - add explode support to curl

### DIFF
--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -87,16 +87,18 @@
 {{- end -}}
 {{- end -}}
 <span class="n">curl</span> <span class="o">-X</span> <span class="s1">{{ $endpoint.actionType | upper }}</span> {{ range $region, $url := $endpoint.regions }}{{ if ne $region "local" }}<span class="kn d-none" data-region="{{ $region }}">"{{ $url }}</span>{{ else }}<span class="kn">"{{ $url }}</span>{{ end }}{{ end }}<span class="kn">{{ replace $endpoint.pathKey "{" "${" }}</span>
+{{- $count := 0 -}}
 {{- range $qi, $q := $parameters.queryStrings -}}
       {{- if or (eq $q.required true) (eq (index $q "x-docs-curl-required") true) -}}
         {{- $val := .example | default (.schema.example | default .name) -}}
         {{- if and ($q.explode | default false) (reflect.IsSlice $val) -}}
           {{- range $k, $v := $val -}}
-            <span class="kn">{{ cond (gt $k 0) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}}_{{- $k -}} }</span>
+            <span class="kn">{{ cond (or (gt $count 0) (gt $k 0)) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}}_{{- $k -}} }</span>
           {{- end -}}
         {{- else -}}
-          <span class="kn">{{ cond (gt $qi 0) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}} }</span>
+          <span class="kn">{{ cond (gt $count 0) "&" "?" }}</span><span class="kn">{{ $q.name }}</span><span class="kn">=</span><span class="kn">${ {{- $q.name -}} }</span>
         {{- end -}}
+        {{- $count = add $count 1 -}}
       {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

https://datadoghq.atlassian.net/browse/DOCSENG-192
If query params have `explode:true` we should break out the variables individually

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes

See the new feature:
https://docs-staging.datadoghq.com/david.jones/explode-support/api/latest/reference-tables/#get-rows-by-id

curl example should change from something like
```
...
# Required query arguments
export row_id="[row1 row2]"
# Curl command
curl -X GET "https://api.datadoghq.com/api/v2/reference-tables/tables/${id}/rows?row_id=${row_id}" \
...
```
to something like
```
...
# Required query arguments
export row_1_id="row1"
export row_2_id="row2"
# Curl command
curl -X GET "https://api.datadoghq.com/api/v2/reference-tables/tables/${id}/rows?row_id=${row_1_id}&row_id=${row_2_id}" \
...
```

Also fixed a bug with existing queryparams that were broken

https://docs-staging.datadoghq.com/david.jones/explode-support/api/latest/incidents/#search-for-incidents

From ```/v2/incidents/search&query=${query}``` to ```/v2/incidents/search?query=${query}```