### PR TITLE
[WEB-7930] Add mapping tables for Kafka producer, consumer, and metrics receiver

### DIFF
--- a/content/en/opentelemetry/integrations/kafka_metrics.md
+++ b/content/en/opentelemetry/integrations/kafka_metrics.md
@@ -251,7 +251,23 @@ In order to ensure this attribute only gets added to your Kafka logs, use [inclu
 
 ## Data collected
 
+### Kafka metrics receiver
+
+{{< mapping-table resource="kafkametrics.csv">}}
+
+### JMX receiver / JMX Metrics Gatherer
+
+#### Kafka broker
+
 {{< mapping-table resource="kafka.csv">}}
+
+#### Kafka producer
+
+{{< mapping-table resource="kafka-producer.csv">}}
+
+#### Kafka consumer
+
+{{< mapping-table resource="kafka-consumer.csv">}}
 
 **Note:** In Datadog `-` gets translated to `_`. For the metrics prepended by `otel.`, this means that the OTel metric name and the Datadog metric name are the same (for example, `kafka.producer.request-rate` and `kafka.producer.request_rate`). In order to avoid double counting for these metrics, the OTel metric is then prepended with `otel.`.
 


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Fixes WEB-7930

The Kafka OTel integration page only showed the JMX broker mapping table (`kafka.csv`). After the semantic-core naming fix ([PR #578](https://github.com/DataDog/semantic-core/pull/578)), the producer, consumer, and kafkametricsreceiver metrics are now in separate CSVs. This adds the missing mapping table shortcodes:

- `kafkametrics.csv` — Kafka metrics receiver (3 metrics)
- `kafka-producer.csv` — JMX Kafka producer (10 metrics)
- `kafka-consumer.csv` — JMX Kafka consumer (5 metrics)

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Depends on the updated CSVs being available in the websites-sources tarball. The staging preview should confirm whether the tables render correctly.