### PR TITLE
[DOCS-13214] Fix broken "Send a Page" link

### DIFF
--- a/content/en/incident_response/on-call/teams.md
+++ b/content/en/incident_response/on-call/teams.md
@@ -55,5 +55,5 @@ Ensure that your On-Call Team members have set up their [Profile Settings][8].
 [4]: https://app.datadoghq.com/on-call/
 [5]: /incident_response/on-call/escalation_policies
 [6]: /incident_response/on-call/schedules
-[7]: /incident_response/on-call/pages
+[7]: /incident_response/on-call/triggering_pages/
 [8]: /incident_response/on-call/profile_settings


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13214

Fixed a broken link in the On-Call Teams documentation. The "Send a Page" link in the Next Steps section was pointing to a non-existent URL (`/incident_response/on-call/pages`) and now correctly points to `/incident_response/on-call/triggering_pages/`.

This was reported via Hotjar feedback.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Single line fix to correct a 404 link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)