### PR TITLE
[DOCS-13122] Clarify Plan & Usage visibility for Cost Summary Sub-Orgs

### DIFF
--- a/content/en/account_management/plan_and_usage/cost_details.md
+++ b/content/en/account_management/plan_and_usage/cost_details.md
@@ -76,6 +76,8 @@ To query estimated cost data through the API, see [Get estimated cost across you
 
 As a sub-organization, you can view the costs for your organization only. This restriction allows for more distributed ownership and removes the need to grant broader Admin permissions to the parent organization.
 
+**Note**: Activating Cost Summary (Sub-Org) allows Admins in the Sub-Org to see the costs of their own organization in Plan & Usage.
+
 {{< img src="account_management/plan_and_usage/suborg-cost-trends.png" alt="Screenshot of the current month's Cost Summary for a sub-organization, showing the overall month-to-date cost, projected cost, a graph with cumulative cost breakdowns, and a summary table including month-over-month cost changes.">}}
 
 View historical costs by toggling back to previous months, or use the date dropdown to view costs over 1,3, 6 or 12 months.


### PR DESCRIPTION
## Summary

Fixes DOCS-13122

Added a note to the Cost Summary (Sub-Organization) section to clarify that activating this feature allows Sub-Org admins to see their organization's costs in Plan & Usage, not just in CCM.

This addresses customer confusion (Honda Motor) where they expected only CCM to be affected by activation, not Plan & Usage visibility.

## Merge instructions

Merge readiness:
- [ ] Ready for merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)