### PR TITLE
Add interactive MCP Server setup widget with site and toolset selection

### DIFF
--- a/assets/scripts/components/copy-code.js
+++ b/assets/scripts/components/copy-code.js
@@ -4,7 +4,7 @@ import Tooltip from 'bootstrap/js/dist/tooltip';
 // Script to add copy buttons to markdown fenced (```), and {{ highlight }} hugo function code blocks
 
 function initCopyCode () {
-    addCopyButton(['shell', 'json', 'yaml', 'sql'])
+    addCopyButton(['shell', 'bash', 'json', 'yaml', 'toml', 'sql'])
 
     // Add Event Listener
     const copyButtons = document.querySelectorAll(['.js-copy-button', '#tryRuleModal .copy-icon']);

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -267,8 +267,10 @@ MCP Server tools require the following [RBAC permissions][18]:
 
 | Permission | Required for |
 |------------|-------------|
-| `mcp_read` | Tools that read data from Datadog (for example, querying monitors, searching logs, retrieving dashboards) |
-| `mcp_write` | Tools that create or modify resources in Datadog (for example, creating monitors, muting hosts) |
+| <code style="white-space:nowrap">mcp_read</code> | Tools that read data from Datadog (for example, querying monitors, searching logs, retrieving dashboards) |
+| <code style="white-space:nowrap">mcp_write</code> | Tools that create or modify resources in Datadog (for example, creating monitors, muting hosts) |
+
+In addition to `mcp_read` or `mcp_write`, users need the standard Datadog permissions for the underlying resource. For example, using an MCP tool that reads monitors requires both `mcp_read` and the [Monitors Read][20] permission. See [RBAC Permissions][18] for the full list of resource-level permissions.
 
 Users with the **Datadog Standard Role** have both permissions by default. If your organization uses [custom roles][19], add the permissions manually:
 
@@ -341,3 +343,4 @@ For security, use a scoped API key and application key from a [service account][
 [17]: /getting_started/site/#navigate-the-datadog-documentation-by-site
 [18]: /account_management/rbac/permissions/
 [19]: /account_management/rbac/?tab=datadogapplication#custom-roles
+[20]: /account_management/rbac/permissions/#monitors

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -20,63 +20,26 @@ This page explains how to set up and configure the Datadog MCP Server, which let
 Select your client to see setup instructions:
 
 {{< tabs >}}
-{{% tab "Cursor" %}}
-
-Datadog's [Cursor and VS Code extension][1] includes built-in access to the managed Datadog MCP Server. Benefits include:
-
-* No additional MCP Server setup after you install the extension and connect to Datadog.
-* One-click transitions between multiple Datadog organizations.
-* Better fixes from **Fix in Chat** on Code Insights (issues from Error Tracking, Code Vulnerabilities, and Library Vulnerabilities), informed by context from the MCP Server.
-
-To install the extension:
-
-1. If you previously installed the Datadog MCP Server manually, remove it from the IDE's configuration to avoid conflicts. Go to **Cursor Settings** (`Shift` + `Cmd/Ctrl` + `J`) and select the **MCP** tab.
-2. Install the Datadog extension following [these instructions][2]. If you have the extension installed already, make sure it's the latest version, as new features are released regularly.
-3. Sign in to your Datadog account.
-   {{< img src="bits_ai/mcp_server/ide_sign_in.png" alt="Sign in to Datadog from the IDE extension" style="width:70%;" >}}
-4. **Restart the IDE.**
-5. Confirm the Datadog MCP Server is available and the [tools][3] are listed: Go to **Cursor Settings** (`Shift` + `Cmd/Ctrl` + `J`), and select the **MCP** tab.
-
-[1]: /ide_plugins/vscode/
-[2]: /ide_plugins/vscode/?tab=cursor#installation
-[3]: /bits_ai/mcp_server#available-tools
-
-{{% /tab %}}
-
 {{% tab "Claude Code" %}}
 
 You can connect Claude Code to the Datadog MCP Server using remote authentication (HTTP) or local binary authentication (stdio).
 
 ### Remote authentication
 
-{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
-Point your AI agent to the MCP Server endpoint for your regional [Datadog site][1]. For example, the endpoint for your selected site ({{< region-param key="dd_site_name" >}}) is: <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
+{{< mcp-toolset-selector client="claude-code" >}}
 
-* **Command line**: Run:
-  <pre><code>claude mcp add --transport http datadog-mcp {{< region-param key="mcp_server_endpoint" >}}
-  </code></pre>
+Alternatively, add the server directly to `~/.claude.json`:
 
-* **Configuration file**: Add to `~/.claude.json`:
-  <pre><code>{
-    "mcpServers": {
-      "datadog": {
-        "type": "http",
-        "url": "{{< region-param key="mcp_server_endpoint" >}}"
-      }
+```json
+{
+  "mcpServers": {
+    "datadog": {
+      "type": "http",
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
     }
   }
-  </code></pre>
-
-[1]: /getting_started/site/
-{{< /site-region >}}
-
-{{< site-region region="gov" >}}
-Point your AI agent to the MCP Server endpoint for your regional [Datadog site][1].
-
-<div class="alert alert-danger">Datadog MCP Server is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
-
-[1]: /getting_started/site/
-{{< /site-region >}}
+}
+```
 
 ### Local binary authentication
 
@@ -106,6 +69,74 @@ Use this option if remote authentication is not available. After installation, y
    Or run: `claude mcp add datadog --scope user -- ~/.local/bin/datadog_mcp_cli`
 
 [1]: /getting_started/site/
+{{% /tab %}}
+
+{{% tab "Cursor" %}}
+
+Datadog's [Cursor and VS Code extension][1] includes built-in access to the managed Datadog MCP Server. Benefits include:
+
+* No additional MCP Server setup after you install the extension and connect to Datadog.
+* One-click transitions between multiple Datadog organizations.
+* Better fixes from **Fix in Chat** on Code Insights (issues from Error Tracking, Code Vulnerabilities, and Library Vulnerabilities), informed by context from the MCP Server.
+
+To install the extension:
+
+1. If you previously installed the Datadog MCP Server manually, remove it from the IDE's configuration to avoid conflicts. Go to **Cursor Settings** (`Shift` + `Cmd/Ctrl` + `J`) and select the **MCP** tab.
+2. Install the Datadog extension following [these instructions][2]. If you have the extension installed already, make sure it's the latest version, as new features are released regularly.
+3. Sign in to your Datadog account.
+   {{< img src="bits_ai/mcp_server/ide_sign_in.png" alt="Sign in to Datadog from the IDE extension" style="width:70%;" >}}
+4. **Restart the IDE.**
+5. Confirm the Datadog MCP Server is available and the [tools][3] are listed: Go to **Cursor Settings** (`Shift` + `Cmd/Ctrl` + `J`), and select the **MCP** tab.
+
+[1]: /ide_plugins/vscode/
+[2]: /ide_plugins/vscode/?tab=cursor#installation
+[3]: /bits_ai/mcp_server#available-tools
+
+{{% /tab %}}
+
+{{% tab "Codex" %}}
+
+{{< mcp-toolset-selector client="url" >}}
+
+Copy the endpoint URL above into `~/.codex/config.toml` (or your Codex CLI configuration file):
+
+```toml
+[mcp_servers.datadog]
+url = "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
+```
+
+Then log in to the Datadog MCP Server by running:
+
+   ```bash
+   codex mcp login datadog
+   ```
+
+   This opens your browser to complete the OAuth flow. Codex stores the resulting credentials so you don't need to log in again until the token expires.
+
+[1]: /getting_started/site/
+
+{{% /tab %}}
+
+{{% tab "VS Code" %}}
+
+Datadog's [Cursor and VS Code extension][1] includes built-in access to the managed Datadog MCP Server. Benefits include:
+
+* No additional MCP Server setup after you install the extension and connect to Datadog.
+* One-click transitions between multiple Datadog organizations.
+
+To install the extension:
+
+1. If you previously installed the Datadog MCP Server manually, remove it from the IDE's configuration to avoid conflicts. Open the command palette (`Shift` + `Cmd/Ctrl` + `P`) and run `MCP: Open User Configuration`.
+2. Install the Datadog extension following [these instructions][2]. If you have the extension installed already, make sure it's the latest version.
+3. Sign in to your Datadog account.
+4. **Restart the IDE.**
+5. Confirm the Datadog MCP Server is available and the [tools][3] are listed: Open the chat panel, select agent mode, and click the **Configure Tools** button.
+   {{< img src="bits_ai/mcp_server/vscode_configure_tools_button.png" alt="Configure Tools button in VS Code" style="width:70%;" >}}
+
+[1]: /ide_plugins/vscode/
+[2]: /ide_plugins/vscode/?tab=vscode#installation
+[3]: /bits_ai/mcp_server#available-tools
+
 {{% /tab %}}
 
 {{% tab "Claude Desktop" %}}
@@ -144,99 +175,33 @@ Claude Desktop has limited support for remote authentication. Use **local binary
 
 {{% /tab %}}
 
-{{% tab "Codex" %}}
-
-You can connect Codex CLI to the Datadog MCP Server using HTTP transport.
-
-{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
-Point your AI agent to the MCP Server endpoint for your regional [Datadog site][1]. For example, the endpoint for your selected site ({{< region-param key="dd_site_name" >}}) is: <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
-
-1. Edit `~/.codex/config.toml` (or your Codex CLI configuration file) to add the Datadog MCP Server with HTTP transport and the endpoint URL for your site. Example configuration ({{< region-param key="dd_site_name" >}}):
-
-   <pre><code>[mcp_servers.datadog]
-   url = "{{< region-param key="mcp_server_endpoint" >}}"
-   </code></pre>
-
-2. Log in to the Datadog MCP Server by running:
-
-   ```bash
-   codex mcp login datadog
-   ```
-
-   This opens your browser to complete the OAuth flow. Codex stores the resulting credentials so you don't need to log in again until the token expires.
-
-[1]: /getting_started/site/
-{{< /site-region >}}
-
-{{< site-region region="gov" >}}
-Point your AI agent to the MCP Server endpoint for your regional [Datadog site][1].
-
-<div class="alert alert-danger">Datadog MCP Server is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
-
-[1]: /getting_started/site/
-{{< /site-region >}}
-{{% /tab %}}
-
-{{% tab "VS Code" %}}
-
-Datadog's [Cursor and VS Code extension][1] includes built-in access to the managed Datadog MCP Server. Benefits include:
-
-* No additional MCP Server setup after you install the extension and connect to Datadog.
-* One-click transitions between multiple Datadog organizations.
-
-To install the extension:
-
-1. If you previously installed the Datadog MCP Server manually, remove it from the IDE's configuration to avoid conflicts. Open the command palette (`Shift` + `Cmd/Ctrl` + `P`) and run `MCP: Open User Configuration`.
-2. Install the Datadog extension following [these instructions][2]. If you have the extension installed already, make sure it's the latest version.
-3. Sign in to your Datadog account.
-4. **Restart the IDE.**
-5. Confirm the Datadog MCP Server is available and the [tools][3] are listed: Open the chat panel, select agent mode, and click the **Configure Tools** button.
-   {{< img src="bits_ai/mcp_server/vscode_configure_tools_button.png" alt="Configure Tools button in VS Code" style="width:70%;" >}}
-
-[1]: /ide_plugins/vscode/
-[2]: /ide_plugins/vscode/?tab=vscode#installation
-[3]: /bits_ai/mcp_server#available-tools
-
-{{% /tab %}}
-
 {{% tab "Other" %}}
 
 The following clients can connect to the Datadog MCP Server: [Goose][1], [Kiro][2], [Kiro CLI][3], [Cline][4], and other MCP-compatible clients. Use **remote authentication** when your client supports it. For Cline or when remote authentication is unreliable, use **local binary authentication**.
 
 ### Remote authentication
 
-{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
-Point your AI agent to the MCP Server endpoint for your regional [Datadog site][1]. For example, the endpoint for your selected site ({{< region-param key="dd_site_name" >}}) is: <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
+{{< mcp-toolset-selector client="url" >}}
 
-Add the Datadog MCP Server to your client's configuration using the HTTP transport and the endpoint above. Example config file locations:
+Copy the endpoint URL above into your client's MCP configuration using the HTTP transport. Example config file locations:
 
 | Client | Configuration file |
 |--------|---------------------|
 | Gemini CLI | `~/.gemini/settings.json` |
 | Kiro CLI | `~/.kiro/settings/mcp.json` |
 
-Example JSON configuration ({{< region-param key="dd_site_name" >}}):
+Example JSON configuration:
 
-<pre><code>{
+```json
+{
   "mcpServers": {
     "datadog": {
       "type": "http",
-      "url": "{{< region-param key="mcp_server_endpoint" >}}"
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp"
     }
   }
 }
-</code></pre>
-
-[1]: /getting_started/site/
-{{< /site-region >}}
-
-{{< site-region region="gov" >}}
-Point your AI agent to the MCP Server endpoint for your regional [Datadog site][1].
-
-<div class="alert alert-danger">Datadog MCP Server is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
-
-[1]: /getting_started/site/
-{{< /site-region >}}
+```
 
 ### Local binary authentication
 
@@ -326,10 +291,7 @@ For security, use a scoped API key and application key from a [service account][
    npx @modelcontextprotocol/inspector
    ```
 2. In the inspector's web UI, for **Transport Type**, select **Streamable HTTP**.
-3. For **URL**, enter the MCP Server endpoint for your regional Datadog site. 
-   {{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
-   For example, for {{< region-param key="dd_site_name" >}}: <code>{{< region-param key="mcp_server_endpoint" >}}</code>
-   {{< /site-region >}}
+3. For **URL**, enter the MCP Server endpoint for your selected Datadog site: `https://mcp.datadoghq.com/api/unstable/mcp-server/mcp`.
 4. Click **Connect**, then go to **Tools** > **List Tools**.
 5. Check if the [available tools][12] appear.
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -41,7 +41,7 @@ Alternatively, add the server directly to `~/.claude.json`:
 }
 ```
 
-### Local binary authentication
+{{% collapse-content title="Local binary authentication" level="h4" %}}
 
 Use this option if remote authentication is not available. After installation, you typically do not need to update the local binary to benefit from MCP Server updates, as the tools are remote.
 
@@ -67,6 +67,8 @@ Use this option if remote authentication is not available. After installation, y
    }
    ```
    Or run: `claude mcp add datadog --scope user -- ~/.local/bin/datadog_mcp_cli`
+
+{{% /collapse-content %}}
 
 [1]: /getting_started/site/
 {{% /tab %}}
@@ -203,7 +205,7 @@ Example JSON configuration:
 }
 ```
 
-### Local binary authentication
+{{% collapse-content title="Local binary authentication" level="h4" %}}
 
 Local authentication is recommended for Cline and when remote authentication is unreliable.
 
@@ -234,6 +236,8 @@ Local authentication is recommended for Cline and when remote authentication is 
    ```
    On Windows, replace the `command` path with the location of the downloaded `.exe` file (for example, `C:\Users\<USERNAME>\bin\datadog_mcp_cli.exe`).
 
+{{% /collapse-content %}}
+
 [1]: https://github.com/block/goose
 [2]: https://kiro.dev/
 [3]: https://kiro.dev/cli/
@@ -256,6 +260,25 @@ Local authentication is recommended for Cline and when remote authentication is 
 | [Goose][8], [Kiro][9], [Kiro CLI][10], [Cline][11] | Various | See the **Other** tab above. Use local binary authentication for Cline if remote authentication is unreliable. |
 
 <div class="alert alert-info">The Datadog MCP Server is under significant development, and additional supported clients may become available.</div>
+
+## Permissions
+
+MCP Server tools require the following [RBAC permissions][18]:
+
+| Permission | Required for |
+|------------|-------------|
+| `mcp_read` | Tools that read data from Datadog (for example, querying monitors, searching logs, retrieving dashboards) |
+| `mcp_write` | Tools that create or modify resources in Datadog (for example, creating monitors, muting hosts) |
+
+Users with the **Datadog Standard Role** have both permissions by default. If your organization uses [custom roles][19], add the permissions manually:
+
+1. Go to <a href="https://app.datadoghq.com/organization-settings/roles" class="mcp-app-link" data-path="/organization-settings/roles">Organization Settings > Roles</a> as an admin.
+2. Click the role you want to update.
+3. Click **Edit Role** (pencil icon).
+4. Under the permissions list, select the **MCP Read** and **MCP Write** checkboxes.
+5. Click **Save**.
+
+Organization administrators can manage global MCP access and disable write capabilities from the <a href="https://app.datadoghq.com/organization-settings/preferences" class="mcp-app-link" data-path="/organization-settings/preferences">Organization Settings</a> page.
 
 ## Authentication
 
@@ -316,3 +339,5 @@ For security, use a scoped API key and application key from a [service account][
 [15]: /ide_plugins/vscode/?tab=cursor
 [16]: /ide_plugins/vscode/
 [17]: /getting_started/site/#navigate-the-datadog-documentation-by-site
+[18]: /account_management/rbac/permissions/
+[19]: /account_management/rbac/?tab=datadogapplication#custom-roles

--- a/layouts/shortcodes/mcp-toolset-selector.html
+++ b/layouts/shortcodes/mcp-toolset-selector.html
@@ -1,0 +1,435 @@
+{{ $client := .Get "client" | default "url" }}
+
+<div class="mcp-url-builder" data-mcp-client="{{ $client }}">
+  <div class="mcp-config-bar">
+    <div class="mcp-config-row">
+      <span class="mcp-config-label">Site</span>
+      <select class="mcp-site-sel">
+        <option value="US1" selected>US1 (datadoghq.com)</option>
+        <option value="US3">US3 (us3.datadoghq.com)</option>
+        <option value="US5">US5 (us5.datadoghq.com)</option>
+        <option value="EU1">EU1 (datadoghq.eu)</option>
+        <option value="AP1">AP1 (ap1.datadoghq.com)</option>
+        <option value="AP2">AP2 (ap2.datadoghq.com)</option>
+      </select>
+    </div>
+    <details class="mcp-toolsets-expand">
+      <summary>
+        <span class="mcp-toolsets-label">Additional Toolsets</span>
+        <span class="mcp-toolsets-badge">Default</span>
+      </summary>
+      <div class="mcp-toolset-grid">
+        <label data-tooltip="Validate monitors, search monitor groups, and retrieve monitor templates"><input type="checkbox" value="alerting"> Alerting</label>
+        <label data-tooltip="In-depth trace analysis, span search, Watchdog insights, and performance investigation"><input type="checkbox" value="apm"> APM</label>
+        <label data-tooltip="Query execution plans and query samples for database performance analysis"><input type="checkbox" value="dbm"> Database Monitoring</label>
+        <label data-tooltip="Search and analyze Error Tracking issues across RUM, Logs, and Traces"><input type="checkbox" value="error-tracking"> Error Tracking</label>
+        <label data-tooltip="Create, list, and manage feature flags and their environments"><input type="checkbox" value="feature-flags"> Feature Flags</label>
+        <label data-tooltip="Search and analyze LLM Observability spans, token usage, and costs"><input type="checkbox" value="llmobs"> LLM Observability</label>
+        <label data-tooltip="Cloud Network Monitoring analysis and Network Device Monitoring"><input type="checkbox" value="networks"> Networks</label>
+        <label data-tooltip="Guided Datadog setup and configuration for various products"><input type="checkbox" value="onboarding"> Onboarding</label>
+        <label data-tooltip="Code security scanning, security signals, and security findings analysis"><input type="checkbox" value="security"> Security</label>
+        <label data-tooltip="CI Visibility, Test Optimization, and flaky test management"><input type="checkbox" value="software-delivery"> Software Delivery</label>
+        <label data-tooltip="Create, edit, and search Synthetic tests"><input type="checkbox" value="synthetics"> Synthetics</label>
+      </div>
+    </details>
+  </div>
+  <div class="mcp-output-bar">
+    <div class="mcp-output-label">
+      <svg class="mcp-terminal-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="4 17 10 11 4 5"></polyline><line x1="12" y1="19" x2="20" y2="19"></line></svg>
+      {{ if eq $client "claude-code" }}Run in terminal{{ else }}Copy endpoint URL{{ end }}
+    </div>
+    <div class="mcp-output-code-row">
+      <code class="mcp-output-text"></code>
+      <button class="mcp-output-copy" title="Copy to clipboard">Copy</button>
+    </div>
+  </div>
+</div>
+
+{{ if not (.Page.Scratch.Get "mcp-toolset-assets") }}
+{{ .Page.Scratch.Set "mcp-toolset-assets" true }}
+<style>
+.mcp-url-builder {
+  margin: 0 0 0.5rem;
+  border: 1px solid #d4d8dd;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+/* Config bar */
+.mcp-config-bar {
+  background: #f8f9fa;
+}
+
+/* Output bar */
+.mcp-output-bar {
+  background: #1e1e2e;
+  padding: 0 12px 10px;
+  border-top: 1px solid #333;
+}
+
+.mcp-output-label {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.68rem;
+  font-weight: 500;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 8px 0 6px;
+}
+
+.mcp-terminal-icon {
+  width: 13px;
+  height: 13px;
+  color: #888;
+}
+
+.mcp-output-text {
+  flex: 1;
+  font-family: 'SFMono-Regular', Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82rem;
+  color: #e0e0e0;
+  background: none;
+  white-space: nowrap;
+  overflow-x: auto;
+  padding: 0;
+  margin: 0;
+  line-height: 1.5;
+  scrollbar-width: thin;
+}
+
+.mcp-output-code-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.mcp-output-copy {
+  flex-shrink: 0;
+  background: transparent;
+  border: 1px solid rgba(255,255,255,0.25);
+  color: #ccc;
+  font-size: 0.75rem;
+  padding: 3px 10px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.mcp-output-copy:hover {
+  background: rgba(255,255,255,0.1);
+  color: #fff;
+  border-color: rgba(255,255,255,0.4);
+}
+
+.mcp-config-row {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  gap: 10px;
+}
+
+.mcp-config-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #555;
+  min-width: 30px;
+}
+
+.mcp-site-sel {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #23232f;
+  padding: 6px 32px 6px 10px;
+  border: 1px solid #d4d8dd;
+  border-radius: 6px;
+  background: #fff url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' viewBox='0 0 24 24'%3E%3Cpath stroke='%23777' stroke-linecap='round' stroke-linejoin='round' stroke-width='2.5' d='m6 9 6 6 6-6'/%3E%3C/svg%3E") no-repeat right 8px center / 14px;
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  line-height: 1.4;
+}
+
+.mcp-site-sel:hover {
+  border-color: #b0b5bb;
+}
+
+.mcp-site-sel:focus {
+  outline: none;
+  border-color: #632ca6;
+  box-shadow: 0 0 0 3px rgba(99, 44, 166, 0.12);
+}
+
+/* Toolsets expandable */
+.mcp-toolsets-expand {
+  border-top: 1px solid #e8eaed;
+  margin: 0;
+}
+
+.mcp-toolsets-expand > summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  cursor: pointer;
+  list-style: none;
+  font-size: 0.78rem;
+  color: #555;
+  user-select: none;
+}
+
+.mcp-toolsets-expand > summary::-webkit-details-marker { display: none; }
+
+.mcp-toolsets-expand > summary::before {
+  content: "";
+  display: inline-block;
+  width: 0;
+  height: 0;
+  border-left: 5px solid #888;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  transition: transform 0.15s;
+  flex-shrink: 0;
+}
+
+.mcp-toolsets-expand[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.mcp-toolsets-label {
+  font-weight: 600;
+}
+
+.mcp-toolsets-badge {
+  font-size: 0.7rem;
+  font-weight: 500;
+  color: #6c757d;
+  background: #e8eaed;
+  padding: 1px 8px;
+  border-radius: 10px;
+}
+
+.mcp-toolsets-badge.mcp-active {
+  background: #f0ebf8;
+  color: #632ca6;
+}
+
+/* Grid */
+.mcp-toolset-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  padding: 2px 12px 10px;
+}
+
+@media (max-width: 768px) {
+  .mcp-toolset-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.mcp-toolset-grid label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: #23232f;
+  padding: 5px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.1s;
+}
+
+.mcp-toolset-grid label:hover {
+  background: #eef0f3;
+}
+
+.mcp-toolset-grid input[type="checkbox"] {
+  accent-color: #632ca6;
+  margin: 0;
+  cursor: pointer;
+  width: 14px;
+  height: 14px;
+}
+
+/* CSS tooltips */
+.mcp-toolset-grid label[data-tooltip] {
+  position: relative;
+}
+
+.mcp-toolset-grid label[data-tooltip]::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: #23232f;
+  color: #f0f0f0;
+  font-size: 0.72rem;
+  font-weight: 400;
+  line-height: 1.4;
+  padding: 6px 10px;
+  border-radius: 6px;
+  white-space: normal;
+  width: max-content;
+  max-width: 240px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 100;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+}
+
+.mcp-toolset-grid label[data-tooltip]::before {
+  content: "";
+  position: absolute;
+  bottom: calc(100% + 2px);
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: #23232f;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.15s;
+  z-index: 100;
+}
+
+.mcp-toolset-grid label[data-tooltip]:hover::after,
+.mcp-toolset-grid label[data-tooltip]:hover::before {
+  opacity: 1;
+}
+</style>
+
+<script>
+(function() {
+  var SITES = {
+    'US1': 'mcp.datadoghq.com',
+    'US3': 'mcp.us3.datadoghq.com',
+    'US5': 'mcp.us5.datadoghq.com',
+    'EU1': 'mcp.datadoghq.eu',
+    'AP1': 'mcp.ap1.datadoghq.com',
+    'AP2': 'mcp.ap2.datadoghq.com'
+  };
+
+  if (!window._mcpState) {
+    window._mcpState = { site: 'US1', toolsets: [] };
+  }
+
+  var MCP_URL_PATTERN = /https:\/\/mcp\.[a-z0-9.]+\/api\/unstable\/mcp-server\/mcp(\?[^\s"'`\\<\])]*)?/g;
+
+  function buildUrl() {
+    var s = window._mcpState;
+    var domain = SITES[s.site] || SITES['US1'];
+    var url = 'https://' + domain + '/api/unstable/mcp-server/mcp';
+    if (s.toolsets.length > 0) {
+      var all = ['core'].concat(s.toolsets.slice().sort());
+      url += '?toolsets=' + all.join(',');
+    }
+    return url;
+  }
+
+  function buildOutput(client, url) {
+    if (client === 'claude-code') {
+      return 'claude mcp add --transport http datadog-mcp ' + url;
+    }
+    return url;
+  }
+
+  function updateAll() {
+    var url = buildUrl();
+
+    document.querySelectorAll('.mcp-url-builder').forEach(function(widget) {
+      var client = widget.dataset.mcpClient;
+      var outputEl = widget.querySelector('.mcp-output-text');
+      if (outputEl) {
+        outputEl.textContent = buildOutput(client, url);
+      }
+    });
+
+    document.querySelectorAll('.mcp-site-sel').forEach(function(sel) {
+      sel.value = window._mcpState.site;
+    });
+    document.querySelectorAll('.mcp-toolset-grid input[type="checkbox"]').forEach(function(cb) {
+      cb.checked = window._mcpState.toolsets.indexOf(cb.value) !== -1;
+    });
+
+    document.querySelectorAll('.mcp-toolsets-badge').forEach(function(badge) {
+      if (window._mcpState.toolsets.length === 0) {
+        badge.textContent = 'Default';
+        badge.classList.remove('mcp-active');
+      } else {
+        badge.textContent = window._mcpState.toolsets.length + ' selected';
+        badge.classList.add('mcp-active');
+      }
+    });
+
+    var codeElements = document.querySelectorAll('#mainContent pre, #mainContent code, #mainContent .highlight');
+    codeElements.forEach(function(el) {
+      if (el.classList.contains('mcp-output-text')) return;
+      var walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT, null, false);
+      var node;
+      while (node = walker.nextNode()) {
+        MCP_URL_PATTERN.lastIndex = 0;
+        var original = node.nodeValue;
+        var updated = original.replace(MCP_URL_PATTERN, function() { return url; });
+        if (updated !== original) {
+          node.nodeValue = updated;
+        }
+      }
+    });
+
+    var tableCells = document.querySelectorAll('#mainContent td');
+    tableCells.forEach(function(td) {
+      var walker = document.createTreeWalker(td, NodeFilter.SHOW_TEXT, null, false);
+      var node;
+      while (node = walker.nextNode()) {
+        MCP_URL_PATTERN.lastIndex = 0;
+        var orig = node.nodeValue;
+        var upd = orig.replace(MCP_URL_PATTERN, function() { return url; });
+        if (upd !== orig) {
+          node.nodeValue = upd;
+        }
+      }
+    });
+  }
+
+  function collectToolsets(source) {
+    var checked = source.closest('.mcp-url-builder').querySelectorAll('.mcp-toolset-grid input:checked');
+    var ts = [];
+    checked.forEach(function(cb) { ts.push(cb.value); });
+    return ts;
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    updateAll();
+
+    document.querySelectorAll('.mcp-site-sel').forEach(function(sel) {
+      sel.addEventListener('change', function() {
+        window._mcpState.site = this.value;
+        updateAll();
+      });
+    });
+
+    document.querySelectorAll('.mcp-toolset-grid input[type="checkbox"]').forEach(function(cb) {
+      cb.addEventListener('change', function() {
+        window._mcpState.toolsets = collectToolsets(this);
+        updateAll();
+      });
+    });
+
+    document.querySelectorAll('.mcp-output-copy').forEach(function(btn) {
+      btn.addEventListener('click', function() {
+        var text = this.closest('.mcp-output-bar').querySelector('.mcp-output-text').textContent;
+        navigator.clipboard.writeText(text).then(function() {
+          btn.textContent = 'Copied!';
+          setTimeout(function() { btn.textContent = 'Copy'; }, 1200);
+        });
+      });
+    });
+  });
+})();
+</script>
+{{ end }}

--- a/layouts/shortcodes/mcp-toolset-selector.html
+++ b/layouts/shortcodes/mcp-toolset-selector.html
@@ -45,9 +45,7 @@
   </div>
 </div>
 
-{{ if not (.Page.Scratch.Get "mcp-toolset-assets") }}
-{{ .Page.Scratch.Set "mcp-toolset-assets" true }}
-<style>
+<style data-mcp-assets>
 .mcp-url-builder {
   margin: 0 0 0.5rem;
   border: 1px solid #d4d8dd;
@@ -305,6 +303,13 @@
 
 <script>
 (function() {
+  if (window._mcpAssetsLoaded) return;
+  window._mcpAssetsLoaded = true;
+
+  // Remove duplicate style blocks (keep only the first)
+  var styles = document.querySelectorAll('style[data-mcp-assets]');
+  for (var i = 1; i < styles.length; i++) styles[i].remove();
+
   var SITES = {
     'US1': 'mcp.datadoghq.com',
     'US3': 'mcp.us3.datadoghq.com',
@@ -312,6 +317,15 @@
     'EU1': 'mcp.datadoghq.eu',
     'AP1': 'mcp.ap1.datadoghq.com',
     'AP2': 'mcp.ap2.datadoghq.com'
+  };
+
+  var APP_SITES = {
+    'US1': 'app.datadoghq.com',
+    'US3': 'us3.datadoghq.com',
+    'US5': 'us5.datadoghq.com',
+    'EU1': 'app.datadoghq.eu',
+    'AP1': 'ap1.datadoghq.com',
+    'AP2': 'ap2.datadoghq.com'
   };
 
   if (!window._mcpState) {
@@ -364,6 +378,12 @@
         badge.textContent = window._mcpState.toolsets.length + ' selected';
         badge.classList.add('mcp-active');
       }
+    });
+
+    var appDomain = APP_SITES[window._mcpState.site] || APP_SITES['US1'];
+    document.querySelectorAll('.mcp-app-link').forEach(function(link) {
+      var path = link.getAttribute('data-path') || '';
+      link.href = 'https://' + appDomain + path;
     });
 
     var codeElements = document.querySelectorAll('#mainContent pre, #mainContent code, #mainContent .highlight');
@@ -432,4 +452,3 @@
   });
 })();
 </script>
-{{ end }}


### PR DESCRIPTION
This is something we are discussing on the mcp-services team at the moment to make the onboarding instructions more basic and straight forward for MCP.

Introduce a new mcp-toolset-selector shortcode that lets users configure their Datadog site region and MCP toolsets, then generates a ready-to-copy terminal command or endpoint URL. The widget is embedded directly in the Claude Code, Codex, and Other client tabs on the MCP setup page, replacing the static endpoint tables.

- Site dropdown dynamically updates all MCP URLs across the page
- Collapsible toolset grid with hover tooltips for descriptions
- All widget instances share state and stay in sync across tabs
- Add bash and toml to copy-code.js for copy button support

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Adds in a URL designer widget and wires it in to the MCP documentation page.

https://github.com/user-attachments/assets/9254b90e-1e10-4694-b1e8-b4432a1830e2


### Merge instructions

N/A

Merge readiness:
- [ ] Ready for merge

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
