### PR TITLE
[DOCS-13309] Add links to regex parsing guide in OP processor docs

### DIFF
--- a/layouts/shortcodes/observability_pipelines/processors/custom_processor.md
+++ b/layouts/shortcodes/observability_pipelines/processors/custom_processor.md
@@ -7,7 +7,7 @@ Use this processor with Vector Remap Language (VRL) to modify and enrich your lo
 - [Convert syslog values](#convert) to read-able values.
 - Enrich values by using [enrichment tables](#enrichment).
 - [Manipulate IP values](#ip).
-- [Parse](#parse) values with custom rules (for example, grok, regex, and so on) and out-of-the-box functions (for example, syslog, apache, VPC flow logs, and so on). See [Writing Effective Grok Parsing Rules with Regular Expressions][10194] for information.
+- [Parse](#parse) values with custom rules (for example, grok, regex, and so on) and out-of-the-box functions (for example, syslog, apache, VPC flow logs, and so on).
 - Manipulate event [metadata](#event) and [paths](#path).
 
 See [Custom functions][10191] for the full list of available functions.
@@ -31,4 +31,3 @@ To set up this processor:
 [10191]: /observability_pipelines/processors/custom_processor#custom-functions
 [10192]: /observability_pipelines/guide/get_started_with_the_custom_processor
 [10193]: /observability_pipelines/guide/remap_reserved_attributes
-[10194]: /logs/guide/regex_log_parsing/

--- a/layouts/shortcodes/observability_pipelines/processors/sds_custom_rules.md
+++ b/layouts/shortcodes/observability_pipelines/processors/sds_custom_rules.md
@@ -1,4 +1,4 @@
-1. In the **Define match conditions** section, specify the regex pattern to use for matching against events in the **Define the regex** field. Enter sample data in the **Add sample data** field to verify that your regex pattern is valid. See [Writing Effective Grok Parsing Rules with Regular Expressions][1] for information.
+1. In the **Define match conditions** section, specify the regex pattern to use for matching against events in the **Define the regex** field. Enter sample data in the **Add sample data** field to verify that your regex pattern is valid.
     Sensitive Data Scanner supports Perl Compatible Regular Expressions (PCRE), but the following patterns are not supported:
     - Backreferences and capturing sub-expressions (lookarounds)
     - Arbitrary zero-width assertions
@@ -43,5 +43,3 @@
 
 - Use `outer_key.inner_key` to refer to the key with the value `inner_value`.
 - Use `outer_key.inner_key.double_inner_key` to refer to the key with the value `double_inner_value`.
-
-[1]: /logs/guide/regex_log_parsing/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13309
- **Custom Processor**: Added link in the parsing bullet point where regex is mentioned
- **SDS Processor**: Added link in the regex pattern definition section

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes