### PR TITLE
add insight to which agent processes and versions support SGC

### DIFF
--- a/content/en/agent/configuration/secrets-management.md
+++ b/content/en/agent/configuration/secrets-management.md
@@ -49,13 +49,13 @@ secret_backend_config:
 
 #### Supported Agent processes
 
-| Agent process | Description | Supported | Version |
-|---|---|---|---|
-| [**Datadog Agent**](/agent/) | The main Agent process. | Yes | 7.70+ |
-| [**DogStatsD**](/developers/dogstatsd/) | Receives custom metrics from applications. Typically runs as part of the main Agent. | Yes | 7.70+ |
-| [**Trace Agent**](/tracing/) | Collects APM traces. Typically runs as part of the main Agent. | Yes | 7.70+ |
-| [**Cluster Agent**](/containers/cluster_agent/) | Collects cluster-level Kubernetes data. Enabled by default in Helm and Operator deployments. | Yes | 7.77+ |
-| [**DDOT Collector**](/opentelemetry/setup/ddot_collector/) | The Datadog Distribution of OpenTelemetry collector. | Transparent — resolved values are synced from the core Agent automatically via config-sync. No separate configuration needed. | 7.70+ |
+| Agent process | Description  | Version |
+|---|---|---|
+| [**Datadog Agent**](/agent/) | The main Agent process. | 7.70+ |
+| [**DogStatsD**](/developers/dogstatsd/) | Receives custom metrics from applications. Typically runs as part of the main Agent. | 7.70+ |
+| [**Trace Agent**](/tracing/) | Collects APM traces. Typically runs as part of the main Agent. | 7.70+ |
+| [**Cluster Agent**](/containers/cluster_agent/) | Collects cluster-level Kubernetes data. Enabled by default in Helm and Operator deployments. | 7.77+ |
+| [**DDOT Collector**](/opentelemetry/setup/ddot_collector/) | The Datadog Distribution of OpenTelemetry collector.<br />Resolved values are synced from the core Agent automatically using config-sync, with no separate configuration needed. | 7.70+ |
 
 <div class="alert alert-info">Native secrets fetching is the recommended approach for managing secrets in the Datadog Agent. If your deployment includes other Agent processes or versions that do not support it, use <a href="#option-2-using-the-built-in-script-for-kubernetes-and-docker">Option 2</a> or <a href="#option-3-creating-a-custom-executable">Option 3</a> for those configurations.</div>
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Clears up where exactly SGC is supported to prevent issues like this: https://github.com/DataDog/datadog-agent/issues/46502

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
This is based on this spec [confluence](https://datadoghq.atlassian.net/wiki/spaces/agent/pages/3074132329/Overview+of+Agents+Binaries+Shared+Features+and+IPC) 