### PR TITLE
Move Enrichment Table shortcode content

### DIFF
--- a/content/en/observability_pipelines/processors/enrichment_table.md
+++ b/content/en/observability_pipelines/processors/enrichment_table.md
@@ -8,6 +8,45 @@ products:
 
 {{< product-availability >}}
 
-{{% observability_pipelines/processors/enrichment_table %}}
+Use this processor to enrich your logs with information from a reference table, which could be a local file or database.
+
+To set up the enrichment table processor:
+1. Define a **filter query**. Only logs that match the specified [filter query](#filter-query-syntax) are processed. All logs, regardless of whether they do or do not match the filter query, are sent to the next step in the pipeline.
+2. Enter the source attribute of the log. The source attribute's value is what you want to find in the reference table.
+3. Enter the target attribute. The target attribute's value stores, as a JSON object, the information found in the reference table.
+4. Select the type of reference table you want to use, **File** or **GeoIP**.
+   - For the **File** type:
+        1. Enter the file path.<br>**Note**: All file paths are made relative to the configuration data directory, which is `/var/lib/observability-pipelines-worker/config/` by default. See [Advanced Worker Configurations][1] for more information. The file must be owned by the `observability-pipelines-worker group` and `observability-pipelines-worker` user, or at least readable by the group or user.
+        1. Enter the column name. The column name in the enrichment table is used for matching the source attribute value. See the [Enrichment file example](#enrichment-file-example).
+   - For the **GeoIP** type, enter the GeoIP path.
+
+##### Enrichment file example
+
+For this example, `merchant_id` is used as the source attribute and `merchant_info` as the target attribute.
+
+This is the example reference table that the enrichment processor uses:
+
+| merch_id | merchant_name   | city      | state    |
+| -------- | --------------- | --------- | -------- |
+| 803      | Andy's Ottomans | Boise     | Idaho    |
+| 536      | Cindy's Couches | Boulder   | Colorado |
+| 235      | Debra's Benches | Las Vegas | Nevada   |
+
+`merch_id` is set as the column name the processor uses to find the source attribute's value. **Note**: The source attribute's value does not have to match the column name.
+
+If the enrichment processor receives a log with `"merchant_id":"536"`:
+
+- The processor looks for the value `536` in the reference table's `merch_id` column.
+- After it finds the value, it adds the entire row of information from the reference table to the `merchant_info` attribute as a JSON object:
+
+```
+merchant_info {
+    "merchant_name":"Cindy's Couches",
+    "city":"Boulder",
+    "state":"Colorado"
+}
+```
 
 {{% observability_pipelines/processors/filter_syntax %}}
+
+[1]: /observability_pipelines/configuration/install_the_worker/advanced_worker_configurations/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

- Moves Enrichment Table shortcode content into the doc. No net new content, except updating the one link, so doesn't need detailed content review.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
