### PR TITLE
Include more links to Data Observability monitors from DO warehouse / data lake pages

### DIFF
--- a/content/en/data_observability/quality_monitoring/data_lakes/aws_glue.md
+++ b/content/en/data_observability/quality_monitoring/data_lakes/aws_glue.md
@@ -8,6 +8,9 @@ further_reading:
   - link: '/integrations/amazon-web-services/'
     tag: 'Documentation'
     text: 'AWS Integration'
+  - link: '/monitors/types/data_observability/'
+    tag: 'Documentation'
+    text: 'Data Observability Monitors'
 ---
 
 ## Overview

--- a/content/en/data_observability/quality_monitoring/data_warehouses/bigquery.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/bigquery.md
@@ -7,6 +7,9 @@ further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Learn about Data Observability'
+  - link: '/monitors/types/data_observability/'
+    tag: 'Documentation'
+    text: 'Data Observability Monitors'
 ---
 
 ## Overview

--- a/content/en/data_observability/quality_monitoring/data_warehouses/databricks.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/databricks.md
@@ -7,6 +7,9 @@ further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Data Observability Overview'
+  - link: '/monitors/types/data_observability/'
+    tag: 'Documentation'
+    text: 'Data Observability Monitors'
 
 ---
 

--- a/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
@@ -7,6 +7,9 @@ further_reading:
   - link: '/data_observability/'
     tag: 'Documentation'
     text: 'Data Observability Overview'
+  - link: '/monitors/types/data_observability/'
+    tag: 'Documentation'
+    text: 'Data Observability Monitors'
 ---
 
 ## Overview


### PR DESCRIPTION
After connecting a data warehouse, data engineers will want to add monitors. Now that we have a [Data Observability docs](https://docs.datadoghq.com/monitors/types/data_observability/?tab=freshness) page, we should link to that page.

This PR extends: https://github.com/DataDog/documentation/pull/34872

Merge readiness:
- [x] Ready for merge
