### PR TITLE
[DOCS-12784] Mark Linear integration not supported in GovCloud

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -305,6 +305,7 @@ unsupported_sites:
   iac_security: [gov]
   incident_ai: [gov]
   internal_developer_portal: [gov]
+  linear: [gov]
   live_debugger: [gov]
   llm_observability: [gov]
   mobile_app_testing: [gov]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The Linear integration is not supported in GovCloud. This PR adds the Linear docs directory to the `unsupported_sites` mappings so that the correct banner will be applied to the integration's docs when the user has the US1-FED site selected:

<img width="754" height="72" alt="image" src="https://github.com/user-attachments/assets/e9bed212-e88d-4be1-80f3-beed22c6ef65" />

See also https://github.com/DataDog/integrations-internal-core/pull/2493 removing an older version of the banner from Linear.

### Merge instructions

Merge readiness:
- [x] Ready for merge