### PR TITLE
Restore missing Client SDKs nav entry under Feature Flags

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -5747,6 +5747,11 @@ menu:
       parent: software_delivery_heading
       identifier: feature_flags
       weight: 80000
+    - name: Client SDKs
+      url: feature_flags/client
+      parent: feature_flags
+      identifier: feature_flags_client
+      weight: 1
     - name: Android and Android TV
       url: feature_flags/client/android
       parent: feature_flags_client


### PR DESCRIPTION
### What does this PR do? What is the motivation?

The `Client SDKs` menu entry (`identifier: feature_flags_client`) under the Feature Flags section was accidentally removed in 63b69a22a3 (PR #34337, "Refactor RUM SDK Setup docs using Cdocs"), likely as a merge conflict casualty.

The child entries (Android, Angular, iOS, JavaScript, React, React Native) still referenced `feature_flags_client` as their parent, so Hugo rendered `FEATURE_FLAGS_CLIENT` as a raw top-level section header in the left nav instead of a proper "Client SDKs" submenu under Feature Flags.

This restores the entry to match what was present before that commit.

Current:
<img width="315" height="501" alt="Screenshot 2026-03-17 at 9 33 42 PM" src="https://github.com/user-attachments/assets/b9e38e90-8121-4095-81ae-147f8dde023d" />


### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes