### PR TITLE
Add limitations for Adaptive and Remote Sampling

### DIFF
--- a/content/en/tracing/trace_pipeline/adaptive_sampling.md
+++ b/content/en/tracing/trace_pipeline/adaptive_sampling.md
@@ -48,24 +48,25 @@ The following table lists minimum tracing library versions required for adaptive
 | C++/Proxies | [v0.2.2][14]             |
 | PHP         | [v1.4.0][17]             |
 
-### Limitations
-To ensure performance and scalability, limits apply to service and environment combinations depending on the sampling configuration used:
+## Limitations
 
-**Adaptive Sampling**
+Limits apply to service and environment combinations depending on the sampling configuration:
 
-- The maximum number of `service/env` combinations onboarded to Adaptive Sampling is 800.
-- Each unique `service/env` pair configured for Adaptive Sampling counts toward this limit.
+#### Adaptive sampling
 
-**Remote Sampling Configuration**
+- The maximum number of `service/env` combinations onboarded to adaptive sampling is 800.
+- Each unique `service/env` pair configured for adaptive sampling counts toward this limit.
 
-- The maximum number of `service/env` combinations using Remote Sampling Configuration is **1000**.
-- This applies regardless of the number of sampling rules defined for each service.
+#### Remote sampling configuration
+
+- The maximum number of `service/env` combinations using remote sampling configuration is **1000**.
+- This limit applies regardless of how many sampling rules are defined for each service.
 - Each unique `service/env` pair with remote sampling enabled counts once toward this limit.
 
-**Services Using Both Adaptive and Remote Sampling**
+#### Services using both adaptive and remote sampling
 
-- If a `service/env` combination uses both Adaptive Sampling and Remote Sampling Configuration, it counts as one (1) service toward the applicable limits.
-- It does **not** count separately toward each limit.
+- If a `service/env` combination uses both adaptive sampling and remote sampling configuration, it counts once toward each respective limit (once toward the 800 adaptive sampling limit and once toward the 1000 remote sampling limit).
+- It does **not** count twice within either individual limit.
 
 ## Configure the adaptive sampling target
 


### PR DESCRIPTION
Added limitations section for Adaptive and Remote Sampling configurations, detailing maximum service/env combinations.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
