### PR TITLE
Add minimum agent version for live workload scaling

### DIFF
--- a/content/en/containers/autoscaling/_index.md
+++ b/content/en/containers/autoscaling/_index.md
@@ -57,6 +57,7 @@ Each cluster can have a maximum of 1000 workloads optimized with Datadog Kuberne
    | Feature | Minimum Agent Version |
    |---------|----------------------|
    | In-app workload scaling recommendations | 7.50+ |
+   | Live workload scaling | 7.66.1+ |
    | Argo Rollout recommendations and autoscaling | 7.71+ |
    | Cluster autoscaling ([preview sign-up][10]) | 7.72+ |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Datadog Kubernetes Autoscaling docs provide a feature compatibility matrix that specifies minimum agent version for each feature.

However, this matrix doesn't mention the minimum agent version for live workload scaling, which is mentioned in the Setup section below:

> Ensure you are using Agent and Cluster Agent v7.66.1+

Let's add it to the compatibility table for clarity and to keep all required agent versions in a single, easily skimmable place.

| Before | After |
|--------|--------|
| <img width="744" height="221" alt="Screenshot 2026-01-29 at 15 20 11" src="https://github.com/user-attachments/assets/9a6f27e3-0bf5-448d-abbb-4a38aa322824" /> | <img width="753" height="279" alt="Screenshot 2026-01-29 at 15 19 57" src="https://github.com/user-attachments/assets/e055ae3f-e76c-4b59-8bc9-9f6d854173a8" /> |

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
