### PR TITLE
[OTAGENT-840] Fix RBAC permissions in load balancing exporter

### DIFF
--- a/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_gateway.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_gateway.md
@@ -742,7 +742,10 @@ metadata:
   name: otel-collector-k8s-resolver
 rules:
 - apiGroups: [""]
-  resources: ["endpoints"]
+  resources: ["endpoints"] # for v0.139.0 and before
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"] # for v0.140.0 and after
   verbs: ["get", "watch", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -785,7 +788,10 @@ datadog:
       create: true
       rules:
         - apiGroups: [""]
-          resources: ["endpoints"]
+          resources: ["endpoints"] # for v0.139.0 and before
+          verbs: ["get", "watch", "list"]
+        - apiGroups: ["discovery.k8s.io"]
+          resources: ["endpointslices"] # for v0.140.0 and after
           verbs: ["get", "watch", "list"]
     config: |
       receivers:


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Add correct RBAC permissions for new versions of OTel load balancing exporter. After v0.140.0 the OTel load balancing exporter uses k8s endpointslices instead of k8s endpoints

Context: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/44494 & https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/40871

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
