### PR TITLE
[draft] Add automatic process-based log collection to host setup docs

### DIFF
--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -55,13 +55,66 @@ After activating log collection, the Agent is ready to forward logs to Datadog. 
 
 <div class="alert alert-info">Requires Agent version 7.71 or later.</div>
 
-Set `process_collect_all: true` in `datadog.yaml` to have the Agent automatically collect log files from processes running on the host. This removes the need to configure each log source individually. See [Log Collection - Host setup][15] for full configuration details, including privileged log access and workload filtering.
+To have the Agent automatically collect log files from processes running on the host, enable process-based log discovery. This removes the need to configure each log source individually.
+
+Add the following settings to the respective configuration files:
 
 {{< code-block lang="yaml" filename="datadog.yaml" disable_copy="false" collapsible="true" >}}
 logs_enabled: true
 logs_config:
-    process_collect_all: true
+  process_exclude_agent: true
+  auto_multi_line_detection: true
+extra_config_providers:
+  - process_log
 {{< /code-block >}}
+
+{{< code-block lang="yaml" filename="system-probe.yaml" disable_copy="false" collapsible="true" >}}
+discovery:
+  enabled: true
+{{< /code-block >}}
+
+You can set all of these options automatically during Agent installation by passing `DD_LOGS_CONFIG_PROCESS_COLLECT_ALL=true` to the install script:
+
+```shell
+DD_API_KEY=<YOUR_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_LOGS_CONFIG_PROCESS_COLLECT_ALL=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+```
+
+### Privileged logs
+
+To allow the Agent to access log files without manually granting file permissions, enable privileged logs (requires Agent 7.72+). Add the following to `system-probe.yaml`:
+
+{{< code-block lang="yaml" filename="system-probe.yaml" disable_copy="false" collapsible="true" >}}
+privileged_logs:
+  enabled: true
+{{< /code-block >}}
+
+Privileged logs is automatically enabled when using the install script above.
+
+### Filter collected log files
+
+<div class="alert alert-info">Workload filtering requires Agent version 7.73 or later.</div>
+
+To exclude specific processes or log files from automatic collection, add [CEL-based][16] workload filter rules to `datadog.yaml`:
+
+{{< code-block lang="yaml" filename="datadog.yaml" disable_copy="false" collapsible="true" >}}
+cel_workload_exclude:
+  - products: ["logs"]
+    rules:
+      processes:
+        - "process.name == 'mysql'"
+        - "process.name == 'nginx' && process.log_file.contains('error.log')"
+        - "process.log_file.startsWith('/var/log/noisy/')"
+{{< /code-block >}}
+
+Supported filter expressions:
+
+| Expression | Description |
+|---|---|
+| `process.name == '<NAME>'` | Match by process name |
+| `process.log_file.contains('<SUBSTRING>')` | Match by substring in the log file path |
+| `process.log_file.startsWith('<PREFIX>')` | Match by log file path prefix |
+
+Combine expressions with `&&` (AND) and `||` (OR) operators.
 
 ## Custom log collection
 
@@ -277,3 +330,4 @@ For both file and journald tailer types, if an `end` or `beginning` position is 
 [13]: /metrics/custom_metrics/#overview
 [14]: /getting_started/tagging/
 [15]: /logs/log_collection/?tab=host
+[16]: https://github.com/google/cel-spec

--- a/content/en/agent/logs/_index.md
+++ b/content/en/agent/logs/_index.md
@@ -51,6 +51,18 @@ DD_LOGS_ENABLED=true
 
 After activating log collection, the Agent is ready to forward logs to Datadog. Next, configure the Agent on where to collect logs from.
 
+## Automatic collection from running processes
+
+<div class="alert alert-info">Requires Agent version 7.71 or later.</div>
+
+Set `process_collect_all: true` in `datadog.yaml` to have the Agent automatically collect log files from processes running on the host. This removes the need to configure each log source individually. See [Log Collection - Host setup][15] for full configuration details, including privileged log access and workload filtering.
+
+{{< code-block lang="yaml" filename="datadog.yaml" disable_copy="false" collapsible="true" >}}
+logs_enabled: true
+logs_config:
+    process_collect_all: true
+{{< /code-block >}}
+
 ## Custom log collection
 
 Datadog Agent v6 can collect logs and forward them to Datadog from files, the network (TCP or UDP), journald, and Windows channels:
@@ -264,3 +276,4 @@ For both file and journald tailer types, if an `end` or `beginning` position is 
 [12]: /getting_started/tagging/unified_service_tagging
 [13]: /metrics/custom_metrics/#overview
 [14]: /getting_started/tagging/
+[15]: /logs/log_collection/?tab=host

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -46,13 +46,73 @@ Consult the [list of available Datadog log collection endpoints](#logging-endpoi
 
 1. Install the [Datadog Agent][1].
 2. To enable log collection, change `logs_enabled: false` to `logs_enabled: true` in your Agent's main configuration file (`datadog.yaml`). See the [Host Agent Log collection documentation][5] for more information and examples.
-3. Once enabled, the Datadog Agent can be configured to [tail log files or listen for logs sent over UDP/TCP][2], [filter out logs or scrub sensitive data][3], and [aggregate multi-line logs][4].
+3. Configure log sources using one of the following options:
+
+   **Automatic collection from running processes**
+
+   <div class="alert alert-info">Requires Agent version 7.71 or later.</div>
+
+   Set `process_collect_all: true` in `datadog.yaml` to have the Agent automatically collect log files from processes running on the host:
+
+   ```yaml
+   logs_enabled: true
+   logs_config:
+     process_collect_all: true
+   ```
+
+   You can also enable this during Agent installation by passing `DD_LOGS_CONFIG_PROCESS_COLLECT_ALL=true` to the install script:
+
+   ```shell
+   DD_API_KEY=<YOUR_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_LOGS_CONFIG_PROCESS_COLLECT_ALL=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
+   ```
+
+   This sets both `logs_enabled: true` and `process_collect_all: true` in a single step.
+
+   To allow the Agent to access log files without manually granting file permissions, enable privileged logs (requires Agent 7.72+). Add the following to `system-probe.yaml`:
+
+   ```yaml
+   privileged_logs:
+     enabled: true
+   ```
+
+   With install script version 1.42.0 or later, privileged logs is automatically enabled when `DD_LOGS_CONFIG_PROCESS_COLLECT_ALL=true` is set.
+
+   **Filter collected log files**
+
+   <div class="alert alert-info">Workload filtering requires Agent version 7.73 or later.</div>
+
+   To exclude specific processes or log files from collection, add [CEL-based][6] workload filter rules to `datadog.yaml`:
+
+   ```yaml
+   cel_workload_exclude:
+     - products: ["logs"]
+       rules:
+         processes:
+           - "process.name == 'mysql'"
+           - "process.name == 'nginx' && process.log_file.contains('error.log')"
+           - "process.log_file.startsWith('/var/log/noisy/')"
+   ```
+
+   Supported filter expressions:
+
+   | Expression | Description |
+   |---|---|
+   | `process.name == '<NAME>'` | Match by process name |
+   | `process.log_file.contains('<SUBSTRING>')` | Match by substring in the log file path |
+   | `process.log_file.startsWith('<PREFIX>')` | Match by log file path prefix |
+
+   Combine expressions with `&&` (AND) and `||` (OR) operators.
+
+   **Manual collection**
+
+   Configure the Agent to [tail specific log files or listen for logs sent over UDP/TCP][2], [filter out logs or scrub sensitive data][3], and [aggregate multi-line logs][4].
 
 [1]: https://app.datadoghq.com/account/settings/agent/latest
 [2]: /agent/logs/#custom-log-collection
 [3]: /agent/logs/advanced_log_collection/#filter-logs
 [4]: /agent/logs/advanced_log_collection/#multi-line-aggregation
 [5]: /agent/logs/
+[6]: https://github.com/google/cel-spec
 {{% /tab %}}
 
 {{% tab "Application" %}}

--- a/content/en/logs/log_collection/_index.md
+++ b/content/en/logs/log_collection/_index.md
@@ -52,56 +52,7 @@ Consult the [list of available Datadog log collection endpoints](#logging-endpoi
 
    <div class="alert alert-info">Requires Agent version 7.71 or later.</div>
 
-   Set `process_collect_all: true` in `datadog.yaml` to have the Agent automatically collect log files from processes running on the host:
-
-   ```yaml
-   logs_enabled: true
-   logs_config:
-     process_collect_all: true
-   ```
-
-   You can also enable this during Agent installation by passing `DD_LOGS_CONFIG_PROCESS_COLLECT_ALL=true` to the install script:
-
-   ```shell
-   DD_API_KEY=<YOUR_API_KEY> DD_SITE="{{< region-param key="dd_site" >}}" DD_LOGS_CONFIG_PROCESS_COLLECT_ALL=true bash -c "$(curl -L https://install.datadoghq.com/scripts/install_script_agent7.sh)"
-   ```
-
-   This sets both `logs_enabled: true` and `process_collect_all: true` in a single step.
-
-   To allow the Agent to access log files without manually granting file permissions, enable privileged logs (requires Agent 7.72+). Add the following to `system-probe.yaml`:
-
-   ```yaml
-   privileged_logs:
-     enabled: true
-   ```
-
-   With install script version 1.42.0 or later, privileged logs is automatically enabled when `DD_LOGS_CONFIG_PROCESS_COLLECT_ALL=true` is set.
-
-   **Filter collected log files**
-
-   <div class="alert alert-info">Workload filtering requires Agent version 7.73 or later.</div>
-
-   To exclude specific processes or log files from collection, add [CEL-based][6] workload filter rules to `datadog.yaml`:
-
-   ```yaml
-   cel_workload_exclude:
-     - products: ["logs"]
-       rules:
-         processes:
-           - "process.name == 'mysql'"
-           - "process.name == 'nginx' && process.log_file.contains('error.log')"
-           - "process.log_file.startsWith('/var/log/noisy/')"
-   ```
-
-   Supported filter expressions:
-
-   | Expression | Description |
-   |---|---|
-   | `process.name == '<NAME>'` | Match by process name |
-   | `process.log_file.contains('<SUBSTRING>')` | Match by substring in the log file path |
-   | `process.log_file.startsWith('<PREFIX>')` | Match by log file path prefix |
-
-   Combine expressions with `&&` (AND) and `||` (OR) operators.
+   Enable process-based log discovery to have the Agent automatically collect log files from processes running on the host. This removes the need to configure each log source individually. See [Host Agent Log collection - Automatic collection][6] for full configuration details, including privileged log access and workload filtering.
 
    **Manual collection**
 
@@ -112,7 +63,7 @@ Consult the [list of available Datadog log collection endpoints](#logging-endpoi
 [3]: /agent/logs/advanced_log_collection/#filter-logs
 [4]: /agent/logs/advanced_log_collection/#multi-line-aggregation
 [5]: /agent/logs/
-[6]: https://github.com/google/cel-spec
+[6]: /agent/logs/#automatic-collection-from-running-processes
 {{% /tab %}}
 
 {{% tab "Application" %}}


### PR DESCRIPTION
Adds documentation for process_collect_all, privileged logs, and CEL workload filtering to the Log Collection Host tab as the primary source, with a brief pointer from the Agent logs page.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
