### PR TITLE
[CSPM] Add RHEL 10 to the list of supported infrastructure frameworks

### DIFF
--- a/content/en/security/cloud_security_management/misconfigurations/frameworks_and_benchmarks/supported_frameworks.md
+++ b/content/en/security/cloud_security_management/misconfigurations/frameworks_and_benchmarks/supported_frameworks.md
@@ -42,8 +42,9 @@ Cloud Security Misconfigurations comes with more than 1,000 out-of-the-box compl
 | [CIS Kubernetes (EKS) Benchmark**][5]           | v1.7.0, v1.4.0                 | `cis-eks`                           | Cloud and Infrastructure |
 | [CIS Kubernetes Benchmark**][5]                 | v1.9.0                         | `cis-kubernetes`                    | Infrastructure           |
 | [CIS Red Hat Linux 7][24]                       | v3.1.1                         | `cis-rhel7`                         | Infrastructure           |
-| [CIS Red Hat Linux 8][24]                       | v3.0.0                         | `cis-rhel8`                         | Infrastructure           |
-| [CIS Red Hat Linux 9][24]                       | v2.0.0                         | `cis-rhel9`                         | Infrastructure           |
+| [CIS Red Hat Linux 8][24]                       | v2.0.0                         | `cis-rhel8`                         | Infrastructure           |
+| [CIS Red Hat Linux 9][24]                       | v1.0.0                         | `cis-rhel9`                         | Infrastructure           |
+| [CIS Red Hat Linux 10][24]                      | v1.0.0                         | `cis-rhel10`                        | Infrastructure           |
 | [CIS Ubuntu 20.04][23]                          | v1.0.0                         | `cis-ubuntu2004`                    | Infrastructure           |
 | [CIS Ubuntu 22.04][23]                          | v2.0.0                         | `cis-ubuntu2204`                    | Infrastructure           |
 | [CIS Ubuntu 24.04][23]                          | v1.0.0                         | `cis-ubuntu2404`                    | Infrastructure           |


### PR DESCRIPTION
This change adds Red Hat Enterprise Linux 10 to the list of supported infrastructure frameworks.