### PR TITLE
update deref build order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ vector_data: integrations_data/extracted/vector
 
 # only build placeholders in ci
 placeholders: hugpython update_pre_build
+	make build-api-derefs
 	@. hugpython/bin/activate && ./local/bin/py/placehold_translations.py -c "config/_default/languages.yaml"
 	@. hugpython/bin/activate && ./local/bin/py/placehold_translations.py -c "config/_default/languages.yaml" -f "./_vendor/content/en/"
 
@@ -166,7 +167,6 @@ hugpython: local/etc/requirements3.txt
 
 update_pre_build: hugpython
 	@. hugpython/bin/activate && GITHUB_TOKEN=$(GITHUB_TOKEN) CONFIGURATION_FILE=$(CONFIGURATION_FILE) ./local/bin/py/build/update_pre_build.py
-	make build-api-derefs
 
 # Only to be run during deployment
 # Updates hugo preview config file for feature branch naming scheme


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Files can come through the cached artifact are overwriting deref spec files since moving them to gitignore.
This pr changes the order so we build the files after retrieving cached files. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
