### PR TITLE
feat: add isDefined() function to check variable existence

### DIFF
--- a/assets/scripts/components/expression-language-parser.js
+++ b/assets/scripts/components/expression-language-parser.js
@@ -11,6 +11,17 @@ class ExpressionLanguageParser {
 
     // Built-in functions
     this.builtinFunctions = {
+      // Variable operations
+      isDefined: (varNameNode) => {
+        // isDefined receives the AST node directly, not the evaluated value
+        // This allows us to check if a variable exists without throwing an error
+        if (varNameNode && varNameNode.type === 'VARIABLE') {
+          return this.environment.hasOwnProperty(varNameNode.name);
+        }
+        // If it's not a variable node, it must be a value that exists
+        return true;
+      },
+
       // String functions
       len: (value) => {
         if (typeof value === 'string') return value.length;
@@ -290,6 +301,7 @@ class ExpressionLanguageParser {
    */
   _getFunctionDescription(funcName) {
     const descriptions = {
+      'isDefined': 'Checks whether a variable is defined',
       'len': 'Returns the length of a string, array, or object',
       'count': 'Returns the length of a string, array, or object',
       'isEmpty': 'Checks if a string, array, or object is empty',
@@ -1044,6 +1056,15 @@ class ExpressionLanguageParser {
 
       case 'CALL':
         const callee = this._evaluateAst(ast.callee);
+
+        // Special handling for isDefined - pass the AST node directly
+        if (ast.callee.type === 'VARIABLE' && ast.callee.name === 'isDefined') {
+          if (ast.args.length !== 1) {
+            throw new Error('isDefined() requires exactly one argument');
+          }
+          return callee(ast.args[0]);
+        }
+
         const args = ast.args.map(arg => {
           if (arg.type === 'PREDICATE') {
             return arg;

--- a/assets/scripts/tests/expression-language-parser.test.js
+++ b/assets/scripts/tests/expression-language-parser.test.js
@@ -818,6 +818,45 @@ describe('ExpressionLanguageParser', () => {
     });
   });
 
+  describe('isDefined function', () => {
+    test('should return true for defined variables', () => {
+      const parser = new ExpressionLanguageParser();
+      parser.evaluate('x = 5');
+
+      const result = parser.evaluate('isDefined(x)');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('True');
+    });
+
+    test('should return false for undefined variables', () => {
+      const parser = new ExpressionLanguageParser();
+
+      const result = parser.evaluate('isDefined(undefinedVar)');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('False');
+    });
+
+    test('should return true for built-in variables', () => {
+      const parser = new ExpressionLanguageParser();
+
+      const result = parser.evaluate('isDefined(myString)');
+      expect(result.success).toBe(true);
+      expect(result.result).toBe('True');
+    });
+
+    test('should work in conditional expressions', () => {
+      const parser = new ExpressionLanguageParser();
+
+      const result1 = parser.evaluate('isDefined(myString) && len(myString) > 0');
+      expect(result1.success).toBe(true);
+      expect(result1.result).toBe('True');
+
+      const result2 = parser.evaluate('isDefined(notDefined) || mySequence[0] == 1');
+      expect(result2.success).toBe(true);
+      expect(result2.result).toBe('True');
+    });
+  });
+
   describe('Simulator Mode', () => {
     let parser;
 

--- a/content/en/tracing/trace_collection/dynamic_instrumentation/expression-language.md
+++ b/content/en/tracing/trace_collection/dynamic_instrumentation/expression-language.md
@@ -38,9 +38,9 @@ For example, you can create a histogram from the length of a string using `len(d
 
 Logs can be emitted using templates. In log templates and tag values, expressions are delimited from the static parts of the template with brackets, for example: `User name is {user.name}`. Log template expressions can evaluate to any value.
 
-Probe conditions must evaluate to a Boolean, for example: 
+Probe conditions must evaluate to a Boolean, for example:
  - `startsWith(user.name, "abc")`
- - `len(str) > 20` 
+ - `len(str) > 20`
  - `a == b`
 
 ## Contextual variables
@@ -56,18 +56,19 @@ The Expression Language provides contextual variables for different instrumentat
 | `@key`      | Provides access to the current key during dictionary iteration. Used in predicates for dictionary operations. |
 | `@value`    | Provides access to the current value during dictionary iteration. Used in predicates for dictionary operations. |
 
-## String operations
+## General operations
 
 The following examples assume a variable named `myString` with value `Hello, world!`:
 
 | Operation | Description | Example |
 |-----------|-------------|---------|
+| `isDefined(var)` | Checks whether a variable is defined. Returns `true` if the variable exists in the current scope, `false` otherwise. Useful for conditional logic when a variable may not be present. | {{< expression-language-evaluator expression="isDefined(myString)" >}} |
 | `len(value_src)` | Gets the string length. | {{< expression-language-evaluator expression="len(myString)" >}} |
 | `isEmpty(value_src)` | Checks whether the string is empty. Equivalent to `len(value_src) == 0`. | {{< expression-language-evaluator expression="isEmpty(myString)" >}} |
 | `substring(value_src, startIndex, endIndex)` | Gets a substring. | {{< expression-language-evaluator expression="substring(myString, 0, 2)" >}} |
 | `startsWith(value_src, string_literal)` | Checks whether a string starts with the given string literal. | {{< expression-language-evaluator expression="startsWith(myString, \"He\")" >}} |
 | `endsWith(value_src, string_literal)` | Checks whether the string ends with the given string literal. | {{< expression-language-evaluator expression="endsWith(myString, \"rdl!\")" >}} |
-| `contains(value_src, string_literal)` | Checks whether the string contains the string literal. | {{< expression-language-evaluator expression="contains(myString, \"ll\")" >}} |
+| `contains(value_src, string_literal)` | Checks whether the string contains the string literal, or whether a collection contains an element. | {{< expression-language-evaluator expression="contains(myString, \"ll\")" >}} |
 | `matches(value_src, string_literal)` | Checks whether the string matches the regular expression provided as a string literal. | {{< expression-language-evaluator expression="matches(myString, \"^H.*!$\")" >}} |
 
 ## Collection operations


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR adds some additional docs to the expression language page to cover `isDefined` and updates the `contains(...)` to mention that it can handle collections to check for keys:

- Implement isDefined(var) in expression language parser
- Add tests for defined/undefined variables and conditional expressions
- Reorganize docs: rename "String operations" to "General operations"
- Update contains() description to include collection support

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
