### PR TITLE
Add Prisma support information to Node.js compatibility

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -144,6 +144,7 @@ Or, modify the `package.json` file if you typically start an application with np
 | [redis][39]            | `>=0.12` | Fully supported |                                                  |
 | [sharedb][40]          | `>=1`    | Fully supported |                                                  |
 | [tedious][41]          | `>=1`    | Fully supported | SQL Server driver for `mssql` and `sequelize`    |
+| [Prisma][69]           | `>=6.1.0`| Fully supported |                                                  |
 
 ### Worker compatibility
 


### PR DESCRIPTION
Prisma support is missing from the doc.

We added support with this PR: https://github.com/DataDog/dd-trace-js/pull/5605

Starting in v5.57.0
