### PR TITLE
[SEC-27541] Restrict CSM Jira issues page to GovCloud only

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -7461,11 +7461,6 @@ menu:
       parent: csm_review_remediate
       identifier: csm_workflow_automation
       weight: 102
-    - name: Create Jira Issues
-      url: security/cloud_security_management/review_remediate/jira
-      parent: csm_review_remediate
-      identifier: csm_jira
-      weight: 103
     - name: Severity Scoring
       url: security/cloud_security_management/severity_scoring/
       parent: csm

--- a/config/_default/menus/main.es.yaml
+++ b/config/_default/menus/main.es.yaml
@@ -6520,11 +6520,6 @@ menu:
       parent: csm_review_remediate
       identifier: csm_workflow_automation
       weight: 102
-    - name: Crear incidencias de Jira
-      url: security/cloud_security_management/review_remediate/jira
-      parent: csm_review_remediate
-      identifier: csm_jira
-      weight: 103
     - name: Puntuación de la gravedad
       url: security/cloud_security_management/severity_scoring/
       parent: csm

--- a/config/_default/menus/main.fr.yaml
+++ b/config/_default/menus/main.fr.yaml
@@ -6525,11 +6525,6 @@ menu:
       parent: csm_review_remediate
       identifier: csm_workflow_automation
       weight: 102
-    - name: Create Jira Issues
-      url: security/cloud_security_management/review_remediate/jira
-      parent: csm_review_remediate
-      identifier: csm_jira
-      weight: 103
     - name: Severity Scoring
       url: security/cloud_security_management/severity_scoring/
       parent: csm

--- a/config/_default/menus/main.ja.yaml
+++ b/config/_default/menus/main.ja.yaml
@@ -6525,11 +6525,6 @@ menu:
       parent: csm_review_remediate
       identifier: csm_workflow_automation
       weight: 102
-    - name: Create Jira Issues
-      url: security/cloud_security_management/review_remediate/jira
-      parent: csm_review_remediate
-      identifier: csm_jira
-      weight: 103
     - name: Severity Scoring
       url: security/cloud_security_management/severity_scoring/
       parent: csm

--- a/config/_default/menus/main.ko.yaml
+++ b/config/_default/menus/main.ko.yaml
@@ -6525,11 +6525,6 @@ menu:
       parent: csm_review_remediate
       identifier: csm_workflow_automation
       weight: 102
-    - name: Jira 이슈 생성
-      url: security/cloud_security_management/review_remediate/jira
-      parent: csm_review_remediate
-      identifier: csm_jira
-      weight: 103
     - name: '심각도 점수 '
       url: security/cloud_security_management/severity_scoring/
       parent: csm

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -141,9 +141,9 @@ code_language_ids:
     haproxy: "HAProxy"
     traces: "Traces"
     metrics: "Metrics"
-    logs: "Logs"    
+    logs: "Logs"
     topology: "Topology Map"
-    geomap: "Geomap" 
+    geomap: "Geomap"
 branch: ""
 
 signupclass: sign-up-trigger
@@ -289,6 +289,7 @@ unsupported_sites:
   continuous_integration: [gov]
   correlation: [gov] #Event management correlation
   cloudprem: [gov]
+  csm_jira: [us,us3,us5,eu,ap1,ap2]
   data_jobs: [gov]
   data_streams: [gov]
   datadog_disaster_recovery: [gov]

--- a/content/en/security/cloud_security_management/misconfigurations/_index.md
+++ b/content/en/security/cloud_security_management/misconfigurations/_index.md
@@ -13,7 +13,7 @@ Cloud Security Misconfigurations makes it easier to assess and visualize the cur
 
 ## Detect misconfigurations across your cloud resources
 
-Strengthen your security posture and achieve continuous compliance by detecting, prioritizing, and remediating misconfigurations across all your cloud resources using Datadog's [out-of-the-box compliance rules](#maintain-compliance-with-industry-frameworks-and-benchmarks). 
+Strengthen your security posture and achieve continuous compliance by detecting, prioritizing, and remediating misconfigurations across all your cloud resources using Datadog's [out-of-the-box compliance rules](#maintain-compliance-with-industry-frameworks-and-benchmarks).
 
 View a high-level overview of your security posture on the [Overview page][1]. Examine the details of misconfigurations and analyze historical configurations with the [Misconfigurations Findings page][2].
 
@@ -46,7 +46,7 @@ Use template variables and Markdown to [customize notification messages][9]. Edi
 Investigate details using the [Misconfigurations Findings page][10], where you can view detailed information about a resource, such as configuration, compliance rules applied to the resource, and tags that provide additional context about who owns the resource and its location within your environment. If a misconfiguration does not match your business use case or is an accepted risk, you can [mute the misconfiguration][13] up to an indefinite period of time.
 
 To remediate a misconfiguration, you can:
-- [Create a Jira issue][15] and assign it to a team
+- [Create a ticket][15] and assign it to a team
 - Use [Workflow Automation][14] to create automated remediation workflows (with or without human involvement)
 - For supported Terraform resources:
   - Locate the file and line the misconfiguration is in and identify the code owners
@@ -83,4 +83,4 @@ To remediate a misconfiguration, you can:
 [12]: https://www.pcisecuritystandards.org/pci_security/maintaining_payment_security
 [13]: /security/cloud_security_management/mute_issues
 [14]: /security/cloud_security_management/review_remediate/workflows/
-[15]: /security/cloud_security_management/review_remediate/jira?tab=csmmisconfigurations
+[15]: /security/ticketing_integrations

--- a/content/en/security/cloud_security_management/misconfigurations/kspm.md
+++ b/content/en/security/cloud_security_management/misconfigurations/kspm.md
@@ -38,7 +38,7 @@ This allows Datadog to detect risks in your Kubernetes deployments for each of t
 
 With KSPM, Datadog scans your environment for risks defined by more than 50+ out-of-the-box Kubernetes detection rules. When at least one case defined in a rule is matched over a given period of time, [a notification alert is sent][6], and a finding is generated in the [Misconfigurations explorer][11].
 
-Each finding contains the context you need to identify the issue's impact, such as the full resource configuration, resource-level tags, and a map of the resource's relationships with other components of your infrastructure. After you understand the problem and its impact, you can start remediating the issue by [creating a Jira ticket][7] from within Cloud Security or by [executing a pre-defined workflow][8].
+Each finding contains the context you need to identify the issue's impact, such as the full resource configuration, resource-level tags, and a map of the resource's relationships with other components of your infrastructure. After you understand the problem and its impact, you can start remediating the issue by [creating a ticket][7] from within Cloud Security or by [executing a pre-defined workflow][8].
 
 **Note**: You can also use the [API to programmatically interact with findings][10].
 
@@ -76,7 +76,7 @@ After you create the detection rule, you can customize its severity (`Critical`,
 [4]: https://www.openpolicyagent.org/docs/latest/policy-language/
 [5]: /security/cloud_security_management/guide/writing_rego_rules/
 [6]: /security/misconfigurations/compliance_rules#set-notification-targets-for-compliance-rules
-[7]: /security/cloud_security_management/review_remediate/jira
+[7]: /security/ticketing_integrations
 [8]: /security/cloud_security_management/review_remediate/workflows
 [9]: https://app.datadoghq.com/security/compliance/home
 [10]: /api/latest/security-monitoring/#list-findings

--- a/content/en/security/cloud_security_management/review_remediate/_index.md
+++ b/content/en/security/cloud_security_management/review_remediate/_index.md
@@ -6,5 +6,5 @@ disable_toc: true
 {{< whatsnext desc="" >}}
     {{< nextlink href="/security/cloud_security_management/review_remediate/mute_issues" >}}Mute Issues in Cloud Security{{< /nextlink >}}
     {{< nextlink href="/security/cloud_security_management/review_remediate/workflows" >}}Automate Security Workflows with Workflow Automation{{< /nextlink >}}
-    {{< nextlink href="/security/cloud_security_management/review_remediate/jira" >}}Create Jira Issues for Cloud Security Issues{{< /nextlink >}}
+    {{< nextlink href="/security/ticketing_integrations" >}}Create a ticket for Cloud Security Issues{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/security/cloud_security_management/review_remediate/jira.md
+++ b/content/en/security/cloud_security_management/review_remediate/jira.md
@@ -1,5 +1,6 @@
 ---
 title: Create Jira Issues for Cloud Security Issues
+site_support_id: csm_jira
 further_reading:
   - link: "/security/cloud_security_management/guide"
     tag: "Documentation"


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

[SEC-27541](https://datadoghq.atlassian.net/browse/SEC-27541)

The "Create Jira Issues for Cloud Security Issues" feature is deprecated on all Datadog sites except GovCloud (US1-FED / ddog-gov.com). This PR restricts the page accordingly:

- Adds `csm_jira: [us,us3,us5,eu,ap1,ap2]` to the `unsupported_sites` map in `params.yaml`, so the site-support banner system recognizes the feature as unsupported on non-GovCloud sites.
- Adds `site_support_id: csm_jira` to the page front matter, causing a red alert banner to render for non-GovCloud users who visit the URL directly.
- Removes the "Create Jira Issues" entry from the sidebar navigation.
- Removes the `nextlink` to the Jira page from the `review_remediate/_index.md` parent page.

GovCloud users are unaffected: the page renders normally with no banner, as `gov` is not in the unsupported list.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Verification:
1. Navigate to `/security/cloud_security_management/review_remediate/` — "Create Jira Issues" should not appear in the sidebar nav or the whatsnext links.
2. Visit `/security/cloud_security_management/review_remediate/jira` directly:
   - With site selector set to a non-gov site (e.g. US1) → red alert banner appears.
   - With site selector set to `US1-FED` → no banner, page content displays normally.


[SEC-27541]: https://datadoghq.atlassian.net/browse/SEC-27541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ