### PR TITLE
Clean up Data Observability warehouse IP whitelisting language

### DIFF
--- a/content/en/data_observability/quality_monitoring/data_warehouses/bigquery.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/bigquery.md
@@ -15,7 +15,7 @@ The BigQuery integration connects Datadog to your Google Cloud project to sync m
 
 ## Prerequisites
 
-If your Google Cloud project restricts network access by IP, add the Datadog webhook IPs to your allowlist. For the list of IPs, see the {{< region-param key="ip_ranges_url" link="true" text="IP ranges list" >}}.
+If your Google Cloud project restricts network access by IP, add the Datadog webhook IPs to your allowlist. For the list of IPs, see the `webhooks` section of {{< region-param key="ip_ranges_url" link="true" text="IP ranges list" >}}.
 
 ## Configure the BigQuery integration in Datadog
 

--- a/content/en/data_observability/quality_monitoring/data_warehouses/databricks.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/databricks.md
@@ -20,7 +20,7 @@ The Databricks integration connects Datadog to your Databricks workspace to sync
 
 ## Prerequisites
 
-If your Databricks workspace restricts network access by IP, add the Datadog webhook IPs to your allowlist. For the list of IPs, see the {{< region-param key="ip_ranges_url" link="true" text="IP ranges list" >}}.
+If your Databricks workspace restricts network access by IP, add the Datadog webhook IPs to your allowlist. For the list of IPs, see the `webhooks` section of {{< region-param key="ip_ranges_url" link="true" text="IP ranges list" >}}.
 
 ## Set up your account in Databricks
 

--- a/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
@@ -19,7 +19,7 @@ Before you begin, make sure you have:
 
 - Access to the `ACCOUNTADMIN` role in Snowflake.
 - An RSA key pair. For more information, see the [Snowflake key-pair authentication docs][1].
-- If your Snowflake account restricts network access by IP, the Datadog webhook IPs added to your network policy allowlist. For the list of IPs, see the {{< region-param key="ip_ranges_url" link="true" text="IP ranges list" >}}.
+- If your Snowflake account restricts network access by IP, Datadog webhook IPs must be included in your network policy allowlist. For the list of IPs, see the `webhooks` section of {{< region-param key="ip_ranges_url" link="true" text="IP ranges list" >}}.
 
 ## Set up your account in Snowflake
 


### PR DESCRIPTION
Lightly update the language in the IP whitelisting sections for Data Observability warehouses:
1. Make the Snowflake section less choppy
2. Be very explicit that we're looking at the `webhooks` IPs

Merge readiness:
- [x] Ready for merge