### PR TITLE
Upgrade Cdocs to improve filters menu responsiveness on initial page load

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@popperjs/core": "^2.11.8",
         "alpinejs": "^3.13.7",
         "bootstrap": "^5.2",
-        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.5.0.tgz",
+        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.5.1.tgz",
         "del": "4.1.1",
         "fancy-log": "^1.3.3",
         "geo-locate": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.2.tgz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6566,9 +6566,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.5.0.tgz":
-  version: 2.5.0
-  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.5.0.tgz"
+"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.5.1.tgz":
+  version: 2.5.1
+  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.5.1.tgz"
   dependencies:
     "@prettier/sync": "npm:^0.5.2"
     "@types/markdown-it": "npm:^14.1.2"
@@ -6593,7 +6593,7 @@ __metadata:
     vite: "npm:^5.4.10"
     vite-plugin-singlefile: "npm:^2.0.2"
     zod: "npm:^4.1.12"
-  checksum: 10/0b4034a4a7ec48ece4090b51a9882fd114b0970ea554e23d3fdfe40238d6329660eaf0738f97e1b2977d03ab8cee5957cd86ef343146f8f7b5a3708f92ccf960
+  checksum: 10/ab46f4e94e4aefa7e55ce942f4a1db9c553b924f7774f15634a07c6dee060241fe7d8b033e418e384633a75687f5b8c578cbb13398750b268eac93ca22f0bf91
   languageName: node
   linkType: hard
 
@@ -7640,7 +7640,7 @@ __metadata:
     acorn: "npm:^7.4.1"
     alpinejs: "npm:^3.13.7"
     bootstrap: "npm:^5.2"
-    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.5.0.tgz"
+    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.5.1.tgz"
     cross-env: "npm:^5.2.1"
     del: "npm:4.1.1"
     eslint: "npm:^6.8.0"


### PR DESCRIPTION
This PR bumps the Cdocs version to include a filters menu responsiveness fix. We tested the fix in [this PR](https://github.com/DataDog/corp-node-packages/pull/192), which includes a video comparing the fixed version to the original.

I've also verified that Cdocs pages in this PR's staging build ([example](https://docs-staging.datadoghq.com/jen.gilbert/cdocs-menu-fix/real_user_monitoring/guide/proxy-rum-data/?lib_src=npm&rum_browser_sdk_version=gte_5_4_0#overview)) are working as expected.