### PR TITLE
[DOCS-13649] Document custom schedule limitations for non-reporting groups

### DIFF
--- a/content/en/monitors/guide/custom_schedules.md
+++ b/content/en/monitors/guide/custom_schedules.md
@@ -14,7 +14,7 @@ further_reading:
   text: "Cumulative time windows"
 ---
 
-## Overview 
+## Overview
 
 Set a specific evaluation time and control the evaluation frequency for monitors to track the execution of critical jobs running in your environment. Monitor Custom Schedules enable you to alert on systems and processes that do not need to be continuously monitored, such as cron jobs.
 
@@ -24,16 +24,16 @@ Monitor Custom Schedules are supported on events, logs, and metrics monitors wit
 
 {{< img src="/monitors/guide/custom_schedules/add_custom_schedule.png" alt="Button to add custom schedule in the monitor configuration" style="width:100%;" >}}
 
-Click **Add Custom Schedule** to configure your evaluation frequency. 
+Click **Add Custom Schedule** to configure your evaluation frequency.
 
-<div class="alert alert-danger">After a custom schedule has been enabled on a monitor, the schedule cannot be disabled. Custom schedules can only be added or removed during monitor creation.
+<div class="alert alert-danger">When a custom schedule is enabled on a monitor, the custom schedule cannot be disabled. Custom schedules can only be added or removed during monitor creation. The <strong>Remove non-reporting groups</strong> setting is unavailable. To work around this, create a new monitor without custom schedules.
 </div>
 
 {{< tabs >}}
 {{% tab "Day" %}}
 Select the time of the day you want the monitor to evaluate at.
 
-For example, the following monitor checks every day at 8:00PM that the daily backup job generated a success event for each database instance. 
+For example, the following monitor checks every day at 8:00PM that the daily backup job generated a success event for each database instance.
 
 {{< img src="monitors/guide/custom_schedules/custom_day.png" alt="Monitor configuration to check every day at 8pm that a success event has been generated for each database instance as a result of the daily backup job" style="width:100%;" >}}
 
@@ -42,7 +42,7 @@ For example, the following monitor checks every day at 8:00PM that the daily bac
 {{% tab "Week" %}}
 Select the days of the week as well as the time of the day you want the monitor to evaluate at.
 
-For example, the following monitor checks every week on Tuesday and Saturday at 6:00AM that marketing emails have been sent for each individual campaign. 
+For example, the following monitor checks every week on Tuesday and Saturday at 6:00AM that marketing emails have been sent for each individual campaign.
 
 {{< img src="monitors/guide/custom_schedules/custom_week.png" alt="Monitor configuration to check every week on Tuesday and Saturday at 6am that marketing emails have been sent for each individual campaign" style="width:100%;" >}}
 
@@ -60,11 +60,11 @@ For example, the following monitor checks on the first day of each month whether
 
 ## RRULES
 
-Recurrence rule (RRULE) is a property name from the [iCalendar RFC][1], which is the standard for defining recurring events. Use the [official RRULE generator][2] to generate recurring rules. Leverage RRULEs to cover more advanced scheduling use cases. 
+Recurrence rule (RRULE) is a property name from the [iCalendar RFC][1], which is the standard for defining recurring events. Use the [official RRULE generator][2] to generate recurring rules. Leverage RRULEs to cover more advanced scheduling use cases.
 
 To write a custom RRULE for your monitor, click **Use RRULE**.
 
-**Notes**: 
+**Notes**:
 - Attributes specifying the duration in RRULE are not supported (for example, DTSTART, DTEND, DURATION).
 - Evaluation frequencies must be a day or longer. For shorter evaluation frequencies, use the default monitor schedules.
 
@@ -84,13 +84,13 @@ FREQ=MONTHLY;INTERVAL=2;BYDAY=1SU,-1SU
 
 ## Alerting behavior of monitors with custom schedules
 
-Monitors using default scheduling run the query with the default evaluation frequency and send alerts based on monitor status transitions (for example, when a monitor goes from WARN to OK or from OK to ALERT). 
+Monitors using default scheduling run the query with the default evaluation frequency and send alerts based on monitor status transitions (for example, when a monitor goes from WARN to OK or from OK to ALERT).
 
 The timeline below illustrates the behavior of a monitor with default scheduling. The monitor sends alerts corresponding to status changes.
 
 {{< img src="monitors/guide/custom_schedules/alerting_behavior_regular.png" alt="Visual diagram showing a when a monitor sends an alert based on monitor state transitions for the default schedule with a thirty minute evaluation frequency" style="width:100%;" >}}
 
-Monitors with custom schedules, on the other hand, evaluate on a daily, weekly, or monthly basis and send alerts based on the results of individual evaluations. Each evaluation is independent from the previous one and sends a notification when the result is not OK. 
+Monitors with custom schedules, on the other hand, evaluate on a daily, weekly, or monthly basis and send alerts based on the results of individual evaluations. Each evaluation is independent from the previous one and sends a notification when the result is not OK.
 
 The timeline below illustrates the behavior of a monitor running on a custom schedule. Unlike the default scheduled monitor, the custom scheduled monitor sends an alert during its evaluation time based on the monitor state.
 {{< img src="monitors/guide/custom_schedules/alerting_behavior_custom.png" alt="Visual diagram showing a when a monitor sends an alert based on monitor state for the custom schedule with a daily evaluation frequency" style="width:100%;" >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Fixes [DOCS-13649](https://datadoghq.atlassian.net/browse/DOCS-13649)
- Trim whitespace

Adds documentation to the Custom Schedules page noting that when a custom schedule is enabled on a monitor, the **Remove non-reporting groups** setting is unavailable. Decommissioned or renamed hosts continue to be evaluated past the standard retention window, and the workaround is to recreate the monitor without a custom schedule.

### Merge instructions

Merge readiness:
- [x] Ready for merge


[DOCS-13649]: https://datadoghq.atlassian.net/browse/DOCS-13649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ