### PR TITLE
Rename "account crawling" to "account access for Bits AI" in docs

### DIFF
--- a/content/en/bits_ai/bits_ai_sre/chat_bits_ai_sre.md
+++ b/content/en/bits_ai/bits_ai_sre/chat_bits_ai_sre.md
@@ -14,7 +14,7 @@ The Bits AI SRE chatbot has access to:
 - **Incidents**: Details on incidents and their status, severity, and more
 - **Services**: Services in Software Catalog with their dependencies, owners, and more
 - **Datadog documentation**: Documented Datadog product information
-- **Confluence documentation**: Relevant documentation or runbooks from your Confluence documentation (if the [Confluence integration is configured to enable account crawling][1])
+- **Confluence documentation**: Relevant documentation or runbooks from your Confluence documentation (if the [Confluence integration is configured to enable account access for Bits AI][1])
 
 ## Example questions
 

--- a/content/en/bits_ai/bits_ai_sre/configure.md
+++ b/content/en/bits_ai/bits_ai_sre/configure.md
@@ -44,7 +44,7 @@ Bits AI SRE integrates with Confluence to:
 To set up Bits AI SRE to use Confluence:
 
 1. Connect your Confluence Cloud account by following the instructions in the [Confluence integration tile][7].
-1. Optionally, enable account crawling to make Confluence a data source within Bits' chat interface. If you don't enable account crawling, Bits can still use Confluence to inform its investigation plan.
+1. Optionally, enable account access for Bits AI to make Confluence a data source within Bits' chat interface. If you don't enable account access for Bits AI, Bits can still use Confluence to inform its investigation plan.
 1. Add a link to a Confluence page in your monitor's message. Bits reads the page to extract Datadog telemetry links and other context when forming its investigation plan.
 1. You can view all connected Confluence accounts on the [Bits Settings page][4].
 


### PR DESCRIPTION
## Summary
- Rename "Enable account crawling" to "Enable account access for Bits AI" in Bits AI SRE documentation to match the updated checkbox label in the Confluence integration configuration UI.
- Updated in `configure.md` and `chat_bits_ai_sre.md`.

## Test plan
- [ ] Verify the updated text renders correctly in the branch preview
- [ ] Confirm the label matches the web UI after the corresponding web-ui change ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)