### PR TITLE
[SDTEST-3098] Improve TIA docs for ruby and add static dependency analysis docs

### DIFF
--- a/content/en/tests/test_impact_analysis/setup/ruby.md
+++ b/content/en/tests/test_impact_analysis/setup/ruby.md
@@ -39,7 +39,7 @@ After completing setup, run your tests as you normally do.
 
 ## Known limitations
 
-Test Impact Analysis uses code coverage data to determine whether or not tests should be skipped. There are some situations where this coverage data may not be sufficient to make this determination.
+Test Impact Analysis uses code coverage data to determine whether or not tests should be skipped. In certain situations, code coverage data alone is not enough to determine whether to skip a test.
 
 ### Coverage limitations
 
@@ -98,7 +98,7 @@ The following limitations apply to static dependencies analysis:
 * **Dynamic lookups not supported**: Constants accessed through metaprogramming (such as `const_get` or `constantize`) are not detected.
 * **Unqualified constant names**: Constants accessed without their full namespace path may not be resolved correctly (for example `MyConst` instead of `MyModule::MyConst`)
 
-## Disabling skipping for specific tests
+## Unskippable tests
 
 You can override the Test Impact Analysis's behavior and prevent specific tests from being skipped. These tests are referred to as unskippable tests.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Recently we introduced tracking of static dependencies to improve the correctness of Test Impact Analysis in Ruby. This PR explains how to enable this experimental feature. Also, I used this opportunity to make documentation for Ruby library more clear and explain limitations of Test Impact Analysis better.

### Merge instructions

Merge readiness:
- [x] Ready for merge