### PR TITLE
[K9VULN-11234] Bump datadog-static-analyzer-github-action to v3.0.0

### DIFF
--- a/.github/workflows/datadog-static-analysis.yml
+++ b/.github/workflows/datadog-static-analysis.yml
@@ -17,11 +17,9 @@ jobs:
         persist-credentials: false
     - name: Check code meets quality and security standards
       id: datadog-static-analysis
-      uses: DataDog/datadog-static-analyzer-github-action@2707598b1182dce1d1792186477b5b4132338e1c # v1.2.3
+      uses: DataDog/datadog-static-analyzer-github-action@8340f18875fcefca86844b5f947ce2431387e552 # v3.0.0
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: documentation
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Updates the `datadog-static-analyzer-github-action` to the latest version, [v3.0.0](https://github.com/DataDog/datadog-static-analyzer-github-action/releases/tag/v3.0.0) (`8340f18`).

We've recently released this version and recommend all users upgrade to ensure the latest feature set.

Note that the deletion of `dd_service` and `dd_env` reflects the deprecation of those inputs. This will not change any behavior, as those inputs have been nonfunctional for over a year now.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
