### PR TITLE
Update latest websites-modules version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module documentation
 
 go 1.24.4
 
-require github.com/DataDog/websites-modules v1.5.1-0.20260114152424-93c976a8c49b // indirect
+require github.com/DataDog/websites-modules v1.4.279 // indirect
 
 // replace github.com/DataDog/websites-modules => /Users/lisiane.turlure/guac/websites-modules

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/DataDog/websites-modules v1.5.1-0.20260114152424-93c976a8c49b h1:1TWpRoZZRogbL+zBDOXsJeJxy3l3C9GwCpSPkWw6A1U=
-github.com/DataDog/websites-modules v1.5.1-0.20260114152424-93c976a8c49b/go.mod h1:0pAe0O1KehxRBoWbXv2H3tHgMpd1kZylyQhFADlLpd0=
+github.com/DataDog/websites-modules v1.4.279 h1:Yzk3yAEG7QTOjE8LhU6mRxUipkpZAmSpxEjWoM+53uk=
+github.com/DataDog/websites-modules v1.4.279/go.mod h1:0pAe0O1KehxRBoWbXv2H3tHgMpd1kZylyQhFADlLpd0=


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Update site with latest websites-modules update to address footer CTA text wrap bug, seen on the Spanish-language version of the site.

### Merge instructions

After websites-modules is merged and this branch is auto-updated, it can be reviewed/approved and then merged.

Merge readiness:
- [x] Ready for merge

### Preview

Preview site:
Purple CTA in footer adjusts to text sizing, with minimum width and height on tablet+
- https://docs-staging.datadoghq.com/websites-modules/generated/483/
- https://docs-staging.datadoghq.com/websites-modules/generated/483/es/
- https://docs-staging.datadoghq.com/websites-modules/generated/483/fr/
- https://docs-staging.datadoghq.com/websites-modules/generated/483/ko/
- https://docs-staging.datadoghq.com/websites-modules/generated/483/ja/