### PR TITLE
Add Network Path monitors section under Network Path

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -3674,16 +3674,21 @@ menu:
       parent: network_path
       identifier: network_path_path_view
       weight: 504
+    - name: Monitors
+      url: monitors/types/network_path/
+      parent: network_path
+      identifier: network_path_monitor
+      weight: 505
     - name: Guides
       url: network_monitoring/network_path/guide
       parent: network_path
       identifier: network_path_guides
-      weight: 505
+      weight: 506
     - name: Terms and Concepts
       url: network_monitoring/network_path/glossary
       parent: network_path
       identifier: network_path_glossary
-      weight: 506
+      weight: 507
     - name: Storage Management
       url: /infrastructure/storage_management/
       pre: file-wui


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR adds a small section under Network Path that links to its monitors. This is to provide more visibility and easier navigation. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
