### PR TITLE
added flexible tops to log monitor

### DIFF
--- a/content/en/monitors/types/log.md
+++ b/content/en/monitors/types/log.md
@@ -49,7 +49,7 @@ As you define the search query, the graph above the search fields updates.
 
    Datadog aggregates all logs matching the query into groups based on the values of tags, attributes, and up to four facets. When there are multiple dimensions, you can select the number of top or bottom values for each dimension.
 
-   The total limit, irrespective of the number of facets, is 1000 top values. If this is increased above 1000, the top values for the other dimensions are adjusted to ensure the number of the resulting combinations is less than 1000. The default top values for every group-by is 10, with the exception of the fourth which will default to 5 top values.
+   The total limit, irrespective of the number of facets, is 1000 top values. If you increase this above 1000, Datadog adjusts the top values for the other dimensions to ensure the number of the resulting combinations is less than 1000. The default top values for every group-by is 10, with the exception of the fourth, which defaults to 5 top values.
 
    As an example, a Log Monitor with four groupings on the search query could have:
    * **First facet**: 10 top values


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Over 2 years ago, Flexible Tops was introduced as a method of adjusting the number of dimensions available in a query.

The Log Monitor documentation still reflects the original limitations which have a set number of group limits depending on the number of dimensions in the query.

### Merge instructions

Will need some form of review.

Merge readiness:
- [ ❌ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
