### PR TITLE
[MLOB-5690] Add APM Trace correlation note to Experiments setup

### DIFF
--- a/content/en/llm_observability/experiments/setup.md
+++ b/content/en/llm_observability/experiments/setup.md
@@ -44,7 +44,7 @@ To correlate your Experiment spans with [APM Traces][5], run LLM Observability t
    )
    ```
 
-If you are running without an Agent (for example, in a notebook or CI environment), you can set `agentless_enabled=True`, but APM Trace correlation is not available in that mode.
+If you are running without an Agent (for example, in a notebook or CI environment), you can set `agentless_enabled=True`, but corresponding APM spans are not generated for Experiment spans from agentless runs.
 
 ## Create a project
 _Projects_ are the core organizational layer for LLM Experiments. All datasets and experiments live in a project.


### PR DESCRIPTION
## Summary
- Adds an "APM Trace correlation" subsection to the [Experiments Setup page](https://docs.datadoghq.com/llm_observability/experiments/setup/) explaining that users must run with a Datadog Agent (`agentless_enabled=False`) to enable Experiment ↔ APM Trace correlation
- Includes a code example showing the `LLMObs.enable()` call with `agentless_enabled=False`
- Links to the existing [Correlating LLM Observability and APM](https://docs.datadoghq.com/llm_observability/monitoring/llm_observability_and_apm/) page

## Test plan
- [ ] Verify the preview site renders the new section correctly
- [ ] Confirm the link to the APM correlation page works

🤖 Generated with [Claude Code](https://claude.com/claude-code)