### PR TITLE
[RUM-14302] [React Native][V3] Update missing configuration snippets to align with v3

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/react_native/setup/expo.md
+++ b/content/en/real_user_monitoring/application_monitoring/react_native/setup/expo.md
@@ -313,9 +313,9 @@ Then, import it before initializing the Datadog React Native SDK:
 
 ```typescript
 import './mockDatadog';
-import { DdSdkReactNative } from 'expo-datadog';
+import { CoreConfiguration } from 'expo-datadog';
 
-const config = new DdSdkReactNativeConfiguration(/* your config */);
+const config = new CoreConfiguration(/* your config */);
 DdSdkReactNative.initialize(config);
 ```
 
@@ -461,11 +461,12 @@ The most common patterns of Expo dev server host URL are filtered by the SDK, th
 If this error occurs, add the following Resource mapper to filter out the calls:
 
 ```js
-import { DdSdkReactNativeConfiguration } from 'expo-datadog';
+import { CoreConfiguration } from 'expo-datadog';
+
 import Constants from 'expo-constants';
 
-const config = new DdSdkReactNativeConfiguration(/* your config */);
-config.resourceEventMapper = event => {
+const config = new CoreConfiguration(/* your config */);
+config.rumConfiguration.resourceEventMapper = event => {
   if (
     event.resourceContext?.responseURL ===
     `http://${Constants.expoConfig.hostUri}/logs`

--- a/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
+++ b/content/en/real_user_monitoring/error_tracking/mobile/reactnative.md
@@ -40,15 +40,21 @@ If you have not set up the React Native SDK yet, follow the [in-app setup instru
 Update your initialization snippet to enable native JavaScript crash reporting:
 
 ```javascript
-const config = new DdSdkReactNativeConfiguration(
+const config = new DatadogProviderConfiguration(
     '<CLIENT_TOKEN>',
     '<ENVIRONMENT_NAME>',
-    '<APPLICATION_ID>',
-    true,
-    true,
-    true // enable JavaScript crash reporting
+    {
+        rumConfiguration: {
+            applicationId: '<APPLICATION_ID>',
+            trackInteractions: true,
+            trackResources: true,
+            trackErrors: true, // <-- Enable JavaScript Crash Reporting
+            nativeCrashReportEnabled: true, // Optional: Enable Native Crash Reporting
+        },
+        logsConfiguration: {},
+        traceConfiguration: {}
+    }
 );
-config.nativeCrashReportEnabled = true; // enable native crash reporting
 ```
 
 ## Get deobfuscated stack traces


### PR DESCRIPTION
### What does this PR do? What is the motivation?
When [updating the documentation to reflect the updated API for React Native SDK v3](https://github.com/DataDog/documentation/pull/33967) we forgot to update the configuration snipets for Expo, Codepush and Error Tracking.

### Merge instructions

Merge readiness:
- [x] Ready for merge