### PR TITLE
Remove Prometheus exclusion note from GCP quick start region filtering docs

### DIFF
--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -348,8 +348,6 @@ You can also specify additional locations not listed and disable any global metr
 
 {{< img src="integrations/google_cloud_platform/metric_region_filtering.png" alt="The metric collection tab in the Datadog Google Cloud integration page, with the Enable Global Metrics option highlighted and a subset of regions selected. The Additional Locations option is also highlighted with a multi-region filter defined" style="width:80%;">}}
 
-**Note**: These metric collection filters do not apply to `gcp.prometheus.*` metrics and a subset of `gcp.gke.*` metrics.
-
 {{% /collapse-content %}}
 
 {{% collapse-content title="Limit metric collection by host or Cloud Run instance" level="h4" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Removing a note in our region filtering feature documentation on our QuickStart guide that warns customers Prometheus metrics cannot be filtered by region. This functionality is now supported, so the note is being removed.

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
Preview Link: https://docs-staging.datadoghq.com/sujay.desai/GCP-3283/remove-prometheus-note/getting_started/integrations/google_cloud
