### PR TITLE
[DOCS-13532] Add synthetics.pl.time_to_poll to private locations metrics

### DIFF
--- a/content/en/synthetics/platform/metrics/_index.md
+++ b/content/en/synthetics/platform/metrics/_index.md
@@ -92,7 +92,7 @@ For more information on API test timings, read the guide on [API Test Timings an
 
 ### Private locations
 
-{{< get-metrics-from-git "synthetics" "synthetics.pl.worker" >}}
+{{< get-metrics-from-git "synthetics" "synthetics.pl" >}}
 
 ### Continuous Testing
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13532 (follow-up to PR #35041)

The private locations section of the Synthetics metrics page used `synthetics.pl.worker` as the prefix filter for `get-metrics-from-git`, which excluded non-worker `synthetics.pl.*` metrics. This PR broadens the prefix to `synthetics.pl` to include all private location metrics, including `synthetics.pl.time_to_poll`, which has been in `synthetics/metadata.csv` since April 2024 but was not surfaced on the docs metrics page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

This change also surfaces `synthetics.pl.awaiting_tests` and the deprecated `synthetics.pl.liveness` metric, both of which are already in metadata.csv.