### PR TITLE
fix: use consistent formatting for serverless node options

### DIFF
--- a/content/en/serverless/azure_app_service/linux_code.md
+++ b/content/en/serverless/azure_app_service/linux_code.md
@@ -48,7 +48,7 @@ Instrumentation starts when the application is launched.
    ```
 2. Initialize the Node.js tracer with the `NODE_OPTIONS` environment variable:
    ```
-   NODE_OPTIONS='--require=dd-trace/init'
+   NODE_OPTIONS='--require dd-trace/init'
    ```
 
 {{% /tab %}}

--- a/content/en/serverless/azure_functions/_index.md
+++ b/content/en/serverless/azure_functions/_index.md
@@ -40,7 +40,7 @@ If you haven't already, install the [Datadog-Azure integration][5] to collect me
    Use the `--require` option to load and initialize the Serverless Compatibility Layer and the Datadog Node.js tracer in one step. Node options in Azure Functions can be configured with the environment variable `languageWorkers__node__arguments`.
 
    ```
-   languageWorkers__node__arguments='--require=@datadog/serverless-compat/init --require=dd-trace/init'
+   languageWorkers__node__arguments='--require @datadog/serverless-compat/init --require dd-trace/init'
    ```
 
 3. **Configure the Datadog Node.js tracer**

--- a/content/en/serverless/google_cloud_run/functions_1st_gen.md
+++ b/content/en/serverless/google_cloud_run/functions_1st_gen.md
@@ -43,7 +43,7 @@ Google has integrated Cloud Run functions into the Cloud Run UI. Starting August
    Use the `--require` option to load and initialize the Serverless Compatibility Layer and the Datadog Node.js tracer in one step.
 
    ```
-   NODE_OPTIONS='--require=@datadog/serverless-compat/init --require=dd-trace/init'
+   NODE_OPTIONS='--require @datadog/serverless-compat/init --require dd-trace/init'
    ```
 
 3. (Optional) **Enable runtime metrics**. See [Node.js Runtime Metrics][2].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Uses consistent formatting for `NODE_OPTIONS` in Serverless installation instructions. Both `--require=dd-trace/init` and `--require dd-trace/init` are valid syntax but the latter is what is used across the rest of Datadog documentation.

Follows https://github.com/DataDog/documentation/pull/34685

https://datadoghq.atlassian.net/browse/SVLS-8485

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
