### PR TITLE
[DOCS-12865] Add mobile app test metrics to Synthetics metrics page

### DIFF
--- a/content/en/synthetics/platform/metrics/_index.md
+++ b/content/en/synthetics/platform/metrics/_index.md
@@ -37,6 +37,7 @@ Metrics starting with:
     * `synthetics.icmp.*` come from your API [ICMP tests][8]
 * `synthetics.multi.*` come from your [multistep API tests][9]
 * `synthetics.browser.*` come from your [browser tests][10]
+* `synthetics.mobile.*` come from your [mobile app tests][14]
 * `synthetics.pl.*`come from your [private locations][11]
 
 ### General metrics
@@ -85,6 +86,10 @@ For more information on API test timings, read the guide on [API Test Timings an
 
 {{< get-metrics-from-git "synthetics" "synthetics.browser" >}}
 
+### Mobile app tests
+
+{{< get-metrics-from-git "synthetics" "synthetics.mobile" >}}
+
 ### Private locations
 
 {{< get-metrics-from-git "synthetics" "synthetics.pl.worker" >}}
@@ -112,3 +117,4 @@ For more information about parallelization, see [Continuous Testing Settings][13
 [11]: /synthetics/private_locations/
 [12]: /synthetics/guide/api_test_timing_variations/
 [13]: /continuous_testing/settings/#parallelization
+[14]: /mobile_app_testing/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-12865

Adds a "Mobile app tests" section to the Synthetic Monitoring & Continuous Testing metrics page. The mobile metrics (`synthetics.mobile.*`) were added to the synthetics metadata in [integrations-internal-core#2796](https://github.com/DataDog/integrations-internal-core/pull/2796) and are now available through the `get-metrics-from-git` shortcode.

Changes:
- Add `synthetics.mobile.*` to the overview list of metric prefixes
- Add a "Mobile app tests" section with the `get-metrics-from-git` shortcode filtering on `synthetics.mobile`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
