### PR TITLE
Add two warnings to Operations Monitoring documentation

### DIFF
--- a/content/en/real_user_monitoring/operations_monitoring.md
+++ b/content/en/real_user_monitoring/operations_monitoring.md
@@ -91,6 +91,8 @@ RUMMonitor.shared().startFeatureOperation(
 {{% /tab %}}
 {{< /tabs >}}
 
+<div class="alert alert-warning">The Operation's name cannot contain any whitespaces.</div>
+
 ### Stop an operation with success
 
 Every started operation must have a stop. Use `succeedFeatureOperation` to stop an operation with a successful outcome.
@@ -139,6 +141,8 @@ RUMMonitor.shared().succeedFeatureOperation(
 
 {{% /tab %}}
 {{< /tabs >}}
+
+<div class="alert alert-warning">The <code>operationKey</code> must be the same in the start and end Operation event.</div>
 
 ### Stop an operation with failure
 


### PR DESCRIPTION
Warning 1: Do not use whitespaces in the Operation's name.
Warning 2: The operationKey value must be the same.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Added 2 warnings:
Warning 1: Do not use whitespaces in the Operation's name.
Warning 2: The operationKey value must be the same.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
