### PR TITLE
fix references for slack and teams to reflect new incident response navigation

### DIFF
--- a/content/en/service_management/incident_management/integrations/microsoft_teams/_index.md
+++ b/content/en/service_management/incident_management/integrations/microsoft_teams/_index.md
@@ -18,7 +18,7 @@ The Microsoft Teams integration for Datadog Incident Management enables you to d
 
 To use Incident Management's Microsoft Teams features, you must first [install the Microsoft Teams integration for Datadog][1] and connect your Microsoft Teams account to your Datadog account.
 
-After installation, go to **[Service Management > Incidents > Settings > Integrations][2]** to configure the Microsoft Teams features for Incident Management.
+After installation, go to **[Incident Response > Incident Management > Settings > Integrations][2]** to configure the Microsoft Teams features for Incident Management.
 
 ## Incident channels
 
@@ -57,7 +57,7 @@ You can configure Incident Management to automatically archive an incident chann
 
 Use an incident updates channel to provide your stakeholders with organization-wide visibility into the status of all incidents directly from Microsoft Teams.
 
-1. In Datadog, navigate to [**Incidents > Settings > Integrations**][2].
+1. In Datadog, navigate to **[Incident Response > Incident Management > Settings > Integrations][2]**.
 1. Select the Microsoft Teams integration and enable **Send all incident updates to a global channel**.
 1. Select the Team and channel where you want the incident updates to be posted.
 

--- a/content/en/service_management/incident_management/integrations/slack/_index.md
+++ b/content/en/service_management/incident_management/integrations/slack/_index.md
@@ -57,7 +57,7 @@ To allow any Slack user in the workspace to declare incidents, enable **Allow Sl
 
 You can configure Incident Management to automatically create a dedicated Slack channel for each incident that meets criteria you define. Your responders can then manage the incident directly in Slack from the incident channel.
 
-To use incident channels, go to [**Incidents** > **Settings** > **Integrations**][3] and enable **Create Slack channels for incidents**.
+To use incident channels, go to **[Incident Response > Incident Management > Settings > Integrations][3]** and enable **Create Slack channels for incidents**.
 
 The **channel name template** you define determines how Datadog names the incident channels it creates. The following variables are available in channel name templates:
 
@@ -116,7 +116,7 @@ Access all configuration options for Slack in Incident Management through the [*
 
 You can configure Incident Management to automatically post updates about incidents to a selected Slack channel. To enable this:
 
-1. In Datadog, navigate to [**Incidents** > **Settings** > **Integrations**][3].
+1. In Datadog, navigate to **[Incident Response > Incident Management > Settings > Integrations][3]**.
 1. In the Slack section, enable **Send all incident updates to a global channel**.
 1. Select the Slack workspace and Slack channel where you want the incident updates to be posted.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Swapped references of "Service Management" to "Incident Response" with the appropriate navigation paths for both the slack and teams integrations of Incident Management

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
