### PR TITLE
[k8s log collection] Link to Autodiscovery Container Identifiers page

### DIFF
--- a/content/en/containers/kubernetes/log.md
+++ b/content/en/containers/kubernetes/log.md
@@ -387,7 +387,7 @@ With the key-value store enabled as a template source, the Agent looks for templ
 {{% /tab %}}
 {{< /tabs >}}
 
-To match a log configuration towards a set of containers with more granularity than the containers' short image name, refer to [Autodiscovery Container Identifiers][22].
+To match a log configuration to a set of containers with more granularity than the container short image name, see [Autodiscovery Container Identifiers][22].
 
 ## Advanced log collection
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

It's currently difficult to discover the advanced Autodiscovery Container Identifiers options available for Log collection when looking at the main k8s Log collection page. This PR adds a link to that page to make it more discoverable.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
