### PR TITLE
[CONTP-1051] hide pod and node labels/annotations as tags in a collapsed legacy configuration section

### DIFF
--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -326,7 +326,7 @@ spec:
         baz: qux
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all resource annotations as tags to your metrics, except those from KSM (`kubernetes_state.*`). In this example, pod tag names are prefixed with `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all resource annotations as tags to your metrics. In this example, pod tag names are prefixed with `<PREFIX>_`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -337,7 +337,7 @@ spec:
   global:
     kubernetesResourcesAnnotationsAsTags:
       pods:
-        "*": <PREFIX>_%%annotation%%
+        "*": <PREFIX>_%%annotation%% # 
 ```
 
 {{% /tab %}}
@@ -439,7 +439,7 @@ bar: quuz
 
 
 {{% collapse-content title="Legacy Configuration" level="h4" expanded=false id="legacy-configuration" %}}
-### Node labels as tags
+#### Node labels as tags
 
 <div class="alert alert-info">
 
@@ -476,7 +476,7 @@ spec:
       kubernetes.io/arch: arch
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics, except those from KSM (`kubernetes_state.*`). In this example, the tag' names are prefixed with `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tag' names are prefixed with `<PREFIX>_`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -486,7 +486,7 @@ metadata:
 spec:
   global:
     nodeLabelsAsTags:
-      "*": <PREFIX>_%%label%% # Note: wildcards do not work for KSM metrics
+      "*": <PREFIX>_%%label%% # Note: wildcards do not work for KSM metrics before version 7.73
 ```
 {{% /tab %}}
 
@@ -506,13 +506,13 @@ datadog:
     kubernetes.io/arch: arch
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics, except those from KSM (`kubernetes_state.*`). In this example, the tags' names are prefixed with `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags' names are prefixed with `<PREFIX>_`:
 
 
 ```yaml
 datadog:
   nodeLabelsAsTags:
-    "*": <PREFIX>_%%label%% # Note: wildcards do not work for KSM metrics
+    "*": <PREFIX>_%%label%% # Note: wildcards do not work for KSM metrics before version 7.73
 ```
 {{% /tab %}}
 
@@ -529,17 +529,17 @@ For example, you could set up:
 DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"kubernetes.io/arch":"arch"}'
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics, except those from KSM (`kubernetes_state.*`). In this example, the tags' tag names are prefixed with `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all node labels as tags to your metrics. In this example, the tags' tag names are prefixed with `<PREFIX>_`:
 
 ```bash
-DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
+DD_KUBERNETES_NODE_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}' # Note: wildcards do not work for KSM metrics before version 7.73
 ```
 {{% /tab %}}
 {{< /tabs >}}
 
 **Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
-### Pod labels as tags
+#### Pod labels as tags
 
 <div class="alert alert-info">
 
@@ -576,7 +576,7 @@ spec:
       app: kube_app
 ```
 
-For Agent v7.24.0+, use the following environment variable configuration to add all pod labels as tags to your metrics, except those from KSM (`kubernetes_state.*`). In this example, the tags' names are prefixed with `<PREFIX>_`:
+For Agent v7.24.0+, use the following environment variable configuration to add all pod labels as tags to your metrics In this example, the tags' names are prefixed with `<PREFIX>_`:
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -586,7 +586,7 @@ metadata:
 spec:
   global:
     podLabelsAsTags:
-      "*": <PREFIX>_%%label%% # Note: wildcards do not work for KSM metrics
+      "*": <PREFIX>_%%label%% # Note: wildcards do not work for KSM metrics before version 7.73
 ```
 {{% /tab %}}
 
@@ -638,7 +638,7 @@ DD_KUBERNETES_POD_LABELS_AS_TAGS='{"*":"<PREFIX>_%%label%%"}'
 
 **Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
-### Pod annotations as tags
+#### Pod annotations as tags
 
 <div class="alert alert-info">
 
@@ -737,7 +737,7 @@ DD_KUBERNETES_POD_ANNOTATIONS_AS_TAGS='{"*":"<PREFIX>_%%annotation%%"}'
 
 **Note**: Custom metrics may impact billing. See the [custom metrics billing page][3] for more information.
 
-### Namespace labels as tags
+#### Namespace labels as tags
 
 <div class="alert alert-info">
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Hides the following configuration options in a collapsed legacy configuration section:
- `nodeLabelsAsTags`
- `nodeAnnotationsAsTags`
- `podAnnotationsAsTags`
- `podLabelsAsTags`

This is done in favor of increasing reader's focus on the more recent + more generic configuration options:
- `kubernetesResourcesLabelsAsTags`
- `kubernetesResourcesAnnotationsAsTags`

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
