### PR TITLE
[CHORE] Remove duplicate import in Expo Setup

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/react_native/setup/expo.md
+++ b/content/en/real_user_monitoring/application_monitoring/react_native/setup/expo.md
@@ -110,8 +110,6 @@ import {
     TraceConfiguration
 } from 'expo-datadog';
 
-import { DatadogProviderConfiguration } from '@datadog/mobile-react-native';
-
 const config = new DatadogProviderConfiguration(
     '<CLIENT_TOKEN>', 
     '<ENVIRONMENT_NAME>',


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Removes duplicate `DatadogProviderConfiguration` import in Expo Setup docs.

### Merge instructions
Merge readiness:
- [x] Ready for merge


