### PR TITLE
k8s secrets support for secret backend

### DIFF
--- a/content/en/agent/configuration/secrets-management.md
+++ b/content/en/agent/configuration/secrets-management.md
@@ -598,7 +598,7 @@ roleRef:
   name: datadog-secret-reader
 subjects:
 - kind: ServiceAccount
-  name: datadog-agent
+  name: <serviceaccount name>  # datadog is typically the default ServiceAccount name
   namespace: datadog  # Where Agent runs
 ```
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds documentation for https://github.com/DataDog/datadog-secret-backend/pull/279
Also includes hyperlink re-ordering and fixes from this PR: https://github.com/DataDog/documentation/pull/34281

### Merge instructions

Merge readiness:
- [x] Requires a new Datadog-Agent release 7.75 that contains K8s support changes in the secret-backend

### Additional notes

