### PR TITLE
MCP Server: rename Amazon Q CLI to Kiro CLI [DOCS-12750]

### DIFF
--- a/content/en/bits_ai/mcp_server/setup/_index.md
+++ b/content/en/bits_ai/mcp_server/setup/_index.md
@@ -55,8 +55,8 @@ The following AI clients are compatible with the Datadog MCP Server.
 | [Codex CLI][7] | OpenAI | |
 | [VS Code][11] | Microsoft | Datadog [Cursor & VS Code extension](#connect-in-cursor-and-vs-code) recommended. |
 | [Goose][9] | Block | |
-| [Q CLI][10] | Amazon | For remote authentication, add `"oauthScopes": []` to the server [configuration](?tab=remoteauthentication#example-configurations). |
 | [Kiro][23] | Amazon | |
+| [Kiro CLI][10] | Amazon | |
 | [Cline][18] | Cline Bot | Limited support for remote authentication. Use [local binary authentication](?tab=localbinaryauthentication#connect-in-supported-ai-clients) as needed. |
 
 ## Requirements
@@ -118,6 +118,7 @@ These examples are for the US1 site:
 * **Configuration file**: Edit the configuration file for your AI agent:
   * Codex CLI: `~/.codex/config.toml`
   * Gemini CLI: `~/.gemini/settings.json`
+  * Kiro CLI: `~/.kiro/settings/mcp.json`
 
   ```json
   {
@@ -125,19 +126,6 @@ These examples are for the US1 site:
       "datadog": {
         "type": "http",
         "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
-      }
-    }
-  }
-  ```
-  * Amazon Q CLI: `~/.aws/amazonq/default.json`
-
-  ```json
-  {
-    "mcpServers": {
-      "datadog": {
-        "type": "http",
-        "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp",
-        "oauthScopes": []
       }
     }
   }
@@ -428,7 +416,7 @@ The Datadog MCP Server is under significant development. During the Preview, use
 [7]: https://help.openai.com/en/articles/11096431-openai-codex-cli-getting-started
 [8]: https://www.cursor.com/
 [9]: https://github.com/block/goose
-[10]: https://github.com/aws/amazon-q-developer-cli
+[10]: https://kiro.dev/cli/
 [11]: https://code.visualstudio.com/
 [12]: /developers/ide_plugins/vscode/
 [13]: https://nodejs.org/en/about/previous-releases


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Rename Amazon’s “Q CLI” to “Kiro CLI” in the Client Compatibility section
- Remove oauthscopes[] from Client Compatibility and Example Configurations

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
