### PR TITLE
Remove MCP Server private preview language

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -25,10 +25,6 @@ algolia:
   rank: 90
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/datadog-mcp-server/" >}}
-The Datadog MCP Server is in Preview. There is no charge for using the Datadog MCP Server during the Preview, but pricing may change when the feature becomes generally available. If you're interested in the MCP server and need access, complete this form.
-{{< /callout >}}
-
 The Datadog MCP Server acts as a bridge between your observability data in Datadog and any AI agents that support the [Model Context Protocol (MCP)][1]. Providing structured access to relevant Datadog contexts, features, and tools, the MCP Server lets you query and retrieve observability insights directly from AI-powered clients such as Cursor, OpenAI Codex, Claude Code, or your own AI agent.
 
 Ready to get started? See [Set Up the Datadog MCP Server][27] for connection instructions.
@@ -40,8 +36,6 @@ This demo shows the Datadog MCP Server being used in Cursor and Claude Code (unm
 
 ## Disclaimers
 
-- The Datadog MCP Server is not supported for production use during the Preview.
-- Only Datadog organizations that have been specifically allowlisted can use the Datadog MCP Server. It is not available to the general public.
 - The Datadog MCP Server is HIPAA-eligible. You are responsible for ensuring that the AI tools you connect to the Datadog MCP Server meet your compliance requirements, such as HIPAA.
 - Datadog collects certain information about your usage of the Remote Datadog MCP Server, including how you interact with it, whether errors occurred while using it, what caused those errors, and user identifiers in accordance with the <a href="https://www.datadoghq.com/legal/privacy/" target="_blank">Datadog Privacy Policy</a> and Datadog's <a href="https://www.datadoghq.com/legal/eula/" target="_blank">EULA</a>. This data is used to help improve the server's performance and features, including transitions to and from the server and the applicable Datadog login page for accessing the Services, and context (for example, user prompts) leading to the use of MCP tools. The data is stored for 120 days.
 
@@ -73,7 +67,7 @@ To use a toolset, include the `toolsets` query parameter in the endpoint URL whe
 
 This section lists the tools available in the Datadog MCP Server and provides example prompts for using them.
 
-<div class="alert alert-info">Datadog MCP Server tools are under significant development and are subject to change. Use <a href="https://docs.google.com/forms/d/e/1FAIpQLSeorvIrML3F4v74Zm5IIaQ_DyCMGqquIp7hXcycnCafx4htcg/viewform">this feedback form</a> to share any feedback, use cases, or issues encountered with your prompts and queries.</div>
+<div class="alert alert-info">Use <a href="https://docs.google.com/forms/d/e/1FAIpQLSeorvIrML3F4v74Zm5IIaQ_DyCMGqquIp7hXcycnCafx4htcg/viewform">this feedback form</a> to share any feedback, use cases, or issues encountered with your prompts and queries.</div>
 
 ### `search_datadog_events`
 *Toolset: **core***\
@@ -336,7 +330,7 @@ You can view information about calls made by MCP Server tools in Datadog's [Audi
 
 ## Feedback
 
-The Datadog MCP Server is under significant development. During the Preview, use [this feedback form][19] to share any feedback, use cases, or issues encountered with your prompts and queries.
+Use [this feedback form][19] to share any feedback, use cases, or issues encountered with your prompts and queries.
 
 ## Further reading
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -13,17 +13,13 @@ further_reading:
   text: "Datadog Extension for Cursor"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/datadog-mcp-server/" >}}
-The Datadog MCP Server is in Preview. There is no charge for using the Datadog MCP Server during the Preview, but pricing may change when the feature becomes generally available. If you're interested in the MCP server and need access, complete this form.
-{{< /callout >}}
-
 This page explains how to set up and configure the Datadog MCP Server, which lets you query and retrieve observability insights directly from AI-powered clients such as Cursor, OpenAI Codex, Claude Code, or your own AI agent.
 
 ## Client compatibility
 
 The following AI clients are known to be compatible with the Datadog MCP Server.
 
-<div class="alert alert-info">The Datadog MCP Server is under significant development, and additional supported clients may become available.</div>
+<div class="alert alert-info">Additional supported clients may become available.</div>
 
 | Client | Developer | Notes |
 |--------|------|------|
@@ -51,7 +47,7 @@ To install the extension:
    - Cursor: Go to **Cursor Settings** (`Shift` + `Cmd/Ctrl` + `J`) and select the **MCP** tab.
    - VS Code: Open the command palette (`Shift` + `Cmd/Ctrl` + `P`) and run `MCP: Open User Configuration`.
 2. Install the Datadog extension following [these instructions][14]. If you have the extension installed already, make sure it's the latest version, as new features are released regularly.
-3. Sign in to your Datadog account. If you have multiple accounts, use the account included in your Product Preview.
+3. Sign in to your Datadog account.
     {{< img src="bits_ai/mcp_server/ide_sign_in.png" alt="Sign in to Datadog from the IDE extension" style="width:70%;" >}}
 4. **Restart the IDE.**
 5. Confirm the Datadog MCP Server is available and the [tools][20] are listed in your IDE:

--- a/content/en/developers/ide_plugins/vscode/_index.md
+++ b/content/en/developers/ide_plugins/vscode/_index.md
@@ -79,8 +79,6 @@ Install the extension either directly in the IDE, or from the web:
 
 ### MCP Server setup
 
-<div class="alert alert-info">The Datadog MCP Server is in Preview. Complete <a href="https://www.datadoghq.com/product-preview/datadog-mcp-server">this form</a> to request access.</div>
-
 The extension includes access to the [Datadog Model Context Protocol (MCP) Server][3]. Ensure the MCP Server is enabled to enhance the editor's AI capabilities with your specific Datadog environment:
 
 1. Open the chat panel, select agent mode, and click the **Configure Tools** button.
@@ -100,8 +98,6 @@ Install the extension either directly in the IDE, or from the web:
 - **From the web**: Download the VSIX file from [Open VSX Registry][2], and install with `Extensions: Install from VSIX` in the command palette (`Shift` + `Cmd/Ctrl` + `P`).
 
 ### MCP Server setup
-
-<div class="alert alert-info">The Datadog MCP Server is in Preview. Complete <a href="https://www.datadoghq.com/product-preview/datadog-mcp-server">this form</a> to request access.</div>
 
 The extension includes access to the [Datadog Model Context Protocol (MCP) Server][3]. Ensure the MCP Server is enabled to enhance the editor's AI capabilities with your specific Datadog environment:
 

--- a/content/en/getting_started/software_delivery_mcp_tools/_index.md
+++ b/content/en/getting_started/software_delivery_mcp_tools/_index.md
@@ -16,10 +16,6 @@ further_reading:
   text: "Connect your AI agents to Datadog tools and context using the Datadog MCP Server"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/datadog-mcp-server/" >}}
-The Datadog MCP Server is in Preview. There is no charge for using the Datadog MCP Server during the Preview, but pricing may change when the feature becomes generally available. If you're interested in the MCP server and need access, complete this form.
-{{< /callout >}}
-
 ## Overview
 
 The [Datadog MCP Server][1] enables AI agents to access your Software Delivery data through the [Model Context Protocol (MCP)][2]. The `software-delivery` toolset provides tools for interacting with [CI Visibility][3] and [Test Optimization][4] directly from AI-powered clients like Cursor, Claude Code, or OpenAI Codex.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The MCP Server is being opened up to all customers soon (late this week? next week?), no more allowlisting or preview signup forms. This PR removes the private preview language from the MCP docs:

- Remove "in Preview" callout banners with product-preview signup forms
- Remove disclaimers about allowlisting and no production use
- Remove "request access" alerts from the VS Code/Cursor extension page
- Remove "under significant development" caveats
- Remove "use the account included in your Product Preview" from setup instructions

### Merge instructions

Merge readiness:
- [ ] Ready for merge
    - Not yet; will wait until we actually open it up