### PR TITLE
(maint) Fix site-support banner on action catalog

### DIFF
--- a/layouts/actioncatalog/list.html
+++ b/layouts/actioncatalog/list.html
@@ -74,7 +74,7 @@
       {{ partial "breadcrumbs.html" . }}
   </div>
 </div>
-
+{{ partial "site_support_banner/site_support_banner.html" . }}
 {{ .Content }}
 <div class="form-group clearfix">
   <input type="input" data-ref="search" class="form-control grouped-item-search mb-3 position-relative" id="keywords" placeholder="Search here" aria-label="keywords"/>


### PR DESCRIPTION
Fix missing site support banner on the actions catalog page: https://docs-staging.datadoghq.com/heston/fix-site-support-actions/actions/actions_catalog/?site=gov