### PR TITLE
Move preview callout inside Host-wide tab for Windows SSI

### DIFF
--- a/content/en/tracing/trace_collection/single-step-apm/windows.md
+++ b/content/en/tracing/trace_collection/single-step-apm/windows.md
@@ -50,7 +50,7 @@ After installation, the Agent automatically loads the Datadog .NET SDK into supp
 
 <div class="alert alert-info">
 <strong>Join the Preview!</strong><br>
-Host-wide instrumentation for Windows is in Preview and limited to Preview participants. The installation and configuration options described in this tab appear in the Datadog UI only after you're enrolled. <a href="https://www.datadoghq.com/product-preview/single-step-instrumentation-on-windows-vms/" class="alert-link">Request Access</a>
+Host-wide instrumentation for Windows is in Preview and limited to Preview participants. The installation and configuration options described in this tab appear in Datadog only after you are enrolled. <a href="https://www.datadoghq.com/product-preview/single-step-instrumentation-on-windows-vms/" class="alert-link">Request access</a> to join the Preview.
 </div>
 
 To instrument Java and .NET applications across your entire Windows host:


### PR DESCRIPTION
- Move the 'Join the Preview!' callout from above the tabs into the Host-wide (Preview) tab only
- This clarifies that only host-wide instrumentation requires preview access
- IIS instrumentation is generally available and does not require preview enrollment
