### PR TITLE
Add an alert about deleted synthetic monitors

### DIFF
--- a/content/en/monitors/settings/_index.md
+++ b/content/en/monitors/settings/_index.md
@@ -91,6 +91,9 @@ To create and manage monitor notification rules, see [Monitor notification rules
 
 
 ## Deleted monitors
+
+<div class="alert alert-warning">Deleted Synthetic monitors are not recoverable and cannot be restored.</div>
+
 Monitors are retained for 7 days before being permanently deleted. To restore recently deleted Datadog monitors:
 1. Navigate to the [**Monitors** > **Settings**][1] page.
 1. Open the **Deleted Monitors** tab.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Add an alert that you cannot recover deleted Synthetic Monitors.
- [DOCS-13378](https://datadoghq.atlassian.net/browse/DOCS-13378)
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge