### PR TITLE
Fix discrepancy in Android SDK requirements

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/android/_index.md
+++ b/content/en/real_user_monitoring/application_monitoring/android/_index.md
@@ -18,7 +18,7 @@ further_reading:
 
 Datadog Real User Monitoring (RUM) enables you to visualize and analyze the real-time performance and user journeys of your application's individual users.
 
-The Datadog Android SDK supports Android 5.0+ (API level 21) and Android TV. It works for Android apps written using Java or Kotlin.
+The Datadog Android SDK supports Android 6.0+ (API level 23) and Android TV. It works for Android apps written using Java or Kotlin.
 
 ## Start monitoring Android applications
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
I updated the minimum requirements for the Datadog Android SDK, from "Android 5.0+ (API level 21)" to "Android 6.0+ (API level 23)" to bring it into alignment with the Android and Android TV Monitoring Setup doc. I assume the latter requirements are correct, but in any case wanted to flag the discrepancy.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
