### PR TITLE
Fix typo: on-premise → on-premises in geomap documentation

### DIFF
--- a/content/en/network_monitoring/devices/geomap.md
+++ b/content/en/network_monitoring/devices/geomap.md
@@ -7,7 +7,7 @@ code_lang_weight: 1
 further_reading:
 - link: "https://www.datadoghq.com/blog/visualize-network-device-topology/"
   tag: "Blog"
-  text: "Visualize relationships across your on-premise network with the Device Topology Map"
+  text: "Visualize relationships across your on-premises network with the Device Topology Map"
 - link: "/network_monitoring/devices/data"
   tag: "Documentation"
   text: "Data Collected with Network Device Monitoring"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes a typo in the Network Device Monitoring geomap documentation where a blog post link incorrectly said "on-premise" instead of "on-premises".

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Minor typo fix in further reading link text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)