### PR TITLE
Remove noisy integration page not found warnings from shortcodes - [WEB-7919]

### DIFF
--- a/layouts/shortcodes/get-metrics-from-git.html
+++ b/layouts/shortcodes/get-metrics-from-git.html
@@ -48,8 +48,7 @@
         {{ $page = .GetPage (print "/integrations/" $int_name ".md") }}
       {{ end }}
     {{ end }}
-    {{- if not $page -}}
-    {{- else -}}
+    {{- if $page -}}
       <!-- We find and use the metrics from the integration page markdown -->
       {{- $pattern := `(?s)### Metrics\n(.*?)(#{2,3}\s)` -}}
       {{- $matches := findRE $pattern $page.RawContent 1 -}}

--- a/layouts/shortcodes/get-service-checks-from-git.html
+++ b/layouts/shortcodes/get-service-checks-from-git.html
@@ -9,8 +9,7 @@
         {{ $page = .GetPage (print "/integrations/" $int_name ".md") }}
       {{ end }}
     {{ end }}
-    {{- if not $page -}}
-    {{- else -}}
+    {{- if $page -}}
       {{- $pattern := `(?s)### Service Checks\n(.*?)(#{2,3}\s)` -}}
       {{- $matches := findRE $pattern $page.RawContent 1 -}}
       {{- if not $matches -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes noisy `WARN` log lines from the `get-metrics-from-git` and `get-service-checks-from-git` shortcodes. 

These warnings fired whenever a shortcode referenced an integration name with no corresponding page in the site (for example, `openstack_controller`, `sqlserver`, `google_cloud_functions`). These warnings seem to be coming from integration name changes.For example, the following Warning occurred due to a `sqlserver` being renamed to `sql-server`

`WARN  Integration page for 'sqlserver' not found in get-service-checks-from-git shortcode.` 

Removing the warnings has no effect on the build or content output.

**Motivation**: https://datadoghq.atlassian.net/jira/people/5fd13b2734847e0069ea3ec5/boards/18030?selectedIssue=WEB-7919

**Preview**: https://docs-staging.datadoghq.com/stefon.simmons/web-7919
  - https://docs-staging.datadoghq.com/stefon.simmons/web-7919/integrations/sql-server/?tab=host 
  - https://docs.datadoghq.com/integrations/openstack-controller/#metrics
  - https://docs.datadoghq.com/integrations/google-cloud-functions/#metrics


### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes