### PR TITLE
docs: add CI_PROJECT_URL for GitLab and JOB_CHECK_RUN_ID for GitHub Actions

### DIFF
--- a/content/en/tests/containers.md
+++ b/content/en/tests/containers.md
@@ -210,6 +210,7 @@ For a comprehensive list of environment variables set by Codefresh for every bui
 | `GITHUB_HEAD_REF`          | The head ref or source branch of the pull request (only set for `pull_request` or `pull_request_target` events). For example: `feature-branch-1`. |
 | `GITHUB_REF`               | The fully-formed ref of the branch or tag that triggered the workflow. For example: `refs/heads/feature-branch-1`. |
 | `GITHUB_JOB`               | The job ID of the current job. For example: `greeting_job`.                                           |
+| `JOB_CHECK_RUN_ID`         | The check run ID of the current job. Must be set manually: `JOB_CHECK_RUN_ID: ${{ job.check_run_id }}`. |
 
 
 For a comprehensive list of environment variables set by GitHub Actions for every build, see the [official GitHub documentation][101].


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This PR adds environment variables to the tests/containers documentation:

- **GitLab CI**: Add `CI_PROJECT_URL` - the HTTP(S) address of the project ([Link](https://docs-staging.datadoghq.com/dani.fernandez/add-ci-project-url-gitlab/tests/containers/?tab=gitlabci))
- **GitHub Actions**: Add `JOB_CHECK_RUN_ID` - the check run ID of the current job (must be set manually using `${{ job.check_run_id }}`) ([Link](https://docs-staging.datadoghq.com/dani.fernandez/add-ci-project-url-gitlab/tests/containers/?tab=githubactions))

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

The `JOB_CHECK_RUN_ID` is not a default GitHub Actions environment variable, but can be set from the job context:
```yaml
env:
  JOB_CHECK_RUN_ID: ${{ job.check_run_id }}
```