### PR TITLE
[DOCS-13318] Link to CloudPrem OP guide

### DIFF
--- a/content/en/observability_pipelines/guide/_index.md
+++ b/content/en/observability_pipelines/guide/_index.md
@@ -7,7 +7,7 @@ disable_toc: false
     {{< nextlink href="observability_pipelines/guide/strategies_for_reducing_log_volume" >}}Strategies for reducing log volume{{< /nextlink >}}
     {{< nextlink href="observability_pipelines/guide/set_up_the_worker_in_ecs_fargate" >}}Set up the Worker in ECS Fargate{{< /nextlink >}}
     {{< nextlink href="observability_pipelines/guide/environment_variables" >}}Environment variables for sources, processors, and destinations{{< /nextlink >}}
-    {{< nextlink href="/cloudprem/guides/send_otel_logs_observability_pipelines" >}}Send OpenTelemetry logs with Observability Pipelines{{< /nextlink >}}
+    {{< nextlink href="/cloudprem/guides/send_otel_logs_observability_pipelines" >}}Send OpenTelemetry logs to CloudPrem with Observability Pipelines{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Worker Upgrade Guides" >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13318

Add link to the CloudPrem guide "Send OpenTelemetry logs with Observability Pipelines" in the Observability Pipelines guides index.

The CloudPrem team published a new guide that shows how to use Observability Pipelines with OpenTelemetry logs and CloudPrem using the API. This PR adds a link to that guide in the Observability Pipelines guides page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes