### PR TITLE
[DOCS-13522] Add custom DNS ports configuration to CNM setup

### DIFF
--- a/content/en/network_monitoring/cloud_network_monitoring/setup.md
+++ b/content/en/network_monitoring/cloud_network_monitoring/setup.md
@@ -200,7 +200,7 @@ To enable Cloud Network Monitoring for Windows hosts:
 
    [DEPRECATED] _(version 7.44 or below)_ During installation pass `ADDLOCAL="MainApplication,NPM"` to the `msiexec` command, or select "Cloud Network Monitoring" when running the Agent installation through the GUI.
 
-1. Edit `C:\ProgramData\Datadog\system-probe.yaml` to set the enabled flag to `true`:
+2. Edit `C:\ProgramData\Datadog\system-probe.yaml` to set the enabled flag to `true`:
 
     ```yaml
     network_config:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13522

Adds documentation for custom DNS port monitoring support (Agent v7.76.0+) to the Cloud Network Monitoring setup page. Users can now configure non-standard DNS ports via `dns_monitoring_ports` in `system-probe.yaml` (Linux/Windows) or `dnsMonitoringPorts` in `values.yaml` (Helm).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Supported on Linux, Windows, and Kubernetes (Helm). Datadog Operator and ECS Fargate support is pending.