### PR TITLE
Move kubectl plugin doc to Kubernetes section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,12 +156,14 @@ content/en/static_analysis/github_actions.md
 content/en/static_analysis/circleci_orbs.md
 content/en/static_analysis/rules/
 
+# containers - kubernetes
+content/en/containers/kubernetes/kubectl_plugin.md
+
 # containers - datadog-operator
 content/en/containers/datadog_operator/advanced_install.md
 content/en/containers/datadog_operator/configuration.md
 content/en/containers/datadog_operator/custom_check.md
 content/en/containers/datadog_operator/data_collected.md
-content/en/containers/datadog_operator/kubectl_plugin.md
 content/en/containers/datadog_operator/secret_management.md
 content/en/containers/guide/v2alpha1_migration.md
 

--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -3283,16 +3283,21 @@ menu:
       parent: containers_kubernetes
       identifier: containers_kubernetes_data_collected
       weight: 410
+    - name: kubectl Plugin
+      url: containers/kubernetes/kubectl_plugin
+      parent: containers_kubernetes
+      identifier: containers_kubernetes_kubectlplugin
+      weight: 411
     - name: Datadog CSI Driver
       url: containers/kubernetes/csi_driver
       parent: containers_kubernetes
       identifier: csi_driver
-      weight: 411
+      weight: 412
     - name: Data security
       url: data_security/kubernetes
       parent: containers_kubernetes
       identifier: container_kubernetes_data_security
-      weight: 412
+      weight: 413
     - name: Cluster Agent
       url: containers/cluster_agent/
       parent: containers
@@ -3383,11 +3388,6 @@ menu:
       identifier: containers_datadog_operator_datacollected
       parent: containers_datadog_operator
       weight: 804
-    - name: kubectl Plugin
-      url: containers/datadog_operator/kubectl_plugin
-      identifier: containers_datadog_operator_kubectlplugin
-      parent: containers_datadog_operator
-      weight: 805
     - name: Secret Management
       url: containers/datadog_operator/secret_management
       identifier: containers_datadog_operator_secretmanagement

--- a/local/bin/py/build/configurations/pull_config.yaml
+++ b/local/bin/py/build/configurations/pull_config.yaml
@@ -485,7 +485,7 @@
             globs:
               - 'docs/kubectl-plugin.md'
             options:
-              dest_path: '/containers/datadog_operator/'
+              dest_path: '/containers/kubernetes/'
               file_name: 'kubectl_plugin.md'
               front_matters:
                 title: Datadog Operator Plugin for kubectl


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"4f37ad8a-3ebc-44fe-9b33-7cd832800604","workflowId":"d56824b3-f52d-4819-a22c-a310439065e9","codeChangeId":"d56824b3-f52d-4819-a22c-a310439065e9","sourceType":"chat"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/4f37ad8a-3ebc-44fe-9b33-7cd832800604)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do? What is the motivation?

- Move the kubectl plugin doc under the Kubernetes section with aliases from the Datadog Operator path
- Adjust navigation to point to the new kubectl plugin page location

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
- currently the documentation is part of the datadog-operator repo, see: https://github.com/DataDog/datadog-operator/blob/main/docs/kubectl-plugin.md IMO we can keep the documentation in the same repo but just move the page in the documentation site. However I didn't found yet how the synchronisation work between the 2 repositories.