### PR TITLE
Sync LLM Observability API documentation with Go implementation

### DIFF
--- a/content/en/llm_observability/evaluations/export_api.md
+++ b/content/en/llm_observability/evaluations/export_api.md
@@ -280,7 +280,7 @@ Both endpoints have the same response format. [Results are paginated](/logs/guid
 
 | Field | Type | Description |
 |-------|------|-------------|
-| limit | integer | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. |
+| limit | int64 | Maximum number of spans in the response. Default: 10. Maximum configurable limit: 5000. |
 | cursor | string | List following results with a cursor provided in the previous query. |
 
 ### SearchedSpanResource
@@ -301,8 +301,8 @@ Both endpoints have the same response format. [Results are paginated](/logs/guid
 | tags        | [string]                        | Array of tags associated with your span. |
 | name        | string                       | The name of the span. |
 | status        | string                       | Error status ("ok" or "error"). |
-| start_ns        | integer                       | The span’s start time in nanoseconds. |
-| duration        | float                       | The span’s duration in nanoseconds. |
+| start_ns        | uint64                       | The span's start time in nanoseconds. |
+| duration        | float                       | The span's duration in nanoseconds. |
 | ml_app        | string                       | The name of the span’s LLM Application. |
 | metadata        | Dict[key (string), any]                       | Data about the span that is not input or output related. |
 | span_kind        | string                       | The span kind: "agent", "workflow", "llm", "tool", "task", "embedding", or "retrieval". |


### PR DESCRIPTION
Updated API documentation to match the Go implementation (source of truth).

## Changes by Endpoint

### POST /api/intake/llm-obs/v1/trace/spans
📄 **Doc:** `content/en/llm_observability/instrumentation/api.md` 🔧 **Handler:** `TraceHandler.CreateSpans` (`internal/adapters/handlersv1/http/trace.go`)

| Change | Field | Details |
|--------|-------|---------|
| ✅ Added | `ml_app_version` | string (in SpansPayload) | | ✅ Added | `model_name` | string (in Meta) |
| ✅ Added | `model_provider` | string (in Meta) |
| ✅ Added | `model_version` | string (in Meta) |
| ✅ Added | `tool_calls` | array of ToolCall (in Message) | | ✅ Added | `tool_results` | array of ToolResult (in Message) | | ✅ Added | `tool_definitions` | array of ToolDefinition (in Meta) | | ✅ Added | `ranking` | int (in Document) |
| ✅ Added | `metadata` | object (in Document) |
| ✅ Added | `name` | string (in Prompt, primary field) | | 🔄 Type fix | `metrics` | Updated to flexible map structure | | 🔄 Required fix | `content` | Made optional in Message |

---

### POST /api/intake/llm-obs/v2/eval-metric
📄 **Doc:** `content/en/llm_observability/instrumentation/api.md` 🔧 **Handler:** `EvalMetricsHandlerV2.CreateEvalMetrics` (`internal/adapters/handlersv1/http/eval_metric.go`)

| Change | Field | Details |
|--------|-------|---------|
| ✅ Added | `ml_app_version` | string (in EvalMetric) | | ✅ Added | `trace_id` | string (top-level in EvalMetric) | | ✅ Added | `span_id` | string (top-level in EvalMetric) | | ✅ Added | `metadata` | object (in EvalMetric) |
| 🔄 Required fix | `span_id`, `trace_id` | Marked as required in SpanContext | | 🔄 Required fix | `key`, `value` | Marked as required in TagContext |

---

### POST /api/v2/llm-obs/v1/spans/events/search
📄 **Doc:** `content/en/llm_observability/evaluations/export_api.md` 🔧 **Handler:** `TraceHandler.SearchSpans` (`internal/adapters/handlersv2/http/trace.go`)

| Change | Field | Details |
|--------|-------|---------|
| 🔄 Type fix | `limit` | integer → int64 (in PageQuery) |

---

### GET /api/v2/llm-obs/v1/spans/events
📄 **Doc:** `content/en/llm_observability/evaluations/export_api.md` 🔧 **Handler:** `TraceHandler.ListSpans` (`internal/adapters/handlersv2/http/trace.go`)

| Change | Field | Details |
|--------|-------|---------|
| 🔄 Type fix | `start_ns` | integer → uint64 (in SearchedSpan) |

---

## Summary

| Change Type | Count |
|-------------|-------|
| Fields added | 14 |
| Type fixes | 3 |
| Required fixes | 1 |
| **Total** | **18** |

## Key Updates

- **Tool support**: Added `tool_calls` and `tool_results` to Message type for LLM function calling
- **Model tracking**: Added model_name, model_provider, model_version fields to Meta
- **Tool definitions**: Added tool_definitions array to Meta for documenting available tools
- **RAG support**: Added ranking and metadata fields to Document type
- **Flexible metrics**: Updated Metrics to reflect flexible map structure accepting custom keys
- **Prompt identifier**: Changed primary field from `id` to `name` (kept `id` as deprecated)
- **Version tracking**: Added ml_app_version to both SpansPayload and EvalMetric
- **Required fields**: Fixed required status for SpanContext and TagContext fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
