### PR TITLE
Add Incident Response header page

### DIFF
--- a/content/en/incident_response/_index.md
+++ b/content/en/incident_response/_index.md
@@ -1,0 +1,25 @@
+---
+title: Incident Response
+further_reading:
+- link: "https://app.datadoghq.com/release-notes?category=Incident%20Response"
+  tag: "Release Notes"
+  text: "Check out the latest Datadog Incident Response releases! (App login required)."
+cascade:
+    algolia:
+        rank: 70
+---
+
+## Components
+
+{{< whatsnext desc="Explore Incident Response Components" >}}
+    {{< nextlink href="/incident_response/incident_management/" >}}<u>Incident Management</u> - Learn how to manage and resolve incidents efficiently.{{< /nextlink >}}
+    {{< nextlink href="/incident_response/case_management/" >}}<u>Case Management</u> - Track and organize cases related to incidents.{{< /nextlink >}}
+    {{< nextlink href="/incident_response/status_pages/" >}}<u>Status Pages</u> - Communicate real-time system status with internal or public pages.{{< /nextlink >}}
+    {{< nextlink href="/incident_response/on_call/" >}}<u>On Call</u> - Manage on-call schedules and responder rotations.{{< /nextlink >}}
+{{< /whatsnext >}}
+
+
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Added a header index so the search results point to Incident Response instead of incident_response
https://datadoghq.atlassian.net/browse/DOCS-13098
<img alt="image" src="https://github.com/user-attachments/assets/337c70dd-4270-4284-9b9b-946c7a7234cd" style="width:60%;" />


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
