### PR TITLE
Add LLM agent detection and markdown redirect for RUM pages

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -28,6 +28,10 @@
   {{- if and (ne $.Params.disable_opengraph_meta_tags true) .File -}}
     {{- partial "meta.html" . -}}
   {{- end -}}
+
+  {{ if hasPrefix .RelPermalink "/real_user_monitoring/" }}
+    {{ partial "llm-agent-redirect.html" . }}
+  {{ end }}
 </head>
 {{- $bodyClass := $.Scratch.Get "bodyClass" -}}
 {{- $customClass := $.Params.customclass -}}

--- a/layouts/partials/llm-agent-redirect.html
+++ b/layouts/partials/llm-agent-redirect.html
@@ -1,0 +1,23 @@
+{{- $mdURL := printf "%s.md" (strings.TrimRight "/" .Permalink) -}}
+<link rel="alternate" type="text/markdown" href="{{ $mdURL }}">
+<script>
+(function() {
+  var patterns = [
+    /GPTBot/i, /ChatGPT-User/i, /OAI-SearchBot/i,
+    /ClaudeBot/i, /Claude-User/i, /Claude-SearchBot/i, /anthropic-ai/i,
+    /PerplexityBot/i, /Perplexity-User/i,
+    /Google-Extended/i, /Google-CloudVertexBot/i,
+    /Amazonbot/i, /meta-externalagent/i,
+    /cohere-ai/i, /MistralAI-User/i,
+    /Bytespider/i, /CCBot/i, /DuckAssistBot/i,
+    /FirecrawlAgent/i, /Applebot-Extended/i
+  ];
+  var ua = navigator.userAgent;
+  for (var i = 0; i < patterns.length; i++) {
+    if (patterns[i].test(ua)) {
+      window.location.replace(window.location.href.split('#')[0].split('?')[0].replace(/\/+$/, '') + '.md');
+      break;
+    }
+  }
+})();
+</script>


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Adds LLM agent detection to RUM documentation pages that redirects crawlers to the existing `.md` version of each page, providing cleaner markdown content for AI consumption.

Two complementary mechanisms:
- **`<link rel="alternate" type="text/markdown">`** tag in `<head>` for agents that parse HTML but don't execute JS
- **Inline JavaScript redirect** that detects known LLM crawler user-agents and redirects to the `.md` URL

Scoped to `/real_user_monitoring/` pages only for initial rollout.

### Files changed
- `layouts/partials/llm-agent-redirect.html` — New partial with link tag + JS redirect
- `layouts/_default/baseof.html` — Conditional include for RUM pages
- `docs/plans/2026-02-16-llm-agent-markdown-redirect-design.md` — Design doc

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

- The `.md` endpoint already works in production (e.g., `docs.datadoghq.com/real_user_monitoring/application_monitoring/browser.md`)
- JS redirect only catches agents that execute JavaScript; the `<link>` tag covers agents that parse HTML
- Future work: expand beyond RUM pages, move detection server-side (CloudFront Function)

🤖 Generated with [Claude Code](https://claude.com/claude-code)