### PR TITLE
WEB-8164 - rank search results on in page integration searching

### DIFF
--- a/assets/scripts/components/integrations.js
+++ b/assets/scripts/components/integrations.js
@@ -254,9 +254,27 @@ export function initializeIntegrations() {
             }
         }
 
-        // Sort partial matches by score (highest first), then extract items
-        partialMatches.sort((a, b) => b.matchScore - a.matchScore);
+        // Sort partial matches by:
+        // 1. Non-marketplace (native) integrations first
+        // 2. Match score (highest first)
+        // 3. Marketplace integrations last
+        partialMatches.sort((a, b) => {
+            // Prioritize non-marketplace over marketplace
+            if (a.item.is_marketplace !== b.item.is_marketplace) {
+                return a.item.is_marketplace ? 1 : -1;
+            }
+            // Within same marketplace status, sort by match score
+            return b.matchScore - a.matchScore;
+        });
         const sortedPartialMatches = partialMatches.map(m => m.item);
+
+        // Sort exact matches the same way (non-marketplace first)
+        exactMatches.sort((a, b) => {
+            if (a.is_marketplace !== b.is_marketplace) {
+                return a.is_marketplace ? 1 : -1;
+            }
+            return 0;
+        });
 
         // Combine exact matches first, then sorted partial matches, then hidden items
         const show = [...exactMatches, ...sortedPartialMatches];


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

**Problem:** 

Searching for "temporal cloud openmetrics" on the integration page search, the exact match appears far to low on the page. https://docs.datadoghq.com/integrations/?q=temporal%20cloud%20openmetrics

**Solution:**

Check for exact matches and then partial matches on searching integration tiles
Then sort based on how many search terms match.
This gives us the same results but will promote exact matches higher.
(Additional) we also tried to promote native integrations but don't have a great way to differentiate so its a marginal improvement

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes

https://docs-staging.datadoghq.com/david.jones/WEB-8164/integrations/?q=temporal%20cloud%20openmetrics
