### PR TITLE
Mapping Canonical Cloud Resources ID to OpenTelemetry resource attributes

### DIFF
--- a/content/en/opentelemetry/mapping/host_metadata.md
+++ b/content/en/opentelemetry/mapping/host_metadata.md
@@ -110,9 +110,9 @@ See below for the list of identifier formats per-cloud:
 How to form a CCRID:
  * [AWS (EC2 Instance)][13]: `arn:aws:ec2:{region}:{accountId}:instance/{instanceId}`. 
     Use this command to retrieve the `instanceId`:
- ```bash
- ec2metadata --instance-id
- ```
+    ```shell
+    ec2metadata --instance-id
+    ```
  * [Azure][11]: `/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}`
  * GCP: `//compute.googleapis.com/projects/{projectID}/zones/{zoneName}/instances/{instanceName}"`
  * OCI/Oracle: The CCRID can be obtained by [sending a request][12] at: `http://169.254.169.254/opc/v2/instance/id`


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Documenting Canonical Cloud Resource IDs (CCRIDs) usage for DDOT

### Merge instructions
The merge shall remain blocked until CCRID Metapayload support is implemented in DDOT

Merge readiness:
- [ ] Ready for merge


TO BE REMOVED:
[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.


