### PR TITLE
Add Network Path callout to CNM docs

### DIFF
--- a/content/en/network_monitoring/cloud_network_monitoring/_index.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/_index.md
@@ -49,6 +49,8 @@ Datadog Cloud Network Monitoring (CNM) gives you visibility into your network tr
 * Identify outages of cloud provider regions and third-party tools
 * Troubleshoot client-side and server-side DNS server issues
 
+<div class="alert alert-info"><a href="/network_monitoring/network_path/">Network Path</a> can use CNM data to automatically discover and monitor network paths based on actual traffic. See <a href="/network_monitoring/network_path/setup/#dynamic-tests-preview">Dynamic tests</a> to get started.</div>
+
 {{< whatsnext desc="This section includes the following topics:">}}
     {{< nextlink href="network_monitoring/cloud_network_monitoring/setup" >}}<u>Setup</u>: Configure the Agent to collect network data.{{< /nextlink >}}
     {{< nextlink href="network_monitoring/cloud_network_monitoring/network_health" >}}<u>Network Health</u>: Review the health of your network environment.{{< /nextlink >}}


### PR DESCRIPTION
<!-- dd-meta {"pullId":"afd09d73-b158-458f-bd7a-5f8d752b8e28","source":"chat","resourceId":"413589df-1e7c-4d8d-8bb9-bbfa8c9a717e","workflowId":"6b73cc3e-0879-4831-8933-17f49317a96c","codeChangeId":"6b73cc3e-0879-4831-8933-17f49317a96c","sourceType":"chat"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/413589df-1e7c-4d8d-8bb9-bbfa8c9a717e)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do? What is the motivation?

Adds a callout to the Cloud Network Monitoring (CNM) docs to highlight the Network Path integration. Network Path's Dynamic tests feature uses CNM to gather connections and automatically run Network Path tests to those hosts.

The callout is placed after the CNM overview bullet points and links to:
- The main Network Path documentation
- The Dynamic tests setup section

This improves feature discoverability for users who have CNM enabled and may benefit from Network Path's automated discovery capabilities.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The CNM index already had Network Path links in the `whatsnext` section, but this callout makes the feature more prominent and explains the relationship between CNM and Network Path Dynamic tests.