### PR TITLE
Fix markdown formatting in Bits AI SRE investigate issues doc

### DIFF
--- a/content/en/bits_ai/bits_ai_sre/investigate_issues.md
+++ b/content/en/bits_ai/bits_ai_sre/investigate_issues.md
@@ -121,6 +121,7 @@ Investigations happen in two phases:
      - Dashboards
      - [Change events][4]
      - Kubernetes events
+
    Each hypothesis ends in one of three states: validated, invalidated, or inconclusive. When a hypothesis is validated, Bits generates sub-hypotheses and repeats the same investigative process on them.
 
    {{< img src="bits_ai/bits_ai_sre_investigation_hypotheses.png" alt="Flowchart showing the hypotheses Bits AI SRE built and tested" style="width:100%;" >}}


### PR DESCRIPTION
## Summary
- Fix missing blank line after the bullet list of data sources in the "How Bits AI SRE investigates" section
- This prevents "Kubernetes events" from incorrectly merging with the following paragraph when rendered

## Before
The last bullet item runs into the next paragraph:
> - Kubernetes events Each hypothesis ends in one of three states...

## After
Properly separated:
> - Kubernetes events
>
> Each hypothesis ends in one of three states...