### PR TITLE
Configure Hugo to ignore Cdocs partials

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -8,6 +8,7 @@ enableRobotsTXT: true
 # don't publish cdocs source files
 ignoreFiles:
   - "\\.mdoc\\.md$"
+  - "\\.tempAst\\.json$"
   - "^integrations_data/"
   - "^hugpython/"
   - "^examples/"
@@ -136,6 +137,9 @@ module:
       target: static
     - source: layouts
       target: layouts
+      excludeFiles:
+        - 'shortcodes/.cdocs_temp/*'
+        - 'shortcodes/mdoc/*'
     - source: data
       target: data
     - source: static


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Hugo is still trying to process Cdocs partials, which is causing errors for some writers if their partial contains a code block with `{{` in it (just as one example). We don't need Hugo to process Cdocs partials at all, so I've strengthened the ignores in hopes of fixing the issue.

On the branch of the writer with the above problem, I verified that this new config prevents the Hugo errors she was seeing. But we'll have to test it more as migrated content comes in to know if we've successfully avoided all future Hugo complaints.

Cdocs is unaffected, see [this example Cdocs page](https://docs-staging.datadoghq.com/jen.gilbert/WEB-8244-cdocs-config-fix/error_tracking/error_grouping) which is made entirely of partials, all of which still build as expected. Hugo wasn't using these files, so no impact to non-Cdocs pages is expected.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
