### PR TITLE
Add Case Management toolset to MCP Server docs

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -419,7 +419,7 @@ Adds a comment to a case's timeline. Comments support markdown formatting.
 - Document the root cause analysis findings on this case.
 
 ### `link_jira_issue_to_datadog_case`
-*Toolset: **cases***\
+*Toolset: **cases***
 
 - Link the Jira ticket for the infrastructure migration to this case so we can track both together.
 - Connect PROJ-456 to the Datadog case so the engineering team has visibility.


### PR DESCRIPTION
## Motivation

The Cases toolset has been implemented and shipped in the Datadog MCP Server but is missing from the public documentation. Users have no way to discover these tools exist.

## Changes

Adds the `cases` toolset and its 9 tools to the MCP Server documentation page:
- **Toolsets section**: Added `cases` entry with link to Case Management docs
- **Available tools section**: Added documentation for all 9 tools with descriptions and example prompts:
  - `search_datadog_cases` — Search cases with filters (status, priority, project, assignee)
  - `get_datadog_case` — Get case details with optional timeline activity
  - `create_datadog_case` — Create a new case
  - `update_datadog_case` — Update case fields (status, priority, assignee, etc.)
  - `add_comment_to_datadog_case` — Add a comment to a case timeline
  - `link_jira_issue_to_datadog_case` — Link a Jira issue to a case
  - `list_datadog_case_projects` — List available case projects
  - `get_datadog_case_project` — Get project details
  - `search_datadog_users` — Search users for case assignment

## QA Instructions

- Preview the docs page and verify the cases toolset appears in the toolsets list (alphabetically between `core` and `dbm`)
- Verify all 9 case tools appear in the Available tools section with correct toolset labels
- Verify the `[38]` reference link to `/service_management/case_management/` resolves correctly

## Blast Radius

- Only affects the MCP Server docs page (`bits_ai/mcp_server/_index.md`)
- Additive change — no existing content modified