### PR TITLE
docs(sast): add AI-native SAST preview section

### DIFF
--- a/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
+++ b/content/en/security/code_security/static_analysis/ai_enhanced_sast.md
@@ -70,7 +70,7 @@ Datadog's AI-native SAST engine uses large language models (LLMs) to detect secu
 AI-native SAST uses a two-phase approach:
 
 1. **Detection**: An LLM scans each file and reasons about whether user-controlled data can reach a dangerous operation without being sanitized.
-2. **Verification**: A second LLM independently re-evaluates each candidate finding through taint analysis, confirming or dismissing it to reduce false positives.
+2. **Verification**: A second LLM independently re-evaluates each candidate finding through taint analysis, confirming or dismissing each finding to reduce false positives.
 
 ### Supported languages
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for the AI-native SAST (SAIST) engine, which is currently in Preview.

Changes:
- Adds a new **AI-native SAST** section to the AI-Enhanced Static Code Analysis page with a preview callout
- Documents the two-phase LLM detection/verification approach
- Includes supported languages table (Java, Python, Go available; C# coming soon)
- Includes detected vulnerability types table (14 CWEs)
- Notes that this feature is only available for Datadog Hosted Scans
- Updates the summary table at the top of the page to include the new capability

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)