### PR TITLE
[CCR-2912] Add recommendation statuses section to Cloud Cost Recommendations docs

### DIFF
--- a/content/en/cloud_cost_management/recommendations/_index.md
+++ b/content/en/cloud_cost_management/recommendations/_index.md
@@ -701,7 +701,7 @@ For each cloud account that you would like to receive recommendations for:
 
 ## Recommendation statuses
 
-Assign a status to each recommendation to track triage progress across your team. Statuses persist when recommendations regenerate daily. You don't need to re-triage the same recommendations.
+Assign a status to each recommendation to track cost optimization progress across your teams. Statuses persist when recommendations regenerate daily. You don't need to re-triage the same recommendations.
 
 | Status | Description |
 |--------|-------------|


### PR DESCRIPTION
[CCR-2912](https://datadoghq.atlassian.net/browse/CCR-2912)

### What does this PR do? What is the motivation?

Adds a "Recommendation statuses" section to the Cloud Cost Recommendations documentation. This documents the new status feature (Open, In Progress, Completed, Dismissed) that allows teams to track triage progress on cost recommendations without re-triaging daily.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code for initial draft and style guide compliance checking.

### Additional notes

This covers Milestone 1 scope only (side panel status view and modification). Table column, filter tabs, and bulk operations will be documented in follow-up PRs as those milestones ship.


[CCR-2912]: https://datadoghq.atlassian.net/browse/CCR-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ