### PR TITLE
[DOCS-13539] Refine AWS Getting Started page

### DIFF
--- a/content/en/getting_started/integrations/aws.md
+++ b/content/en/getting_started/integrations/aws.md
@@ -37,7 +37,7 @@ This guide walks you through integrating an Amazon Web Services (AWS) account wi
 
 ## Prerequisites
 
-Before getting started, ensure you have an [AWS][7] account. The CloudFormation template creates an IAM role and associated policy. This allows Datadog's AWS account to make API calls into your AWS account for collecting and pushing data. Your AWS user needs the following IAM permissions to successfully run the template:
+Before you begin, ensure that you have an [AWS][7] account. The CloudFormation template creates an IAM role and associated policy, allowing Datadog's AWS account to make API calls to your AWS account to collect and push data. Your AWS user must have the following IAM permissions to run the template:
 
 {{% collapse-content title="Required IAM permissions" level="h4" expanded=false id="iam-permissions" %}}
 - cloudformation:CreateStack


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13539

Refines the Getting Started with AWS page to reduce verbosity and improve clarity for customers setting up the AWS integration for the first time.

Changes include:
- Condensed the Overview to two sentences focused on what the guide accomplishes
- Added context to Prerequisites explaining what the CloudFormation template creates (IAM role/policy)
- Collapsed the IAM permissions list under a `collapse-content` shortcode
- Moved the multi-account alternatives paragraph and the CloudFormation limitation Note to the end of the Setup section
- Condensed the Send logs section to remove duplication with the main AWS integration page
- Fixed word-list violations: "leveraging" → "using", "screen shot" → "screenshot"
- Removed marketing framing from the Explore related products section

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes