### PR TITLE
Update compatibility.md to warn on Java native access flag usage

### DIFF
--- a/content/en/tracing/trace_collection/single-step-apm/compatibility.md
+++ b/content/en/tracing/trace_collection/single-step-apm/compatibility.md
@@ -130,7 +130,7 @@ If either requirement is not met, SSI falls back gracefully and your application
 
 For a complete list of supported Java versions, see the [Java SDK compatibility documentation][1].
 
-<div class="alert alert-info">SSI uses the <code>--enable-native-access=ALL-UNNAMED</code> flag on Java 24+ to enable native access for all code on the class path. This is necessary for products such as Profiling that require native access. See <a href="https://openjdk.org/jeps/472">JEP 472</a> for more information.</div>
+<div class="alert alert-info">SSI uses the <code>--enable-native-access=ALL-UNNAMED</code> flag on Java 24+ to enable native access for all code on the class path. This is necessary for products such as Profiling, which requires native access. See <a href="https://openjdk.org/jeps/472">JEP 472</a> for more information.</div>
 
 ### Limitations
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

SSI uses the `--enable-native-access=ALL-UNNAMED` flag to explicitly allow native access for Java 24+. This directly relates to [JEP 472](https://openjdk.org/jeps/472). Given the override of default settings, this PR updates the `Known issues` section to document this flag usage.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
