### PR TITLE
Add API key type guidance and permission requirements to Fivetran docs

### DIFF
--- a/content/en/data_observability/quality_monitoring/elt/fivetran.md
+++ b/content/en/data_observability/quality_monitoring/elt/fivetran.md
@@ -20,6 +20,13 @@ Lineage is derived for all [supported data warehouse destinations][4].
 
 ### Generate an API key
 
+Fivetran supports two types of API keys:
+
+- **Scoped Key**: Links to a specific user account and inherits that user's RBAC permissions. Any Fivetran user can create one.
+- **System Key**: An organization-managed API key-secret pair with permissions set at the key level, managed centrally by an administrator.
+
+Datadog recommends using a **Scoped Key** created by a user with the **Account Administrator** role. This is the simplest way to get started and helps ensure the key has the required permissions to connect to Datadog.
+
 To generate a Fivetran API key and secret, navigate to **Settings > API Config** in your Fivetran account. For details, see the [Fivetran API authentication documentation][1].
 
 ### Add the Fivetran integration


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds guidance on which Fivetran API key type to use and what permissions are required

Changes to the "Generate an API key" section:
- Explains the two Fivetran API key types (Scoped Key vs. System Key)
- Recommends using a Scoped Key created by an Account Administrator
- Clarifies that the Account Administrator role provides the required permissions

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

This PR targets the `kevinzenghu/add-fivetran-docs` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)