### PR TITLE
Add search_datadog_test_events tool to MCP Server docs

### DIFF
--- a/content/en/bits_ai/mcp_server/setup/_index.md
+++ b/content/en/bits_ai/mcp_server/setup/_index.md
@@ -451,7 +451,6 @@ Aggregates Datadog Test Optimization events to quantify reliability and performa
 Searches [Test Optimization][24] test events with filters and returns details on them.
 
 - Show me failed tests on branch `main` from the last 24 hours.
-- Find tests matching name pattern `*login*` and show their results.
 - Get test executions for commit `abc123` to see what passed and failed.
 - Show me all flaky test runs for the checkout service.
 - Find tests owned by `@team-name` that are failing.


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Adds documentation for the new `search_datadog_test_events` MCP tool in the software-delivery toolset.

This tool was added in https://github.com/DataDog/dd-source/pull/347297 and allows AI agents to search and retrieve individual test events from Datadog Test Optimization.

## Merge instructions

Merge readiness:
- [x] Ready for merge