### PR TITLE
fix(ld): add multi-code-lang tag to PHP

### DIFF
--- a/content/en/tracing/trace_collection/dynamic_instrumentation/enabling/php.md
+++ b/content/en/tracing/trace_collection/dynamic_instrumentation/enabling/php.md
@@ -4,7 +4,9 @@ description: Set up Dynamic Instrumentation for PHP applications to add probes a
 aliases:
     - /dynamic_instrumentation/enabling/php/
     - /tracing/dynamic_instrumentation/enabling/php
-private: true
+private: false
+code_lang: php
+type: multi-code-lang
 further_reading:
     - link: 'agent'
       tag: 'Documentation'


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Add missing `multi-code-lang` tag to PHP for Dynamic Instrumentation setup instructions

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
