### PR TITLE
[DOCS-13183] Update buffer metrics for 2.13

### DIFF
--- a/layouts/shortcodes/observability_pipelines/metrics/buffer.en.md
+++ b/layouts/shortcodes/observability_pipelines/metrics/buffer.en.md
@@ -27,6 +27,9 @@ Track buffer behavior with these additional metrics:
 `pipelines.source_buffer_utilization_level`
 : Current event count in a source's buffer. Sources ingest events, then write them to this buffer.
 
+`pipelines.source_buffer_utilization_mean`
+: The exponentially weighted moving average (EWMA) of the number of events in the source's buffer.
+
 `pipelines.source_buffer_max_size_events`
 : A source's maximum buffer size, defined as the number of events.
 
@@ -35,6 +38,9 @@ Track buffer behavior with these additional metrics:
 
 `pipelines.transform_buffer_utilization_level`
 : Current event count in a processor's buffer. Processors pull from this buffer, transform the event, and then send it downstream.
+
+`pipelines.transform_buffer_utilization_mean`
+: The exponentially weighted moving average (EWMA) of the number of events in the processor's buffer.
 
 `pipelines.transform_buffer_max_size_events`
 : A processor's maximum buffer size, defined as the number of events.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Update buffer metrics.
Preview: https://docs-staging.datadoghq.com/may/2.13-buffer-metrics/observability_pipelines/monitoring_and_troubleshooting/pipeline_usage_metrics/#buffer-metrics-when-buffering-is-enabled

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
