### PR TITLE
Add Azure Container Apps AAP setup documentation

### DIFF
--- a/content/en/security/application_security/setup/_index.md
+++ b/content/en/security/application_security/setup/_index.md
@@ -79,4 +79,5 @@ Learn how to enable App and API Protection on all the following supported platfo
 
 {{< appsec-integrations >}}
   {{< appsec-integration name="Azure App Service" avatar="azure-appserviceenvironment" link="./azure/app-service" >}}
+  {{< appsec-integration name="Azure Container Apps" avatar="azure-container-apps" link="./azure/container-apps" >}}
 {{< /appsec-integrations >}}

--- a/content/en/security/application_security/setup/azure/container-apps/_index.md
+++ b/content/en/security/application_security/setup/azure/container-apps/_index.md
@@ -1,0 +1,43 @@
+---
+title: Enabling App and API Protection for Azure Container Apps
+disable_sidebar: true
+further_reading:
+- link: "/security/application_security/"
+  tag: "Documentation"
+  text: "Protect against Threats with Datadog App and API Protection"
+- link: "/security/application_security/add-user-info/"
+  tag: "Documentation"
+  text: "Tracking user activity"
+- link: "/security/default_rules/?category=cat-application-security"
+  tag: "Documentation"
+  text: "OOTB App and API Protection Rules"
+- link: "/security/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting App and API Protection"
+- link: "/security/application_security/how-it-works/"
+  tag: "Documentation"
+  text: "How App and API Protection Works in Datadog"
+---
+
+Learn how to set up App and API Protection (AAP) on your Azure Container Apps by selecting the programming language your application is written in.
+
+<div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
+
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][1] to block IPs in your [WAF][2].
+
+{{< appsec-integrations >}}
+  {{< appsec-integration name="Python" avatar="python" link="./python" >}}
+  {{< appsec-integration name="Node.js" avatar="node" link="./nodejs" >}}
+  {{< appsec-integration name="Java" avatar="java" link="./java" >}}
+  {{< appsec-integration name="Go" avatar="go" link="./go" >}}
+  {{< appsec-integration name="Ruby" avatar="ruby" link="./ruby" >}}
+  {{< appsec-integration name=".NET" avatar="dotnet" link="./dotnet" >}}
+  {{< appsec-integration name="PHP" avatar="php" link="./php" >}}
+{{< /appsec-integrations >}}
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /actions/workflows/
+[2]: /security/application_security/waf-integration/

--- a/content/en/security/application_security/setup/azure/container-apps/dotnet.md
+++ b/content/en/security/application_security/setup/azure/container-apps/dotnet.md
@@ -1,0 +1,146 @@
+---
+title: Enabling App and API Protection for Azure Container Apps in .NET
+further_reading:
+    - link: "/security/application_security/how-it-works/"
+      tag: "Documentation"
+      text: "How App and API Protection Works"
+    - link: "/security/default_rules/?category=cat-application-security"
+      tag: "Documentation"
+      text: "OOTB App and API Protection Rules"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+    - link: "/security/application_security/threats/"
+      tag: "Documentation"
+      text: "App and API Protection"
+---
+
+<div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
+
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][5] to block IPs in your [WAF][6].
+
+## Setup
+
+{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
+
+Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
+
+1. **Install the Datadog .NET tracer** in your Dockerfile.
+
+   {{< tabs >}}
+   {{% tab "Standard Linux (glibc)" %}}
+{{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
+ARG TRACER_VERSION
+RUN curl -L -s "https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm_${TRACER_VERSION}_amd64.deb" --output datadog-dotnet-apm.deb && \
+   dpkg -i datadog-dotnet-apm.deb
+{{< /code-block >}}
+   {{% /tab %}}
+
+   {{% tab "Alpine (musl)" %}}
+{{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
+# For alpine use datadog-dotnet-apm-2.57.0-musl.tar.gz
+ARG TRACER_VERSION
+ADD https://github.com/DataDog/dd-trace-dotnet/releases/download/v${TRACER_VERSION}/datadog-dotnet-apm-${TRACER_VERSION}.tar.gz /tmp/datadog-dotnet-apm.tar.gz
+
+RUN mkdir -p /dd_tracer/dotnet/ && tar -xzvf /tmp/datadog-dotnet-apm.tar.gz -C /dd_tracer/dotnet/ && rm /tmp/datadog-dotnet-apm.tar.gz
+{{< /code-block >}}
+   {{% /tab %}}
+   {{< /tabs >}}
+
+   See the [dd-trace-dotnet releases][1] to view the latest tracer version.
+
+   For more information, see [Tracing .NET applications][2].
+
+2. **Enable App and API Protection**.
+
+   Set the following environment variable in your application container:
+
+   ```
+   DD_APPSEC_ENABLED=true
+   ```
+
+3. **Install serverless-init as a sidecar**.
+
+   {{% serverless-init-install mode="sidecar" %}}
+
+   {{< tabs >}}
+
+   {{% tab "Datadog CLI" %}}
+   {{% aca-install-sidecar-datadog-ci %}}
+   {{% /tab %}}
+
+   {{% tab "Terraform" %}}
+   {{% aca-install-sidecar-terraform %}}
+   {{% /tab %}}
+
+   {{% tab "Bicep" %}}
+   {{% aca-install-sidecar-bicep %}}
+   {{% /tab %}}
+
+   {{% tab "ARM Template" %}}
+   {{% aca-install-sidecar-arm-template %}}
+   {{% /tab %}}
+
+   {{% tab "Manual" %}}
+   {{% aca-install-sidecar-manual %}}
+   {{% /tab %}}
+
+   {{< /tabs >}}
+
+4. **Set up logs**.
+
+   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. In .NET, Datadog recommends writing logs in a JSON format. For example, you can use a third-party logging library such as `Serilog`:
+   {{< code-block lang="csharp" disable_copy="false" >}}
+using Serilog;
+
+const string LOG_FILE = "/LogFiles/app.log";
+
+builder.Host.UseSerilog((context, config) =>
+{
+    // Ensure the directory exists
+    Directory.CreateDirectory(Path.GetDirectoryName(LOG_FILE)!);
+
+    config.WriteTo.Console(new Serilog.Formatting.Json.JsonFormatter(renderMessage: true))
+          .WriteTo.File(new Serilog.Formatting.Json.JsonFormatter(renderMessage: true), LOG_FILE);
+});
+
+logger.LogInformation("Hello World!");
+{{< /code-block >}}
+
+   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=csharp` (in your sidecar container) to enable advanced Datadog log parsing.
+
+   For more information, see [Correlating .NET Logs and Traces][3].
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
+To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
+
+Follow the same steps as above, but set the following environment variables in your application container:
+
+```
+DD_APPSEC_ENABLED=true
+DD_APM_TRACING_ENABLED=false
+```
+
+{{% /collapse-content %}}
+
+## Testing threat detection
+
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][4] attempt:
+```sh
+curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
+```
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][8].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/dd-trace-dotnet/releases/
+[2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core/?tab=linux
+[3]: /tracing/other_telemetry/connect_logs_and_traces/dotnet/
+[4]: /security/default_rules/security-scan-detected/
+[5]: /actions/workflows/
+[6]: /security/application_security/waf-integration/
+[8]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/dotnet.md
+++ b/content/en/security/application_security/setup/azure/container-apps/dotnet.md
@@ -1,29 +1,25 @@
 ---
 title: Enabling App and API Protection for Azure Container Apps in .NET
 further_reading:
-    - link: "/security/application_security/how-it-works/"
-      tag: "Documentation"
-      text: "How App and API Protection Works"
-    - link: "/security/default_rules/?category=cat-application-security"
-      tag: "Documentation"
-      text: "OOTB App and API Protection Rules"
-    - link: "/security/application_security/troubleshooting"
-      tag: "Documentation"
-      text: "Troubleshooting App and API Protection"
-    - link: "/security/application_security/threats/"
-      tag: "Documentation"
-      text: "App and API Protection"
+- link: "/security/application_security/how-it-works/"
+  tag: "Documentation"
+  text: "How App and API Protection Works"
+- link: "/security/default_rules/?category=cat-application-security"
+  tag: "Documentation"
+  text: "OOTB App and API Protection Rules"
+- link: "/security/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting App and API Protection"
+- link: "/security/application_security/threats/"
+  tag: "Documentation"
+  text: "App and API Protection"
 ---
 
 <div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
 
-**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][5] to block IPs in your [WAF][6].
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][3] to block IPs in your [WAF][4].
 
 ## Setup
-
-{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
-
-Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
 
 1. **Install the Datadog .NET tracer** in your Dockerfile.
 
@@ -51,15 +47,7 @@ RUN mkdir -p /dd_tracer/dotnet/ && tar -xzvf /tmp/datadog-dotnet-apm.tar.gz -C /
 
    For more information, see [Tracing .NET applications][2].
 
-2. **Enable App and API Protection**.
-
-   Set the following environment variable in your application container:
-
-   ```
-   DD_APPSEC_ENABLED=true
-   ```
-
-3. **Install serverless-init as a sidecar**.
+2. **Install serverless-init as a sidecar**.
 
    {{% serverless-init-install mode="sidecar" %}}
 
@@ -87,51 +75,31 @@ RUN mkdir -p /dd_tracer/dotnet/ && tar -xzvf /tmp/datadog-dotnet-apm.tar.gz -C /
 
    {{< /tabs >}}
 
-4. **Set up logs**.
+## Configuration
 
-   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. In .NET, Datadog recommends writing logs in a JSON format. For example, you can use a third-party logging library such as `Serilog`:
-   {{< code-block lang="csharp" disable_copy="false" >}}
-using Serilog;
+### Enable App and API Protection
 
-const string LOG_FILE = "/LogFiles/app.log";
+Set the environment variable `DD_APPSEC_ENABLED=true` in your application container to enable App and API Protection.
 
-builder.Host.UseSerilog((context, config) =>
-{
-    // Ensure the directory exists
-    Directory.CreateDirectory(Path.GetDirectoryName(LOG_FILE)!);
+### Disable APM tracing
 
-    config.WriteTo.Console(new Serilog.Formatting.Json.JsonFormatter(renderMessage: true))
-          .WriteTo.File(new Serilog.Formatting.Json.JsonFormatter(renderMessage: true), LOG_FILE);
-});
+To use App and API Protection without APM tracing, set `DD_APM_TRACING_ENABLED=false` in your application container in addition to `DD_APPSEC_ENABLED=true`.
 
-logger.LogInformation("Hello World!");
-{{< /code-block >}}
+{{% serverless-init-env-vars-sidecar language="csharp" defaultSource="containerapp" %}}
 
-   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=csharp` (in your sidecar container) to enable advanced Datadog log parsing.
-
-   For more information, see [Correlating .NET Logs and Traces][3].
-
-{{% /collapse-content %}}
-
-{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
-To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
-
-Follow the same steps as above, but set the following environment variables in your application container:
-
-```
-DD_APPSEC_ENABLED=true
-DD_APM_TRACING_ENABLED=false
-```
-
-{{% /collapse-content %}}
+{{% svl-tracing-env %}}
 
 ## Testing threat detection
 
-To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][4] attempt:
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][5] attempt:
 ```sh
 curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
 ```
-After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][8].
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][6].
+
+## Troubleshooting
+
+{{% serverless-init-troubleshooting productNames="Azure Container Apps" %}}
 
 ## Further reading
 
@@ -139,8 +107,7 @@ After you enable your application and exercise it, threat information appears in
 
 [1]: https://github.com/DataDog/dd-trace-dotnet/releases/
 [2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/dotnet-core/?tab=linux
-[3]: /tracing/other_telemetry/connect_logs_and_traces/dotnet/
-[4]: /security/default_rules/security-scan-detected/
-[5]: /actions/workflows/
-[6]: /security/application_security/waf-integration/
-[8]: https://app.datadoghq.com/security/appsec
+[3]: /actions/workflows/
+[4]: /security/application_security/waf-integration/
+[5]: /security/default_rules/security-scan-detected/
+[6]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/go.md
+++ b/content/en/security/application_security/setup/azure/container-apps/go.md
@@ -1,29 +1,25 @@
 ---
 title: Enabling App and API Protection for Azure Container Apps in Go
 further_reading:
-    - link: "/security/application_security/how-it-works/"
-      tag: "Documentation"
-      text: "How App and API Protection Works"
-    - link: "/security/default_rules/?category=cat-application-security"
-      tag: "Documentation"
-      text: "OOTB App and API Protection Rules"
-    - link: "/security/application_security/troubleshooting"
-      tag: "Documentation"
-      text: "Troubleshooting App and API Protection"
-    - link: "/security/application_security/threats/"
-      tag: "Documentation"
-      text: "App and API Protection"
+- link: "/security/application_security/how-it-works/"
+  tag: "Documentation"
+  text: "How App and API Protection Works"
+- link: "/security/default_rules/?category=cat-application-security"
+  tag: "Documentation"
+  text: "OOTB App and API Protection Rules"
+- link: "/security/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting App and API Protection"
+- link: "/security/application_security/threats/"
+  tag: "Documentation"
+  text: "App and API Protection"
 ---
 
 <div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
 
-**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][5] to block IPs in your [WAF][6].
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][4] to block IPs in your [WAF][5].
 
 ## Setup
-
-{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
-
-Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
 
 1. **Install the Datadog Go tracer**.
 
@@ -48,23 +44,14 @@ go get github.com/DataDog/dd-trace-go/v2/profiler
 go get github.com/DataDog/dd-trace-go/contrib/net/http/v2
 {{< /code-block >}}
 
-   For more information, see [Tracing Go Applications][1] and the [Tracer README][2].
-
    Compile your Go binary with the `appsec` build tag enabled:
-
    {{< code-block lang="shell" disable_copy="false" >}}
 go build --tags "appsec" ...
 {{< /code-block >}}
 
-2. **Enable App and API Protection**.
+   For more information, see [Tracing Go Applications][1] and the [Tracer README][2].
 
-   Set the following environment variable in your application container:
-
-   ```
-   DD_APPSEC_ENABLED=true
-   ```
-
-3. **Install serverless-init as a sidecar**.
+2. **Install serverless-init as a sidecar**.
 
    {{% serverless-init-install mode="sidecar" %}}
 
@@ -92,48 +79,31 @@ go build --tags "appsec" ...
 
    {{< /tabs >}}
 
-4. **Set up logs**.
+## Configuration
 
-   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. In Go, Datadog recommends writing logs in a JSON format. For example, you can use a third-party logging library such as `logrus`:
-   {{< code-block lang="go" disable_copy="false" >}}
-const LOG_FILE = "/LogFiles/app.log"
+### Enable App and API Protection
 
-os.MkdirAll(filepath.Dir(LOG_FILE), 0755)
-logFile, err := os.OpenFile(LOG_FILE, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
-defer logFile.Close()
+Set the environment variable `DD_APPSEC_ENABLED=true` in your application container to enable App and API Protection.
 
-logrus.SetOutput(logFile)
-logrus.SetFormatter(&logrus.JSONFormatter{})
-logrus.AddHook(&dd_logrus.DDContextLogHook{})
+### Disable APM tracing
 
-logrus.WithContext(ctx).Info("Hello World!")
-{{< /code-block >}}
+To use App and API Protection without APM tracing, set `DD_APM_TRACING_ENABLED=false` in your application container in addition to `DD_APPSEC_ENABLED=true`.
 
-   Datadog recommends setting the environment variable `DD_SOURCE=go` in your sidecar container to enable advanced Datadog log parsing.
+{{% serverless-init-env-vars-sidecar language="go" defaultSource="containerapp" %}}
 
-   For more information, see [Correlating Go Logs and Traces][3].
-
-{{% /collapse-content %}}
-
-{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
-To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
-
-Follow the same steps as above, but set the following environment variables in your application container:
-
-```
-DD_APPSEC_ENABLED=true
-DD_APM_TRACING_ENABLED=false
-```
-
-{{% /collapse-content %}}
+{{% svl-tracing-env %}}
 
 ## Testing threat detection
 
-To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][4] attempt:
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][6] attempt:
 ```sh
 curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
 ```
-After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][8].
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][7].
+
+## Troubleshooting
+
+{{% serverless-init-troubleshooting productNames="Azure Container Apps" %}}
 
 ## Further reading
 
@@ -142,7 +112,7 @@ After you enable your application and exercise it, threat information appears in
 [1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/go/
 [2]: https://github.com/DataDog/dd-trace-go?tab=readme-ov-file#installing
 [3]: /tracing/other_telemetry/connect_logs_and_traces/go/
-[4]: /security/default_rules/security-scan-detected/
-[5]: /actions/workflows/
-[6]: /security/application_security/waf-integration/
-[8]: https://app.datadoghq.com/security/appsec
+[4]: /actions/workflows/
+[5]: /security/application_security/waf-integration/
+[6]: /security/default_rules/security-scan-detected/
+[7]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/go.md
+++ b/content/en/security/application_security/setup/azure/container-apps/go.md
@@ -1,0 +1,148 @@
+---
+title: Enabling App and API Protection for Azure Container Apps in Go
+further_reading:
+    - link: "/security/application_security/how-it-works/"
+      tag: "Documentation"
+      text: "How App and API Protection Works"
+    - link: "/security/default_rules/?category=cat-application-security"
+      tag: "Documentation"
+      text: "OOTB App and API Protection Rules"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+    - link: "/security/application_security/threats/"
+      tag: "Documentation"
+      text: "App and API Protection"
+---
+
+<div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
+
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][5] to block IPs in your [WAF][6].
+
+## Setup
+
+{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
+
+Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
+
+1. **Install the Datadog Go tracer**.
+
+   1. In your main application, add the tracing library from `dd-trace-go`.
+
+      {{< code-block lang="shell" disable_copy="false" >}}
+go get github.com/DataDog/dd-trace-go/v2/ddtrace/tracer
+{{< /code-block >}}
+
+   2. Add the following to your application code to initialize the tracer:
+      {{< code-block lang="go" disable_copy="false" >}}
+tracer.Start()
+defer tracer.Stop()
+{{< /code-block >}}
+
+   You can also add additional packages:
+   {{< code-block lang="shell" disable_copy="false" >}}
+# Enable Profiling
+go get github.com/DataDog/dd-trace-go/v2/profiler
+
+# Patch /net/http
+go get github.com/DataDog/dd-trace-go/contrib/net/http/v2
+{{< /code-block >}}
+
+   For more information, see [Tracing Go Applications][1] and the [Tracer README][2].
+
+   Compile your Go binary with the `appsec` build tag enabled:
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+go build --tags "appsec" ...
+{{< /code-block >}}
+
+2. **Enable App and API Protection**.
+
+   Set the following environment variable in your application container:
+
+   ```
+   DD_APPSEC_ENABLED=true
+   ```
+
+3. **Install serverless-init as a sidecar**.
+
+   {{% serverless-init-install mode="sidecar" %}}
+
+   {{< tabs >}}
+
+   {{% tab "Datadog CLI" %}}
+   {{% aca-install-sidecar-datadog-ci %}}
+   {{% /tab %}}
+
+   {{% tab "Terraform" %}}
+   {{% aca-install-sidecar-terraform %}}
+   {{% /tab %}}
+
+   {{% tab "Bicep" %}}
+   {{% aca-install-sidecar-bicep %}}
+   {{% /tab %}}
+
+   {{% tab "ARM Template" %}}
+   {{% aca-install-sidecar-arm-template %}}
+   {{% /tab %}}
+
+   {{% tab "Manual" %}}
+   {{% aca-install-sidecar-manual %}}
+   {{% /tab %}}
+
+   {{< /tabs >}}
+
+4. **Set up logs**.
+
+   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. In Go, Datadog recommends writing logs in a JSON format. For example, you can use a third-party logging library such as `logrus`:
+   {{< code-block lang="go" disable_copy="false" >}}
+const LOG_FILE = "/LogFiles/app.log"
+
+os.MkdirAll(filepath.Dir(LOG_FILE), 0755)
+logFile, err := os.OpenFile(LOG_FILE, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+defer logFile.Close()
+
+logrus.SetOutput(logFile)
+logrus.SetFormatter(&logrus.JSONFormatter{})
+logrus.AddHook(&dd_logrus.DDContextLogHook{})
+
+logrus.WithContext(ctx).Info("Hello World!")
+{{< /code-block >}}
+
+   Datadog recommends setting the environment variable `DD_SOURCE=go` in your sidecar container to enable advanced Datadog log parsing.
+
+   For more information, see [Correlating Go Logs and Traces][3].
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
+To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
+
+Follow the same steps as above, but set the following environment variables in your application container:
+
+```
+DD_APPSEC_ENABLED=true
+DD_APM_TRACING_ENABLED=false
+```
+
+{{% /collapse-content %}}
+
+## Testing threat detection
+
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][4] attempt:
+```sh
+curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
+```
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][8].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/go/
+[2]: https://github.com/DataDog/dd-trace-go?tab=readme-ov-file#installing
+[3]: /tracing/other_telemetry/connect_logs_and_traces/go/
+[4]: /security/default_rules/security-scan-detected/
+[5]: /actions/workflows/
+[6]: /security/application_security/waf-integration/
+[8]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/java.md
+++ b/content/en/security/application_security/setup/azure/container-apps/java.md
@@ -1,29 +1,25 @@
 ---
 title: Enabling App and API Protection for Azure Container Apps in Java
 further_reading:
-    - link: "/security/application_security/how-it-works/"
-      tag: "Documentation"
-      text: "How App and API Protection Works"
-    - link: "/security/default_rules/?category=cat-application-security"
-      tag: "Documentation"
-      text: "OOTB App and API Protection Rules"
-    - link: "/security/application_security/troubleshooting"
-      tag: "Documentation"
-      text: "Troubleshooting App and API Protection"
-    - link: "/security/application_security/threats/"
-      tag: "Documentation"
-      text: "App and API Protection"
+- link: "/security/application_security/how-it-works/"
+  tag: "Documentation"
+  text: "How App and API Protection Works"
+- link: "/security/default_rules/?category=cat-application-security"
+  tag: "Documentation"
+  text: "OOTB App and API Protection Rules"
+- link: "/security/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting App and API Protection"
+- link: "/security/application_security/threats/"
+  tag: "Documentation"
+  text: "App and API Protection"
 ---
 
 <div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
 
-**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][6] to block IPs in your [WAF][7].
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][4] to block IPs in your [WAF][5].
 
 ## Setup
-
-{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
-
-Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
 
 1. **Install the Datadog Java tracer**.
 
@@ -59,15 +55,7 @@ implementation 'com.datadoghq:dd-trace-api:DD_TRACE_JAVA_VERSION_HERE'
 
    For more information, see [Tracing Java Applications][2].
 
-2. **Enable App and API Protection**.
-
-   Set the following environment variable in your application container:
-
-   ```
-   DD_APPSEC_ENABLED=true
-   ```
-
-3. **Install serverless-init as a sidecar**.
+2. **Install serverless-init as a sidecar**.
 
    {{% serverless-init-install mode="sidecar" %}}
 
@@ -95,52 +83,31 @@ implementation 'com.datadoghq:dd-trace-api:DD_TRACE_JAVA_VERSION_HERE'
 
    {{< /tabs >}}
 
-4. **Set up logs**.
+## Configuration
 
-   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. In Java, Datadog recommends writing logs in a JSON format. For example, you can use a third-party logging library such as `Log4j 2`:
+### Enable App and API Protection
 
-   {{< code-block lang="java" disable_copy="false" >}}
-private static final Logger logger = LogManager.getLogger(App.class);
-logger.info("Hello World!");
-{{< /code-block >}}
+Set the environment variable `DD_APPSEC_ENABLED=true` in your application container to enable App and API Protection.
 
-   {{< code-block lang="xml" filename="resources/log4j2.xml" disable_copy="false" >}}
-<Configuration>
-  <Appenders>
-    <Console name="Console"><JsonLayout compact="true" eventEol="true" properties="true"/></Console>
-    <File name="FileAppender" fileName="/LogFiles/app.log">
-      <JsonLayout compact="true" eventEol="true" properties="true"/>
-    </File>
-  </Appenders>
-  <Loggers><Root level="info"><AppenderRef ref="FileAppender"/></Root></Loggers>
-</Configuration>
-{{< /code-block >}}
+### Disable APM tracing
 
-   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=java` (in your sidecar container) to enable advanced Datadog log parsing.
+To use App and API Protection without APM tracing, set `DD_APM_TRACING_ENABLED=false` in your application container in addition to `DD_APPSEC_ENABLED=true`.
 
-   For more information, see [Correlating Java Logs and Traces][3].
+{{% serverless-init-env-vars-sidecar language="java" defaultSource="containerapp" %}}
 
-{{% /collapse-content %}}
-
-{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
-To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
-
-Follow the same steps as above, but set the following environment variables in your application container:
-
-```
-DD_APPSEC_ENABLED=true
-DD_APM_TRACING_ENABLED=false
-```
-
-{{% /collapse-content %}}
+{{% svl-tracing-env %}}
 
 ## Testing threat detection
 
-To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][5] attempt:
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][6] attempt:
 ```sh
 curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
 ```
-After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][4].
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][7].
+
+## Troubleshooting
+
+{{% serverless-init-troubleshooting productNames="Azure Container Apps" %}}
 
 ## Further reading
 
@@ -149,7 +116,7 @@ After you enable your application and exercise it, threat information appears in
 [1]: https://github.com/DataDog/dd-trace-java/releases
 [2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
 [3]: /tracing/other_telemetry/connect_logs_and_traces/java/
-[4]: https://app.datadoghq.com/security/appsec
-[5]: /security/default_rules/security-scan-detected/
-[6]: /actions/workflows/
-[7]: /security/application_security/waf-integration/
+[4]: /actions/workflows/
+[5]: /security/application_security/waf-integration/
+[6]: /security/default_rules/security-scan-detected/
+[7]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/java.md
+++ b/content/en/security/application_security/setup/azure/container-apps/java.md
@@ -1,0 +1,155 @@
+---
+title: Enabling App and API Protection for Azure Container Apps in Java
+further_reading:
+    - link: "/security/application_security/how-it-works/"
+      tag: "Documentation"
+      text: "How App and API Protection Works"
+    - link: "/security/default_rules/?category=cat-application-security"
+      tag: "Documentation"
+      text: "OOTB App and API Protection Rules"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+    - link: "/security/application_security/threats/"
+      tag: "Documentation"
+      text: "App and API Protection"
+---
+
+<div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
+
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][6] to block IPs in your [WAF][7].
+
+## Setup
+
+{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
+
+Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
+
+1. **Install the Datadog Java tracer**.
+
+   1. Add the Datadog Java tracer to your Dockerfile:
+
+      {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
+ADD 'https://dtdg.co/latest-java-tracer' agent.jar
+ENV JAVA_TOOL_OPTIONS="-javaagent:agent.jar"
+{{< /code-block >}}
+
+   2. Add the tracer artifacts.
+      {{< tabs >}}
+      {{% tab "Maven" %}}
+{{< code-block lang="xml" disable_copy="false" >}}
+<dependency>
+  <groupId>com.datadoghq</groupId>
+  <artifactId>dd-trace-api</artifactId>
+  <version>DD_TRACE_JAVA_VERSION_HERE</version>
+</dependency>
+{{< /code-block >}}
+      {{% /tab %}}
+
+      {{% tab "Gradle" %}}
+{{< code-block lang="groovy" disable_copy="false" >}}
+implementation 'com.datadoghq:dd-trace-api:DD_TRACE_JAVA_VERSION_HERE'
+{{< /code-block >}}
+      {{% /tab %}}
+      {{< /tabs >}}
+
+      See [dd-trace-java releases][1] for the latest tracer version.
+
+   3. Add the `@Trace` annotation to any method you want to trace.
+
+   For more information, see [Tracing Java Applications][2].
+
+2. **Enable App and API Protection**.
+
+   Set the following environment variable in your application container:
+
+   ```
+   DD_APPSEC_ENABLED=true
+   ```
+
+3. **Install serverless-init as a sidecar**.
+
+   {{% serverless-init-install mode="sidecar" %}}
+
+   {{< tabs >}}
+
+   {{% tab "Datadog CLI" %}}
+   {{% aca-install-sidecar-datadog-ci %}}
+   {{% /tab %}}
+
+   {{% tab "Terraform" %}}
+   {{% aca-install-sidecar-terraform %}}
+   {{% /tab %}}
+
+   {{% tab "Bicep" %}}
+   {{% aca-install-sidecar-bicep %}}
+   {{% /tab %}}
+
+   {{% tab "ARM Template" %}}
+   {{% aca-install-sidecar-arm-template %}}
+   {{% /tab %}}
+
+   {{% tab "Manual" %}}
+   {{% aca-install-sidecar-manual %}}
+   {{% /tab %}}
+
+   {{< /tabs >}}
+
+4. **Set up logs**.
+
+   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. In Java, Datadog recommends writing logs in a JSON format. For example, you can use a third-party logging library such as `Log4j 2`:
+
+   {{< code-block lang="java" disable_copy="false" >}}
+private static final Logger logger = LogManager.getLogger(App.class);
+logger.info("Hello World!");
+{{< /code-block >}}
+
+   {{< code-block lang="xml" filename="resources/log4j2.xml" disable_copy="false" >}}
+<Configuration>
+  <Appenders>
+    <Console name="Console"><JsonLayout compact="true" eventEol="true" properties="true"/></Console>
+    <File name="FileAppender" fileName="/LogFiles/app.log">
+      <JsonLayout compact="true" eventEol="true" properties="true"/>
+    </File>
+  </Appenders>
+  <Loggers><Root level="info"><AppenderRef ref="FileAppender"/></Root></Loggers>
+</Configuration>
+{{< /code-block >}}
+
+   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=java` (in your sidecar container) to enable advanced Datadog log parsing.
+
+   For more information, see [Correlating Java Logs and Traces][3].
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
+To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
+
+Follow the same steps as above, but set the following environment variables in your application container:
+
+```
+DD_APPSEC_ENABLED=true
+DD_APM_TRACING_ENABLED=false
+```
+
+{{% /collapse-content %}}
+
+## Testing threat detection
+
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][5] attempt:
+```sh
+curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
+```
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][4].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://github.com/DataDog/dd-trace-java/releases
+[2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/java/
+[3]: /tracing/other_telemetry/connect_logs_and_traces/java/
+[4]: https://app.datadoghq.com/security/appsec
+[5]: /security/default_rules/security-scan-detected/
+[6]: /actions/workflows/
+[7]: /security/application_security/waf-integration/

--- a/content/en/security/application_security/setup/azure/container-apps/nodejs.md
+++ b/content/en/security/application_security/setup/azure/container-apps/nodejs.md
@@ -1,29 +1,25 @@
 ---
 title: Enabling App and API Protection for Azure Container Apps in Node.js
 further_reading:
-    - link: "/security/application_security/how-it-works/"
-      tag: "Documentation"
-      text: "How App and API Protection Works"
-    - link: "/security/default_rules/?category=cat-application-security"
-      tag: "Documentation"
-      text: "OOTB App and API Protection Rules"
-    - link: "/security/application_security/troubleshooting"
-      tag: "Documentation"
-      text: "Troubleshooting App and API Protection"
-    - link: "/security/application_security/threats/"
-      tag: "Documentation"
-      text: "App and API Protection"
+- link: "/security/application_security/how-it-works/"
+  tag: "Documentation"
+  text: "How App and API Protection Works"
+- link: "/security/default_rules/?category=cat-application-security"
+  tag: "Documentation"
+  text: "OOTB App and API Protection Rules"
+- link: "/security/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting App and API Protection"
+- link: "/security/application_security/threats/"
+  tag: "Documentation"
+  text: "App and API Protection"
 ---
 
 <div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
 
-**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][5] to block IPs in your [WAF][6].
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][4] to block IPs in your [WAF][5].
 
 ## Setup
-
-{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
-
-Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
 
 1. **Install the Datadog Node.js tracer**.
 
@@ -40,15 +36,7 @@ ENV NODE_OPTIONS="--require dd-trace/init"
 
    For more information, see [Tracing Node.js applications][1].
 
-2. **Enable App and API Protection**.
-
-   Set the following environment variable in your application container:
-
-   ```
-   DD_APPSEC_ENABLED=true
-   ```
-
-3. **Install serverless-init as a sidecar**.
+2. **Install serverless-init as a sidecar**.
 
    {{% serverless-init-install mode="sidecar" %}}
 
@@ -76,52 +64,31 @@ ENV NODE_OPTIONS="--require dd-trace/init"
 
    {{< /tabs >}}
 
-4. **Set up logs**.
+## Configuration
 
-   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. In Node.js, Datadog recommends writing logs in a JSON format. For example, you can use a third-party logging library such as `winston`:
-   {{< code-block lang="javascript" disable_copy="false" >}}
-const { createLogger, format, transports } = require('winston');
+### Enable App and API Protection
 
-const LOG_FILE = "/LogFiles/app.log"
+Set the environment variable `DD_APPSEC_ENABLED=true` in your application container to enable App and API Protection.
 
-const logger = createLogger({
-  level: 'info',
-  exitOnError: false,
-  format: format.json(),
-  transports: [
-    new transports.File({ filename: LOG_FILE }),
-    new transports.Console()
-  ],
-});
+### Disable APM tracing
 
-logger.info('Hello world!');
-{{< /code-block >}}
+To use App and API Protection without APM tracing, set `DD_APM_TRACING_ENABLED=false` in your application container in addition to `DD_APPSEC_ENABLED=true`.
 
-   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=nodejs` (in your sidecar container) to enable advanced Datadog log parsing.
+{{% serverless-init-env-vars-sidecar language="nodejs" defaultSource="containerapp" %}}
 
-   For more information, see [Correlating Node.js Logs and Traces][2].
-
-{{% /collapse-content %}}
-
-{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
-To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
-
-Follow the same steps as above, but set the following environment variables in your application container:
-
-```
-DD_APPSEC_ENABLED=true
-DD_APM_TRACING_ENABLED=false
-```
-
-{{% /collapse-content %}}
+{{% svl-tracing-env %}}
 
 ## Testing threat detection
 
-To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][4] attempt:
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][6] attempt:
 ```sh
 curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
 ```
-After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][3].
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][7].
+
+## Troubleshooting
+
+{{% serverless-init-troubleshooting productNames="Azure Container Apps" %}}
 
 ## Further reading
 
@@ -129,7 +96,8 @@ After you enable your application and exercise it, threat information appears in
 
 [1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/
 [2]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
-[3]: https://app.datadoghq.com/security/appsec
-[4]: /security/default_rules/security-scan-detected/
-[5]: /actions/workflows/
-[6]: /security/application_security/waf-integration/
+[3]: /metrics/custom_metrics/dogstatsd_metrics_submission/?tab=nodejs#code-examples-5
+[4]: /actions/workflows/
+[5]: /security/application_security/waf-integration/
+[6]: /security/default_rules/security-scan-detected/
+[7]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/nodejs.md
+++ b/content/en/security/application_security/setup/azure/container-apps/nodejs.md
@@ -1,0 +1,135 @@
+---
+title: Enabling App and API Protection for Azure Container Apps in Node.js
+further_reading:
+    - link: "/security/application_security/how-it-works/"
+      tag: "Documentation"
+      text: "How App and API Protection Works"
+    - link: "/security/default_rules/?category=cat-application-security"
+      tag: "Documentation"
+      text: "OOTB App and API Protection Rules"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+    - link: "/security/application_security/threats/"
+      tag: "Documentation"
+      text: "App and API Protection"
+---
+
+<div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
+
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][5] to block IPs in your [WAF][6].
+
+## Setup
+
+{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
+
+Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
+
+1. **Install the Datadog Node.js tracer**.
+
+   1. In your main application, install the `dd-trace` package.
+
+      {{< code-block lang="shell" disable_copy="false" >}}
+npm install dd-trace
+{{< /code-block >}}
+
+   2. Initialize the Node.js tracer with the `NODE_OPTIONS` environment variable:
+   {{< code-block lang="dockerfile" disable_copy="false" >}}
+ENV NODE_OPTIONS="--require dd-trace/init"
+{{< /code-block >}}
+
+   For more information, see [Tracing Node.js applications][1].
+
+2. **Enable App and API Protection**.
+
+   Set the following environment variable in your application container:
+
+   ```
+   DD_APPSEC_ENABLED=true
+   ```
+
+3. **Install serverless-init as a sidecar**.
+
+   {{% serverless-init-install mode="sidecar" %}}
+
+   {{< tabs >}}
+
+   {{% tab "Datadog CLI" %}}
+   {{% aca-install-sidecar-datadog-ci %}}
+   {{% /tab %}}
+
+   {{% tab "Terraform" %}}
+   {{% aca-install-sidecar-terraform %}}
+   {{% /tab %}}
+
+   {{% tab "Bicep" %}}
+   {{% aca-install-sidecar-bicep %}}
+   {{% /tab %}}
+
+   {{% tab "ARM Template" %}}
+   {{% aca-install-sidecar-arm-template %}}
+   {{% /tab %}}
+
+   {{% tab "Manual" %}}
+   {{% aca-install-sidecar-manual %}}
+   {{% /tab %}}
+
+   {{< /tabs >}}
+
+4. **Set up logs**.
+
+   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. In Node.js, Datadog recommends writing logs in a JSON format. For example, you can use a third-party logging library such as `winston`:
+   {{< code-block lang="javascript" disable_copy="false" >}}
+const { createLogger, format, transports } = require('winston');
+
+const LOG_FILE = "/LogFiles/app.log"
+
+const logger = createLogger({
+  level: 'info',
+  exitOnError: false,
+  format: format.json(),
+  transports: [
+    new transports.File({ filename: LOG_FILE }),
+    new transports.Console()
+  ],
+});
+
+logger.info('Hello world!');
+{{< /code-block >}}
+
+   Datadog recommends setting the environment variables `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=nodejs` (in your sidecar container) to enable advanced Datadog log parsing.
+
+   For more information, see [Correlating Node.js Logs and Traces][2].
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
+To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
+
+Follow the same steps as above, but set the following environment variables in your application container:
+
+```
+DD_APPSEC_ENABLED=true
+DD_APM_TRACING_ENABLED=false
+```
+
+{{% /collapse-content %}}
+
+## Testing threat detection
+
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][4] attempt:
+```sh
+curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
+```
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][3].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/nodejs/
+[2]: /tracing/other_telemetry/connect_logs_and_traces/nodejs/
+[3]: https://app.datadoghq.com/security/appsec
+[4]: /security/default_rules/security-scan-detected/
+[5]: /actions/workflows/
+[6]: /security/application_security/waf-integration/

--- a/content/en/security/application_security/setup/azure/container-apps/php.md
+++ b/content/en/security/application_security/setup/azure/container-apps/php.md
@@ -1,0 +1,133 @@
+---
+title: Enabling App and API Protection for Azure Container Apps in PHP
+further_reading:
+    - link: "/security/application_security/how-it-works/"
+      tag: "Documentation"
+      text: "How App and API Protection Works"
+    - link: "/security/default_rules/?category=cat-application-security"
+      tag: "Documentation"
+      text: "OOTB App and API Protection Rules"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+    - link: "/security/application_security/threats/"
+      tag: "Documentation"
+      text: "App and API Protection"
+---
+
+<div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
+
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][4] to block IPs in your [WAF][5].
+
+## Setup
+
+{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
+
+Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
+
+1. **Install the Datadog PHP tracer** in your Dockerfile.
+
+   {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
+RUN curl -LO https://github.com/DataDog/dd-trace-php/releases/latest/download/datadog-setup.php \
+  && php datadog-setup.php --php-bin=all --enable-appsec
+{{< /code-block >}}
+
+   When running the `datadog-setup.php` script, you can also enable Profiling by using the `--enable-profiling` flag.
+
+   If you are using Alpine Linux, you need to install `libgcc_s` prior to running the installer:
+
+   {{< code-block lang="shell" disable_copy="false" >}}
+apk add libgcc
+{{< /code-block >}}
+
+   For more information, see [Tracing PHP applications][1].
+
+2. **Enable App and API Protection**.
+
+   Set the following environment variable in your application container:
+
+   ```
+   DD_APPSEC_ENABLED=true
+   ```
+
+3. **Install serverless-init as a sidecar**.
+
+   {{% serverless-init-install mode="sidecar" %}}
+
+   {{< tabs >}}
+
+   {{% tab "Datadog CLI" %}}
+   {{% aca-install-sidecar-datadog-ci %}}
+   {{% /tab %}}
+
+   {{% tab "Terraform" %}}
+   {{% aca-install-sidecar-terraform %}}
+   {{% /tab %}}
+
+   {{% tab "Bicep" %}}
+   {{% aca-install-sidecar-bicep %}}
+   {{% /tab %}}
+
+   {{% tab "ARM Template" %}}
+   {{% aca-install-sidecar-arm-template %}}
+   {{% /tab %}}
+
+   {{% tab "Manual" %}}
+   {{% aca-install-sidecar-manual %}}
+   {{% /tab %}}
+
+   {{< /tabs >}}
+
+4. **Set up logs**.
+
+   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. For example:
+
+   {{< code-block lang="php" disable_copy="false" >}}
+const LOG_FILE = "/LogFiles/app.log";
+
+function logInfo($message) {
+    Log::build([
+        'driver' => 'single',
+        'path' => LOG_FILE,
+    ])->info($message);
+}
+
+logInfo('Hello World!');
+{{< /code-block >}}
+
+   Datadog recommends setting the environment variable `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=php` (in your sidecar container) to enable advanced Datadog log parsing.
+
+   For more information, see [Correlating PHP Logs and Traces][2].
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
+To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
+
+Follow the same steps as above, but set the following environment variables in your application container:
+
+```
+DD_APPSEC_ENABLED=true
+DD_APM_TRACING_ENABLED=false
+```
+
+{{% /collapse-content %}}
+
+## Testing threat detection
+
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][3] attempt:
+```sh
+curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
+```
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][8].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/php/
+[2]: /tracing/other_telemetry/connect_logs_and_traces/php/
+[3]: /security/default_rules/security-scan-detected/
+[4]: /actions/workflows/
+[5]: /security/application_security/waf-integration/
+[8]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/php.md
+++ b/content/en/security/application_security/setup/azure/container-apps/php.md
@@ -1,29 +1,25 @@
 ---
 title: Enabling App and API Protection for Azure Container Apps in PHP
 further_reading:
-    - link: "/security/application_security/how-it-works/"
-      tag: "Documentation"
-      text: "How App and API Protection Works"
-    - link: "/security/default_rules/?category=cat-application-security"
-      tag: "Documentation"
-      text: "OOTB App and API Protection Rules"
-    - link: "/security/application_security/troubleshooting"
-      tag: "Documentation"
-      text: "Troubleshooting App and API Protection"
-    - link: "/security/application_security/threats/"
-      tag: "Documentation"
-      text: "App and API Protection"
+- link: "/security/application_security/how-it-works/"
+  tag: "Documentation"
+  text: "How App and API Protection Works"
+- link: "/security/default_rules/?category=cat-application-security"
+  tag: "Documentation"
+  text: "OOTB App and API Protection Rules"
+- link: "/security/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting App and API Protection"
+- link: "/security/application_security/threats/"
+  tag: "Documentation"
+  text: "App and API Protection"
 ---
 
 <div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
 
-**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][4] to block IPs in your [WAF][5].
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][3] to block IPs in your [WAF][4].
 
 ## Setup
-
-{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
-
-Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
 
 1. **Install the Datadog PHP tracer** in your Dockerfile.
 
@@ -42,15 +38,7 @@ apk add libgcc
 
    For more information, see [Tracing PHP applications][1].
 
-2. **Enable App and API Protection**.
-
-   Set the following environment variable in your application container:
-
-   ```
-   DD_APPSEC_ENABLED=true
-   ```
-
-3. **Install serverless-init as a sidecar**.
+2. **Install serverless-init as a sidecar**.
 
    {{% serverless-init-install mode="sidecar" %}}
 
@@ -78,48 +66,31 @@ apk add libgcc
 
    {{< /tabs >}}
 
-4. **Set up logs**.
+## Configuration
 
-   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. For example:
+### Enable App and API Protection
 
-   {{< code-block lang="php" disable_copy="false" >}}
-const LOG_FILE = "/LogFiles/app.log";
+Set the environment variable `DD_APPSEC_ENABLED=true` in your application container to enable App and API Protection.
 
-function logInfo($message) {
-    Log::build([
-        'driver' => 'single',
-        'path' => LOG_FILE,
-    ])->info($message);
-}
+### Disable APM tracing
 
-logInfo('Hello World!');
-{{< /code-block >}}
+To use App and API Protection without APM tracing, set `DD_APM_TRACING_ENABLED=false` in your application container in addition to `DD_APPSEC_ENABLED=true`.
 
-   Datadog recommends setting the environment variable `DD_LOGS_INJECTION=true` (in your main container) and `DD_SOURCE=php` (in your sidecar container) to enable advanced Datadog log parsing.
+{{% serverless-init-env-vars-sidecar language="php" defaultSource="containerapp" %}}
 
-   For more information, see [Correlating PHP Logs and Traces][2].
-
-{{% /collapse-content %}}
-
-{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
-To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
-
-Follow the same steps as above, but set the following environment variables in your application container:
-
-```
-DD_APPSEC_ENABLED=true
-DD_APM_TRACING_ENABLED=false
-```
-
-{{% /collapse-content %}}
+{{% svl-tracing-env %}}
 
 ## Testing threat detection
 
-To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][3] attempt:
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][5] attempt:
 ```sh
 curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
 ```
-After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][8].
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][6].
+
+## Troubleshooting
+
+{{% serverless-init-troubleshooting productNames="Azure Container Apps" %}}
 
 ## Further reading
 
@@ -127,7 +98,7 @@ After you enable your application and exercise it, threat information appears in
 
 [1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/php/
 [2]: /tracing/other_telemetry/connect_logs_and_traces/php/
-[3]: /security/default_rules/security-scan-detected/
-[4]: /actions/workflows/
-[5]: /security/application_security/waf-integration/
-[8]: https://app.datadoghq.com/security/appsec
+[3]: /actions/workflows/
+[4]: /security/application_security/waf-integration/
+[5]: /security/default_rules/security-scan-detected/
+[6]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/python.md
+++ b/content/en/security/application_security/setup/azure/container-apps/python.md
@@ -1,0 +1,147 @@
+---
+title: Enabling App and API Protection for Azure Container Apps in Python
+further_reading:
+    - link: "/security/application_security/how-it-works/"
+      tag: "Documentation"
+      text: "How App and API Protection Works"
+    - link: "/security/default_rules/?category=cat-application-security"
+      tag: "Documentation"
+      text: "OOTB App and API Protection Rules"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+    - link: "/security/application_security/threats/"
+      tag: "Documentation"
+      text: "App and API Protection"
+---
+
+<div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
+
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][6] to block IPs in your [WAF][7].
+
+## Setup
+
+{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
+
+Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
+
+1. **Install the Datadog Python tracer**.
+
+   Add `ddtrace` to your `requirements.txt` or `pyproject.toml`. You can find the latest version on [PyPI][1]:
+   {{< code-block lang="text" filename="requirements.txt" disable_copy="false" collapsible="true" >}}
+ddtrace==<VERSION>
+{{< /code-block >}}
+
+   Alternatively, you can install the tracer in your Dockerfile:
+   {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
+RUN pip install ddtrace
+{{< /code-block >}}
+
+   Then, wrap your start command with `ddtrace-run`:
+   {{< code-block lang="dockerfile" filename="Dockerfile" disable_copy="false" collapsible="true" >}}
+CMD ["ddtrace-run", "python", "app.py"]
+{{< /code-block >}}
+
+   For more information, see [Tracing Python applications][2].
+
+2. **Enable App and API Protection**.
+
+   Set the following environment variable in your application container:
+
+   ```
+   DD_APPSEC_ENABLED=true
+   ```
+
+3. **Install serverless-init as a sidecar**.
+
+   {{% serverless-init-install mode="sidecar" %}}
+
+   {{< tabs >}}
+
+   {{% tab "Datadog CLI" %}}
+   {{% aca-install-sidecar-datadog-ci %}}
+   {{% /tab %}}
+
+   {{% tab "Terraform" %}}
+   {{% aca-install-sidecar-terraform %}}
+   {{% /tab %}}
+
+   {{% tab "Bicep" %}}
+   {{% aca-install-sidecar-bicep %}}
+   {{% /tab %}}
+
+   {{% tab "ARM Template" %}}
+   {{% aca-install-sidecar-arm-template %}}
+   {{% /tab %}}
+
+   {{% tab "Manual" %}}
+   {{% aca-install-sidecar-manual %}}
+   {{% /tab %}}
+
+   {{< /tabs >}}
+
+4. **Set up logs**.
+
+   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. Datadog recommends setting the following environment variables:
+   - `ENV PYTHONUNBUFFERED=1`: In your main container. Helps ensure Python outputs appear immediately in container logs instead of being buffered.
+   - `ENV DD_LOGS_INJECTION=true`: In your main container. Enable log/trace correlation for supported loggers.
+   - `DD_SOURCE=python`: In your sidecar container. Enable advanced Datadog log parsing.
+
+   Then, update your logging library. For example, you can use Python's native `logging` library:
+   {{< code-block lang="python" disable_copy="false" >}}
+LOG_FILE = "/LogFiles/app.log"
+os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+
+FORMAT = ('%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] '
+        '[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] '
+        '- %(message)s')
+
+logging.basicConfig(
+    level=logging.INFO,
+    format=FORMAT,
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler(sys.stdout)
+    ]
+)
+logger = logging.getLogger(__name__)
+logger.level = logging.INFO
+
+logger.info('Hello world!')
+{{< /code-block >}}
+
+   For more information, see [Correlating Python Logs and Traces][3].
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
+To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
+
+Follow the same steps as above, but set the following environment variables in your application container:
+
+```
+DD_APPSEC_ENABLED=true
+DD_APM_TRACING_ENABLED=false
+```
+
+{{% /collapse-content %}}
+
+## Testing threat detection
+
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][5] attempt:
+```sh
+curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
+```
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][4].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: https://pypi.org/project/ddtrace/
+[2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/python
+[3]: /tracing/other_telemetry/connect_logs_and_traces/python/
+[4]: https://app.datadoghq.com/security/appsec
+[5]: /security/default_rules/security-scan-detected/
+[6]: /actions/workflows/
+[7]: /security/application_security/waf-integration/

--- a/content/en/security/application_security/setup/azure/container-apps/python.md
+++ b/content/en/security/application_security/setup/azure/container-apps/python.md
@@ -1,29 +1,25 @@
 ---
 title: Enabling App and API Protection for Azure Container Apps in Python
 further_reading:
-    - link: "/security/application_security/how-it-works/"
-      tag: "Documentation"
-      text: "How App and API Protection Works"
-    - link: "/security/default_rules/?category=cat-application-security"
-      tag: "Documentation"
-      text: "OOTB App and API Protection Rules"
-    - link: "/security/application_security/troubleshooting"
-      tag: "Documentation"
-      text: "Troubleshooting App and API Protection"
-    - link: "/security/application_security/threats/"
-      tag: "Documentation"
-      text: "App and API Protection"
+- link: "/security/application_security/how-it-works/"
+  tag: "Documentation"
+  text: "How App and API Protection Works"
+- link: "/security/default_rules/?category=cat-application-security"
+  tag: "Documentation"
+  text: "OOTB App and API Protection Rules"
+- link: "/security/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting App and API Protection"
+- link: "/security/application_security/threats/"
+  tag: "Documentation"
+  text: "App and API Protection"
 ---
 
 <div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
 
-**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][6] to block IPs in your [WAF][7].
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][3] to block IPs in your [WAF][4].
 
 ## Setup
-
-{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
-
-Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
 
 1. **Install the Datadog Python tracer**.
 
@@ -44,15 +40,7 @@ CMD ["ddtrace-run", "python", "app.py"]
 
    For more information, see [Tracing Python applications][2].
 
-2. **Enable App and API Protection**.
-
-   Set the following environment variable in your application container:
-
-   ```
-   DD_APPSEC_ENABLED=true
-   ```
-
-3. **Install serverless-init as a sidecar**.
+2. **Install serverless-init as a sidecar**.
 
    {{% serverless-init-install mode="sidecar" %}}
 
@@ -80,51 +68,19 @@ CMD ["ddtrace-run", "python", "app.py"]
 
    {{< /tabs >}}
 
-4. **Set up logs**.
+## Configuration
 
-   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. Datadog recommends setting the following environment variables:
-   - `ENV PYTHONUNBUFFERED=1`: In your main container. Helps ensure Python outputs appear immediately in container logs instead of being buffered.
-   - `ENV DD_LOGS_INJECTION=true`: In your main container. Enable log/trace correlation for supported loggers.
-   - `DD_SOURCE=python`: In your sidecar container. Enable advanced Datadog log parsing.
+### Enable App and API Protection
 
-   Then, update your logging library. For example, you can use Python's native `logging` library:
-   {{< code-block lang="python" disable_copy="false" >}}
-LOG_FILE = "/LogFiles/app.log"
-os.makedirs(os.path.dirname(LOG_FILE), exist_ok=True)
+Set the environment variable `DD_APPSEC_ENABLED=true` in your application container to enable App and API Protection.
 
-FORMAT = ('%(asctime)s %(levelname)s [%(name)s] [%(filename)s:%(lineno)d] '
-        '[dd.service=%(dd.service)s dd.env=%(dd.env)s dd.version=%(dd.version)s dd.trace_id=%(dd.trace_id)s dd.span_id=%(dd.span_id)s] '
-        '- %(message)s')
+### Disable APM tracing
 
-logging.basicConfig(
-    level=logging.INFO,
-    format=FORMAT,
-    handlers=[
-        logging.FileHandler(LOG_FILE),
-        logging.StreamHandler(sys.stdout)
-    ]
-)
-logger = logging.getLogger(__name__)
-logger.level = logging.INFO
+To use App and API Protection without APM tracing, set `DD_APM_TRACING_ENABLED=false` in your application container in addition to `DD_APPSEC_ENABLED=true`.
 
-logger.info('Hello world!')
-{{< /code-block >}}
+{{% serverless-init-env-vars-sidecar language="python" defaultSource="containerapp" %}}
 
-   For more information, see [Correlating Python Logs and Traces][3].
-
-{{% /collapse-content %}}
-
-{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
-To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
-
-Follow the same steps as above, but set the following environment variables in your application container:
-
-```
-DD_APPSEC_ENABLED=true
-DD_APM_TRACING_ENABLED=false
-```
-
-{{% /collapse-content %}}
+{{% svl-tracing-env %}}
 
 ## Testing threat detection
 
@@ -132,7 +88,11 @@ To see App and API Protection threat detection in action, send known attack patt
 ```sh
 curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
 ```
-After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][4].
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][6].
+
+## Troubleshooting
+
+{{% serverless-init-troubleshooting productNames="Azure Container Apps" %}}
 
 ## Further reading
 
@@ -140,8 +100,7 @@ After you enable your application and exercise it, threat information appears in
 
 [1]: https://pypi.org/project/ddtrace/
 [2]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/python
-[3]: /tracing/other_telemetry/connect_logs_and_traces/python/
-[4]: https://app.datadoghq.com/security/appsec
+[3]: /actions/workflows/
+[4]: /security/application_security/waf-integration/
 [5]: /security/default_rules/security-scan-detected/
-[6]: /actions/workflows/
-[7]: /security/application_security/waf-integration/
+[6]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/ruby.md
+++ b/content/en/security/application_security/setup/azure/container-apps/ruby.md
@@ -1,29 +1,25 @@
 ---
 title: Enabling App and API Protection for Azure Container Apps in Ruby
 further_reading:
-    - link: "/security/application_security/how-it-works/"
-      tag: "Documentation"
-      text: "How App and API Protection Works"
-    - link: "/security/default_rules/?category=cat-application-security"
-      tag: "Documentation"
-      text: "OOTB App and API Protection Rules"
-    - link: "/security/application_security/troubleshooting"
-      tag: "Documentation"
-      text: "Troubleshooting App and API Protection"
-    - link: "/security/application_security/threats/"
-      tag: "Documentation"
-      text: "App and API Protection"
+- link: "/security/application_security/how-it-works/"
+  tag: "Documentation"
+  text: "How App and API Protection Works"
+- link: "/security/default_rules/?category=cat-application-security"
+  tag: "Documentation"
+  text: "OOTB App and API Protection Rules"
+- link: "/security/application_security/troubleshooting"
+  tag: "Documentation"
+  text: "Troubleshooting App and API Protection"
+- link: "/security/application_security/threats/"
+  tag: "Documentation"
+  text: "App and API Protection"
 ---
 
 <div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
 
-**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][4] to block IPs in your [WAF][5].
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][3] to block IPs in your [WAF][4].
 
 ## Setup
-
-{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
-
-Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
 
 1. **Install the Datadog Ruby tracer**.
 
@@ -35,15 +31,7 @@ gem 'datadog'
 
    See [Tracing Ruby applications][1] for additional information on how to configure the tracer and enable auto instrumentation.
 
-2. **Enable App and API Protection**.
-
-   Set the following environment variable in your application container:
-
-   ```
-   DD_APPSEC_ENABLED=true
-   ```
-
-3. **Install serverless-init as a sidecar**.
+2. **Install serverless-init as a sidecar**.
 
    {{% serverless-init-install mode="sidecar" %}}
 
@@ -71,46 +59,31 @@ gem 'datadog'
 
    {{< /tabs >}}
 
-4. **Set up logs**.
+## Configuration
 
-   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. Datadog recommends setting the environment variable `DD_SOURCE=ruby` in your sidecar container to enable advanced Datadog log parsing.
+### Enable App and API Protection
 
-   Then, update your logging library. For example, you can use Ruby's native `logger` library:
-   {{< code-block lang="ruby" disable_copy="false" >}}
-LOG_FILE = "/LogFiles/app.log"
-FileUtils.mkdir_p(File.dirname(LOG_FILE))
+Set the environment variable `DD_APPSEC_ENABLED=true` in your application container to enable App and API Protection.
 
-logger = Logger.new(LOG_FILE)
-logger.formatter = proc do |severity, datetime, progname, msg|
-  "[#{datetime}] #{severity}: [#{Datadog::Tracing.log_correlation}] #{msg}\n"
-end
+### Disable APM tracing
 
-logger.info "Hello World!"
-{{< /code-block >}}
+To use App and API Protection without APM tracing, set `DD_APM_TRACING_ENABLED=false` in your application container in addition to `DD_APPSEC_ENABLED=true`.
 
-   For more information, see [Correlating Ruby Logs and Traces][2].
+{{% serverless-init-env-vars-sidecar language="ruby" defaultSource="containerapp" %}}
 
-{{% /collapse-content %}}
-
-{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
-To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
-
-Follow the same steps as above, but set the following environment variables in your application container:
-
-```
-DD_APPSEC_ENABLED=true
-DD_APM_TRACING_ENABLED=false
-```
-
-{{% /collapse-content %}}
+{{% svl-tracing-env %}}
 
 ## Testing threat detection
 
-To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][3] attempt:
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][5] attempt:
 ```sh
 curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
 ```
-After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][8].
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][6].
+
+## Troubleshooting
+
+{{% serverless-init-troubleshooting productNames="Azure Container Apps" %}}
 
 ## Further reading
 
@@ -118,7 +91,7 @@ After you enable your application and exercise it, threat information appears in
 
 [1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/ruby/#instrument-your-application
 [2]: /tracing/other_telemetry/connect_logs_and_traces/ruby/
-[3]: /security/default_rules/security-scan-detected/
-[4]: /actions/workflows/
-[5]: /security/application_security/waf-integration/
-[8]: https://app.datadoghq.com/security/appsec
+[3]: /actions/workflows/
+[4]: /security/application_security/waf-integration/
+[5]: /security/default_rules/security-scan-detected/
+[6]: https://app.datadoghq.com/security/appsec

--- a/content/en/security/application_security/setup/azure/container-apps/ruby.md
+++ b/content/en/security/application_security/setup/azure/container-apps/ruby.md
@@ -1,0 +1,124 @@
+---
+title: Enabling App and API Protection for Azure Container Apps in Ruby
+further_reading:
+    - link: "/security/application_security/how-it-works/"
+      tag: "Documentation"
+      text: "How App and API Protection Works"
+    - link: "/security/default_rules/?category=cat-application-security"
+      tag: "Documentation"
+      text: "OOTB App and API Protection Rules"
+    - link: "/security/application_security/troubleshooting"
+      tag: "Documentation"
+      text: "Troubleshooting App and API Protection"
+    - link: "/security/application_security/threats/"
+      tag: "Documentation"
+      text: "App and API Protection"
+---
+
+<div class="alert alert-info">AAP support for Azure Container Apps is in Preview.</div>
+
+**Note**: Threat Protection through Remote Configuration is not supported. Use [Workflows][4] to block IPs in your [WAF][5].
+
+## Setup
+
+{{% collapse-content title="APM Tracing Enabled" level="h4" %}}
+
+Follow these steps to enable App and API Protection with APM tracing on your Azure Container App.
+
+1. **Install the Datadog Ruby tracer**.
+
+   Add the `datadog` gem to your Gemfile:
+   {{< code-block lang="gemfile" disable_copy="false" >}}
+source 'https://rubygems.org'
+gem 'datadog'
+{{< /code-block >}}
+
+   See [Tracing Ruby applications][1] for additional information on how to configure the tracer and enable auto instrumentation.
+
+2. **Enable App and API Protection**.
+
+   Set the following environment variable in your application container:
+
+   ```
+   DD_APPSEC_ENABLED=true
+   ```
+
+3. **Install serverless-init as a sidecar**.
+
+   {{% serverless-init-install mode="sidecar" %}}
+
+   {{< tabs >}}
+
+   {{% tab "Datadog CLI" %}}
+   {{% aca-install-sidecar-datadog-ci %}}
+   {{% /tab %}}
+
+   {{% tab "Terraform" %}}
+   {{% aca-install-sidecar-terraform %}}
+   {{% /tab %}}
+
+   {{% tab "Bicep" %}}
+   {{% aca-install-sidecar-bicep %}}
+   {{% /tab %}}
+
+   {{% tab "ARM Template" %}}
+   {{% aca-install-sidecar-arm-template %}}
+   {{% /tab %}}
+
+   {{% tab "Manual" %}}
+   {{% aca-install-sidecar-manual %}}
+   {{% /tab %}}
+
+   {{< /tabs >}}
+
+4. **Set up logs**.
+
+   In the previous step, you created a shared volume. In this step, configure your logging library to write logs to the file set in `DD_SERVERLESS_LOG_PATH`. Datadog recommends setting the environment variable `DD_SOURCE=ruby` in your sidecar container to enable advanced Datadog log parsing.
+
+   Then, update your logging library. For example, you can use Ruby's native `logger` library:
+   {{< code-block lang="ruby" disable_copy="false" >}}
+LOG_FILE = "/LogFiles/app.log"
+FileUtils.mkdir_p(File.dirname(LOG_FILE))
+
+logger = Logger.new(LOG_FILE)
+logger.formatter = proc do |severity, datetime, progname, msg|
+  "[#{datetime}] #{severity}: [#{Datadog::Tracing.log_correlation}] #{msg}\n"
+end
+
+logger.info "Hello World!"
+{{< /code-block >}}
+
+   For more information, see [Correlating Ruby Logs and Traces][2].
+
+{{% /collapse-content %}}
+
+{{% collapse-content title="APM Tracing Disabled" level="h4" %}}
+To disable APM tracing while keeping App and API Protection enabled, you must set the APM tracing variable to false.
+
+Follow the same steps as above, but set the following environment variables in your application container:
+
+```
+DD_APPSEC_ENABLED=true
+DD_APM_TRACING_ENABLED=false
+```
+
+{{% /collapse-content %}}
+
+## Testing threat detection
+
+To see App and API Protection threat detection in action, send known attack patterns to your application. For example, send a request with the user agent header set to `dd-test-scanner-log` to trigger a [security scanner attack][3] attempt:
+```sh
+curl -A 'dd-test-scanner-log' https://<YOUR_APP_URL>/existing-route
+```
+After you enable your application and exercise it, threat information appears in the [Application Signals Explorer][8].
+
+## Further reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /tracing/trace_collection/automatic_instrumentation/dd_libraries/ruby/#instrument-your-application
+[2]: /tracing/other_telemetry/connect_logs_and_traces/ruby/
+[3]: /security/default_rules/security-scan-detected/
+[4]: /actions/workflows/
+[5]: /security/application_security/waf-integration/
+[8]: https://app.datadoghq.com/security/appsec


### PR DESCRIPTION
Add App and API Protection setup pages for Azure Container Apps
using the sidecar instrumentation pattern. Includes pages for all
7 supported languages (Node.js, Java, Python, Go, .NET, Ruby, PHP)
with APM Tracing Enabled/Disabled collapse sections.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
