### PR TITLE
[DOCS-13281] Change URL from /service_override_removal/ to /integration_override_removal/

### DIFF
--- a/content/en/tracing/services/integration_override_removal.md
+++ b/content/en/tracing/services/integration_override_removal.md
@@ -3,6 +3,8 @@ title: Integration Override Removal
 description: Learn how to remove integration overrides from Datadog.
 disable_toc: false
 site_support_id: service_override_removal
+aliases:
+- /tracing/services/service_override_removal/
 further_reading:
 - link: "/tracing/guide/service_overrides"
   tag: "Documentation"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13281

Changes the URL for the integration override removal documentation page from `/tracing/services/service_override_removal/` to `/tracing/services/integration_override_removal/` to reflect the feature's rename from "service override removal" to "integration override removal".

Changes made:
- Renamed the markdown file from `service_override_removal.md` to `integration_override_removal.md`
- Added an alias to preserve the old URL as a redirect

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The old URL will continue to work via the alias redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)