### PR TITLE
Fix circular reference in source maps documentation

### DIFF
--- a/content/en/error_tracking/frontend/browser.md
+++ b/content/en/error_tracking/frontend/browser.md
@@ -198,14 +198,6 @@ Learn more about [tagging][19] in Datadog.
 
 Refer to the [Browser SDK API Reference][9] for the full list of available configuration options.
 
-## Advanced features (optional)
-
-### Manage uploaded source maps
-
-See all uploaded symbols and manage your source maps on the [Explore RUM Debug Symbols][17] page.
-
-**Note**: Source maps are limited in size to **500 MB** each.
-
 ## Next steps
 
 You can monitor unhandled exceptions, unhandled promise rejections, handled exceptions, handled promise rejections, and other errors that the Browser SDK does not automatically track. Learn more about [Collecting Browser Errors][3].
@@ -230,6 +222,6 @@ You can monitor unhandled exceptions, unhandled promise rejections, handled exce
 [14]: https://bitbucket.org/product
 [15]: /integrations/guide/source-code-integration/
 [16]: /error_tracking/explorer
-[17]: https://app.datadoghq.com/source-code/setup/rum
+[17]: /real_user_monitoring/guide/upload-javascript-source-maps
 [18]: /getting_started/tagging/unified_service_tagging/
 [19]: /getting_started/tagging/

--- a/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
+++ b/content/en/real_user_monitoring/guide/upload-javascript-source-maps.md
@@ -24,7 +24,7 @@ If your front-end JavaScript source code is minified, upload your source maps to
 Configure your JavaScript bundler such that when minifying your source code, it generates source maps that directly include the related source code in the `sourcesContent` attribute.
 
 <div class="alert alert-danger">
-Ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of **500 MB**.
+Ensure that the size of each source map augmented with the size of the related minified file does not exceed the limit of <b>500 MB</b>.
 </div>
 
 See the following configurations for popular JavaScript bundlers.
@@ -104,7 +104,7 @@ See the following example:
 ```
 
 <div class="alert alert-danger">
-If the sum of the file size for <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds the <b>the 500 MB</b> limit, reduce it by configuring your bundler to split the source code into multiple smaller chunks. For more information, see <a href="https://webpack.js.org/guides/code-splitting/">Code Splitting with WebpackJS</a>.
+If the sum of the file size for <code>javascript.364758.min.js</code> and <code>javascript.364758.js.map</code> exceeds the <b>500 MB</b> limit, reduce it by configuring your bundler to split the source code into multiple smaller chunks. For more information, see <a href="https://webpack.js.org/guides/code-splitting/">Code Splitting with WebpackJS</a>.
 </div>
 
 ## Upload your source maps
@@ -157,6 +157,8 @@ Only source maps with the `.js.map` extension work to correctly unminify stack t
 
 <div class="alert alert-info">If you are serving the same JavaScript source files from different subdomains, upload the related source map once and make it work for multiple subdomains by using the absolute prefix path instead of the full URL. For example, specify <code>/static/js</code> instead of <code>https://hostname.com/static/js</code>.</div>
 
+See all uploaded symbols and manage your source maps on the [Explore RUM Debug Symbols][5] page.
+
 ### Link stack frames to your source code
 
 If you run `datadog-ci sourcemaps upload` within a Git working directory, Datadog collects repository metadata. The `datadog-ci` command collects the repository URL, the current commit hash, and the list of file paths in the repository that relate to your source maps. For more details about Git metadata collection, refer to the [datadog-ci documentation][4].
@@ -183,3 +185,4 @@ On the other hand, an unminified stack trace provides you with all the context y
 [2]: https://docs.datadoghq.com/real_user_monitoring/application_monitoring/browser/setup/#initialization-parameters
 [3]: https://docs.datadoghq.com/logs/log_collection/javascript/#initialization-parameters
 [4]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/sourcemaps#link-errors-with-your-source-code
+[5]: https://app.datadoghq.com/source-code/setup/rum


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The browser error tracking page was linking to the app URL for source map uploads, which then linked back to the same page, creating a circular loop. This commit:

- Fix circular reference by changing link [17] in browser.md to point to
  the upload guide documentation instead of the app URL
- Move "See all uploaded symbols" information from browser.md to the
  upload guide where it's more contextually relevant
- Remove redundant "Manage uploaded source maps" section from browser.md
- Fix "the the" typo in upload guide
- Fix markdown bold syntax to HTML in alert blocks

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
