### PR TITLE
Add MCP Server monitoring section and rate limit disclaimer

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -50,7 +50,7 @@ For setup instructions, see [Set Up the Datadog MCP Server][27].
 
 ## Monitoring the Datadog MCP Server usage
 
-You can track Datadog MCP Server usage for your organization using Datadog Metrics and Audit Trail.
+You can track Datadog MCP Server usage for your organization using Datadog metrics and Audit Trail.
 
 All tool calls are recorded in the Datadog [Audit Trail][16] with metadata identifying them as MCP actions, including the tool name, arguments, user identity, and the MCP client used. See [Track tool calls in Audit Trail](#track-tool-calls-in-audit-trail) for more information.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds two changes to the MCP Server documentation:

1. **New "Monitoring the Datadog MCP Server usage" section** under Requirements — documents how customers can track MCP Server usage via Audit Trail and two standard metrics (`datadog.mcp.session.starts` and `datadog.mcp.tool.calls`).

2. **New disclaimer bullet** — adds a note about fair-use rate limits with a link to Datadog support.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes