### PR TITLE
Document all MCP Server toolsets

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -480,43 +480,43 @@ Retrieves all network interfaces for a specific device.
 - Show me all interfaces on device `device:abc123`.
 - List the interface statuses for my core router.
 
-### `onboarding_browser`
+### `browser_onboarding`
 *Toolset: **onboarding***\
 Guides you through onboarding Browser RUM to Datadog.
 
 - Help me set up Browser RUM monitoring for my web application.
 
-### `onboarding_devices`
+### `devices_onboarding`
 *Toolset: **onboarding***\
 Guides you through onboarding devices to Datadog monitoring.
 
 - Help me set up device monitoring in Datadog.
 
-### `onboarding_kubernetes`
+### `kubernetes_onboarding`
 *Toolset: **onboarding***\
 Guides you through onboarding Kubernetes clusters to Datadog.
 
 - Help me set up Datadog monitoring for my Kubernetes cluster.
 
-### `onboarding_llmobs`
+### `llm_observability_onboarding `
 *Toolset: **onboarding***\
 Guides you through onboarding LLM Observability in Datadog.
 
 - Help me set up LLM Observability for my AI application.
 
-### `onboarding_test_optimization`
+### `test_optimization_onboarding`
 *Toolset: **onboarding***\
 Guides you through onboarding Test Optimization in Datadog.
 
 - Help me set up Test Optimization for my CI pipeline.
 
-### `onboarding_serverless`
+### `serverless_onboarding`
 *Toolset: **onboarding***\
 Guides you through onboarding serverless applications to Datadog.
 
 - Help me monitor my AWS Lambda functions with Datadog.
 
-### `onboarding_source_maps`
+### `source_map_uploads `
 *Toolset: **onboarding***\
 Guides you through uploading source maps for RUM error mapping.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The MCP Server will have 12 accessible-to-everyone toolsets at GA, but only 5 were documented. This adds documentation for the remaining 7:

- **alerting** (3 tools) - monitor validation, templates, and group search
- **apm** (16 tools) - span search, trace analysis, Watchdog insights, latency investigation, recommendations
- **feature-flags** (8 tools) - create, list, update, and check feature flags
- **llmobs** (1 tool) - LLM Observability span search
- **networks** (4 tools) - Cloud Network Monitoring analysis and Network Device Monitoring
- **onboarding** (8 tools) - guided setup for Browser RUM, Kubernetes, ECS, serverless, and more
- **security** (5 tools) - SAST/secrets scanning, security signals, and security findings

Also reorganizes the tool sections alphabetically by toolset for easier navigation.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Tool names and descriptions sourced from the MCP server codebase by Claude Code+Opus 4.6.