### PR TITLE
 [CONTP-1096] Document check_tag_cardinality in Kubernetes Autodiscovery annotations

### DIFF
--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -371,6 +371,37 @@ The `ad_identifiers` parameter takes a list, so you can supply multiple containe
 `<LOGS_CONFIG>`
 : The configuration parameters listed under `logs` in your integration's `<INTEGRATION_NAME>.d/conf.yaml.example` file.
 
+### Advanced annotation parameters
+
+In addition to the core Autodiscovery annotations for checks, logs, and instances, you can use additional annotations to customize check behavior:
+
+#### Tag cardinality
+
+Set the tag cardinality level for a specific check using the `check_tag_cardinality` annotation. This overrides the global Agent tag cardinality setting for metrics collected by that check.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: '<POD_NAME>'
+  annotations:
+    ad.datadoghq.com/<CONTAINER_NAME>.checks: |
+      {
+        "<INTEGRATION_NAME>": {
+          "init_config": <INIT_CONFIG>,
+          "instances": [<INSTANCES_CONFIG>]
+        }
+      }
+    ad.datadoghq.com/<CONTAINER_NAME>.check_tag_cardinality: "<low|orchestrator|high>"
+spec:
+  containers:
+    - name: '<CONTAINER_NAME>'
+```
+
+<div class="alert alert-info">The <code>check_tag_cardinality</code> annotation only affects metrics collected by integration checks. It does not affect metrics sent through DogStatsD. To configure DogStatsD tag cardinality, use the global <code>dogstatsd_tag_cardinality</code> configuration parameter or the <code>DD_DOGSTATSD_TAG_CARDINALITY</code> environment variable.</div>
+
+For more information about tag cardinality, see [Per-check tag configuration][27].
+
 ### Auto-configuration
 
 The Datadog Agent automatically recognizes and supplies basic configuration for some common technologies. For a complete list, see [Autodiscovery auto-configuration][20].
@@ -673,3 +704,4 @@ For more examples, including how to configure multiple checks for multiple sets 
 [24]: /containers/guide/autodiscovery-examples
 [25]: /integrations/istio/
 [26]: /integrations/postgres
+[27]: /getting_started/integrations/#per-check-tag-configuration

--- a/content/en/getting_started/integrations/_index.md
+++ b/content/en/getting_started/integrations/_index.md
@@ -108,11 +108,11 @@ To better unify your environment, it is also recommended to configure the `env` 
 You can customize tag behavior for individual checks, overriding the global Agent-level settings:
 
 1. **Disable Autodiscovery tags**
-    
+
     By default, the metrics reported by integrations include tags automatically detected from the environment. For example, the metrics reported by a Redis check that runs inside a container include tags associated with the container, such as `image_name`. You can turn this behavior off by setting the `ignore_autodiscovery_tags` parameter to `true`.
 
 1. **Set tag cardinality per integration check**
-    
+
     You can define the level of tag cardinality (low, orchestrator, or high) on a per-check basis using the `check_tag_cardinality` parameter. This overrides the global tag cardinality setting defined in the Agent configuration.
 
 ```yaml
@@ -125,6 +125,8 @@ check_tag_cardinality: low
 
 # Rest of the config here
 ```
+
+For containerized environments, you can also set these parameters through [Kubernetes Autodiscovery annotations][47].
 
 ### Validation
 
@@ -275,3 +277,4 @@ tagging
 [44]: /monitors/guide/visualize-your-service-check-in-the-datadog-ui/
 [45]: /account_management/rbac/permissions/#integrations
 [46]: /integrations/
+[47]: /containers/kubernetes/integrations/#tag-cardinality


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do?  
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
 This PR documents the check_tag_cardinality parameter support in Kubernetes Autodiscovery annotations. Specifically:

  1. Updates the "Per-check tag configuration" section in /getting_started/integrations/ to include a tabbed view showing both configuration file and Kubernetes annotation methods
  2. Adds an "Advanced annotation parameters" section in /containers/kubernetes/integrations/ documenting the check_tag_cardinality annotation
  3. Adds an info callout clarifying that check_tag_cardinality only affects integration check metrics, not DogStatsD metrics

###  Motivation

  The Datadog Agent supports setting tag cardinality (check_tag_cardinality) on a per-check basis through both configuration files and Kubernetes Autodiscovery annotations. However, the public documentation only covered the config file usage and did not mention the Autodiscovery annotation support.

  This PR closes that documentation gap by showing users how to use the annotation:
  ad.datadoghq.com/<CONTAINER_NAME>.check_tag_cardinality: "<low|orchestrator|high>"



### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
