### PR TITLE
Revise APM Instrumentation library injection details

### DIFF
--- a/content/en/containers/cluster_agent/admission_controller.md
+++ b/content/en/containers/cluster_agent/admission_controller.md
@@ -153,7 +153,7 @@ You can configure the Cluster Agent (version 7.39 and higher) to inject instrume
 
 If you do not want to use Single Step Instrumentation, the Datadog Admission Controller can be used to inject APM tracer libraries directly as a manual, pod-level alternative. Read [Local SDK Injection][7] for more information.
 
-### APM and DogStatsD Environment Variable Injection
+### APM and DogStatsD environment variable injection
 
 To configure DogStatsD clients or other APM libraries that do not support library injection, inject the environment variables `DD_AGENT_HOST` and `DD_ENTITY_ID` by doing one of the following:
 - Add the label `admission.datadoghq.com/enabled: "true"` to your Pod.


### PR DESCRIPTION
Updated the section on instrumentation library injection to specify Single Step Instrumentation and added information on manual APM tracer library injection.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

**Motivation:** We recently received feedback from a customer that this documentation is confusing and does not highlight the "APM and DogStatsD" section will only result in environment variables being injected, and not tracing SDKs. The instrumentation section also uses an old URL which now redirects to the SSI documentation, and does not clearly state the difference between SSI and local SDK injection methods.

**Changes made:** 
The PR aims clarify the different APM configuration methods by doing the following:
- Updates the "Instrumentation library injection" and "APM and DogStatsD" section titles to highlight the former is for APM instrumentation, while the latter is for environment variable injection only.
- Update the "Instrumentation library injection" section to specify the current method is Single Step Instrumentation, and fix the old URL to the current SSI doc it was redirecting to.
- Add a second point which includes details and a link to the alternative APM injection method, Local SDK Injection (many customers prefer to use this over SSI, but struggle to locate the correct documentation).

Merge readiness:
- [ ] Ready for merge