### PR TITLE
Add instructions for docker label integration on ecs managed instances

### DIFF
--- a/content/en/containers/amazon_ecs/managed_instances.md
+++ b/content/en/containers/amazon_ecs/managed_instances.md
@@ -122,7 +122,7 @@ aws ecs create-service --cluster <CLUSTER_NAME> \
 
 ### Metrics collection
 
-To enable integrations, add Docker Label Annotations to your application containers in the ECS task definition.
+To enable integrations, add Docker label annotations to your application containers in the ECS task definition.
 
 #### Add an integration
 
@@ -203,7 +203,7 @@ aws ecs update-service --cluster <CLUSTER_NAME> \
 #### Examples
 
 {{< tabs >}}
-{{% tab "Redis - Web UI" %}}
+{{% tab "AWS Console" %}}
 Use the following table to enter the Docker labels with the [AWS Web Console][1] for a Redis container:
 
 | Key                           | Value                                  |
@@ -214,8 +214,8 @@ Use the following table to enter the Docker labels with the [AWS Web Console][1]
 
 [1]: https://aws.amazon.com/console
 {{% /tab %}}
-{{% tab "Redis - AWS CLI" %}}
-Use the following JSON under `containerDefinitions` to create a Redis container through the [AWS CLI][1]:
+{{% tab "AWS CLI" %}}
+Use the following JSON under `containerDefinitions` to configure a Redis container with Docker labels through the [AWS CLI][1]:
 
 ```json
 {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds instructions for setting up agent integrations on ECS Managed Instances using docker labels. Docker labels were previously unsupported so this was left out, but AWS has recently added support for docker labels.

EXP-199

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
