### PR TITLE
[IDE-5535] Add RubyMine to JetBrains IDE plugin documentation

### DIFF
--- a/content/en/developers/ide_plugins/_index.md
+++ b/content/en/developers/ide_plugins/_index.md
@@ -13,6 +13,6 @@ aliases:
 Use Datadog plugins in your preferred integrated development environment (IDE) to interact with Datadog services as you code.
 
 {{< whatsnext desc="See the documentation for information about the following integrations:">}}
-    {{< nextlink href="developers/ide_plugins/idea/" >}}<u>JetBrains IDEs</u>: The Datadog plugin for IntelliJ IDEA, GoLand, PyCharm, WebStorm, and PhpStorm.{{< /nextlink >}}
+    {{< nextlink href="developers/ide_plugins/idea/" >}}<u>JetBrains IDEs</u>: The Datadog plugin for IntelliJ IDEA, GoLand, PyCharm, RubyMine, WebStorm, and PhpStorm.{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/vscode/" >}}<u>VS Code & Cursor</u>: The Datadog extension for VS Code, Cursor, and other related forks.{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/developers/ide_plugins/idea/_index.md
+++ b/content/en/developers/ide_plugins/idea/_index.md
@@ -31,7 +31,7 @@ further_reading:
 
 ## Overview
 
-The Datadog plugin for JetBrains IDEs helps improve software performance by providing code insights in the IDE based on real-time observability data. The plugin is for developers that use Datadog products including [Error Tracking][25], [Logs][23], [Live Debugger][20] and [Code Security][24] to monitor their services. It is available for IntelliJ IDEA, GoLand, PyCharm, WebStorm, and PhpStorm.
+The Datadog plugin for JetBrains IDEs helps improve software performance by providing code insights in the IDE based on real-time observability data. The plugin is for developers that use Datadog products including [Error Tracking][25], [Logs][23], [Live Debugger][20] and [Code Security][24] to monitor their services. It is available for IntelliJ IDEA, GoLand, PyCharm, RubyMine, WebStorm, and PhpStorm.
 
 {{< img src="/developers/ide_plugins/idea/overview1.png" alt="The Datadog tool window open in IDEA" style="width:100%;" >}}
 

--- a/content/en/getting_started/code_security/_index.md
+++ b/content/en/getting_started/code_security/_index.md
@@ -45,7 +45,7 @@ Install the [Datadog IDE plugins][5] to run Static Code Analysis (SAST) scans lo
 To start running code scans in your IDE, see the respective documentation for your code editor of choice.
 
 {{< whatsnext desc="See the documentation for information about the following integrations:">}}
-    {{< nextlink href="developers/ide_plugins/idea/#static-analysis" >}}<u>JetBrains IDEs</u>: IntelliJ IDEA, GoLand, PyCharm, WebStorm, and PhpStorm{{< /nextlink >}}
+    {{< nextlink href="developers/ide_plugins/idea/#static-analysis" >}}<u>JetBrains IDEs</u>: IntelliJ IDEA, GoLand, PyCharm, RubyMine, WebStorm, and PhpStorm{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/vscode/#static-analysis" >}}<u>Visual Studio Code</u>{{< /nextlink >}}
 {{< /whatsnext >}}
 

--- a/content/en/security/code_security/dev_tool_int/ide_plugins/_index.md
+++ b/content/en/security/code_security/dev_tool_int/ide_plugins/_index.md
@@ -11,7 +11,7 @@ disable_toc: false
 [Code Security][1] integrates directly with integrated development environment (IDE) tools to provide real-time feedback on the security and quality of your code. IDE integrations are supported for SAST, SCA, and IAST.
 
 {{< whatsnext desc="See the documentation for information about the following integrations:">}}
-    {{< nextlink href="developers/ide_plugins/idea/#static-analysis" >}}<u>JetBrains IDEs</u>: IntelliJ IDEA, GoLand, PyCharm, WebStorm, and PhpStorm{{< /nextlink >}}
+    {{< nextlink href="developers/ide_plugins/idea/#static-analysis" >}}<u>JetBrains IDEs</u>: IntelliJ IDEA, GoLand, PyCharm, RubyMine, WebStorm, and PhpStorm{{< /nextlink >}}
     {{< nextlink href="developers/ide_plugins/vscode/#static-analysis" >}}<u>Visual Studio Code</u>{{< /nextlink >}}
 {{< /whatsnext >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Adds RubyMine to the list of supported JetBrains IDEs.

### Merge instructions
RubyMine will be supported in the next release of the Datadog plugin for JetBrains IDEs.

Merge readiness:
- [ ] Ready for merge

### Additional notes
@joepeeples 
