### PR TITLE
add verbiage about use_device_id_as_hostname since it is required for network device tagging to work

### DIFF
--- a/content/en/integrations/guide/servicenow-cmdb-enrichment-setup.md
+++ b/content/en/integrations/guide/servicenow-cmdb-enrichment-setup.md
@@ -79,8 +79,6 @@ To enable ingestion of device tags:
 1. Select any optional field name remappings.
 1. Click **Save**.
 
-**Note**: In order for tags ingested through the CMDB query, your `conf.yaml` used for polling your network devices must have the parameter `use_device_id_as_hostname` set to `true`.
-
 You can expect to see network device tags populated in Datadog within a few minutes after your queries' scheduled executions. Any ingestion errors are reported through events viewable in your events explorer.
 
 You can monitor the ingestion process in the Datadog [Events Explorer][2] by scoping your search query on `source:servicenow`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
The documentation does not explicitly mention the parameter of `use_device_id_as_hostname` must be set to `true` in order for network device tagging to work for CMDB tag ingestion.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
