### PR TITLE
(cdocs) Upgrade to cdocs 2.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "@popperjs/core": "^2.11.8",
         "alpinejs": "^3.13.7",
         "bootstrap": "^5.2",
-        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.6.0.tgz",
+        "cdocs-hugo-integration": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.7.0.tgz",
         "del": "4.1.1",
         "fancy-log": "^1.3.3",
         "geo-locate": "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/geo-locate-v1.0.2.tgz",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6548,9 +6548,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cdocs-data@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-data-v1.3.0.tgz":
-  version: 1.3.0
-  resolution: "cdocs-data@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-data-v1.3.0.tgz"
+"cdocs-data@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-data-v1.3.2.tgz":
+  version: 1.3.2
+  resolution: "cdocs-data@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-data-v1.3.2.tgz"
   dependencies:
     "@types/semver": "npm:^7.7.0"
     js-yaml: "npm:^4.1.0"
@@ -6562,19 +6562,19 @@ __metadata:
     typedoc-plugin-zod: "npm:^1.3.1"
     uuid: "npm:^11.0.5"
     zod: "npm:^4.1.12"
-  checksum: 10/5582490d1b31ffcfcc496c1753603bf5f7d07ccc6a1177b3136855b403a4f3c2cd4d8ac82e56a41541741a43705dbb8f3a586a95857a47312b3316addce0a072
+  checksum: 10/83ba74da164764200040aeca9871864ab3aaecb543355b8b20f240412486b2e996d43960d26b4129419eac6838f2eb0aa0946174325324f481361070edab7e28
   languageName: node
   linkType: hard
 
-"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.6.0.tgz":
-  version: 2.6.0
-  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.6.0.tgz"
+"cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.7.0.tgz":
+  version: 2.7.0
+  resolution: "cdocs-hugo-integration@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.7.0.tgz"
   dependencies:
     "@prettier/sync": "npm:^0.5.2"
     "@types/markdown-it": "npm:^14.1.2"
     "@vitejs/plugin-react": "npm:^4.3.3"
-    cdocs-data: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-data-v1.3.0.tgz"
-    cdocs-markdoc: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-markdoc-v1.0.2.tgz"
+    cdocs-data: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-data-v1.3.2.tgz"
+    cdocs-markdoc: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-markdoc-v1.1.1.tgz"
     chokidar: "npm:^4.0.3"
     chroma-highlight: "npm:^2.4.2"
     interweave: "npm:^13.1.0"
@@ -6593,13 +6593,13 @@ __metadata:
     vite: "npm:^5.4.10"
     vite-plugin-singlefile: "npm:^2.0.2"
     zod: "npm:^4.1.12"
-  checksum: 10/865ec88ffbf1a6b9c26c9baa934998936babef817c97ef9615c23cda55448486c2a1612de7ed686b2648480b188181a9725f624440af76d6c7cc3ded37571376
+  checksum: 10/0a3fc59522ce9e401aef5b486da7215cd5e1ec32f4a9a252a93770360e4e46de5d998c29344c4f89d38d1d62335750713631e4dc66ba3ae1050193daf2c2657f
   languageName: node
   linkType: hard
 
-"cdocs-markdoc@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-markdoc-v1.0.2.tgz":
-  version: 1.0.2
-  resolution: "cdocs-markdoc@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-markdoc-v1.0.2.tgz"
+"cdocs-markdoc@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-markdoc-v1.1.1.tgz":
+  version: 1.1.1
+  resolution: "cdocs-markdoc@https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-markdoc-v1.1.1.tgz"
   dependencies:
     "@types/linkify-it": "npm:^3.0.1"
     "@types/markdown-it": "npm:12.2.3"
@@ -6608,7 +6608,7 @@ __metadata:
       optional: true
     "@types/markdown-it":
       optional: true
-  checksum: 10/844190c9cbb525414c8f24cf874908535504cacb8d5ecbe86edfff00bb595f233d29044ed763b0b612e6fdccaa2376aa4999a56e3d94cfef0f4b325fcad9602e
+  checksum: 10/d0754d0020ab4a7f3eac48e2c729f10d0ccc9c374e6be0552c53225b4461c12f0106d46cda886a2585bb25b78c11374b5f88c3b8a5a725b0cd08fe1f8e1252e9
   languageName: node
   linkType: hard
 
@@ -7640,7 +7640,7 @@ __metadata:
     acorn: "npm:^7.4.1"
     alpinejs: "npm:^3.13.7"
     bootstrap: "npm:^5.2"
-    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.6.0.tgz"
+    cdocs-hugo-integration: "https://s3.amazonaws.com/origin-static-assets/corp-node-packages/master/cdocs-hugo-integration-v2.7.0.tgz"
     cross-env: "npm:^5.2.1"
     del: "npm:4.1.1"
     eslint: "npm:^6.8.0"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

This version introduces a new custom Markdoc function, `semverIsAtLeast()`, which allows versioning in our customizable documentation. The function compares a user-selected version option (like a library version) against a target version string, and returns `true` if the version option  is greater than or equal to the target. 

Writers can use the function along with an `if` block to show or hide information depending on whether it applies to the specified version.

For example:
```
{% if semverIsAtLeast($rum_browser_sdk_version, "4.13.0") %}
This content only appears when the user selects a version >= 4.13.0
{% /if %}
``` 

### Review

Here are some URLS that can be used for review:
- [Proxy Your Mobile RUM Data](https://docs-staging.datadoghq.com/heston/cdocs-2.7.0/real_user_monitoring/guide/proxy-mobile-rum-data/)
- [Proxy Your Browser RUM Data](https://docs-staging.datadoghq.com/heston/cdocs-2.7.0/real_user_monitoring/guide/proxy-rum-data/)
- [Mobile Session Replay Privacy Options](https://docs-staging.datadoghq.com/heston/cdocs-2.7.0/session_replay/mobile/privacy_options/)
- [Mobile Session Replay Setup and Configuration](https://docs-staging.datadoghq.com/heston/cdocs-2.7.0/session_replay/mobile/setup_and_configuration/)
- [OpenTelemetry API Support](https://docs-staging.datadoghq.com/heston/cdocs-2.7.0/opentelemetry/instrument/dd_sdks/api_support/)

### Merge instructions

Merge readiness:
- [x] Ready for merge