### PR TITLE
[LCLZTN-328] docs(agentless): fix agentless name in french translation

### DIFF
--- a/content/fr/security/cloud_security_management/setup/agentless_scanning/_index.md
+++ b/content/fr/security/cloud_security_management/setup/agentless_scanning/_index.md
@@ -6,22 +6,22 @@ further_reading:
 - link: /security/vulnerabilities
   tag: Documentation
   text: En savoir plus sur les vulnérabilités de Cloud Security
-title: Scanning sans Agent Cloud Security
+title: Agentless Scanning Cloud Security
 ---
 
 ## Section Overview
 
-Le scanning sans Agent offre une visibilité sur les vulnérabilités qui existent dans votre infrastructure cloud, sans nécessiter l'installation de l'Agent Datadog. Datadog recommande d'activer le scanning sans Agent comme première étape pour obtenir une visibilité complète sur vos ressources cloud, puis d'installer l'Agent Datadog sur vos ressources principales au fil du temps pour un contexte de sécurité et d'observabilité plus approfondi. 
+Agentless Scanning offre une visibilité sur les vulnérabilités qui existent dans votre infrastructure cloud, sans nécessiter l'installation de l'Agent Datadog. Datadog recommande d'activer Agentless Scanning comme première étape pour obtenir une visibilité complète sur vos ressources cloud, puis d'installer l'Agent Datadog sur vos ressources principales au fil du temps pour un contexte de sécurité et d'observabilité plus approfondi. 
 
 ## Fonctionnement
 
-Après avoir [configuré le scanning sans Agent][1] pour vos ressources, Datadog planifie des scans automatisés toutes les 12 heures via la [Configuration à distance][2]. Lors d'un cycle de scan, les scanners sans Agent recueillent les dépendances du code Lambda et créent des instantanés de vos instances de VM. Avec ces instantanés, les scanners sans Agent scannent, génèrent et transmettent une liste de paquets à Datadog pour rechercher les vulnérabilités, ainsi que les dépendances du code Lambda. Lorsque les scans d'un instantané sont terminés, l'instantané est supprimé. Aucune information confidentielle ou personnelle privée n'est jamais transmise en dehors de votre infrastructure. 
+Après avoir [configuré Agentless Scanning][1] pour vos ressources, Datadog planifie des scans automatisés toutes les 12 heures via la [Configuration à distance][2]. Lors d'un cycle de scan, les Agentless scanners recueillent les dépendances du code Lambda et créent des instantanés de vos instances de VM. Avec ces instantanés, les Agentless scanners scannent, génèrent et transmettent une liste de paquets à Datadog pour rechercher les vulnérabilités, ainsi que les dépendances du code Lambda. Lorsque les scans d'un instantané sont terminés, l'instantané est supprimé. Aucune information confidentielle ou personnelle privée n'est jamais transmise en dehors de votre infrastructure. 
 
-Si vous avez configuré des [filtres d'évaluation Cloud Security][15], le scanning sans Agent respecte ces filtres et scanne uniquement les ressources qui correspondent aux critères configurés.
+Si vous avez configuré des [filtres d'évaluation Cloud Security][15], Agentless Scanning respecte ces filtres et scanne uniquement les ressources qui correspondent aux critères configurés.
 
-Le diagramme suivant illustre le fonctionnement du scanning sans Agent :
+Le diagramme suivant illustre le fonctionnement d'Agentless Scanning :
 
-{{< img src="/security/agentless_scanning/how_agentless_works.png" alt="Diagramme montrant le fonctionnement du scanning sans Agent" width="90%" >}}
+{{< img src="/security/agentless_scanning/how_agentless_works.png" alt="Diagramme montrant le fonctionnement d'Agentless Scanning" width="90%" >}}
 
 1. Datadog planifie un scan et envoie les ressources à scanner via la Configuration à distance.
 
@@ -40,7 +40,7 @@ Le diagramme suivant illustre le fonctionnement du scanning sans Agent :
 
 ## Scanning à la demande
 
-Par défaut, le scanning sans Agent scanne automatiquement vos ressources toutes les 12 heures. Vous pouvez également déclencher un scan immédiat d'une ressource spécifique (host, conteneur, fonction Lambda ou compartiment S3) à l'aide de l'API de scanning à la demande.
+Par défaut, Agentless Scanning scanne automatiquement vos ressources toutes les 12 heures. Vous pouvez également déclencher un scan immédiat d'une ressource spécifique (host, conteneur, fonction Lambda ou compartiment S3) à l'aide de l'API de scanning à la demande.
 
 Cela est utile lorsque vous devez :
 - Vérifier qu'une vulnérabilité a été corrigée
@@ -50,7 +50,7 @@ Cela est utile lorsque vous devez :
 Pour plus d'informations, consultez la [documentation de l'API de scanning à la demande][14].
 
 ## Données envoyées à Datadog
-Le scanner sans Agent utilise le format [cycloneDX][3] d'OWASP pour transmettre une liste de paquets à Datadog. Aucune information confidentielle ou personnelle privée n'est jamais transmise en dehors de votre infrastructure.
+Agentless scanner utilise le format [cycloneDX][3] d'OWASP pour transmettre une liste de paquets à Datadog. Aucune information confidentielle ou personnelle privée n'est jamais transmise en dehors de votre infrastructure.
 
 Datadog n'envoie **pas** :
 - Les configurations des systèmes et paquets
@@ -73,15 +73,15 @@ Pour atténuer davantage ce risque, Datadog met en œuvre les mesures de sécuri
 - L'accès aux instances de scanner est étroitement contrôlé par l'utilisation de groupes de sécurité. Aucun accès entrant au scanner n'est autorisé, limitant ainsi la possibilité de compromettre l'instance.
 - Aucune information confidentielle ou personnelle privée n'est jamais transmise en dehors de votre infrastructure.
 
-## Scanning sans Agent avec des installations existantes de l'Agent
+## Agentless Scanning avec des installations existantes de l'Agent
 
 Lorsqu'il est installé, l'Agent Datadog offre une visibilité approfondie en temps réel sur les risques et vulnérabilités qui existent dans vos charges de travail cloud. Il est recommandé d'installer complètement l'Agent Datadog.
 
-Par conséquent, le scanning sans Agent exclut de ses scans les ressources sur lesquelles l'Agent Datadog est installé et configuré pour la [gestion des vulnérabilités][5]. De cette manière, Cloud Security offre une visibilité complète de votre paysage de risques sans annuler les avantages reçus de l'installation de l'Agent Datadog avec la gestion des vulnérabilités.
+Par conséquent, Agentless Scanning exclut de ses scans les ressources sur lesquelles l'Agent Datadog est installé et configuré pour la [gestion des vulnérabilités][5]. De cette manière, Cloud Security offre une visibilité complète de votre paysage de risques sans annuler les avantages reçus de l'installation de l'Agent Datadog avec la gestion des vulnérabilités.
 
-Le diagramme suivant illustre le fonctionnement du scanning sans Agent avec des installations existantes de l'Agent :
+Le diagramme suivant illustre le fonctionnement d'Agentless Scanning avec des installations existantes de l'Agent :
 
-{{< img src="/security/agentless_scanning/agentless_existing.png" alt="Diagramme montrant le fonctionnement du scanning sans Agent lorsque l'Agent est déjà installé avec la gestion des vulnérabilités Cloud Security" width="90%" >}}
+{{< img src="/security/agentless_scanning/agentless_existing.png" alt="Diagramme montrant le fonctionnement d'Agentless Scanning lorsque l'Agent est déjà installé avec la gestion des vulnérabilités Cloud Security" width="90%" >}}
 
 ## Scanning du stockage cloud
 
@@ -90,17 +90,17 @@ Le diagramme suivant illustre le fonctionnement du scanning sans Agent avec des 
 
 Si vous avez activé le [Sensitive Data Scanner][8], vous pouvez cataloguer et classifier les données sensibles dans vos compartiments Amazon S3.
 
-Le Sensitive Data Scanner recherche les données sensibles en déployant des [scanners sans Agent][1] dans vos environnements cloud. Ces instances de scanning récupèrent une liste de tous les compartiments S3 via la [Configuration à distance][10], et ont des instructions définies pour scanner les fichiers texte, tels que les CSV et JSON au fil du temps. Le Sensitive Data Scanner exploite l'ensemble de sa [bibliothèque de règles][11] pour trouver des correspondances. Lorsqu'une correspondance est trouvée, l'emplacement de la correspondance est envoyé à Datadog par l'instance de scanning. Les magasins de données et leurs fichiers sont uniquement lus dans votre environnement : aucune donnée sensible n'est renvoyée à Datadog. 
+Le Sensitive Data Scanner recherche les données sensibles en déployant des [Agentless scanners][1] dans vos environnements cloud. Ces instances de scanning récupèrent une liste de tous les compartiments S3 via la [Configuration à distance][10], et ont des instructions définies pour scanner les fichiers texte, tels que les CSV et JSON au fil du temps. Le Sensitive Data Scanner exploite l'ensemble de sa [bibliothèque de règles][11] pour trouver des correspondances. Lorsqu'une correspondance est trouvée, l'emplacement de la correspondance est envoyé à Datadog par l'instance de scanning. Les magasins de données et leurs fichiers sont uniquement lus dans votre environnement : aucune donnée sensible n'est renvoyée à Datadog. 
 
 En plus d'afficher les correspondances de données sensibles, le Sensitive Data Scanner fait apparaître tous les problèmes de sécurité détectés par [Cloud Security][9] affectant les magasins de données sensibles. Vous pouvez cliquer sur n'importe quel problème pour poursuivre le triage et la remédiation dans Cloud Security.
 
 ## Coût du fournisseur de services cloud
 
-Lors de l'utilisation du scanning sans Agent, des coûts supplémentaires du fournisseur de cloud s'appliquent pour l'exécution des scanners et le scanning de vos environnements cloud.
+Lors de l'utilisation d'Agentless Scanning, des coûts supplémentaires du fournisseur de cloud s'appliquent pour l'exécution des scanners et le scanning de vos environnements cloud.
 
 Votre configuration cloud affecte les coûts de votre fournisseur de cloud. Généralement, en utilisant la [configuration recommandée][13], ceux-ci se situent dans la fourchette de 1 USD par host scanné par an. Vous devez consulter les informations de votre fournisseur de cloud pour connaître les montants exacts, qui sont susceptibles de changer sans l'intervention de Datadog.
 
-Pour les charges de travail cloud volumineuses réparties sur plusieurs régions, Datadog recommande de configurer le [scanning sans Agent avec Terraform][6] pour éviter la mise en réseau inter-régions.
+Pour les charges de travail cloud volumineuses réparties sur plusieurs régions, Datadog recommande de configurer le [Agentless Scanning avec Terraform][6] pour éviter la mise en réseau inter-régions.
 
 
 ## Pour aller plus loin

--- a/content/fr/security/cloud_security_management/setup/agentless_scanning/compatibility.md
+++ b/content/fr/security/cloud_security_management/setup/agentless_scanning/compatibility.md
@@ -1,16 +1,16 @@
 ---
 aliases:
 - /fr/security/cloud_security_management/agentless_scanning/compatibility
-title: Compatibilité du scanning sans Agent
+title: Compatibilité d'Agentless Scanning
 ---
 
 ## Disponibilité
 
-Le scanning sans Agent est pris en charge sur AWS, Azure et GCP. Oracle Cloud Infrastructure (OCI) n'est pas encore pris en charge.
+Agentless Scanning est pris en charge sur AWS, Azure et GCP. Oracle Cloud Infrastructure (OCI) n'est pas encore pris en charge.
 
 Cette fonctionnalité est disponible dans tous les datacenters commerciaux Datadog. GovCloud n'est pas pris en charge.
 
-Le tableau suivant fournit un résumé des technologies de scanning sans Agent par rapport à leurs composants correspondants pour chaque fournisseur de cloud pris en charge :
+Le tableau suivant fournit un résumé des technologies de Agentless Scanning par rapport à leurs composants correspondants pour chaque fournisseur de cloud pris en charge :
 
 | Composant                                       | AWS                                                                                                                                       | Azure                                                                                                                                                                             | GCP                                                                                                                                                                             |
 |-------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -68,7 +68,7 @@ Les registres d'images de conteneur suivants sont pris en charge pour les scans 
 - Amazon ECR public
 - Amazon ECR privé
 
-**Remarque** : le scanning d'images de conteneur à partir du registre n'est pris en charge que si vous avez installé le scanning sans Agent avec :
+**Remarque** : le scanning d'images de conteneur à partir du registre n'est pris en charge que si vous avez installé Agentless Scanning avec :
   - Cloudformation Integrations >= v2.0.8
   - Terraform Agentless Module >= v0.11.7
 
@@ -79,7 +79,7 @@ Les runtimes de conteneur suivants sont pris en charge :
 - containerd : v1.5.6 ou version ultérieure
 - Docker
 
-**Remarque pour les observations de conteneur** : le scanning sans Agent nécessite des couches d'images de conteneur non compressées. Comme solution de contournement, vous pouvez définir l'option de configuration `discard_unpacked_layers=false` dans le fichier de configuration de containerd.
+**Remarque pour les observations de conteneur** : Agentless Scanning nécessite des couches d'images de conteneur non compressées. Comme solution de contournement, vous pouvez définir l'option de configuration `discard_unpacked_layers=false` dans le fichier de configuration de containerd.
 
 [1]: https://secdb.alpinelinux.org/
 [2]: https://packages.wolfi.dev/os/security.json

--- a/content/fr/security/cloud_security_management/setup/agentless_scanning/deployment_methods.md
+++ b/content/fr/security/cloud_security_management/setup/agentless_scanning/deployment_methods.md
@@ -4,31 +4,31 @@ aliases:
 further_reading:
 - link: /security/cloud_security_management/agentless_scanning
   tag: Documentation
-  text: Scanning sans Agent Cloud Security
-title: Déploiement du scanning sans Agent
+  text: Agentless Scanning Cloud Security
+title: Déploiement d'Agentless Scanning
 ---
 
-Il existe deux méthodes recommandées pour déployer les scanners sans Agent dans votre environnement : soit en utilisant le scanning inter-comptes, soit le scanning dans le même compte.
+Il existe deux méthodes recommandées pour déployer les Agentless scanners dans votre environnement : soit en utilisant le scanning inter-comptes, soit le scanning dans le même compte.
 
 {{< tabs >}}
 {{% tab "Cross-account scanning" %}}
 
-Avec le scanning inter-comptes, les scanners sans Agent sont déployés dans plusieurs régions au sein d'un seul compte cloud. Les scanners sans Agent déployés bénéficient d'une visibilité sur plusieurs comptes sans avoir besoin d'effectuer des scans inter-régions, qui sont coûteux en pratique.
+Avec le scanning inter-comptes, les Agentless scanners sont déployés dans plusieurs régions au sein d'un seul compte cloud. Les Agentless scanners déployés bénéficient d'une visibilité sur plusieurs comptes sans avoir besoin d'effectuer des scans inter-régions, qui sont coûteux en pratique.
 
-Pour les comptes plus importants avec 250 hosts ou plus, il s'agit de l'option la plus rentable car elle évite les scans inter-régions et réduit les frictions liées à la gestion de vos scanners sans Agent. Vous pouvez soit créer un compte dédié pour vos scanners sans Agent, soit en choisir un existant. Le compte où se trouvent les scanners sans Agent peut également être scanné.
+Pour les comptes plus importants avec 250 hosts ou plus, il s'agit de l'option la plus rentable car elle évite les scans inter-régions et réduit les frictions liées à la gestion de vos Agentless scanners. Vous pouvez soit créer un compte dédié pour vos Agentless scanners, soit en choisir un existant. Le compte où se trouvent les Agentless scanners peut également être scanné.
 
-Le diagramme suivant illustre le fonctionnement du scanning sans Agent lorsqu'il est déployé dans un compte cloud central :
+Le diagramme suivant illustre le fonctionnement d'Agentless Scanning lorsqu'il est déployé dans un compte cloud central :
 
-{{< img src="/sensitive_data_scanner/setup/cloud_storage/central-scanner.png" alt="Diagramme du scanning sans Agent montrant que le scanner sans Agent est déployé dans un compte cloud central" width="90%" >}}
+{{< img src="/sensitive_data_scanner/setup/cloud_storage/central-scanner.png" alt="Diagramme d'Agentless Scanning montrant que Agentless scanner est déployé dans un compte cloud central" width="90%" >}}
 
 {{% /tab %}}
 {{% tab "Same account scanning" %}}
 
-Avec le scanning dans le même compte, un seul scanner sans Agent est déployé par compte. Bien que cela puisse entraîner des coûts plus élevés, car chaque scanner sans Agent doit effectuer des scans inter-régions par compte, Datadog recommande cette option si vous ne souhaitez pas accorder d'autorisations inter-comptes.
+Avec le scanning dans le même compte, un seul Agentless scanner est déployé par compte. Bien que cela puisse entraîner des coûts plus élevés, car chaque Agentless scanner doit effectuer des scans inter-régions par compte, Datadog recommande cette option si vous ne souhaitez pas accorder d'autorisations inter-comptes.
 
-Le diagramme suivant illustre le fonctionnement du scanning sans Agent lorsqu'il est déployé dans chaque compte cloud :
+Le diagramme suivant illustre le fonctionnement d'Agentless Scanning lorsqu'il est déployé dans chaque compte cloud :
 
-{{< img src="/sensitive_data_scanner/setup/cloud_storage/scanner-in-each-account.png" alt="Diagramme du scanning sans Agent montrant que le scanner sans Agent est déployé dans chaque compte cloud" width="90%" >}}
+{{< img src="/sensitive_data_scanner/setup/cloud_storage/scanner-in-each-account.png" alt="Diagramme d'Agentless Scanning montrant que Agentless scanner est déployé dans chaque compte cloud" width="90%" >}}
 
 [3]: https://app.datadoghq.com/security/csm/vm
 [4]: /fr/remote_configuration
@@ -37,7 +37,7 @@ Le diagramme suivant illustre le fonctionnement du scanning sans Agent lorsqu'il
 {{< /tabs >}}
 
 ## Configuration recommandée
-Le scanning sans Agent entraîne des [coûts supplémentaires du fournisseur de services cloud][2] pour l'exécution des scanners dans vos environnements cloud. Pour gérer les coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le scanning sans Agent avec Terraform comme modèle par défaut. Terraform permet de déployer un scanner par région, ce qui évite la mise en réseau inter-régions.
+Agentless Scanning entraîne des [coûts supplémentaires du fournisseur de services cloud][2] pour l'exécution des scanners dans vos environnements cloud. Pour gérer les coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer Agentless Scanning avec Terraform comme modèle par défaut. Terraform permet de déployer un scanner par région, ce qui évite la mise en réseau inter-régions.
 Pour améliorer l'efficacité du scanner, assurez-vous que votre configuration respecte ces directives :
 
 - Déployer les scanners dans un seul compte AWS

--- a/content/fr/security/cloud_security_management/setup/agentless_scanning/enable.md
+++ b/content/fr/security/cloud_security_management/setup/agentless_scanning/enable.md
@@ -12,21 +12,21 @@ further_reading:
   text: Configurer Cloud Security
 - link: /security/cloud_security_management/agentless_scanning
   tag: Documentation
-  text: Scanning sans Agent Cloud Security
-title: Activer le scanning sans Agent
+  text: Agentless Scanning Cloud Security
+title: Activer Agentless Scanning
 ---
 
-Le scanning sans Agent offre une visibilité sur les vulnérabilités qui existent dans votre infrastructure cloud, sans nécessiter l'installation de l'Agent Datadog. Pour en savoir plus sur les capacités du scanning sans Agent et son fonctionnement, consultez la documentation sur le [scanning sans Agent][12].
+Agentless Scanning offre une visibilité sur les vulnérabilités qui existent dans votre infrastructure cloud, sans nécessiter l'installation de l'Agent Datadog. Pour en savoir plus sur les capacités d'Agentless Scanning et son fonctionnement, consultez la documentation sur le [Agentless Scanning][12].
 
 ## Prérequis
 
-Avant de configurer le scanning sans Agent, assurez-vous que les prérequis suivants sont remplis :
+Avant de configurer Agentless Scanning, assurez-vous que les prérequis suivants sont remplis :
 
-- **Configuration à distance** : la [Configuration à distance][3] est requise pour permettre à Datadog d'envoyer des informations aux scanners sans Agent, telles que les ressources cloud à scanner.
+- **Configuration à distance** : la [Configuration à distance][3] est requise pour permettre à Datadog d'envoyer des informations aux Agentless scanners, telles que les ressources cloud à scanner.
 - **Clés d'API et d'application** :
   - Une clé d'API avec la Configuration à distance activée est requise pour que les scanners signalent les résultats de scan à Datadog.
   - Une clé d'application avec les autorisations **Integrations Manage** ou **Org Management** est requise pour activer les fonctionnalités de scanning via l'API Datadog.
-- **Autorisations cloud** : l'instance de scanning sans Agent nécessite des autorisations spécifiques pour scanner les hosts, les images de host, les registres de conteneurs et les fonctions. Ces autorisations sont automatiquement appliquées dans le cadre du processus d'installation et sont strictement limitées aux autorisations minimales requises pour effectuer les scans nécessaires, conformément au principe du moindre privilège.<br><br>
+- **Autorisations cloud** : l'instance de Agentless Scanning nécessite des autorisations spécifiques pour scanner les hosts, les images de host, les registres de conteneurs et les fonctions. Ces autorisations sont automatiquement appliquées dans le cadre du processus d'installation et sont strictement limitées aux autorisations minimales requises pour effectuer les scans nécessaires, conformément au principe du moindre privilège.<br><br>
   {{< collapse-content title="Autorisations de scanning AWS" level="h5" >}}
   <p>Autorisations de scanning :</p>
   <ul>
@@ -94,9 +94,9 @@ Avant de configurer le scanning sans Agent, assurez-vous que les prérequis suiv
 
 ## Configuration
 
-<div class="alert alert-danger">L'exécution des scanners sans Agent entraîne des coûts supplémentaires. Pour optimiser ces coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le <a href="#terraform-setup">scanning sans Agent avec Terraform</a> comme modèle par défaut.</div>
+<div class="alert alert-danger">L'exécution des Agentless scanners entraîne des coûts supplémentaires. Pour optimiser ces coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le <a href="#terraform-setup">Agentless Scanning avec Terraform</a> comme modèle par défaut.</div>
 
-Pour activer le scanning sans Agent, utilisez l'un des workflows suivants :
+Pour activer Agentless Scanning, utilisez l'un des workflows suivants :
 
 ### Prise en main rapide
 
@@ -105,23 +105,23 @@ Conçu pour les nouveaux utilisateurs, le workflow de démarrage rapide offre un
 {{% collapse-content title="Guide de configuration du démarrage rapide" level="h4" id="quick-start-setup" %}} 
 Conçu pour les nouveaux utilisateurs, le workflow de démarrage rapide offre un processus de configuration efficace pour Cloud Security, permettant une surveillance immédiate des ressources AWS. Il utilise AWS CloudFormation pour automatiser la configuration et inclut les fonctionnalités Cloud Security : Misconfigurations, Identity Risks (CIEM) et Vulnerability Management.
 
-<div class="alert alert-info">Cet article fournit des instructions pour le workflow de démarrage rapide pour nouveaux utilisateurs qui utilise AWS CloudFormation pour configurer le scanning sans Agent.
-Pour les utilisateurs existants qui souhaitent ajouter un nouveau compte AWS ou activer le scanning sans Agent sur un compte AWS intégré existant, consultez les instructions pour
+<div class="alert alert-info">Cet article fournit des instructions pour le workflow de démarrage rapide pour nouveaux utilisateurs qui utilise AWS CloudFormation pour configurer Agentless Scanning.
+Pour les utilisateurs existants qui souhaitent ajouter un nouveau compte AWS ou activer Agentless Scanning sur un compte AWS intégré existant, consultez les instructions pour
 <a href="#terraform-setup">Terraform</a> ou <a href="#aws-cloudformation-setup">AWS CloudFormation</a>.</div>
 
-<div class="alert alert-danger">L'exécution des scanners sans Agent entraîne des coûts supplémentaires. Pour optimiser ces coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le <a href="#terraform-setup">scanning sans Agent avec Terraform</a> comme modèle par défaut.</div>
+<div class="alert alert-danger">L'exécution des Agentless scanners entraîne des coûts supplémentaires. Pour optimiser ces coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le <a href="#terraform-setup">Agentless Scanning avec Terraform</a> comme modèle par défaut.</div>
 
 <div class="alert alert-danger">Le Scanner de données sensibles pour le stockage cloud est en disponibilité limitée. <a href="https://www.datadoghq.com/private-beta/data-security">Demandez l'accès</a> pour vous inscrire.</div>
 
 ##### Installation
 
 1. Sur la page [Introduction à Cloud Security][4], cliquez sur **Get Started with Cloud Security**.
-1. Cliquez sur **Quick Start**. La page **Features** s'affiche, montrant les fonctionnalités incluses avec le démarrage rapide du scanning sans Agent.
+1. Cliquez sur **Quick Start**. La page **Features** s'affiche, montrant les fonctionnalités incluses avec le démarrage rapide d'Agentless Scanning.
 1. Cliquez sur **Start Using Cloud Security** pour continuer.
 1. Sélectionnez la région AWS où vous souhaitez créer la stack CloudFormation.
 1. Sélectionnez une clé API déjà configurée pour la Configuration à distance. Si la clé API que vous sélectionnez n'a pas la Configuration à distance activée, la Configuration à distance est automatiquement activée pour cette clé lors de la sélection.
 1. Choisissez d'activer ou non le **Sensitive Data Scanner** pour le stockage cloud. Cela catalogue et classifie automatiquement les données sensibles dans les ressources Amazon S3.
-1. Cliquez sur **Launch CloudFormation Template**. Une nouvelle fenêtre s'ouvre, affichant l'écran AWS CloudFormation. Utilisez le modèle CloudFormation fourni pour créer une stack. Le modèle inclut les autorisations IAM requises pour déployer et gérer les scanners sans Agent.
+1. Cliquez sur **Launch CloudFormation Template**. Une nouvelle fenêtre s'ouvre, affichant l'écran AWS CloudFormation. Utilisez le modèle CloudFormation fourni pour créer une stack. Le modèle inclut les autorisations IAM requises pour déployer et gérer les Agentless scanners.
 
 ##### Mettre à jour la stack CloudFormation
 
@@ -138,12 +138,12 @@ Datadog recommande de mettre à jour régulièrement la stack CloudFormation, af
 
 ### Terraform
 
-Le [module Terraform Datadog Agentless Scanner][6] fournit une configuration simple et réutilisable pour installer le scanner sans Agent Datadog pour AWS, Azure et GCP.
+Le [module Terraform Datadog Agentless Scanner][6] fournit une configuration simple et réutilisable pour installer Agentless scanner Datadog pour AWS, Azure et GCP.
 
 {{% collapse-content title="Guide de configuration Terraform" level="h4" id="terraform-setup" %}}
-Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouveau compte cloud ou activer le [scanning sans Agent][1] sur un compte cloud intégré existant, vous pouvez utiliser Terraform, [AWS CloudFormation][2] ou [Azure Resource Manager][5]. Cet article fournit des instructions détaillées pour l'approche Terraform.
+Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouveau compte cloud ou activer le [Agentless Scanning][1] sur un compte cloud intégré existant, vous pouvez utiliser Terraform, [AWS CloudFormation][2] ou [Azure Resource Manager][5]. Cet article fournit des instructions détaillées pour l'approche Terraform.
 
-<div class="alert alert-info">Si vous configurez Cloud Security pour la première fois, vous pouvez suivre le <a href="#quick-start-setup">workflow de démarrage rapide</a>, qui utilise AWS CloudFormation pour activer le scanning sans Agent.</div>
+<div class="alert alert-info">Si vous configurez Cloud Security pour la première fois, vous pouvez suivre le <a href="#quick-start-setup">workflow de démarrage rapide</a>, qui utilise AWS CloudFormation pour activer Agentless Scanning.</div>
 
 {{< tabs >}}
 {{% tab "New AWS account" %}}
@@ -164,7 +164,7 @@ Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouv
 {{% tab "Existing AWS account" %}}
 
 1. Sur la page [Configuration de Cloud Security][1], cliquez sur **Cloud Integrations > AWS**.
-1. Cliquez sur le bouton **Edit scanning** ({{< img src="security/csm/setup/edit-button.png" inline="true" style="width:24px;">}}) pour le compte AWS où vous souhaitez déployer le scanner sans Agent.
+1. Cliquez sur le bouton **Edit scanning** ({{< img src="security/csm/setup/edit-button.png" inline="true" style="width:24px;">}}) pour le compte AWS où vous souhaitez déployer Agentless scanner.
 1. **Enable Resource Scanning** devrait déjà être activé. Si ce n'est pas le cas, activez **Enable Resource Scanning**.
 1. Dans la section **How would you like to set up Agentless Scanning?**, sélectionnez **Terraform**.
 1. Suivez les instructions pour installer le [module Datadog Agentless Scanner][2].
@@ -179,8 +179,8 @@ Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouv
 {{% tab "Existing Azure account" %}}
 
 1. Sur la page [Configuration de Cloud Security][1], cliquez sur **Cloud Integrations > Azure**.
-1. Développez le locataire contenant l'abonnement où vous souhaitez déployer le scanner sans Agent.
-1. Cliquez sur le bouton **Enable** pour le compte Azure où vous souhaitez déployer le scanner sans Agent.
+1. Développez le locataire contenant l'abonnement où vous souhaitez déployer Agentless scanner.
+1. Cliquez sur le bouton **Enable** pour le compte Azure où vous souhaitez déployer Agentless scanner.
 1. Activez **Vulnerability Scanning**.
 1. Dans la section **How would you like to set up Agentless Scanning?**, sélectionnez **Terraform**. 
 1. Suivez les instructions pour installer le [module Datadog Agentless Scanner][2].
@@ -194,8 +194,8 @@ Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouv
 {{% tab "Existing GCP project" %}}
 
 1. Sur la page [Configuration de Cloud Security][1], cliquez sur **Cloud Integrations > GCP**.
-1. Développez le compte contenant le projet où vous souhaitez déployer le scanner sans Agent.
-1. Cliquez sur le bouton **Enable** pour le projet GCP où vous souhaitez déployer le scanner sans Agent.
+1. Développez le compte contenant le projet où vous souhaitez déployer Agentless scanner.
+1. Cliquez sur le bouton **Enable** pour le projet GCP où vous souhaitez déployer Agentless scanner.
 1. Activez **Vulnerability Scanning**.
 1. Suivez les instructions pour installer le [module Datadog Agentless Scanner][2].
 1. Cliquez sur **Done**.
@@ -222,14 +222,14 @@ Pour des exemples d'utilisation, consultez notre [référentiel Github](https://
 
 ### AWS Cloudformation
 
-Utilisez le modèle AWS CloudFormation pour créer une stack CloudFormation. Le modèle inclut les autorisations IAM requises pour déployer et gérer les scanners sans Agent.
+Utilisez le modèle AWS CloudFormation pour créer une stack CloudFormation. Le modèle inclut les autorisations IAM requises pour déployer et gérer les Agentless scanners.
 
 {{% collapse-content title="Guide de configuration AWS CloudFormation" level="h4" id="aws-cloudformation-setup" %}}
-Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouveau compte cloud ou activer le [scanning sans Agent][1] sur un compte AWS intégré existant, vous pouvez utiliser [Terraform][7] ou AWS CloudFormation. Cet article fournit des instructions détaillées pour l'approche AWS CloudFormation.
+Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouveau compte cloud ou activer le [Agentless Scanning][1] sur un compte AWS intégré existant, vous pouvez utiliser [Terraform][7] ou AWS CloudFormation. Cet article fournit des instructions détaillées pour l'approche AWS CloudFormation.
 
-<div class="alert alert-info">Si vous configurez Cloud Security pour la première fois, vous pouvez suivre le <a href="#quick-start-setup">workflow de démarrage rapide</a>, qui utilise également AWS CloudFormation pour activer le scanning sans Agent.</div>
+<div class="alert alert-info">Si vous configurez Cloud Security pour la première fois, vous pouvez suivre le <a href="#quick-start-setup">workflow de démarrage rapide</a>, qui utilise également AWS CloudFormation pour activer Agentless Scanning.</div>
 
-<div class="alert alert-danger">L'exécution des scanners sans Agent entraîne des coûts supplémentaires. Pour optimiser ces coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le <a href="#terraform-setup">scanning sans Agent avec Terraform</a> comme modèle par défaut.</div>
+<div class="alert alert-danger">L'exécution des Agentless scanners entraîne des coûts supplémentaires. Pour optimiser ces coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le <a href="#terraform-setup">Agentless Scanning avec Terraform</a> comme modèle par défaut.</div>
 
 <div class="alert alert-danger">Le Scanner de données sensibles pour le stockage cloud est en disponibilité limitée. <a href="https://www.datadoghq.com/private-beta/data-security">Demandez l'accès</a> pour vous inscrire.</div>
 
@@ -243,7 +243,7 @@ Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouv
 1. Sélectionnez la région AWS où vous souhaitez créer la stack CloudFormation.
 1. Sélectionnez une clé API déjà configurée pour la Configuration à distance. Si la clé API que vous sélectionnez n'a pas la Configuration à distance activée, la Configuration à distance est automatiquement activée pour cette clé lors de la sélection.
 1. Choisissez d'activer ou non le **Sensitive Data Scanner** pour le stockage cloud. Cela catalogue et classifie automatiquement les données sensibles dans les ressources Amazon S3.
-1. Cliquez sur **Launch CloudFormation Template**. Une nouvelle fenêtre s'ouvre, affichant l'écran AWS CloudFormation. Utilisez le modèle CloudFormation fourni pour créer une stack. Le modèle inclut les autorisations IAM requises pour déployer et gérer les scanners sans Agent.
+1. Cliquez sur **Launch CloudFormation Template**. Une nouvelle fenêtre s'ouvre, affichant l'écran AWS CloudFormation. Utilisez le modèle CloudFormation fourni pour créer une stack. Le modèle inclut les autorisations IAM requises pour déployer et gérer les Agentless scanners.
 
 [1]: https://app.datadoghq.com/security/configuration/csm/setup
 
@@ -252,7 +252,7 @@ Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouv
 {{% tab "Existing AWS account" %}}
 
 1. Sur la page [Configuration de Cloud Security][1], cliquez sur **Cloud Integrations** > **AWS**.
-1. Cliquez sur le bouton **Edit** ({{< img src="security/csm/setup/edit-button.png" inline="true" style="width:24px;">}}) pour le compte AWS où vous souhaitez déployer le scanner sans Agent.
+1. Cliquez sur le bouton **Edit** ({{< img src="security/csm/setup/edit-button.png" inline="true" style="width:24px;">}}) pour le compte AWS où vous souhaitez déployer Agentless scanner.
 1. Vérifiez que **Enable Resource Scanning** est activé. Si ce n'est pas le cas, activez **Enable Resource Scanning** et suivez les étapes 3 à 7 dans [Nouveau compte AWS][2].
 1. Dans la section **Agentless Scanning**, activez **Enable Vulnerability Management (Host, Container and Lambda)**.
 1. Choisissez d'activer ou non **Enable Sensitive Data Scanner for Cloud Storage**. Cela catalogue et classifie automatiquement les données sensibles dans les ressources Amazon S3.
@@ -278,12 +278,12 @@ Datadog recommande de mettre à jour régulièrement la stack CloudFormation, af
 
 ### Azure Resource Manager
 
-Utilisez le modèle Azure Resource Manager pour déployer le scanner sans Agent. Le modèle inclut les définitions de rôles requises pour déployer et gérer les scanners sans Agent.
+Utilisez le modèle Azure Resource Manager pour déployer Agentless scanner. Le modèle inclut les définitions de rôles requises pour déployer et gérer les Agentless scanners.
 
 {{% collapse-content title="Guide de configuration Azure Resource Manager" level="h4" id="azure-resource-manager-setup" %}}
-Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouveau compte Azure ou activer le [scanning sans Agent][1] sur un compte Azure intégré existant, vous pouvez utiliser [Terraform][7] ou Azure Resource Manager. Cet article fournit des instructions détaillées pour l'approche Azure Resource Manager.
+Si vous avez déjà [configuré Cloud Security][10] et souhaitez ajouter un nouveau compte Azure ou activer le [Agentless Scanning][1] sur un compte Azure intégré existant, vous pouvez utiliser [Terraform][7] ou Azure Resource Manager. Cet article fournit des instructions détaillées pour l'approche Azure Resource Manager.
 
-<div class="alert alert-danger">L'exécution des scanners sans Agent entraîne des coûts supplémentaires. Pour optimiser ces coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le <a href="#terraform-setup">scanning sans Agent avec Terraform</a> comme modèle par défaut.</div>
+<div class="alert alert-danger">L'exécution des Agentless scanners entraîne des coûts supplémentaires. Pour optimiser ces coûts tout en garantissant des scans fiables toutes les 12 heures, Datadog recommande de configurer le <a href="#terraform-setup">Agentless Scanning avec Terraform</a> comme modèle par défaut.</div>
 
 {{< tabs >}}
 {{% tab "New Azure account" %}}
@@ -310,11 +310,11 @@ Suivez les instructions pour configurer l'[intégration Azure Datadog][1].
 
 ### Vérifier votre configuration
 
-Après avoir terminé la configuration, vous pouvez vérifier que le scanning sans Agent fonctionne correctement en recherchant les résultats de scan dans Datadog. Les résultats apparaissent généralement après la fin du premier cycle de scan.
+Après avoir terminé la configuration, vous pouvez vérifier que Agentless Scanning fonctionne correctement en recherchant les résultats de scan dans Datadog. Les résultats apparaissent généralement après la fin du premier cycle de scan.
 
 Consultez les résultats de scan aux emplacements suivants :
 
-- **Pour les vulnérabilités de host et de conteneur** : [Explorateur de vulnérabilités CSM][15]. Pour afficher uniquement les vulnérabilités détectées par le scanning sans Agent, utilisez le filtre `origin:"Agentless scanner"` dans la barre de recherche.
+- **Pour les vulnérabilités de host et de conteneur** : [Explorateur de vulnérabilités CSM][15]. Pour afficher uniquement les vulnérabilités détectées par Agentless Scanning, utilisez le filtre `origin:"Agentless scanner"` dans la barre de recherche.
 - **Pour les vulnérabilités Lambda** : [Explorateur Code Security (SCA)][16]
 - **Pour les résultats de données sensibles** : [Scanner de données sensibles][17]
 
@@ -322,15 +322,15 @@ Consultez les résultats de scan aux emplacements suivants :
 
 {{% csm-agentless-exclude-resources %}}
 
-## Désactiver le scanning sans Agent
+## Désactiver Agentless Scanning
 
 {{< tabs >}}
 {{% tab "AWS" %}}
 1. Sur la page [Configuration de Cloud Security][10], cliquez sur **Cloud Integrations** > **AWS**.
-1. Si nécessaire, utilisez les filtres pour trouver le compte pour lequel vous souhaitez arrêter le scanning sans Agent. Cliquez sur le compte pour ouvrir le panneau latéral qui contient ses paramètres.
-1. Sur l'onglet **Features**, cliquez sur **Configure Agentless Scanning** ou **Manage** pour ouvrir la fenêtre de configuration du scanning sans Agent.
+1. Si nécessaire, utilisez les filtres pour trouver le compte pour lequel vous souhaitez arrêter Agentless Scanning. Cliquez sur le compte pour ouvrir le panneau latéral qui contient ses paramètres.
+1. Sur l'onglet **Features**, cliquez sur **Configure Agentless Scanning** ou **Manage** pour ouvrir la fenêtre de configuration d'Agentless Scanning.
 1. Sous **How would you like to set up Agentless scanning?**, cliquez sur **Terraform**.
-1. Sous **Enable Features**, à côté de **Enable Agentless Vulnerability management**, désactivez le bouton.
+1. Sous **Enable Features**, à côté de **EnabAgentless Vulnerability management**, désactivez le bouton.
 1. Cliquez sur **Done**.
 
 [10]: https://app.datadoghq.com/security/configuration/csm/setup
@@ -339,7 +339,7 @@ Consultez les résultats de scan aux emplacements suivants :
 
 {{% tab "Azure" %}}
 1. Sur la page [Configuration de Cloud Security][10], cliquez sur **Cloud Integrations** > **Azure**.
-1. Localisez le locataire de votre abonnement, développez la liste des abonnements et identifiez l'abonnement pour lequel vous souhaitez désactiver le scanning sans Agent.
+1. Localisez le locataire de votre abonnement, développez la liste des abonnements et identifiez l'abonnement pour lequel vous souhaitez désactiver Agentless Scanning.
 1. À côté de l'étiquette **Enabled**, cliquez sur le bouton **Edit** ({{< img src="security/csm/setup/edit-button.png" inline="true" style="width:24px;">}}) pour ouvrir la fenêtre Vulnerability Scanning.
 1. À côté de **Vulnerability Scanning**, désactivez le bouton.
 1. Cliquez sur **Done**.
@@ -350,7 +350,7 @@ Consultez les résultats de scan aux emplacements suivants :
 
 {{% tab "GCP" %}}
 1. Sur la page [Configuration de Cloud Security][10], cliquez sur **Cloud Integrations** > **GCP**.
-1. Développez le compte contenant le projet où vous souhaitez désactiver le scanning sans Agent.
+1. Développez le compte contenant le projet où vous souhaitez désactiver Agentless Scanning.
 1. À côté de l'étiquette **Enabled**, cliquez sur le bouton **Edit** ({{< img src="security/csm/setup/edit-button.png" inline="true" style="width:24px;">}}) pour ouvrir la fenêtre Vulnerability Scanning.
 1. À côté de **Vulnerability Scanning**, désactivez le bouton.
 1. Cliquez sur **Done**.
@@ -360,22 +360,22 @@ Consultez les résultats de scan aux emplacements suivants :
 {{% /tab %}}
 {{< /tabs >}}
 
-## Désinstaller le scanning sans Agent
+## Désinstaller Agentless Scanning
 
 {{< tabs >}}
 {{% tab "Terraform" %}}
-Pour désinstaller le scanning sans Agent, supprimez le module scanner de votre code Terraform. Pour plus d'informations, consultez la documentation du [module Terraform][9].
+Pour désinstaller Agentless Scanning, supprimez le module scanner de votre code Terraform. Pour plus d'informations, consultez la documentation du [module Terraform][9].
 
 [9]: https://github.com/DataDog/terraform-module-datadog-agentless-scanner/blob/main/README.md#uninstall
 
 {{% /tab %}}
 
 {{% tab "AWS CloudFormation" %}}
-Pour désinstaller le scanning sans Agent, connectez-vous à votre console AWS et supprimez la stack CloudFormation créée pour le scanning sans Agent.
+Pour désinstaller Agentless Scanning, connectez-vous à votre console AWS et supprimez la stack CloudFormation créée pour Agentless Scanning.
 {{% /tab %}}
 
 {{% tab "Azure Resource Manager" %}}
-Pour désinstaller le scanning sans Agent, connectez-vous à votre compte Azure. Si vous avez créé un groupe de ressources dédié pour le scanner sans Agent, supprimez ce groupe de ressources ainsi que les définitions de rôles Azure suivantes :
+Pour désinstaller Agentless Scanning, connectez-vous à votre compte Azure. Si vous avez créé un groupe de ressources dédié pour Agentless scanner, supprimez ce groupe de ressources ainsi que les définitions de rôles Azure suivantes :
   - Datadog Agentless Scanner Role
   - Datadog Agentless Scanner Delegate Role
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Replaces all French translations of "sans Agent" / "scanning sans Agent" with the English product name **Agentless Scanning** in the French documentation for Cloud Security Management Agentless Scanning.

Product names like "Agentless Scanning" should remain in English across all localized documentation to ensure consistency with the product UI and avoid confusion when users switch between the app and the docs.

**Replacements performed (73 total):**
- "Scanning sans Agent" / "scanning sans Agent" → "Agentless Scanning"
- "scanners sans Agent" → "Agentless scanners"
- "scanner sans Agent" → "Agentless scanner"

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

- No content changes beyond the terminology replacement and associated French grammar fixes (article contractions before vowels)
- The surrounding French text is preserved as-is; only the product name terminology was updated