### PR TITLE
[DOCS-13616] Add VPC Service Controls disclaimer to GCP Getting Started

### DIFF
--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -71,6 +71,8 @@ Use this guide to get started with monitoring your Google Cloud environment. Thi
 
 ### Metric collection
 
+<div class="alert alert-info">If your Google Cloud organization uses <a href="https://cloud.google.com/vpc-service-controls/docs/overview">VPC Service Controls</a>, you must explicitly allow Datadog service accounts to access protected resources. If these service accounts are not permitted within your service perimeter, metric, resource, and metadata collection may fail. Contact <a href="/help/">Datadog Support</a> for the service account identifiers for your site or region.</div>
+
 {{< tabs >}}
 
 {{% tab "Org-level" %}}
@@ -218,7 +220,7 @@ To use the Quick Start method, your Datadog user role must be able to create API
    2. Choose whether to apply tags to the metrics associated with the created service account.
    3. Choose whether to disable metric collection for specific Google Cloud services to help control Google Cloud Monitoring costs.
    4. Choose whether to apply granular metric filters for any Google Cloud services enabled for metric collection.
-   5. Choose whether to filter metrics by tags for GCP resource types `Cloud Run Revision`, `VM Intance`, or `Cloud Function` to help control Datadog costs.
+   5. Choose whether to filter metrics by tags for GCP resource types `Cloud Run Revision`, `VM Instance`, or `Cloud Function` to help control Datadog costs.
 7. Configure **Resource Collection** (attributes and configuration information of the resources in your Google Cloud environment).
 8. Copy the provided **Terraform Code**.
 9. Paste the code into a `.tf` file, and run the **Initialize and apply the Terraform** command. If successful, the command:
@@ -253,7 +255,7 @@ To use the Quick Start method, your Datadog user role must be able to create API
    2. Choose whether to apply tags to the metrics associated with the created service account.
    3. Choose whether to disable metric collection for specific Google Cloud services to help control Google Cloud Monitoring costs.
    4. Choose whether to apply granular metric filters for any Google Cloud services enabled for metric collection.
-   5. Choose whether to filter metrics by tags for GCP resource types `Cloud Run Revision`, `VM Intance`, or `Cloud Function` to help control Datadog costs.
+   5. Choose whether to filter metrics by tags for GCP resource types `Cloud Run Revision`, `VM Instance`, or `Cloud Function` to help control Datadog costs.
 9. Configure **Resource Collection** (attributes and configuration information of the resources in your Google Cloud environment, optional).
 10. Click **Verify and Save Account**.
 
@@ -388,7 +390,7 @@ Use the [Datadog Dataflow template][14] to batch and compresses your log events 
 
 ## Leveraging the Datadog Agent
 
-After the Google Cloud integration is configured, Datadog automatically starts collecting Google Cloud metrics. However, you can leverage the Datadog Agent to gather deeper insights into your infrastructure.
+After the Google Cloud integration is configured, Datadog automatically starts collecting Google Cloud metrics. However, you can use the Datadog Agent to gather deeper insights into your infrastructure.
 
 The [Datadog Agent][31] provides the [most granular, low-latency metrics][32] from your infrastructure, delivering real-time insights into CPU, memory, disk usage, and more for your Google Cloud hosts.
 The Agent can be installed on any host, including [GKE][33].


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13616

Adds a VPC Service Controls disclaimer under the Metric Collection section of the GCP Getting Started page. If a customer's Google Cloud organization uses VPC Service Controls, Datadog service accounts must be explicitly allowed within the service perimeter or metric, resource, and metadata collection may fail.

Also fixes two typos ("VM Intance" → "VM Instance") and a Vale substitution ("leverage" → "use").

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

### References

- [Google Cloud VPC Service Controls documentation](https://cloud.google.com/vpc-service-controls/docs/overview)