### PR TITLE
[SVLS-8624] add web app slot support

### DIFF
--- a/content/en/serverless/azure_app_service/linux_code.md
+++ b/content/en/serverless/azure_app_service/linux_code.md
@@ -462,10 +462,9 @@ Path to the instrumentation library loaded by the .NET runtime.<br>
 
 {{% collapse-content title="Instrument a deployment slot" level="h4" %}}
 
-To instrument a [deployment slot][801] instead of the main web app, use one of the following methods. Configure [unified service tagging][802] with distinct tag values for each slot to differentiate their telemetry.
+To instrument a [deployment slot][801] instead of the main web app, use one of the following methods.
 
 [801]: https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots
-[802]: /getting_started/tagging/unified_service_tagging/
 
 {{< tabs >}}
 {{% tab "Datadog CLI" %}}

--- a/content/en/serverless/azure_app_service/linux_container.md
+++ b/content/en/serverless/azure_app_service/linux_container.md
@@ -527,10 +527,9 @@ If you are setting up monitoring for a .NET application, configure the following
 
 {{% collapse-content title="Instrument a deployment slot" level="h4" %}}
 
-To instrument a [deployment slot][901] instead of the main web app, use one of the following methods. Configure [unified service tagging][902] with distinct tag values for each slot to differentiate their telemetry.
+To instrument a [deployment slot][901] instead of the main web app, use one of the following methods.
 
 [901]: https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots
-[902]: /getting_started/tagging/unified_service_tagging/
 
 {{< tabs >}}
 {{% tab "Datadog CLI" %}}

--- a/content/en/serverless/azure_app_service/windows_code.md
+++ b/content/en/serverless/azure_app_service/windows_code.md
@@ -371,10 +371,9 @@ See the [Manual tab](?tab=manual#instrumentation) for descriptions of all enviro
 
 {{% collapse-content title="Instrument a deployment slot" level="h4" %}}
 
-To instrument a [deployment slot][101] instead of the main web app, use one of the following methods. Configure [unified service tagging][102] with distinct tag values for each slot to differentiate their telemetry.
+To instrument a [deployment slot][101] instead of the main web app, use one of the following methods.
 
 [101]: https://learn.microsoft.com/en-us/azure/app-service/deploy-staging-slots
-[102]: /getting_started/tagging/unified_service_tagging/
 
 {{< tabs >}}
 {{% tab "Datadog CLI" %}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

With the release of the web app slot terraform modules as well as support for them in the CLI, lets add a section to the docs to mention those for customers using them.

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:

- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->