### PR TITLE
[K9VULN-11234] Update GitHub action versions for Code Security

### DIFF
--- a/content/en/security/code_security/secret_scanning/github_actions.md
+++ b/content/en/security/code_security/secret_scanning/github_actions.md
@@ -21,10 +21,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -51,7 +51,6 @@ You can set the following parameters.
 | `cpu_count`  | Set the number of CPUs used to by the analyzer.                                                                                                         | No      | `2`             |
 | `enable_performance_statistics` | Get the execution time statistics for analyzed files.                                                                                                   | No      | `false`         |
 | `debug`      | Lets the analyzer print additional logs useful for debugging. To enable, set to `yes`.                                                                  | No      | `no`            |
-| `architecture` | The CPU architecture to use for the analyzer. Supported values are `x86_64` and `aarch64`.                                                              | No      | `x86_64`        |
 
 
 

--- a/content/en/security/code_security/static_analysis/github_actions.md
+++ b/content/en/security/code_security/static_analysis/github_actions.md
@@ -25,10 +25,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -58,17 +58,11 @@ You can set the following parameters for Static Code Analysis.
 | `enable_performance_statistics` | Get the execution time statistics for analyzed files.                                                                                                   | No      | `false`         |
 | `debug`      | Lets the analyzer print additional logs useful for debugging. To enable, set to `yes`.                                                                  | No      | `no`            |
 | `subdirectory` | A subdirectory pattern or glob (or space-delimited subdirectory patterns) that the analysis should be limited to. For example: "src" or "src packages". | `false` |                 |
-| `architecture` | The CPU architecture to use for the analyzer. Supported values are `x86_64` and `aarch64`.                                                              | No      | `x86_64`        |
 | `diff_aware` | Enable [diff-aware scanning mode][5].                                                                                                                   | No      | `true`          |
 
 ### Notes
 
 1. Diff-aware scanning only scans the files modified by a commit when analyzing feature branches. Diff-aware is enabled by default. To disable diff-aware scanning, set the GitHub action `diff_aware` parameter to `false`.
-
-### Deprecated Inputs
-The following action inputs have been deprecated and no longer have any effect. Passing these in will emit a warning.
-* `dd_service`
-* `dd_env`
 
 ## Customizing rules
 

--- a/content/es/code_analysis/static_analysis/github_actions.md
+++ b/content/es/code_analysis/static_analysis/github_actions.md
@@ -28,10 +28,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -57,7 +57,6 @@ Puedes configurar los siguientes parámetros para Static Analysis.
 | `enable_performance_statistics` | Obtener las estadísticas de tiempo de ejecución de los archivos analizados.                                                                                                   | No      | `false`         |
 | `debug`      | Permite al analizador imprimir logs adicionales útiles para la depuración. Para activarlo, establece `yes`.                                                                  | No      | `no`            |
 | `subdirectory` | Un patrón de subdirectorio o glob (o patrones de subdirectorio delimitados por espacios) al que debe limitarse el análisis. Por ejemplo: "src" o "paquetes src". | `false` |                 |
-| `architecture` | La arquitectura de CPU a utilizar para el analizador. Los valores admitidos son `x86_64` y `aarch64`.                                                              | No      | `x86_64`        |
 | `diff_aware` | Activa el [modo de escaneo diferenciado][5].                                                                                                                   | No      | `true`          |
 | `secrets_enabled` | Activar la detección de secretos (en función beta privada)                                                                                                              | No      | `false`         |
 
@@ -65,11 +64,6 @@ Puedes configurar los siguientes parámetros para Static Analysis.
 
 1. El análisis diferenciado sólo analiza los archivos modificados por una confirmación cuando se analizan ramas de características. Esta opción está activada por defecto. Para desactivar el análisis diferenciado, establece el parámetro de la acción de GitHub `diff_aware` en `false`.
 2. El escaneado de secretos está en fase beta privada. Para activar la exploración de secretos, ponte en contacto con tu asesor de clientes en Datadog.
-
-### Entradas obsoletas
-Las siguientes entradas de acción han sido obsoletas y ya no tienen ningún efecto. Si se introducen, se emitirá una advertencia.
-* `dd_service`
-* `dd_env`
 
 ## Personalización de reglas
 

--- a/content/es/getting_started/code_analysis/_index.md
+++ b/content/es/getting_started/code_analysis/_index.md
@@ -92,8 +92,6 @@ Debes [ejecutar un análisis de tu repositorio](#run-code-analysis-in-your-ci-pr
 
 Para cargar resultados en Datadog, asegúrate de que dispones de [una clave de API y una clave de aplicación Datadog][110].
 
-Especifica un nombre para el servicio o la librería en el campo `dd_service`, como por ejemplo, `shopist`.
-
 ### Acción de GitHub
 
 Puedes configurar una acción de GitHub para ejecutar un análisis de Static Analysis y Software Composition Analysis como parte de tus flujos de trabajo CI.
@@ -111,15 +109,13 @@ jobs:
     name: Datadog Static Analyzer
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Check code meets quality and security standards
       id: datadog-static-analysis
-      uses: DataDog/datadog-static-analyzer-github-action@v1
+      uses: DataDog/datadog-static-analyzer-github-action@v3
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2
 ```
@@ -137,15 +133,13 @@ jobs:
     name: Datadog SBOM Generation and Upload
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Check imported libraries are secure and compliant
       id: datadog-software-composition-analysis
       uses: DataDog/datadog-sca-github-action@main
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
 ```
 
@@ -178,7 +172,7 @@ mv /tmp/datadog-static-analyzer /usr/local/datadog-static-analyzer
 /usr/local/datadog-static-analyzer -i . -o /tmp/report.sarif -f sarif
 
 # Upload results
-datadog-ci sarif upload /tmp/report.sarif --service "shopist" --env "ci"
+datadog-ci sarif upload /tmp/report.sarif
 ```
 
 #### Software Composition Analysis
@@ -208,7 +202,7 @@ chmod 755 /osv-scanner/osv-scanner
 /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-5 --paths-relative-to-scan-dir  --output=/tmp/sbom.json /path/to/repository
 
 # Upload results
-datadog-ci sbom upload --service "shopist" --env "ci" /tmp/sbom.json
+datadog-ci sbom upload /tmp/sbom.json
 ```
 
 Una vez que hayas configurado estos scripts, ejecuta un análisis de tu repositorio en la rama por defecto. Los resultados empezarán a aparecer en la página **Repositorios**.

--- a/content/es/security/code_security/secret_scanning/github_actions.md
+++ b/content/es/security/code_security/secret_scanning/github_actions.md
@@ -22,10 +22,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -52,7 +52,6 @@ Puedes configurar los siguientes parámetros.
 | `cpu_count`  | Establece el número de CPUs utilizadas por el analizador.                                                                                                         | No      | `2`             |
 | `enable_performance_statistics` | Obtén las estadísticas de tiempo de ejecución de los archivos analizados.                                                                                                   | No      | `false`         |
 | `debug`      | Permite al analizador imprimir logs adicionales útiles para la depuración. Para activarlo, establece `yes`.                                                                  | No      | `no`            |
-| `architecture` | La arquitectura de CPU a utilizar para el analizador. Los valores admitidos son `x86_64` y `aarch64`.                                                              | No      | `x86_64`        |
 
 
 

--- a/content/es/security/code_security/static_analysis/github_actions.md
+++ b/content/es/security/code_security/static_analysis/github_actions.md
@@ -26,10 +26,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -55,17 +55,11 @@ Puedes configurar los siguientes parámetros para Static Code Analysis.
 | `enable_performance_statistics` | Obtener las estadísticas de tiempo de ejecución de los archivos analizados.                                                                                                   | No      | `false`         |
 | `debug`      | Permite al analizador imprimir logs adicionales útiles para la depuración. Para activarlo, establece `yes`.                                                                  | No      | `no`            |
 | `subdirectory` | Un patrón de subdirectorio o glob (o patrones de subdirectorio delimitados por espacios) al que debe limitarse el análisis. Por ejemplo: "src" o "paquetes src". | `false` |                 |
-| `architecture` | La arquitectura de CPU a utilizar para el analizador. Los valores admitidos son `x86_64` y `aarch64`.                                                              | No      | `x86_64`        |
 | `diff_aware` | Activa el [modo de escaneo diferenciado][5].                                                                                                                   | No      | `true`          |
 
 ### Notas
 
 1. El análisis diferenciado sólo analiza los archivos modificados por una confirmación cuando se analizan ramas de características. Esta opción está activada por defecto. Para desactivar el análisis diferenciado, establece el parámetro de la acción de GitHub `diff_aware` en `false`.
-
-### Entradas obsoletas
-Las siguientes entradas de acción han sido obsoletas y ya no tienen ningún efecto. Si se introducen, se emitirá una advertencia.
-* `dd_service`
-* `dd_env`
 
 ## Personalización de las reglas
 

--- a/content/fr/code_analysis/static_analysis/github_actions.md
+++ b/content/fr/code_analysis/static_analysis/github_actions.md
@@ -28,10 +28,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -57,7 +57,6 @@ Vous pouvez définir les paramètres suivants pour Static Analysis.
 | `enable_performance_statistics` | Récupérer les statistiques de temps d'exécution pour les fichiers analysés.                                                                                                   | Non      | `false`         |
 | `debug`      | Permet à l'analyseur d'afficher des logs supplémentaires utiles pour le debugging. Pour activer, définir sur `yes`.                                                                  | Non      | `no`            |
 | `subdirectory` | Un pattern de sous-répertoire ou glob (ou patterns de sous-répertoires délimités par des espaces) auquel l'analyse doit être limitée. Par exemple : "src" ou "src packages". | `false` |                 |
-| `architecture` | L'architecture CPU à utiliser pour l'analyseur. Les valeurs prises en charge sont `x86_64` et `aarch64`.                                                              | Non      | `x86_64`        |
 | `diff_aware` | Activer le [mode d'analyse différentielle][5].                                                                                                                   | Non      | `true`          |
 | `secrets_enabled` | Activer la détection de secrets (en bêta privée)                                                                                                              | Non      | `false`         |
 
@@ -65,11 +64,6 @@ Vous pouvez définir les paramètres suivants pour Static Analysis.
 
 1. L'analyse différentielle analyse uniquement les fichiers modifiés par un commit lors de l'analyse des branches de fonctionnalité. L'analyse différentielle est activée par défaut. Pour désactiver l'analyse différentielle, définir le paramètre `diff_aware` de l'action GitHub sur `false`.
 2. L'analyse de secrets est en bêta privée. Pour activer l'analyse de secrets, contactez votre responsable de la réussite client Datadog.
-
-### Entrées obsolètes
-Les entrées d'action suivantes sont obsolètes et n'ont plus aucun effet. Leur transmission émettra un avertissement.
-* `dd_service`
-* `dd_env`
 
 ## Personnaliser les règles
 

--- a/content/fr/getting_started/code_analysis/_index.md
+++ b/content/fr/getting_started/code_analysis/_index.md
@@ -93,8 +93,6 @@ Il faut [exécuter une analyse de votre référentiel](#executer-code-analysis-d
 
 Pour téléverser les résultats vers Datadog, assurez-vous de disposer d'une [clé d'API Datadog et d'une clé d'application][110].
 
-Indiquez un nom pour le service ou la bibliothèque dans le champ `dd_service`, comme `shopist`.
-
 ### Action GitHub
 
 Il est possible de configurer une GitHub Action pour exécuter des analyses Static Analysis et Software Composition Analysis dans le cadre de vos workflows CI.
@@ -112,15 +110,13 @@ jobs:
     name: Datadog Static Analyzer
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Check code meets quality and security standards
       id: datadog-static-analysis
-      uses: DataDog/datadog-static-analyzer-github-action@v1
+      uses: DataDog/datadog-static-analyzer-github-action@v3
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2
 ```
@@ -138,15 +134,13 @@ jobs:
     name: Datadog SBOM Generation and Upload
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Check imported libraries are secure and compliant
       id: datadog-software-composition-analysis
       uses: DataDog/datadog-sca-github-action@main
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
 ```
 
@@ -179,7 +173,7 @@ mv /tmp/datadog-static-analyzer /usr/local/datadog-static-analyzer
 /usr/local/datadog-static-analyzer -i . -o /tmp/report.sarif -f sarif
 
 # Upload results
-datadog-ci sarif upload /tmp/report.sarif --service "shopist" --env "ci"
+datadog-ci sarif upload /tmp/report.sarif
 ```
 
 #### Software Composition Analysis
@@ -209,7 +203,7 @@ chmod 755 /osv-scanner/osv-scanner
 /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-5 --paths-relative-to-scan-dir  --output=/tmp/sbom.json /path/to/repository
 
 # Upload results
-datadog-ci sbom upload --service "shopist" --env "ci" /tmp/sbom.json
+datadog-ci sbom upload /tmp/sbom.json
 ```
 
 Une fois que vous avez configuré ces scripts, exécutez une analyse de votre référentiel sur la branche par défaut. Les résultats commenceront ensuite à apparaître sur la page **Repositories**.

--- a/content/ja/code_analysis/static_analysis/github_actions.md
+++ b/content/ja/code_analysis/static_analysis/github_actions.md
@@ -26,10 +26,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -55,7 +55,6 @@ Static Analysis に以下のパラメーターを設定することができま�
 | `enable_performance_statistics` | 分析されたファイルの実行時間統計を取得します。                                                                                                   | いいえ      | `false`         |
 | `debug`      | デバッグに役立つ追加ログをアナライザーに出力させます。有効にするには `yes` を設定します。                                                                  | いいえ      | `no`            |
 | `subdirectory` | 解析対象を制限するサブディレクトリ パターンまたはグロブ (複数の場合はスペース区切り) を指定します。例: "src" または "src packages"。 | `false` |                 |
-| `architecture` | アナライザーで使用する CPU アーキテクチャを指定します。サポートされている値は `x86_64` と `aarch64` です。                                                              | いいえ      | `x86_64`        |
 | `diff_aware` | [差分認識スキャン モード][5] を有効にします。                                                                                                                   | いいえ      | `true`          |
 | `secrets_enabled` | シークレット スキャンを有効にします (非公開ベータ)。                                                                                                              | いいえ      | `false`         |
 
@@ -63,11 +62,6 @@ Static Analysis に以下のパラメーターを設定することができま�
 
 1. 差分認識スキャンでは、フィーチャ ブランチを解析する際にコミットで変更されたファイルのみをスキャンします。差分認識はデフォルトで有効です。無効にするには、GitHub アクションの `diff_aware` パラメーターを `false` に設定してください。
 2. シークレット スキャンは非公開ベータです。シークレット スキャンを有効にするには、Datadog カスタマー サクセス マネージャーにお問い合わせください。
-
-### 廃止済み入力
-以下のアクション入力は廃止されており、もはや効果はありません。これらを指定すると警告が表示されます。
-* `dd_service`
-* `dd_env`
 
 ## ルールのカスタマイズ
 

--- a/content/ja/continuous_integration/static_analysis/github_actions.md
+++ b/content/ja/continuous_integration/static_analysis/github_actions.md
@@ -46,10 +46,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -65,8 +65,6 @@ Static Analysis に以下のパラメーターを設定することができま�
 |--------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
 | `dd_api_key` | Datadog API キー。このキーは [Datadog 組織][1]によって作成され、[シークレット][2]として保存する必要があります。         | はい     |                 |
 | `dd_app_key` | Datadog アプリケーションキー。このキーは [Datadog 組織][1]によって作成され、[シークレット][2]として保存する必要があります。 | はい     |                 |
-| `dd_service` | 結果のタグ付けを希望するサービス。                                                                             | はい     |                 |
-| `dd_env`     | 結果をタグ付けしたい環境。Datadog は、この入力値として `ci` を使用することを推奨します。              | ✕      | `none`          |
 | `dd_site`    | 情報を送信する [Datadog サイト][3]。                                                                              | ✕      | `datadoghq.com` |
 
 [1]: https://docs.datadoghq.com/ja/account_management/api-app-keys/

--- a/content/ko/code_analysis/static_analysis/github_actions.md
+++ b/content/ko/code_analysis/static_analysis/github_actions.md
@@ -26,10 +26,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -55,7 +55,6 @@ Static Analysis에 대해 다음 파라미터를 설정합니다.
 | `enable_performance_statistics` | 분석된 파일의 실행 시간 통계를 가져옵니다.                                                                                                   | No      | `false`         |
 | `debug`      | 분석기가 디버깅에 유용한 추가 로그를 출력하도록 합니다. 활성화하려면 `yes`로 설정하세요.                                                                  | No      | `no`            |
 | `subdirectory` | 분석 대상을 제한해야 하는 하위 디렉터리 패턴 또는 글로브(또는 공백으로 구분된 하위 디렉터리 패턴). 예: "src" 또는 "src packages". | `false` |                 |
-| `architecture` | 분석기에 사용할 CPU 아키텍처. 지원되는 값은 `x86_64` 및 `aarch64`.                                                              | 아니요      | `x86_64`        |
 | `diff_aware` | [Diff-aware scanning 모드][5]를 활성화합니다.                                                                                                                   | No      | `true`          |
 | `secrets_enabled` | 시크릿 감지 활성화(비공개 베타 버전)                                                                                                              | No      | `false`         |
 
@@ -63,11 +62,6 @@ Static Analysis에 대해 다음 파라미터를 설정합니다.
 
 1. Diff-aware 스캐닝은 기능 브랜치를 분석할 때 커밋으로 수정된 파일만 스캔합니다. Diff-aware 스캐닝은 기본적으로 활성화되어 있습니다. Diff-aware 스캐닝을 비활성화하려면 GitHub 작업 `diff_aware` 파라미터를 `false`로 설정하세요.
 2. 시크릿 스캐닝은 비공개 베타 버전입니다. 시크릿 스캐닝을 활성화하려면 Datadog 고객 성공 관리자에게 문의하세요.
-
-### 더 이상 사용되지 않는 입력
-다음 작업 입력은 더 이상 사용되지 않으며 효과가 없습니다. 이러한 입력을 전달하면 경고가 발생합니다.
-* `dd_service`
-* `dd_env`
 
 ## 규칙 사용자 지정
 

--- a/content/ko/continuous_integration/static_analysis/github_actions.md
+++ b/content/ko/continuous_integration/static_analysis/github_actions.md
@@ -46,10 +46,10 @@ jobs:
     name: Datadog Static Analyzer
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check code meets quality standards
         id: datadog-static-analysis
-        uses: DataDog/datadog-static-analyzer-github-action@v1
+        uses: DataDog/datadog-static-analyzer-github-action@v3
         with:
           dd_app_key: ${{ secrets.DD_APP_KEY }}
           dd_api_key: ${{ secrets.DD_API_KEY }}
@@ -65,8 +65,6 @@ Static Analysis에 대해 다음 파라미터를 설정합니다.
 |--------------|----------------------------------------------------------------------------------------------------------------------------|----------|-----------------|
 | `dd_api_key` | Datadog API 키입니다. 이 키는 [Datadog 조직][1]에서 생성되고 [비밀][2]로 저장되어야 합니다.         | 예     |                 |
 | `dd_app_key` | Datadog 애플리케이션 키입니다. 이 키는 [Datadog 조직][1]에서 생성되고 [비밀][2]로 저장되어야 합니다. | 예     |                 |
-| `dd_service` | 결과에 태그를 지정할 서비스입니다.                                                                             | 예     |                 |
-| `dd_env`     | 결과에 태그를 지정할 환경입니다. Datadog은 `ci`를 입력 값으로 권장합니다.              | 아니요      | `none`          |
 | `dd_site`    | 정보를 전송할 [Datadog 사이트][3]입니다.                                                                              | 아니요      | `datadoghq.com` |
 
 [1]: https://docs.datadoghq.com/ko/account_management/api-app-keys/

--- a/content/ko/getting_started/code_analysis/_index.md
+++ b/content/ko/getting_started/code_analysis/_index.md
@@ -91,8 +91,6 @@ GitHub 리포지토리를 사용하는 경우, [GitHub 통합][103]을 설정하
 
 Datadog에 결과를 업로드하려면 [Datadog API 키 및 애플리케이션 키][110]가 있어야 합니다. 
 
-`dd_service` 필드에 서비스 또는 라이브러리 이름을 지정합니다(예: `shopist`).
-
 ### GitHub 작업
 
 CI 워크플로의 일부로 Static Analysis 및 Software Composition Analysis 스캔을 실행하도록 GitHub 작업을 구성할 수 있습니다.
@@ -110,15 +108,13 @@ jobs:
     name: Datadog Static Analyzer
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Check code meets quality and security standards
       id: datadog-static-analysis
-      uses: DataDog/datadog-static-analyzer-github-action@v1
+      uses: DataDog/datadog-static-analyzer-github-action@v3
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
         cpu_count: 2
 ```
@@ -136,15 +132,13 @@ jobs:
     name: Datadog SBOM Generation and Upload
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
     - name: Check imported libraries are secure and compliant
       id: datadog-software-composition-analysis
       uses: DataDog/datadog-sca-github-action@main
       with:
         dd_api_key: ${{ secrets.DD_API_KEY }}
         dd_app_key: ${{ secrets.DD_APP_KEY }}
-        dd_service: shopist
-        dd_env: ci
         dd_site: datadoghq.com
 ```
 
@@ -177,7 +171,7 @@ mv /tmp/datadog-static-analyzer /usr/local/datadog-static-analyzer
 /usr/local/datadog-static-analyzer -i . -o /tmp/report.sarif -f sarif
 
 # 결과 업로드
-datadog-ci sarif upload /tmp/report.sarif --service "shopist" --env "ci"
+datadog-ci sarif upload /tmp/report.sarif
 ```
 
 #### Software Composition Analysis
@@ -207,7 +201,7 @@ chmod 755 /osv-scanner/osv-scanner
 /osv-scanner/osv-scanner --skip-git -r --experimental-only-packages --format=cyclonedx-1-5 --paths-relative-to-scan-dir  --output=/tmp/sbom.json /path/to/repository
 
 # 결과 업로드
-datadog-ci sbom upload --service "shopist" --env "ci" /tmp/sbom.json
+datadog-ci sbom upload /tmp/sbom.json
 ```
 
 본 스크립트를 구성한 후 기본 브랜치에서 리포지토리 분석을 실행합니다. 그러면 **Repositories** 페이지에 결과가 표시되기 시작합니다.


### PR DESCRIPTION
### What does this PR do?
Updates the code snippets for using the [Code Security](https://docs.datadoghq.com/security/code_security/) product to reference actively-maintained versions of GitHub actions. Removes stale references to action inputs that no longer exist in actively-maintained versions.

### Motivation
Our documentation provides code snippets for onboarding to the Code Security product using GitHub actions. They currently recommend `v1`, which is no longer actively being developed. Additionally, they also suggest using `v3` of GitHub's `actions/checkout`, which uses Node.js 16 (which reached its end-of-life in September 2023).

### Change Details
* Suggests using [v6](https://github.com/actions/checkout/releases/tag/v6.0.0) of `actions/checkout` (which uses Node.js 24, with an end-of-life in April 2028)
* Suggests using [v3](https://github.com/DataDog/datadog-static-analyzer-github-action/releases/tag/v3.0.0) of our `DataDog/datadog-static-analyzer-github-action` action. This requires:
    * Removing references to action inputs `dd_service` and `dd_env`. These have been formally removed as of February 2025 and have no effect. Passing them in will cause an error, not a "warning" as the documentation suggests.
    * Removing code snippets referencing `service` and `env` (e.g. `--service "shopist" --env "ci"`). As mentioned above, these no longer do anything.
    * Removing documentation referencing action input `architecture`. Long story short, this field has not actually done anything for over a year.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge


### Additional notes
None
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
