### PR TITLE
Typo - Update reference rule for double inner key

### DIFF
--- a/content/en/observability_pipelines/search_syntax/logs.md
+++ b/content/en/observability_pipelines/search_syntax/logs.md
@@ -105,7 +105,7 @@ To understand path notation, let's look at the following log structure:
 ```
 In this example, use the following reference rules:
 - Use `outer_key.inner_key` to reference the key with the value `inner_value`.
-- Use `outer_key.inner_key.double_inner_key` to reference the key with the value `double_inner_value`.
+- Use `outer_key.a.double_inner_key` to reference the key with the value `double_inner_value`.
 
 If you want to search for a literal `.` in the attribute key, wrap the key in escaped quotes in the search query. For example, the search query `"service.status":disabled` matches the event `{"service.status": "disabled"}`.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Fix reference path. Currently: 

<img width="773" height="573" alt="Screenshot 2026-03-02 at 4 21 35 PM" src="https://github.com/user-attachments/assets/2c83425f-3cd1-4f12-9a82-993d7358e5f6" />

### Merge instructions
Merge readiness:
- [X] Ready for merge
