### PR TITLE
Fix right column Iac rules page

### DIFF
--- a/content/en/security/code_security/iac_security/iac_rules/_index.md
+++ b/content/en/security/code_security/iac_security/iac_rules/_index.md
@@ -1,8 +1,6 @@
 ---
 title: IaC Security Rules
 type: iac_security
-cascade:
-  - disable_edit: true
 further_reading:
   - link: "/security/code_security/iac_security/setup"
     tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

## What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

On the [docs page of the IaC rules](https://docs.datadoghq.com/security/code_security/iac_security/iac_rules/), the right column is broken. The goal of this PR is to fix this.

This PR removes the `disable-edit` parameter to fix the issue.

### Before

<img width="137" height="244" alt="Screenshot 2026-02-18 at 14 19 19" src="https://github.com/user-attachments/assets/cfd00a68-e8e6-4c69-8bad-9961cbef5af0" />

### After

<img width="137" height="274" alt="Screenshot 2026-02-18 at 14 20 00" src="https://github.com/user-attachments/assets/9ed1cde6-78f1-4f4d-b3e7-cfec6cba7b0e" />

## Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

## Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
