### PR TITLE
[DOCS-13753] Add missing destinations to batching shortcode

### DIFF
--- a/layouts/shortcodes/observability_pipelines/destination_batching.en.md
+++ b/layouts/shortcodes/observability_pipelines/destination_batching.en.md
@@ -5,11 +5,15 @@
 | Amazon Security Lake                       | None           | 256               | 300                 |
 | Azure Storage (Datadog Log Archives)       | None           | 100               | 900                 |
 | CrowdStrike                                | None           | 1                 | 1                   |
+| Datadog CloudPrem                          | 1,000          | 4.25              | 5                   |
 | Datadog Logs                               | 1,000          | 4.25              | 5                   |
+| Datadog Metrics                            | 100,000        | None              | 2                   |
 | Elasticsearch                              | None           | 10                | 1                   |
 | Google Chronicle                           | None           | 1                 | 15                  |
 | Google Cloud Storage (Datadog Log Archives)| None           | 100               | 900                 |
+| Google Pub/Sub                             | 1,000          | 10                | 1                   |
 | HTTP Client                                | 1000           | 1                 | 1                   |
+| Kafka                                      | 10,000         | 1                 | 1                   |
 | Microsoft Sentinel                         | None           | 10                | 1                   |
 | New Relic                                  | 100            | 1                 | 1                   |
 | OpenSearch                                 | None           | 10                | 1                   |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-13753

Adds 4 missing destinations to the `destination_batching` shortcode table: Datadog CloudPrem, Datadog Metrics, Google Pub/Sub, and Kafka.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes