### PR TITLE
[DOCS-10534] Add nested array search examples to log search syntax docs

### DIFF
--- a/content/en/logs/explorer/search_syntax.md
+++ b/content/en/logs/explorer/search_syntax.md
@@ -216,9 +216,9 @@ To search a nested field in an array attribute, use the `@` prefix with the full
 
 * `@network.ip.attributes.ip:2a02\:1810*` matches all logs where at least one item in the `network.ip.attributes` array has an `ip` field starting with `2a02:1810`.
 
-To match logs where an array contains at least one of multiple specific values, list the values in parentheses:
+To match logs where an array contains multiple specific values, list the values in parentheses:
 
-* `@user_perms:(4 6)` matches all logs where the `user_perms` array contains `4` or `6`.
+* `@user_perms:(4 6)` matches all logs where the `user_perms` array contains both `4` and `6`.
 
 To match logs where an array contains any value within a range, use a range query:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes [DOCS-10534](https://datadoghq.atlassian.net/browse/DOCS-10534)

Adds a new "Nested array search" subsection to the Arrays section of the log search syntax docs, with examples showing how to:
- Search nested fields within array attributes
- Match arrays containing at least one of multiple values
- Match arrays containing a value within a range

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes