### PR TITLE
Update DI pages to Limited Availability

### DIFF
--- a/content/en/tracing/trace_collection/dynamic_instrumentation/enabling/php.md
+++ b/content/en/tracing/trace_collection/dynamic_instrumentation/enabling/php.md
@@ -13,6 +13,8 @@ further_reading:
       text: 'Getting Started with Datadog Agent'
 ---
 
+{{< partial name="dynamic_instrumentation/beta-callout.html" language="PHP" limitations_anchor="unsupported-features" >}}
+
 Dynamic Instrumentation is a feature provided by the Datadog tracing library. If you are already using [APM to collect traces][1] for your application, ensure your Agent and tracing library are on the required version. Then, go directly to enabling Dynamic Instrumentation in step 4.
 
 ## Installation

--- a/layouts/partials/dynamic_instrumentation/beta-callout.html
+++ b/layouts/partials/dynamic_instrumentation/beta-callout.html
@@ -2,11 +2,11 @@
 {{- $limitations_anchor := .Get "limitations_anchor" -}}
 <div class="card callout-card mb-4">
     <div class="card-body d-flex flex-column">
-        <h5 class="card-title text-black mt-0 mb-1">Join the Preview</h5>
+        <h5 class="card-title text-black mt-0 mb-1">Limited Availability</h5>
         <p class="card-text">
-            Dynamic Instrumentation for {{ $language }} is in limited preview and may not be available for your organization.
+            Dynamic Instrumentation for {{ $language }} is in Limited Availability and may not be available for your organization.
             Request access to join the waiting list.<br>
-            <b>Note</b>: <a href="#{{ $limitations_anchor }}">Some limitations</a> apply to the preview.
+            <b>Note</b>: <a href="#{{ $limitations_anchor }}">Some limitations</a> apply.
         </p>
         <a href="https://www.datadoghq.com/product-preview/live-debugger/"
             target="_blank"

--- a/layouts/partials/dynamic_instrumentation/dynamic-instrumentation-languages.html
+++ b/layouts/partials/dynamic_instrumentation/dynamic-instrumentation-languages.html
@@ -40,14 +40,14 @@
       <div class="col">
         <a class="card h-100" href="/dynamic_instrumentation/enabling/ruby">
           <div class="card-body text-center py-2 px-1">
-            {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby-preview.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
         <a class="card h-100" href="/dynamic_instrumentation/enabling/php">
           <div class="card-body text-center py-2 px-1">
-            {{ partial "img.html" (dict "root" . "src" "integrations_logos/php-preview.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
+            {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This pull request updates the documentation and UI for Dynamic Instrumentation. The changes clarify that Live Debugger for PHP/Go/Ruby is in "Limited Availability" rather than "preview," and update the preview callout and language logos to remove "preview" references.

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
