### PR TITLE
Add WP for spur threat intelligence

### DIFF
--- a/content/en/security/threat_intelligence.md
+++ b/content/en/security/threat_intelligence.md
@@ -85,11 +85,11 @@ Sources, categories, and intents are available as facets and filters on relevant
 | Datadog Threat Research| scanners, Redis exploitation, Docker exploitation, malware, bruteforcer | Honeypots focused on software specific threats | AAP, CWS and Cloud SIEM |
 | [Datadog AAP](https://docs.datadoghq.com/security/application_security/) | scanner | List of IPs that have been observed attacking multiple AAP customers | AAP |
 | [Spur](https://spur.us/) | residential_proxy | Proxies associated credential stuffing and fraud | AAP and Cloud SIEM |
-| [Spur](https://spur.us/) | malware_proxy | Proxies associated with malware command and control | Cloud SIEM |
+| [Spur](https://spur.us/) | malware_proxy | Proxies associated with malware command and control | Cloud SIEM and Workload Protection |
 | [Abuse.ch](https://abuse.ch/) Malware Bazaar| malware | Malware on hosts | CWS |
 | [Minerstat](https://minerstat.com/mining-pool-whitelist.txt) | cryptomining | Coinminer activity with known mining pools| Workload Protection and Cloud SIEM |
 | Tor | tor | Policy violations for user activity | App and API Protection, Cloud SIEM, and Workload Protection |
-| [Threatfox](https://threatfox.abuse.ch/) | malware | Identify hosts communicating with known malware infrastructure | Cloud SIEM, and Workload Protection |
+| [Threatfox](https://threatfox.abuse.ch/) | malware | Identify hosts communicating with known malware infrastructure | Cloud SIEM and Workload Protection |
 
 
 ### Threat intelligence categories


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Spur threat intelligence tables are also used in Workload Protection.
Malwares are a primary case we want to cover with Workload Protection, so we want to highlight it in the documentation.

### Merge instructions

Merge readiness:
- [x] Ready for merge
