### PR TITLE
[DOCS-13238] Document Kubernetes headless service

### DIFF
--- a/content/en/observability_pipelines/configuration/install_the_worker/_index.md
+++ b/content/en/observability_pipelines/configuration/install_the_worker/_index.md
@@ -159,6 +159,15 @@ See [Update Existing Pipelines][2] if you want to make changes to your pipeline'
 
 **Note**: If you enable [disk buffering][6] for destinations, you must enable Kubernetes [persistent volumes][7] in the Observability Pipelines helm chart.
 
+#### Kubernetes services
+
+When you install the Observability Pipelines Worker on Kubernetes, the Helm chart creates two services:
+
+- **Headless service**: Provides stable DNS names per pod and direct Pod IP resolution without load balancing. This service is for the Worker itself and is not intended for end users.
+- **Load balancer service**: Provides load balancing for both internal and external cluster communications.
+
+**Use the load balancer service** (non-headless service) to send logs to the Observability Pipelines Worker.
+
 #### Self-hosted and self-managed Kubernetes clusters
 
 If you are running a self-hosted and self-managed Kubernetes cluster, and defined zones with node labels using `topology.kubernetes.io/zone`, then you can use the Helm chart values file as is. However, if you are not using the label `topology.kubernetes.io/zone`, you need to update the `topologyKey` in the `values.yaml` file to match the key you are using. Or if you run your Kubernetes install without zones, remove the entire `topology.kubernetes.io/zone` section.
@@ -344,6 +353,15 @@ The Observability Pipelines Worker supports all major Kubernetes distributions, 
 See [Update Existing Pipelines][2] if you want to make changes to your pipeline's configuration.
 
 **Note**: If you enable [disk buffering][5] for destinations, you must enable Kubernetes [persistent volumes][6] in the Observability Pipelines helm chart.
+
+#### Kubernetes services
+
+When you install the Observability Pipelines Worker on Kubernetes, the Helm chart creates two services:
+
+- **Headless service**: Provides stable DNS names per pod and direct Pod IP resolution without load balancing. This service is for the Worker itself and is not intended for end users.
+- **Load balancer service**: Provides load balancing for both internal and external cluster communications.
+
+**Use the load balancer service** (non-headless service) to send logs to the Observability Pipelines Worker.
 
 #### Self-hosted and self-managed Kubernetes clusters
 

--- a/layouts/shortcodes/observability_pipelines/install_worker/amazon_eks.en.md
+++ b/layouts/shortcodes/observability_pipelines/install_worker/amazon_eks.en.md
@@ -27,5 +27,14 @@
 
 See [Update Existing Pipelines][602] if you want to make changes to your pipeline's configuration.
 
+#### Kubernetes services
+
+When you install the Observability Pipelines Worker on Kubernetes, the Helm chart creates two services:
+
+- **Headless service**: Provides stable DNS names per pod and direct Pod IP resolution without load balancing. This service is for the Worker itself and is not intended for end users.
+- **Load balancer service**: Provides load balancing for both internal and external cluster communications.
+
+**Use the load balancer service** (non-headless service) to send logs to the Observability Pipelines Worker.
+
 [601]: /resources/yaml/observability_pipelines/v2/setup/aws_eks.yaml
 [602]: /observability_pipelines/configuration/update_existing_pipelines

--- a/layouts/shortcodes/observability_pipelines/install_worker/azure_aks.en.md
+++ b/layouts/shortcodes/observability_pipelines/install_worker/azure_aks.en.md
@@ -27,5 +27,14 @@
 
 See [Update Existing Pipelines][702] if you want to make changes to your pipeline's configuration.
 
+#### Kubernetes services
+
+When you install the Observability Pipelines Worker on Kubernetes, the Helm chart creates two services:
+
+- **Headless service**: Provides stable DNS names per pod and direct Pod IP resolution without load balancing. This service is for the Worker itself and is not intended for end users.
+- **Load balancer service**: Provides load balancing for both internal and external cluster communications.
+
+**Use the load balancer service** (non-headless service) to send logs to the Observability Pipelines Worker.
+
 [701]: /resources/yaml/observability_pipelines/v2/setup/azure_aks.yaml
 [702]: /observability_pipelines/configuration/update_existing_pipelines

--- a/layouts/shortcodes/observability_pipelines/install_worker/google_gke.en.md
+++ b/layouts/shortcodes/observability_pipelines/install_worker/google_gke.en.md
@@ -27,5 +27,14 @@
 
 See [Update Existing Pipelines][802] if you want to make changes to your pipeline's configuration.
 
+#### Kubernetes services
+
+When you install the Observability Pipelines Worker on Kubernetes, the Helm chart creates two services:
+
+- **Headless service**: Provides stable DNS names per pod and direct Pod IP resolution without load balancing. This service is for the Worker itself and is not intended for end users.
+- **Load balancer service**: Provides load balancing for both internal and external cluster communications.
+
+**Use the load balancer service** (non-headless service) to send logs to the Observability Pipelines Worker.
+
 [801]: /resources/yaml/observability_pipelines/v2/setup/google_gke.yaml
 [802]: /observability_pipelines/configuration/update_existing_pipelines

--- a/layouts/shortcodes/observability_pipelines/install_worker/kubernetes.md
+++ b/layouts/shortcodes/observability_pipelines/install_worker/kubernetes.md
@@ -39,6 +39,15 @@ See [Update Existing Pipelines][602] if you want to make changes to your pipelin
 
 **Note**: If you enable [disk buffering][605] for destinations, you must enable Kubernetes [persistent volumes][606] in the Observability Pipelines helm chart .
 
+#### Kubernetes services
+
+When you install the Observability Pipelines Worker on Kubernetes, the Helm chart creates two services:
+
+- **Headless service**: Provides stable DNS names per pod and direct Pod IP resolution without load balancing. This service is for the Worker itself and is not intended for end users.
+- **Load balancer service**: Provides load balancing for both internal and external cluster communications.
+
+**Use the load balancer service** (non-headless service) to send logs to the Observability Pipelines Worker.
+
 #### Self-hosted and self-managed Kubernetes clusters
 
 If you are running a self-hosted and self-managed Kubernetes cluster, and defined zones with node labels using `topology.kubernetes.io/zone`, then you can use the Helm chart values file as is. However, if you are not using the label `topology.kubernetes.io/zone`, you need to update the `topologyKey` in the `values.yaml` file to match the key you are using. Or if you run your Kubernetes install without zones, remove the entire `topology.kubernetes.io/zone` section.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13238

This PR adds documentation explaining the two Kubernetes services created by the Helm chart when deploying Observability Pipelines Worker:
- **Headless service**: Provides stable DNS names per pod and direct Pod IP resolution without load balancing. For the Worker itself, not for end users.
- **Load balancer service**: Provides load balancing for both internal and external cluster communications.

The documentation clarifies that users should use the load balancer service (non-headless) to send logs to the Observability Pipelines Worker.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

This documentation was added to the following files:
- Main Kubernetes installation page (both API/Terraform and Pipeline UI sections)
- Kubernetes shortcodes (generic, Azure AKS, Amazon EKS, Google GKE)