### PR TITLE
[OTAGENT-572] Add a warning on potential duplicated Prometheus metrics

### DIFF
--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -32,7 +32,7 @@ receivers:
 ```
 
 <div class="alert alert-warning">
-When you have an OpenTelemetry Collector or DDOT Collector with a Prometheus metrics pipeline to scrape Collector health metrics, and you have a Datadog Agent running on the same host, ensure that the <a href="/integrations/openmetrics/">OpenMetrics integration</a> in the Datadog Agent is either turned off or scraping a different endpoint than the Collector health metrics endpoint. Otherwise you may see duplicated Collector health metrics being scraped by both the Collector and Datadog Agent.
+If you have a Datadog Agent running on the same host as an OpenTelemetry Collector or DDOT Collector that uses a Prometheus receiver to scrape Collector health metrics, make sure the Agent's <a href="/integrations/openmetrics/">OpenMetrics integration</a> is either turned off or scraping a different endpoint than the Collector health metrics endpoint. Otherwise, both the Agent and Collector scrape the same endpoint, resulting in duplicate Collector health metrics.
 </div>
 
 ## Data collected


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Add a warning on potential duplicated Prometheus metrics
Background is in https://datadoghq.atlassian.net/browse/OTAGENT-572. A customer ran into a weird bug where they saw duplicated OTel collector health metrics. That is due to they have Agent OpenMetrics integration scraping the OTel collector health metrics in addition to OTel collector Prometheus receiver, thus the same collector health metrics are scraped and sent to Datadog twice.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
