### PR TITLE
specify which agent version GCP backend was released

### DIFF
--- a/content/en/agent/configuration/secrets-management.md
+++ b/content/en/agent/configuration/secrets-management.md
@@ -418,6 +418,8 @@ api_key: "ENC[secretKeyNameInKeyVault]"
 
 {{% collapse-content title="GCP Secret Manager" level="h4" expanded=false id="id-for-gcp" %}}
 
+**Available in Agent version 7.74+**
+
 The following GCP services are supported:
 
 | secret_backend_type value                               | GCP Service                    |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Specifies the agent version (7.74) that GCP secrets became available. 

### Merge instructions
Ready to merge