### PR TITLE
Add LookML repository parsing section to Looker docs

### DIFF
--- a/content/en/data_observability/quality_monitoring/business_intelligence/looker.md
+++ b/content/en/data_observability/quality_monitoring/business_intelligence/looker.md
@@ -9,7 +9,7 @@ further_reading:
 
 ## Overview
 
-Datadog's Looker integration collects metadata and field-level lineage for objects in your Looker account. When Datadog connects, it:
+Datadog's Looker integration helps data teams make changes to their data platform without breaking dashboards and Looks, and identify unused content to remove. The integration collects metadata and field-level lineage for objects in your Looker account. When Datadog connects, it:
 
 - Pulls metadata from your Looker instance, including projects, models, explores, views, dashboards, Looks, and folders
 - Generates field-level lineage between warehouse tables and columns and downstream Looker views and derived tables, and between Looker views and other Looker objects such as dashboards and explores


### PR DESCRIPTION
Prominently surfaces that the Looker integration parses LookML files from linked Git repositories to extract lineage for derived tables, view extensions, and refinements. Adds a dedicated setup section with steps to connect repositories via the Source Code Integration.

Merge readiness:
- [x] Ready for merge