### PR TITLE
[DOCS-13285] Add Integration column to NDM Supported Devices table

### DIFF
--- a/content/en/network_monitoring/devices/supported_devices.md
+++ b/content/en/network_monitoring/devices/supported_devices.md
@@ -13,12 +13,10 @@ further_reading:
 
 multifiltersearch:
   headers:
-    - name: Vendor
+    - name: Vendor/Integration
       id: vendor
     - name: Config Files
       id: config_files
-    - name: Integration
-      id: integration
   data:
     - vendor: 3com
       config_files: '[3com.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/3com.yaml) <br> [3com-huawei.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/3com-huawei.yaml)'
@@ -32,12 +30,10 @@ multifiltersearch:
       config_files: '[anue.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/anue.yaml)'
     - vendor: APC
       config_files: '[_apc.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_apc.yaml) <br> [apc_ups.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/apc_ups.yaml) <br> [_apc-metadata.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_apc-metadata.yaml)'
-    - vendor: Arista
+    - vendor: '[Arista](https://docs.datadoghq.com/integrations/snmp_arista/)'
       config_files: '[arista.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/arista.yaml) <br> [_arista.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_arista.yaml)'
-      integration: '[Arista](https://docs.datadoghq.com/integrations/snmp_arista/)'
-    - vendor: Aruba
+    - vendor: '[Aruba](https://docs.datadoghq.com/integrations/snmp_aruba/)'
       config_files: '[aruba-switch.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/aruba-switch.yaml) <br> [_aruba-base.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_aruba-base.yaml) <br> [aruba-access-point.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/aruba-access-point.yaml) <br> [aruba.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/aruba.yaml)'
-      integration: '[Aruba](https://docs.datadoghq.com/integrations/snmp_aruba/)'
     - vendor: Audiocodes
       config_files: '[audiocodes-mediant-sbc.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/audiocodes-mediant-sbc.yaml)'
     - vendor: Avaya
@@ -46,42 +42,38 @@ multifiltersearch:
       config_files: '[avocent-acs.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/avocent-acs.yaml)'
     - vendor: Avtech
       config_files: '[avtech.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/avtech.yaml)'
-    - vendor: Barracuda
+    - vendor: '[Barracuda](https://docs.datadoghq.com/integrations/crest_data_systems_barracuda_waf/)'
       config_files: '[barracuda.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/barracuda.yaml)'
-      integration: '[Barracuda](https://docs.datadoghq.com/integrations/crest_data_systems_barracuda_waf/)'
     - vendor: BlueCat
       config_files: '[bluecat-server.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/bluecat-server.yaml)'
     - vendor: Brocade
       config_files: '[brocade.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/brocade.yaml)'
     - vendor: Brother
       config_files: '[brother.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/brother.yaml)'
-    - vendor: Chatsworth
+    - vendor: '[Chatsworth](https://docs.datadoghq.com/integrations/snmp_chatsworth_products/)'
       config_files: '[chatsworth_pdu.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/chatsworth_pdu.yaml)'
-      integration: '[Chatsworth](https://docs.datadoghq.com/integrations/snmp_chatsworth_products/)'
     - vendor: Checkpoint
       config_files: '[checkpoint.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/checkpoint.yaml) <br> [checkpoint-firewall.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/checkpoint-firewall.yaml)'
     - vendor: Chrysalis
       config_files: '[chrysalis.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/chrysalis.yaml)'
-    - vendor: Cisco
+    - vendor: '[Cisco](https://docs.datadoghq.com/integrations/snmp_cisco/)'
       config_files: '[cisco-3850.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-3850.yaml) <br> [cisco-csr1000v.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-csr1000v.yaml) <br> [_cisco-metadata.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_cisco-metadata.yaml) <br> [cisco_uc_virtual_machine.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco_uc_virtual_machine.yaml) <br> [_cisco-voice.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_cisco-voice.yaml)'
-      integration: '[Cisco](https://docs.datadoghq.com/integrations/snmp_cisco/)'
-    - vendor: Cisco ACI
+    - vendor: '[Cisco ACI](https://docs.datadoghq.com/integrations/cisco_aci/)'
       config_files: '[cisco-aci.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-aci.yaml)'
-      integration: '[Cisco ACI](https://docs.datadoghq.com/integrations/cisco_aci/)'
-    - vendor: Cisco ASA
+    - vendor: '[Cisco ASA](https://docs.datadoghq.com/integrations/crest_data_systems_cisco_asa/)'
       config_files: '[cisco-asa.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-asa.yaml) <br> [cisco-asa-5525.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-asa-5525.yaml)'
-      integration: '[Cisco ASA](https://docs.datadoghq.com/integrations/crest_data_systems_cisco_asa/)'
     - vendor: Cisco ASR
       config_files: '[cisco-asr.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-asr.yaml)'
     - vendor: Cisco Catalyst
       config_files: '[cisco-catalyst.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-catalyst.yaml) <br> [cisco-catalyst-wlc.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-catalyst-wlc.yaml)'
     - vendor: Cisco ICM
       config_files: '[cisco_icm.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco_icm.yaml)'
-    - vendor: Cisco ISE
+    - vendor: '[Cisco ISE](https://docs.datadoghq.com/integrations/crest_data_systems_cisco_ise/)'
       config_files: '[cisco-ise.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-ise.yaml)'
-      integration: '[Cisco ISE](https://docs.datadoghq.com/integrations/crest_data_systems_cisco_ise/)'
     - vendor: Cisco ISR
       config_files: '[cisco-isr.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-isr.yaml) <br> [cisco_isr_4431.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco_isr_4431.yaml)'
+    - vendor: '[Cisco Meraki](https://docs.datadoghq.com/integrations/meraki/)'
+      config_files: '[meraki-cloud-controller.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/meraki-cloud-controller.yaml) <br> [meraki.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/meraki.yaml)'
     - vendor: Cisco Nexus
       config_files: '[cisco-nexus.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cisco-nexus.yaml)'
     - vendor: Cisco SB
@@ -96,9 +88,8 @@ multifiltersearch:
       config_files: '[cradlepoint.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cradlepoint.yaml)'
     - vendor: Cyberpower
       config_files: '[cyberpower-pdu.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/cyberpower-pdu.yaml)'
-    - vendor: Dell
+    - vendor: '[Dell](https://docs.datadoghq.com/integrations/snmp_dell/)'
       config_files: '[dell-poweredge.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/dell-poweredge.yaml) <br> [_dell.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_dell.yaml) <br> [idrac.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/idrac.yaml) <br> [isilon.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/isilon.yaml)'
-      integration: '[Dell](https://docs.datadoghq.com/integrations/snmp_dell/)'
     - vendor: Dialogic
       config_files: '[dialogic-media-gateway.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/dialogic-media-gateway.yaml)'
     - vendor: D-Link
@@ -109,19 +100,16 @@ multifiltersearch:
       config_files: '[exagrid.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/exagrid.yaml)'
     - vendor: Extreme Networks
       config_files: '[extreme-switching.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/extreme-switching.yaml)'
-    - vendor: F5
+    - vendor: '[F5](https://docs.datadoghq.com/integrations/snmp_f5/)'
       config_files: '[f5-big-ip.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/f5-big-ip.yaml)'
-      integration: '[F5](https://docs.datadoghq.com/integrations/snmp_f5/)'
     - vendor: FireEye
       config_files: '[fireeye.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/fireeye.yaml)'
-    - vendor: Fortinet
+    - vendor: '[Fortinet](https://docs.datadoghq.com/integrations/snmp_fortinet/)'
       config_files: '[fortinet.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/fortinet.yaml) <br> [fortinet-fortigate.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/fortinet-fortigate.yaml)'
-      integration: '[Fortinet](https://docs.datadoghq.com/integrations/snmp_fortinet/)'
     - vendor: Gigamon
       config_files: '[gigamon.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/gigamon.yaml)'
-    - vendor: HP
+    - vendor: '[HP](https://docs.datadoghq.com/integrations/snmp_hewlett_packard_enterprise/)'
       config_files: '[hp-ilo.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/hp-ilo.yaml) <br> [_hp.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_hp.yaml) <br> [hpe-proliant.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/hpe-proliant.yaml)'
-      integration: '[HP](https://docs.datadoghq.com/integrations/snmp_hewlett_packard_enterprise/)'
     - vendor: Huawei
       config_files: '[huawei.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/huawei.yaml)'
     - vendor: iXsystems
@@ -130,19 +118,14 @@ multifiltersearch:
       config_files: '[ibm.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/ibm.yaml)'
     - vendor: Infinera
       config_files: '[infinera-coriant-groove.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/infinera-coriant-groove.yaml)'
-    - vendor: Infoblox
+    - vendor: '[Infoblox](https://docs.datadoghq.com/integrations/rapdev_infoblox/)'
       config_files: '[infoblox-ipam.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/infoblox-ipam.yaml)'
-      integration: '[Infoblox](https://docs.datadoghq.com/integrations/rapdev_infoblox/)'
-    - vendor: Juniper Networks
+    - vendor: '[Juniper Networks](https://docs.datadoghq.com/integrations/snmp_juniper/)'
       config_files: '[juniper.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/juniper.yaml) <br> [juniper-ex.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/juniper-ex.yaml) <br> [_juniper-junos-generic.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_juniper-junos-generic.yaml) <br> [juniper-mx.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/juniper-mx.yaml)'
-      integration: '[Juniper Networks](https://docs.datadoghq.com/integrations/snmp_juniper/)'
     - vendor: Linksys
       config_files: '[linksys.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/linksys.yaml)'
     - vendor: McAfee
       config_files: '[mcafee-web-gateway.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/mcafee-web-gateway.yaml)'
-    - vendor: Meraki
-      config_files: '[meraki-cloud-controller.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/meraki-cloud-controller.yaml) <br> [meraki.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/meraki.yaml)'
-      integration: '[Meraki](https://docs.datadoghq.com/integrations/meraki/)'
     - vendor: Mikrotik
       config_files: '[mikrotik-router.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/mikrotik-router.yaml)'
     - vendor: Nasuni
@@ -159,14 +142,12 @@ multifiltersearch:
       config_files: '[omron-cj-ethernet-ip.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/omron-cj-ethernet-ip.yaml)'
     - vendor: Opengear
       config_files: '[_opengear.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/_opengear.yaml)'
-    - vendor: Palo Alto Networks
+    - vendor: '[Palo Alto Networks](https://docs.datadoghq.com/integrations/pan_firewall/)'
       config_files: '[palo-alto.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/palo-alto.yaml) <br> [palo-alto-base.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/palo-alto-base.yaml)'
-      integration: '[Palo Alto Networks](https://docs.datadoghq.com/integrations/pan_firewall/)'
     - vendor: Peplink
       config_files: '[peplink.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/peplink.yaml)'
-    - vendor: pfSense
+    - vendor: '[pfSense](https://docs.datadoghq.com/integrations/crest_data_systems_pfsense/)'
       config_files: '[pf-sense.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/pf-sense.yaml)'
-      integration: '[pfSense](https://docs.datadoghq.com/integrations/crest_data_systems_pfsense/)'
     - vendor: Raritan
       config_files: '[raritan-dominion.yaml](https://github.com/DataDog/integrations-core/blob/master/snmp/datadog_checks/snmp/data/default_profiles/raritan-dominion.yaml)'
     - vendor: Riverbed
@@ -215,9 +196,10 @@ The [generic profile][114] collects metrics for all devices not supported by a v
 
 ### Vendor profiles
 
-The following vendor devices are supported with dedicated profiles. Some vendors provide dedicated integration pages with additional setup instructions, dashboards, and enhanced monitoring capabilities. All vendors provide SNMP profile configuration files that define which metrics to collect from devices.
+The following vendor devices are supported with dedicated profiles.
 If a vendor or device type isn't listed, see the [Troubleshooting](#troubleshooting) section below.
 
+**Note**: Vendors with links in the **Vendor/Integration** column have dedicated integration pages with additional setup instructions, dashboards, and enhanced monitoring capabilities. All listed vendors are supported through SNMP with the configuration files shown in the **Config files** column.
 
 {{< multifilter-search >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13285

This PR enhances the NDM Supported Devices page by adding a dedicated "Integration" column to the table. Previously, some vendors had integration links embedded in their vendor names, making it unclear which vendors have additional integration support beyond SNMP profiles.

Changes include:
- Added new "Integration" column to the supported devices table
- Cleaned up vendor names by removing embedded integration links
- Added 17 vendors with dedicated integration links to the new column
- Added explanatory note differentiating between Config files (SNMP profiles) and Integration pages (dedicated integration support with dashboards and enhanced capabilities)

This makes it easier for users to discover which vendors have both SNMP profiles and dedicated integrations available.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The Integration column is only populated for vendors that have dedicated integration pages. All vendors listed have SNMP profile support via the Config Files column.