### PR TITLE
[DOCS-13311] Update US1-FED support portal link

### DIFF
--- a/content/en/account_management/guide/access-your-support-ticket.md
+++ b/content/en/account_management/guide/access-your-support-ticket.md
@@ -16,7 +16,7 @@ To create a new support ticket, click on the appropriate Site link and click **S
 
 {{< whatsnext desc="Support page by Datadog site:">}}
     {{< nextlink href="https://help.datadoghq.com/" >}} US1, US3, US5, EU, AP1, AP2 {{< /nextlink >}}
-    {{< nextlink href="http://help.ddog-gov.com/" >}}US1-FED{{< /nextlink >}}
+    {{< nextlink href="https://govsupport.ddog-gov.com/" >}}US1-FED{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< img src="/account_management/guide/access_your_support_ticket/support_page.png" alt="Datadog Support landing page" style="width:100%;" >}}
@@ -40,7 +40,7 @@ If you have opened at least one Datadog support ticket, follow this process to a
 
 {{< whatsnext desc="Support Page by Datadog Site:">}}
     {{< nextlink href="https://help.datadoghq.com/" >}} US1, US3, US5, EU, AP1, AP2 {{< /nextlink >}}
-    {{< nextlink href="http://help.ddog-gov.com/" >}}US1-FED{{< /nextlink >}}
+    {{< nextlink href="https://govsupport.ddog-gov.com/" >}}US1-FED{{< /nextlink >}}
 {{< /whatsnext >}}
 
 ## Password requirements


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13311

Updated the support portal link for US1-FED from `http://help.ddog-gov.com/` to `https://govsupport.ddog-gov.com/` in two locations on the [Access Your Support Ticket](https://docs.datadoghq.com/account_management/guide/access-your-support-ticket/) page.

The old link is no longer valid. The new link matches what's documented on the [Datadog GovCloud Support Terms](https://www.datadoghq.com/legal/datadog-govcloud-support-terms/) page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Changes made:
- Line 19: Updated support page link in "Creating a support ticket" section
- Line 43: Updated support page link in "Accessing existing tickets" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)