### PR TITLE
Update get_started_with_the_custom_processor guide.md

### DIFF
--- a/content/en/observability_pipelines/guide/get_started_with_the_custom_processor.md
+++ b/content/en/observability_pipelines/guide/get_started_with_the_custom_processor.md
@@ -428,7 +428,7 @@ Splunk and CrowdStrike prefer a format called `_raw` for log ingestion. Sending 
 
 **Notes**:
 - You should add other processing, remapping, and parsing steps before serializing your logs in `_raw` format.
-- Select `Raw` as the encoding option when you set up the Splunk HEC or CrowdStrike destination.
+- To ensure your logs are correctly routed after serialization, configure your preferred destination with **Raw** as the encoding type. 
 
 An example input log:
 


### PR DESCRIPTION
Fixes wording around the _raw script in the Custom processor guide