### PR TITLE
Add site support banner for event triage inbox

### DIFF
--- a/content/en/events/triage_inbox.md
+++ b/content/en/events/triage_inbox.md
@@ -1,5 +1,6 @@
 ---
 title: Event Management Triage Inbox
+site_support_id: case_management
 aliases:
 - /service_management/events/triage_inbox/
 further_reading:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Gov support for triage inbox is dependent on case management
- Add site support banner

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
