### PR TITLE
[AWSX] feat(docs): update AWS log tag filters to avoid casing confusion

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-lambda-function.md
@@ -231,7 +231,7 @@ The following sources and locations are supported:
 3. In the [AWS Integration page][44], select the AWS Account to collect logs from and click on the **Log Collection** tab.
 4. In the **Datadog Forwarder Lambda** section, enter the ARN of the Lambda created in the previous section and click **Add**. The Lambda function appears in the table below with its name, version, and region.
 5. In the **Log Autosubscription** section, under **Log Sources**, enable the services from which you'd like to collect logs by toggling them on. To stop collecting logs from a particular service, toggle the log source off.
-6. (Optional) In the **Log Source Tag Filters** section, you can filter log collection by resource tags for each log source. Select a log source from the dropdown menu and add tags in `key:value` format to limit which resources' logs are collected.
+6. (Optional) In the **Log Source Tag Filters** section, you can filter log collection by resource tags for each log source. Select a log source from the dropdown menu and add tags in `key:value` format to limit which resources' logs are collected. **Note**: Resource tags are automatically lowercased to match Datadog platform conventions. Define your tag filters in lowercase to avoid mismatches.
 7. If you have logs across multiple regions, you must create additional Lambda functions in those regions and add them in the **Datadog Forwarder Lambda** section.
 8. To stop collecting all AWS logs from a specific Lambda function, hover over the Lambda in the table and click the delete icon. All triggers for that function are removed.
 9. Within a few minutes of this initial setup, your AWS Logs appear in the Datadog [Log Explorer][45].


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Following this support [ticket](https://datadoghq.atlassian.net/browse/CLOUDS-7409) we're updating the Log Forwarder guide to reflect the intended behaviour around autosubscription tag filtering, especially with regards to lowercased tags.

### Merge instructions

Merge readiness:
- [X] Ready for merge

