### PR TITLE
[DOCS-13254] Add Queries and Databases tabs to Service Page doc

### DIFF
--- a/content/en/tracing/services/service_page.md
+++ b/content/en/tracing/services/service_page.md
@@ -207,10 +207,15 @@ The next section of the panel lists all the vulnerabilities and signals concerni
 {{< img src="tracing/visualization/service/security_tab_1.jpg" alt="Security" style="width:90%;">}}
 
 ### Databases
-View the list of downstream database dependencies identified by Database Monitoring and identify latency or load outliers.
-[Learn more about connecting DBM and APM][21].
+View host details, queries, recommendations, and downstream database dependencies, and identify latency and load outliers.
 
-{{< img src="tracing/visualization/service/databases_tab_1.png" alt="Databases" style="width:90%;">}}
+#### Queries
+The Queries tab includes a visualization of sampled span durations and a full list of queries from the selected time interval. Select a query from the table to open the query panel and view diagnostics, error details, and traces.
+
+#### Databases
+The Databases tab includes active connection and average query duration visualizations to help identify outliers, and a full list of database hosts for the selected service. Select a database host from the list to view it in Database Monitoring.
+
+[Learn more about connecting DBM and APM][21].
 
 ### Infrastructure
 If your service is running on Kubernetes, you can see an Infrastructure tab on the Service Page. The live Kubernetes Pods table displays detailed information on your pods, such as if memory usage is close to its limit, and allows you to improve resource allocation by seeing if provisioned compute resources exceed what is required for optimal application performance.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13254
https://datadoghq.atlassian.net/browse/DOCS-13254

Adds documentation for the newly available Queries and Databases tabs in the Databases section of the Service Page. The update includes:
- New Queries tab section explaining how to view span durations and query details
- New Databases tab section explaining how to view database hosts and identify outliers
- Updated intro text for the Databases section
- Removed outdated screenshot

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

This documents the new tab structure in the Databases section, providing users with clear guidance on how to access and use both the Queries tab (for query-level insights) and the Databases tab (for host-level insights).

🤖 Generated with [Claude Code](https://claude.com/claude-code)