### PR TITLE
Fix broken Go migration guide link

### DIFF
--- a/content/en/tracing/trace_collection/custom_instrumentation/server-side/_index.mdoc.md
+++ b/content/en/tracing/trace_collection/custom_instrumentation/server-side/_index.mdoc.md
@@ -92,8 +92,6 @@ aliases:
   - /tracing/trace_collection/custom_instrumentation/elixir
   # Swift alias
   - /tracing/trace_collection/custom_instrumentation/swift
-  # Go migration alias
-  - /tracing/trace_collection/custom_instrumentation/go/migration
   # Index aliases for old URL structures
   - /tracing/trace_collection/custom_instrumentation/dd_libraries/
   - /tracing/trace_collection/custom_instrumentation/otel_instrumentation/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The "migration guide" link on the [Server-Side Custom Instrumentation page](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/server-side/?api_type=dd_api&prog_lang=go) (Go + Datadog API view) was broken — clicking it redirected back to the same page instead of navigating to the Go tracer v2 migration guide.

The root cause: `/tracing/trace_collection/custom_instrumentation/go/migration` was listed as a Hugo alias on `_index.mdoc.md`. Hugo aliases create redirect HTML files at those paths that redirect to the page declaring the alias, which overrode the actual `migration.md` page living at that URL.

Fix: remove the erroneous alias. The `migration.md` file at `content/en/tracing/trace_collection/custom_instrumentation/go/migration.md` will now be served correctly at its own URL.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes