### PR TITLE
Update MCP Server HIPAA compliance language

### DIFF
--- a/content/en/bits_ai/mcp_server/setup/_index.md
+++ b/content/en/bits_ai/mcp_server/setup/_index.md
@@ -28,7 +28,7 @@ The Datadog MCP Server is in Preview. There is no charge for using the Datadog M
 
 - The Datadog MCP Server is not supported for production use during the Preview.
 - Only Datadog organizations that have been specifically allowlisted can use the Datadog MCP Server. It is not available to the general public.
-- The Datadog MCP Server is not available for organizations that require HIPAA compliance.
+- The Datadog MCP Server is HIPAA-eligible. You are responsible for ensuring that the AI tools you connect to the Datadog MCP Server meet your compliance requirements, such as HIPAA.
 - Datadog collects certain information about your usage of the Remote Datadog MCP Server, including how you interact with it, whether errors occurred while using it, what caused those errors, and user identifiers in accordance with the <a href="https://www.datadoghq.com/legal/privacy/" target="_blank">Datadog Privacy Policy</a> and Datadog's <a href="https://www.datadoghq.com/legal/eula/" target="_blank">EULA</a>. This data is used to help improve the server's performance and features, including transitions to and from the server and the applicable Datadog login page for accessing the Services, and context (for example, user prompts) leading to the use of MCP tools. The data is stored for 120 days.
 
 ## Overview


### PR DESCRIPTION
As part of enabling the MCP server for HIPAA customers, Legal [requested](https://datadoghq.atlassian.net/browse/CATL-45?focusedCommentId=2886863) explicit documentation about data export boundaries for MCP Server. The new language clarifies it's HIPAA-eligible but customers are responsible for ensuring connected AI tools meet their compliance requirements.

This PR should not be merged until we remove the HIPAA block from the MCP server side.

Merge readiness:
- [x] Ready for merge