### PR TITLE
Add Error Tracking toolset MCP server docs

### DIFF
--- a/content/en/bits_ai/mcp_server/setup/_index.md
+++ b/content/en/bits_ai/mcp_server/setup/_index.md
@@ -224,6 +224,7 @@ The Datadog MCP Server supports _toolsets_, which allow you to use only the tool
 - `core`: The default toolset
 - `synthetics`: Tools for interacting with Datadog [Synthetic tests][21]
 - `software-delivery`: Tools for interacting with Software Delivery ([CI Visibility][22] and [Test Optimization][25])
+- `error-tracking`: Tools for interacting with Datadog [Error Tracking][26]
 
 To use a toolset, include the `toolsets` query parameter in the endpoint URL when connecting to the MCP Server ([remote authentication](?tab=remote-authentication#connect-in-supported-ai-clients) only). For example:
 
@@ -451,6 +452,22 @@ Aggregates Datadog Test Optimization events to quantify reliability and performa
 - Show me the 95th-percentile duration for each test suite to identify the slowest ones.
 - Count all passing and failing tests, grouped by code owners.
 
+### `search_datadog_error_tracking_issues`
+*Toolset: **error-tracking***\
+Searches Error Tracking Issues across data sources (RUM, Logs, Traces).
+
+- Show me all Error Tracking Issues in the checkout service from the last 24 hours.
+- What are the most common errors in my application over the past week?
+- Find Error Tracking Issues in the production environment with `service:api`.
+
+### `get_datadog_error_tracking_issue`
+*Toolset: **error-tracking***\
+Retrieves detailed information about a specific Error Tracking Issue from Datadog.
+
+- Help me solve Error Tracking Issue `550e8400-e29b-41d4-a716-446655440000`.
+- What is the impact of Error Tracking Issue `a3c8f5d2-1b4e-4c9a-8f7d-2e6b9a1c3d5f`?
+- Create a test case to reproduce Error Tracking Issue `7b2d4f6e-9c1a-4e3b-8d5f-1a7c9e2b4d6f`.
+
 ## Context efficiency
 
 The Datadog MCP Server is optimized to provide responses in a way that AI agents get relevant context without being overloaded with unnecessary information. For example:
@@ -495,3 +512,4 @@ The Datadog MCP Server is under significant development. During the Preview, use
 [23]: https://kiro.dev/
 [24]: /account_management/org_settings/service_accounts/
 [25]: /tests/
+[26]: /error_tracking/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds documentation for the Error Tracking tools in the MCP server.

### Merge instructions

Do **not** merge. https://github.com/DataDog/dd-source/pull/339627 must go live first.
<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge