### PR TITLE
[DOCS-12922] Link OpenTelemetry and DDSketch across metrics docs

### DIFF
--- a/content/en/metrics/distributions.md
+++ b/content/en/metrics/distributions.md
@@ -8,12 +8,17 @@ further_reading:
   - link: "/metrics/custom_metrics/dogstatsd_metrics_submission/"
     tag: "Documentation"
     text: "Using Distributions in DogStatsD"
+  - link: "/metrics/open_telemetry/otlp_metric_types/"
+    tag: "Documentation"
+    text: "OTLP Metric Types"
 ---
 ## Overview
 
 Distributions are a metric type that aggregate values sent from multiple hosts during a flush interval to measure statistical distributions across your entire infrastructure.
 
-Global distributions instrument logical objects, like services, independently from the underlying hosts. Unlike [histograms][1] which aggregate on the Agent-side, global distributions send all raw data collected during the flush interval and the aggregation occurs server-side using Datadog's [DDSketch data structure][2]. 
+Global distributions instrument logical objects, like services, independently from the underlying hosts. Unlike [histograms][1] which aggregate on the Agent-side, global distributions send all raw data collected during the flush interval and the aggregation occurs server-side using Datadog's [DDSketch data structure][2].
+
+If you use OpenTelemetry, OTLP Histogram metrics are mapped to Datadog distributions by default. See [OTLP Metric Types][5] for details on this mapping and available configuration options.
 
 Distributions provide enhanced query functionality and configuration options that aren't offered with other metric types (count, rate, gauge, histogram):
 * **Calculation of percentile aggregations**: Distributions are stored as DDSketch data structures that represent raw, unaggregated data such that globally accurate percentile aggregations (p50, p75, p90, p95, p99 or any percentile of your choosing with up to two decimal points) can be calculated across the raw data from all your hosts. Enabling percentile aggregations can unlock advanced query functionalities such as: 
@@ -130,3 +135,4 @@ https://app.datadoghq.com/event/stream?tags_execution=and&per_page=30&query=tags
 [2]: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/
 [3]: https://app.datadoghq.com/event/explorer
 [4]: https://app.datadoghq.com/metric/summary
+[5]: /metrics/open_telemetry/otlp_metric_types/

--- a/content/en/metrics/open_telemetry/otlp_metric_types.md
+++ b/content/en/metrics/open_telemetry/otlp_metric_types.md
@@ -75,6 +75,8 @@ The default mapping is as follows:
 
 **Note**: Histogram metrics in OTLP are mapped by default to Distribution metrics. Because of how OTLP sends this data, percentile aggregations and the max and min (if not available on the original OTLP data) are approximations, not accurate calculations.
 
+Datadog distributions are powered by the [DDSketch data structure][4]. See [Distributions][5] for details on enabling percentile aggregations and threshold queries on your mapped metrics.
+
 The Datadog Agent and the OpenTelemetry Collector Datadog exporter allow changing the Histogram export in the `histogram` subsection.
 - If the `mode` is set to `counters`, the following metrics are produced:
 
@@ -217,3 +219,5 @@ Suppose you are submitting a legacy OTLP Summary metric, `request.response_time.
 [1]: /opentelemetry/schema_semantics/hostname/
 [2]: https://opentelemetry.io/docs/reference/specification/metrics/data-model/#temporality
 [3]: /opentelemetry/guide/otlp_delta_temporality/
+[4]: https://www.datadoghq.com/blog/engineering/computing-accurate-percentiles-with-ddsketch/
+[5]: /metrics/distributions/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-12922

A user on the Distributions page asked how to support DDSketch for OpenTelemetry. The connection between OTLP Histograms → Datadog Distributions → DDSketch wasn't documented anywhere. This PR adds bidirectional cross-references:

- **Distributions page**: Added a paragraph noting that OTLP Histograms map to distributions, with a link to the OTLP Metric Types page. Added OTLP Metric Types to further reading.
- **OTLP Metric Types page**: Added a paragraph in the Histogram section explaining that distributions are powered by DDSketch, with links to the DDSketch blog post and the Distributions page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes