### PR TITLE
[DOCS-12642] Add US1-FED unavailability notices to RUM Auto-Instrumentation pages

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/setup/_index.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/setup/_index.md
@@ -9,6 +9,10 @@ further_reading:
   text: 'RUM Browser Monitoring'
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">RUM Auto-Instrumentation is not available for the selected site ({{< region-param key="dd_site_name" >}}). Use <a href="/real_user_monitoring/application_monitoring/browser/setup/client">Client-Side instrumentation</a> instead.</div>
+{{< /site-region >}}
+
 ## Setup
 
 {{< whatsnext desc="Choose the instrumentation type for the Browser SDK:" >}}

--- a/content/en/real_user_monitoring/application_monitoring/browser/setup/server/_index.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/setup/server/_index.md
@@ -16,6 +16,10 @@ further_reading:
   text: 'Learn about the Datadog Browser SDK for Logs'
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">RUM Auto-Instrumentation is not available for the selected site ({{< region-param key="dd_site_name" >}}). Use <a href="/real_user_monitoring/application_monitoring/browser/setup/client">Client-Side instrumentation</a> instead.</div>
+{{< /site-region >}}
+
 {{< callout url=https://www.datadoghq.com/product-preview/rum-sdk-auto-instrumentation/
  btn_hidden="false" header="Join the Preview!">}}
 RUM Auto-Instrumentation is in Preview. Use this form to sign up.

--- a/content/en/real_user_monitoring/application_monitoring/browser/setup/server/apache.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/setup/server/apache.md
@@ -13,6 +13,10 @@ further_reading:
   text: 'Browser Monitoring Auto-Instrumentation'
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">RUM Auto-Instrumentation is not available for the selected site ({{< region-param key="dd_site_name" >}}). Use <a href="/real_user_monitoring/application_monitoring/browser/setup/client">Client-Side instrumentation</a> instead.</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">To try the preview for RUM Auto-Instrumentation, follow the instructions on this page.</div>
 
 ## Overview

--- a/content/en/real_user_monitoring/application_monitoring/browser/setup/server/ibm.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/setup/server/ibm.md
@@ -13,6 +13,10 @@ further_reading:
   text: 'Browser Monitoring Auto-Instrumentation'
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">RUM Auto-Instrumentation is not available for the selected site ({{< region-param key="dd_site_name" >}}). Use <a href="/real_user_monitoring/application_monitoring/browser/setup/client">Client-Side instrumentation</a> instead.</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">To try the preview for RUM Auto-Instrumentation, follow the instructions on this page.</div>
 
 ## Overview

--- a/content/en/real_user_monitoring/application_monitoring/browser/setup/server/java.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/setup/server/java.md
@@ -15,6 +15,10 @@ further_reading:
   text: 'Single Step APM Instrumentation'
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">RUM Auto-Instrumentation is not available for the selected site ({{< region-param key="dd_site_name" >}}). Use <a href="/real_user_monitoring/application_monitoring/browser/setup/client">Client-Side instrumentation</a> instead.</div>
+{{< /site-region >}}
+
 ## Overview
 
 RUM Auto-Instrumentation automatically adds RUM monitoring to your web application server, so you can start collecting RUM data by editing a configuration file instead of having to modify your frontend code directly. However, if you want to track specific user actions (custom actions) or add custom event details (event attributes), you still need to add some code to your application.

--- a/content/en/real_user_monitoring/application_monitoring/browser/setup/server/nginx.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/setup/server/nginx.md
@@ -13,6 +13,10 @@ further_reading:
   text: 'Browser Monitoring Auto-Instrumentation'
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">RUM Auto-Instrumentation is not available for the selected site ({{< region-param key="dd_site_name" >}}). Use <a href="/real_user_monitoring/application_monitoring/browser/setup/client">Client-Side instrumentation</a> instead.</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">To try the preview for RUM Auto-Instrumentation, follow the instructions on this page.</div>
 
 ## Overview

--- a/content/en/real_user_monitoring/application_monitoring/browser/setup/server/windows_iis.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/setup/server/windows_iis.md
@@ -13,6 +13,10 @@ further_reading:
   text: 'Browser Monitoring Auto-Instrumentation'
 ---
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">RUM Auto-Instrumentation is not available for the selected site ({{< region-param key="dd_site_name" >}}). Use <a href="/real_user_monitoring/application_monitoring/browser/setup/client">Client-Side instrumentation</a> instead.</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">To try the preview for RUM Auto-Instrumentation, follow the instructions on this page.</div>
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds banners to RUM Auto-Instrumentation pages for gov, which is not supported.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Confirmed by Javi Alvarez that Auto-Instrumentation preview is not available for US1-FED customers.