### PR TITLE
Add Network Path to CNM Further Reading

### DIFF
--- a/content/en/network_monitoring/cloud_network_monitoring/network_analytics.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/network_analytics.md
@@ -19,6 +19,9 @@ further_reading:
     - link: '/network_monitoring/cloud_network_monitoring/guide/detecting_application_availability/'
       tag: 'Guide'
       text: 'Detecting Application Availability using Network Insights'
+    - link: '/network_monitoring/network_path'
+      tag: 'Documentation'
+      text: 'Network Path'
 ---
 
 ## Overview

--- a/content/en/network_monitoring/cloud_network_monitoring/network_map.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/network_map.md
@@ -17,6 +17,9 @@ further_reading:
     - link: '/network_monitoring/cloud_network_monitoring/setup'
       tag: 'Documentation'
       text: 'Collect your Network Data with the Datadog Agent.'
+    - link: '/network_monitoring/network_path'
+      tag: 'Documentation'
+      text: 'Network Path'
 ---
 
 ## Overview


### PR DESCRIPTION
<!-- dd-meta {"pullId":"fcea51b5-e2db-41ac-9715-0a1afc01f6c1","source":"chat","resourceId":"98895723-1d54-41fd-a536-b3ebe4569f1d","workflowId":"97b07715-67b7-430d-baa1-f2284fd106c8","codeChangeId":"97b07715-67b7-430d-baa1-f2284fd106c8","sourceType":"chat"} -->
PR by Bits
[View Dev Agent Session](https://app.datadoghq.com/code/98895723-1d54-41fd-a536-b3ebe4569f1d)

You can ask for changes by mentioning @datadog in a comment.

Feedback (especially what can be better) welcome in [#code-gen-feedback](https://dd.enterprise.slack.com/archives/C07JA5N2D25)!

---

### What does this PR do? What is the motivation?

Adds callouts to the Network Path product in the Cloud Network Monitoring documentation:
- Network Analytics page: Added Network Path to the Further Reading section
- Network Map page: Added Network Path to the Further Reading section

This increases visibility of the Network Path feature for users exploring CNM documentation.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Simple documentation update adding cross-references between related Network Monitoring features.