### PR TITLE
[APPSEC-61834] Fix Python IAST OS compatibility table

### DIFF
--- a/content/en/security/code_security/iast/setup/_index.md
+++ b/content/en/security/code_security/iast/setup/_index.md
@@ -834,7 +834,12 @@ Two release branches are supported:
 
 And the library supports the following runtimes:
 
-{{< partial name="trace_collection/python/supported_runtimes.html" >}}
+| OS      | CPU                   | Runtime   | Runtime version | Supported ddtrace versions   |
+|---------|-----------------------|-----------|-----------------|------------------------------|
+| Linux   | x86-64, AArch64       | CPython   | 3.9+            | >=4, <5                      |
+| macOS   | Intel, Apple Silicon  | CPython   | 3.9+            | >=4, <5                      |
+| Linux   | x86-64, i686, AArch64 | CPython   | 3.8+            | >=3, <4                      |
+| macOS   | Intel, Apple Silicon  | CPython   | 3.8+            | >=3, <4                      |
 
 #### Web framework compatibility
 ##### Code Security Capability Notes


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes APPSEC-61834: https://datadoghq.atlassian.net/browse/APPSEC-61834

The Python IAST OS compatibility table:

- The macOS row for ddtrace v3 (`>=3, <4`) was missing — macOS is supported for IAST in both v3 and v4, as IAST native extensions are compiled on all non-Windows platforms.
- Windows was correctly removed from both v3 and v4 rows since IAST native extensions (`_stacktrace`, `iastpatch`, `_native`) are not compiled on Windows (confirmed in `setup.py`).
