### PR TITLE
Update Node.js tracer integration compatibility list

### DIFF
--- a/content/en/tracing/trace_collection/compatibility/nodejs.md
+++ b/content/en/tracing/trace_collection/compatibility/nodejs.md
@@ -225,7 +225,7 @@ The [JavaScript and TypeScript Tests][66] page contains a list of instrumented t
 
 ### Known transitive package compatibility
 
-While the Datadog tracer doesn't provide direct support for modules listed here they are known to work as they depend on modules that the tracer does instrument.
+While the Datadog tracer doesn't provide direct support for modules listed here, they are known to work, as they depend on modules that the tracer does instrument.
 
 | Module           | Notes           |
 | ---------------- | --------------- |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the Node.js tracer compatibility page to reflect the current state of integrations in the `dd-trace-js` repository.

**Transitive Packages:**
- Adding a section on packages that work since they depend on something we do instrument
- This is so that users can do Ctrl+F to search

**New integrations added:**
- Web frameworks: `hono` (>=4)
- Native modules: `undici` (>=4.4.1)
- Data stores: `aerospike` (>=4), `iovalkey` (>=0.0.1), `mongoose` (>=4.6.4), `sequelize` (>=4)
- Workers: `@azure/event-hubs` (>=6.0.0), `@azure/functions` (>=4), `bullmq` (>=5.66.0)

**Version corrections:**
- `couchbase`: `^2.4.2` → `^2.6.12` (reflects actual minimum hook version in instrumentation)
- `mariadb`: `>=3` → `>=2` (instrumentation supports `>=2.0.4`)
- `next`: `>=9.5` → `>=10.2` (earliest hook version in instrumentation)

**Bug fix:**
- Fixed duplicate `[69]` reference used for both `opensearch` and `Prisma`; Prisma now uses `[70]`

**External Links:**
- Removed LLM content, linked to their [canonical page](https://docs.datadoghq.com/llm_observability/instrumentation/auto_instrumentation/?tab=nodejs#supported-frameworks-and-libraries)
- Added a link to CI / testing's [canonical page](https://docs.datadoghq.com/tests/setup/javascript/)
- note that I'm adding package names in case someone does a Ctrl+F to search for them

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Integration versions were sourced directly from `addHook` calls in `packages/datadog-instrumentations/src/` in the `dd-trace-js` repository.