### PR TITLE
[Cloud Run Jobs] Specify minimum serverless-init version

### DIFF
--- a/layouts/shortcodes/serverless-init-install.html
+++ b/layouts/shortcodes/serverless-init-install.html
@@ -1,4 +1,5 @@
-{{ if eq (.Get "cloudservice") "jobs" }}<div class="alert alert-info">Serverless-init automatically creates a span for the duration of a task, even if the tracer is not installed. You can disable this by setting <code>DD_APM_ENABLED=false</code>. However, tracing is <strong>recommended</strong> because it is required for task-level visibility.</div>{{ end }}
+{{ if eq (.Get "cloudservice") "jobs" }}<div class="alert alert-info">Serverless-init automatically creates a span for the duration of a task, even if the tracer is not installed. You can disable this by setting <code>DD_APM_ENABLED=false</code>. However, tracing is <strong>recommended</strong> because it is required for task-level visibility.</div>
+<div class="alert alert-info">Cloud Run Jobs requires <code>serverless-init</code> version 1.9.0 or later.</div>{{ end }}
 Datadog publishes new releases of the <code>serverless-init</code> container image to Google's gcr.io, AWS's ECR, and on Docker Hub:
 
 | hub.docker.com | gcr.io | public.ecr.aws |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Only `serverless-init` version 1.9.0+ is supported for Cloud Run Jobs observability.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
