### PR TITLE
[CONTP-1159] docs(container_discovery): Add CEL exclude option to Datadog Operator section of Container Discovery Management guide.

### DIFF
--- a/content/en/containers/guide/container-discovery-management.md
+++ b/content/en/containers/guide/container-discovery-management.md
@@ -299,7 +299,7 @@ You can also configure CEL-backed workload exclusion using one of the following 
 - Set the `DD_CEL_WORKLOAD_EXCLUDE` environment variable with a JSON-formatted string containing your rules, in any containerized Agent setup.
 - For the Datadog Operator or Helm Chart, add your CEL rules to the appropriate configuration option (as shown in the examples below).
 
-{{% collapse-content title="Setting environment variables" level="h4" expanded=false id="setting-environment-variables" %}}
+{{% collapse-content title="Configuring CEL exclusion rules" level="h4" expanded=false id="setting-environment-variables" %}}
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the Datadog Operator tab under CEL exclusion rules to include a option added in `v1.23.0` instead of relying on an environment variable.

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
