### PR TITLE
Revert "[BARX-1606] Add registry.datadoghq.com as the new default container registry"

### DIFF
--- a/content/en/agent/configuration/network.md
+++ b/content/en/agent/configuration/network.md
@@ -177,12 +177,13 @@ Open the following ports to benefit from all the **Agent** functionalities:
 
 {{% site-region region="us,eu" %}}
 
-| Product/Functionality                                                                                                                                                    | Port                                           | Protocol         | Description                                                                                                                                                                                 |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Agent<br>APM<br>Containers<br>Live Processes<br>Metrics<br>Cloud Network Monitoring<br>Universal Service Monitoring                                                      | 443                                            | TCP              | Most Agent data uses port 443.                                                                                                                                                              |
-| [Custom Agent Autoscaling][22]                                                                                                                                           | 8443                                           | TCP              |                                                                                                                                                                                             |
-| Log collection                                                                                                                                                           | {{< region-param key=web_integrations_port >}} | (Deprecated) TCP | Logging over TCP. <br>**Note**:TCP log collection is **not supported**. Datadog provides **no delivery or reliability guarantees** when using TCP, and log data may be lost without notice. For reliable ingestion, use the HTTP intake endpoint, an official Datadog Agent, or forwarder integration instead. For other connection types, see [logs endpoints][21]. |
-| NTP                                                                                                                                                                      | 123                                            | UDP              | Network Time Protocol (NTP). See [default NTP targets][20].<br>For information on troubleshooting NTP, see [NTP issues][19].                                                                |
+| Product/Functionality | Port | Protocol | Description |
+| ------  | ---- | ------- | ----------- |
+| Agent<br>APM<br>Containers<br>Live Processes<br>Metrics<br>Cloud Network Monitoring<br>Universal Service Monitoring | 443 | TCP | Most Agent data uses port 443. |
+| [Custom Agent Autoscaling][22] | 8443 | TCP |  |
+| Log collection | {{< region-param key=web_integrations_port >}} | (Deprecated) TCP | Logging over TCP. <br>**Note**:TCP log collection is **not supported**. Datadog provides **no delivery or reliability guarantees** when using TCP, and log data may be lost without notice.
+For reliable ingestion, use the HTTP intake endpoint, an official Datadog Agent, or forwarder integration instead. For other connection types, see [logs endpoints][21]. |
+| NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][20].<br>For information on troubleshooting NTP, see [NTP issues][19]. |
 
 [19]: /agent/faq/network-time-protocol-ntp-offset-issues/
 [20]: /integrations/ntp/#overview
@@ -193,10 +194,10 @@ Open the following ports to benefit from all the **Agent** functionalities:
 
 {{% site-region region="us3,us5,gov,ap1,ap2" %}}
 
-| Product/Functionality                                                                                               | Port | Protocol | Description                                                                                                                  |
-| ------------------------------------------------------------------------------------------------------------------- | ---- | -------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Agent<br>APM<br>Containers<br>Live Processes<br>Metrics<br>Cloud Network Monitoring<br>Universal Service Monitoring | 443  | TCP      | Most Agent data uses port 443.                                                                                               |
-| NTP                                                                                                                 | 123  | UDP      | Network Time Protocol (NTP). See [default NTP targets][20].<br>For information on troubleshooting NTP, see [NTP issues][19]. |
+| Product/Functionality | Port | Protocol | Description |
+| ------  | ---- | ------- | ----------- |
+| Agent<br>APM<br>Containers<br>Live Processes<br>Metrics<br>Cloud Network Monitoring<br>Universal Service Monitoring | 443 | TCP | Most Agent data uses port 443. |
+| NTP | 123 | UDP | Network Time Protocol (NTP). See [default NTP targets][20].<br>For information on troubleshooting NTP, see [NTP issues][19]. |
 
 [19]: /agent/faq/network-time-protocol-ntp-offset-issues/
 [20]: /integrations/ntp/#overview
@@ -207,16 +208,16 @@ Open the following ports to benefit from all the **Agent** functionalities:
 
 Used for Agent services communicating with each other locally within the host only.
 
-| Product/Functionality        | Port | Protocol | Description                                                                                                                    |
-| ---------------------------- | ---- | -------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| [Agent browser GUI][16]      | 5002 | TCP      |                                                                                                                                |
-| APM receiver                 | 8126 | TCP      | Includes Tracing and the Profiler.                                                                                             |
-| [DogStatsD][18]              | 8125 | UDP      | Port for DogStatsD unless `dogstatsd_non_local_traffic` is set to true. This port is available on IPv4 localhost: `127.0.0.1`. |
-| go_expvar server (APM)       | 5012 | TCP      | For more information, see [the go_expar integration documentation][15].                                                        |
-| go_expvar integration server | 5000 | TCP      | For more information, see [the go_expar integration documentation][15].                                                        |
-| IPC API                      | 5001 | TCP      | Port used for Inter Process Communication (IPC).                                                                               |
-| Process Agent debug          | 6062 | TCP      | Debug endpoints for the Process Agent.                                                                                         |
-| Process Agent runtime        | 6162 | TCP      | Runtime configuration settings for the Process Agent.                                                                          |
+| Product/Functionality | Port | Protocol | Description |
+| ------  | ---- | ------- | ----------- |
+| [Agent browser GUI][16] | 5002 | TCP |  |
+| APM receiver | 8126 | TCP | Includes Tracing and the Profiler. |
+| [DogStatsD][18] | 8125 | UDP | Port for DogStatsD unless `dogstatsd_non_local_traffic` is set to true. This port is available on IPv4 localhost: `127.0.0.1`. |
+| go_expvar server (APM) | 5012 | TCP | For more information, see [the go_expar integration documentation][15]. |
+| go_expvar integration server | 5000 | TCP | For more information, see [the go_expar integration documentation][15]. |
+| IPC API | 5001 | TCP | Port used for Inter Process Communication (IPC). |
+| Process Agent debug | 6062 | TCP | Debug endpoints for the Process Agent. |
+| Process Agent runtime | 6162 | TCP | Runtime configuration settings for the Process Agent. |
 
 ## Configure ports
 
@@ -287,10 +288,8 @@ To avoid running out of storage space, the Agent stores the metrics on disk only
 
 ## Installing the Datadog Operator
 
-If you are installing the Datadog Operator in a Kubernetes environment with limited connectivity, you need to allowlist the following endpoints for TCP port 443, based on your registry:
+If you are installing the Datadog Operator in a Kubernetes environment with limited connectivity, you need to allowlist the following endpoints for TCP port 443, based on your location:
 
-- `registry.datadoghq.com` (Datadog Container Registry)
-  - `us-docker.pkg.dev/datadog-prod/public-images` (may receive redirects from `registry.datadoghq.com`)
 - `gcr.io/datadoghq` (GCR US)
 - `eu.gcr.io/datadoghq` (GCR Europe)
 - `asia.gcr.io/datadoghq` (GCR Asia)

--- a/content/en/agent/faq/docker-hub.md
+++ b/content/en/agent/faq/docker-hub.md
@@ -2,9 +2,9 @@
 title: Docker Hub
 ---
 
-<div class="alert alert-warning">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from the Datadog Container Registry, GCR, or ECR. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+<div class="alert alert-danger">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
 
-If you are using Docker, there are several container images available through the [Datadog Container Registry][13], [GCR][11], and [ECR][12]. If you need to use Docker Hub:
+If you are using Docker, there are several container images available through [GCR][11], and [ECR][12]. If you need to use Docker Hub:
 
 | Datadog service                         | Docker Hub                               | Docker Pull Command                                        |
 |-----------------------------------------|------------------------------------------|------------------------------------------------------------|
@@ -29,4 +29,3 @@ To ensure that the images are not tampered with, enable content trust by setting
 [10]: https://docs.docker.com/engine/security/trust/
 [11]: /agent/guide/container-images-for-docker-environments/?tab=gcr
 [12]: /agent/guide/container-images-for-docker-environments/?tab=ecr
-[13]: /containers/guide/changing_container_registry/

--- a/content/en/agent/faq/log-collection-with-docker-socket.md
+++ b/content/en/agent/faq/log-collection-with-docker-socket.md
@@ -47,7 +47,7 @@ docker run -d --name datadog-agent \
     -v /proc/:/host/proc/:ro \
     -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
     -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-    registry.datadoghq.com/agent:latest
+    gcr.io/datadoghq/agent:latest
 ```
 
 [1]: /containers/docker/log

--- a/content/en/agent/faq/log4j_mitigation.md
+++ b/content/en/agent/faq/log4j_mitigation.md
@@ -194,7 +194,7 @@ Use the following Dockerfile to build the custom image:
 ```
 ARG AGENT_VERSION=7.32.2
 
-FROM registry.datadoghq.com/agent:$AGENT_VERSION-jmx
+FROM gcr.io/datadoghq/agent:$AGENT_VERSION-jmx
 
 RUN apt update && apt install zip -y
 

--- a/content/en/agent/guide/agent-v6-python-3.md
+++ b/content/en/agent/guide/agent-v6-python-3.md
@@ -59,7 +59,7 @@ To keep the Datadog Agent updated, edit your `datadog-values.yaml` to remove any
 
 To use a specific container registry, set it with `agent.image.repository` and `clusterChecksRunner.image.repository`. Ensure that `agents.image.tag` and  `clusterChecksRunner.image.tag` are undefined.
 
-The default registry is `registry.datadoghq.com/agent`.
+The default registry is `gcr.io/datadoghq/agent`.
 
 ```yaml
 agent:
@@ -143,7 +143,7 @@ spec:
         name: gcr.io/datadoghq/agent:6.33.0
 ```
 
-Use the `spec.global.registry` if you need to change the default registry. The default is `gcr.io/datadoghq`.
+Use the `spec.global.registry` if you need to change the default registry. The default is `gcr.io/datadoghq/agent`.
 
 Then, pin the Agent 7 image tag in `spec.override.nodeAgent.image.tag`.
 
@@ -199,7 +199,7 @@ In your DaemonSet manifest, update the image tag in each container definition:
 * Each `spec.template.spec.containers[*].image` value
 * Each `spec.template.spec.initContainers[*].image` value
 
-For example, if your previous image value was `gcr.io/datadoghq/agent:6.33.0`, update it to `registry.datadoghq.com/agent:7.33.0`.
+For example, if your previous image value was `gcr.io/datadoghq/agent:6.33.0`, update it to `gcr.io/datadoghq/agent:7.33.0`.
 
 **Before**:
 
@@ -224,7 +224,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: registry.datadoghq.com/agent:7.33.0
+        image: gcr.io/datadoghq/agent:7.33.0
         # ...
 ```
 

--- a/content/en/agent/guide/use-community-integrations.md
+++ b/content/en/agent/guide/use-community-integrations.md
@@ -48,7 +48,7 @@ Building a custom image ensures the integration persists across deployments each
 Use the following Dockerfile to build a custom version of the Agent that includes the `<INTEGRATION_NAME>` from [integrations-extras][2]. If you are installing a Marketplace integration, the `<INTEGRATION_NAME>` is available in the configuration instructions.
 
 ```dockerfile
-FROM registry.datadoghq.com/agent:latest
+FROM gcr.io/datadoghq/agent:latest
 RUN agent integration install -r -t datadog-<INTEGRATION_NAME>==<INTEGRATION_VERSION>
 ```
 Build and push the image:

--- a/content/en/cloudprem/ingest/agent.md
+++ b/content/en/cloudprem/ingest/agent.md
@@ -161,7 +161,7 @@ spec:
     spec:
       containers:
       - name: agent
-        image: registry.datadoghq.com/agent:latest
+        image: gcr.io/datadoghq/agent:latest
         env:
         - name: DD_API_KEY
           value: <YOUR_API_KEY>

--- a/content/en/cloudprem/install/docker.md
+++ b/content/en/cloudprem/install/docker.md
@@ -81,7 +81,7 @@ docker run \
   -v /proc/:/host/proc/:ro \
   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
   -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
-  registry.datadoghq.com/agent:latest
+  gcr.io/datadoghq/agent:latest
 ```
 {{% /tab %}}
 
@@ -108,7 +108,7 @@ services:
     restart: unless-stopped
 
   datadog-agent:
-    image: registry.datadoghq.com/agent:latest
+    image: gcr.io/datadoghq/agent:latest
     environment:
       - DD_API_KEY=${DD_API_KEY}
       - DD_SITE=${DD_SITE:-datadoghq.com}

--- a/content/en/containers/cluster_agent/_index.md
+++ b/content/en/containers/cluster_agent/_index.md
@@ -32,13 +32,15 @@ Using the Datadog Cluster Agent allows you to:
 
 If you installed the Datadog Agent using Helm chart v2.7.0 or Datadog Operator v1.0.0+, the **Datadog Cluster Agent is enabled by default**.
 
-Datadog publishes container images to the Datadog Container Registry, Google Artifact Registry (GAR), Amazon ECR, Azure ACR, and Docker Hub:
+Datadog publishes container images to Google Artifact Registry, Amazon ECR, Azure ACR, and Docker Hub:
 
-{{% container-images-table %}}
+| Google Artifact Registry | Amazon ECR             | Azure ACR            | Docker Hub        |
+| ------------------------ | ---------------------- | -------------------- | ----------------- |
+| gcr.io/datadoghq         | public.ecr.aws/datadog | datadoghq.azurecr.io | docker.io/datadog |
 
-By default, the Helm chart and Datadog Operator pull images from Google Artifact Registry (`gcr.io/datadoghq`).
+By default, the Cluster Agent image is pulled from Google Artifact Registry (`gcr.io/datadoghq`). If Artifact Registry is not accessible in your deployment region, use another registry.
 
-<div class="alert alert-warning">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from another registry. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+<div class="alert alert-danger">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
 
 ### Minimum Agent and Cluster Agent versions
 

--- a/content/en/containers/docker/_index.md
+++ b/content/en/containers/docker/_index.md
@@ -55,7 +55,7 @@ docker run -d --cgroupns host --pid host --name dd-agent \
   -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
   -e DD_SITE=<DATADOG_SITE> \
   -e DD_API_KEY=<DATADOG_API_KEY> \
-  registry.datadoghq.com/agent:7
+  gcr.io/datadoghq/agent:7
 ```
 {{% /tab %}}
 {{% tab "Windows" %}}
@@ -66,7 +66,7 @@ docker run -d --name dd-agent `
   -v \\.\pipe\docker_engine:\\.\pipe\docker_engine `
   -e DD_SITE=<DATADOG_SITE> `
   -e DD_API_KEY=<DATADOG_API_KEY> `
-  registry.datadoghq.com/agent:7
+  gcr.io/datadoghq/agent:7
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -81,13 +81,17 @@ After the Datadog Docker Agent is up and running, you can [configure Datadog int
 
 ### Container registries
 
-Images are available for 64-bit x86 and Arm v8 architectures. Datadog publishes container images to the Datadog Container Registry, Google Artifact Registry (GAR), Amazon ECR, Azure ACR, and Docker Hub:
+Images are available for 64-bit x86 and Arm v8 architectures. Datadog publishes container images to Google Artifact Registry, Amazon ECR, Azure ACR, and Docker Hub:
 
-{{% container-images-table %}}
+| Google Artifact Registry | Amazon ECR             | Azure ACR            | Docker Hub        |
+| ------------------------ | ---------------------- | -------------------- | ----------------- |
+| gcr.io/datadoghq         | public.ecr.aws/datadog | datadoghq.azurecr.io | docker.io/datadog |
 
-By default, the above instructions pull the image from the Datadog Container Registry (`registry.datadoghq.com`). If you use this registry, ensure your firewall allows traffic to `us-docker.pkg.dev/datadog-prod/public-images`, as the registry may redirect requests to this URL.
+By default, the above instructions pull the image from Google Artifact Registry (`gcr.io/datadoghq`). If Google Artifact Registry is not accessible in your deployment region, use another registry.
 
-<div class="alert alert-warning">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your configuration to pull from another registry. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+If you are deploying the Agent in an AWS environment, Datadog recommend that you use Amazon ECR.
+
+<div class="alert alert-danger">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from Google Artifact Registry or Amazon ECR. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
 
 ### Environment variables
 
@@ -270,8 +274,8 @@ See the [Agent Commands guides][21] to discover all the Docker Agent commands.
 By default, the Docker Agent collects metrics with the following core checks. To collect metrics from other technologies, see the [Integrations](#integrations) section.
 
 | Check       | Metrics       |
-| ----------- | ------------- |
-| Container   | [Metrics][22] |
+|-------------|---------------|
+| Container   | [Metrics][22]
 | CPU         | [System][23]  |
 | Disk        | [Disk][24]    |
 | Docker      | [Docker][25]  |

--- a/content/en/containers/docker/apm.md
+++ b/content/en/containers/docker/apm.md
@@ -27,7 +27,7 @@ further_reading:
       text: "Assign tags to all data emitted by a container"
 ---
 
-As of Agent 6.0.0, the Trace Agent is enabled by default. If it has been turned off, you can re-enable it in the `registry.datadoghq.com/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
+As of Agent 6.0.0, the Trace Agent is enabled by default. If it has been turned off, you can re-enable it in the `gcr.io/datadoghq/agent` container by passing `DD_APM_ENABLED=true` as an environment variable.
 
 The CLI commands on this page are for the Docker runtime. Replace `docker` with `nerdctl` for the containerd runtime, or `podman` for the Podman runtime.
 
@@ -54,7 +54,7 @@ docker run -d --cgroupns host \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               -e DD_SITE=<DATADOG_SITE> \
-              registry.datadoghq.com/agent:latest
+              gcr.io/datadoghq/agent:latest
 ```
 Where your `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
 
@@ -66,7 +66,7 @@ docker run -d -p 127.0.0.1:8126:8126/tcp \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_APM_ENABLED=true \
               -e DD_SITE=<DATADOG_SITE> \
-              registry.datadoghq.com/agent:latest
+              gcr.io/datadoghq/agent:latest
 ```
 Where your `<DATADOG_SITE>` is {{< region-param key="dd_site" code="true" >}} (defaults to `datadoghq.com`).
 
@@ -187,7 +187,7 @@ docker run -d --name datadog-agent \
               -e DD_APM_ENABLED=true \
               -e DD_SITE=<DATADOG_SITE> \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              registry.datadoghq.com/agent:latest
+              gcr.io/datadoghq/agent:latest
 # Application
 docker run -d --name app \
               --network <NETWORK_NAME> \
@@ -210,7 +210,7 @@ docker run -d --name datadog-agent \
               -e DD_APM_ENABLED=true \
               -e DD_SITE=<DATADOG_SITE> \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              registry.datadoghq.com/agent:latest
+              gcr.io/datadoghq/agent:latest
 # Application
 docker run -d --name app \
               --network "<NETWORK_NAME>" \
@@ -372,7 +372,7 @@ docker run -d --name datadog-agent \
               -e DD_SITE=<DATADOG_SITE> \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
               -e DD_APM_RECEIVER_SOCKET=/var/run/datadog/apm.socket \
-              registry.datadoghq.com/agent:latest
+              gcr.io/datadoghq/agent:latest
 # Application
 docker run -d --name app \
               --network <NETWORK_NAME> \

--- a/content/en/containers/docker/log.md
+++ b/content/en/containers/docker/log.md
@@ -68,7 +68,7 @@ docker run -d --name datadog-agent \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-           registry.datadoghq.com/agent:latest
+           gcr.io/datadoghq/agent:latest
 ```
 
 ### Windows
@@ -84,7 +84,7 @@ docker run -d --name datadog-agent \
            -e DD_SITE=<DD_SITE> \
            -v \\.\pipe\docker_engine:\\.\pipe\docker_engine \
            -v c:\programdata\docker\containers:c:\programdata\docker\containers:ro
-           registry.datadoghq.com/agent:latest
+           gcr.io/datadoghq/agent:latest
 ```
 
 ### macOS
@@ -104,7 +104,7 @@ docker run -d --name datadog-agent \
            -v /var/run/docker.sock:/var/run/docker.sock:ro \
            -v /var/lib/docker/containers:/var/lib/docker/containers:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
-           registry.datadoghq.com/agent:latest
+           gcr.io/datadoghq/agent:latest
 ```
 
 It is recommended that you pick the latest version of the Datadog Agent. Consult the full list of available [images for Agent v6][2] on GCR.

--- a/content/en/containers/docker/prometheus.md
+++ b/content/en/containers/docker/prometheus.md
@@ -48,7 +48,7 @@ docker run -d --cgroupns host \
     -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
     -e DD_API_KEY="<DATADOG_API_KEY>" \
     -e DD_SITE="<YOUR_DATADOG_SITE>" \
-    registry.datadoghq.com/agent:latest
+    gcr.io/datadoghq/agent:latest
 ```
 
 {{% /tab %}}
@@ -60,7 +60,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
     -v /cgroup/:/host/sys/fs/cgroup:ro \
     -e DD_API_KEY="<DATADOG_API_KEY>" \
     -e DD_SITE="<YOUR_DATADOG_SITE>" \
-    registry.datadoghq.com/agent:latest
+    gcr.io/datadoghq/agent:latest
 ```
 
 {{% /tab %}}
@@ -69,7 +69,7 @@ docker run -d --name dd-agent -v /var/run/docker.sock:/var/run/docker.sock:ro \
 ```shell
 docker run -d -e DD_API_KEY="<DATADOG_API_KEY>" \
     -e DD_SITE="<YOUR_DATADOG_SITE>" \
-    registry.datadoghq.com/agent:latest
+    gcr.io/datadoghq/agent:latest
 ```
 
 {{% /tab %}}
@@ -208,14 +208,14 @@ docker run -d --cgroupns host \
     -v /proc/:/host/proc/:ro \
     -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
     -e DD_API_KEY="<DATADOG_API_KEY>" \
-    registry.datadoghq.com/agent:latest
+    gcr.io/datadoghq/agent:latest
 ```
     {{% /tab %}}
     {{% tab "Windows" %}}
 
 ```shell
 docker run -d -e DD_API_KEY="<DATADOG_API_KEY>" \
-    registry.datadoghq.com/agent:latest \
+    gcr.io/datadoghq/agent:latest \
     -v \\.\pipe\docker_engine:\\.\pipe\docker_engine
 ```
     {{% /tab %}}

--- a/content/en/containers/guide/autodiscovery-with-jmx.md
+++ b/content/en/containers/guide/autodiscovery-with-jmx.md
@@ -28,7 +28,7 @@ If you are using the Java tracer for your applications, you can alternatively ta
 ## Installation
 
 ### Use a JMX-enabled Agent
-JMX utilities are not installed in the Agent by default. To set up a JMX integration, append `-jmx` to your Agent's image tag. For example, `registry.datadoghq.com/agent:latest-jmx`.
+JMX utilities are not installed in the Agent by default. To set up a JMX integration, append `-jmx` to your Agent's image tag. For example, `gcr.io/datadoghq/agent:latest-jmx`.
 
 If you are using Datadog Operator or Helm, the following configurations append `-jmx` to your Agent's image tag:
 

--- a/content/en/containers/guide/changing_container_registry.md
+++ b/content/en/containers/guide/changing_container_registry.md
@@ -5,31 +5,18 @@ aliases:
  - /agent/guide/changing_container_registry
 ---
 
-Datadog publishes container images on the Datadog Container Registry, Google Artifact Registry (GAR), Amazon ECR, Azure ACR, and Docker Hub:
+Datadog publishes container images in Google's gcr.io, Azure ACR, AWS' ECR, and on Docker Hub:
 
 {{% container-images-table %}}
 
-## Choosing a container registry
+Pulling from the ACR, GCR or ECR registry works the same (except for Notary) as pulling from Docker Hub. You can use the same command (with different parameters) and get the same image.
 
-When selecting a container registry, Datadog recommends the following approach:
+**Note**: ACR, ECR and GCR do not support Notary. If you are verifying the signature of images pulled from Docker, this feature does not work on GCR or ECR.
 
-1. **Private pull-through cache**: Set up a pull-through cache in your own infrastructure. This provides the best control over your image dependencies. See your cloud provider's documentation:
-   - AWS: [Amazon ECR pull through cache][12]
-   - GCP: [Artifact Registry remote repositories][13]
-   - Azure: [Azure Container Registry cache][14]
+To update your registry, you need to update your registry values based on the type of container environment you are deploying on.
 
-2. **Cloud-provider registries**: If your deployment is in a specific cloud provider (AWS, GCP, or Azure), use the corresponding Datadog public registry:
-   - AWS deployments: `public.ecr.aws/datadog`
-   - GCP deployments: `gcr.io/datadoghq`, `eu.gcr.io/datadoghq`, or `asia.gcr.io/datadoghq`
-   - Azure deployments: `datadoghq.azurecr.io`
-
-3. **Datadog Container Registry**: Use `registry.datadoghq.com` for simplicity. This registry requires no additional setup and has very high rate limits. Ensure your firewall allows traffic to `us-docker.pkg.dev/datadog-prod/public-images`, as the registry may redirect requests to this URL.
-
-4. **Docker Hub**: Avoid unless you have a Docker Hub subscription, as it is subject to rate limits. Only Docker Hub supports Notary for image signature verification.
-
-<div class="alert alert-info">The Helm chart and Datadog Operator will default to the Datadog Container Registry in a future release.</div>
-
-To update your registry, update your registry values based on the type of container environment you are deploying on. You can also use a private registry, but you need to [create a pull secret][1] to pull the images.
+**Note**: You can also use a private registry, but you will need to create a pull secret to be able the pull the images from the private registry.
+For more information about creating a pull secret, see the [Kubernetes documentation][1].
 
 ## Docker
 
@@ -45,26 +32,26 @@ To update your containers registry while deploying the Datadog Agent (or Datadog
 
 1. Update your `values.yaml`:
     ```yaml
-    registry: registry.datadoghq.com
+    registry: gcr.io/datadoghq
     ```
 2. Remove any overrides for `agents.image.repository`, `clusterAgent.image.repository`, or `clusterChecksRunner.image.repository` in the `values.yaml`.
 
 ### Datadog Helm chart < v2.7.0
 
-Change the repository to the registry of your choice. For example, using the Datadog Container Registry:
+Change the repository to `gcr.io`:
 
 ```yaml
 agents:
   image:
-    repository: registry.datadoghq.com/agent
+    repository: gcr.io/datadoghq/agent
 
 clusterAgent:
   image:
-    repository: registry.datadoghq.com/cluster-agent
+    repository: gcr.io/datadoghq/cluster-agent
 
 clusterChecksRunner:
   image:
-    repository: registry.datadoghq.com/agent
+    repository: gcr.io/datadoghq/agent
 ```
 
 For more information about using the Datadog Helm chart, see the [Datadog Kubernetes documentation][3] and the example [`values.yaml`][4] file.
@@ -99,7 +86,7 @@ metadata:
   name: datadog
 spec:
   global:
-    registry: public.ecr.aws/datadog
+    registry: gcr.io/datadoghq
   // ..
 ```
 
@@ -132,13 +119,13 @@ For more information about the Datadog Operator, see [Deploying an Agent with th
 
 ### Using another container registry with Helm
 
-You can switch from the default `gcr.io/datadoghq` registry to another registry, such as `public.ecr.aws/datadog` when installing the Operator with the Helm chart:
+You could also switch from the default `gcr.io/datadoghq` registry to another registry, such as `datadoghq.azurecr.io` when installing the Operator with the Helm chart:
 
 Update [`values.yaml`][6] with the new image:
 
 ```yaml
 image:
-  repository: public.ecr.aws/datadog
+  repository: datadoghq.azurecr.io
 ```
 
 ## ECS
@@ -171,13 +158,13 @@ For more information about the Datadog Cluster Agent, see the [Cluster Agent doc
 
 ## Kubernetes Helm for the Datadog Private Location worker
 
-To update your registry for the Private Location worker, update the `datadog/synthetics-private-location-worker` image to a different registry such as `public.ecr.aws/datadog/synthetics-private-location-worker` or `gcr.io/datadoghq/synthetics-private-location-worker`.
+To update your registry for the Private Location worker, update the `datadog/synthetics-private-location-worker` image to the `public.ecr.aws/datadog/synthetics-private-location-worker` or `gcr.io/datadoghq/synthetics-private-location-worker` images.
 
 To change the default repository (`gcr.io/datadoghq`), update the `values.yaml` with the new image:
 
 ```yaml
 image:
-  repository: public.ecr.aws/datadog/synthetics-private-location-worker
+  repository: gcr.io/datadoghq/synthetics-private-location-worker
 ```
 
 [1]: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#registry-secret-existing-credentials
@@ -191,6 +178,3 @@ image:
 [9]: https://www.datadoghq.com/blog/aws-fargate-monitoring-with-datadog/#deploy-the-agent-on-eks
 [10]: https://docs.datadoghq.com/agent/cluster_agent/
 [11]: https://docs.datadoghq.com/agent/cluster_agent/setup/?tab=helm
-[12]: https://docs.aws.amazon.com/AmazonECR/latest/userguide/pull-through-cache.html
-[13]: https://cloud.google.com/artifact-registry/docs/repositories/remote-repo
-[14]: https://learn.microsoft.com/en-us/azure/container-registry/container-registry-artifact-cache

--- a/content/en/containers/guide/compose-and-the-datadog-agent.md
+++ b/content/en/containers/guide/compose-and-the-datadog-agent.md
@@ -64,7 +64,7 @@ instances:
 The `Dockerfile` is used to instruct Docker compose to build a Datadog Agent image including the `redisdb.yaml` file at the right location:
 
 ```
-FROM registry.datadoghq.com/agent:latest
+FROM gcr.io/datadoghq/agent:latest
 ADD conf.d/redisdb.yaml /etc/datadog-agent/conf.d/redisdb.yaml
 ```
 

--- a/content/en/containers/guide/container-images-for-docker-environments.md
+++ b/content/en/containers/guide/container-images-for-docker-environments.md
@@ -14,36 +14,19 @@ further_reading:
 
 ## Overview
 
-If you are using Docker, there are several container images available through the Datadog Container Registry, GCR, ECR, and ACR that you may want to use within your environment:
+If you are using Docker, there are several container images available through GCR and ECR that you may want to use within your environment:
 
 {{< tabs >}}
-{{% tab "Datadog Container Registry" %}}
-
-| Datadog service            | Registry           | Pull Command                                       |
-| -------------------------- | ------------------ | -------------------------------------------------- |
-| [Docker Agent][1]          | Docker Agent (v6+) | `docker pull registry.datadoghq.com/agent`         |
-| [DogStatsD][2]             | DogStatsD          | `docker pull registry.datadoghq.com/dogstatsd`     |
-| [Datadog Cluster Agent][3] | Cluster Agent      | `docker pull registry.datadoghq.com/cluster-agent` |
-
-**Note:** Additional images such as the Synthetics Private Location Worker will be added to this registry in the future.
-
-[1]: /agent/docker/
-[2]: /developers/dogstatsd/
-[3]: /agent/cluster_agent/
-{{% /tab %}}
 {{% tab "GCR" %}}
 
-| Datadog service                         | GCR                                     | GCR Pull Command                                                  |
-| --------------------------------------- | --------------------------------------- | ----------------------------------------------------------------- |
-| [Docker Agent][1]                       | [Docker Agent (v6+)][2]                 | `docker pull gcr.io/datadoghq/agent`                              |
-| Docker Agent (v 5)                      | [Docker Agent (v5)][2]                  | `docker pull gcr.io/datadoghq/docker-dd-agent`                    |
-| [DogStatsD][3]                          | [DogStatsD][4]                          | `docker pull gcr.io/datadoghq/dogstatsd`                          |
-| [Datadog Cluster Agent][5]              | [Cluster Agent][6]                      | `docker pull gcr.io/datadoghq/cluster-agent`                      |
-| [Synthetics Private Location Worker][7] | [Synthetics Private Location Worker][8] | `docker pull gcr.io/datadoghq/synthetics-private-location-worker` |
+| Datadog service                          | GCR                                      | GCR Pull Command                                                  |
+|------------------------------------------|------------------------------------------|-------------------------------------------------------------------|
+| [Docker Agent][1]                        | [Docker Agent (v6+)][2]                  | `docker pull gcr.io/datadoghq/agent`                              |
+| Docker Agent (v 5)                       | [Docker Agent (v5)][2]                   | `docker pull gcr.io/datadoghq/docker-dd-agent`                    |
+| [DogStatsD][3]                           | [DogStatsD][4]                           | `docker pull gcr.io/datadoghq/dogstatsd`                          |
+| [Datadog Cluster Agent][5]               | [Cluster Agent][6]                       | `docker pull gcr.io/datadoghq/cluster-agent`                      |
+| [Synthetics Private Location Worker][7]  | [Synthetics Private Location Worker][8]  | `docker pull gcr.io/datadoghq/synthetics-private-location-worker` |
 
-Regional GCR registries are also available:
-- **Europe**: `eu.gcr.io/datadoghq`
-- **Asia**: `asia.gcr.io/datadoghq`
 
 [1]: /agent/docker/
 [2]: https://console.cloud.google.com/artifacts/docker/datadoghq/us/gcr.io/agent
@@ -56,13 +39,13 @@ Regional GCR registries are also available:
 {{% /tab %}}
 {{% tab "ECR" %}}
 
-| Datadog service                         | ECR                                     | ECR Pull Command                                                        |
-| --------------------------------------- | --------------------------------------- | ----------------------------------------------------------------------- |
-| [Docker Agent][1]                       | [Docker Agent (v6+)][2]                 | `docker pull public.ecr.aws/datadog/agent`                              |
-| Docker Agent (v 5)                      | [Docker Agent (v5)][3]                  | `docker pull public.ecr.aws/datadog/docker-dd-agent`                    |
-| [DogStatsD][4]                          | [DogStatsD][5]                          | `docker pull public.ecr.aws/datadog/dogstatsd`                          |
-| [Datadog Cluster Agent][6]              | [Cluster Agent][7]                      | `docker pull public.ecr.aws/datadog/cluster-agent`                      |
-| [Synthetics Private Location Worker][8] | [Synthetics Private Location Worker][9] | `docker pull public.ecr.aws/datadog/synthetics-private-location-worker` |
+| Datadog service                         | Docker Hub                               | Docker Pull Command                                                     |
+|-----------------------------------------|------------------------------------------|-------------------------------------------------------------------------|
+| [Docker Agent][1]                       | [Docker Agent (v6+)][2]                  | `docker pull public.ecr.aws/datadog/agent`                              |
+| Docker Agent (v 5)                      | [Docker Agent (v5)][3]                   | `docker pull public.ecr.aws/datadog/docker-dd-agent`                    |
+| [DogStatsD][4]                          | [DogStatsD][5]                           | `docker pull public.ecr.aws/datadog/dogstatsd`                          |
+| [Datadog Cluster Agent][6]              | [Cluster Agent][7]                       | `docker pull public.ecr.aws/datadog/cluster-agent`                      |
+| [Synthetics Private Location Worker][8] | [Synthetics Private Location Worker][9]  | `docker pull public.ecr.aws/datadog/synthetics-private-location-worker` |
 
 
 [1]: /agent/docker/
@@ -74,21 +57,6 @@ Regional GCR registries are also available:
 [7]: https://gallery.ecr.aws/datadog/cluster-agent
 [8]: /getting_started/synthetics/private_location
 [9]: https://gallery.ecr.aws/datadog/synthetics-private-location-worker
-{{% /tab %}}
-{{% tab "ACR" %}}
-
-| Datadog service                         | ACR                                | ACR Pull Command                                                      |
-| --------------------------------------- | ---------------------------------- | --------------------------------------------------------------------- |
-| [Docker Agent][1]                       | Docker Agent (v6+)                 | `docker pull datadoghq.azurecr.io/agent`                              |
-| [DogStatsD][2]                          | DogStatsD                          | `docker pull datadoghq.azurecr.io/dogstatsd`                          |
-| [Datadog Cluster Agent][3]              | Cluster Agent                      | `docker pull datadoghq.azurecr.io/cluster-agent`                      |
-| [Synthetics Private Location Worker][4] | Synthetics Private Location Worker | `docker pull datadoghq.azurecr.io/synthetics-private-location-worker` |
-
-
-[1]: /agent/docker/
-[2]: /developers/dogstatsd/
-[3]: /agent/cluster_agent/
-[4]: /getting_started/synthetics/private_location
 {{% /tab %}}
 {{< /tabs >}}
 

--- a/content/en/containers/guide/operator-advanced.md
+++ b/content/en/containers/guide/operator-advanced.md
@@ -105,7 +105,7 @@ spec:
   override:
     nodeAgent:
       image:
-        name: registry.datadoghq.com/agent:latest
+        name: gcr.io/datadoghq/agent:latest
       tolerations:
         - operator: Exists
 ```

--- a/content/en/containers/guide/podman-support-with-docker-integration.md
+++ b/content/en/containers/guide/podman-support-with-docker-integration.md
@@ -52,7 +52,7 @@ Agent versions 7.54.0 and greater can autodetect the Podman DB if the proper `co
         -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
         -e DD_API_KEY=<API_KEY> \
         -e DD_HOSTNAME=<DD_HOSTNAME> \
-        registry.datadoghq.com/agent:latest
+        gcr.io/datadoghq/agent:latest
       ```
 
     1. To deploy the Agent with log collection run the agent as follows:
@@ -67,7 +67,7 @@ Agent versions 7.54.0 and greater can autodetect the Podman DB if the proper `co
            -e DD_LOGS_ENABLED=true \
            -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
            -e DD_LOGS_CONFIG_USE_PODMAN_LOGS=true \
-           registry.datadoghq.com/agent:latest
+           gcr.io/datadoghq/agent:latest
        ```
 
 **Note:** The Datadog Agent can only collect logs for Podman containers started with `--log-driver=k8s-file`.
@@ -98,7 +98,7 @@ Podman versions 4.8 or greater use SQLite as the default database backend, and B
        -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
        -e DD_API_KEY=<API_KEY> \
        -e DD_HOSTNAME=<DD_HOSTNAME> \
-       registry.datadoghq.com/agent:latest
+       gcr.io/datadoghq/agent:latest
     ```
 
 {{% /tab %}}
@@ -125,7 +125,7 @@ Podman versions below 4.8 use BoltDB as the default database backend.
        -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
        -e DD_API_KEY=<API_KEY> \
        -e DD_HOSTNAME=<DD_HOSTNAME> \
-       registry.datadoghq.com/agent:latest
+       gcr.io/datadoghq/agent:latest
     ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -155,7 +155,7 @@ sudo podman run -d --name dd-agent \
     -e DD_API_KEY=<API_KEY> \
     -e DD_HOSTNAME=<DD_HOSTNAME> \
     -e DOCKER_HOST=unix:///run/podman/podman.sock \
-    registry.datadoghq.com/agent:latest
+    gcr.io/datadoghq/agent:latest
 ```
 
 In both cases the Agent should detect all the containers managed by root and emit `container.*` metrics for all of them.

--- a/content/en/containers/guide/readonly-root-filesystem.md
+++ b/content/en/containers/guide/readonly-root-filesystem.md
@@ -38,13 +38,13 @@ Complete example:
 ```yaml
 services:
   datadog-init:
-    image: registry.datadoghq.com/agent:latest
+    image: gcr.io/datadoghq/agent:latest
     command: ["sh", "-c", "cp -R /etc/datadog-agent/* /opt/datadog-agent-config/"]
     volumes:
       - datadog-config:/opt/datadog-agent-config
 
   datadog:
-    image: registry.datadoghq.com/agent:latest
+    image: gcr.io/datadoghq/agent:latest
     read_only: true
     pid: host
     depends_on:
@@ -125,13 +125,13 @@ services:
 
 Following [Linux Filesystem Hierarchy Standard (FHS)][4] guidelines, the Datadog Agent writes defaults to the following directories, which require read/write permissions:
 
-| Directory                 | Purpose                                    | Read/Write Required |
-| ------------------------- | ------------------------------------------ | ------------------- |
-| `/etc/datadog-agent/`     | Configuration and check files              | Yes                 |
-| `/opt/datadog-agent/run/` | Runtime state files                        | Yes                 |
-| `/var/run/datadog/`       | APM and DogStatsD sockets                  | Yes                 |
-| `/var/log/datadog/`       | Agent log output                           | No                  |
-| `/tmp/`                   | Temporary files for flares and diagnostics | No                  |
+| Directory | Purpose | Read/Write Required |
+|-----------|---------|----------|
+| `/etc/datadog-agent/` | Configuration and check files | Yes |
+| `/opt/datadog-agent/run/` | Runtime state files | Yes |
+| `/var/run/datadog/` | APM and DogStatsD sockets | Yes |
+| `/var/log/datadog/` | Agent log output | No |
+| `/tmp/` | Temporary files for flares and diagnostics | No |
 
 ## Troubleshooting
 

--- a/content/en/containers/guide/sync_container_images.md
+++ b/content/en/containers/guide/sync_container_images.md
@@ -33,14 +33,14 @@ crane copy <REGISTRY>/<SOURCE_IMAGE>:<IMAGE_TAG> <REGISTRY>/<DEST_IMAGE>:<IMAGE_
 
 You can use the `-n` flag to avoid overwriting an existing tag in the destination registry.
 
-For example, to copy the default images needed for the Datadog Operator to a private registry:
+For example, to copy the default images needed for the Datadog Operator from Docker Hub to a private registry:
 ```shell
 AGENT_VERSION=<AGENT_IMAGE_TAG>
 OPERATOR_VERSION=<OPERATOR_IMAGE_TAG>
 REGISTRY=<REGISTRY_URL>
-crane copy registry.datadoghq.com/operator:$OPERATOR_VERSION $REGISTRY/operator:$OPERATOR_VERSION
-crane copy registry.datadoghq.com/agent:$AGENT_VERSION $REGISTRY/agent:$AGENT_VERSION
-crane copy registry.datadoghq.com/cluster-agent:$AGENT_VERSION $REGISTRY/cluster-agent:$AGENT_VERSION
+crane copy gcr.io/datadoghq/operator:$OPERATOR_VERSION $REGISTRY/operator:$OPERATOR_VERSION
+crane copy gcr.io/datadoghq/agent:$AGENT_VERSION $REGISTRY/agent:$AGENT_VERSION
+crane copy gcr.io/datadoghq/cluster-agent:$AGENT_VERSION $REGISTRY/cluster-agent:$AGENT_VERSION
 ```
 
 ## How to use a private registry

--- a/content/en/containers/kubernetes/control_plane.md
+++ b/content/en/containers/kubernetes/control_plane.md
@@ -70,10 +70,10 @@ spec:
   override:
     clusterAgent:
       image:
-        name: registry.datadoghq.com/cluster-agent:latest
+        name: gcr.io/datadoghq/cluster-agent:latest
     nodeAgent:
       image:
-        name: registry.datadoghq.com/agent:latest
+        name: gcr.io/datadoghq/agent:latest
       extraConfd:
         configMap:
           name: datadog-checks
@@ -181,10 +181,10 @@ spec:
   override:
     clusterAgent:
       image:
-        name: registry.datadoghq.com/cluster-agent:latest
+        name: gcr.io/datadoghq/cluster-agent:latest
     nodeAgent:
       image:
-        name: registry.datadoghq.com/agent:latest
+        name: gcr.io/datadoghq/agent:latest
       extraConfd:
         configMap:
           name: datadog-checks

--- a/content/en/containers/kubernetes/distributions.md
+++ b/content/en/containers/kubernetes/distributions.md
@@ -547,10 +547,10 @@ spec:
   override:
     clusterAgent:
       image:
-        name: registry.datadoghq.com/cluster-agent:latest
+        name: gcr.io/datadoghq/cluster-agent:latest
     nodeAgent:
       image:
-        name: registry.datadoghq.com/agent:latest
+        name: gcr.io/datadoghq/agent:latest
       tolerations:
         - key: node-role.kubernetes.io/controlplane
           operator: Exists

--- a/content/en/containers/kubernetes/installation.md
+++ b/content/en/containers/kubernetes/installation.md
@@ -29,13 +29,13 @@ For dedicated documentation and examples for monitoring the Kubernetes control p
 
 Some features related to later Kubernetes versions require a minimum Datadog Agent version.
 
-| Kubernetes version | Agent version | Cluster Agent version | Reason                                                                         |
-| ------------------ | ------------- | --------------------- | ------------------------------------------------------------------------------ |
-| 1.16.0+            | 7.19.0+       | 1.9.0+                | Kubelet metrics deprecation                                                    |
-| 1.21.0+            | 7.36.0+       | 1.20.0+               | Kubernetes resource deprecation                                                |
-| 1.22.0+            | 7.37.0+       | 7.37.0+               | Supports dynamic service account token                                         |
-| 1.25.0+            | 7.40.0+       | 7.40.0+               | Supports `v1` API group                                                        |
-| 1.33.0+            | 7.67.0+       | 7.67.0+               | Fixes incompatibilities with Kubernetes `AllocatedResources` in `/pods` output |
+| Kubernetes version | Agent version  | Cluster Agent version | Reason                                                                         |
+|--------------------|----------------|-----------------------|--------------------------------------------------------------------------------|
+| 1.16.0+            | 7.19.0+        | 1.9.0+                | Kubelet metrics deprecation                                                    |
+| 1.21.0+            | 7.36.0+        | 1.20.0+               | Kubernetes resource deprecation                                                |
+| 1.22.0+            | 7.37.0+        | 7.37.0+               | Supports dynamic service account token                                         |
+| 1.25.0+            | 7.40.0+        | 7.40.0+               | Supports `v1` API group                                                        |
+| 1.33.0+            | 7.67.0+        | 7.67.0+               | Fixes incompatibilities with Kubernetes `AllocatedResources` in `/pods` output |
 
 For optimal compatibility Datadog recommends to keep your Cluster Agent and Agent on matching versions.
 
@@ -222,13 +222,17 @@ helm install datadog-agent -f datadog-values.yaml datadog/datadog
 
 ### Container registries
 
-Datadog publishes container images to the Datadog Container Registry, Google Artifact Registry (GAR), Amazon ECR, Azure ACR, and Docker Hub:
+Datadog publishes container images to Google Artifact Registry, Amazon ECR, Azure ACR, and Docker Hub:
 
-{{% container-images-table %}}
+| Google Artifact Registry | Amazon ECR             | Azure ACR            | Docker Hub        |
+| ------------------------ | ---------------------- | -------------------- | ----------------- |
+| gcr.io/datadoghq         | public.ecr.aws/datadog | datadoghq.azurecr.io | docker.io/datadog |
 
-By default, the Helm chart and Datadog Operator pull images from Google Artifact Registry (`gcr.io/datadoghq`).
+By default, the Agent image is pulled from Google Artifact Registry (`gcr.io/datadoghq`). If Artifact Registry is not accessible in your deployment region, use another registry.
 
-<div class="alert alert-warning">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from another registry. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+If you are deploying the Agent in an AWS environment, Datadog recommend that you use Amazon ECR.
+
+<div class="alert alert-danger">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from Google Artifact Registry or Amazon ECR. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
 
 {{< tabs >}}
 {{% tab "Datadog Operator" %}}

--- a/content/en/database_monitoring/setup_mysql/aurora.md
+++ b/content/en/database_monitoring/setup_mysql/aurora.md
@@ -236,7 +236,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
     "username": "datadog",
     "password": "<UNIQUEPASSWORD>"
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile
@@ -244,7 +244,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM registry.datadoghq.com/agent:<AGENT_VERSION>
+FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_mysql/azure.md
+++ b/content/en/database_monitoring/setup_mysql/azure.md
@@ -181,7 +181,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "fully_qualified_domain_name": "<AZURE_INSTANCE_ENDPOINT>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile

--- a/content/en/database_monitoring/setup_mysql/gcsql.md
+++ b/content/en/database_monitoring/setup_mysql/gcsql.md
@@ -249,7 +249,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "instance_id": "<INSTANCE_ID>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile
@@ -257,7 +257,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM registry.datadoghq.com/agent:<AGENT_VERSION>
+FROM gcr.io/datadoghq/agent:7.36.1
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_mysql/rds.md
+++ b/content/en/database_monitoring/setup_mysql/rds.md
@@ -256,7 +256,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "region": "<AWS_REGION>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile
@@ -264,7 +264,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM registry.datadoghq.com/agent:<AGENT_VERSION>
+FROM gcr.io/datadoghq/agent:<AGENT_VERSION>
 
 LABEL "com.datadoghq.ad.check_names"='["mysql"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_postgres/alloydb.md
+++ b/content/en/database_monitoring/setup_postgres/alloydb.md
@@ -195,7 +195,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "instance_id": "<INSTANCE_ID>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile
@@ -203,7 +203,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM registry.datadoghq.com/agent:<AGENT_VERSION>
+FROM gcr.io/datadoghq/agent:<AGENT_VERSION>
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -263,7 +263,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "tags": ["dbinstanceidentifier:<DB_INSTANCE_NAME>"]
     }]
   }}' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -278,7 +278,7 @@ For Postgres 9.6, add the following settings to the instance config where host a
 You can also specify labels in a `Dockerfile`, allowing you to build and deploy a custom Agent without modifying your infrastructure configuration:
 
 ```Dockerfile
-FROM registry.datadoghq.com/agent:<AGENT_VERSION>
+FROM gcr.io/datadoghq/agent:<AGENT_VERSION>
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_postgres/azure.md
+++ b/content/en/database_monitoring/setup_postgres/azure.md
@@ -298,7 +298,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "name": "<AZURE_INSTANCE_ENDPOINT>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:

--- a/content/en/database_monitoring/setup_postgres/gcsql.md
+++ b/content/en/database_monitoring/setup_postgres/gcsql.md
@@ -194,7 +194,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "instance_id": "<INSTANCE_ID>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 ### Dockerfile
@@ -202,7 +202,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
 Labels can also be specified in a `Dockerfile`, so you can build and deploy a custom agent without changing any infrastructure configuration:
 
 ```Dockerfile
-FROM registry.datadoghq.com/agent:<AGENT_VERSION>
+FROM gcr.io/datadoghq/agent:<AGENT_VERSION>
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_postgres/rds/_index.md
+++ b/content/en/database_monitoring/setup_postgres/rds/_index.md
@@ -354,7 +354,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "tags": ["dbinstanceidentifier:<DB_INSTANCE_NAME>"]
     }]
   }}' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 For Postgres 9.6, add the following settings to the instance config where host and port are specified:
@@ -369,7 +369,7 @@ For Postgres 9.6, add the following settings to the instance config where host a
 You can also specify labels in a `Dockerfile`, allowing you to build and deploy a custom Agent without modifying your infrastructure configuration:
 
 ```Dockerfile
-FROM registry.datadoghq.com/agent:<AGENT_VERSION>
+FROM gcr.io/datadoghq/agent:<AGENT_VERSION>
 
 LABEL "com.datadoghq.ad.check_names"='["postgres"]'
 LABEL "com.datadoghq.ad.init_configs"='[{}]'

--- a/content/en/database_monitoring/setup_sql_server/azure.md
+++ b/content/en/database_monitoring/setup_sql_server/azure.md
@@ -290,7 +290,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "name": "<AZURE_ENDPOINT_ADDRESS>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 See the [SQL Server integration spec][3] for additional information on setting `deployment_type` and `name` fields.

--- a/content/en/database_monitoring/setup_sql_server/gcsql.md
+++ b/content/en/database_monitoring/setup_sql_server/gcsql.md
@@ -209,7 +209,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "instance_id": "<INSTANCE_ID>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 See the [SQL Server integration spec][3] for additional information on setting `project_id` and `instance_id` fields.

--- a/content/en/database_monitoring/setup_sql_server/rds.md
+++ b/content/en/database_monitoring/setup_sql_server/rds.md
@@ -227,7 +227,7 @@ docker run -e "DD_API_KEY=${DD_API_KEY}" \
       "instance_endpoint": "<INSTANCE_ENDPOINT>"
     }
   }]' \
-  registry.datadoghq.com/agent:${DD_AGENT_VERSION}
+  gcr.io/datadoghq/agent:${DD_AGENT_VERSION}
 ```
 
 Use the `service` and `env` tags to link your database telemetry to other telemetry through a common tagging scheme. See [Unified Service Tagging][4] on how these tags are used throughout Datadog.

--- a/content/en/developers/dogstatsd/_index.md
+++ b/content/en/developers/dogstatsd/_index.md
@@ -36,17 +36,13 @@ Any compliant StatsD client works with DogStatsD and the Agent, but does not inc
 
 **Note**: DogStatsD does NOT implement timers from StatsD as a native metric type (though it does support them through [histograms][2]).
 
-DogStatsD is available on the Datadog Container Registry, GAR, ECR, Azure ACR, and Docker Hub:
+DogStatsD is available on Docker Hub and GCR:
 
-| Registry                   | Image                                   |
-| -------------------------- | --------------------------------------- |
-| Datadog Container Registry | [registry.datadoghq.com/dogstatsd][33]  |
-| Google Artifact Registry   | [gcr.io/datadoghq/dogstatsd][4]         |
-| Amazon ECR                 | [public.ecr.aws/datadog/dogstatsd][34]  |
-| Azure ACR                  | datadoghq.azurecr.io/dogstatsd          |
-| Docker Hub                 | [hub.docker.com/r/datadog/dogstatsd][3] |
+| Docker Hub                                       | GCR                                                       |
+|--------------------------------------------------|-----------------------------------------------------------|
+| [hub.docker.com/r/datadog/dogstatsd][3]          | [gcr.io/datadoghq/dogstatsd][4]                           |
 
-<div class="alert alert-warning">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you use the Datadog Container Registry or a cloud-provider registry instead. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
+<div class="alert alert-danger">Docker Hub is subject to image pull rate limits. If you are not a Docker Hub customer, Datadog recommends that you update your Datadog Agent and Cluster Agent configuration to pull from GCR or ECR. For instructions, see <a href="/agent/guide/changing_container_registry">Changing your container registry</a>.</div>
 
 ## How it works
 
@@ -100,7 +96,7 @@ docker run -d --cgroupns host \
               -e DD_API_KEY=<DATADOG_API_KEY> \
               -e DD_DOGSTATSD_NON_LOCAL_TRAFFIC="true" \
               -p 8125:8125/udp \
-              registry.datadoghq.com/agent:latest
+              gcr.io/datadoghq/agent:latest
 ```
 
 If you need to change the port used to collect StatsD metrics, use the `DD_DOGSTATSD_PORT="<NEW_DOGSTATSD_PORT>` environment variable. You can also configure DogStatsD to use a [UNIX domain socket][1].
@@ -536,10 +532,10 @@ For the full list of optional parameters, see the [dogstatsd-ruby repo][1] on Gi
 
 The Go client has multiple options for configuring the behavior of your client.
 
-| Parameter         | Type            | Description                                                                 |
-| ----------------- | --------------- | --------------------------------------------------------------------------- |
-| `WithNamespace()` | String          | Configure a namespace to prefix to all metrics, events, and service checks. |
-| `WithTags()`      | List of strings | Global tags applied to every metric, event, and service check.              |
+| Parameter                     | Type            | Description                                                                  |
+| ----------------------------- | --------------- | ---------------------------------------------------------------------------- |
+| `WithNamespace()`             | String          | Configure a namespace to prefix to all metrics, events, and service checks.  |
+| `WithTags()`                  | List of strings | Global tags applied to every metric, event, and service check.               |
 
 For all available options, see [Datadog's GoDoc][1].
 
@@ -551,23 +547,23 @@ For all available options, see [Datadog's GoDoc][1].
 As of v2.10.0 the recommended way to instantiate the client is with the NonBlockingStatsDClientBuilder. You
 can use the following builder methods to define the client parameters.
 
-| Builder Method                               | Type           | Default   | Description                                                                        |
-| -------------------------------------------- | -------------- | --------- | ---------------------------------------------------------------------------------- |
-| `prefix(String val)`                         | String         | null      | The prefix to apply to all metrics, events, and service checks.                    |
-| `hostname(String val)`                       | String         | localhost | The host name of the targeted StatsD server.                                       |
-| `port(int val)`                              | Integer        | 8125      | The port of the targeted StatsD server.                                            |
-| `constantTags(String... val)`                | String varargs | null      | Global tags to be applied to every metric, event, and service check.               |
-| `blocking(boolean val)`                      | Boolean        | false     | The type of client to instantiate: blocking vs non-blocking.                       |
-| `socketBufferSize(int val)`                  | Integer        | -1        | The size of the underlying socket buffer.                                          |
-| `enableTelemetry(boolean val)`               | Boolean        | false     | Client telemetry reporting.                                                        |
-| `entityID(String val)`                       | String         | null      | Entity ID for origin detection.                                                    |
-| `errorHandler(StatsDClientErrorHandler val)` | Integer        | null      | Error handler in case of an internal client error.                                 |
-| `maxPacketSizeBytes(int val)`                | Integer        | 8192/1432 | The maximum packet size; 8192 over UDS, 1432 for UDP.                              |
-| `processorWorkers(int val)`                  | Integer        | 1         | The number of processor worker threads assembling buffers for submission.          |
-| `senderWorkers(int val)`                     | Integer        | 1         | The number of sender worker threads submitting buffers to the socket.              |
-| `poolSize(int val)`                          | Integer        | 512       | Network packet buffer pool size.                                                   |
-| `queueSize(int val)`                         | Integer        | 4096      | Maximum number of unprocessed messages in the queue.                               |
-| `timeout(int val)`                           | Integer        | 100       | the timeout in milliseconds for blocking operations. Applies to unix sockets only. |
+| Builder Method                               | Type           | Default   | Description                                                                         |
+| -------------------------------------------- | -------------- | --------- | ----------------------------------------------------------------------------------- |
+| `prefix(String val)`                         | String         | null      | The prefix to apply to all metrics, events, and service checks.                     |
+| `hostname(String val)`                       | String         | localhost | The host name of the targeted StatsD server.                                        |
+| `port(int val)`                              | Integer        | 8125      | The port of the targeted StatsD server.                                             |
+| `constantTags(String... val)`                | String varargs | null      | Global tags to be applied to every metric, event, and service check.                |
+| `blocking(boolean val)`                      | Boolean        | false     | The type of client to instantiate: blocking vs non-blocking.                        |
+| `socketBufferSize(int val)`                  | Integer        | -1        | The size of the underlying socket buffer.                                           |
+| `enableTelemetry(boolean val)`               | Boolean        | false     | Client telemetry reporting.                                                         |
+| `entityID(String val)`                       | String         | null      | Entity ID for origin detection.                                                   |
+| `errorHandler(StatsDClientErrorHandler val)` | Integer        | null      | Error handler in case of an internal client error.                                  |
+| `maxPacketSizeBytes(int val)`                | Integer        | 8192/1432 | The maximum packet size; 8192 over UDS, 1432 for UDP.                               |
+| `processorWorkers(int val)`                  | Integer        | 1         | The number of processor worker threads assembling buffers for submission.           |
+| `senderWorkers(int val)`                     | Integer        | 1         | The number of sender worker threads submitting buffers to the socket.               |
+| `poolSize(int val)`                          | Integer        | 512       | Network packet buffer pool size.                                                    |
+| `queueSize(int val)`                         | Integer        | 4096      | Maximum number of unprocessed messages in the queue.                                |
+| `timeout(int val)`                           | Integer        | 100       | the timeout in milliseconds for blocking operations. Applies to unix sockets only.  |
 
 For more information, search the Java DogStatsD [package][1] for the NonBlockingStatsDClient Class and NonBlockingStatsDClientBuilder Class. Make sure you view the version that matches your client release.
 
@@ -628,5 +624,3 @@ If you're interested in learning more about the datagram format used by DogStats
 [10]: /developers/community/libraries/
 [11]: /getting_started/tagging/assigning_tags/?tab=containerizedenvironments#tags-cardinality
 [12]: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
-[33]: https://registry.datadoghq.com/v2/dogstatsd/tags/list
-[34]: https://gallery.ecr.aws/datadog/dogstatsd

--- a/content/en/error_tracking/backend/getting_started/dd_libraries.md
+++ b/content/en/error_tracking/backend/getting_started/dd_libraries.md
@@ -67,7 +67,7 @@ docker run -d --name datadog-agent \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-           registry.datadoghq.com/agent:latest
+           gcr.io/datadoghq/agent:latest
 ```
 
 {{% /tab %}}

--- a/content/en/getting_started/tagging/assigning_tags.md
+++ b/content/en/getting_started/tagging/assigning_tags.md
@@ -217,7 +217,7 @@ services:
       - DD_API_KEY= "<DATADOG_API_KEY>"
       - DD_CONTAINER_LABELS_AS_TAGS={"my.custom.label.project":"projecttag","my.custom.label.version":"versiontag"}
       - DD_TAGS="key1:value1 key2:value2 key3:value3"
-    image: 'registry.datadoghq.com/agent:latest'
+    image: 'gcr.io/datadoghq/agent:latest'
     deploy:
       restart_policy:
         condition: on-failure

--- a/content/en/glossary/terms/short_image.md
+++ b/content/en/glossary/terms/short_image.md
@@ -3,4 +3,4 @@ title: short image
 core_product:
   - infrastructure monitoring
 ---
-A short image is a container image name that does not include the registry hostname, namespace, or tag. You can also think of a short image as a substring between the last slash (`/`) and the last colon (`:`) of a full container image string. For example: for the container image `registry.datadoghq.com/agent:latest`, the short image is `agent`. 
+A short image is a container image name that does not include the registry hostname, namespace, or tag. You can also think of a short image as a substring between the last slash (`/`) and the last colon (`:`) of a full container image string. For example: for the container image `gcr.io/datadoghq/agent:latest`, the short image is `agent`. 

--- a/content/en/gpu_monitoring/setup.md
+++ b/content/en/gpu_monitoring/setup.md
@@ -121,7 +121,7 @@ docker run \
 -v /var/run/docker.sock:/var/run/docker.sock:ro \
 -v /proc/:/host/proc/:ro \
 -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-registry.datadoghq.com/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 To enable advanced eBPF metrics, use the following configuration for the required permissions to run eBPF programs:
@@ -157,7 +157,7 @@ docker run \
 --cap-add=SYS_PTRACE \
 --cap-add=IPC_LOCK \
 --cap-add=CHOWN \
-registry.datadoghq.com/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 Replace `<DATADOG_API_KEY>` with your [Datadog API key][1].
@@ -173,7 +173,7 @@ If using `docker-compose`, make the following additions to the Datadog Agent ser
 version: '3'
 services:
   datadog:
-    image: "registry.datadoghq.com/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_GPU_ENABLED=true
       - DD_API_KEY=<DATADOG_API_KEY>
@@ -196,7 +196,7 @@ To enable advanced eBPF metrics, use the following configuration for the require
 version: '3'
 services:
   datadog:
-    image: "registry.datadoghq.com/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_GPU_MONITORING_ENABLED=true  # only for advanced eBPF metrics
       - DD_GPU_ENABLED=true

--- a/content/en/integrations/faq/troubleshooting-jmx-integrations.md
+++ b/content/en/integrations/faq/troubleshooting-jmx-integrations.md
@@ -163,7 +163,7 @@ The default Agent installation does not come with a bundled JVM and uses the one
 
 **Notes**:
 
-- The `registry.datadoghq.com/agent:latest-jmx` Docker image does include a JVM, which the Agent needs to run jmxfetch. Alternatively, you can specify the JVM path in the integration's configuration file with the `java_bin_path` parameter.
+- The `gcr.io/datadoghq/agent:latest-jmx` Docker image does include a JVM, which the Agent needs to run jmxfetch. Alternatively, you can specify the JVM path in the integration's configuration file with the `java_bin_path` parameter.
 - Only one valid Java path needs to be specified for JMXFetch.
 
 ### JVM metrics

--- a/content/en/logs/guide/container-agent-to-tail-logs-from-host.md
+++ b/content/en/logs/guide/container-agent-to-tail-logs-from-host.md
@@ -133,7 +133,7 @@ docker run -d --name datadog-agent \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
            -v /<host log directory>/:<container log directory>/ \
            -v /<config location>/logs.yaml:/conf.d/logs.yaml \
-           registry.datadoghq.com/agent:latest
+           gcr.io/datadoghq/agent:latest
 ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/logs/guide/how-to-set-up-only-logs.md
+++ b/content/en/logs/guide/how-to-set-up-only-logs.md
@@ -64,7 +64,7 @@ docker run -d --name datadog-agent \
            -v /proc/:/host/proc/:ro \
            -v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
            -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-           registry.datadoghq.com/agent:latest
+           gcr.io/datadoghq/agent:latest
 ```
 
 {{% /tab %}}

--- a/content/en/network_monitoring/cloud_network_monitoring/setup.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/setup.md
@@ -350,7 +350,7 @@ If you already have the [Agent running with a manifest][3]:
                 serviceAccountName: datadog-agent
                 containers:
                     - name: datadog-agent
-                      image: 'registry.datadoghq.com/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                       # (...)
                   volumeMounts:
                       - name: procdir
@@ -376,10 +376,10 @@ If you already have the [Agent running with a manifest][3]:
                 serviceAccountName: datadog-agent
                 containers:
                     - name: datadog-agent
-                      image: 'registry.datadoghq.com/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                     # (...)
                     - name: system-probe
-                      image: 'registry.datadoghq.com/agent:latest'
+                      image: 'gcr.io/datadoghq/agent:latest'
                       imagePullPolicy: Always
                       securityContext:
                           capabilities:
@@ -484,7 +484,7 @@ docker run --cgroupns host \
 --cap-add=NET_RAW \
 --cap-add=IPC_LOCK \
 --cap-add=CHOWN \
-registry.datadoghq.com/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 Replace `<DATADOG_API_KEY>` with your [Datadog API key][1].
@@ -495,7 +495,7 @@ If using `docker-compose`, make the following additions to the Datadog Agent ser
 version: '3'
 services:
   datadog:
-    image: "registry.datadoghq.com/agent:latest"
+    image: "gcr.io/datadoghq/agent:latest"
     environment:
       - DD_SYSTEM_PROBE_NETWORK_ENABLED=true
       - DD_PROCESS_AGENT_ENABLED=true

--- a/content/en/security/application_security/setup/single_step/_index.md
+++ b/content/en/security/application_security/setup/single_step/_index.md
@@ -108,7 +108,7 @@ For a Docker Linux container:
      -e DD_DOGSTATSD_SOCKET=/opt/datadog/apm/inject/run/dsd.socket \
      -v /opt/datadog/apm:/opt/datadog/apm \
      -v /var/run/docker.sock:/var/run/docker.sock:ro \
-     registry.datadoghq.com/agent:7
+     gcr.io/datadoghq/agent:7
    ```
    Replace `<YOUR_DD_API_KEY>` with your [Datadog API][5].
    <div class="alert alert-info">
@@ -162,7 +162,7 @@ docker run -d --name dd-agent \
   -e DD_DOGSTATSD_SOCKET=/opt/datadog/apm/inject/run/dsd.socket \
   -v /opt/datadog/apm:/opt/datadog/apm \
   -v /var/run/docker.sock:/var/run/docker.sock:ro \
-  registry.datadoghq.com/agent:7
+  gcr.io/datadoghq/agent:7
 {{< /highlight >}}
 
 [5]: https://app.datadoghq.com/organization-settings/api-keys

--- a/content/en/security/cloud_security_management/guide/eBPF-free-agent.md
+++ b/content/en/security/cloud_security_management/guide/eBPF-free-agent.md
@@ -109,7 +109,7 @@ docker run -d --name dd-agent \
   -e DD_RUNTIME_SECURITY_CONFIG_EBPFLESS_ENABLED=true \
   -e HOST_ROOT=/host/root \
   -e DD_API_KEY=<API KEY> \
-  registry.datadoghq.com/agent:7
+  gcr.io/datadoghq/agent:7
 ```
 {{% /tab %}}
 
@@ -279,7 +279,7 @@ exit 0
 For Docker application deployments, you should modify your Dockerfile to wrap your application like this:
 
 ```shell
-FROM registry.datadoghq.com/agent:7 AS datadogagent
+FROM gcr.io/datadoghq/agent:7 AS datadogagent
 
 FROM ubuntu:latest
 
@@ -393,7 +393,7 @@ exit 0
 To attach the wrapper to a Docker image running an application, use the following Dockerfile:
 
 ```shell
-FROM registry.datadoghq.com/agent:7
+FROM gcr.io/datadoghq/agent:7
 
 ENTRYPOINT ["/opt/datadog-agent/embedded/bin/cws-instrumentation", "trace", "--pid", "$PID"]
 ```

--- a/content/en/security/cloud_security_management/setup/agent/docker.md
+++ b/content/en/security/cloud_security_management/setup/agent/docker.md
@@ -50,7 +50,7 @@ docker run -d --name dd-agent \
   -e DD_SBOM_HOST_ENABLED=true
   -e HOST_ROOT=/host/root \
   -e DD_API_KEY=<API KEY> \
-  registry.datadoghq.com/agent:7
+  gcr.io/datadoghq/agent:7
 
 {{< /code-block >}}
 

--- a/content/en/security/workload_protection/guide/eBPF-free-agent.md
+++ b/content/en/security/workload_protection/guide/eBPF-free-agent.md
@@ -111,7 +111,7 @@ docker run -d --name dd-agent \
   -e DD_RUNTIME_SECURITY_CONFIG_EBPFLESS_ENABLED=true \
   -e HOST_ROOT=/host/root \
   -e DD_API_KEY=<API KEY> \
-  registry.datadoghq.com/agent:7
+  gcr.io/datadoghq/agent:7
 ```
 {{% /tab %}}
 
@@ -281,7 +281,7 @@ exit 0
 For Docker application deployments, you should modify your Dockerfile to wrap your application like this:
 
 ```shell
-FROM registry.datadoghq.com/agent:7 AS datadogagent
+FROM gcr.io/datadoghq/agent:7 AS datadogagent
 
 FROM ubuntu:latest
 
@@ -395,7 +395,7 @@ exit 0
 To attach the wrapper to a Docker image running an application, use the following Dockerfile:
 
 ```shell
-FROM registry.datadoghq.com/agent:7
+FROM gcr.io/datadoghq/agent:7
 
 ENTRYPOINT ["/opt/datadog-agent/embedded/bin/cws-instrumentation", "trace", "--pid", "$PID"]
 ```

--- a/content/en/security/workload_protection/setup/agent/docker.md
+++ b/content/en/security/workload_protection/setup/agent/docker.md
@@ -45,7 +45,7 @@ docker run -d --name dd-agent \
   -e DD_RUNTIME_SECURITY_CONFIG_REMOTE_CONFIGURATION_ENABLED=true \
   -e HOST_ROOT=/host/root \
   -e DD_API_KEY=<API KEY> \
-  registry.datadoghq.com/agent:7
+  gcr.io/datadoghq/agent:7
 
 {{< /code-block >}}
 

--- a/content/en/tracing/guide/ignoring_apm_resources.md
+++ b/content/en/tracing/guide/ignoring_apm_resources.md
@@ -319,7 +319,7 @@ docker run -d --name datadog-agent \
               -e DD_APM_IGNORE_RESOURCES="Api::HealthchecksController#index$" \
               -e DD_APM_ENABLED=true \
               -e DD_APM_NON_LOCAL_TRAFFIC=true \
-              registry.datadoghq.com/agent:latest
+              gcr.io/datadoghq/agent:latest
 {{< /code-block >}}
 
 For multiple values:
@@ -335,7 +335,7 @@ In the dedicated trace-agent container, add the environment variable `DD_APM_IGN
 
 {{< code-block lang="yaml" >}}
     - name: trace-agent
-        image: "registry.datadoghq.com/agent:latest"
+        image: "gcr.io/datadoghq/agent:latest"
         imagePullPolicy: IfNotPresent
         command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
         resources: {}

--- a/content/en/tracing/guide/tutorial-enable-go-containers.md
+++ b/content/en/tracing/guide/tutorial-enable-go-containers.md
@@ -65,10 +65,10 @@ This tutorial uses the `all-docker-compose.yaml` file, which builds containers f
 
 1. Verify that the containers are running with the `docker ps` command. You should see something like this:
    {{< code-block lang="shell" disable_copy="true" >}}
-   CONTAINER ID   IMAGE                                  COMMAND                  CREATED              STATUS                          PORTS                    NAMES
-   0a4704ebed09   docker-notes                           "./cmd/notes/notes"      About a minute ago   Up About a minute               0.0.0.0:8080->8080/tcp   notes
-   9c428d7f7ad1   docker-calendar                        "./cmd/calendar/cale…"   About a minute ago   Up About a minute               0.0.0.0:9090->9090/tcp   calendar
-   b2c2bafa6b36   registry.datadoghq.com/agent:latest    "/bin/entrypoint.sh"     About a minute ago   Up About a minute (unhealthy)   8125/udp, 8126/tcp       datadog-ag
+   CONTAINER ID   IMAGE                           COMMAND                  CREATED              STATUS                          PORTS                    NAMES
+   0a4704ebed09   docker-notes                    "./cmd/notes/notes"      About a minute ago   Up About a minute               0.0.0.0:8080->8080/tcp   notes
+   9c428d7f7ad1   docker-calendar                 "./cmd/calendar/cale…"   About a minute ago   Up About a minute               0.0.0.0:9090->9090/tcp   calendar
+   b2c2bafa6b36   gcr.io/datadoghq/agent:latest   "/bin/entrypoint.sh"     About a minute ago   Up About a minute (unhealthy)   8125/udp, 8126/tcp       datadog-ag
    {{< /code-block >}}
 
 1. The sample `notes` application is a basic REST API that stores data in an in-memory database. Use `curl` to send a few API requests:
@@ -143,7 +143,7 @@ Add the Datadog Agent in the services section of your `all-docker-compose.yaml` 
    {{< code-block lang="yaml" filename="docker/all-docker-compose.yaml">}}
      datadog-agent:
      container_name: datadog-agent
-     image: "registry.datadoghq.com/agent:latest"
+     image: "gcr.io/datadoghq/agent:latest"
      pid: host
      environment:
        - DD_API_KEY=<DD_API_KEY_HERE>

--- a/content/en/tracing/guide/tutorial-enable-java-containers.md
+++ b/content/en/tracing/guide/tutorial-enable-java-containers.md
@@ -141,7 +141,7 @@ Add the Datadog Agent in the services section of your `all-docker-compose.yaml` 
    ```yaml
      datadog-agent:
        container_name: datadog-agent
-       image: "registry.datadoghq.com/agent:latest"
+       image: "gcr.io/datadoghq/agent:latest"
        pid: host
        environment:
          - DD_API_KEY=<DD_API_KEY_HERE>

--- a/content/en/tracing/guide/tutorial-enable-python-containers.md
+++ b/content/en/tracing/guide/tutorial-enable-python-containers.md
@@ -158,7 +158,7 @@ Add the Datadog Agent in the services section of the `docker/containers/exercise
    ```yaml
      datadog:
        container_name: dd-agent
-       image: "registry.datadoghq.com/agent:latest"
+       image: "gcr.io/datadoghq/agent:latest"
        environment:
           - DD_API_KEY=<DD_API_KEY>
           - DD_SITE=datadoghq.com  # Default. Change to eu.datadoghq.com, us3.datadoghq.com, us5.datadoghq.com as appropriate for your org

--- a/content/en/universal_service_monitoring/setup.md
+++ b/content/en/universal_service_monitoring/setup.md
@@ -196,7 +196,7 @@ To enable Universal Service Monitoring with the [Datadog Operator][1], update yo
      serviceAccountName: datadog-agent
      containers:
        - name: datadog-agent
-         image: 'registry.datadoghq.com/agent:latest'
+         image: 'gcr.io/datadoghq/agent:latest'
          ...
      volumeMounts:
        ...
@@ -212,10 +212,10 @@ To enable Universal Service Monitoring with the [Datadog Operator][1], update yo
      serviceAccountName: datadog-agent
      containers:
        - name: datadog-agent
-         image: 'registry.datadoghq.com/agent:latest'
+         image: 'gcr.io/datadoghq/agent:latest'
          ...
        - name: system-probe
-         image: 'registry.datadoghq.com/agent:latest'
+         image: 'gcr.io/datadoghq/agent:latest'
          imagePullPolicy: Always
          securityContext:
            capabilities:
@@ -396,7 +396,7 @@ docker run --cgroupns host \
 --cap-add=NET_RAW \
 --cap-add=IPC_LOCK \
 --cap-add=CHOWN \
-registry.datadoghq.com/agent:latest
+gcr.io/datadoghq/agent:latest
 ```
 
 {{% /tab %}}

--- a/layouts/shortcodes/container-images-table.en.md
+++ b/layouts/shortcodes/container-images-table.en.md
@@ -1,9 +1,7 @@
-| Registry                          | Path                       |
-| --------------------------------- | -------------------------- |
-| Datadog Container Registry        | `registry.datadoghq.com`   |
-| Google Artifact Registry          | `gcr.io/datadoghq`         |
-| Google Artifact Registry (Europe) | `eu.gcr.io/datadoghq`      |
-| Google Artifact Registry (Asia)   | `asia.gcr.io/datadoghq`    |
-| Amazon ECR                        | `public.ecr.aws/datadog`   |
-| Azure ACR                         | `datadoghq.azurecr.io`     |
-| Docker Hub                        | `docker.io/datadog`        |
+| datadoghq.azurecr.io                                    | dockerhub.io                               | gcr.io                                              | public.ecr.aws                                            |
+| ------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------- | --------------------------------------------------------- |
+| datadoghq.azurecr.io/agent                              | datadog/agent                              | gcr.io/datadoghq/agent                              | public.ecr.aws/datadog/agent                              |
+| datadoghq.azurecr.io/cluster-agent                      | datadog/cluster-agent                      | gcr.io/datadoghq/cluster-agent                      | public.ecr.aws/datadog/cluster-agent                      |
+| datadoghq.azurecr.io/operator                           | datadog/operator                           | gcr.io/datadoghq/operator                           | public.ecr.aws/datadog/operator                           |
+| datadoghq.azurecr.io/dogstatsd                          | datadog/dogstatsd                          | gcr.io/datadoghq/dogstatsd                          | public.ecr.aws/datadog/dogstatsd                          |
+| datadoghq.azurecr.io/synthetics-private-location-worker | datadog/synthetics-private-location-worker | gcr.io/datadoghq/synthetics-private-location-worker | public.ecr.aws/datadog/synthetics-private-location-worker |


### PR DESCRIPTION
Reverts DataDog/documentation#34267

We are rolling out the public doc of registry.datadoghq.com. See #incident-49899.
We prepare revert PRs in case we need to revert quickly https://docs.google.com/document/d/1ufmS1vRCuAWBUC6t8DgrI_eMnNlT9T3oYTEMuRDcNqk/edit?usp=sharing