### PR TITLE
Document MCP Read and MCP Write permissions for MCP Server

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -48,7 +48,7 @@ This demo shows the Datadog MCP Server being used in Cursor and Claude Code (unm
 
 ## Requirements
 
-Datadog users must have the `MCP Read` [permission][18] to use the MCP Server for read-access and `MCP Write` [permission][18] for write access.
+Datadog users must have the `MCP Read` and/or `MCP Write` [permissions][18] to use the MCP server.
 
 For setup instructions, see [Set Up the Datadog MCP Server](/bits_ai/mcp_server/setup).
 


### PR DESCRIPTION
## What does this PR do?

Updates the MCP Server docs to document the correct RBAC permissions:
- **MCP Read** for read-access to the MCP Server
- **MCP Write** for write access

Changes:
- content/en/bits_ai/mcp_server/_index.md: Update Requirements section from Incidents Read to MCP Read / MCP Write; point permission link to #mcp

Subset of the GA branch (permissions docs only) for ASAP release.

## Merge instructions

Merge readiness:
- [ ] Ready for merge
