### PR TITLE
[DOCS-12837] Add monitor title/description guidelines

### DIFF
--- a/content/en/extend/integrations/create-an-integration-monitor-template.md
+++ b/content/en/extend/integrations/create-an-integration-monitor-template.md
@@ -63,7 +63,7 @@ After you've created and tested your monitor, add it to your listing in the Deve
 2. Click **Import Monitor**.
 3. Search for and select the monitor you created. You can include up to 10 monitors per integration.
 4. For each monitor, provide a **Display Name** and **Description**. These appear on the [**Monitors > Templates**][2] page:
-    - **Display Name**: A concise title that clearly communicates what the alert covers. Use active voice and start with an object followed by a verb (for example, `Database latency exceeds threshold`). Do not use template variables.
+    - **Display Name**: A concise title that clearly communicates what the alert covers. Use active voice and start with the resource or metric followed by a verb (for example, `Database latency exceeds threshold`). Do not use template variables.
 
       | Needs revision                                         | Better                                | Best                                          |
       |--------------------------------------------------------|---------------------------------------|-----------------------------------------------|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds back guidelines for technology partners on creating monitor templates (wording guidance for the title and description; removed in [#32291](https://github.com/DataDog/documentation/pull/32291/changes#diff-6adc3565415f07c451a1f15d25f2a974ad8fdcc81e4f241414fc8436895dcbadL48)). It's useful content for partners, plus the Docs team refers to these guidelines when reviewing integration submissions.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge