### PR TITLE
[error-tracking] team attribute based ownership

### DIFF
--- a/content/en/error_tracking/issue_team_ownership.md
+++ b/content/en/error_tracking/issue_team_ownership.md
@@ -26,7 +26,7 @@ You can programmatically assign team ownership at the time an error is raised by
 
 ### APM
 
-Set the `team` attribute on the span:
+Set the `team` attribute on the span, for example:
 
 ```python
 span.set_tag("team", "payments-backend")


### PR DESCRIPTION
## Why

The `team` attribute is now a way for users to programmatically assign team ownership when an error is raised, complementing the existing CODEOWNERS and service ownership methods. The documentation needs to reflect this capability.

## What

- Updates the Error Tracking Issue Team Ownership documentation to reflect the addition of the `team` attribute as a new method for defining team ownership at runtime.
- Restructures the page to document three independent ownership methods (CODEOWNERS, team attribute, service ownership), their priority order, and adds usage examples for setting the `team` attribute across APM, Logs, and RUM.