### PR TITLE
[DOCS-13642] Add US1-FED port restriction note to log forwarding docs

### DIFF
--- a/content/en/logs/log_configuration/forwarding_custom_destinations.md
+++ b/content/en/logs/log_configuration/forwarding_custom_destinations.md
@@ -40,7 +40,9 @@ The following metrics report on logs that have been forwarded successfully, incl
 ## Set up log forwarding to custom destinations
 
 {{< site-region region="gov" >}}
-<div class="alert alert-danger">Sending logs to a custom destination is outside of the Datadog GovCloud environment, which is outside the control of Datadog. Datadog shall not be responsible for any logs that have left the Datadog GovCloud environment, including without limitation, any obligations or requirements that the user may have related to FedRAMP, DoD Impact Levels, ITAR, export compliance, data residency or similar regulations applicable to such logs.</div>
+<div class="alert alert-danger">Sending logs to a custom destination is outside of the Datadog GovCloud environment, which is outside the control of Datadog. Datadog shall not be responsible for any logs that have left the Datadog GovCloud environment, including without limitation, any obligations or requirements that the user may have related to FedRAMP, DoD Impact Levels, ITAR, export compliance, data residency or similar regulations applicable to such logs.
+<br><br>
+Due to security protocols for the US1-FED site, only port 443 and 8088 are open for log forwarding. To use a different port, contact <a href="https://www.datadoghq.com/support/">Datadog Support</a>.</div>
 {{< /site-region >}}
 
 1. Add webhook IPs from the {{< region-param key="ip_ranges_url" link="true" text="IP ranges list">}} to the allowlist.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
- https://datadoghq.atlassian.net/browse/DOCS-13642
- Add available ports for US1-FED
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
