### PR TITLE
[Product Analytics] Add browser-intake domains to exact_domains for API docs region mapping

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -163,42 +163,49 @@ allowedRegions:
     domain: datadoghq.com
     exact_domains:
       - "navy.oncall.datadoghq.com"
+      - "browser-intake-datadoghq.com"
   - name: US3
     value: us3
     weight: 13
     domain: us3.datadoghq.com
     exact_domains:
       - "teal.oncall.datadoghq.com"
+      - "browser-intake-us3-datadoghq.com"
   - name: US5
     value: us5
     weight: 15
     domain: us5.datadoghq.com
     exact_domains:
       - "coral.oncall.datadoghq.com"
+      - "browser-intake-us5-datadoghq.com"
   - name: EU
     value: eu
     weight: 20
     domain: datadoghq.eu
     exact_domains:
        "beige.oncall.datadoghq.eu"
+      - "browser-intake-datadoghq.eu"
   - name: AP1
     value: ap1
     weight: 25
     domain: ap1.datadoghq.com
     exact_domains:
       - "saffron.oncall.datadoghq.com"
+      - "browser-intake-ap1-datadoghq.com"
   - name: AP2
     value: ap2
     weight: 30
     domain: ap2.datadoghq.com
     exact_domains:
       - "lava.oncall.datadoghq.com"
+      - "browser-intake-ap2-datadoghq.com"
   - name: US1-FED
     value: gov
     weight: 35
     domain: ddog-gov.com
     exact_domains:
       - "navy.oncall.datadoghq.com"
+      - "browser-intake-ddog-gov.com"
 
 core_product:
   value_required: false


### PR DESCRIPTION
## Summary
- Add browser-intake domains to `exact_domains` in `config/_default/params.yaml` so the API docs rendering pipeline can map Product Analytics server URLs to the correct region tabs
- The Product Analytics server-side events endpoint (`/api/v2/prodlytics`) uses non-standard domains like `browser-intake-datadoghq.com` that don't follow the `{subdomain}.{site}` pattern
- Without `exact_domains` entries, the docs site can't map these URLs to region tabs (US1, US3, US5, EU, AP1, AP2)

Related API spec PR: https://github.com/DataDog/datadog-api-spec/pull/5100

## Jira
[PANA-6150](https://datadoghq.atlassian.net/browse/PANA-6150)

## Test plan
- [x] Verify the API docs for `/api/v2/prodlytics` show correct region tabs
- [ ] Verify each region tab displays the correct browser-intake URL

[PANA-6150]: https://datadoghq.atlassian.net/browse/PANA-6150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ