### PR TITLE
Remove PLCrashReporter references on iOS docs

### DIFF
--- a/content/en/error_tracking/frontend/mobile/ios.md
+++ b/content/en/error_tracking/frontend/mobile/ios.md
@@ -394,7 +394,6 @@ github "DataDog/dd-sdk-ios"
 In Xcode, link the following frameworks:
 ```
 DatadogCrashReporting.xcframework
-CrashReporter.xcframework
 ```
 
 [1]: https://github.com/Carthage/Carthage
@@ -446,7 +445,7 @@ To enable app hang monitoring:
 
    See [Configure the app hang threshold](#configure-app-hang-threshold) for more guidance on setting this value.
 
-   Make sure you follow the steps below to get [deobfuscated stack traces](#step-6---get-deobfuscated-stack-traces), which transform cryptic memory addresses into readable function names and line numbers for effective debugging. 
+   Make sure you follow the steps below to get [deobfuscated stack traces](#step-6---get-deobfuscated-stack-traces), which transform cryptic memory addresses into readable function names and line numbers for effective debugging.
 
 {{% /collapse-content %}}
 

--- a/content/en/real_user_monitoring/application_monitoring/ios/supported_versions.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/supported_versions.md
@@ -37,21 +37,21 @@ The RUM iOS SDK supports the following iOS versions:
 | macOS (Designed for iPad) | {{< X >}} | 11+ | |
 | macOS (Catalyst) | partially supported | 12+ | Catalyst is supported in build mode only, which means that macOS targets build, but functionalities for the SDK might not work for this target. |
 | macOS | | 12+ | macOS is not officially supported by the Datadog SDK. Some features may not be fully functional. **Note**:  `DatadogRUM`, `DatadogSessionReplay`, and `DatadogObjc`, which heavily depend on `UIKit`, do not build on macOS. |
-| visionOS | | 1.0+ | visionOS is not officially supported by the Datadog SDK. Some features may not be fully functional. **Note**: `DatadogCrashReporting` is not supported on visionOS due to a lack of support on the [PLCrashReporter][1] side. |
+| visionOS | | 1.0+ | visionOS is not officially supported by the Datadog SDK. Some features may not be fully functional. |
 | watchOS | | 7.0+ | watchOS is not officially supported by the Datadog SDK. Some features may not be fully functional. **Note**: only `DatadogLogs` and `DatadogTrace` can build on watchOS. |
 | Linux | | n/a | |
 
 ## Supported platforms
 
 ### Xcode
-The SDK is built using the most recent version of [Xcode][2], but is always backwards compatible with the [lowest supported Xcode version][3] for App Store submission.
+The SDK is built using the most recent version of [Xcode][1], but is always backwards compatible with the [lowest supported Xcode version][2] for App Store submission.
 
 ### Dependency managers
 We currently support integration of the SDK using the following dependency managers:
 
-- [Swift Package Manager][4]
-- [Cocoapods][5]
-- [Carthage][6]
+- [Swift Package Manager][3]
+- [Cocoapods][4]
+- [Carthage][5]
 
 ### Languages
 
@@ -72,30 +72,29 @@ We currently support integration of the SDK using the following dependency manag
 | Framework | Automatic | Manual |
 |--------|-------|-------|
 | URLSession | {{< X >}} | {{< X >}} |
-| [Alamofire][7] | {{< X >}} | {{< X >}} |
-| [Apollo GraphQL][8] | {{< X >}} | {{< X >}} |
-| [SDWebImage][9] | {{< X >}} | {{< X >}} |
-| [OpenAPI Generator][10] | {{< X >}} | {{< X >}} |
+| [Alamofire][6] | {{< X >}} | {{< X >}} |
+| [Apollo GraphQL][7] | {{< X >}} | {{< X >}} |
+| [SDWebImage][8] | {{< X >}} | {{< X >}} |
+| [OpenAPI Generator][9] | {{< X >}} | {{< X >}} |
 | SwiftNIO | | |
 
 ### Dependencies
 
 The Datadog RUM SDK depends on the following third-party library:
 
-- [PLCrashReporter][11] 1.12.0
+- [KSCrash][10] 2.5.0
 
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://github.com/microsoft/plcrashreporter/issues/288
-[2]: https://developer.apple.com/xcode/
-[3]: https://developer.apple.com/news/?id=fxu2qp7b
-[4]: /real_user_monitoring/application_monitoring/ios/setup/?tab=swiftpackagemanagerspm#declare-the-sdk-as-a-dependency
-[5]: /real_user_monitoring/application_monitoring/ios/setup/?tab=cocoapods#declare-the-sdk-as-a-dependency
-[6]: /real_user_monitoring/application_monitoring/ios/setup/?tab=carthage#declare-the-sdk-as-a-dependency
-[7]: /real_user_monitoring/application_monitoring/ios/integrated_libraries/#alamofire
-[8]: /real_user_monitoring/application_monitoring/ios/integrated_libraries/#apollo-graphql
-[9]: /real_user_monitoring/application_monitoring/ios/integrated_libraries#sdwebimage
-[10]: /real_user_monitoring/application_monitoring/ios/integrated_libraries#openapi-generator
-[11]: https://github.com/microsoft/plcrashreporter
+[1]: https://developer.apple.com/xcode/
+[2]: https://developer.apple.com/news/?id=fxu2qp7b
+[3]: /real_user_monitoring/application_monitoring/ios/setup/?tab=swiftpackagemanagerspm#declare-the-sdk-as-a-dependency
+[4]: /real_user_monitoring/application_monitoring/ios/setup/?tab=cocoapods#declare-the-sdk-as-a-dependency
+[5]: /real_user_monitoring/application_monitoring/ios/setup/?tab=carthage#declare-the-sdk-as-a-dependency
+[6]: /real_user_monitoring/application_monitoring/ios/integrated_libraries/#alamofire
+[7]: /real_user_monitoring/application_monitoring/ios/integrated_libraries/#apollo-graphql
+[8]: /real_user_monitoring/application_monitoring/ios/integrated_libraries#sdwebimage
+[9]: /real_user_monitoring/application_monitoring/ios/integrated_libraries#openapi-generator
+[10]: https://github.com/kstenerud/KSCrash

--- a/content/en/real_user_monitoring/error_tracking/mobile/ios.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/ios.md
@@ -54,7 +54,7 @@ pod 'DatadogCrashReporting'
 
 To integrate using Apple's Swift Package Manager, add the following as a dependency to your `Package.swift`:
 ```swift
-.package(url: "https://github.com/Datadog/dd-sdk-ios.git", .upToNextMajor(from: "2.0.0"))
+.package(url: "https://github.com/Datadog/dd-sdk-ios.git", .upToNextMajor(from: "3.0.0"))
 ```
 
 In your project, link the following libraries:
@@ -73,7 +73,6 @@ github "DataDog/dd-sdk-ios"
 In Xcode, link the following frameworks:
 ```
 DatadogCrashReporting.xcframework
-CrashReporter.xcframework
 ```
 
 [1]: https://github.com/Carthage/Carthage

--- a/content/en/real_user_monitoring/guide/mobile-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/mobile-sdk-upgrade.md
@@ -121,7 +121,7 @@ In Xcode, you **must** link the following frameworks:
 
 Then, you can select the modules you want to use:
   ```
-  DatadogCrashReporting.xcframework + CrashReporter.xcframework
+  DatadogCrashReporting.xcframework
   DatadogLogs.xcframework
   DatadogRUM.xcframework
   DatadogSessionReplay.xcframework


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates iOS SDK documentation to reflect the migration from `PLCrashReporter` to `KSCrash` in iOS SDK version [3.5.0](https://github.com/DataDog/dd-sdk-ios/releases/tag/3.5.0).

### Merge instructions

N/A

Merge readiness:
- [x] Ready for merge