### PR TITLE
Revert "Add site support banner for logs scheduled reports"

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -321,7 +321,6 @@ unsupported_sites:
   linear: [gov]
   live_debugger: [gov]
   llm_observability: [gov]
-  logs_scheduled_reports: [gov]
   mcp_server: [gov]
   mobile_app_testing: [gov]
   network_config_management: [gov]

--- a/content/en/logs/reports/_index.md
+++ b/content/en/logs/reports/_index.md
@@ -1,6 +1,5 @@
 ---
 title: Scheduled CSV Reports
-site_support_id: logs_scheduled_reports
 ---
 
 ## Overview


### PR DESCRIPTION
This reverts commit 0addc2e55e589a6140554fa9fc9482b2733a9e22. (https://github.com/DataDog/documentation/pull/34570)

<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- Product Team confirmed this is available in US1-FED

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

