### PR TITLE
Fix installation command for ddev in documentation

### DIFF
--- a/content/en/network_monitoring/devices/snmp_traps.md
+++ b/content/en/network_monitoring/devices/snmp_traps.md
@@ -159,7 +159,7 @@ You can write these mappings by hand, or generate mappings from a list of MIBs u
 
 **Prerequisites**:
 - Python 3
-- [`ddev`][4] (`pip3 install "datadog-checks-dev[cli]"`)
+- [`ddev`][4] (`pip3 install ddev`)
 - [`pysmi`][5] (`pip3 install pysmi`)
 
 Place all your MIBs in a dedicated folder and run:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
updates ddev install command so it actually works. source: https://datadoghq.dev/integrations-core/setup/#pypi

### Merge instructions

n/a

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
n/a
