### PR TITLE
Make DDOT Gateway page public and update to Agent 7.77.0

### DIFF
--- a/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_gateway.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_gateway.md
@@ -1,9 +1,8 @@
 ---
 title: Install the DDOT Collector as a Gateway on Kubernetes
-private: true
-# code_lang: kubernetes_gateway
-# type: multi-code-lang
-# code_lang_weight: 2
+code_lang: kubernetes_gateway
+type: multi-code-lang
+code_lang_weight: 2
 further_reading:
 - link: https://www.datadoghq.com/blog/ddot-gateway
   tag: Blog
@@ -562,7 +561,7 @@ spec:
       # Custom image (optional)
       image:
         name: ddot-collector
-        tag: "7.74.0"
+        tag: "{{< version key="ddot_gateway_version" >}}"
         pullPolicy: IfNotPresent
 
       # Pod-level security context
@@ -868,8 +867,8 @@ To use a custom-built Collector image for your gateway, specify the image reposi
 <strong>Note:</strong> The Datadog Operator supports the following image name formats:
 <ul>
   <li><code>name</code> - The image name (for example, <code>ddot-collector</code>)</li>
-  <li><code>name:tag</code> - Image name with tag (for example, <code>ddot-collector:7.74.0</code>)</li>
-  <li><code>registry/name:tag</code> - Full image reference (for example, <code>gcr.io/datadoghq/ddot-collector:7.74.0</code>)</li>
+  <li><code>name:tag</code> - Image name with tag (for example, <code>ddot-collector:{{% version key="ddot_gateway_version" %}}</code>)</li>
+  <li><code>registry/name:tag</code> - Full image reference (for example, <code>gcr.io/datadoghq/ddot-collector:{{% version key="ddot_gateway_version" %}}</code>)</li>
 </ul>
 The <code>registry/name</code> format (without tag in the name field) is <strong>not supported</strong> when using a separate <code>tag</code> field. Either include the full image reference with tag in the <code>name</code> field, or use the image name with a separate <code>tag</code> field.
 </div>

--- a/data/versions.yaml
+++ b/data/versions.yaml
@@ -3,5 +3,7 @@ agent_version: "7.71.2"
 agent_branch: "7.71.x"
 collector_version: "0.133.0"
 
+ddot_gateway_version: "7.77.0"
+
 # Tags
 agent_tag: "7.71.2-full"


### PR DESCRIPTION
## What does this PR do? What is the motivation?

- Makes the DDOT Collector Gateway Kubernetes page public (removes `private: true`)
- Re-enables the page in multi-code-lang tabs so it appears alongside DaemonSet, Linux, ECS Fargate, and EKS Fargate options
- Updates the required Agent version to 7.77.0
- Adds a `ddot_gateway_version` key to `data/versions.yaml` for centralized version management across the page

## Merge instructions

Merge readiness:
- [ ] Ready for merge

## Additional notes