### PR TITLE
Update main data observability page title

### DIFF
--- a/content/en/data_observability/_index.md
+++ b/content/en/data_observability/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Data Observability
+title: Data Observability Overview
 description: "Monitor data quality, performance, and cost with Data Observability to detect anomalies, analyze data lineage, and prevent issues affecting downstream systems."
 further_reading:
  - link: '/data_observability/quality_monitoring/'


### PR DESCRIPTION
Small change to update the title of the "Data Observability" main page to "Data Observability Overview."

This goal is to avoid implying that Data Observability is a product alongside the Quality Monitoring and Jobs Monitoring products. Instead, Data Observability is a product suite that contains Quality Monitoring and Jobs Monitoring.

This change is consistent with the Security Overview page.

<img width="556" height="614" alt="CleanShot 2026-01-14 at 13 27 35@2x" src="https://github.com/user-attachments/assets/4992a4d7-a55a-49ee-9419-af9ccb9605a9" />

Merge readiness:
- [x] Ready for merge