### PR TITLE
[SYNTH-22428] Add references to synthetics monitor vars to monitors docs

### DIFF
--- a/content/en/monitors/notify/_index.md
+++ b/content/en/monitors/notify/_index.md
@@ -33,7 +33,7 @@ Notifications are a key component of monitors that keep your team informed of is
 
 This approach helps ensure your monitor titles and messages are clear, actionable, and tailored to your audience's needs.
 - **Unique titles**: Add a unique title to your monitor (this is required). For multi alert monitors, some tags identifying your triggering scope are automatically inserted. You can use [tag variables][3] to enhance specificity.
-- **Message field**: The message field supports standard [Markdown formatting][4] and [variables][5]. Use [conditional variables][6] to modulate the notification text sent to different contacts with [@notifications](#notifications).
+- **Message field**: The message field supports standard [Markdown formatting][4] and [variables][5]. Use [conditional variables][6] to modulate the notification text sent to different contacts with [@notifications](#notifications). Use [synthetics template variables][23] to enrich the alert message with synthetics failure context. 
 
 {{% collapse-content title="Example monitor message" level="h4" expanded=false %}}
 A common use-case for the monitor message is to include a step-by-step way to resolve the problem, for example:
@@ -238,3 +238,4 @@ Message variables auto-populate with a randomly selected group based on the scop
 [20]: /monitors/configuration/
 [21]: /monitors/guide/recovery-thresholds/
 [22]: /monitors/notify/notification_rules
+[23]: /synthetics/notifications/template_variables/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
When clicking on the docs link here it directs the user to the monitors notifications page however there is no info on the synthetics template vars even though they're in the autocomplete form. 
<img width="1151" height="807" alt="Screenshot 2026-01-14 at 14 12 55" src="https://github.com/user-attachments/assets/3dabbc28-0423-44d2-9c28-1328ce7d6e40" />
This PR adds them to the docs

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
