### PR TITLE
document new fields on experiment Metric object

### DIFF
--- a/content/en/llm_observability/experiments/api.md
+++ b/content/en/llm_observability/experiments/api.md
@@ -529,16 +529,19 @@ Push events (spans and metrics) for an experiment.
 
 #### Object: Metric
 
-| Field | Type | Description |
-| ---- | ---- | ---- |
-| `span_id` | string | Associated span ID. |
-| `metric_type` | string | Metric type. One of: `score`, `categorical`. |
-| `timestamp_ms` | number | UNIX timestamp in milliseconds. |
-| `label` | string | Metric label (evaluator name). |
-| `score_value` | number | Score value (when `metric_type` is `score`). |
-| `categorical_value` | string | Categorical value (when `metric_type` is `categorical`). |
-| `metadata` | json | Arbitrary key-value metadata associated with the metric. |
-| `error.message` | string | Optional error message for the metric. |
+| Field               | Type     | Description                                              |
+|---------------------|----------|----------------------------------------------------------|
+| `span_id`           | string   | Associated span ID.                                      |
+| `metric_type`       | string   | Metric type. One of: `score`, `categorical`.             |
+| `timestamp_ms`      | number   | UNIX timestamp in milliseconds.                          |
+| `label`             | string   | Metric label (evaluator name).                           |
+| `score_value`       | number   | Score value (when `metric_type` is `score`).             |
+| `categorical_value` | string   | Categorical value (when `metric_type` is `categorical`). |
+| `metadata`          | json     | Arbitrary key-value metadata associated with the metric. |
+| `error.message`     | string   | Optional error message for the metric.                   |
+| `reasoning`         | string   | Optional explanation for the metric.                     |
+| `assessment`        | string   | Optional assessment. One of: `pass`, `fail`.             |
+| `tags`              | []string | Tags to associate with the metric.                       |
 
 **Response**
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?
Document additional fields that we now support on the Metric object used in the POST /api/v2/llm-obs/v1/experiments/{experiment_id}/events endpoint: 
- reasoning
- assessment
- tags 

### Merge instructions


Merge readiness:
- [x] Ready for merge


### Additional notes

This is a follow-up to an earlier PR documenting the EvaluatorResult class we added to ddtrace, which uses these new fields: https://github.com/DataDog/documentation/pull/34009
