### PR TITLE
[LOGSQ-1454] Document Flex Logs fair use limits and observability

### DIFF
--- a/content/en/logs/guide/flex_compute.md
+++ b/content/en/logs/guide/flex_compute.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-Monitor the usage of Flex compute through various graphs on the [Flex Logs Controls][1] page. Track both concurrent query utilization and fair use limit impact to make informed decisions on cost-performance tradeoffs and balance operational success with financial efficiency.
+Monitor the usage of Flex compute through various graphs on the [Flex Logs Controls][1] page. Track concurrent query utilization and fair use limit impact to make informed decisions on cost-performance tradeoffs.
 
 {{< img src="/logs/guide/flex_compute/flex_compute_graphs_1.png" alt="Dashboard showing the query performance and compute size metrics, including query slowdowns, top sources of slowdowns, and compute usage over time" style="width:100%;" >}}
 
@@ -20,7 +20,7 @@ Monitor the usage of Flex compute through various graphs on the [Flex Logs Contr
 
 Flex compute is limited by two factors:
 - The number of concurrent queries
-- The maximum number of logs that can be scanned per query
+- The per-query [fair use limit][4] on addressable logs
 
 Query slowdowns occur when the concurrent query limit is reached, and a query is retrying to find an available slot to run in. If an available slot is not found, the query will not run. Datadog displays an error message advising you to retry your query at a later time.
 
@@ -63,7 +63,7 @@ Use this information to optimize your usage.
 ### Reduce fair use limit rejections
 
 1. **Narrow query time ranges** to reduce the number of addressable logs targeted by each query.
-1. **Scope queries to a specific index** using `index:<name>` to avoid scanning all Flex-enabled indexes. If the logs you are querying belong to a specific index, scoping to that index reduces the addressable logs count and can speed up your search.
+1. **Scope queries to a specific index** using `index:<name>` to reduce the number of addressable logs counted by the query.
 1. **Consider upgrading your Flex compute size** if queries regularly reach the fair use limit. Larger compute tiers support a higher number of addressable logs per query.
 
 To learn more about compute sizes, see the [Flex Logs][3] documentation.

--- a/content/en/logs/guide/flex_compute.md
+++ b/content/en/logs/guide/flex_compute.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-Monitor the usage of Flex compute through various graphs on the [Flex Logs Controls][1] page. Track concurrent query utilization and fair use limit impact to make informed decisions on cost-performance tradeoffs.
+Monitor the usage of Flex compute through various graphs on the [Flex Logs Controls][1] page. Track concurrent query utilization and Fair Use limit impact to make informed decisions on cost-performance tradeoffs.
 
 {{< img src="/logs/guide/flex_compute/flex_compute_graphs_1.png" alt="Dashboard showing the query performance and compute size metrics, including query slowdowns, top sources of slowdowns, and compute usage over time" style="width:100%;" >}}
 
@@ -20,7 +20,7 @@ Monitor the usage of Flex compute through various graphs on the [Flex Logs Contr
 
 Flex compute is limited by two factors:
 - The number of concurrent queries
-- The per-query [fair use limit][4] on addressable logs
+- The per-query [Fair Use limit][4] on addressable logs
 
 Query slowdowns occur when the concurrent query limit is reached, and a query is retrying to find an available slot to run in. If an available slot is not found, the query will not run. Datadog displays an error message advising you to retry your query at a later time.
 
@@ -31,16 +31,16 @@ Query slowdowns occur when the concurrent query limit is reached, and a query is
 - **Top sources of slowdowns:** Breaks down whether delays originate from the Log Explorer, dashboards, or API queries, making it easier to target areas for optimization.
 - **Drilldowns:** Click on a dashboard or user to open directly to the dashboard or the user history of Flex queries in [Audit Trail][2]. **Note**: Only Logs List queries are audited. This does not include queries used for visualizations, such as timeseries or top list.
 
-## Monitoring fair use limits
+## Monitoring Fair Use limits
 
 Each Flex compute tier enforces a per-query limit on the number of [addressable logs][4]. Queries that exceed this limit are rejected. The **Compute Usage - Fair Use Limit** section on the [Flex Logs Controls][1] page provides visibility into how these limits affect your queries.
 
-{{< img src="/logs/guide/flex_compute/flex_compute_fair_use.png" alt="Dashboard showing fair use limit metrics, including rejected queries over time, percentage of limited queries by day, and top sources of limited queries" style="width:100%;" >}}
+{{< img src="/logs/guide/flex_compute/flex_compute_fair_use.png" alt="Dashboard showing Fair Use limit metrics, including rejected queries over time, percentage of limited queries by day, and top sources of limited queries" style="width:100%;" >}}
 
 ### Available metrics
 
-- **Rejected queries over time:** Shows the number of queries rejected due to the fair use limit as a timeseries, helping you identify spikes in rejected queries.
-- **Percentage of limited queries by day of the week:** Provides an overview of the percentage of queries reaching the fair use limit by day, helping identify patterns in compute demand.
+- **Rejected queries over time:** Shows the number of queries rejected due to the Fair Use limit as a timeseries, helping you identify spikes in rejected queries.
+- **Percentage of limited queries by day of the week:** Provides an overview of the percentage of queries reaching the Fair Use limit by day, helping identify patterns in compute demand.
 - **Top sources of limited queries:** Breaks down whether rejected queries originate from the Log Explorer, dashboards, or API queries, and identifies the top dashboards and users affected. Click on a dashboard or user to open the dashboard directly or view the user's history of Flex queries in [Audit Trail][2].
 
 ## Optimization recommendations
@@ -60,11 +60,11 @@ Use this information to optimize your usage.
 1. **Consider upgrading your Flex compute size** to increase the concurrent query limit if you notice sustained query slowdowns.
 1. **Scope to the index** you are querying. If the logs you are querying belong to a specific index, scoping to that index can speed up your search.
 
-### Reduce fair use limit rejections
+### Reduce Fair Use limit rejections
 
 1. **Narrow query time ranges** to reduce the number of addressable logs targeted by each query.
 1. **Scope queries to a specific index** using `index:<name>` to reduce the number of addressable logs counted by the query.
-1. **Consider upgrading your Flex compute size** if queries regularly reach the fair use limit. Larger compute tiers support a higher number of addressable logs per query.
+1. **Consider upgrading your Flex compute size** if queries regularly reach the Fair Use limit. Larger compute tiers support a higher number of addressable logs per query.
 
 To learn more about compute sizes, see the [Flex Logs][3] documentation.
 

--- a/content/en/logs/guide/flex_compute.md
+++ b/content/en/logs/guide/flex_compute.md
@@ -12,7 +12,7 @@ further_reading:
 
 ## Overview
 
-Monitor the usage of Flex compute through various graphs on the [Flex Logs Controls][1] page. Make informed decisions using data on cost-performance tradeoffs and balance operational success with financial efficiency.
+Monitor the usage of Flex compute through various graphs on the [Flex Logs Controls][1] page. Track both concurrent query utilization and fair use limit impact to make informed decisions on cost-performance tradeoffs and balance operational success with financial efficiency.
 
 {{< img src="/logs/guide/flex_compute/flex_compute_graphs_1.png" alt="Dashboard showing the query performance and compute size metrics, including query slowdowns, top sources of slowdowns, and compute usage over time" style="width:100%;" >}}
 
@@ -31,9 +31,23 @@ Query slowdowns occur when the concurrent query limit is reached, and a query is
 - **Top sources of slowdowns:** Breaks down whether delays originate from the Log Explorer, dashboards, or API queries, making it easier to target areas for optimization.
 - **Drilldowns:** Click on a dashboard or user to open directly to the dashboard or the user history of Flex queries in [Audit Trail][2]. **Note**: Only Logs List queries are audited. This does not include queries used for visualizations, such as timeseries or top list.
 
+## Monitoring fair use limits
+
+Each Flex compute tier enforces a per-query limit on the number of [addressable logs][4]. Queries that exceed this limit are rejected. The **Compute Usage - Fair Use Limit** section on the [Flex Logs Controls][1] page provides visibility into how these limits affect your queries.
+
+{{< img src="/logs/guide/flex_compute/flex_compute_fair_use.png" alt="Dashboard showing fair use limit metrics, including rejected queries over time, percentage of limited queries by day, and top sources of limited queries" style="width:100%;" >}}
+
+### Available metrics
+
+- **Rejected queries over time:** Shows the number of queries rejected due to the fair use limit as a timeseries, helping you identify spikes in rejected queries.
+- **Percentage of limited queries by day of the week:** Provides an overview of the percentage of queries reaching the fair use limit by day, helping identify patterns in compute demand.
+- **Top sources of limited queries:** Breaks down whether rejected queries originate from the Log Explorer, dashboards, or API queries, and identifies the top dashboards and users affected. Click on a dashboard or user to open the dashboard directly or view the user's history of Flex queries in [Audit Trail][2].
+
 ## Optimization recommendations
 
 Use this information to optimize your usage.
+
+### Reduce concurrent query slowdowns
 
 1. **Reach out to outlier users to:**
    - Discuss their querying needs
@@ -46,6 +60,12 @@ Use this information to optimize your usage.
 1. **Consider upgrading your Flex compute size** to increase the concurrent query limit if you notice sustained query slowdowns.
 1. **Scope to the index** you are querying. If the logs you are querying belong to a specific index, scoping to that index can speed up your search.
 
+### Reduce fair use limit rejections
+
+1. **Narrow query time ranges** to reduce the number of addressable logs targeted by each query.
+1. **Scope queries to a specific index** using `index:<name>` to avoid scanning all Flex-enabled indexes. If the logs you are querying belong to a specific index, scoping to that index reduces the addressable logs count and can speed up your search.
+1. **Consider upgrading your Flex compute size** if queries regularly reach the fair use limit. Larger compute tiers support a higher number of addressable logs per query.
+
 To learn more about compute sizes, see the [Flex Logs][3] documentation.
 
 ## Further reading
@@ -55,3 +75,4 @@ To learn more about compute sizes, see the [Flex Logs][3] documentation.
 [1]: https://app.datadoghq.com/logs/pipelines/flex-logs-controls
 [2]: /account_management/audit_trail/#explore-audit-events
 [3]: /logs/log_configuration/flex_logs/
+[4]: /logs/log_configuration/flex_logs/#fair-use-limit

--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -78,7 +78,7 @@ Compute is the querying capacity to run queries for Flex Logs. It is used when q
 - Medium (M)
 - Large (L)
 
-Each compute tier is approximately 2X the query performance and capacity of the previous tier. The compute size is constrained by the number of concurrent queries and the maximum limit on how many logs can be scanned per query
+Each compute tier is approximately 2X the query performance and capacity of the previous tier. The compute size is constrained by two factors: the number of concurrent queries and the [Fair Use limit](#fair-use-limit)
 
 ### Determine the compute size that you need
 
@@ -225,9 +225,26 @@ The following list is an example of log sources that are good candidates for sen
 
 For each organization where you want to use Flex Logs, you must enable a compute size. Datadog recommends Flex Logs scalable compute sizes (XS, S, M, and L) for organizations with large log volumes. In a multi-organization setup, there are often many organizations with lower log volumes, so for these organizations, Datadog recommends the Starter compute size for Flex Logs.
 
-### When the compute limit is reached
+### When the concurrent query limit is reached
 
 When your organization reaches the compute limit in terms of concurrent queries, you may experience slower queries because queries continue to retry until capacity is available. If a query retries multiple times, it may fail to run. In such situations, there is an error message that says Flex Logs compute capacity is constrained and you should contact your admin.
+
+### Fair Use limit
+
+Each Flex Logs compute tier enforces a per-query Fair Use limit on the number of **addressable logs**. Addressable logs are the total number of logs (stored inside and outside of the Flex tier) that match a query's time range and index scope. This count includes all logs in matching indexes for that time range, regardless of other search filters such as tags or keywords.
+
+The addressable logs for a query are determined as follows:
+- If the query specifies an index (for example, `index:my-index`), only logs in that index within the query's time range count toward the limit.
+- If no index is specified, logs across all indexes within the query's time range count toward the limit.
+
+Each compute tier has a different maximum threshold for addressable logs per query. If a query exceeds this limit, it is rejected and not automatically retried. The error message indicates that the query request exceeds the maximum query size limit of your Flex compute tier.
+
+To reduce the number of addressable logs and avoid reaching this limit:
+- **Narrow the query's time range** to target a smaller window of logs.
+- **Scope the query to a specific index** using `index:<name>` to avoid scanning all Flex-enabled indexes.
+- **Upgrade to a larger compute size** if queries regularly reach the limit. See [Determine the compute size that you need](#determine-the-compute-size-that-you-need) for guidance.
+
+To monitor how fair use limits affect your queries, see [Monitor Flex Compute Usage][9].
 
 ## Further reading
 
@@ -241,3 +258,4 @@ When your organization reaches the compute limit in terms of concurrent queries,
 [6]: https://www.datadoghq.com/pricing/?product=log-management#products
 [7]: mailto:success@datadoghq.com
 [8]: https://docs.datadoghq.com/account_management/rbac/permissions/#log-management
+[9]: /logs/guide/flex_compute/

--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -78,7 +78,7 @@ Compute is the querying capacity to run queries for Flex Logs. It is used when q
 - Medium (M)
 - Large (L)
 
-Each compute tier is approximately 2X the query performance and capacity of the previous tier. The compute size is constrained by two factors: the number of concurrent queries and the [Fair Use limit](#fair-use-limit)
+Each compute tier is approximately 2X the query performance and capacity of the previous tier. The compute size is constrained by two factors: the number of concurrent queries and the [fair use limit](#fair-use-limit).
 
 ### Determine the compute size that you need
 
@@ -227,11 +227,11 @@ For each organization where you want to use Flex Logs, you must enable a compute
 
 ### When the concurrent query limit is reached
 
-When your organization reaches the compute limit in terms of concurrent queries, you may experience slower queries because queries continue to retry until capacity is available. If a query retries multiple times, it may fail to run. In such situations, there is an error message that says Flex Logs compute capacity is constrained and you should contact your admin.
+When your organization reaches the concurrent query limit, you may experience slower queries because queries continue to retry until capacity is available. If a query retries multiple times, it may fail to run. In such situations, there is an error message that says Flex Logs compute capacity is constrained and you should contact your admin.
 
-### Fair Use limit
+### Fair use limit
 
-Each Flex Logs compute tier enforces a per-query Fair Use limit on the number of **addressable logs**. Addressable logs are the total number of logs (stored inside and outside of the Flex tier) that match a query's time range and index scope. This count includes all logs in matching indexes for that time range, regardless of other search filters such as tags or keywords.
+Each Flex Logs compute tier enforces a per-query fair use limit on the number of **addressable logs**. Addressable logs are the total number of logs (stored inside and outside of the Flex tier) that match a query's time range and index scope. This count includes all logs in matching indexes for that time range, regardless of other search filters such as tags or keywords.
 
 The addressable logs for a query are determined as follows:
 - If the query specifies an index (for example, `index:my-index`), only logs in that index within the query's time range count toward the limit.
@@ -241,10 +241,10 @@ Each compute tier has a different maximum threshold for addressable logs per que
 
 To reduce the number of addressable logs and avoid reaching this limit:
 - **Narrow the query's time range** to target a smaller window of logs.
-- **Scope the query to a specific index** using `index:<name>` to avoid scanning all Flex-enabled indexes.
+- **Scope the query to a specific index** using `index:<name>` to reduce the number of addressable logs counted by the query.
 - **Upgrade to a larger compute size** if queries regularly reach the limit. See [Determine the compute size that you need](#determine-the-compute-size-that-you-need) for guidance.
 
-To monitor how fair use limits affect your queries, see [Monitor Flex Compute Usage][9].
+To track rejected queries and identify usage patterns, see [Monitor Flex Compute Usage][9].
 
 ## Further reading
 

--- a/content/en/logs/log_configuration/flex_logs.md
+++ b/content/en/logs/log_configuration/flex_logs.md
@@ -78,7 +78,7 @@ Compute is the querying capacity to run queries for Flex Logs. It is used when q
 - Medium (M)
 - Large (L)
 
-Each compute tier is approximately 2X the query performance and capacity of the previous tier. The compute size is constrained by two factors: the number of concurrent queries and the [fair use limit](#fair-use-limit).
+Each compute tier is approximately 2X the query performance and capacity of the previous tier. The compute size is constrained by two factors: the number of concurrent queries and the [Fair Use limit](#fair-use-limit).
 
 ### Determine the compute size that you need
 
@@ -229,9 +229,9 @@ For each organization where you want to use Flex Logs, you must enable a compute
 
 When your organization reaches the concurrent query limit, you may experience slower queries because queries continue to retry until capacity is available. If a query retries multiple times, it may fail to run. In such situations, there is an error message that says Flex Logs compute capacity is constrained and you should contact your admin.
 
-### Fair use limit
+### Fair Use limit
 
-Each Flex Logs compute tier enforces a per-query fair use limit on the number of **addressable logs**. Addressable logs are the total number of logs (stored inside and outside of the Flex tier) that match a query's time range and index scope. This count includes all logs in matching indexes for that time range, regardless of other search filters such as tags or keywords.
+Each Flex Logs compute tier enforces a per-query Fair Use limit on the number of **addressable logs**. Addressable logs are the total number of logs (stored inside and outside of the Flex tier) that match a query's time range and index scope. This count includes all logs in matching indexes for that time range, regardless of other search filters such as tags or keywords.
 
 The addressable logs for a query are determined as follows:
 - If the query specifies an index (for example, `index:my-index`), only logs in that index within the query's time range count toward the limit.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes LOGSQ-1454

Documents Flex Logs fair use limits (per-query addressable logs limit) and the new fair use observability panel on the Flex Logs Controls page.

**Changes to `flex_logs.md`:**
- Defines "addressable logs" (total logs matching a query's time range and index scope)
- Adds new "Per-query addressable logs limit" subsection explaining the fair use limit behavior, how addressable logs are counted, and mitigation strategies
- Renames existing section to "When the concurrent query limit is reached" for clarity

**Changes to `flex_compute.md`:**
- Adds new "Monitoring fair use limits" section documenting the Compute Usage - Fair Use Limit panel (rejected queries timeseries, % by day, top sources)
- Reorganizes optimization recommendations into concurrent query and fair use subsections
- Screenshot placeholder added (`flex_compute_fair_use.png` — needs to be provided)

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

- Screenshot `static/images/logs/guide/flex_compute/flex_compute_fair_use.png` needs to be added before merge
- Backend: https://github.com/DataDog/logs-backend/pull/124934
- Frontend: https://github.com/DataDog/web-ui/pull/270639
- Design doc: https://datadoghq.atlassian.net/wiki/spaces/~879558607/pages/6134759514/Flex+Logs+-+Fair+Use+observability

🤖 Generated with [Claude Code](https://claude.com/claude-code)