### PR TITLE
[ACTP] update for simplified PAR onboarding

### DIFF
--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -45,10 +45,10 @@ In addition, the host must have the following:
 
 ### Set up from Datadog
 
-From the [Actions Catalog][6], navigate to **Private Action Runners** and click **New Private Action Runner**.
-
+1. Go to [**Actions Catalog**][6] > **Private Action Runners**, and click **New Private Action Runner**.
 1. Enter a name for your runner and select the allowed actions.
-1. Create a directory on your host where the runner can store its configuration, such as ./config, and follow the guidelines to deploy your runner with Docker, Docker Compose, or Kubernetes.
+1. Create a directory on your host where the runner can store its configuration, such as `./config`.
+1. Deploy your runner by following the steps for your container platform:
 
 {{< tabs >}}
 {{% tab "Docker" %}}
@@ -71,8 +71,8 @@ From the [Actions Catalog][6], navigate to **Private Action Runners** and click 
 
 {{% tab "Kubernetes" %}}
 1. Click **Kubernetes**.
-1. Confirm that you have installed `kubectl` on your machine by running `kubectl version` and verifying that there is output.
-1. Confirm that you have installed `helm` on your machine by running `helm version` and verifying that there is output.
+1. Confirm that you have installed `kubectl` on your machine: run `kubectl version` and verify that there is output.
+1. Confirm that you have installed `helm` on your machine: run `helm version` and verify that there is output.
 1. Confirm that you have sufficient permissions to create Kubernetes resources in your cluster.
 1. Follow the instructions provided in the app to:
     1. Enroll the runner and generate the config.
@@ -88,7 +88,7 @@ From the [Actions Catalog][6], navigate to **Private Action Runners** and click 
 
 As an alternative to the UI-based setup, you can enroll and configure a private action runner programmatically using your [API key][19] and [Application key][20]. This approach is ideal for automated deployments, CI/CD pipelines, and infrastructure-as-code workflows.
 
-To use this authentication method:
+To set up the runner programmatically:
 1. Provide your Datadog API and App keys through the `DD_API_KEY` and `DD_APP_KEY` environment variables.
 2. Pass the `--with-api-key` flag to the runner container.
 
@@ -96,13 +96,13 @@ The runner uses these credentials to register itself with your Datadog organizat
 
 #### Example commands
 
-Use the following commands to create an auto-enrollment script that can be re-run as needed for automated deployments. Once auto-enrollment succeeds, the runner appears on the **Private Action Runners** page.
+Use the following commands to create an auto-enrollment script that can be rerun for automated deployments. After the runner enrolls successfully, it appears on the **Private Action Runners** page.
 
 Before running the commands, update the following values:
-- **RUNNER_NAME**: A unique name for your runner.
-- **DD_BASE_URL**: Your Datadog site URL (for example, `https://app.datadoghq.com`).
-- **./config**: The path to your runner configuration directory.
-- (Optional) **Image version**: Update the image tag to use a newer version of the runner.
+- `RUNNER_NAME`: A unique name for your runner.
+- `DD_BASE_URL`: Your Datadog site URL (for example, `https://app.datadoghq.com`).
+- `./config`: The path to your runner configuration directory.
+- (Optional) Image version: The container image tag to use for the runner.
 
 {{< tabs >}}
 {{% tab "Docker" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR updates PAR Setup documentation to follow new simplified path described in [this proposal.](https://docs.google.com/document/d/1L8DNcyXfQXUer79nJ6ypQqE4RtstJp8Sa_3PWoMoma4/edit?tab=t.0#heading=h.3t0vdtvbd0ji) 
Main changes include:

**1. Simplified setup instructions**
No Workflows/App Builder distinction anymore, the setup process is now streamlined to a common 2-step flow:
1) Enter a name and select allowed actions
2) Deploy with Docker, Docker Compose, or Kubernetes

**2. Update of the Kubernetes instructions** 
Removed the manual "Create a values.yaml file" step, the command now handles it automatically.

**3. Additional instruction to enroll a PAR programmatically**
We've introduced API and App-key-based method allowing PAR enrollment from a script. 
This PR adds a section about it, with examples.

**4. Update of the navigation path**
Entry point to "Private Action Runner" page is now accessible only from the Actions Catalog page (`actions/action-catalog`). This PR handles it and cleans up outdated 404 reference links leading from Workflows and App Builder product pages.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
