### PR TITLE
update secret documentation with native helm and operator values

### DIFF
--- a/content/en/agent/configuration/secrets-management.md
+++ b/content/en/agent/configuration/secrets-management.md
@@ -133,11 +133,11 @@ datadog:
       instances:
         - [...]
           password: "ENC[secretId;secretKey]"
-  secretBackend:
-    type: "aws.secrets"
-    config:
-      aws_session:
-        aws_region: "<AWS_REGION>"
+  env:
+   - name: DD_SECRET_BACKEND_TYPE
+     value: "aws.secrets"
+   - name: DD_SECRET_BACKEND_CONFIG
+     value: '{"aws_session":{"aws_region":"<AWS_REGION>"}}'
 agents:
   rbac:
     # IAM role ARN required to grant the Agent permissions to access the AWS secret
@@ -153,11 +153,11 @@ agents:
 ##### Cluster check: without cluster check runners enabled
 ```sh
 datadog:
-  secretBackend:
-    type: "aws.secrets"
-    config:
-      aws_session:
-        aws_region: "<AWS_REGION>"
+  env:
+   - name: DD_SECRET_BACKEND_TYPE
+     value: "aws.secrets"
+   - name: DD_SECRET_BACKEND_CONFIG
+     value: '{"aws_session":{"aws_region":"<AWS_REGION>"}}'
 agents:
   rbac:
     # IAM role ARN required to grant the Agent permissions to access the AWS secret
@@ -176,11 +176,11 @@ clusterAgent:
 ##### Cluster check: with cluster check runners enabled
 ```sh
 datadog:
-  secretBackend:
-    type: "aws.secrets"
-    config:
-      aws_session:
-        aws_region: "<AWS_REGION>"
+  env:
+   - name: DD_SECRET_BACKEND_TYPE
+     value: "aws.secrets"
+   - name: DD_SECRET_BACKEND_CONFIG
+     value: '{"aws_session":{"aws_region":"<AWS_REGION>"}}'
 clusterAgent:
   confd:
   # This is an example
@@ -191,12 +191,19 @@ clusterAgent:
           password: "ENC[secretId;secretKey]"
 clusterChecksRunner:
   enabled: true
+  env:
+   - name: DD_SECRET_BACKEND_TYPE
+     value: "aws.secrets"
+   - name: DD_SECRET_BACKEND_CONFIG
+     value: '{"aws_session":{"aws_region":"<AWS_REGION>"}}'
   rbac:
     # IAM role ARN required to grant the Agent permissions to access the AWS secret
     serviceAccountAnnotations:
       eks.amazonaws.com/role-arn: <IAM_ROLE_ARN>
 
 ```
+
+**Alternatively**, with Helm chart v3.171.0+ and Agent v7.70+, you can use native `secretBackend.type` and `secretBackend.config` fields instead of environment variables. For example: `datadog.secretBackend.type: "aws.secrets"` and `datadog.secretBackend.config.aws_session.aws_region: "<AWS_REGION>"`.
 
 {{% /tab %}}
 
@@ -214,13 +221,13 @@ metadata:
   name: datadog
 spec:
   [...]
-  global:
-    secretBackend:
-      type: "aws.secrets"
-      config:
-        aws_session.aws_region: "<AWS_REGION>"
   override:
     nodeAgent:
+      env:
+       - name: DD_SECRET_BACKEND_TYPE
+         value: "aws.secrets"
+       - name: DD_SECRET_BACKEND_CONFIG
+         value: '{"aws_session":{"aws_region":"<AWS_REGION>"}}'
       # IAM role ARN is required to grant the Agent permissions to access the AWS secret
       serviceAccountAnnotations:
         eks.amazonaws.com/role-arn: <IAM_ROLE_ARN>
@@ -250,13 +257,13 @@ metadata:
   name: datadog
 spec:
   [...]
-  global:
-    secretBackend:
-      type: "aws.secrets"
-      config:
-        aws_session.aws_region: "<AWS_REGION>"
   override:
     nodeAgent:
+      env:
+       - name: DD_SECRET_BACKEND_TYPE
+         value: "aws.secrets"
+       - name: DD_SECRET_BACKEND_CONFIG
+         value: '{"aws_session":{"aws_region":"<AWS_REGION>"}}'
       # IAM role ARN required to grant the Agent permissions to access the AWS secret
       serviceAccountAnnotations:
         eks.amazonaws.com/role-arn: <IAM_ROLE_ARN>
@@ -282,17 +289,18 @@ metadata:
   name: datadog
 spec:
   [...]
-  global:
-    secretBackend:
-      type: "aws.secrets"
-      config:
-        aws_session.aws_region: "<AWS_REGION>"
+spec:
   features:
     clusterChecks:
       useClusterChecksRunners: true
   override:
     [...]
     clusterChecksRunner:
+      env:
+       - name: DD_SECRET_BACKEND_TYPE
+         value: "aws.secrets"
+       - name: DD_SECRET_BACKEND_CONFIG
+         value: '{"aws_session":{"aws_region":"<AWS_REGION>"}}'
       # IAM role ARN required to grant the Agent permissions to access the AWS secret
       serviceAccountAnnotations:
         eks.amazonaws.com/role-arn: <IAM_ROLE_ARN>
@@ -307,6 +315,8 @@ spec:
                 password: "ENC[secretId;secretKey]"
 
 ```
+
+**Alternatively**, with Datadog Operator v1.25.0+ and Agent v7.70+, you can use native `secretBackend.type` and `secretBackend.config` fields instead of environment variables. For example: `spec.global.secretBackend.type: "aws.secrets"` and `spec.global.secretBackend.config` with `aws_session.aws_region: "<AWS_REGION>"`.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -657,15 +667,16 @@ Configure the Datadog Agent to use Kubernetes Secrets with Helm:
 datadog:
   apiKey: "placeholder-will-be-overridden"
 
-  secretBackend:
-    type: "k8s.secrets"
-
   env:
+  - name: DD_SECRET_BACKEND_TYPE
+    value: "k8s.secrets"
   - name: DD_API_KEY
     value: "ENC[secrets-ns/dd-api-key;api_key]"
 ```
 
 **Note:** A placeholder `apiKey` is required for Helm chart validation when using secret backend to resolve the API key. The `DD_API_KEY` environment variable overrides it. You must manually create RBAC (Role + RoleBinding) for each namespace containing secrets. For more information, see the [RBAC setup](#rbac-setup) section.
+
+**Alternatively**, with Helm chart v3.171.0+ and Agent v7.70+, you can use the native `datadog.secretBackend.type` field instead of environment variables.
 
 {{% /tab %}}
 
@@ -682,17 +693,19 @@ spec:
   global:
     credentials:
       apiKey: "placeholder-will-be-overridden"
-    secretBackend:
-      type: "k8s.secrets"
 
   override:
     nodeAgent:
       env:
+      - name: DD_SECRET_BACKEND_TYPE
+        value: "k8s.secrets"
       - name: DD_API_KEY
         value: "ENC[secrets-ns/dd-api-key;api_key]"
 ```
 
 **Note:** A placeholder API key satisfies Operator validation when using secret backend to resolve the API key. The `DD_API_KEY` environment variable overrides it. You must manually create RBAC (Role + RoleBinding) for each namespace containing secrets. For more information, see the [RBAC setup](#rbac-setup) section.
+
+**Alternatively**, with Datadog Operator v1.25.0+ and Agent v7.70+, you can use the native `spec.global.secretBackend.type` field instead of environment variables.
 
 {{% /tab %}}
 {{< /tabs >}}
@@ -713,24 +726,30 @@ secret_backend_config:
 {{% tab "Helm" %}}
 ```yaml
 datadog:
-  secretBackend:
-    type: "k8s.secrets"
-    config:
-      token_path: "/custom/path/to/token"
-      ca_path: "/custom/path/to/ca.crt"
+  env:
+  - name: DD_SECRET_BACKEND_TYPE
+    value: "k8s.secrets"
+  - name: DD_SECRET_BACKEND_CONFIG
+    value: '{"token_path":"/custom/path/to/token","ca_path":"/custom/path/to/ca.crt"}'
 ```
+
+**Alternatively**, with Helm chart v3.171.0+, you can use: `datadog.secretBackend.type: "k8s.secrets"` and `datadog.secretBackend.config` with `token_path` and `ca_path` keys.
+
 {{% /tab %}}
 
 {{% tab "Operator" %}}
 ```yaml
-spec:
-  global:
-    secretBackend:
-      type: "k8s.secrets"
-      config:
-        token_path: "/custom/path/to/token"
-        ca_path: "/custom/path/to/ca.crt"
+override:
+  nodeAgent:
+    env:
+    - name: DD_SECRET_BACKEND_TYPE
+      value: "k8s.secrets"
+    - name: DD_SECRET_BACKEND_CONFIG
+      value: '{"token_path":"/custom/path/to/token","ca_path":"/custom/path/to/ca.crt"}'
 ```
+
+**Alternatively**, with Datadog Operator v1.25.0+, you can use: `spec.global.secretBackend.type: "k8s.secrets"` and `spec.global.secretBackend.config` with `token_path` and `ca_path` keys.
+
 {{% /tab %}}
 {{< /tabs >}}
 
@@ -750,22 +769,30 @@ secret_backend_config:
 {{% tab "Helm" %}}
 ```yaml
 datadog:
-  secretBackend:
-    type: "k8s.secrets"
-    config:
-      api_server: "https://{KUBERNETES_SERVICE_HOST}:{KUBERNETES_SERVICE_PORT}"
+  env:
+  - name: DD_SECRET_BACKEND_TYPE
+    value: "k8s.secrets"
+  - name: DD_SECRET_BACKEND_CONFIG
+    value: '{"api_server":"https://{KUBERNETES_SERVICE_HOST}:{KUBERNETES_SERVICE_PORT}"}'
 ```
+
+**Alternatively**, with Helm chart v3.171.0+, you can use: `datadog.secretBackend.type: "k8s.secrets"` and `datadog.secretBackend.config` with the `api_server` key.
+
 {{% /tab %}}
 
 {{% tab "Operator" %}}
 ```yaml
-spec:
-  global:
-    secretBackend:
-      type: "k8s.secrets"
-      config:
-        api_server: "https://{KUBERNETES_SERVICE_HOST}:{KUBERNETES_SERVICE_PORT}"
+override:
+  nodeAgent:
+    env:
+    - name: DD_SECRET_BACKEND_TYPE
+      value: "k8s.secrets"
+    - name: DD_SECRET_BACKEND_CONFIG
+      value: '{"api_server":"https://{KUBERNETES_SERVICE_HOST}:{KUBERNETES_SERVICE_PORT}"}'
 ```
+
+**Alternatively**, with Datadog Operator v1.25.0+, you can use: `spec.global.secretBackend.type: "k8s.secrets"` and `spec.global.secretBackend.config` with the `api_server` key.
+
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Updates the SGC documentation with native helm and operator secret backend values and practices. 

### Merge instructions

Merge readiness:
- [x] https://github.com/DataDog/datadog-operator/pull/2587
- [x] https://github.com/DataDog/helm-charts/pull/2371
- [x] Operator [v1.25.0](https://github.com/DataDog/datadog-operator/milestone/45)
- [x] Helm charts updated

### Additional notes

