### PR TITLE
[CONTP-669] Document availability_zone tag deprecation in ECS documentation

### DIFF
--- a/content/en/containers/amazon_ecs/tags.md
+++ b/content/en/containers/amazon_ecs/tags.md
@@ -33,6 +33,8 @@ The Agent can autodiscover and attach tags to all data emitted by the entire tas
   | `image_name`                  | Low          | Docker               |
   | `short_image`                 | Low          | Docker               |
   | `image_tag`                   | Low          | Docker               |
+  | `availability-zone`           | Low          | ECS API              |
+  | `availability_zone` (deprecated) | Low       | ECS API              |
   | `aws_account`                 | Low          | ECS API              |
   | `cluster_arn`                 | Low          | ECS API              |
   | `service_arn`                 | Low          | ECS API              |
@@ -47,6 +49,8 @@ The Agent can autodiscover and attach tags to all data emitted by the entire tas
   | `task_version`                | Low          | ECS API              |
 
 </div>
+
+**Note**: The `availability_zone` tag is deprecated in favor of `availability-zone`. Both tags are currently sent by the Agent, but `availability_zone` may be removed in a future release.
 
 ## Unified service tagging
 

--- a/content/en/containers/monitoring/amazon_elastic_container_explorer.md
+++ b/content/en/containers/monitoring/amazon_elastic_container_explorer.md
@@ -195,7 +195,7 @@ Some resources have specific tags. The following tags are available in addition 
 
 * A newly created ECS Service is typically collected within approximately 15 seconds. However, for status changes in an existing Service, a refresh within 15 seconds is not guaranteed.
 * Installing the Datadog Agent in your cluster enables visibility into task lifecycle changes. Without the Datadog Agent, stopped tasks can appear as running for up to 15 minutes.
-* Installing the Datadog Agent in your cluster provides additional, relevant host-level tags, such as `availability_zone`.
+* Installing the Datadog Agent in your cluster provides additional, relevant host-level tags, such as `availability-zone`.
 
 ## Further reading
 


### PR DESCRIPTION
Add documentation for the availability-zone tag and clarify that availability_zone is deprecated. Both tags are currently sent by the Agent but availability_zone may be removed in a future release.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
