### PR TITLE
Normalize alerts by removing blockquote tags

### DIFF
--- a/content/en/real_user_monitoring/guide/sampling-browser-plans.md
+++ b/content/en/real_user_monitoring/guide/sampling-browser-plans.md
@@ -22,15 +22,17 @@ The `sessionReplaySampleRate` parameter is a percentage of `sessionSampleRate`.
 
 This feature requires the Datadog Browser SDK v3.0.0+.
 
-<blockquote class="alert alert-info">
+<div class="alert alert-info">
 The Datadog Browser SDK v4.20.0 introduces the <code>sessionReplaySampleRate</code> initialization parameter, deprecating the <code>premiumSampleRate</code> and <code>replaySampleRate</code> initialization parameter.
-</blockquote>
-<blockquote class="alert alert-info">
+</div>
+<div class="alert alert-info">
 The Datadog Browser SDK v5.0.0 introduces two major behavior changes:
 
-- Only sessions that have recorded a replay are considered as Browser RUM & Session Replay
-- The <code>sessionReplaySampleRate</code> initialization parameter default value is `0` . Previous versions of the SDK use `100`.
-</blockquote>
+<ul>
+<li>Only sessions that have recorded a replay are considered as Browser RUM & Session Replay</li>
+<li>The <code>sessionReplaySampleRate</code> initialization parameter default value is <code>0</code>. Previous versions of the SDK use <code>100</code>.</li>
+</ul>
+</div>
 When a session is created, RUM tracks it as either:
 
 - [**Browser RUM**][2]: Sessions, views, actions, resources, long tasks, and errors are collected.

--- a/content/en/tests/browser_tests.md
+++ b/content/en/tests/browser_tests.md
@@ -44,9 +44,9 @@ RUM integration is supported for Cypress browser tests and Selenium-driven brows
 * `dd-trace-js` >= 5.46.0
 * `browser-sdk` >= 5.15.0
 
-<blockquote class="alert alert-info">
-From Browser SDK v5.0.0, enable the `allowUntrustedEvents` initialization parameter during the tests to correctly capture clicks.
-</blockquote>
+<div class="alert alert-info">
+From Browser SDK v5.0.0, enable the <code>allowUntrustedEvents</code> initialization parameter during the tests to correctly capture clicks.
+</div>
 
 ## Connect browser tests and RUM
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

A few alerts were using `blockquote` instead of `div`, which causes issues with plaintext parsing / Cdocs migration parsing. Since it was only a couple, it seemed better to just normalize them than to add support for blockquote alerts.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
