### PR TITLE
[CONTINT-4938] Control plane monitoring with Helm on EKS/OpenShift

### DIFF
--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -319,7 +319,7 @@ scheduler:
 
 ## Kubernetes on Amazon EKS {#EKS}
 
-### Recommended Method
+### Recommended method
 
 <div class="alert alert-info">This feature is in Preview.</div>
 
@@ -495,13 +495,15 @@ Since this feature is enabled by default, you can deploy a minimal DatadogAgent 
 
 Enable `features.clusterChecks.useClusterChecksRunners` to schedule checks there; otherwise, control plane checks run on the Node Agent.
 
-For OpenShift 4.14 and higher, etcd monitoring requires copying certificates. Check the operator logs for the exact command. See the following example (adjust namespace as needed):
+For OpenShift 4.14 and later, etcd monitoring requires you to copy the etcd certificates. Check the operator logs for the exact command. See the following example (adjust namespace as needed):
 
 ```shell
 oc get secret etcd-metric-client -n openshift-etcd-operator -o yaml | \
   sed 's/namespace: openshift-etcd-operator/namespace: datadog/' | \
   oc apply -f -
 ```
+
+[12]: https://github.com/DataDog/helm-charts/tree/main/charts/datadog-operator
 
 {{% /tab %}}
 {{% tab "Helm" %}}
@@ -527,7 +529,7 @@ providers:
     controlPlaneMonitoring: true
 {{< /code-block >}}
 
-For OpenShift 4.14 and higher, etcd monitoring requires copying certificates. To copy them into the same namespace the Datadog Agent is running in:
+For OpenShift 4.14 and later, etcd monitoring requires you to copy the etcd certificates. To copy them into the same namespace as the Datadog Agent:
 
 ```shell
 oc get secret etcd-metric-client -n openshift-etcd-operator -o yaml | sed 's/namespace: openshift-etcd-operator/namespace: <datadog agent namespace>/'  | oc create -f -
@@ -665,9 +667,9 @@ The Datadog Cluster Agent schedules the checks as endpoint checks and dispatches
 {{% /collapse-content %}}
 
 
-{{% collapse-content title="Etcd OpenShift 4.14 and higher" level="h4" %}}
+{{% collapse-content title="Etcd OpenShift 4.14 and later" level="h4" %}}
 
-Certificates are needed to communicate with the Etcd service, which can be found in the secret `etcd-metric-client` in the `openshift-etcd-operator` namespace. To give the Datadog Agent access to these certificates, first copy them into the same namespace the Datadog Agent is running in:
+Certificates are needed to communicate with the Etcd service, which can be found in the secret `etcd-metric-client` in the `openshift-etcd-operator` namespace. To give the Datadog Agent access to these certificates, copy them into the same namespace as the Datadog Agent:
 
 ```shell
 oc get secret etcd-metric-client -n openshift-etcd-operator -o yaml | sed 's/namespace: openshift-etcd-operator/namespace: <datadog agent namespace>/'  | oc create -f -
@@ -1389,4 +1391,3 @@ On other managed services, such as Azure Kubernetes Service (AKS) and Google Kub
 [9]: https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/nodes-and-node-pools
 [10]: https://github.com/DataDog/helm-charts/blob/main/examples/datadog/agent_on_rancher_values.yaml
 [11]: https://docs.aws.amazon.com/eks/latest/userguide/view-raw-metrics.html
-[12]: https://github.com/DataDog/helm-charts/tree/main/charts/datadog-operator


### PR DESCRIPTION
### What does this PR do? What is the motivation?
This PR updates the public control plane monitoring documentation with instructions for how to enable control plane monitoring using the new `datadog` Helm chart options for users on EKS or OpenShift. It is the helm equivalent of the Operator method provided, so both sections have been refactored into tabs and the section headers were renamed to "Recommended Method". 


### Merge instructions
This will be ready to merge once the helm chart update is released: https://github.com/DataDog/helm-charts/pull/2220

Merge readiness:
- [ ] Ready for merge