### PR TITLE
[NETUI-3591] Remove Sentence about Default "Past 2 Days"

### DIFF
--- a/content/en/network_monitoring/devices/config_management.md
+++ b/content/en/network_monitoring/devices/config_management.md
@@ -104,7 +104,7 @@ Network Configuration Management is accessible from the device side panel in Net
 
 ### Time picker and retention
 
-The time controls at the top of the page allow you to select which configuration history to view. By default, the view shows the last 2 days of configuration changes. You can extend this range to view older versions, up to the retention limit (1 year).
+The time controls at the top of the page allow you to select which configuration history to view. You can extend this range to view older versions, up to the retention limit (1 year).
 
 The timeline and configuration version list automatically update based on your selected time range.
 


### PR DESCRIPTION
### Motivation

https://datadoghq.atlassian.net/browse/NETUI-3591

### What does this PR do? 

Removed "Past 2 Days" sentence in the Configuration Management doc. Since customers navigate from the Metrics tab (which has a "Past 2 Hours"), it would be an odd flow to switch to default timeframe for one tab. 

While we'll look into better ways to look past weekends. It doesn't make sense to single out the Config tab. 

Here's the [Time picker and retention](https://docs-staging.datadoghq.com/dan.chiniara/remove-2-days-from-ncm-doc/network_monitoring/devices/config_management/#time-picker-and-retention).

<img width="756" height="230" alt="2026-01-22_11-22-36" src="https://github.com/user-attachments/assets/eff5b6b2-f082-4d3b-aa89-59de5ae8c462" />

Here's the current behavior: 

https://github.com/user-attachments/assets/273976d9-9d20-41aa-b051-06f54fa4eb78

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
