### PR TITLE
Update Azure standalone log forwarder deploy link

### DIFF
--- a/content/en/getting_started/integrations/azure.md
+++ b/content/en/getting_started/integrations/azure.md
@@ -384,5 +384,5 @@ Still need help? Contact [Datadog support][17].
 [48]: https://learn.microsoft.com/azure/azure-functions/functions-get-started
 [49]: https://github.com/DataDog/datadog-serverless-functions/blob/master/azure/blobs_logs_monitoring/index.js
 [51]: https://app.datadoghq.com/logs
-[52]: https://portal.azure.com/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fddazurelfo.blob.core.windows.net%2Ftemplates%2Fforwarder.json
+[52]: https://portal.azure.com/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDataDog%2Fintegrations-management%2Fmain%2Fazure%2Flogging_install%2Fdist%2Fforwarder.json
 [53]: https://learn.microsoft.com/azure/azure-monitor/platform/diagnostic-settings

--- a/content/en/logs/guide/azure-manual-log-forwarding.md
+++ b/content/en/logs/guide/azure-manual-log-forwarding.md
@@ -35,7 +35,7 @@ You can forward your logs through an [Azure Container App][4], or [Azure Blob St
 
 **Note**: Resources can only stream to a Storage Account in the same Azure region.
 
-[200]: https://portal.azure.com/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fddazurelfo.blob.core.windows.net%2Ftemplates%2Fforwarder.json
+[200]: https://portal.azure.com/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDataDog%2Fintegrations-management%2Fmain%2Fazure%2Flogging_install%2Fdist%2Fforwarder.json
 [201]: https://learn.microsoft.com/azure/azure-monitor/platform/diagnostic-settings
 {{% /tab %}}
 

--- a/content/es/getting_started/integrations/azure.md
+++ b/content/es/getting_started/integrations/azure.md
@@ -292,7 +292,7 @@ Consulta [Azure Automated Log Forwarding Architecture][34] para obtener más det
 
 {{% azure-log-archiving %}}
 
-## Obtén más información de la plataforma de Datadog 
+## Obtén más información de la plataforma de Datadog
 
 ### Instala el Agent para obtener una mayor visibilidad de tu aplicación.
 
@@ -387,5 +387,5 @@ Consulta [Solución de problemas][16] en la guía de configuración avanzada de 
 [48]: https://learn.microsoft.com/azure/azure-functions/functions-get-started
 [49]: https://github.com/DataDog/datadog-serverless-functions/blob/master/azure/blobs_logs_monitoring/index.js
 [51]: https://app.datadoghq.com/logs
-[52]: https://portal.azure.com/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fddazurelfo.blob.core.windows.net%2Ftemplates%2Fforwarder.json
+[52]: https://portal.azure.com/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDataDog%2Fintegrations-management%2Fmain%2Fazure%2Flogging_install%2Fdist%2Fforwarder.json
 [53]: https://learn.microsoft.com/azure/azure-monitor/platform/diagnostic-settings

--- a/content/es/logs/guide/azure-manual-log-forwarding.md
+++ b/content/es/logs/guide/azure-manual-log-forwarding.md
@@ -35,7 +35,7 @@ Puedes reenviar tus logs a través de una cuenta de [Azure Container App][4] o [
 
 **Nota**: Los recursos solo pueden transmitirse a una cuenta de almacenamiento en la misma región de Azure.
 
-[200]: https://portal.azure.com/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fddazurelfo.blob.core.windows.net%2Ftemplates%2Fforwarder.json
+[200]: https://portal.azure.com/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDataDog%2Fintegrations-management%2Fmain%2Fazure%2Flogging_install%2Fdist%2Fforwarder.json
 [201]: https://learn.microsoft.com/azure/azure-monitor/platform/diagnostic-settings
 {{% /tab %}}
 


### PR DESCRIPTION
We needed to move this to a different URL. See https://github.com/DataDog/integrations-management/pull/142.