### PR TITLE
Add missing quotation mark to Directory check description

### DIFF
--- a/data/partials/requests.yaml
+++ b/data/partials/requests.yaml
@@ -24,7 +24,7 @@ requests:
     link: "/infrastructure/process"
     image: "int_processes.png"
   - name: "Files and Directories"
-    description: The Directory check measures the age of files, the number of files in a directory, or the size of a directory.
+    description: "The Directory check measures the age of files, the number of files in a directory, or the size of a directory."
     link: "/integrations/directory"
     image: "int_files.png"
   - name: "Endpoint"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes a stray quotation mark at the end of the Directory check description in the commonly requested technologies table on the Developers page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes