### PR TITLE
[DOCS-XXXXX] Document DD_METRICS_OTEL_ENABLED for flag evaluation metrics

### DIFF
--- a/content/en/feature_flags/server/_index.md
+++ b/content/en/feature_flags/server/_index.md
@@ -61,9 +61,14 @@ DD_REMOTE_CONFIG_ENABLED=true
 
 # Enable the feature flagging provider (required for most SDKs)
 DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
+
+# Enable flag evaluation metrics (required for flag evaluation tracking)
+DD_METRICS_OTEL_ENABLED=true
 {{< /code-block >}}
 
 <div class="alert alert-warning">The <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code> environment variable is required to enable the feature flagging provider. Java also supports the system property <code>-Ddd.experimental.flagging.provider.enabled=true</code>, and Ruby and Node.js support code-based configuration as an alternative. See the SDK-specific documentation for details.</div>
+
+<div class="alert alert-info">Set <code>DD_METRICS_OTEL_ENABLED=true</code> to enable flag evaluation metrics. Without this, the SDK does not emit metrics for flag evaluations. When enabled, each evaluation records a <code>feature_flag.evaluations</code> counter metric tagged with the flag key, result variant, and evaluation reason.</div>
 
 ## Context attribute requirements
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-XXXXX

`DD_METRICS_OTEL_ENABLED=true` must be set for flag evaluation metrics to be emitted. Without it, the SDK uses a no-op metrics provider and no `feature_flag.evaluations` data is recorded. This adds the env var to the common server-side SDK configuration page so users know to enable it.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Implementation reference: `dd-trace-go openfeature/flageval_metrics.go` — metrics are gated on `isMetricsEnabled()` which checks `DD_METRICS_OTEL_ENABLED`.