### PR TITLE
Remove note on recs not supporting acct filtering

### DIFF
--- a/content/en/cloud_cost_management/setup/aws.md
+++ b/content/en/cloud_cost_management/setup/aws.md
@@ -197,7 +197,7 @@ Use Account Filtering to control which AWS member accounts to pull into Cloud Co
 
 Using Account Filtering requires an AWS management account. You can configure account filters after an account has been configured in Cloud Cost Management.
 
-**Note:** Account filters are not supported for Recommendations or tag search.
+**Note:** Account filters are not supported for tag search.
 
 #### Configure account filters for an existing account
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

https://datadoghq.atlassian.net/browse/CCR-2843

CCM Recommendations now supports account filtering. Updates the note in the AWS setup docs to reflect this.

### Merge instructions

Merge readiness:
- [x] Ready for merge
- [x] Verify preview

### Additional notes

None.
