### PR TITLE
Update syslog.md to correct log type

### DIFF
--- a/content/en/network_monitoring/devices/syslog.md
+++ b/content/en/network_monitoring/devices/syslog.md
@@ -38,15 +38,16 @@ Network Device Monitoring (NDM) uses Syslog to provide visibility into the healt
 
       ```yaml
       logs:
-        - type: syslog
+        - type: udp
           port: 514
           protocol: udp
           source: syslog
           service: <service> # optional tag
       ```
 
+      - **`type`**: Set to `udp` or `tcp` based on your device configuration.
       - **`port`**: The port the Agent listens on for Syslog messages. Default is 514.
-      - **`protocol`**: Set to `udp` or `tcp` based on your device configuration.
+      - **`protocol`**: Should match `type`, set to `udp` or `tcp` based on your device configuration.
       - **`source`**: Custom source name for these logs in Datadog. Use `syslog` to correlate with NDM devices.
       - **`service`**: Optional service name for unified service tagging.
 
@@ -66,7 +67,7 @@ Network Device Monitoring (NDM) uses Syslog to provide visibility into the healt
    ```yaml
    logs_enabled: true # enable logs collection
    logs_config:
-   use_sourcehost_tag: true # adds a source_host tags to logs with the source IP
+     use_sourcehost_tag: true # adds a source_host tags to logs with the source IP
    ```
 
 2. Create a Syslog listener configuration:
@@ -76,14 +77,15 @@ Network Device Monitoring (NDM) uses Syslog to provide visibility into the healt
 
       ```yaml
       logs:
-        - type: syslog
+        - type: udp
           port: 514
           protocol: udp
           source: syslog
           service: <service> # optional tag
        ```
-       * **`port`**: The port the Agent listens on for Syslog messages. Default is 514.
-       * **`protocol`**: Set to `udp` or `tcp` based on your device configuration.
+       - **`type`**: Set to `udp` or `tcp` based on your device configuration.
+       - **`port`**: The port the Agent listens on for Syslog messages. Default is 514.
+       - **`protocol`**: Should match `type`, set to `udp` or `tcp` based on your device configuration.
        * **`source`**: Custom source name for these logs in Datadog. Use `syslog` to correlate with NDM devices.
        * **`service`**: Optional service name for unified service tagging.
 
@@ -99,7 +101,7 @@ Network Device Monitoring (NDM) uses Syslog to provide visibility into the healt
    ```yaml
    logs_enabled: true # enable logs collection
    logs_config:
-   use_sourcehost_tag: true # adds a source_host tags to logs with the source IP
+     use_sourcehost_tag: true # adds a source_host tags to logs with the source IP
    ```
 
 2. Create a Syslog listener configuration:
@@ -109,17 +111,18 @@ Network Device Monitoring (NDM) uses Syslog to provide visibility into the healt
 
       ```yaml
       logs:
-        - type: syslog
+        - type: udp
           port: 514
           protocol: udp
           source: syslog
           service: <service> # optional tag
       ```
 
-      * **`port`**: The port the Agent listens on for Syslog messages. Default is 514.
-      * **`protocol`**: Set to `udp` or `tcp` based on your device configuration.
-      * **`source`**: Custom source name for these logs in Datadog. Use `syslog` to correlate with NDM devices.
-      * **`service`**: Optional service name for unified service tagging.
+      - **`type`**: Set to `udp` or `tcp` based on your device configuration.
+      - **`port`**: The port the Agent listens on for Syslog messages. Default is 514.
+      - **`protocol`**: Should match `type`, set to `udp` or `tcp` based on your device configuration.
+      - **`source`**: Custom source name for these logs in Datadog. Use `syslog` to correlate with NDM devices.
+      - **`service`**: Optional service name for unified service tagging.
 
 3. Restart the [Docker container][101] where the Agent is installed to apply the changes.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Update the syslog NDM log collection examples the match the supported custom log configurations described [here](https://docs.datadoghq.com/agent/logs/?tab=tcpudp#custom-log-collection:~:text=DESCRIPTION-,type,-Yes). 

Encountered an issue with a customer Windows Agent where using `type:syslog` in the log configuration would cause the log listener to initialize and stay stuck in pending state. 

I was able to recreate the behavior on my local macOS in our lab account with this configuration:
```
# in /opt/datadog-agent/etc/conf.d/syslog.d/conf.yaml

logs:
  - type: syslog
    port: 514
    protocol: udp
    source: syslog
    service: test-type-syslog # optional tag
  - type: udp
    port: 514
    protocol: udp
    source: syslog
    service: test-type-udp # optional tag
```

datadog.yaml
```
# in /opt/datadog-agent/etc/datadog.yaml
tags:
  - env:lab
api_key:
log_level: info
logs_enabled: true
logs_config:
  use_sourcehost_tag: true

apm_config:
  enabled: true

process_config:
  process_collection:
    enabled: true

site: datadoghq.com
```

<img width="884" height="731" alt="image" src="https://github.com/user-attachments/assets/484b217f-4921-466e-b9ea-5f4d4e3ff4c5" />


### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
Happy to provide a flare or further details if needed, just let me know!