### PR TITLE
[DOCS-13541] Add US1-FED unsupported banner to Experimentation pages

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -297,6 +297,7 @@ unsupported_sites:
   eng_reports: [gov]
   events_from_sns_emails: [gov]
   exception_replay: [gov]
+  experimentation: [gov]
   feature_flags: [gov]
   forwarding_audit_events: [gov]
   getting_started_feature_flags: [gov]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13541

Adds a US1-FED unsupported site banner to all Experimentation doc pages. Experimentation requires Feature Flags as a dependency, and Feature Flags is confirmed unavailable on US1-FED. This adds `experimentation: [gov]` to the `unsupported_sites` config so the banner displays automatically on all pages under `/product_analytics/experimentation/`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)