### PR TITLE
Clarify default PL monitor behavior

### DIFF
--- a/content/en/synthetics/platform/private_locations/monitoring.md
+++ b/content/en/synthetics/platform/private_locations/monitoring.md
@@ -43,7 +43,7 @@ By default, no handle is set in these monitors. To be alerted in case one of you
 
 Monitors in the **Monitors** tab either have a group that corresponds to your private location ID or are tagged with `location_id:<ID_OF_THE_PL>`.
 
-> **Note:** These default monitors are created **only once**, when the first private location is created. If you previously had a private location that was deleted, creating a new private location later will **not** recreate the default monitors.  
+> **Note:** Default monitors are created **only once**, when the first private location is created. Deleting a private location and creating a new one does **not** recreate the default monitors.
 
 ## Monitor your private locations with the Datadog Agent
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Clarify that default monitors are created only once when the first private location is created and will not be recreated if the private location is deleted.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
