### PR TITLE
[AAP] Add custom Endpoint Authentication tagging documentation

### DIFF
--- a/content/en/security/application_security/api-inventory/_index.md
+++ b/content/en/security/application_security/api-inventory/_index.md
@@ -186,8 +186,7 @@ Custom authentication detection is possible by configuring [Endpoint Tagging Rul
 |Technology| Minimum tracer version |
 |----------|------------------------|
 |Java      | v1.55.0                |
-|.NET Core | Coming Soon            |
-|.NET Fx   | v2.47.0                |
+|.NET      | Coming Soon            |
 |Node.js   | v5.76.0                |
 |Python    | v3.17.0                |
 |Ruby      | v2.23.0                |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a minimum tracer versions table to the Endpoint authentication section in the API Security Inventory documentation, matching the format used elsewhere in the file.

### Merge instructions

Merge readiness:
- [x] Ready for merge
