### PR TITLE
[DOCS-13593] Add NDM integration tables by section

### DIFF
--- a/content/en/network_monitoring/devices/integrations.md
+++ b/content/en/network_monitoring/devices/integrations.md
@@ -25,17 +25,21 @@ Network Device Monitoring (NDM) supports a growing set of integrations for route
 
 The following integrations cover **software-defined and edge networking platforms** that support NDM collection. SD-WAN is a type of networking technology that uses software-defined networking (SDN) principles to manage and optimize the performance of wide area networks (WANs). They provide visibility into link health, throughput, and connectivity across distributed sites.
 
+{{< partial name="ndm/sd-wan.html" >}}
+
 | Integration | Summary | Collection type |
 |---|---|---|
 | [Cisco ACI](/integrations/cisco-aci/) | Monitors Cisco Application Centric Infrastructure (ACI) fabric topology, endpoint group health, and tenant policy status through the APIC REST API. | Agent-based |
 | [Cisco SD-WAN](/integrations/cisco-sdwan/) | Collects device health, tunnel status, and WAN link performance metrics from Cisco Catalyst SD-WAN (vManage) through the vManage REST API. | Agent-based |
-| [VMware VeloCloud SD-WAN](/integrations/velocloud-sd-wan/) | Monitors SD-WAN edge device health, link quality, and application performance from the VMware VeloCloud Orchestrator API. | Agent-based |
-| [Fortinet FortiManager](/integrations/fortinet-fortimanager/) | Collects managed device inventory, policy deployment status, and system health metrics from Fortinet FortiManager through its JSON-RPC API. | Agent-based |
+| [VMware VeloCloud SD-WAN](/integrations/velocloud-sd-wan/) | Monitors SD-WAN edge device health, link quality, and application performance from the VMware VeloCloud Orchestrator API. | Crawler-based |
+| [Fortinet FortiManager](/integrations/fortinet-fortimanager/) | Collects managed device inventory, policy deployment status, and system health metrics from Fortinet FortiManager through its JSON-RPC API. | Crawler-based |
 | [Versa Networks](/integrations/versa/) | Monitors Versa SD-WAN appliances for device health, SLA performance, and application-aware routing metrics through the Versa Director API. | Agent-based |
 
 ## Wireless Networking
 
 The following integrations cover **wireless networking platforms** that support NDM collection. These integrations provide visibility into wireless access points, client connections, and network performance across your wireless infrastructure.
+
+{{< partial name="ndm/wireless.html" >}}
 
 | Integration | Summary | Collection type |
 |---|---|---|
@@ -44,6 +48,8 @@ The following integrations cover **wireless networking platforms** that support 
 ## Virtualization
 
 NDM can also monitor **virtualized environments** that expose network telemetry through SNMP or API-based integrations. These integrations help you correlate host-level performance with physical network metrics.
+
+{{< partial name="ndm/virtualization.html" >}}
 
 | Integration | Summary | Collection type |
 |---|---|---|


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13593

Adds per-section tables that include the integration name, a summary, and the collection type (agent-based or crawler-based). This gives users a clear, scannable overview of how each integration connects to Datadog before they start planning — addressing customer confusion about which integrations require an agent.

Rework of #34964 with proper branch naming and editorial fixes.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Original PR: #34964 by @ethomatos