### PR TITLE
(maint) Add snippets for includes, u, and sup

### DIFF
--- a/.vscode/markdoc.code-snippets
+++ b/.vscode/markdoc.code-snippets
@@ -168,5 +168,31 @@
         "prefix": ";;check",
         "body": "{% x/ %}",
         "description": "X tag (self-closing) for checkmark"
+    },
+
+    "Includes": {
+        "scope": "markdoc",
+        "prefix": ";;includes",
+        "body": [
+            "<!-- Content applies to specified options: ${2:option_id_1} ${3:option_id_2} -->",
+            "{% if includes($${1:trait_id}, [\"${2:option_id_1}\", \"${3:option_id_2}\"]) %}",
+            "${4:Content shown for the specified options}",
+            "{% /if %}"
+        ],
+        "description": "Markdoc includes function to show content for specific trait options"
+    },
+
+    "Underline": {
+        "scope": "markdoc",
+        "prefix": ";;u",
+        "body": "{% u %}${1:underlined text}{% /u %}",
+        "description": "Markdoc underline tag"
+    },
+
+    "Superscript": {
+        "scope": "markdoc",
+        "prefix": ";;sup",
+        "body": "{% sup %}${1:superscript text}{% /sup %}",
+        "description": "Markdoc superscript tag"
     }
 }


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

Adds some missing Markdoc snippets.

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

Merge readiness:
- [x] Ready for merge
