### PR TITLE
Document that categorical evaluation values should not be empty strings

### DIFF
--- a/content/en/llm_observability/evaluations/external_evaluations.md
+++ b/content/en/llm_observability/evaluations/external_evaluations.md
@@ -27,6 +27,8 @@ While LLM Observability provides a few out-of-the-box evaluations for your trace
   * Unicode is not supported.
 * Evaluation labels must not exceed 200 characters. Fewer than 100 is preferred from a UI perspective.
 
+Additionally, for categorical evaluations, the value may not be an empty string.
+
 <div class="alert alert-info">
 
 Evaluation labels must be unique for a given LLM application (<code>ml_app</code>) and organization.

--- a/content/en/llm_observability/experiments/_index.md
+++ b/content/en/llm_observability/experiments/_index.md
@@ -1022,7 +1022,7 @@ Push events (spans and metrics) for an experiment.
 | `timestamp_ms` | number | UNIX timestamp in milliseconds. |
 | `label` | string | Metric label (evaluator name). |
 | `score_value` | number | Score value (when `metric_type` is `score`). |
-| `categorical_value` | string | Categorical value (when `metric_type` is `categorical`). |
+| `categorical_value` | string | Categorical value (when `metric_type` is `categorical`). May not be empty string. |
 | `metadata` | json | Arbitrary key-value metadata associated with the metric. |
 | `error.message` | string | Optional error message for the metric. |
 

--- a/content/en/llm_observability/instrumentation/api.md
+++ b/content/en/llm_observability/instrumentation/api.md
@@ -468,7 +468,7 @@ Evaluations must be joined to a unique span. You can identify the target span us
 | ml_app [*required*]                                                | string              | The name of your LLM application. See [Application naming guidelines](#application-naming-guidelines). |
 | metric_type [*required*]                                           | string              | The type of evaluation: `"categorical"`, `"score"`, or `"boolean"`.                                    |
 | label [*required*]                                                 | string              | The unique name or label for the provided evaluation .                                                 |
-| categorical_value [*required if the metric_type is "categorical"*] | string              | A string representing the category that the evaluation belongs to.                                     |
+| categorical_value [*required if the metric_type is "categorical"*] | string              | A string representing the category that the evaluation belongs to. May not be empty string.                                    |
 | score_value [*required if the metric_type is "score"*]             | number              | A score value of the evaluation.                                                                       |
 | boolean_value [*required if the metric_type is "boolean"*]         | boolean             | A boolean value of the evaluation.                                                                     |
 | assessment                                                         | string              | An assessment of this evaluation. Accepted values are `pass` and `fail`.                               |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This documents a guideline that almost all customers are already following: when submitting categorical evaluations for LLM Observability, the values are expected to be meaningful strings and not the empty string.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
