### PR TITLE
fivetran: add ACCOUNT READ to system key permissions

### DIFF
--- a/content/en/data_observability/quality_monitoring/elt/fivetran.md
+++ b/content/en/data_observability/quality_monitoring/elt/fivetran.md
@@ -26,6 +26,7 @@ Follow the [Fivetran System Keys documentation][1] to generate an API key and se
 
 ```json
 [
+  {"resource_type": "ACCOUNT", "access_level": "READ"},
   {"resource_type": "DESTINATION", "access_level": "READ"},
   {"resource_type": "CONNECTOR", "access_level": "READ"}
 ]


### PR DESCRIPTION
## What

Add `{"resource_type": "ACCOUNT", "access_level": "READ"}` to the Fivetran system key permissions in the setup instructions.

The full permissions are now:
```json
[
  {"resource_type": "ACCOUNT", "access_level": "READ"},
  {"resource_type": "DESTINATION", "access_level": "READ"},
  {"resource_type": "CONNECTOR", "access_level": "READ"}
]
```