### PR TITLE
Add unsupported action note to AWS Organizations setup

### DIFF
--- a/content/en/integrations/guide/aws-organizations-setup.md
+++ b/content/en/integrations/guide/aws-organizations-setup.md
@@ -43,7 +43,7 @@ The Datadog CloudFormation StackSet performs the following steps:
 1. **Access to the management account**: Your AWS user needs to be able to access the AWS management account.
 2. **An account administrator has enabled Trusted Access with AWS Organizations**: Refer to [Enable trusted access with AWS Organizations][3] to enable trusted access between StackSets and Organizations, to create and deploy stacks using service-managed permissions.
 
-**Note**: The AWS Organizations multi-account setup does not support deployment over existing individually configured AWS account integrations. If a StackSet targets an account that is already individually integrated with Datadog, the existing account integration is deleted and replaced by the Organizations-managed integration.
+**Note**: The AWS Organizations multi-account setup does not support deployment over existing individually configured AWS account integrations. If a StackSet targets an account that is already individually integrated with Datadog, the existing account integration is deleted.
 
 ## Setup
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
Adding a note in the docs for AWS Organizations, since we currently do not support multi-account setup over individual integrations. 

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
