### PR TITLE
Fix iOS Objective-C code snippet for DDTrace initialization

### DIFF
--- a/content/en/tracing/trace_collection/dd_libraries/ios.md
+++ b/content/en/tracing/trace_collection/dd_libraries/ios.md
@@ -345,7 +345,7 @@ let tracer = Tracer.shared()
 DDTraceConfiguration *configuration = [[DDTraceConfiguration alloc] init];
 configuration.networkInfoEnabled = YES;
 
-[DDTrace enableWithConfiguration:configuration];
+[DDTrace enableWith:configuration];
 
 DDTracer *tracer = [Tracer shared];
 ```
@@ -519,7 +519,7 @@ DDTraceURLSessionTracking *urlSessionTracking = [DDTraceURLSessionTracking alloc
 DDTraceConfiguration *configuration = [[DDTraceConfiguration] alloc] init];
 [configuration setURLSessionTracking:urlSessionTracking];
 
-[DDTrace enableWithConfiguration:configuration];
+[DDTrace enableWith:configuration];
 
 NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConfiguration defaultSessionConfiguration]
                                                         delegate:[[DDNSURLSessionDelegate alloc] init]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fix incorrect Objective-C method name in iOS tracing documentation. Customer feedback reported that `[DDTrace enableWithConfiguration:configuration]` should be `[DDTrace enableWith:configuration]`.

Fixes DOCS-12869

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Two occurrences were fixed in the iOS tracing docs (step 3 and step 8 code examples).