### PR TITLE
Remove Client SDKs section from left nav

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -937,27 +937,6 @@ menu:
       identifier: otel_otlp_metric_types
       parent: otel_reference
       weight: 1104
-    - name: Client SDKs
-      url: client_sdks/
-      pre: building-block
-      identifier: sdk
-      parent: essentials_heading
-      weight: 60000
-    - name: Setup
-      url: client_sdks/setup/
-      parent: sdk
-      identifier: sdk_setup
-      weight: 1
-    - name: Advanced Configuration
-      url: client_sdks/advanced_configuration/
-      parent: sdk
-      identifier: sdk_advanced_configuration
-      weight: 2
-    - name: Data Collected
-      url: client_sdks/data_collected/
-      parent: sdk
-      identifier: sdk_data_collected
-      weight: 3
     - name: Extend Datadog
       url: extend/
       pre: dev-code


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes the Client SDKs section from the left nav. It was added prematurely before the dependent PRs (#34337, #34948, #35011) have been reviewed and merged.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
