### PR TITLE
Remove Code Coverage Preview banner from JUnit XML page [DOCS-13533] 

### DIFF
--- a/content/en/tests/setup/junit_xml.md
+++ b/content/en/tests/setup/junit_xml.md
@@ -541,10 +541,9 @@ The values that you send to Datadog are strings, so the facets are displayed in 
 
 ## Reporting code coverage
 
-{{< callout url="https://www.datadoghq.com/product-preview/code-coverage/" >}}
-This section covers the code coverage feature of the Test Optimization product.
-This feature is being deprecated and replaced by a new dedicated <a href="https://docs.datadoghq.com/code_coverage/">Code Coverage</a> product. Sign up for the Preview!
-{{< /callout >}}
+<div class="alert alert-warning">
+This Test Optimization feature is legacy. Use the new dedicated <a href="https://docs.datadoghq.com/code_coverage/">Code Coverage</a> product instead.
+</div>
 
 It is possible to report code coverage for a given JUnit report via the `--report-measures` option, by setting the `test.code_coverage.lines_pct` measure:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Replaces the outdated Preview callout in the "Reporting code coverage" section of the JUnit Report Uploads setup page with a legacy warning alert. Code Coverage is now GA, so the Preview signup banner is no longer accurate. The new alert matches the pattern used on the Code Coverage product page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes