### PR TITLE
[SVLS-8285] Remove CDK v1 from docs

### DIFF
--- a/content/en/security/application_security/setup/aws/lambda/dotnet.md
+++ b/content/en/security/application_security/setup/aws/lambda/dotnet.md
@@ -141,21 +141,12 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 1. Install the Datadog CDK constructs library:
 
     ```sh
-    # For AWS CDK v1
-    npm install datadog-cdk-constructs --save-dev
-
-    # For AWS CDK v2
     npm install datadog-cdk-constructs-v2 --save-dev
     ```
 
 2. Instrument your Lambda functions
 
     ```typescript
-    // For AWS CDK v1
-    import { Datadog } from "datadog-cdk-constructs";
-    // NOT SUPPORTED IN V1
-
-    // For AWS CDK v2
     import { Datadog, DatadogAppSecMode } from "datadog-cdk-constructs-v2";
 
     const datadog = new Datadog(this, "Datadog", {

--- a/content/en/security/application_security/setup/aws/lambda/go.md
+++ b/content/en/security/application_security/setup/aws/lambda/go.md
@@ -141,21 +141,12 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 1. Install the Datadog CDK constructs library:
 
     ```sh
-    # For AWS CDK v1
-    npm install datadog-cdk-constructs --save-dev
-
-    # For AWS CDK v2
     npm install datadog-cdk-constructs-v2 --save-dev
     ```
 
 2. Instrument your Lambda functions
 
     ```typescript
-    // For AWS CDK v1
-    import { Datadog } from "datadog-cdk-constructs";
-    // NOT SUPPORTED IN V1
-
-    // For AWS CDK v2
     import { Datadog, DatadogAppSecMode } from "datadog-cdk-constructs-v2";
 
     const datadog = new Datadog(this, "Datadog", {

--- a/content/en/security/application_security/setup/aws/lambda/java.md
+++ b/content/en/security/application_security/setup/aws/lambda/java.md
@@ -139,21 +139,12 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 1. Install the Datadog CDK constructs library:
 
     ```sh
-    # For AWS CDK v1
-    npm install datadog-cdk-constructs --save-dev
-
-    # For AWS CDK v2
     npm install datadog-cdk-constructs-v2 --save-dev
     ```
 
 2. Instrument your Lambda functions
 
     ```typescript
-    // For AWS CDK v1
-    import { Datadog } from "datadog-cdk-constructs";
-    // NOT SUPPORTED IN V1
-
-    // For AWS CDK v2
     import { Datadog, DatadogAppSecMode } from "datadog-cdk-constructs-v2";
 
     const datadog = new Datadog(this, "Datadog", {

--- a/content/en/security/application_security/setup/aws/lambda/nodejs.md
+++ b/content/en/security/application_security/setup/aws/lambda/nodejs.md
@@ -141,21 +141,12 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 1. Install the Datadog CDK constructs library:
 
     ```sh
-    # For AWS CDK v1
-    npm install datadog-cdk-constructs --save-dev
-
-    # For AWS CDK v2
     npm install datadog-cdk-constructs-v2 --save-dev
     ```
 
 2. Instrument your Lambda functions
 
     ```javascript
-    // For AWS CDK v1
-    import { Datadog } from "datadog-cdk-constructs";
-    // NOT SUPPORTED IN V1
-
-    // For AWS CDK v2
     import { Datadog, DatadogAppSecMode } from "datadog-cdk-constructs-v2";
 
     const datadog = new Datadog(this, "Datadog", {

--- a/content/en/security/application_security/setup/aws/lambda/python.md
+++ b/content/en/security/application_security/setup/aws/lambda/python.md
@@ -142,21 +142,12 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 1. Install the Datadog CDK constructs library:
 
     ```sh
-    # For AWS CDK v1
-    pip install datadog-cdk-constructs
-
-    # For AWS CDK v2
     pip install datadog-cdk-constructs-v2
     ```
 
 2. Instrument your Lambda functions
 
     ```python
-    # For AWS CDK v1
-    from datadog_cdk_constructs import Datadog
-    # NOT SUPPORTED IN V1
-
-    # For AWS CDK v2
     from datadog_cdk_constructs_v2 import Datadog, DatadogAppSecMode
 
     datadog = Datadog(self, "Datadog",

--- a/content/en/security/application_security/setup/aws/lambda/ruby.md
+++ b/content/en/security/application_security/setup/aws/lambda/ruby.md
@@ -141,21 +141,12 @@ The [Datadog CDK Construct][1] automatically installs Datadog on your functions 
 1. Install the Datadog CDK constructs library:
 
     ```sh
-    # For AWS CDK v1
-    pip install datadog-cdk-constructs
-
-    # For AWS CDK v2
     pip install datadog-cdk-constructs-v2
     ```
 
 2. Instrument your Lambda functions
 
     ```python
-    # For AWS CDK v1
-    from datadog_cdk_constructs import Datadog
-    # NOT SUPPORTED IN V1
-
-    # For AWS CDK v2
     from datadog_cdk_constructs_v2 import Datadog, DatadogAppSecMode
 
     datadog = Datadog(self, "Datadog",


### PR DESCRIPTION
<!-- dd-meta {"pullId":"e452e1f7-1436-465a-9334-c691a03a8acc","source":"chat","resourceId":"17393921-22be-4761-b1bc-429c41b00012","workflowId":"33bb2eee-75b2-46df-9314-0ba09c5c0299","codeChangeId":"33bb2eee-75b2-46df-9314-0ba09c5c0299","sourceType":"chat"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/17393921-22be-4761-b1bc-429c41b00012)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do? What is the motivation?

Remove AWS CDK v1 mentions from Lambda documentation. CDK v1 was EOL in 2023.

Updated files in `content/en/security/application_security/setup/aws/lambda/`:
- `nodejs.md`
- `ruby.md`
- `python.md`
- `java.md`
- `go.md`
- `dotnet.md`

Each file had the CDK v1 install command and import removed from the "AWS CDK" tab, leaving only the v2 instructions.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Related to SVLS-7286.