### PR TITLE
docs(opentelemetry): add additional configuration parameters for OpenTelemetry in Kubernetes

### DIFF
--- a/content/en/opentelemetry/setup/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/setup/otlp_ingest_in_the_agent.md
@@ -186,10 +186,6 @@ These configurations can be applied through either the <code>docker</code> comma
         grpc:
           endpoint: 0.0.0.0:4317
           enabled: true
-    metrics:
-      enabled: true
-    traces:
-      enabled: true
     logs:
       enabled: false
    ```


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR contains adjustements to the OTLP configuration to include the metrics, traces and logs default configuration. There wasn't a clear indication in the Datadog documentation regarding the fact that the logs were disabled by default. Having these default values included in the default configuration will reduce the risk of encountering issues with the logs ingestion process.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

- I kept this PR as simple as it can be, but additional context can be added depending on the feedback received.