### PR TITLE
Update Lambda telemetry logging text

### DIFF
--- a/content/en/serverless/aws_lambda/_index.md
+++ b/content/en/serverless/aws_lambda/_index.md
@@ -49,7 +49,7 @@ To get started, follow the [installation instructions][1] to collect metrics, tr
 
 Datadog Serverless Monitoring makes use of a runtime-specific Datadog Lambda Library, in conjunction with the Datadog Lambda extension, to send telemetry from your Lambda functions.
 
-The Datadog Lambda extension collects logs through CloudWatch, in addition to traces, enhanced metrics, and custom metrics from the Datadog Lambda Library.
+The Datadog Lambda Extension collects function logs using the Lambda Telemetry API, eliminating the need for CloudWatch. It also generates enhanced metrics. It unifies these telemetry signals with APM traces, custom spans, and custom metrics from the Datadog Lambda Library.
 
 ## Usage
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5a4db142-6b52-42a9-a0dc-a52877fd2715","source":"chat","resourceId":"dc62c698-3c1e-4f57-bb56-8cb3de60dbab","workflowId":"45e06bf6-7e99-43ea-96d1-3a0a244dfb31","codeChangeId":"45e06bf6-7e99-43ea-96d1-3a0a244dfb31","sourceType":"chat"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/dc62c698-3c1e-4f57-bb56-8cb3de60dbab)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do? What is the motivation?
- Clarifies Lambda Extension logging, enhanced metrics, and unified telemetry messaging using the Lambda Telemetry API instead of CloudWatch.

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
- None.