### PR TITLE
[DOCS-13597] Add service mapping guidance to Static Endpoint Discovery

### DIFF
--- a/content/en/security/application_security/api-inventory/_index.md
+++ b/content/en/security/application_security/api-inventory/_index.md
@@ -151,7 +151,7 @@ datadog:
         - path/to/service/code/**
 ```
 
-This is the same mapping mechanism used by [Code Security][18]. Without explicit `codeLocations`, endpoints may not merge correctly with data from other sources.
+Without explicit `codeLocations`, endpoints may not merge correctly with data from other sources.
 
 ### Processing sensitive data
 
@@ -313,4 +313,3 @@ Click a finding to view its details and perform a workflow such as Validate > In
 [15]: https://app.datadoghq.com/security/configuration/asm/trace-tagging
 [16]: /integrations/guide/source-code-integration/
 [17]: /internal_developer_portal/software_catalog/entity_model/
-[18]: /security/code_security/static_analysis/setup/?tab=github#link-findings-to-datadog-services-and-teams


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13597

Adds a subsection under Static Endpoint Discovery explaining how to use the `codeLocations` field in Software Catalog v3 service definitions to explicitly map source code endpoints to services. Without this, endpoint-to-service mapping relies on heuristics that may not merge correctly with other data sources.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes