### PR TITLE
Fix[WEB-7604]: introduce group_max_candidates in query presets to fix pagination counter [docs + api]

### DIFF
--- a/typesense.config.json
+++ b/typesense.config.json
@@ -259,7 +259,8 @@
                         "query_by_weights": "4,3,2,2",
                         "group_by": "distinct_base_url",
                         "group_limit": 1,
-                        "stopwords": "stopwords"
+                        "stopwords": "stopwords",
+                        "group_max_candidates": 1000
                     }
                 },
                 {
@@ -270,7 +271,7 @@
                         "group_by": "distinct_base_url",
                         "group_limit": 1,
                         "stopwords": "stopwords",
-                        "group_max_condidates": 1000
+                        "group_max_candidates": 1000
                     }
                 }
             ]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

#### Introduce `group_max_candidates` to docs preset too, previous PR : https://github.com/DataDog/documentation/pull/34364


Typesense uses [HyperLogLog](https://en.wikipedia.org/wiki/HyperLogLog) (a probabilistic approximate counting algorithm) by default for grouped searches. 
This causes:
- Inaccurate found counts — the total can be overestimated
- Pagination discrepancies — page 2 might show fewer results than expected, or be empty when it shouldn't be
#### The Fix
Typesense introduced in v30 `group_max_candidates` https://github.com/typesense/typesense/releases/tag/v30.0.

- Setting `group_max_candidates` to a value different from the default (250) forces Typesense to use exact counting instead of approximation.
- See: [Typesense flow](https://github.com/typesense/typesense/blob/04555fce371661c90267d66e06025f3ddb24cdcb/src/index.cpp#L2787)

```cpp
        if (search_params->group_max_candidates != DEFAULT_TOPSTER_SIZE) {
            // User has set an appropriate upper limit of the expected group count. Assuming all the groups have been
            // processed, no need to rely on approximate count.
            search_params->found_count = search_params->raw_result_kvs.size() + search_params->curation_result_kvs.size();
```

_ps: See [jira ticket](https://datadoghq.atlassian.net/browse/WEB-7604)_
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
### For preview: https://docs-staging.datadoghq.com/reda.elissati/web-7604-use-group-max-candidates/search/?s=page_id