### PR TITLE
Add preview banner to ECS Managed Instances page

### DIFF
--- a/content/en/containers/amazon_ecs/managed_instances.md
+++ b/content/en/containers/amazon_ecs/managed_instances.md
@@ -19,6 +19,10 @@ further_reading:
       text: "Catch and remediate ECS issues faster with default monitors and the ECS Explorer"
 ---
 
+{{< callout btn_hidden="true" header="ECS Managed Instances is in Preview">}}
+Amazon ECS Managed Instances monitoring is in Preview.
+{{< /callout >}}
+
 Datadog Container Monitoring enables visibility into applications running on [Amazon ECS Managed Instances][29].
 
 ### How it works


### PR DESCRIPTION
## What does this PR do?

This PR adds a preview callout banner to the Amazon ECS Managed Instances documentation page.

## Motivation

Amazon ECS Managed Instances is a newly launched feature (September/October 2025) and should be clearly marked as being in preview to set appropriate expectations with customers.

## Changes

- Added preview callout banner at the top of the ECS Managed Instances page
- Banner appears right after the frontmatter and before the main content
- Uses the same callout format as other preview features (e.g., CD Visibility)

## Additional Notes

According to DataDog's internal documentation and Jira tickets:
- ECS Managed Instances was launched in September/October 2025
- Agent support was added in version 7.73.0 (November 2025)
- Feature is currently working toward GA as part of 2026 Q1 OKRs
- Currently tracking adoption via telemetry (EXP-14)

## Reviewer Checklist

- [ ] Content is technically accurate
- [ ] Banner placement is appropriate
- [ ] Messaging is clear and appropriate for preview status