### PR TITLE
[SEC-27555] Update documentation of workflows for security findings

### DIFF
--- a/content/en/actions/workflows/trigger.md
+++ b/content/en/actions/workflows/trigger.md
@@ -115,9 +115,9 @@ Add the workflow to your incident notification rule:
 
 ## Security triggers
 
-You can trigger a workflow automatically for any Security Signal or Security Finding.
-You can also trigger a workflow manually from a Cloud SIEM Security Signal panel, Misconfiguration panel, or Identity Risk panel.
-Before you can add a workflow to a Security Signal or Finding, the workflow must have a security trigger.
+You can trigger a workflow automatically for any Security Signal or Security Finding. You can also trigger a workflow manually from a Cloud SIEM Security Signal panel, Misconfiguration panel, or Identity Risk panel.
+
+**Note**: Before adding a workflow to a Security Signal or Finding, the workflow must have a security trigger.
 
 ### Security Notification Rule triggers
 
@@ -145,7 +145,7 @@ Each time the notification rule fires, it triggers a workflow run.
 
 ### Manual triggers
 
-You can manually start a workflow from a Cloud SIEM Security Signal panel, a Misconfiguration panel, or an Identity Risk panel.
+You can manually start a workflow from a Cloud SIEM Security Signal panel, a Misconfiguration panel, or an Identity Risk panel:
 
 1. Click **Run Workflow** in the **Next Steps** box at the top of the side panel.
 1. In the search modal, enter the name of the workflow you want to run and select it. Only workflows with security triggers appear in the list.

--- a/content/en/security/cloud_security_management/review_remediate/workflows.md
+++ b/content/en/security/cloud_security_management/review_remediate/workflows.md
@@ -51,7 +51,7 @@ This example creates a remediation workflow that sends an interactive Slack mess
 
    **Note**: A workflow must include a security trigger before you can run it. 
 
-   The trigger’s [source object variables][7] allow you to access security misconfiguration data, such as the title `{{ Source.securityFinding.attributes.title }}`.
+   The trigger’s [source object variables][7] allow you to access security misconfiguration data, such as the title (`{{ Source.securityFinding.attributes.title }}`).
 1. Enter a name for the workflow and click **Save**.
 
 #### Add JS function


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Update documentation of security trigger to include Security _Findings_ (in addition to _Signals_). Also include that workflows can be manually triggered from Misconfiguration & Identity Risk side panels.
- Update the "Build a workflow" examples to use the right field paths, and remove the unnecessary step of using the _Get security finding_ action when using the _Security_ trigger.
  - Note: these new paths were introduced with this [PR](https://github.com/DataDog/dd-source/pull/335308)

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


