### PR TITLE
[DOCS-13370] Add EUA authentication note to RUM Browser troubleshooting

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/troubleshooting.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/troubleshooting.md
@@ -82,7 +82,7 @@ If your application uses Enterprise User Administration (EUA) with a redirect to
 To record the browser test successfully:
 
 1. **Record using the popup window mode**: When starting the browser test recording, select **Open in Popup** instead of recording inside the iframe. This allows the authentication flow to complete without losing the CSRF token.
-2. **Log out before recording**: Make sure there is no active session or saved cookies. Begin the recording with a completely clean session.
+2. **Log out before recording**: Make sure there is no active session or saved cookies. Start the recording with a completely clean session.
 3. **Use incognito/private browsing mode**: This prevents cached credentials or cookies from interfering with the authentication flow.
 4. **Record once using the popup window**: After the test is recorded through the popup, it runs correctly from the private location.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13370

Adds a new troubleshooting section to the RUM Browser troubleshooting page explaining the `No cookie support detected` error that occurs when an application uses Enterprise User Administration (EUA) with a redirect to CMS IDM for authentication. The section explains the root cause (CSRF token dropped during iframe redirect) and provides four steps to record browser tests successfully.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes