### PR TITLE
Added `--no-sort` flag to example `terraformer import` commands

### DIFF
--- a/content/en/containers/guide/how-to-import-datadog-resources-into-terraform.md
+++ b/content/en/containers/guide/how-to-import-datadog-resources-into-terraform.md
@@ -40,7 +40,7 @@ Then run `terraform init` from within this directory to pull the datadog terrafo
 
 Now you can use `terraformer` to start importing resources. For example, to import Dashboard `abc-def-ghi` you can run
 
-`terraformer import datadog --resources=dashboard --filter=dashboard=abc-def-ghi --api-key <YOUR_API_KEY> --app-key <YOUR_APP_KEY> --api-url <YOUR_DATADOG_SITE_URL>`
+`terraformer import datadog --resources=dashboard --filter=dashboard=abc-def-ghi --no-sort --api-key <YOUR_API_KEY> --app-key <YOUR_APP_KEY> --api-url <YOUR_DATADOG_SITE_URL>`
 
 This generates a folder `generated` that contains both a terraform state file, as well as HCL terraform config files representing the imported resource.
 
@@ -63,11 +63,13 @@ generated
 
 All example commands require the `--api-key`, `--app-key`, and `--api-url` flags.
 
+The `--no-sort` flag should be added for resources like dashboards where the order of elements is meaningful. Without it `terraformer` may re-sort the widgets on your dashboards.
+
 * Import all monitors: `terraformer import datadog --resources=monitor`
 * Import monitor with id 1234: `terraformer import datadog --resources=monitor --filter=monitor=1234`
 * Import monitors with id 1234 and 12345: `terraformer import datadog --resources=monitor --filter=monitor=1234:12345`
-* Import all monitors and dashboards: `terraformer import datadog --resources=monitor,dashboard`
-* Import monitor with id 1234 and dashboard with id abc-def-ghi: `terraformer import datadog --resources=monitor,dashboard --filter=monitor=1234,dashboard=abc-def-ghi`
+* Import all monitors and dashboards: `terraformer import datadog --no-sort --resources=monitor,dashboard`
+* Import monitor with id 1234 and dashboard with id abc-def-ghi: `terraformer import datadog --resources=monitor,dashboard --no-sort --filter=monitor=1234,dashboard=abc-def-ghi`
 
 ## Generating resources with Terraform v0.13+
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

An internal, and several external bug reports have highlighted the fact that `terraformer` visually re-orders widgets on datadog dashboards in some cases. The fix for this is to add a `--no-sort` flag when using `terraformer` for imports. This PR adds the flag to Datadog's docs for using terraformer, as well as an explanation of the flag's purpose.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
