### PR TITLE
docs: add metric-based SLOs to burn rate alerts on groups

### DIFF
--- a/content/en/service_level_objectives/burn_rate.md
+++ b/content/en/service_level_objectives/burn_rate.md
@@ -105,7 +105,7 @@ $$\text"burn rate" = {7 \text"days" * 24 \text"hours" * 10% \text"error budget c
 
 ### Alerting for SLOs with groups
 
-For Time Slice SLOs containing groups, you can set burn rate alerts based on the SLO groups or the overall SLO. If you alert based on the groups, you can confiure the [alert aggregation][8] to use simple or multi alerts. For metric-based and monitor-based SLOs, you can only set burn rate alerts based on the overall SLO.
+For Metric-based and Time Slice SLOs containing groups, you can set burn rate alerts based on the SLO groups or the overall SLO. If you alert based on the groups, you can confiure the [alert aggregation][8] to use simple or multi alerts. For monitor-based SLOs, you can only set burn rate alerts based on the overall SLO.
 
 ### Examples
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Metric-based SLOs can now also have burn rates alerting by groups

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
