### PR TITLE
Revamp Kubernetes Tag Extraction doc 

### DIFF
--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -113,7 +113,7 @@ com.datadoghq.ad.tags: '["<TAG_KEY>:TAG_VALUE", "<TAG_KEY_1>:<TAG_VALUE_1>"]'
 
 ## Tag extraction
 
-Starting in version 7.64+, the Agent and Cluster Agent can be configured to collect labels and annotations from Kubernetes resources and use them as tags from a common configuration. Datadog recommends using the following options to ensure consistent reporting across the Agent’s core tagging, the Cluster Agent’s KSM reporting, and both Agents’ Orchestrator Explorer reporting:
+Starting in version 7.64+, the Agent and Cluster Agent can be configured to collect labels and annotations from Kubernetes resources and use them as tags from a common configuration. Datadog recommends using the following options to ensure consistent reporting across the Agent's core tagging, the Cluster Agent's KSM reporting, and both Agents' Orchestrator Explorer reporting:
 - `kubernetesResourcesLabelsAsTags`
 - `kubernetesResourcesAnnotationsAsTags`
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Making a few more changes to take the place of https://github.com/DataDog/documentation/pull/33142

Notably:
- Moved a lot of the duplicated context for resource type, tag cascading, wildcards to the top section since it was in each of the 6 groupings
- Provide a few more examples on how to set the datadog resource configuration based on the resource type / api group
- Updated each sample with a consistent nodes, pods, deployments extraction sample
- Clarify wildcard handling for 7.73
- Updated the manual setup to the more K8s yaml name/value syntax
- Updated the `merging with legacy configurations` with its own dedicated subheader, changed the `foo: quux` to simpler ones, removed some reference for annotations as we only supported `podAnnotationsAsTags` (not namespaces/nodes).
- This base feature was officially released in 7.58, however, changed that to 7.64 for simplicity as that is when the full feature suite of the Agent Tagger + Cluster Agent KSM + Both their Orchestrator all fully came together. 

Jira:
- https://datadoghq.atlassian.net/browse/CONTP-1120
- https://datadoghq.atlassian.net/browse/TEEP-3616

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->



<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
