### PR TITLE
Update supported languages for Baggage as span tags config

### DIFF
--- a/content/en/tracing/trace_collection/library_config/_index.md
+++ b/content/en/tracing/trace_collection/library_config/_index.md
@@ -236,7 +236,7 @@ The following configuration options behave consistently across the latest versio
 `DD_TRACE_BAGGAGE_TAG_KEYS`
 : **Default**: `user.id,session.id,account.id` <br>
 **Supported Input**:  A comma-separated string representing a list of case-sensitive baggage keys <br>
-**Caveats**: Not supported in Java, Ruby, Go, C++, and .NET <br>
+**Caveats**: Not supported in C++ <br>
 **Description**: A comma-separated list of baggage keys that are automatically applied as span tags to the local root span. For example, a baggage key `user.id` is tagged as `baggage.user.id` <br>
 This feature only applies to baggage extracted from incoming HTTP headers. Baggage set with the baggage API is not included.
   - To tag all baggage items, set the value to `*`. Use this with caution to avoid exposing sensitive data in tags.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates the `DD_TRACE_BAGGAGE_TAG_KEYS` configuration description now that it's supported for all languages except C++. Versions adding support are documented [here](https://docs.datadoghq.com/tracing/trace_collection/trace_context_propagation/?tab=java#adding-baggage-as-span-tags).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
