### PR TITLE
[DOCS-12780] Rephrase DogStatsD non-local traffic setup step

### DIFF
--- a/content/en/tracing/metrics/runtime_metrics/_index.md
+++ b/content/en/tracing/metrics/runtime_metrics/_index.md
@@ -125,7 +125,7 @@ Enable [DogStatsD for the Agent][2]. By default, the Datadog Agent is configured
 
 When running the Agent in containerized environments, additional configuration is required:
 
-1. Set `dogstatsd_non_local_traffic: true` in your main [`datadog.yaml` configuration file][8], or set the [environment variable][3] `DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true`. **Note**: DogStatsD non‑local traffic is enabled by default, so you only need to set this if you've overridden it.
+1. Verify that DogStatsD non-local traffic is enabled. This setting is enabled by default. If you have previously disabled it, set `dogstatsd_non_local_traffic: true` in your main [`datadog.yaml` configuration file][8], or set the [environment variable][3] `DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true`.
 2. Follow these container-specific setup instructions:
 
 {{< partial name="apm/apm-runtime-metrics-containers.html" >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-12780

A user reported that the container-specific DogStatsD setup instruction was misleading — it tells you to enable a setting, then notes it's already enabled by default. This PR rephrases the step to lead with verification ("Verify that DogStatsD non-local traffic is enabled") and only instructs users to act if they've previously overridden the default.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes