### PR TITLE
Tone down expand/collapse toggle styling

### DIFF
--- a/assets/styles/components/_stepper.scss
+++ b/assets/styles/components/_stepper.scss
@@ -204,9 +204,10 @@ $stepper-circle-center: $stepper-title-pad-top + 1px + ($stepper-circle-size * 0
     border-radius: 0;
     background-color: transparent;
     color: $brand-primary;
-    font-size: 16px;
-    font-weight: 600;
-    text-transform: uppercase;
+    font-size: 14px;
+    font-weight: 500;
+    text-transform: none;
+    letter-spacing: 0.01em;
     line-height: $stepper-circle-size;
     gap: 4px;
 


### PR DESCRIPTION
## Summary
- Reduces visual weight of the expand all / collapse toggle so it reads as a quiet utility control rather than competing with step titles
- font-size: 16px → 14px, font-weight: 600 → 500, sentence case instead of uppercase

Preview: https://docs-staging.datadoghq.com/brett.blue/stepper-css-tweaks/a_demo/stepper/?prog_lang=go&s=btw&tab=python

## Test plan
- [ ] Verify expand/collapse text looks proportionate on desktop
- [ ] Verify mobile icons are unaffected