### PR TITLE
Update Go Live Debugger page with eBPF limitations

### DIFF
--- a/content/en/tracing/trace_collection/dynamic_instrumentation/enabling/go.md
+++ b/content/en/tracing/trace_collection/dynamic_instrumentation/enabling/go.md
@@ -96,6 +96,7 @@ See the [Live Debugger documentation][4] for information about adding instrument
 - Log templates and condition expressions
 - PII redaction based on specific classes or types
 - Propagation of additional `DD_TAGS` set on the service to probe result tags
+- Environments where eBPF is unavailable, including many serverless platforms such as AWS Lambda and AWS Fargate
 
 ## Further reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

This PR notes that the Go Live Debugger and Dynamic Instrumentation do not work on serverless platforms like Lambda and Fargate. This came out of [Zendesk Ticket: 2522573](https://datadog.zendesk.com/agent/tickets/2522573).


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes

<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
