### PR TITLE
Remove preview note from SQL queries

### DIFF
--- a/content/en/security/cloud_siem/detect_and_monitor/custom_detection_rules/create_rule/scheduled_rule.md
+++ b/content/en/security/cloud_siem/detect_and_monitor/custom_detection_rules/create_rule/scheduled_rule.md
@@ -39,8 +39,6 @@ Choose the query language you want to use.
 {{% cloud_siem/unit_testing %}}
 {{% /collapse-content %}}
 {{% collapse-content title="SQL" level="h4" expanded=false id="threshold-sql" %}}
-<div class="alert alert-info">SQL queries are in Preview.</div>
-
 You can use SQL syntax to write detection rules for additional flexibility, consistency, and portability. For information on the available syntax, see [DDSQL Reference][1].
 
 In Datadog, SQL queries are compatible with data stored in [datasets][2]. You can create datasets to format data already stored in tables for the following data types:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removes preview note from the Cloud SIEM detection rules SQL query section.

### Merge instructions
@clementgbcn will post in #documentation when this is ready to go out 🙂
<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
