### PR TITLE
Fix environment variable name on resource annotation as tags

### DIFF
--- a/content/en/containers/kubernetes/tag.md
+++ b/content/en/containers/kubernetes/tag.md
@@ -337,7 +337,7 @@ datadog:
 To extract a given resource annotation `<ANNOTATION>` and transform them as tag keys `<TAG_KEY>` within Datadog, add the following environment variable to **both** your Agent and Cluster Agent containers.
 
 ```yaml
-- name: DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS
+- name: DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS
   value: '{"<RESOURCE>":{"<ANNOTATION>":"<TAG_KEY>"}}'
 ```
 


### PR DESCRIPTION
The variable was shown as DD_KUBERNETES_RESOURCES_LABELS_AS_TAGS, while it needs to be DD_KUBERNETES_RESOURCES_ANNOTATIONS_AS_TAGS

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Updates the example shown in the environment variable for using Kubernetes Resources Annotations as Tags

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
