### PR TITLE
[DOCS-13284] Add Aruba Central and Juniper Mist to wireless integrations

### DIFF
--- a/content/en/network_monitoring/devices/integrations.md
+++ b/content/en/network_monitoring/devices/integrations.md
@@ -35,7 +35,7 @@ The following integrations cover **wireless networking platforms** that support 
 
 {{< partial name="ndm/wireless.html" >}}
 
-<br>
+<div class="alert alert-info">Aruba Central and Juniper Mist integrations are in Preview. Reach out to your Datadog representative to sign up.</div>
 
 ## Virtualization
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13284

Adds Aruba Central and Juniper Mist to the Wireless Networking section of the NDM integrations page. Since both integrations are currently in Preview and don't have dedicated integration pages, they are listed in an info alert note directing users to contact their Datadog representative to sign up.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Pending PM feedback on final approach.