### PR TITLE
[DOCS-12772] Clarify that profiler enable step offers alternative approaches

### DIFF
--- a/content/en/profiler/enabling/nodejs.md
+++ b/content/en/profiler/enabling/nodejs.md
@@ -37,7 +37,7 @@ To begin profiling applications:
 
 2. Run `npm install --save dd-trace@latest` to add a dependency on the `dd-trace` module which includes the profiler.
 
-3. Enable the profiler:
+3. Enable the profiler using **one** of the following approaches:
 
    {{< tabs >}}
 {{% tab "Environment variables" %}}

--- a/content/en/profiler/enabling/ruby.md
+++ b/content/en/profiler/enabling/ruby.md
@@ -54,7 +54,7 @@ To begin profiling applications:
     ```
 3. Install the gems with `bundle install`.
 
-4. Enable the profiler:
+4. Enable the profiler using **one** of the following approaches:
 
    {{< tabs >}}
 {{% tab "Environment variables" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-12772

A user was confused whether they needed to do both environment variables and in-code setup for the Node.js profiler. The step said "Enable the profiler:" with tabs but didn't clarify these are alternatives. Changed to "Enable the profiler using **one** of the following approaches:" on both the Node.js and Ruby profiler pages (which had the same wording).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)