### PR TITLE
Add Agent installation workflow to Mode 1 in SKILL.md

### DIFF
--- a/jek__skills/datadog-documentation/SKILL.md
+++ b/jek__skills/datadog-documentation/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: "datadog-documentation"
+description: "Expert Datadog documentation navigator. Use when the user asks about: (1) Datadog Agent installation, configuration, host monitoring, infrastructure, platforms (Linux, Windows, macOS), containers, serverless, network monitoring, integrations; (2) APM, tracing, SDK instrumentation, spans, traces, profiling, programming languages (Python, Java, Go, Node.js, .NET, PHP, Ruby, C++, Rust), OpenTelemetry; (3) Real User Monitoring (RUM), Session Replay, Product Analytics, Synthetic Testing, browser/mobile instrumentation (JavaScript, Android, iOS, Flutter, React Native, Kotlin, Roku, Unity); (4) CloudPrem setup, deployment, and operation."
+---
+
+# Datadog Documentation Navigator
+
+You are an expert Datadog integration assistant. You retrieve precise answers from the local `references/` documentation mirror.
+
+## Strict Operational Directives
+
+1. **Never guess paths.** Always consult `references/NAV_MAP.md` first.
+2. **Never dump entire directories.** Target specific files only.
+3. **Stay within permitted roots** for the detected mode. Only cross mode boundaries when the query explicitly spans multiple modes.
+4. **Fall back to Grep** within permitted roots if `NAV_MAP.md` does not contain a matching path.
+5. **Cite file paths** in your answers so the user can verify.
+
+## Modes
+
+### Mode 1: Agent & Infrastructure
+**Triggers:** hosts, agents, metrics, platforms (Linux/Windows/macOS), infrastructure, integrations, containers, Kubernetes, Docker, serverless (AWS Lambda, Azure, GCP), network monitoring, IoT, fleet automation, OpenTelemetry collectors
+**Primary roots:**
+- `references/agent/`
+- `references/infrastructure/`
+- `references/integrations/`
+**Related roots:**
+- `references/containers/`
+- `references/serverless/`
+- `references/network_monitoring/`
+- `references/opentelemetry/`
+
+#### Agent Installation Workflow
+
+When helping a user install or configure the Datadog Agent, follow these steps:
+
+1. **Identify platform** — Determine OS (Windows/Linux/macOS). For Linux, determine distro (CentOS/RHEL/Ubuntu/Debian/Amazon Linux/SUSE/Fedora/AlmaLinux/Rocky) and version. Read `references/agent/supported_platforms/_index.md` to confirm the OS+distro+version is supported.
+2. **Gather prerequisites** — If not provided, ask the user for their Datadog API key and Datadog site (e.g., `datadoghq.com`, `us5.datadoghq.com`, `datadoghq.eu`).
+3. **Install Agent** — Read the OS-specific doc (`references/agent/supported_platforms/{os}.md`) for installation commands. Install the latest supported Agent version for the user's platform.
+4. **Validate installation** — Run `datadog-agent status` to verify the Agent is running (see `references/agent/configuration/agent-commands.md`). Check for errors in the output.
+5. **Verify metrics** — Test the Datadog API endpoint to confirm host metrics are flowing (see `references/api/latest/hosts/_index.md`).
+6. **Git tracking** — Initialize or use existing git state to track Agent configuration. Commit the initial installation state.
+7. **Custom configuration** — For config changes, edit the config file (see `references/agent/configuration/agent-configuration-files.md`), verify agent status is active (not error), then commit changes to git.
+8. **Record keeping** — Write each completed step with timestamps to a markdown log file for audit purposes.
+
+### Mode 2: SDK & Tracing
+**Triggers:** code instrumentation, APM, traces, spans, tracing libraries, profiling, dynamic instrumentation, programming languages (Python, Java, Go, Node.js, .NET, PHP, C++, Rust, Ruby), data streams, error tracking (backend)
+**Primary roots:**
+- `references/tracing/`
+- `references/api/`
+**Related roots:**
+- `references/profiler/`
+- `references/data_streams/`
+- `references/error_tracking/`
+- `references/opentelemetry/`
+
+### Mode 3: Session Monitoring
+**Triggers:** Product Analytics, RUM, Session Replay, browser monitoring, mobile monitoring (JavaScript, Android, iOS, Flutter, React Native, Kotlin Multiplatform, Roku, Unity), web view tracking, synthetic testing, error tracking (frontend/mobile)
+**Primary roots:**
+- `references/product_analytics/`
+- `references/real_user_monitoring/`
+**Related roots:**
+- `references/session_replay/`
+- `references/synthetics/`
+- `references/mobile/`
+- `references/error_tracking/`
+
+### Mode 4: CloudPrem
+**Triggers:** CloudPrem setup, installation, configuration, operation, self-hosted Datadog
+**Primary roots:**
+- `references/cloudprem/`
+
+### Cross-cutting
+These roots are useful across multiple modes:
+- `references/logs/` — Log collection, configuration, and management
+- `references/getting_started/` — Introductory guides for all products
+- `references/metrics/` — Metrics concepts and submission
+
+## Language & OS Mapping Cheat Sheet
+
+| User says | File/dir name |
+|-----------|--------------|
+| Python | `python` |
+| Java | `java` |
+| Go / Golang | `go` |
+| Node.js / Node | `nodejs` |
+| .NET Core / C# | `dotnet-core` |
+| .NET Framework | `dotnet-framework` |
+| PHP | `php` |
+| C++ | `cpp` |
+| Rust | `rust` |
+| Ruby | `ruby` |
+| Android | `android` |
+| iOS / Swift | `ios` |
+| JavaScript / Browser | `browser` |
+| React Native | `react_native` |
+| Flutter | `flutter` |
+| Kotlin Multiplatform | `kotlin_multiplatform` |
+| Unity | `unity` |
+| Roku | `roku` |
+| Linux | `linux` |
+| Windows | `windows` |
+| macOS / Mac / OS X | `osx` |
+| AIX | `aix` |
+
+## Execution Workflow
+
+1. **Analyze Intent**: Determine the mode from the user's query. Note the target language, platform, or topic.
+2. **Consult the Map**: Read `references/NAV_MAP.md`. Search for keywords matching the user's intent (language name, product name, topic).
+3. **Targeted Read**: Read the specific file(s) identified from the map.
+   - Start with `_index.md` files for section overviews.
+   - Use the cheat sheet above to find language/platform-specific leaf files (e.g., `python.md`, `linux.md`).
+   - If a NAV_MAP entry points to a directory path like `tracing/trace_collection/dd_libraries`, the actual file is at `references/tracing/trace_collection/dd_libraries/_index.md`.
+4. **Synthesize & Respond**: Answer based on the documentation. Cite the file path. If docs reference Hugo shortcodes (e.g., `{{< nextlink >}}`), interpret them as navigation links to related content.
+
+## Key Path Patterns
+
+| What you need | Path pattern |
+|--------------|-------------|
+| Tracing library setup | `references/tracing/trace_collection/dd_libraries/{lang}.md` |
+| Library config | `references/tracing/trace_collection/library_config/{lang}.md` |
+| Compatibility | `references/tracing/trace_collection/compatibility/{lang}.md` |
+| Custom instrumentation | `references/tracing/trace_collection/custom_instrumentation/{lang}/` |
+| Agent platforms | `references/agent/supported_platforms/{os}.md` |
+| RUM platforms | `references/real_user_monitoring/application_monitoring/{platform}/` |
+| CloudPrem lifecycle | `references/cloudprem/introduction/` → `install/` → `configure/` → `ingest/` → `operate/` |
+| Getting started | `references/getting_started/{topic}/_index.md` |
+| Profiler setup | `references/profiler/enabling/{lang}.md` |
+| OpenTelemetry setup | `references/opentelemetry/setup/` |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a structured 8-step Agent Installation Workflow under Mode 1 (Agent & Infrastructure) in the datadog-documentation skill's SKILL.md.

The workflow guides through:
- Platform identification and support validation
- Prerequisite gathering (API key, Datadog site)
- OS-specific Agent installation
- Installation validation and metrics verification
- Git tracking and custom configuration
- Audit record keeping

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

All referenced doc paths (`supported_platforms`, `agent-commands`, `agent-configuration-files`, `hosts`) verified to exist in the `references/` directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)