### PR TITLE
Add info on exporting pipeline config to JSON/TF

### DIFF
--- a/content/en/observability_pipelines/configuration/set_up_pipelines.md
+++ b/content/en/observability_pipelines/configuration/set_up_pipelines.md
@@ -139,6 +139,28 @@ Use the [datadog_observability_pipeline][10] module to make any changes to an ex
 
 See [Advanced Worker Configurations][5] for bootstrapping options.
 
+## Export pipeline configuration to JSON or Terraform
+
+Setting up and updating a pipeline directly in Terraform or through the API can be time consuming and prone to errors. To address those issues, you can create or update a pipeline in the UI and export the configuration to JSON or Terraform.
+
+### Pipelines that have not been deployed yet
+
+For a pipeline that has not been deployed yet, you can export the pipeline in draft mode to JSON or Terraform.
+
+1. Navigate to [Observability Pipelines][4].
+1. [Set up a pipeline](#set-up-a-pipeline-in-the-ui).
+1. After the source, processors, and destinations have been configured, click **Export Pipeline**.
+1. Copy or download the JSON or Terraform file and programmatically deploy the pipelines.
+1. [Install the Worker][7] to send data through the pipeline.
+
+### Deployed pipelines
+
+If you have a deployed pipeline and want to add additional components, you can set up the components in the UI, then export the configuration to JSON or Terraform to deploy the changes programmatically.
+
+1. Navigate to [Observability Pipelines][4].
+1. Select your pipeline.
+1. After you have updated your pipeline, click **Export Pipeline**.
+
 ## Clone a pipeline
 
 To clone a pipeline in the UI:

--- a/content/en/observability_pipelines/configuration/update_existing_pipelines.md
+++ b/content/en/observability_pipelines/configuration/update_existing_pipelines.md
@@ -9,7 +9,7 @@ aliases:
 
 For existing pipelines in Observability Pipelines, you can update and deploy changes for source settings, destination settings, and processors in the Observability Pipelines UI. But if you are using environment variables and want to update source and destination environment variables, you must manually update the Worker with the new values.
 
-This document goes through updating the pipeline in the UI. You can also use the [update a pipeline][2] API or [datadog_observability_pipeline][3] Terraform resource to update existing pipelines.
+This document goes through updating the pipeline in the UI. You can also use the [update a pipeline][2] API or [datadog_observability_pipeline][3] Terraform resource to update existing pipelines. You can also [export your pipeline configuration to JSON or Terraform][4] to deploy changes programmatically.
 
 ## Update an existing pipeline
 
@@ -235,6 +235,17 @@ On the Worker installation page:
 {{% /tab %}}
 {{< /tabs >}}
 
+## Export pipeline configuration to JSON or Terraform
+
+If you have a deployed pipeline and want to add additional components, you can set up the components in the UI, then export the configuration to JSON or Terraform to deploy the changes programmatically.
+
+1. Navigate to [Observability Pipelines][1].
+1. Select your pipeline.
+1. After you have updated your pipeline, click **Export Pipeline**.
+
+See [Export pipeline configuration to JSON or Terraform][4] for more information, including how to export pipelines that have not been deployed yet.
+
 [1]: https://app.datadoghq.com/observability-pipelines
 [2]: /api/latest/observability-pipelines/#update-a-pipeline
 [3]: https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/observability_pipeline
+[4]: /observability_pipelines/configuration/set_up_pipelines/#export-pipeline-configuration-to-json-or-terraform


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Add info on exporting pipeline configurations to JSON or Terraform in Observability Pipelines.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes