### PR TITLE
Enable documentation plugin from Claude Marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "extraKnownMarketplaces": {
+    "datadog-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "DataDog/claude-marketplace"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "marketplace-auto-update@datadog-claude-plugins": true,
+    "documentation@datadog-claude-plugins": true
+  }
+}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds `.claude/settings.json` to enable the documentation team's Claude Code plugin from the [Datadog Claude Marketplace](https://github.com/DataDog/claude-marketplace).

This gives everyone working in this repo automatic access to team skills:
- `/documentation:incorporate-pr-feedback` — PR review feedback workflow
- `/documentation:cdocs` — Cdocs migration assistant
- `/documentation:migrate-docs` — Page migration automation
- `/documentation:api-spec` — API spec PR reviewer
- `/documentation:process-tickets` — Bulk Jira ticket processing

Also enables `marketplace-auto-update` to keep plugins current.

### Context

- Plugin PR: https://github.com/DataDog/claude-marketplace/pull/444
- Confluence: https://datadoghq.atlassian.net/wiki/spaces/docs4docs/pages/6372786778

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

This replaces the old workflow of symlinking skills from `docs-tooling/skills/` into `~/.claude/skills/`. See the [migration guide](https://github.com/DataDog/docs-tooling/blob/brett.blue/documentation-plugin-migration/skills/README.md#migrating-from-symlinks) for teammate instructions.