### PR TITLE
Add missing documentation for two insights for Node.js

### DIFF
--- a/content/en/profiler/automated_analysis.md
+++ b/content/en/profiler/automated_analysis.md
@@ -111,6 +111,8 @@ Automated Analysis supports finding the following insights:
 {{% tab "Node.js" %}}
 | Name                         | Priority   | Description |
 |------------------------------|------------|-------------|
+| CPU Burst                    | Medium     | Triggers if there is more than 75% CPU utilization across a 10s window. |
+| CPU Starvation               | High       | Triggers if no CPU samples were captured for at least 100ms. |
 | Event Loop Blocking          | Medium     | Triggers if callbacks were running for an extended period of time on the Main Event Loop thread. |
 | GC Overhead                  | Low        | Triggers if more than 20% of CPU time is related to GC activities or allocation overhead. |
 | Libuv Pool Overload          | Low        | Triggers if there were more concurrent tasks scheduled to run on the libuv thread pool than it has threads. |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Two of the profiler insights for Node.js were not documented, I'm remedying this.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge