### PR TITLE
Add critical rule to CLAUDE.md: never push directly to master

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,10 @@ The build system automatically fetches:
 - `Makefile` + `Makefile.config` - Build orchestration
 - Environment-specific parameters in `config/{env}/params.yaml`
 
+## Critical Rules
+
+- **NEVER push directly to `master`.** Always create a PR and go through the review process. Direct pushes bypass branch protection and code review.
+
 ## Branch and PR Guidelines
 
 ### Branch Naming


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds an explicit rule to `CLAUDE.md` instructing Claude Code never to push directly to `master`. This came out of an incident where Claude Code pushed commits directly to master in an autonomous session, bypassing branch protection and code review.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Related cleanup PR: #35023