### PR TITLE
[RUM-14619] Add setViewLoadingTime API documentation

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/monitoring_page_performance.md
@@ -121,7 +121,6 @@ Each call replaces any previously set value (last-call-wins). After it is called
 
 After the loading time is sent, it is accessible as `@view.loading_time` and is visible in the RUM UI.
 
-**Note**: This API is experimental and might change in the future.
 
 ### How page activity is calculated
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents the new `setViewLoadingTime()` experimental API for the Browser RUM SDK. This API allows developers to manually set a view's loading time, overriding the automatic calculation based on network requests and DOM mutations.

The documentation is added to the "Monitoring Page Performance" page, as a new subsection under "How loading time is calculated", consistent with how the mobile SDKs document the equivalent `addViewLoadingTime` API.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

The corresponding SDK change has already been shipped, see https://github.com/DataDog/browser-sdk/pull/4180 released in [v6.31.0](https://github.com/DataDog/browser-sdk/releases/tag/v6.31.0). This PR adds the missing public documentation.