### PR TITLE
Update max HTTP request step assertions from 20 to 25

### DIFF
--- a/content/en/synthetics/mobile_app_testing/mobile_app_tests/steps.md
+++ b/content/en/synthetics/mobile_app_testing/mobile_app_tests/steps.md
@@ -260,7 +260,7 @@ HTTP requests can decompress bodies with the following `content-encoding` header
 
 {{< img src="synthetics/browser_tests/assertions.png" alt="Define assertions for your browser test to succeed or fail on" style="width:80%;" >}}
 
-You can create up to 25 assertions per step by clicking **New Assertion** or by clicking directly on the response preview.
+You can create up to 20 assertions per step by clicking **New Assertion** or by clicking directly on the response preview.
 
 ##### Extract a variable from the response
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the maximum number of assertions per HTTP request step in browser tests from 20 to 25, per the Synthetics Browser Tests technical overview.

Files updated:
- `content/en/synthetics/browser_tests/test_steps.md`
- `content/en/synthetics/mobile_app_testing/mobile_app_tests/steps.md`

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes