### PR TITLE
[ACTP] Retrieve the list of private actions dynamically

### DIFF
--- a/content/en/actions/private_actions/use_private_actions.md
+++ b/content/en/actions/private_actions/use_private_actions.md
@@ -262,10 +262,10 @@ From the **Private Action Runner** page in [Actions Catalog][6], you can view al
 
 To edit the allowlist for a Private Action Runner:
 
-1. Edit the `actionsAllowlist` section of the `config.yaml` file in your runner's environment and add or remove the relevant permissions.
+1. Edit the `actionsAllowlist` section of the `config.yaml` file in your runner's environment and add or remove the relevant actions.
 1. Restart the runner by restarting your container or deployment.
 
-{{% collapse-content title="Available permissions" level="p" %}}
+{{% collapse-content title="Available actions" level="p" %}}
 
 {{< partial name="actions/private_actions_allowlist.html" >}}
 

--- a/layouts/partials/actions/private_actions_allowlist.html
+++ b/layouts/partials/actions/private_actions_allowlist.html
@@ -35,11 +35,49 @@
     {{ end }}
 {{ end }}
 
-{{/* Output details/summary blocks grouped by integration */}}
+{{/* Prefixes whose sub-integrations get nested under a parent accordion */}}
+{{ $grouped_prefixes := slice "Kubernetes" "GitLab" }}
+
+{{/* Separate entries into grouped vs standalone */}}
+{{ $grouped := dict }}
+{{ $standalone := dict }}
+
 {{ range $title, $fqns := $allowlist }}
+    {{ $matched := false }}
+    {{ range $grouped_prefixes }}
+        {{ if hasPrefix $title . }}
+            {{ $existing := index $grouped . | default dict }}
+            {{ $grouped = merge $grouped (dict . (merge $existing (dict $title $fqns))) }}
+            {{ $matched = true }}
+        {{ end }}
+    {{ end }}
+    {{ if not $matched }}
+        {{ $standalone = merge $standalone (dict $title $fqns) }}
+    {{ end }}
+{{ end }}
+
+{{/* Output standalone integrations */}}
+{{ range $title, $fqns := $standalone }}
 <details>
   <summary>{{ $title }}</summary>
   <pre>{{ range $i, $fqn := $fqns }}{{ if $i }}
 {{ end }}"{{ $fqn }}"{{ end }}</pre>
 </details>
+{{ end }}
+
+{{/* Output grouped integrations under a parent accordion */}}
+{{ range $grouped_prefixes }}
+    {{ $children := index $grouped . }}
+    {{ if $children }}
+<details>
+  <summary>{{ . }}</summary>
+        {{ range $title, $fqns := $children }}
+  <details>
+    <summary>{{ $title }}</summary>
+    <pre>{{ range $i, $fqn := $fqns }}{{ if $i }}
+{{ end }}"{{ $fqn }}"{{ end }}</pre>
+  </details>
+        {{ end }}
+</details>
+    {{ end }}
 {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Create the list of private actions dynamically from the workflow bundles object. This way it will be kept up to date automatically

New : https://docs-staging.datadoghq.com/gabriel.plassard/dynamic-list-of-private-actions/fr/actions/private_actions/use_private_actions/?tab=docker
<img width="759" height="840" alt="image" src="https://github.com/user-attachments/assets/50c6ccac-8a94-4f9f-939e-b2ecf3ba1959" />


Old : https://docs.datadoghq.com/fr/actions/private_actions/use_private_actions/?tab=docker#further-reading
<img width="763" height="476" alt="image" src="https://github.com/user-attachments/assets/d03028ed-8964-4b19-b06b-7916e675a08a" />

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->

I also renamed "permissions" into "actions" as its how we refer to them across the product