### PR TITLE
[DOCS-13475] Add US1-FED banner to Send a Flare page

### DIFF
--- a/content/en/agent/troubleshooting/send_a_flare.md
+++ b/content/en/agent/troubleshooting/send_a_flare.md
@@ -20,10 +20,6 @@ This page covers:
 - [Sending a flare from the Datadog site](#send-a-flare-from-the-datadog-site) using Remote Configuration.
 - [Manual submission](#manual-submission).
 
-{{< site-region region="gov" >}}
-<div class="alert alert-warning">On US1-FED, only <a href="#manual-submission">manual flare submission</a> is supported.</div>
-{{< /site-region >}}
-
 A flare gathers all of the Agent's configuration files and logs into an archive file. It removes sensitive information, including passwords, API keys, Proxy credentials, and SNMP community strings. If APM is enabled, the flare includes [tracer debug logs][4] when available.
 
 The Datadog Agent is completely open source, which allows you to [verify the code's behavior][1]. If needed, the flare can be reviewed prior to sending since the flare prompts a confirmation before uploading it.
@@ -33,7 +29,7 @@ When contacting Datadog Support with Remote Configuration enabled for an Agent, 
 ## Send a flare from the Datadog site
 
 {{< site-region region="gov" >}}
-<div class="alert alert-danger">Sending an Agent Flare from Fleet Automation is not supported for this site.</div>
+<div class="alert alert-warning">Sending an Agent Flare from Fleet Automation is not supported for your selected Datadog site (US1-FED). Use <a href="#manual-submission">manual flare submission</a> instead.</div>
 {{< /site-region >}}
 
 To send a flare from the Datadog site, make sure you've enabled [Fleet Automation][2] and [Remote configuration][3] on the Agent.
@@ -43,6 +39,10 @@ To send a flare from the Datadog site, make sure you've enabled [Fleet Automatio
 {{< img src="agent/fleet_automation/fleet_automation_remote_flare.png" alt="The Send Ticket button launches a form to send a flare for an existing or new support ticket" style="width:70%;" >}}
 
 ## Send a flare using the `flare` command
+
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Sending an Agent Flare using the <code>flare</code> subcommand is not supported for your selected Datadog site (US1-FED). Use <a href="#manual-submission">manual flare submission</a> instead.</div>
+{{< /site-region >}}
 
 Use the `flare` subcommand to send a flare. In the commands below, replace `<CASE_ID>` with your Datadog support case ID if you have one, then enter the email address associated with it.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13475

Adds a US1-FED warning banner to the Agent Flare page to clarify that only manual flare submission is supported on US1-FED. The banner is placed after the "This page covers" list so users see it before reading through the submission methods.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Uses an inline `{{< site-region region="gov" >}}` shortcode with specific language and a direct link to the Manual submission section, following the pattern for mid-page banners with custom messaging.