### PR TITLE
Troubleshooting gitlab duration differences

### DIFF
--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -38,6 +38,13 @@ Missing stages or jobs in the _Pipeline Details_ page might be due to a wrong co
 
 [User-defined variables in Gitlab][16] should be reported in the field `@ci.parameters` in CI Visibility. However, this information is only present in some cases like downstream pipelines, and may be missing for the rest of the cases since Gitlab [does not always report this information][17] to Datadog.
 
+## Gitlab pipeline duration mismatch
+
+The pipeline duration shown in CI Visibility is expected to be different for the following reasons:
+* Datadog pipeline duration includes queue time, manual approvals, gaps between jobs, etc, while Gitlab doesn't. To make a fair comparison we need to look at the [execution time][18] instead.
+* The execution time shown in Datadog will also differ from Gitlab if there are downstream pipelines or runner system failures.
+
+
 ## Limitations on running pipelines
 
 ### Delivery of webhook events is not guaranteed by CI providers
@@ -73,3 +80,4 @@ Job data has a three-day limit to be processed after completion. If a pipeline i
 [15]: /continuous_integration/pipelines/#supported-features
 [16]: https://docs.gitlab.com/ee/ci/variables/#define-a-cicd-variable-in-the-gitlab-ciyml-file
 [17]: https://gitlab.com/gitlab-org/gitlab/-/issues/29539
+[18]: /glossary/#pipeline-execution-time

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -41,7 +41,7 @@ Missing stages or jobs in the _Pipeline Details_ page might be due to a wrong co
 ## Gitlab pipeline duration mismatch
 
 The pipeline duration shown in CI Visibility is expected to be different for the following reasons:
-* Datadog pipeline duration includes queue time, manual approvals, and gaps between jobs, whereas GitLab’s does not. Therefore, [execution time][18] provides a fairer comparison.
+* Datadog pipeline duration includes queue time, manual approvals, and gaps between jobs, whereas GitLab's does not. Therefore, [execution time][18] provides a fairer comparison.
 | Datadog | Gitlab |
 |---|---|
 | [Pipeline execution time][18] | Pipeline duration |

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -41,13 +41,13 @@ Missing stages or jobs in the _Pipeline Details_ page might be due to a wrong co
 ## Gitlab pipeline duration mismatch
 
 The pipeline duration shown in CI Visibility is expected to be different for the following reasons:
-* Datadog pipeline duration includes queue time, manual approvals, gaps between jobs, etc, while Gitlab doesn't. To make a fair comparison we need to look at the [execution time][18] instead:
+* Datadog pipeline duration includes queue time, manual approvals, and gaps between jobs, whereas GitLab’s does not. Therefore, [execution time][18] provides a fairer comparison.
 | Datadog | Gitlab |
 |---|---|
 | [Pipeline execution time][18] | Pipeline duration |
 | Pipeline duration | *Not available* |
 
-* The execution time shown in Datadog will also differ from Gitlab in the following cases:
+* The execution time displayed in Datadog also differs from GitLab in the following cases:
 | Use case | Gitlab duration | Datadog execution time |
 |---|---|---|
 | Downstream pipelines | Included | Not included |

--- a/content/en/continuous_integration/troubleshooting.md
+++ b/content/en/continuous_integration/troubleshooting.md
@@ -41,8 +41,17 @@ Missing stages or jobs in the _Pipeline Details_ page might be due to a wrong co
 ## Gitlab pipeline duration mismatch
 
 The pipeline duration shown in CI Visibility is expected to be different for the following reasons:
-* Datadog pipeline duration includes queue time, manual approvals, gaps between jobs, etc, while Gitlab doesn't. To make a fair comparison we need to look at the [execution time][18] instead.
-* The execution time shown in Datadog will also differ from Gitlab if there are downstream pipelines or runner system failures.
+* Datadog pipeline duration includes queue time, manual approvals, gaps between jobs, etc, while Gitlab doesn't. To make a fair comparison we need to look at the [execution time][18] instead:
+| Datadog | Gitlab |
+|---|---|
+| [Pipeline execution time][18] | Pipeline duration |
+| Pipeline duration | *Not available* |
+
+* The execution time shown in Datadog will also differ from Gitlab in the following cases:
+| Use case | Gitlab duration | Datadog execution time |
+|---|---|---|
+| Downstream pipelines | Included | Not included |
+| Runner system failures | Not included | Included |
 
 
 ## Limitations on running pipelines


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The duration shown in gitlab's UI does not match what is shown in Datadog's CI Visibility's pipelines. This adds a small troubleshooting section with an explanation on why this discrepancy is expected

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
