### PR TITLE
Align Metrics Docs Terminology with Reference Table Joins

### DIFF
--- a/content/en/metrics/composite_metrics_queries.md
+++ b/content/en/metrics/composite_metrics_queries.md
@@ -1,5 +1,5 @@
 ---
-title: Composite Metrics Queries
+title: Reference Table Joins for Metrics
 further_reading:
 - link: "/reference_tables/"
   tag: "Documentation"
@@ -8,13 +8,13 @@ further_reading:
 
 ## Overview
 
-Composite metrics queries enhance your monitoring and analysis capabilities by allowing dynamic tagging of metrics at query time. This simplifies the process of adding new tags to your metrics, and requires no code changes. Use composite metrics queries to enable more meaningful and actionable insights from your metric data.
+Reference Tables enhance your monitoring and analysis capabilities by allowing dynamic tagging of metrics at query time. This simplifies the process of adding new tags to your metrics and requires no code changes. Use joins with reference tables to enable more meaningful and actionable insights from your metric data.
 
-Using composite metrics queries, you can accomplish the following:
+Using reference tables, you can accomplish the following:
 
 - **Build context-rich dashboards**. Use [Reference Tables][1] to append more contextual tags such as `team` or `organization` to your metrics.
 - **Simplify troubleshooting**. Alias opaque tag values (for example, IDs or codes) to human-readable values, reducing cognitive effort and resolution time.<br /><br />
-   {{< img src="metrics/nested_queries/composite_metrics_queries/composite_metric_query_example.mp4" alt="How to configure composite metrics queries in the UI" video=true style="width:100%" >}}
+   {{< img src="metrics/nested_queries/composite_metrics_queries/composite_metric_query_example.mp4" alt="How to configure metrics queries using Reference Tables in the UI" video=true style="width:100%" >}}
 
 ## Setup
 


### PR DESCRIPTION
Updated the Metrics documentation to use "reference table" and joins instead of "composite metric queries" to align with the correct product name. Please merge when approved!