### PR TITLE
Update Code Security SCA Page

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/_index.md
@@ -37,8 +37,8 @@ Using Software Composition Analysis provides organizations with the following be
 ## How it works
 
 SCA supports two complementary detection modes:
-- **Static detection** scans your repositories by analyzing dependency files (lockfiles and manifests). Scans run when changes are committed that update supported dependency manifests/lockfiles in an enabled repository. You can also run SCA in your CI/CD pipeline (CI jobs are supported on <code>push</code> event triggers). See [Set up Static SCA][1] to get started.
-- **Runtime detection** identifies libraries that are actually loaded and used by your services at runtime, using instrumentation from Datadog APM. See [Set up Runtime SCA][2] to get started.
+- **Static detection** scans repositories by analyzing dependency files (lockfiles and manifests). By default, scans run when a commit updates a supported dependency manifest or lockfile in an enabled repository. You can also run SCA in your CI/CD pipeline (CI jobs are supported for `push` events). See [Set up Static SCA][1] to get started.
+- **Runtime detection** identifies libraries that are loaded and used by your services at runtime using instrumentation from Datadog APM. See [Set up Runtime SCA][2] to get started.
 
 Datadog SCA uses a curated proprietary database. The database is sourced from Open Source Vulnerabilities (OSV), National Vulnerability Database (NVD), GitHub advisories, and other language ecosystem advisories, as well as Datadog's own Security Research team's findings. There is a maximum of 2 hours between when a new vulnerability is published and when it appears in Datadog, with emerging vulnerabilities typically appearing in Datadog within minutes.
 
@@ -81,13 +81,13 @@ Click on a library with a vulnerability to open a side panel that contains infor
 
 ### Automatically block risky changes with PR Gates
 
-Use [PR Gates][16] to enforce security standards on open source library usage before changes are merged. Datadog scans the dependencies introduced in each pull request, identifies any vulnerabilities or license violations above your configured severity threshold, and reports a pass or fail status to GitHub or Azure DevOps.
+Use [PR Gates][16] to enforce security standards for open source libraries before changes are merged. Datadog scans the dependencies introduced in each pull request, identifies vulnerabilities or license violations that exceed your configured severity threshold, and reports a pass or fail status to GitHub or Azure DevOps.
 
 You can configure PR Gates to block on:
 - **Security vulnerabilities**: libraries with known CVEs above a configured severity threshold.
 - **License violations**: libraries using licenses that do not comply with your organization's policy.
 
-PR Gates marks a PR check as failed only if the developer **introduces a new violation as part of that PR**—existing violations already present in the codebase before the PR and its branch were created do not cause the check to fail. By default, failed checks are informational and do not block merging, but you can configure them as blocking in GitHub or Azure DevOps to prevent merging when critical issues are detected. For setup instructions, see [Set up PR Gate Rules][17].
+PR Gates marks a PR check as failed only if the developer introduces a new violation in that PR. Violations that already existed in the codebase before the PR branch was created do not cause the check to fail. By default, failed checks are informational and do not block merging, but you can configure them as blocking in GitHub or Azure DevOps to prevent merges when critical issues are detected. For setup instructions, see [Set up PR Gate Rules][17].
 
 ### Manage your library inventory
 
@@ -102,24 +102,25 @@ To learn more about how the inventory is generated, how Static and Runtime data 
 
 ### Library vulnerability context in APM
 
-SCA enriches the information that Application Performance Monitoring (APM) is already collecting by flagging libraries that match against current vulnerability advisories. Potentially vulnerable services are highlighted directly in the **Security** view embedded in the [APM Software Catalog][10].
+SCA enriches the information that Application Performance Monitoring (APM) already collects by flagging libraries that match current vulnerability advisories. Potentially vulnerable services are highlighted directly in the Security view in the [APM Software Catalog][10].
 
 ## Understanding SCA views
 
 The Repositories Explorer and Vulnerabilities Explorer serve complementary but distinct purposes.
 
-**Repositories Explorer** reflects a **point-in-time snapshot** of the libraries and vulnerabilities detected at the time of the scan. It shows which libraries were present in a given repository at a specific commit, along with any vulnerabilities that were known at scan time. This view does not update retroactively if new advisories are published after the scan runs.
+Repositories Explorer reflects a point-in-time snapshot of the libraries and vulnerabilities detected at the time of the scan. It shows which libraries were present in a given repository at a specific commit, along with any vulnerabilities that were known at scan time. This view does not update retroactively if new advisories are published after the scan runs.
 
-**Vulnerabilities Explorer** provides a **live view** that is continuously matched against the latest advisory database. If a new vulnerability advisory is published after a repository scan, it automatically appears in the Vulnerabilities Explorer, even if the repository has not been rescanned since that commit or if your last scan was on an older commit. This means your vulnerability exposure is always up to date, regardless of when the last scan ran.
+Vulnerabilities Explorer provides a live view that is continuously matched against the latest advisory database. If a new vulnerability advisory is published after a repository scan, it automatically appears in the Vulnerabilities Explorer, even if the repository has not been rescanned or if your last scan was on an older commit. This ensures your vulnerability exposure is always up to date.
 
-> **Example:** If a scan runs at 10:00 AM and a CVE advisory for a library in your repository is published at 4:00 PM the same day, the Repositories Explorer for that commit will not show the CVE, but the Vulnerabilities Explorer will reflect it as soon as the advisory is available in Datadog's database.
+<div class="alert alert-info"><b>Example</b>: If a scan runs at 10:00 AM and a CVE advisory for a library in your repository is published at 4:00 PM, the Repositories Explorer for that commit will not show the CVE, but the Vulnerabilities Explorer will reflect it as soon as the advisory is available in Datadog's database.</div>
 
 ### Retroactive advisory matching
 
-Datadog continuously matches newly published advisories against the stored library inventory from past scans. This updates vulnerability records in the Vulnerabilities Explorer without changing the original Repositories Explorer snapshots. This means:
-- You do not need to trigger a new scan for a newly published CVE to be reflected in your vulnerability posture in the Vulnerabilities Explorer.
-- The Vulnerabilities Explorer always shows the most current risk picture based on your last known library inventory, even for older commits that have not been rescanned.
-- The Repositories Explorer remains a fixed, point-in-time historical record of what was known at scan time and does not update when new advisories are published.
+Datadog continuously matches newly published advisories against the stored library inventory from past scans. This updates vulnerability records in the Vulnerabilities Explorer without altering the original Repositories Explorer snapshots. This means:
+
+- You do not need to trigger a new scan for a newly published CVE to appear in the Vulnerabilities Explorer.
+- The Vulnerabilities Explorer reflects the most current risk based on your last known library inventory, even for older commits.
+- The Repositories Explorer remains a fixed, point-in-time record of what was known at scan time and does not update when new advisories are published.
 
 ### Vulnerability lifecycle
 Vulnerabilities detected in libraries by SCA **at runtime** are closed by Datadog after a certain period, depending on the service's usage of the vulnerable library.

--- a/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -41,7 +41,7 @@ Datadog SCA scans libraries in the following languages using dependency manifest
 **Note:** If both a `packages.lock.json` and a `.csproj` file are present, the `packages.lock.json` takes precedence and provides more precise version resolution.
 
 ## Select where to run static SCA scans
-By default, scans run when changes are committed that update supported dependency manifests/lockfiles in an enabled repository. You can also run SCA in your CI/CD pipeline (CI jobs are supported on `push` events).
+By default, scans run when you commit changes that update supported dependency manifests or lockfiles in an enabled repository. You can also run SCA in your CI/CD pipeline; CI jobs are supported for `push` events.
 
 ### Scan with Datadog-hosted scanning
 


### PR DESCRIPTION
This PR updates the Software Composition Analysis (SCA) documentation to make the product model and UI views easier to understand.

Changes:
1. Adds a How it works section that explains Static SCA (repo scans) vs Runtime SCA (APM) and how advisory ingestion impacts results.
2. Reorganizes content into Key capabilities with clearer user workflows (prioritize vulnerabilities, view by repository, PR Gates, library inventory, APM context).
3. Adds Understanding SCA views to explain the difference between Repositories Explorer (commit-scoped snapshot) and Vulnerabilities Explorer (continuously matched), including an example.
4. Documents retroactive advisory matching so customers understand why new CVEs can appear without rerunning scans.
5. Keeps existing setup and language support references and updates “Next steps” accordingly.

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
