### PR TITLE
Fix broken action catalog links in private actions list

### DIFF
--- a/layouts/partials/actions/private_actions_list.html
+++ b/layouts/partials/actions/private_actions_list.html
@@ -48,7 +48,7 @@
     {{ end }}
 {{ end }}
 
-{{ $base_url := "https://app.datadoghq.com/workflow/action-catalog#" }}
+{{ $base_url := "https://app.datadoghq.com/actions/action-catalog#" }}
 
 {{ if lt (len $final_actions) 1}}
     {{ $err_msg := "On prem action list is empty" }}
@@ -67,7 +67,7 @@
 <p>The following integrations support private actions:</p>
 <ul>
 {{ range $fqn, $title := $final_actions -}}
-    {{ $full_url := print $base_url $fqn "/" $fqn -}}
+    {{ $full_url := print $base_url "/" $fqn -}}
     <li><a href="{{ $full_url }}">{{ $title}}</a></li>
 {{ end -}}
 </ul>


### PR DESCRIPTION
## Summary
- Update URL base path from `/workflow/action-catalog` to `/actions/action-catalog` in the private actions list partial
- Fix URL construction to produce correct format: `#/com.datadoghq.xxx` instead of `#com.datadoghq.xxx/com.datadoghq.xxx`

Fixes broken links in https://docs.datadoghq.com/actions/private_actions/use_private_actions/?tab=docker#supported-private-actions

## Test plan
- [ ] Verify links in the "Supported private actions" section now point to correct URLs in the datadog app: https://docs-staging.datadoghq.com/benjamin.liu/12-31/fix-broken-action-catalog-links-in-private-actions-list/actions/private_actions/use_private_actions/#supported-private-actions