### PR TITLE
[DOCS-13528] Add SSI cross-reference to Kubernetes APM page

### DIFF
--- a/content/en/containers/kubernetes/apm.md
+++ b/content/en/containers/kubernetes/apm.md
@@ -31,6 +31,8 @@ This page describes how to set up and configure [Application Performance Monitor
 
 You can send traces over Unix Domain Socket (UDS), TCP (`IP:Port`), or Kubernetes service. Datadog recommends that you use UDS, but it is possible to use all three at the same time, if necessary.
 
+**Note**: For automatic instrumentation without manual configuration, see [Single Step Instrumentation for Kubernetes][13].
+
 ## Setup
 1. If you haven't already, [install the Datadog Agent][1] in your Kubernetes environment.
 2. [Configure the Datadog Agent](#configure-the-datadog-agent-to-collect-traces) to collect traces.
@@ -323,3 +325,4 @@ List of environment variables available for configuring APM:
 [10]: /tracing
 [11]: /tracing/guide/ignoring_apm_resources/?tab=kubernetes
 [12]: /agent/configuration/dual-shipping/
+[13]: /tracing/trace_collection/single-step-apm/kubernetes/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13528

Adds a brief note near the top of the Kubernetes APM page pointing readers to Single Step Instrumentation (SSI). The page is a high-traffic entry point for users setting up APM on Kubernetes, but previously had no mention of SSI — the recommended approach for most users. This change surfaces SSI before the manual setup steps so users can make an informed choice.

Related to WEB-8338 (Docs AI not surfacing SSI content).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes


Made with [Cursor](https://cursor.com)