### PR TITLE
docs(trace-retention): clarify span vs trace sampling order and behavior

### DIFF
--- a/content/en/tracing/trace_pipeline/trace_retention.md
+++ b/content/en/tracing/trace_pipeline/trace_retention.md
@@ -149,7 +149,7 @@ To create a retention filter:
 
 For example, if you configure a retention filter to index spans from `service:my-service`:
 - Configuring a span rate of `50%` helps ensure that approximately 50% of traces that contain spans matching `service:my-service` are selected. For selected traces, all spans matching `service:my-service` are indexed.
-- Configuring a trace rate of `10%` ensures that 10% of the traces selected by the span rate are fully indexed. For those traces, all spans in the trace (not just those from `service:my-service`) are indexed. Assuming traces have 100 spans on average and 5 spans from `service:my-service`, configuring a trace rate indexes the remaining 95 spans of the trace for the configured percentage of selected traces.
+- Configuring a trace rate of `10%` helps ensure that 10% of the traces selected by the span rate are fully indexed. For those traces, all spans in the trace (not only those from `service:my-service`) are indexed. Assuming traces have 100 spans on average and 5 spans from `service:my-service`, configuring a trace rate indexes the remaining 95 spans of the trace for the configured percentage of selected traces.
 - Span rate is evaluated first, and trace rate is applied only to traces selected by the span rate.
 
 When you create a new filter or edit the retention rate of an existing filter, Datadog displays an estimate of the percentage change in global indexing volume.


### PR DESCRIPTION
Clarifies the evaluation order and semantics of span rate and trace rate in retention filters.

The previous wording could be interpreted as span and trace rates being applied independently.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Customers have been confused about configurations such as:

Retain 5% of spans from a service but retain full traces for those spans.

It was unclear from the docs whether this required:

span rate = 5%, trace rate = 5%

or span rate = 5%, trace rate = 100%

This update makes it clear that the correct configuration is:

span rate = 5%

trace rate = 100%

---

to confirm accuracy:
code in logs-backend where this happens: https://github.com/DataDog/logs-backend/blob/prod/domains/event-platform/libs/processing/processing-common/src/main/java/com/dd/logs/processing/processors/SpansSamplingProcessor.java

slack thread in #apm-trace-storage where behavior was confirmed: https://dd.slack.com/archives/C02FKLS4ETW/p1771618260243449

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
