### PR TITLE
Sync LLM Observability Spans API documentation with Go implementation

### DIFF
--- a/content/en/llm_observability/instrumentation/api.md
+++ b/content/en/llm_observability/instrumentation/api.md
@@ -153,6 +153,8 @@ If the request is successful, the API responds with a 202 network code and an em
 | messages| [Message](#message) | List of messages. This should only be used for LLM spans. |
 | documents| [Document](#document) | List of documents. This should only be used as the output for retrieval spans |
 | prompt | [Prompt](#prompt) | Structured prompt metadata that includes the template and variables used for the LLM input. This should only be used for input IO on LLM spans. |
+| embedding | [float] | Array of embedding values. **Only valid for embedding spans.** |
+| parameters | Dict[key (string), value] | Additional parameters for the input or output. |
 
 
 **Note**: When only `input.messages` is set for an LLM span, Datadog infers `input.value` from `input.messages` and uses the following inference logic:
@@ -166,6 +168,26 @@ If the request is successful, the API responds with a 202 network code and an em
 |----------------------|--------|--------------------------|
 | content [*required*] | string | The body of the message. |
 | role                 | string | The role of the entity.  |
+| tool_calls           | [[ToolCall](#toolcall)] | List of tool calls made in this message. |
+| tool_results         | [[ToolResult](#toolresult)] | List of tool results returned in this message. |
+
+#### ToolCall
+
+| Field     | Type   | Description              |
+|-----------|--------|--------------------------|
+| name      | string | The name of the tool being called. |
+| arguments | Dict[key (string), value] | Arguments passed to the tool. |
+| tool_id   | string | Unique identifier for this tool call. |
+| type      | string | The type of tool call. |
+
+#### ToolResult
+
+| Field   | Type   | Description              |
+|---------|--------|--------------------------|
+| name    | string | The name of the tool that was called. |
+| result  | string | The result returned by the tool. |
+| tool_id | string | Unique identifier matching the original tool call. |
+| type    | string | The type of tool result. |
 
 #### Document
 | Field                | Type   | Description              |
@@ -215,6 +237,14 @@ If the request is successful, the API responds with a 202 network code and an em
 {{% /tab %}}
 {{< /tabs >}}
 
+#### ToolDefinition
+
+| Field       | Type              | Description  |
+|-------------|-------------------|--------------|
+| name        | string            | The name of the tool. |
+| description | string            | A description of what the tool does. |
+| schema      | Dict[key (string), value] | The schema defining the tool's parameters. |
+
 #### Meta
 | Field       | Type              | Description  |
 |-------------|-------------------|--------------|
@@ -222,7 +252,12 @@ If the request is successful, the API responds with a 202 network code and an em
 | error       | [Error](#error)             | Error information on the span.              |
 | input       | [IO](#io)                | The span's input information.               |
 | output      | [IO](#io)                | The span's output information.              |
-| metadata    | Dict[key (string), value] where the value is a float, bool, or string | Data about the span that is not input or output related. Use the following metadata keys for LLM spans: `temperature`, `max_tokens`, `model_name`, and `model_provider`. |
+| expected_output | [IO](#io) | Expected output for evaluation purposes. |
+| tool_definitions | [[ToolDefinition](#tooldefinition)] | List of available tool definitions. |
+| intent      | string | The intent or purpose of the span. |
+| model_name  | string | The name of the model used. **Only valid for LLM and embedding spans.** |
+| model_provider | string | The provider of the model. **Only valid for LLM and embedding spans.** |
+| metadata    | Dict[key (string), value] where the value is a float, bool, or string | Data about the span that is not input or output related. Use the following metadata keys for LLM spans: `temperature`, `max_tokens`. |
 
 #### Metrics
 | Field                  | Type    | Description  |


### PR DESCRIPTION

### What does this PR do? What is the motivation?

Update API documentation to match the Go implementation (source of truth).

## Changes

### POST /api/intake/llm-obs/v1/trace/spans

**Meta fields:**
- ✅ Added `model_name` as top-level field (was incorrectly documented in metadata dict)
- ✅ Added `model_provider` as top-level field (was incorrectly documented in metadata dict)
- ✅ Added `expected_output` field for evaluation purposes
- ✅ Added `tool_definitions` array for tool integration
- ✅ Added `intent` string field
- 🔄 Updated `metadata` description (removed model_name and model_provider)

**IO fields:**
- ✅ Added `embedding` array for embedding spans
- ✅ Added `parameters` dict for additional input/output data

**Message fields:**
- ✅ Added `tool_calls` array for LLM tool calling
- ✅ Added `tool_results` array for tool responses

**New sections:**
- ✅ Added `ToolCall` structure definition
- ✅ Added `ToolResult` structure definition
- ✅ Added `ToolDefinition` structure definition

## Impact

### Critical fixes:
1. **Model fields**: Moved model_name and model_provider from metadata dict to top-level Meta fields to match Go implementation
2. **Tool integration**: Documented tool_calls, tool_results, and tool_definitions to support LLM function calling
3. **Evaluation support**: Added expected_output for evaluation workflows
4. **Embedding support**: Added embedding array for embedding spans

### Before (incorrect):
```json
{
  "meta": {
    "metadata": {
      "model_name": "gpt-4",
      "model_provider": "openai"
    }
  }
}
```

### After (correct):
```json
{
  "meta": {
    "model_name": "gpt-4",
    "model_provider": "openai",
    "tool_definitions": [...],
    "metadata": {
      "temperature": 0.7
    }
  }
}
```

🤖 Generated with Claude Code


Merge readiness:
- [x ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
