### PR TITLE
Add metric_source as an optional field to experiment events

### DIFF
--- a/content/en/llm_observability/experiments/api.md
+++ b/content/en/llm_observability/experiments/api.md
@@ -540,6 +540,7 @@ Push events (spans and metrics) for an experiment.
 | `boolean_value`     | boolean  | Boolean value (when `metric_type` is `boolean`).         |
 | `json_value`        | json     | JSON value (when `metric_type` is `json`).               |
 | `metadata`          | json     | Arbitrary key-value metadata associated with the metric. |
+| `metric_source`     | string   | Optional metric source. One of: `custom`, `summary` (defaults to `custom`). |
 | `error.message`     | string   | Optional error message for the metric.                   |
 | `reasoning`         | string   | Optional explanation for the metric.                     |
 | `assessment`        | string   | Optional assessment. One of: `pass`, `fail`.             |


### PR DESCRIPTION

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR documents metric_source as an optional field to experiment events which defaults to `custom` now. Related backend PR: https://github.com/DataDog/dd-source/pull/375678


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
