### PR TITLE
opentelemetry-ruby: Remove unused api docs

### DIFF
--- a/content/en/opentelemetry/instrument/api_support/ruby.md
+++ b/content/en/opentelemetry/instrument/api_support/ruby.md
@@ -1,5 +1,0 @@
----
-title: Ruby Custom Instrumentation using the OpenTelemetry API
----
-
-{{< include-markdown "/tracing/trace_collection/custom_instrumentation/ruby/otel/" >}}


### PR DESCRIPTION
### Merge instructions

Removes `content/en/opentelemetry/instrument/api_support/ruby.md`, this file is no longer referenced. `content/en/opentelemetry/instrument/api_support/ruby/_index.md` is used instead.

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
