### PR TITLE
[DDSQL-1503] Follow-up on dd.logs() description

### DIFF
--- a/content/en/ddsql_reference/_index.md
+++ b/content/en/ddsql_reference/_index.md
@@ -957,7 +957,7 @@ SELECT *
 FROM dd.logs(
     columns => ARRAY['timestamp','host','service','message'],
     from_timestamp => now() - INTERVAL '7 days',
-    to_timestamp =>  now()
+    to_timestamp => now()
 ) AS (
     timestamp TIMESTAMP,
     host      VARCHAR,


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

Just a quick PR following up on https://github.com/DataDog/documentation/pull/35171 .
The goal is to better specify DDSQL's default time frame, since it depends on the global time context.

Motivation:
"When the time frame is not specified, DDSQL actually defaults to the global time frame for the page that the query is being run on. In the DDSQL Editor page, this happens to be the past hour, but in a notebook / dashboard / other context this time frame is configurable."

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge