### PR TITLE
[DOCS-13571] Add ENABLE_FIPS=1 environment variable for Windows CLI and standalone

### DIFF
--- a/content/en/synthetics/platform/private_locations/_index.md
+++ b/content/en/synthetics/platform/private_locations/_index.md
@@ -604,6 +604,14 @@ Additional parameters can be added:
 | LOGGING_MAXDAYS | Number of days to keep file logs on the system before deleting them. Can be any number when running an unattended installation. | 7 | `--logFileMaxDays` | Integer |
 | CONFIG_FILEPATH | This should be changed to the path to your Synthetics Private Location Worker JSON configuration file. Wrap this path in quotes if your path contains spaces. | <None> | `--config` | String |
 
+To enable FIPS 140-2 cryptographic mode, set the `ENABLE_FIPS=1` environment variable before running the worker executable. The Windows host must be running in Windows FIPS mode to use this option. Available in Private Location v1.63.0 and above.
+
+Example:
+
+```cmd
+set ENABLE_FIPS=1 && .\synthetics-pl-worker.exe --config "<PathToYourConfiguration>"
+```
+
 [101]: https://ddsynthetics-windows.s3.amazonaws.com/datadog-synthetics-worker-{{< synthetics-worker-version "synthetics-windows-pl" >}}.amd64.msi
 
 {{< /tab >}}
@@ -656,6 +664,14 @@ Example:
 ```text
 set NODE_EXTRA_CA_CERTS=C:\Program Files\Datadog-Synthetics\Synthetics\CACert.pem && .\synthetics-private-location.exe --config "C:\ProgramData\Datadog-Synthetics\Synthetics\worker-config.json"
 ```
+
+To enable FIPS 140-2 cryptographic mode, include `ENABLE_FIPS=1`:
+
+```text
+set ENABLE_FIPS=1 && set NODE_EXTRA_CA_CERTS=C:\Program Files\Datadog-Synthetics\Synthetics\CACert.pem && .\synthetics-private-location.exe --config "C:\ProgramData\Datadog-Synthetics\Synthetics\worker-config.json"
+```
+
+The Windows host must be running in Windows FIPS mode to use this option. Available in Private Location v1.63.0 and above.
 
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13571

Adds documentation for the `ENABLE_FIPS=1` environment variable for FIPS 140-2 compliance when using Windows private locations outside of the GUI installer. The GUI installer already documents the FIPS toggle, but the Windows CLI and standalone methods were missing this information.

**Changes:**

- **Windows via CLI tab**: Adds a note and example command showing how to set `ENABLE_FIPS=1` before running the worker executable after MSI installation.
- **Windows standalone section**: Adds a combined example showing `ENABLE_FIPS=1` alongside `NODE_EXTRA_CA_CERTS`, following the existing pattern for environment variables in that section.

Both additions include the requirement that the Windows host must be running in Windows FIPS mode, and note availability in Private Location v1.63.0 and above.

### Merge instructions

Merge readiness:
- [x] Ready for merge