### PR TITLE
[DOCS-13494] Add resource tag filtering to OCI billing doc

### DIFF
--- a/content/en/account_management/billing/oci.md
+++ b/content/en/account_management/billing/oci.md
@@ -17,9 +17,10 @@ Use the OCI integration tile to control which resources Datadog collects metrics
 1. Open the [OCI integration tile][1].
 2. Go to the **Metric Collection** tab.
 3. For each connected tenancy, optionally:
-   - Limit metric collection to specific compartments.
-  
-**Note**: You can exclude OCI regions from all data collection (metrics and logs) on the **General** tab of the OCI integration tile.
+   - Limit metric collection to specific compartments using compartment tag filters.
+   - Limit metric collection to specific resources within an OCI service using resource tag filters in the **Limit Collection to Specific Resources** section.
+
+**Note**: Filters are evaluated in order: enabled services first, then compartment tag filters, then resource tag filters. Resource tag filters apply only to compartments that pass the compartment tag filter. You can exclude OCI regions from all data collection (metrics and logs) on the **General** tab of the OCI integration tile.
 
 ## OCI log exclusion
 
@@ -28,9 +29,10 @@ Use the OCI integration tile to control which resources Datadog collects logs fr
 1. Open the [OCI integration tile][1].
 2. Go to the **Log Collection** tab.
 3. For each connected tenancy, optionally:
-   - Limit log collection to specific compartments.
-  
-**Note**: You can exclude OCI regions from all data collection (metrics and logs) on the **General** tab of the OCI integration tile.
+   - Limit log collection to specific compartments using compartment tag filters.
+   - Limit log collection to specific resources within an OCI service using resource tag filters in the **Limit Collection to Specific Resources** section.
+
+**Note**: Filters are evaluated in order: enabled services first, then compartment tag filters, then resource tag filters. Resource tag filters apply only to compartments that pass the compartment tag filter. You can exclude OCI regions from all data collection (metrics and logs) on the **General** tab of the OCI integration tile.
 
 When you add or change limits for an existing OCI tenancy, previously discovered Compute instances can remain in the [Infrastructure List][3] for up to two hours while filters propagate. During this transition period, affected instances can display a status of `???`. This does not count toward your billing.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds resource tag filtering information to the OCI integration billing doc, including filter evaluation order and how resource tag filters interact with compartment tag filters.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes