### PR TITLE
[DOCS-12446] Update dead CodePush links to community repo

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/react_native/setup/codepush.md
+++ b/content/en/real_user_monitoring/application_monitoring/react_native/setup/codepush.md
@@ -173,9 +173,9 @@ This means that even if users open your application while offline, no data is lo
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-[1]: https://docs.microsoft.com/en-us/appcenter/distribution/codepush/
+[1]: https://github.com/microsoft/react-native-code-push
 [2]: /real_user_monitoring/reactnative/
 [3]: https://github.com/DataDog/datadog-ci
-[4]: https://docs.microsoft.com/en-us/appcenter/distribution/codepush/rn-api-ref#codepushgetupdatemetadata
+[4]: https://github.com/microsoft/react-native-code-push/blob/master/docs/api-js.md#codepushgetupdatemetadata
 [5]: https://github.com/DataDog/datadog-ci/tree/master/packages/datadog-ci/src/commands/react-native#upload
 [6]: https://github.com/DataDog/dd-sdk-reactnative-examples/tree/main/rum-react-navigation-codepush


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-12446

Replaces two retired Microsoft App Center links in the CodePush setup page with the equivalent community `react-native-code-push` repo links. App Center was retired in March 2025.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The `appcenter codepush release-react` CLI command on line 127 still needs updating, but is blocked on eng confirming the replacement workflow.