### PR TITLE
Remove info severity from dropdown filter in IaC security rules page

### DIFF
--- a/layouts/iac_security/list.html
+++ b/layouts/iac_security/list.html
@@ -278,7 +278,7 @@
                             {{ $pad.SetInMap "filters" "Providers" (union (index ($pad.Get "filters") "Providers") (slice .Params.meta.cloud_provider)) }}
                             {{ $pad.SetInMap "filters" "Platforms" (union (index ($pad.Get "filters") "Platforms") (slice .Params.meta.platform)) }}
                             {{ $pad.SetInMap "filters" "Categories" (union (index ($pad.Get "filters") "Categories") (slice .Params.meta.category)) }}
-                            {{ $pad.SetInMap "filters" "Severities" (slice "CRITICAL" "HIGH" "MEDIUM" "LOW" "INFO") }}
+                            {{ $pad.SetInMap "filters" "Severities" (slice "CRITICAL" "HIGH" "MEDIUM" "LOW") }}
                             {{/*  
                                 build object of arrays with unique cloud provider for each ruleset header (.set-header )
                                 cloudProvidersByRuleset: {


### PR DESCRIPTION
Refs: K9VULN-8409

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

## What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The IaC Team is removing the `Info` rules. They all become `Low` severity instead. Therefore the filter for the `Info` severity is now useless. The goal of this PR is to remove the filter for the documentation to stay clean.

### Before (see [IaC security page](https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/?severities=INFO))

<img width="1350" height="808" alt="Screenshot 2026-02-09 at 10 16 37" src="https://github.com/user-attachments/assets/8c7e9a16-a590-42e8-a72c-d4c1c8f79f7e" />

### After (see [Preview](https://docs-staging.datadoghq.com/benjamin.chouraqui/remove-info-cat-iac-rules/security/code_security/iac_security/iac_rules/))

<img width="1350" height="808" alt="Screenshot 2026-02-09 at 10 29 46" src="https://github.com/user-attachments/assets/3f214e87-03ed-4199-a3e9-dc71096fa755" />

## Merge instructions

-  [x] Move all the `Info` rules to `Low`

The PR is ready to be merged upon validation

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


