### PR TITLE
Replace resources with podSize in CloudPrem install guides

### DIFF
--- a/content/en/cloudprem/install/aws_eks.md
+++ b/content/en/cloudprem/install/aws_eks.md
@@ -238,19 +238,11 @@ echo ""
    # and transforms it into searchable files called "splits" stored in S3.
    #
    # The indexer is horizontally scalable - you can increase `replicaCount` to handle higher indexing throughput.
-   # Resource requests and limits should be tuned based on your indexing workload.
-   #
-   # The default values are suitable for moderate indexing loads of up to 20 MB/s per indexer pod.
+   # The `podSize` parameter sets vCPU, memory, and component-specific settings automatically.
+   # See the sizing guide for available tiers and their configurations.
    indexer:
      replicaCount: 2
-
-     resources:
-       requests:
-         cpu: "4"
-         memory: "8Gi"
-       limits:
-         cpu: "4"
-         memory: "8Gi"
+     podSize: xlarge
 
    # Searcher configuration
    # The searcher is responsible for executing search queries against the indexed data stored in S3.
@@ -267,14 +259,7 @@ echo ""
    # Memory is particularly important for searchers as they cache frequently accessed index data in memory.
    searcher:
      replicaCount: 2
-
-     resources:
-       requests:
-         cpu: "4"
-         memory: "16Gi"
-       limits:
-         cpu: "4"
-         memory: "16Gi"
+     podSize: xlarge
    ```
 
 1. Install or upgrade the Helm chart

--- a/content/en/cloudprem/install/azure_aks.md
+++ b/content/en/cloudprem/install/azure_aks.md
@@ -338,19 +338,11 @@ metastore:
 # and transforms it into searchable files called "splits" stored in S3.
 #
 # The indexer is horizontally scalable - you can increase `replicaCount` to handle higher indexing throughput.
-# Resource requests and limits should be tuned based on your indexing workload.
-#
-# The default values are suitable for moderate indexing loads of up to 20 MB/s per indexer pod.
+# The `podSize` parameter sets vCPU, memory, and component-specific settings automatically.
+# See the sizing guide for available tiers and their configurations.
 indexer:
   replicaCount: 2
-
-  resources:
-    requests:
-      cpu: "4"
-      memory: "8Gi"
-    limits:
-      cpu: "4"
-      memory: "8Gi"
+  podSize: xlarge
 
    # Searcher configuration
    # The searcher is responsible for executing search queries against the indexed data stored in S3.
@@ -367,14 +359,7 @@ indexer:
    # Memory is particularly important for searchers as they cache frequently accessed index data in memory.
    searcher:
      replicaCount: 2
-
-     resources:
-       requests:
-         cpu: "4"
-         memory: "16Gi"
-       limits:
-         cpu: "4"
-         memory: "16Gi"
+     podSize: xlarge
 {{< /code-block >}}
 
 1. Install or upgrade the Helm chart

--- a/content/en/cloudprem/install/custom_k8s.md
+++ b/content/en/cloudprem/install/custom_k8s.md
@@ -200,22 +200,14 @@ metastore:
 # stored in MinIO.
 #
 # The indexer is horizontally scalable - you can increase `replicaCount` to handle higher indexing throughput.
-# Resource requests and limits should be tuned based on your indexing workload.
-#
-# The default values are suitable for moderate indexing loads of up to 20 MB/s per indexer pod.
+# The `podSize` parameter sets vCPU, memory, and component-specific settings automatically.
+# See the sizing guide for available tiers and their configurations.
 indexer:
   replicaCount: 2
+  podSize: xlarge
   extraEnvFrom:
     - secretRef:
         name: cloudprem-minio-credentials
-
-  resources:
-    requests:
-      cpu: "4"
-      memory: "8Gi"
-    limits:
-      cpu: "4"
-      memory: "8Gi"
 
 # Searcher configuration
 # The searcher is responsible for executing search queries against the indexed data stored in MinIO.
@@ -232,17 +224,10 @@ indexer:
 # Memory is particularly important for searchers as they cache frequently accessed index data in memory.
 searcher:
   replicaCount: 2
+  podSize: xlarge
   extraEnvFrom:
     - secretRef:
         name: cloudprem-minio-credentials
-
-  resources:
-    requests:
-      cpu: "4"
-      memory: "16Gi"
-    limits:
-      cpu: "4"
-      memory: "16Gi"
 
 # Control plane configuration
 controlPlane:

--- a/content/en/cloudprem/install/gcp_gke.md
+++ b/content/en/cloudprem/install/gcp_gke.md
@@ -306,27 +306,19 @@ metastore:
       memory: 2Gi
 
 # Searcher configuration
+# The `podSize` parameter sets vCPU, memory, and component-specific settings automatically.
+# Choose a tier based on your query complexity, concurrency, and data access patterns.
 searcher:
   enabled: true
   replicaCount: 2
-  resources:
-    limits:
-      cpu: 2
-      memory: 8Gi
-    requests:
-      cpu: 1
-      memory: 4Gi
+  podSize: xlarge
 
 # Indexer configuration
+# The `podSize` parameter sets vCPU, memory, and component-specific settings automatically.
+# See the sizing guide for available tiers and their configurations.
 indexer:
   replicaCount: 2
-  resources:
-    limits:
-      cpu: 2
-      memory: 8Gi
-    requests:
-      cpu: 1
-      memory: 4Gi
+  podSize: xlarge
 
 # Quickwit configuration
 quickwit:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Replace explicit `resources` (requests/limits) with the `podSize` parameter for indexer and searcher components in all CloudPrem install guides
- `podSize` will be supported in the up coming v0.2.0 Pomsky Helm Chart release, so I'll merge this PR after releasing the version

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes