### PR TITLE
Add max_memory value to ring buffer target

### DIFF
--- a/content/en/database_monitoring/guide/sql_deadlock.md
+++ b/content/en/database_monitoring/guide/sql_deadlock.md
@@ -43,7 +43,7 @@ Supported Agent versions
   ADD EVENT sqlserver.xml_deadlock_report
   ADD TARGET package0.ring_buffer
   (
-  SET MAX_MEMORY = 1024
+    SET MAX_MEMORY = 1024
   )
   WITH (
       MAX_MEMORY = 1024 KB,
@@ -78,7 +78,7 @@ Supported Agent versions
   ADD EVENT sqlserver.database_xml_deadlock_report
   ADD TARGET package0.ring_buffer
   (
-  SET MAX_MEMORY = 1024
+    SET MAX_MEMORY = 1024
   )
   WITH (
       MAX_MEMORY = 1024 KB,

--- a/content/en/database_monitoring/guide/sql_extended_events.md
+++ b/content/en/database_monitoring/guide/sql_extended_events.md
@@ -107,7 +107,7 @@ ADD EVENT sqlserver.module_end( -- capture stored procedure completions
 )
 ADD TARGET package0.ring_buffer -- do not change, datadog is only configured to read from ring buffer at this time
 (
-SET MAX_MEMORY = 1024
+  SET MAX_MEMORY = 1024
 )
 WITH (
     MAX_MEMORY = 1024 KB, -- do not exceed 1024, values above 1 MB may result in data loss due to SQLServer internals
@@ -157,7 +157,7 @@ ADD EVENT sqlserver.attention(
 )
 ADD TARGET package0.ring_buffer -- do not change, datadog is only configured to read from ring buffer at this time
 (
-SET MAX_MEMORY = 1024
+  SET MAX_MEMORY = 1024
 )
 WITH (
     MAX_MEMORY = 1024 KB, -- do not change, setting this larger than 1 MB may result in data loss due to SQLServer internals
@@ -259,7 +259,7 @@ ADD EVENT sqlserver.module_end( -- capture stored procedure completions
 )
 ADD TARGET package0.ring_buffer -- do not change, datadog is only configured to read from ring buffer at this time
 (
-SET MAX_MEMORY = 1024
+  SET MAX_MEMORY = 1024
 )
 WITH (
     MAX_MEMORY = 1024 KB, -- do not exceed 1024, values above 1 MB may result in data loss due to SQLServer internals
@@ -309,7 +309,7 @@ ADD EVENT sqlserver.attention(
 )
 ADD TARGET package0.ring_buffer -- do not change, datadog is only configured to read from ring buffer at this time
 (
-SET MAX_MEMORY = 1024
+  SET MAX_MEMORY = 1024
 )
 WITH (
     MAX_MEMORY = 1024 KB, -- do not change, setting this larger than 1 MB may result in data loss due to SQLServer internals


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Maximum ring buffer size should be set to 1 MB to avoid high memory consumption from extended event sessions. Referencing from Microsoft docs: https://learn.microsoft.com/en-us/sql/relational-databases/extended-events/targets-for-extended-events-in-sql-server?view=sql-server-ver17#ring_buffer-target

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
