### PR TITLE
[DOCS-13075] add Fed callout for Test Suites Alerting

### DIFF
--- a/content/en/synthetics/test_suites/_index.md
+++ b/content/en/synthetics/test_suites/_index.md
@@ -44,7 +44,12 @@ To create a new Test Suite:
    - **Select** one or more tests to include.
 3. Click **Add Tests** to confirm.
 4. _Optionally, remove tests using the Remove Test from Suite icon next to each entry_.
+
 5. Configure alerting for the suite:
+{{% site-region region="gov" %}}
+<div class="alert alert-warning">Alerting for Test Suites is not supported for this <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}})</div>
+{{% /site-region %}}
+
    - By default, all tests are marked as **Critical**, and the alert triggers when any critical test fails. 
 
      **Note**: Suite alerts are separate from individual test alerts. To avoid duplicate notifications, mute alerts on individual tests included in the suite.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The Alerting feature of Synthetics Test Suites is not yet supported for US-FED. This adds a callout to this section until we have this feature enabled for GovCloud.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
