### PR TITLE
[DOCS-13007] Add back removed links to SAML providers

### DIFF
--- a/content/en/account_management/saml/_index.md
+++ b/content/en/account_management/saml/_index.md
@@ -142,3 +142,4 @@ Certain Identity Providers (such as Microsoft's ADFS) can be configured to pull 
 [6]: /account_management/login_methods/#reviewing-user-overrides
 [7]: https://developer.okta.com/docs/concepts/saml/
 [8]: https://thalesdocs.com/sta/operator/applications/apps_saml/index.html
+[9]: /account_management/users/default_roles/


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Support flagged that there were two reference links showing up as `[7]`, `[8]` on this page. It appears that in my previous update to the doc, I accidentally removed the link references from the bottom of the file. This PR adds them back so the links display correctly.

### Merge instructions

Merge readiness:
- [x] Ready for merge
