### PR TITLE
AGENT - correct uninstall page for macOS

### DIFF
--- a/content/en/agent/supported_platforms/osx.md
+++ b/content/en/agent/supported_platforms/osx.md
@@ -93,7 +93,7 @@ To remove the Agent and all Agent configuration files:
     ```
 4. Reboot your machine for the changes to take effect.
 
-## Uninstall the Agent
+### System-wide LaunchDaemon installation
 
 To remove the Agent and all Agent configuration files:
 1. Drag the Datadog application from the application folder to the trash bin.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR corrects an error in the uninstall page for macOS made [here](https://github.com/DataDog/documentation/commit/5a16834ace09bdfd71bb1c42edc90a31096bd4c3#diff-071ad7d246df3195ac9bc36899fc2a7fe744b6264f20da161edcbbbf6a46b4faL85-L86) on line 86

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready for merge
