### PR TITLE
Add DD_TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING to Java config

### DIFF
--- a/content/en/tracing/trace_collection/library_config/java.md
+++ b/content/en/tracing/trace_collection/library_config/java.md
@@ -249,6 +249,11 @@ Request path | Resource path
 `/admin/user/12345/delete` | `/admin/user`
 `/user/12345` | `/user/?`
 
+`dd.trace.http.client.path-resource-name-mapping`<br>
+: **Environment Variable**: `DD_TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING`<br>
+**Default**: `{}` (empty) <br>
+Maps HTTP client request paths to custom resource names. Uses the same format as `dd.trace.http.server.path-resource-name-mapping`, but applies to HTTP client spans instead of server spans.
+
 `dd.trace.status404rule.enabled`
 : **Environment Variable**: `DD_TRACE_STATUS404RULE_ENABLED`<br>
 **Default**: `true`<br>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Add documentation for `DD_TRACE_HTTP_CLIENT_PATH_RESOURCE_NAME_MAPPING` config option to the Java tracing library configuration page. This option allows mapping HTTP client request paths to custom resource names, complementing the existing server-side option.

Fixes DOCS-12456

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The config uses the same format as the existing `dd.trace.http.server.path-resource-name-mapping` option.