### PR TITLE
Fix[WEB-8376]: Doc AI add  user query sanitizer

### DIFF
--- a/assets/scripts/components/conversational-search/index.js
+++ b/assets/scripts/components/conversational-search/index.js
@@ -5,7 +5,7 @@ import { logAction, logError } from './logger';
 import { parseMarkdown, inlineRefChips, extractSources, renderMessageWithSources } from './markdown';
 import { attachTooltips, buildSourceCards, showSourceTooltip, closeAllSourceTooltips, repositionTooltip } from './sources';
 import { addMessageActions, injectCodeCopyButtons } from './actions';
-import { streamConversation } from './streaming';
+import { streamConversation, resetTypesenseClient } from './streaming';
 
 const { env } = document.documentElement.dataset;
 const docsConfig = getConfig(env);
@@ -380,6 +380,7 @@ class ConversationalSearch {
                 responseContainer.textContent = 'Request cancelled.';
             } else {
                 this.logErr('Conversational Search Response Error', error);
+                resetTypesenseClient();
                 responseContainer.textContent = 'Sorry, something went wrong. Please try again.';
             }
         } finally {

--- a/assets/scripts/components/conversational-search/streaming.js
+++ b/assets/scripts/components/conversational-search/streaming.js
@@ -2,6 +2,10 @@ import Typesense from 'typesense';
 
 let client = null;
 
+export function resetTypesenseClient() {
+    client = null;
+}
+
 export function getTypesenseClient(typesenseConfig) {
     if (client) return client;
 
@@ -17,6 +21,20 @@ export function getTypesenseClient(typesenseConfig) {
     });
 
     return client;
+}
+
+/**
+ * Strips Typesense query syntax that breaks hybrid (keyword + vector) search:
+ *  - "double quotes" trigger exact-phrase mode; when 0 keyword hits match,
+ *    Typesense skips vector search entirely and returns 0 results.
+ *  - -dash prefix triggers token exclusion, which is not meaningful for
+ *    a conversational AI query.
+ */
+export function sanitizeQuery(raw) {
+    return raw
+        .replace(/"/g, '')
+        .replace(/(^|\s)-/g, '$1')
+        .trim();
 }
 
 export async function streamConversation({
@@ -42,7 +60,7 @@ export async function streamConversation({
     const commonSearchParams = {
         conversation: true,
         conversation_model_id: modelId,
-        q: query,
+        q: sanitizeQuery(query),
         conversation_stream: true
     };
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
1) Add sanitizer to user query

User search queries can contain characters that Typesense interprets as special operators [Typesense Documentation](https://typesense.org/docs/30.1/api/search.html#search-parameters) 

" (double quotes): triggers exact phrase search, requiring tokens to appear consecutively in order. In hybrid search, this causes a Typesense bug where vector search is skipped entirely when the phrase matches 0 keyword results, returning 0 results even when semantic matches exist.

- (dash prefix): triggers token exclusion, removing documents containing the following word.

These can be unintentionally triggered by user input (e.g. copy-pasting text with quotes, or typing hyphenated terms). Add a sanitizer to strip these characters from the query before sending it to Typesense.

Note: in hybrid search, there is an upstream Typesense bug where a phrase query (") that matches 0 keyword results causes the vector search to be skipped entirely -- returning 0 results even when semantic matches exist [Github](https://github.com/typesense/typesense/blob/10a9e2f571353080a28fdcc417274e9f331b0099/src/index.cpp#L3623C13-L3623C17) (src/index.cpp ~line 3621, the goto process_search_results early exit bypasses the vector search block). Until this is fixed upstream, the client-side sanitizer is our mitigation.

2) Reset Streaming client on error [ to switch to a healthy node for HA]

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->
https://docs-staging.datadoghq.com/reda.elissati/WEB-8376-docs-ai-sanitizer/

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
