### PR TITLE
[DOCS-13531] Expand Backstage plugin documentation in Software Catalog

### DIFF
--- a/content/en/internal_developer_portal/software_catalog/set_up/import_entities.md
+++ b/content/en/internal_developer_portal/software_catalog/set_up/import_entities.md
@@ -32,7 +32,7 @@ If you already have data or services registered in Backstage or ServiceNow, you 
 
 Use the [Datadog Backstage plugin][3] to automatically sync your Backstage catalog entities to the Datadog Software Catalog [entity model][5] on a configurable schedule. The plugin runs as a Backstage backend service and supports entity filtering (for example, you can sync only entities with a specific Backstage component type, such as services or repositories).
 
-You need a Datadog [API key][6], [application key][7], and [Datadog site][8] to configure the plugin. For installation and configuration instructions, see the [plugin README][9].
+You need a Datadog [API key][6], [application key][7], and [Datadog site][8] parameter (for example, `datadoghq.com`) to configure the plugin. For installation and configuration instructions, see the [plugin README][9].
 
 ### Import entity descriptor files from Backstage
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Expands the Backstage plugin section in the Import Entities page to give users enough context to discover and understand the plugin without duplicating content maintained in the plugin's own README.

Changes:
- Expands the "Sync Backstage entities" subsection with a description of what the plugin does, prerequisites (API key, app key, site), and a link to the plugin README for installation/configuration
- Fixes the "Example YAML for catalog-info.yaml" header to be correctly nested under its parent section (h4 instead of h3)

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Follow-up: open a PR in integrations-extras to add a callout on the Backstage integration page pointing to this content.