### PR TITLE
Fix nested context examples in Feature Flags getting started guide

### DIFF
--- a/content/en/getting_started/feature_flags/_index.md
+++ b/content/en/getting_started/feature_flags/_index.md
@@ -119,8 +119,9 @@ const client = OpenFeature.getClient();
 // If applicable, set relevant attributes on the client's global context
 // (e.g. org id, user email)
 await OpenFeature.setContext({
-   org: { id: 2 },
-   user: { id: 'user-123', email: 'user@example.com' },
+   org_id: 2,
+   user_id: 'user-123',
+   email: 'user@example.com',
    targetingKey: 'user-123',
 });
 

--- a/content/es/getting_started/feature_flags/_index.md
+++ b/content/es/getting_started/feature_flags/_index.md
@@ -84,8 +84,9 @@ const client = OpenFeature.getClient();
 // If applicable, set relevant attributes on the client's global context
 // (e.g. org id, user email)
 await OpenFeature.setContext({
-   org: { id: 2 },
-   user: { id: 'user-123', email: 'user@example.com' },
+   org_id: 2,
+   user_id: 'user-123',
+   email: 'user@example.com',
    targetingKey: 'user-123',
 });
 


### PR DESCRIPTION
## Motivation

The Feature Flags evaluation context in OpenFeature SDKs only supports flat key-value pairs. Nested objects like `user: { id: 'user-123', email: '...' }` or `org: { id: 2 }` are **not supported** and will cause exposure events to be dropped silently.

The getting started guide examples were incorrectly showing nested context objects, which could mislead users and cause their targeting to fail.

## Changes

- Flattened nested context objects in the JavaScript code examples
- Changed `org: { id: 2 }` → `org_id: 2`
- Changed `user: { id: 'user-123', email: 'user@example.com' }` → `user_id: 'user-123'`, `email: 'user@example.com'`
- Updated both English and Spanish translations

## Decisions

- Kept the same attributes but flattened them to top-level keys using underscore convention (`org_id`, `user_id`)
- This matches the pattern used in other SDK documentation (JavaScript client, React, Node.js)