### PR TITLE
Added Azure DevOps

### DIFF
--- a/content/en/dora_metrics/calculation/_index.md
+++ b/content/en/dora_metrics/calculation/_index.md
@@ -70,7 +70,7 @@ Using commit-level granularity provides a more accurate view of engineering perf
 * Change lead time is not available if the most recent deployment of a service was more than 60 days ago.
 * The calculation includes a maximum of 5000 commits per deployment.
 * When squashing commits to merge pull requests:
-  * For GitHub and GitLab: Metrics are emitted for the original commits.
+  * For GitHub, GitLab and Azure DevOps: Metrics are emitted for the original commits.
   * For other Git providers: Metrics are emitted for the new commit added to the target branch.
 * When rebasing, either manually or to merge pull requests, metrics are calculated using the original commit timestamps, but the SHA shown reflects the newly created rebased commit.
 
@@ -90,7 +90,7 @@ Datadog breaks down change lead time into the following fields, which represent 
 
 #### Limitations {#limitations-clt-stages}
 
-* Change lead time stage breakdown metrics are only available when the source of repository metadata is GitHub or GitLab.
+* Change lead time stage breakdown metrics are only available when the source of repository metadata is GitHub, GitLab and Azure DevOps.
 * For most stages, there must be a pull request (PR) associated with a commit. A commit is associated with a PR if the commit is first introduced to the target branch when merging that PR. If a commit has no associated PR, only `Time to Deploy` and `Deploy Time` fields are available.
 * When rebasing, either manually or to merge pull requests, the change lead time stage breakdown is unavailable for these commits. This is because rebased commits are not associated with any pull request.
 


### PR DESCRIPTION
Now DORA metrics implements Azure DevOps as one of its integrated git providers, showing pr metrics by default to all users with the SCI integration seted up.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
