### PR TITLE
[DOCS-12606] Add explicit nav steps to access APM metrics

### DIFF
--- a/content/en/tracing/trace_pipeline/generate_metrics.md
+++ b/content/en/tracing/trace_pipeline/generate_metrics.md
@@ -55,14 +55,7 @@ Use custom metrics from traces for:
 
 {{< img src="tracing/span_to_metrics/createspantometrics.png" style="width:100%;" alt="How to create a metric" >}}
 
-To access the Generate Metrics page in Datadog:
-1. In the Datadog app, hover over **APM** in the left navigation menu.
-1. Under the **Ingestion and Sampling** section, click **Generate Metrics**.
-
-Alternatively, navigate directly to [**APM** > **Generate Metrics**][14].
-
-To create a new metric:
-
+1. In Datadog, go to [**APM > Generate Metrics**][14].
 1. Click **New Metric**.
 1. Name your metric following the [metric naming convention][11]. Metric names starting with `trace.*` are not allowed.
 1. Select the metric type: **Spans** or **Traces**. Both use the same [query syntax][10] as APM Search and Analytics.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-12606

User feedback indicated the Generate Metrics page was unclear about how to navigate to the UI. This adds explicit step-by-step instructions showing users how to find the page via the APM menu.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes