### PR TITLE
Fix review state tracking logic

### DIFF
--- a/.github/workflows/codeowner_review_status.yml
+++ b/.github/workflows/codeowner_review_status.yml
@@ -61,6 +61,7 @@ jobs:
             });
 
             // Track latest review state per user (ignore commented state)
+            const latestReviews = new Map();
             reviews.forEach(review => {
               if (review.state === 'COMMENTED') return; 
               const existing = latestReviews.get(review.user.login);


### PR DESCRIPTION
This change adds a single line fix to our `.github/workflows/codeowner_review_status.yml` check.

The Documentation team has noticed flaky failures in the required check on PRs we've already approved. It wasn't clear why this was happening or how to reproduce consistently. @joepeeples and I were able to uncover that this occurs when you _comment_ on an already approved PR.

When you comment on a PR, that changes the `review.state` to `COMMENTED`. So the check runs again, doesn't see it's approved, and fails.

### Testing

Steps to reproduce:

1. Approve a PR with suggested changes.
2. Reply to your comment that contains the suggested change.
3. Notice that the approval check re-runs and fails, because the status is now "COMMENTED" instead of "APPROVED".

We tested this in two branches: one contains the fix and the other doesn't. As you can see, when the fix is applied, the check passes as expected. When the fix is not applied, the check fails.

- Fix applied: https://github.com/DataDog/documentation/pull/33575
  - Approval check re-runs successfully, even after Joe adds a comment.
- Fix NOT applied: https://github.com/DataDog/documentation/pull/33580
  - Joe approves the PR with a suggested change.
  - Check passes.
  - Joe comments again on the suggested change.
  - Check fails, even though he approved. 

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
