### PR TITLE
[DOCS-13404] Add Java APM ebextensions config for Elastic Beanstalk

### DIFF
--- a/static/config/99datadog-java-apm.config
+++ b/static/config/99datadog-java-apm.config
@@ -1,0 +1,28 @@
+# .ebextensions/99datadog-java-apm.config
+# Installs the Datadog Java APM agent on Tomcat-based Elastic Beanstalk environments.
+# For other application servers (Spring Boot, Jetty, JBoss, and so on), see:
+# https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/java/
+
+option_settings:
+    - namespace: aws:elasticbeanstalk:application:environment
+      option_name: DD_SERVICE
+      value: "my-service" # Replace with your service name
+    - namespace: aws:elasticbeanstalk:application:environment
+      option_name: DD_ENV
+      value: "production" # Replace with your environment name
+    - namespace: aws:elasticbeanstalk:application:environment
+      option_name: DD_VERSION
+      value: "1.0" # Replace with your service version
+    - namespace: aws:elasticbeanstalk:application:environment
+      option_name: DD_LOGS_INJECTION
+      value: "true"
+    - namespace: aws:elasticbeanstalk:container:tomcat:jvmoptions
+      option_name: JvmOptions
+      value: "-javaagent:/opt/dd-java-agent.jar"
+
+files:
+  "/opt/dd-java-agent.jar":
+    mode: "000644"
+    owner: root
+    group: root
+    source: https://dtdg.co/latest-java-tracer


### PR DESCRIPTION
## What does this PR do?

Adds a new downloadable `.ebextensions` configuration file for installing the Datadog Java APM agent on Tomcat-based AWS Elastic Beanstalk environments.

## Motivation

Customers deploying Java applications on Elastic Beanstalk had no example of how to install the Java APM agent via `.ebextensions`. This config file is referenced by the Elastic Beanstalk integration docs and provides a working starting point for Tomcat environments, with comments pointing to the Java APM docs for other application servers.

## Additional notes

A companion PR in `integrations-internal-core` updates the Elastic Beanstalk integration README to reference this file and link to relevant APM documentation.

## Review checklist

- [ ] Ready for merge