### PR TITLE
[DOCS-9125] Add OpenSearch to Node.js Compatibility Docs

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -139,6 +139,7 @@ Or, modify the `package.json` file if you typically start an application with np
 | [mysql][35]            | `>=2`    | Fully supported |                                                  |
 | [mysql2][36]           | `>=1`    | Fully supported |                                                  |
 | [oracledb][37]         | `>=5`    | Fully supported |                                                  |
+| [opensearch][69]       | `>=1`    | Fully supported |                                                  |
 | [pg][38]               | `>=4`    | Fully supported | Supports `pg-native` when used with `pg`         |
 | [redis][39]            | `>=0.12` | Fully supported |                                                  |
 | [sharedb][40]          | `>=1`    | Fully supported |                                                  |
@@ -262,3 +263,4 @@ For additional information or to discuss [leave a comment on this github issue][
 [66]: https://js.langchain.com/
 [67]: https://www.npmjs.com/package/@confluentinc/kafka-javascript
 [68]: https://www.npmjs.com/package/@azure/service-bus
+[69]: https://github.com/opensearch-project/opensearch-js


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-9125

Adds OpenSearch (`@opensearch-project/opensearch`) to the Node.js Data Store Compatibility table. The dd-trace-js library supports this integration as documented at https://datadoghq.dev/dd-trace-js/interfaces/export_.plugins.opensearch.html

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes