### PR TITLE
Remove unsupported tags mention from paging instructions

### DIFF
--- a/content/en/incident_response/on-call/triggering_pages/_index.md
+++ b/content/en/incident_response/on-call/triggering_pages/_index.md
@@ -65,7 +65,7 @@ The new recipient is notified immediately, and the Page continues from its curre
 1. Go to [**On-Call** > **Teams**][2].
 1. Find the Team you want to page. Select **Page**.
    {{< img src="service_management/oncall/manual_page.png" alt="The list of On-Call Teams, showing the Checkout Operations Team. Three buttons are displayed: Schedules, Escalation Policies, Page." style="width:80%;" >}}
-1. Enter a **Page title**. You can also select **Tags** and add more context in the **Description** field. Select **Page**.
+1. Enter a **Page title** and add more context in the **Description** field. Select **Page**.
 
 Manually paging a Team through Datadog always results in a `high` urgency Page.
 


### PR DESCRIPTION
Remove the reference to selecting Tags when manually paging a team, as this feature is not actually supported.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
