### PR TITLE
Add agentic onboarding preview banner to serverless Lambda instrumentation pages

### DIFF
--- a/content/en/serverless/aws_lambda/instrumentation/dotnet.md
+++ b/content/en/serverless/aws_lambda/instrumentation/dotnet.md
@@ -17,6 +17,10 @@ further_reading:
 
 <div class="alert alert-info">Version 67+ of the Datadog Lambda Extension is optimized to significantly reduce cold start duration. <a href="/serverless/aws_lambda/configuration/?tab=datadogcli#using-datadog-lambda-extension-v67">Read more</a>.</div>
 
+{{< callout url="https://www.datadoghq.com/product-preview/agentic-onboarding-for-serverless-applications/" btn_hidden="false" header="Agentically add Datadog to your Lambda Functions">}}
+Agentic onboarding for Datadog Serverless is in Preview. Use your favorite AI coding tool such as Cursor or Claude to bulk-add Datadog monitoring to your Lambda functions.
+{{< /callout >}}
+
 ## Setup
 
 {{< tabs >}}

--- a/content/en/serverless/aws_lambda/instrumentation/go.md
+++ b/content/en/serverless/aws_lambda/instrumentation/go.md
@@ -20,6 +20,10 @@ aliases:
 
 <div class="alert alert-info">Version 67+ of the Datadog Lambda Extension is optimized to significantly reduce cold start duration. <a href="/serverless/aws_lambda/configuration/?tab=datadogcli#using-datadog-lambda-extension-v67">Read more</a>.</div>
 
+{{< callout url="https://www.datadoghq.com/product-preview/agentic-onboarding-for-serverless-applications/" btn_hidden="false" header="Agentically add Datadog to your Lambda Functions">}}
+Agentic onboarding for Datadog Serverless is in Preview. Use your favorite AI coding tool such as Cursor or Claude to bulk-add Datadog monitoring to your Lambda functions.
+{{< /callout >}}
+
 ## Setup
 
 **Note**: Datadog recommends that you use Go tracer v1.73.1 for instrumenting AWS Lambda functions. Go tracer v2 is not supported.

--- a/content/en/serverless/aws_lambda/instrumentation/java.md
+++ b/content/en/serverless/aws_lambda/instrumentation/java.md
@@ -24,6 +24,10 @@ If you previously set up your Lambda functions using the Datadog Forwarder, see 
 
 If you are using the Datadog Lambda layers `dd-trace-java:4` (or older) and `Datadog-Extension:24` (or older), follow the [special instructions to upgrade][10].
 
+{{< callout url="https://www.datadoghq.com/product-preview/agentic-onboarding-for-serverless-applications/" btn_hidden="false" header="Agentically add Datadog to your Lambda Functions">}}
+Agentic onboarding for Datadog Serverless is in Preview. Use your favorite AI coding tool such as Cursor or Claude to bulk-add Datadog monitoring to your Lambda functions.
+{{< /callout >}}
+
 ## Setup
 
 {{< tabs >}}

--- a/content/en/serverless/aws_lambda/instrumentation/nodejs.md
+++ b/content/en/serverless/aws_lambda/instrumentation/nodejs.md
@@ -22,6 +22,10 @@ aliases:
 
 <div class="alert alert-info">Version 67+ of the Datadog Lambda Extension is optimized to significantly reduce cold start duration. <a href="/serverless/aws_lambda/configuration/?tab=datadogcli#using-datadog-lambda-extension-v67">Read more</a>.</div>
 
+{{< callout url="https://www.datadoghq.com/product-preview/agentic-onboarding-for-serverless-applications/" btn_hidden="false" header="Agentically add Datadog to your Lambda Functions">}}
+Agentic onboarding for Datadog Serverless is in Preview. Use your favorite AI coding tool such as Cursor or Claude to bulk-add Datadog monitoring to your Lambda functions.
+{{< /callout >}}
+
 ## Setup
 
 {{< tabs >}}

--- a/content/en/serverless/aws_lambda/instrumentation/python.md
+++ b/content/en/serverless/aws_lambda/instrumentation/python.md
@@ -21,6 +21,10 @@ algolia:
 
 <div class="alert alert-info">Version 67+ of the Datadog Lambda Extension is optimized to significantly reduce cold start duration. <a href="/serverless/aws_lambda/configuration/?tab=datadogcli#using-datadog-lambda-extension-v67">Read more</a>.</div>
 
+{{< callout url="https://www.datadoghq.com/product-preview/agentic-onboarding-for-serverless-applications/" btn_hidden="false" header="Agentically add Datadog to your Lambda Functions">}}
+Agentic onboarding for Datadog Serverless is in Preview. Use your favorite AI coding tool such as Cursor or Claude to bulk-add Datadog monitoring to your Lambda functions.
+{{< /callout >}}
+
 ## Setup
 
 {{< tabs >}}

--- a/content/en/serverless/aws_lambda/instrumentation/ruby.md
+++ b/content/en/serverless/aws_lambda/instrumentation/ruby.md
@@ -23,6 +23,10 @@ aliases:
 
 <div class="alert alert-info">Version 67+ of the Datadog Lambda Extension is optimized to significantly reduce cold start duration. <a href="/serverless/aws_lambda/configuration/?tab=datadogcli#using-datadog-lambda-extension-v67">Read more</a>.</div>
 
+{{< callout url="https://www.datadoghq.com/product-preview/agentic-onboarding-for-serverless-applications/" btn_hidden="false" header="Agentically add Datadog to your Lambda Functions">}}
+Agentic onboarding for Datadog Serverless is in Preview. Use your favorite AI coding tool such as Cursor or Claude to bulk-add Datadog monitoring to your Lambda functions.
+{{< /callout >}}
+
 ## Setup
 
 {{< tabs >}}


### PR DESCRIPTION
## What does this PR do?

This PR adds a preview callout banner for the agentic onboarding feature to all language-specific AWS Lambda instrumentation pages.

## Motivation

We want to promote the agentic onboarding feature for serverless applications across all supported Lambda runtimes.

## Changes

- Added preview callout banner to Java instrumentation page
- Added preview callout banner to Python instrumentation page
- Added preview callout banner to Node.js instrumentation page
- Added preview callout banner to Go instrumentation page
- Added preview callout banner to Ruby instrumentation page
- Added preview callout banner to .NET instrumentation page

The banner appears right before the Setup section on each page and links to the product preview sign-up form.

## Additional Notes

This extends the existing agentic onboarding preview banner that was already present on the main serverless instrumentation page to all individual language/runtime pages.

## Reviewer Checklist

- [ ] Content is technically accurate
- [ ] Banner placement is appropriate
- [ ] Links work correctly