### PR TITLE
[CLOUDS-7041] Document Azure consumedservice tag normalization

### DIFF
--- a/content/en/cloud_cost_management/tags/_index.md
+++ b/content/en/cloud_cost_management/tags/_index.md
@@ -88,7 +88,7 @@ For example, a tag `Team:Engineering-Services` appears as `team:engineering-serv
 
 ## Override tag value normalization
 
-Turn on **Tag Normalization** in the Tag Pipelines page to normalize all cost tag values to match the Metrics normalization. From the example above, you would see `team:engineering-services` everywhere. For now, the tag normalization will only apply to user-defined tags from cloud costs and not for tags outputted from Tag Pipelines. For all new users, the Tag Normalization toggle is enabled by default, with normalized tag values backfilled for the past 3 months automatically. To backfill normalized tags for a longer period up to 15 months, contact [Datadog support][13].
+Turn on **Tag Normalization** in the Tag Pipelines page to normalize all cost tag values to match the Metrics normalization. From the example above, you would see `team:engineering-services` everywhere. Tag normalization applies to user-defined tags from cloud costs. Tags created by Tag Pipelines are not normalized. For Azure, the `consumedservice` out-of-the-box tag is also normalized to lowercase. For all new users, the Tag Normalization toggle is enabled by default, with normalized tag values backfilled for the past 3 months automatically. To backfill normalized tags for a longer period up to 15 months, contact [Datadog support][13].
 
 Tag normalization allows you to:
 - View, filter and group Cost Recommendations and cost data with the same tag values


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents that the `consumedservice` Azure out-of-the-box tag is normalized to lowercase when Tag Normalization is enabled.

Related to [CLOUDS-7041](https://datadoghq.atlassian.net/browse/CLOUDS-7041) - customers with tag normalization enabled were seeing duplicate tags with different casing for Azure services.

Backend fix: https://github.com/DataDog/dd-analytics/pull/57569

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

None

[CLOUDS-7041]: https://datadoghq.atlassian.net/browse/CLOUDS-7041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ