### PR TITLE
Add US1-FED note for automated debug log collection

### DIFF
--- a/content/en/tracing/troubleshooting/tracer_debug_logs.md
+++ b/content/en/tracing/troubleshooting/tracer_debug_logs.md
@@ -10,6 +10,10 @@ further_reading:
 ## Automated debug log collection
 <div class="alert alert-danger">Automated debug logs are supported for Java, Python, Node.js, and .NET only. For other languages, use <a href="/tracing/troubleshooting/tracer_debug_logs/#enable-debug-mode">manual debug log collection</a> instead.</div>
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Automated debug log collection is not supported on US1-FED because <a href="/agent/remote_config/">Remote Configuration</a> is not available in this region. Use <a href="/tracing/troubleshooting/tracer_debug_logs/#enable-debug-mode">manual debug log collection</a> instead.</div>
+{{< /site-region >}}
+
 A flare allows you to send necessary troubleshooting information to the Datadog support team, including tracer logs, with sensitive data removed. Flares are useful for troubleshooting issues like high CPU usage, high memory usage, and missing spans.
 
 ### Prerequisites


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Add a warning banner for US1-FED (GovCloud) users that automated debug log collection is not supported because Remote Configuration is unavailable in that region. Directs users to manual debug log collection instead.

Fixes DOCS-12759

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Uses `{{< site-region region="gov" >}}` shortcode so the warning only appears for gov region users.