### PR TITLE
Remove preview tag from Network Path Dynamic Tests

### DIFF
--- a/content/en/network_monitoring/cloud_network_monitoring/_index.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/_index.md
@@ -54,7 +54,7 @@ Datadog Cloud Network Monitoring (CNM) gives you visibility into your network tr
     {{< nextlink href="network_monitoring/cloud_network_monitoring/network_health" >}}<u>Network Health</u>: Review the health of your network environment.{{< /nextlink >}}
     {{< nextlink href="network_monitoring/cloud_network_monitoring/network_analytics" >}}<u>Network Analytics</u>: Graph your network data between each client and server available.{{< /nextlink >}}
     {{< nextlink href="network_monitoring/network_path/setup/#scheduled-tests" >}}<u>Network Path Scheduled Tests</u>: Visualize the route that network traffic follows from its origin to its destination using scheduled tests.{{< /nextlink >}}
-    {{< nextlink href="network_monitoring/network_path/setup/#dynamic-tests-preview" >}}<u>Network Path Dynamic Tests</u>: Dynamically create tests to allow the Agent to automatically discover and monitor network paths.{{< /nextlink >}}
+    {{< nextlink href="network_monitoring/network_path/setup/#dynamic-tests" >}}<u>Network Path Dynamic Tests</u>: Dynamically create tests to allow the Agent to automatically discover and monitor network paths.{{< /nextlink >}}
     {{< nextlink href="network_monitoring/cloud_network_monitoring/network_map" >}}<u>Network Map</u>: Map your network data between your tags.{{< /nextlink >}}
     {{< nextlink href="monitors/types/cloud_network_monitoring/#common-monitors" >}}<u>Common Monitors</u>: Configure Common CNM monitors.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/network_monitoring/network_path/setup.md
+++ b/content/en/network_monitoring/network_path/setup.md
@@ -242,7 +242,7 @@ To increase the number of workers, add the following configuration to your `data
 check_runners: <NUMBER_OF_WORKERS>
 ```
 
-### Dynamic tests (Preview)
+### Dynamic tests
 
 **Prerequisites**: [CNM][1] must be enabled.
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"dce96619-fb17-49ed-a2cf-6e0e25c7516e","source":"chat","resourceId":"dab969b3-835d-4525-a556-d9a165b35da0","workflowId":"956598f3-f011-413d-a202-c069930a81ae","codeChangeId":"956598f3-f011-413d-a202-c069930a81ae","sourceType":"chat"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/dab969b3-835d-4525-a556-d9a165b35da0)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do? What is the motivation?

Removes the "(Preview)" tag from the Network Path Dynamic Tests section as the feature is now generally available to customers.

**Changes:**
- Removed "(Preview)" from the section heading in `content/en/network_monitoring/network_path/setup.md`
- Updated the anchor link in `content/en/network_monitoring/cloud_network_monitoring/_index.md` from `#dynamic-tests-preview` to `#dynamic-tests`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

N/A