### PR TITLE
[Cloud Run Jobs] Bump minimum serverless-init version

### DIFF
--- a/content/en/serverless/google_cloud_run/jobs/dotnet.md
+++ b/content/en/serverless/google_cloud_run/jobs/dotnet.md
@@ -18,7 +18,7 @@ further_reading:
 <div class="alert alert-info">
 For full visibility and access to all Datadog features in Cloud Run Jobs,
 ensure you’ve <a href="http://localhost:1313/integrations/google_cloud_platform/">installed the Google Cloud integration</a>
-and are using <a href="https://hub.docker.com/r/datadog/serverless-init#180">serverless-init version 1.9.0 or later</a>.
+and are using <a href="https://hub.docker.com/r/datadog/serverless-init">serverless-init version 1.9.0 or later</a>.
 </div>
 
 1. **Install the Datadog .NET tracer** in your Dockerfile.

--- a/content/en/serverless/google_cloud_run/jobs/go.md
+++ b/content/en/serverless/google_cloud_run/jobs/go.md
@@ -18,7 +18,7 @@ further_reading:
 <div class="alert alert-info">
 For full visibility and access to all Datadog features in Cloud Run Jobs,
 ensure you’ve <a href="http://localhost:1313/integrations/google_cloud_platform/">installed the Google Cloud integration</a>
-and are using <a href="https://hub.docker.com/r/datadog/serverless-init#180">serverless-init version 1.9.0 or later</a>.
+and are using <a href="https://hub.docker.com/r/datadog/serverless-init">serverless-init version 1.9.0 or later</a>.
 </div>
 
 1. **Install the Datadog Go tracer**.

--- a/content/en/serverless/google_cloud_run/jobs/java.md
+++ b/content/en/serverless/google_cloud_run/jobs/java.md
@@ -18,7 +18,7 @@ further_reading:
 <div class="alert alert-info">
 For full visibility and access to all Datadog features in Cloud Run Jobs,
 ensure you’ve <a href="http://localhost:1313/integrations/google_cloud_platform/">installed the Google Cloud integration</a>
-and are using <a href="https://hub.docker.com/r/datadog/serverless-init#180">serverless-init version 1.9.0 or later</a>.
+and are using <a href="https://hub.docker.com/r/datadog/serverless-init">serverless-init version 1.9.0 or later</a>.
 </div>
 
 1. **Install the Datadog Java tracer**.

--- a/content/en/serverless/google_cloud_run/jobs/nodejs.md
+++ b/content/en/serverless/google_cloud_run/jobs/nodejs.md
@@ -18,7 +18,7 @@ further_reading:
 <div class="alert alert-info">
 For full visibility and access to all Datadog features in Cloud Run Jobs,
 ensure you’ve <a href="http://localhost:1313/integrations/google_cloud_platform/">installed the Google Cloud integration</a>
-and are using <a href="https://hub.docker.com/r/datadog/serverless-init#180">serverless-init version 1.9.0 or later</a>.
+and are using <a href="https://hub.docker.com/r/datadog/serverless-init">serverless-init version 1.9.0 or later</a>.
 </div>
 
 1. **Install the Datadog Node.js tracer**.

--- a/content/en/serverless/google_cloud_run/jobs/python.md
+++ b/content/en/serverless/google_cloud_run/jobs/python.md
@@ -18,7 +18,7 @@ further_reading:
 <div class="alert alert-info">
 For full visibility and access to all Datadog features in Cloud Run Jobs,
 ensure you’ve <a href="http://localhost:1313/integrations/google_cloud_platform/">installed the Google Cloud integration</a>
-and are using <a href="https://hub.docker.com/r/datadog/serverless-init#180">serverless-init version 1.9.0 or later</a>.
+and are using <a href="https://hub.docker.com/r/datadog/serverless-init">serverless-init version 1.9.0 or later</a>.
 </div>
 
 1. **Install the Datadog Python tracer**.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

1.9.0 is required for working observability

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
