### PR TITLE
Update RUM Browser SDK Advance Configuration for Public User

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.md
@@ -725,6 +725,8 @@ The below attributes are optional but Datadog strongly recommends providing at l
 {{% /tab %}}
 {{< /tabs >}}
 
+**Note**: 'Public User' is displayed in the RUM UI when `usr.name` is not set, even if `usr.email` and `usr.id` are defined.
+
 Increase your filtering capabilities by adding extra attributes on top of the recommended ones. For instance, add information about the user plan, or which user group they belong to.
 
 When making changes to the user session object, all RUM events collected after the change contain the updated information.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
This PR updates the RUM Browser SDK Advanced Configuration documentation to clarify how users are displayed when usr.name is not provided. It adds a note explaining that the user is shown as “Public User” even if usr.email and usr.id are set, helping prevent confusion when instrumenting user session attributes.

This was noticed by one of our customers

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
