### PR TITLE
[DOCS-13723] Update Mobile app testing results overview attributes

### DIFF
--- a/content/en/synthetics/mobile_app_testing/mobile_app_tests/results.md
+++ b/content/en/synthetics/mobile_app_testing/mobile_app_tests/results.md
@@ -72,6 +72,9 @@ Test version
 Run type
 : The type of test run (CI, manually triggered, or scheduled).
 
+Video replay
+: A recording of the test execution available for diagnosing failures. See [Video replay](#video-replay).
+
 ### Screenshots and actions
 
 Every executed test step contains a screenshot of the step action, step action name, step ID, and step duration. 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13723

Updates the Overview attributes section of the Mobile App Testing results page to reflect the attributes actually shown in the UI. The previous content was copied from the browser test results page and included fields that don't apply to mobile app tests.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes