### PR TITLE
Add simplified docker instructions back into Docker landing page

### DIFF
--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -36,15 +36,15 @@ further_reading:
 The Datadog Docker Agent is a version of the [Datadog Agent][1] that supports Docker, containerd, and Podman runtimes. For supported Docker versions, see [Supported Platforms][2].
 
 ## Install the Datadog Docker Agent
-Follow the [in-app installation flow in Datadog][3]. This is the recommended flow that helps create your `docker run` command with your API Key, the necessary minimum configurations, and toggles for the different Datadog features.
+Follow the [in-app installation flow in Datadog][3]. This is the recommended flow, which helps you create your `docker run` command with your API key, the required minimum configurations, and toggles for various Datadog features.
 
 {{< img src="/agent/basic_agent_usage/agent_install_docker.png" alt="In-app installation steps for the Datadog Agent on Docker." style="width:90%;">}}
 
 ## Manually run the Datadog Docker Agent
 
-The Fleet Automation flow helps configure your Datadog Agent container with our recommended instructions. To configure this manually see the examples below.
+The Fleet Automation flow helps configure your Datadog Agent container with Datadog's recommended instructions. To configure this manually, see the examples below.
 
-Use the command below to run the Agent as a Docker container once on each host to monitor. Replace the `<DATADOG_API_KEY>` with your Datadog API key, and `<DATADOG_SITE>` with your {{< region-param key=dd_site code="true" >}}.
+Use the following command to run the Agent as a Docker container once on each host you want to monitor. Replace `<DATADOG_API_KEY>` with your Datadog API key and `<DATADOG_SITE>` with your {{< region-param key=dd_site code="true" >}}.
 
 {{< tabs >}}
 {{% tab "Linux" %}}
@@ -59,7 +59,7 @@ docker run -d --cgroupns host --pid host --name dd-agent \
 ```
 {{% /tab %}}
 {{% tab "Windows" %}}
-The Datadog Agent is supported in Windows Server 2019 (LTSC) and Windows Server 2022 (LTSC). The following PowerShell command runs the Datadog Agent container:
+The Datadog Agent is supported on Windows Server 2019 (LTSC) and Windows Server 2022 (LTSC). The following PowerShell command runs the Datadog Agent container:
 
 ```powershell
 docker run -d --name dd-agent `
@@ -71,7 +71,7 @@ docker run -d --name dd-agent `
 {{% /tab %}}
 {{< /tabs >}}
 
-Note: For Docker Compose, see [Compose and the Datadog Agent][4]. For deploying the Agent in [Podman see our instructions here][5].
+**Note**: For Docker Compose, see [Compose and the Datadog Agent][4]. For deploying the Agent in Podman, see the instructions in [Using the Docker integration with Podman container runtime][5].
 
 ## Integrations
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Adds back in a simplified version of the `docker run` instructions for both linux and windows. The recommended flow is still to use Fleet Automation for all the benefits it gives with building your command. But this gives us some basic barebones steps back in. As well as re-introduced the Windows options as those are not yet supported in Fleet Automation.

Some general cleanup too:
- Previously there were several tabs which are no longer needed here for the install, simplified to Linux + Windows
- Added in container registry section to mirror K8s section
  - Slotted this into the `Configuration options for the Datadog Docker Agent` section as this felt like the right spot vs adding in another `Additional Configurations` type of section above
- A lot of general link cleanup

https://datadoghq.atlassian.net/browse/TEEP-3820

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->
Unprivileged instructions were not added back in. We may want to investigate a dedicated guide page for unprivileged Docker + Kubernetes instructions at different levels of unprivileged access (User, Groups, Read Only Root Filesystems, Capabilities, etc)

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
