### PR TITLE
Add PHP Feature Flags documentation

### DIFF
--- a/content/en/feature_flags/server/php.md
+++ b/content/en/feature_flags/server/php.md
@@ -1,0 +1,210 @@
+---
+title: PHP Feature Flags
+description: Set up Datadog Feature Flags for PHP applications.
+further_reading:
+- link: "/feature_flags/server/"
+  tag: "Documentation"
+  text: "Server-Side Feature Flags"
+- link: "/tracing/trace_collection/dd_libraries/php/"
+  tag: "Documentation"
+  text: "PHP Tracing"
+---
+
+## Overview
+
+This page describes how to instrument your PHP application with the Datadog Feature Flags SDK. The PHP SDK integrates with [OpenFeature][1], an open standard for feature flag management, and uses the Datadog tracer's Remote Configuration to receive flag updates in real time.
+
+This guide explains how to install and enable the SDK, create an OpenFeature client, and evaluate feature flags in your application.
+
+## Prerequisites
+
+Before setting up the PHP Feature Flags SDK, ensure you have:
+
+- **Datadog Agent** with [Remote Configuration][2] enabled
+- **Datadog PHP tracer** `ddtrace` version 1.16.0 or later
+- **OpenFeature PHP SDK** `open-feature/sdk` version 2.0 or later
+
+Set the following environment variables:
+
+{{< code-block lang="bash" >}}
+# Required: Enable the feature flags provider
+export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+
+# Required: Service identification
+export DD_SERVICE=<YOUR_SERVICE_NAME>
+export DD_ENV=<YOUR_ENVIRONMENT>
+{{< /code-block >}}
+
+## Installation
+
+Install the Datadog PHP tracer and OpenFeature SDK:
+
+{{< code-block lang="bash" >}}
+# Install the Datadog PHP tracer
+php datadog-setup.php --php-bin=all
+
+# Install the OpenFeature SDK
+composer require open-feature/sdk
+{{< /code-block >}}
+
+Or add the OpenFeature SDK to your `composer.json`:
+
+{{< code-block lang="json" filename="composer.json" >}}
+{
+    "require": {
+        "open-feature/sdk": "^2.0"
+    }
+}
+{{< /code-block >}}
+
+## Initialize the SDK
+
+Register the Datadog OpenFeature provider with the OpenFeature API. The provider connects to the Datadog tracer's Remote Configuration system to receive flag configurations.
+
+{{< code-block lang="php" >}}
+<?php
+
+use OpenFeature\API;
+use DDTrace\OpenFeature\DataDogProvider;
+
+// Create and register the Datadog provider
+$provider = new DataDogProvider();
+API::setProvider($provider);
+
+// Create an OpenFeature client
+$client = API::getClient();
+
+// Your application code here
+{{< /code-block >}}
+
+## Set the evaluation context
+
+Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
+
+{{< code-block lang="php" >}}
+use OpenFeature\implementation\flags\EvaluationContext;
+use OpenFeature\implementation\flags\Attributes;
+
+$context = new EvaluationContext(
+    'user-123',  // Targeting key (typically user ID)
+    new Attributes([
+        'email' => 'user@example.com',
+        'country' => 'US',
+        'tier' => 'premium',
+        'age' => 25,
+    ])
+);
+{{< /code-block >}}
+
+The targeting key is used for consistent traffic distribution (percentage rollouts). Additional attributes enable targeting rules, such as "enable for users in the US" or "enable for premium tier users" in the example above.
+
+## Evaluate flags
+
+After setting up the provider and creating a client, you can evaluate flags throughout your application. Flag evaluation is local and fast—the SDK uses locally cached configuration data, so no network requests occur during evaluation.
+
+Each flag is identified by a key (a unique string) and can be evaluated with a typed method that returns a value of the expected type. If the flag doesn't exist or cannot be evaluated, the SDK returns the provided default value.
+
+### Boolean flags
+
+Use `getBooleanValue` for flags that represent on/off or true/false conditions:
+
+{{< code-block lang="php" >}}
+$enabled = $client->getBooleanValue('new-checkout-flow', false, $context);
+
+if ($enabled) {
+    showNewCheckout();
+} else {
+    showLegacyCheckout();
+}
+{{< /code-block >}}
+
+### String flags
+
+Use `getStringValue` for flags that select between multiple variants or configuration strings:
+
+{{< code-block lang="php" >}}
+$theme = $client->getStringValue('ui-theme', 'light', $context);
+
+if ($theme === 'dark') {
+    setDarkTheme();
+} else {
+    setLightTheme();
+}
+{{< /code-block >}}
+
+### Numeric flags
+
+For numeric flags, use `getIntegerValue` or `getFloatValue`. These are appropriate when a feature depends on a numeric parameter such as a limit, percentage, or multiplier:
+
+{{< code-block lang="php" >}}
+$maxItems = $client->getIntegerValue('cart-max-items', 20, $context);
+
+$discountRate = $client->getFloatValue('discount-rate', 0.0, $context);
+{{< /code-block >}}
+
+### Object flags
+
+For structured data, use `getObjectValue`. This returns an array with complex configuration:
+
+{{< code-block lang="php" >}}
+$config = $client->getObjectValue('feature-config', [
+    'maxRetries' => 3,
+    'timeout' => 30,
+], $context);
+
+$maxRetries = $config['maxRetries'] ?? 3;
+$timeout = $config['timeout'] ?? 30;
+{{< /code-block >}}
+
+### Flag evaluation details
+
+When you need more than just the flag value, use the `*Details` methods. These return both the evaluated value and metadata explaining the evaluation:
+
+{{< code-block lang="php" >}}
+$details = $client->getBooleanDetails('new-feature', false, $context);
+
+echo "Value: " . var_export($details->getValue(), true) . "\n";
+echo "Reason: " . $details->getReason() . "\n";
+echo "Variant: " . $details->getVariant() . "\n";
+{{< /code-block >}}
+
+Flag details help you debug evaluation behavior and understand why a user received a given value.
+
+### Evaluation without context
+
+You can evaluate flags without providing an evaluation context. This is useful for global flags that don't require user-specific targeting:
+
+{{< code-block lang="php" >}}
+// Global feature flag - no context needed
+$maintenanceMode = $client->getBooleanValue('maintenance-mode', false);
+
+if ($maintenanceMode) {
+    echo "Service temporarily unavailable";
+    exit;
+}
+{{< /code-block >}}
+
+## Troubleshooting
+
+### Provider not enabled
+
+If you receive warnings about the provider not being enabled, ensure `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true` is set in your environment:
+
+{{< code-block lang="bash" >}}
+export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+{{< /code-block >}}
+
+### Remote Configuration not working
+
+Verify the following to ensure that Remote Configuration is working:
+- Datadog Agent is version 7.55 or later
+- Remote Configuration is enabled on the Agent
+- `DD_SERVICE` and `DD_ENV` environment variables are set
+- The tracer can communicate with the Agent
+
+[1]: https://openfeature.dev/
+[2]: /agent/remote_config/
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/feature_flags/server/php.md
+++ b/content/en/feature_flags/server/php.md
@@ -22,7 +22,7 @@ Before setting up the PHP Feature Flags SDK, ensure you have:
 
 - **Datadog Agent** with [Remote Configuration][2] enabled
 - **Datadog PHP tracer** `ddtrace` version 1.16.0 or later
-- **OpenFeature PHP SDK** `open-feature/sdk` version 2.0 or later
+- **OpenFeature PHP SDK** `open-feature/sdk` version 1.0 or later
 
 Set the following environment variables:
 
@@ -52,7 +52,7 @@ Or add the OpenFeature SDK to your `composer.json`:
 {{< code-block lang="json" filename="composer.json" >}}
 {
     "require": {
-        "open-feature/sdk": "^2.0"
+        "open-feature/sdk": "^1.0"
     }
 }
 {{< /code-block >}}
@@ -67,9 +67,8 @@ Register the Datadog OpenFeature provider with the OpenFeature API. The provider
 use OpenFeature\API;
 use DDTrace\OpenFeature\DataDogProvider;
 
-// Create and register the Datadog provider
-$provider = new DataDogProvider();
-API::setProvider($provider);
+// Register the Datadog provider
+API::setProvider(new DataDogProvider());
 
 // Create an OpenFeature client
 $client = API::getClient();
@@ -79,7 +78,7 @@ $client = API::getClient();
 
 ## Set the evaluation context
 
-Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations should be returned:
+Define an evaluation context that identifies the user or entity for flag targeting. The evaluation context includes attributes used to determine which flag variations are returned:
 
 {{< code-block lang="php" >}}
 use OpenFeature\implementation\flags\EvaluationContext;
@@ -127,6 +126,8 @@ $theme = $client->getStringValue('ui-theme', 'light', $context);
 
 if ($theme === 'dark') {
     setDarkTheme();
+} elseif ($theme === 'light') {
+    setLightTheme();
 } else {
     setLightTheme();
 }
@@ -164,8 +165,13 @@ When you need more than just the flag value, use the `*Details` methods. These r
 $details = $client->getBooleanDetails('new-feature', false, $context);
 
 echo "Value: " . var_export($details->getValue(), true) . "\n";
-echo "Reason: " . $details->getReason() . "\n";
-echo "Variant: " . $details->getVariant() . "\n";
+echo "Variant: " . ($details->getVariant() ?? '') . "\n";
+echo "Reason: " . ($details->getReason() ?? '') . "\n";
+$error = $details->getError();
+if ($error !== null) {
+    echo "Error Code: " . $error->getErrorCode() . "\n";
+    echo "Error Message: " . ($error->getErrorMessage() ?? '') . "\n";
+}
 {{< /code-block >}}
 
 Flag details help you debug evaluation behavior and understand why a user received a given value.
@@ -184,11 +190,47 @@ if ($maintenanceMode) {
 }
 {{< /code-block >}}
 
+## PHP-specific considerations
+
+### Shared-nothing architecture
+
+PHP uses a shared-nothing model where each request is handled by an independent process or thread. This means:
+
+- **Exposure deduplication is per-process**: The SDK deduplicates exposure events within a single request, so the same flag/subject combination is sent only once per process lifecycle. The cache does not persist across PHP-FPM worker restarts or separate Apache mod_php requests.
+- **No blocking provider initialization**: PHP cannot use `setProviderAndWait()`. The provider initializes at the start of each request by reading the latest flag configuration that the Datadog tracer has already received from Remote Configuration.
+
+### PHP-FPM and Apache mod_php
+
+The SDK supports both **PHP-FPM** and **Apache mod_php**. Both SAPIs behave the same way with respect to flag evaluation and exposure logging. For PHP-FPM, configure the tracer settings through environment variables in your FPM pool configuration file.
+
+### OTel metrics
+
+To emit feature flag evaluation metrics (counter: `feature_flag.evaluations`) through OpenTelemetry, set the following environment variables and install the OTel packages:
+
+{{< code-block lang="bash" >}}
+export DD_METRICS_OTEL_ENABLED=true
+export OTEL_PHP_AUTOLOAD_ENABLED=true
+export OTEL_METRICS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=http://<AGENT_HOST>:4318/v1/metrics
+{{< /code-block >}}
+
+Add the OTel SDK and OTLP exporter to your `composer.json`:
+
+{{< code-block lang="json" filename="composer.json" >}}
+{
+    "require": {
+        "open-feature/sdk": "^1.0",
+        "open-telemetry/sdk": "^1.0.0",
+        "open-telemetry/exporter-otlp": "^1.0.0"
+    }
+}
+{{< /code-block >}}
+
 ## Troubleshooting
 
 ### Provider not enabled
 
-If you receive warnings about the provider not being enabled, ensure `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true` is set in your environment:
+If you receive warnings about the provider not being enabled, confirm `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true` is set in your environment:
 
 {{< code-block lang="bash" >}}
 export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
@@ -196,7 +238,7 @@ export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
 ### Remote Configuration not working
 
-Verify the following to ensure that Remote Configuration is working:
+Verify the following to confirm that Remote Configuration is working:
 - Datadog Agent is version 7.55 or later
 - Remote Configuration is enabled on the Agent
 - `DD_SERVICE` and `DD_ENV` environment variables are set

--- a/layouts/partials/feature_flags/feature_flags_server.html
+++ b/layouts/partials/feature_flags/feature_flags_server.html
@@ -31,6 +31,13 @@
                 </a>
             </div>
             <div class="col">
+                <a class="card h-100" href="/feature_flags/server/php/">
+                    <div class="card-body text-center py-2 px-1">
+                        {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
+                    </div>
+                </a>
+            </div>
+            <div class="col">
                 <a class="card h-100" href="/feature_flags/server/python/">
                     <div class="card-body text-center py-2 px-1">
                         {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}


### PR DESCRIPTION
## Motivation

PHP now has Feature Flagging and Experimentation (FFE) support in the dd-trace-php tracer. This PR adds the corresponding documentation page, matching the style of the existing server-side SDK docs.

## Changes

- Add `content/en/feature_flags/server/php.md` with setup instructions, code examples for all flag types (boolean, string, integer, numeric, JSON), evaluation context, and troubleshooting
- Add PHP card to the server-side SDK selector partial (`feature_flags_server.html`)

## Decisions

- PHP does not use the OpenFeature SDK (unlike Python/Go/Java/Node.js), so the docs describe the `DDTrace\FeatureFlags\Provider` API directly
- Structure and tone match the existing Python doc as the reference template
- PHP is listed alphabetically between Node.js and Python in the SDK selector