### PR TITLE
docs(rofs_guide): Add building a custom image to ROFS guide

### DIFF
--- a/content/en/containers/guide/readonly-root-filesystem.md
+++ b/content/en/containers/guide/readonly-root-filesystem.md
@@ -26,13 +26,13 @@ There are two approaches to configure the Datadog Agent for ROFS:
 {{< tabs >}}
 {{% tab "Mount writable volumes" %}}
 
-Mount writable volumes onto your Datadog Agent container to provide necessary write access for directories at runtime. This method works with any container orchestrator, such as Docker Compose, ECS, or Kubernetes.
+Use writable volumes on your Datadog Agent container to ensure write access at runtime. This method works with any container orchestrator, such as Docker Compose, ECS, or Kubernetes.
 
 ### Steps
 
 1. Create named volumes for the required directories (`/etc/datadog-agent`, `/opt/datadog-agent/run`, `/var/run/datadog`, and optionally `/var/log/datadog`).
 2. Configure an init container to copy default configuration files from the Agent image to the shared `datadog-config` volume.
-3. Configure the Agent container with `read_only: true` and mount the volumes with read-write permissions. Use tmpfs for `/tmp`.
+3. Configure the Agent container with `read_only: true` and mount the volumes with read-write permissions.
 
 Complete example:
 ```yaml
@@ -72,7 +72,7 @@ volumes:
   datadog-logs:
 ```
 
-**Note**: The init container copies default configuration files to the shared volume before the Agent starts. The Agent then runs with a read-only root filesystem while writing to the mounted volumes and tmpfs.
+**Note**: The init container copies default configuration files into the shared volume before the Agent starts. While the Agent can start without the init container prepopulating this volume, some checks might be missing or incomplete.
 
 {{% /tab %}}
 {{% tab "Create a custom Agent image" %}}
@@ -116,7 +116,7 @@ services:
       - /tmp
 ```
 
-**Note**: When using the `VOLUME` directive in a Dockerfile, the container runtime automatically creates anonymous volumes for those paths. This removes the need for an init container, but these volumes are ephemeral and any customizations to `datadog.yaml` or `conf.d/` need to be baked into the image or provided through environment variables.
+**Note**: When using the `VOLUME` directive in a Dockerfile, the container runtime automatically creates anonymous volumes for those paths. This removes the need for an init container, but these volumes are ephemeral so any customizations to `datadog.yaml` or `conf.d/` need to be baked into the image or mounted as named volumes.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

1. Adds another option to configure the Agent for ROFS.
2. Improves docker compose examples to mount tmpfs volumes.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
