### PR TITLE
Remove 'Guardrail cutoffs' section from metrics

### DIFF
--- a/content/en/product_analytics/experimentation/defining_metrics.md
+++ b/content/en/product_analytics/experimentation/defining_metrics.md
@@ -88,10 +88,6 @@ Datadog supports several advanced options specific to experimentation:
 : - Datadog highlights statistically significant results. 
   - Use this setting to specify whether an increase or decrease in this metric is desired.
 
-`Guardrail cutoffs`
-: - Use this to specify a `do no harm` threshold. 
-  - Metrics will be yellow until the confidence interval is small enough to rule out a downside risk larger than this threshold. This indicates that you should continue running your experiment to rule out an effect worse than the number entered here.
-
 `Outlier handling`
 : - Real world data often includes extreme outliers that can impact experiment results. 
   - Use this setting to set a threshold at which data is truncated. For instance, set a 99% upper bound to truncate all results at the metric’s 99th percentile.


### PR DESCRIPTION
Removed details about 'Guardrail cutoffs' from the metrics definition section.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Dropping the section on guardrail metrics

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
