### PR TITLE
apm: document js otel metrics support

### DIFF
--- a/content/en/opentelemetry/instrument/api_support/nodejs/metrics.md
+++ b/content/en/opentelemetry/instrument/api_support/nodejs/metrics.md
@@ -16,7 +16,7 @@ further_reading:
 
 ## Prerequisites
 
-- **Datadog SDK**: dd-trace version 5.81.0 or later.
+- **Datadog SDK**: `dd-trace-js` version 5.81.0 or later.
 - **OpenTelemetry API**: `@opentelemetry/api` version 1.0.0 to 1.10.0. (The Datadog SDK provides the implementation for this API).
 - **An OTLP-compatible destination**: You must have a destination ready to receive OTLP data, such as the Datadog Agent or OpenTelemetry Collector.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

dd-trace-js v5.81.0 will be released after reinvent and will have support for sending otlp metrics.

### Merge instructions

Merge after v5.81.0 release: https://github.com/DataDog/dd-trace-js/releases

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
