### PR TITLE
Add warning about nested context attributes in Feature Flags docs

### DIFF
--- a/content/en/feature_flags/client/_index.md
+++ b/content/en/feature_flags/client/_index.md
@@ -25,6 +25,36 @@ Set up Datadog Feature Flags for your applications. Follow the platform-specific
 
 {{< partial name="feature_flags/feature_flags_client.html" >}}
 
+## Context attribute requirements
+
+<div class="alert alert-warning">
+Evaluation context attributes must be flat primitive values (strings, numbers, booleans). Nested objects and arrays are <strong>not supported</strong> and will cause exposure events to be silently dropped.
+</div>
+
+Use flat attributes in your evaluation context:
+
+{{< code-block lang="javascript" >}}
+const evaluationContext = {
+  targetingKey: 'user-123',
+  userId: 'user-123',
+  tier: 'premium',
+  age: 25
+};
+
+await OpenFeature.setProviderAndWait(provider, evaluationContext);
+{{< /code-block >}}
+
+Avoid nested objects and arrays:
+
+{{< code-block lang="javascript" >}}
+// These attributes will cause exposure events to be dropped
+const evaluationContext = {
+  targetingKey: 'user-123',
+  user: { id: 'user-123' },        // nested object - NOT SUPPORTED
+  features: ['beta', 'analytics']  // array - NOT SUPPORTED
+};
+{{< /code-block >}}
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/feature_flags/server/_index.md
+++ b/content/en/feature_flags/server/_index.md
@@ -67,6 +67,35 @@ DD_REMOTE_CONFIG_ENABLED=true
 
 <div class="alert alert-info">Some SDKs require additional experimental flags to enable feature flagging. See the SDK-specific documentation for details.</div>
 
+## Context attribute requirements
+
+<div class="alert alert-warning">
+Evaluation context attributes must be flat primitive values (strings, numbers, booleans). Nested objects and arrays are <strong>not supported</strong> and will cause exposure events to be silently dropped.
+</div>
+
+Use flat attributes in your evaluation context:
+
+{{< code-block lang="javascript" >}}
+const evaluationContext = {
+  targetingKey: req.session?.userID,
+  companyId: req.session?.companyID,
+  tier: 'enterprise'
+};
+
+const value = client.getBooleanValue('my-flag', false, evaluationContext);
+{{< /code-block >}}
+
+Avoid nested objects and arrays:
+
+{{< code-block lang="javascript" >}}
+// These attributes will cause exposure events to be dropped
+const evaluationContext = {
+  targetingKey: req.session?.userID,
+  company: { id: req.session?.companyID },  // nested object - NOT SUPPORTED
+  roles: ['admin', 'user']                   // array - NOT SUPPORTED
+};
+{{< /code-block >}}
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}


### PR DESCRIPTION
## Motivation

Evaluation context attributes with nested objects or arrays are silently dropped, causing missing exposure events. Users have no indication that their context data is being ignored.

## Changes

- Added "Context attribute requirements" section to client-side Feature Flags documentation with warning and examples
- Added "Context attribute requirements" section to server-side Feature Flags documentation with warning and examples

## Decisions

- Used `alert-warning` styling to make the limitation highly visible
- Provided both correct and incorrect code examples to clearly illustrate the issue
- Used contextually appropriate examples (static context for client-side, request-based for server-side)