### PR TITLE
[DOCS-12823] Add documentation for controlling Error Tracking ingestion

### DIFF
--- a/content/en/tracing/error_tracking/_index.md
+++ b/content/en/tracing/error_tracking/_index.md
@@ -44,12 +44,12 @@ Error Tracking computes a fingerprint for each error span it processes using the
 
 ## Control which errors are tracked
 
-While Error Tracking automatically processes all error spans, you can control which errors are ingested and how they are managed:
+Error Tracking automatically processes all error spans, but you can control which errors are ingested and how they are managed:
 
 - **Filter errors with inclusion and exclusion rules**: Define rules to include or exclude errors based on attributes such as service, environment, or error type. See [Manage Data Collection][7].
 - **Set rate limits**: Control the volume of errors ingested per day to manage costs. See [Manage Data Collection][7].
 - **Exclude specific issues**: Mark recurring non-actionable issues as `EXCLUDED` to stop collecting them. See [Issue States][8].
-- **Filter entire traces**: To prevent traces from being sent to Datadog (rather than filtering errors), see [Ignoring Unwanted Resources in APM][9].
+- **Filter entire traces**: Prevent traces from being sent to Datadog (rather than filtering errors). See [Ignoring Unwanted Resources in APM][9].
 
 ## Examine issues to start troubleshooting or debugging
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-12823

This PR addresses user feedback from a Hotjar survey about the APM Error Tracking page being "too complicated or unclear." The user complained that all exceptions in their Python app result in "Issues" in Datadog, and they couldn't find documentation on how to prevent every exception from becoming an Issue.

**Changes:**
- Added a new "Control which errors are tracked" section to the Error Tracking landing page
- Links to existing documentation rather than duplicating content:
  - Manage Data Collection (for inclusion/exclusion rules and rate limits)
  - Issue States (for EXCLUDED status)
  - Ignoring Unwanted Resources (for trace-level filtering)

**Why this helps:**
The documentation for controlling error ingestion exists but wasn't linked from the main Error Tracking page. Users experiencing "too many errors" couldn't discover the solution. This update makes that documentation discoverable.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The existing documentation in `/error_tracking/manage_data_collection/` already covers everything needed - this PR just adds discoverability by linking to it from the APM Error Tracking landing page.