### PR TITLE
[DOCS-13584] Add US1-FED notice for OCI CSPM not supported

### DIFF
--- a/content/en/security/cloud_security_management/setup/cloud_integrations.md
+++ b/content/en/security/cloud_security_management/setup/cloud_integrations.md
@@ -8,6 +8,10 @@ aliases:
 
 Use the following instructions to enable Misconfigurations and Identity Risks (CIEM) on AWS, Azure, GCP, and OCI.
 
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">Oracle Cloud Infrastructure (OCI) is not supported for the selected site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 ## Enable resource scanning
 
 To enable resource scanning for your cloud accounts, you must first set up the integration and then enable Cloud Security for each AWS, Azure, Google Cloud Platform, or Oracle Cloud Infrastucture account.

--- a/content/en/security/cloud_security_management/setup/without_infrastructure_monitoring.md
+++ b/content/en/security/cloud_security_management/setup/without_infrastructure_monitoring.md
@@ -37,6 +37,11 @@ In addition to setting up Cloud Security with or without an Agent, you can also 
 **Note**: In your Cloud Security settings, set up [resource evaluation filters][1] to limit the number of hosts you need security on.
 
 ### Oracle Cloud Infrastructure
+
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">Oracle Cloud Infrastructure (OCI) is not supported for the selected site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 1. Navigate to the [Oracle Cloud Infrastructure configuration page][5] in Datadog.
 1. Select the tenancy you want to enable Cloud Security on.<br />If you don't see the required tenancy, add it by clicking **Add New Tenancy** and following the onscreen prompts.
 1. To turn off infrastructure monitoring on the selected tenancy, under the tenancy name, navigate to the **Metric Collection** tab. Then, above the Metric Collection table, click **Disable All**.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13584

Adds a US1-FED notice to the Oracle Cloud Infrastructure sections of the Cloud Security setup docs, since OCI is not supported for the US1-FED site.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Changes affect two pages:
- `cloud_integrations.md` — banner added at the top of the page (under the intro paragraph)
- `without_infrastructure_monitoring.md` — banner added under the Oracle Cloud Infrastructure heading