### PR TITLE
(DogstatsD) Link to tags page from DogstatsD

### DIFF
--- a/content/en/developers/dogstatsd/data_aggregation.md
+++ b/content/en/developers/dogstatsd/data_aggregation.md
@@ -53,3 +53,4 @@ Among all values received during the same flush interval, the aggregated value s
 [5]: /metrics/types/?tab=gauge#metric-types
 [6]: /metrics/types/?tab=histogram#metric-types
 [7]: /metrics/types/?tab=distribution#metric-types
+[8]: /getting_started/tagging/


### PR DESCRIPTION
Adds a link to the tagging doc from DogstatsD.
[DOCS-10749](https://datadoghq.atlassian.net/browse/DOCS-10749)

Merge readiness:
- [x] Ready for merge

[DOCS-10749]: https://datadoghq.atlassian.net/browse/DOCS-10749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ