### PR TITLE
Update datadog-disaster-recovery.md

### DIFF
--- a/content/en/agent/guide/datadog-disaster-recovery.md
+++ b/content/en/agent/guide/datadog-disaster-recovery.md
@@ -93,7 +93,7 @@ export USER_EMAIL=<USER_EMAIL>
 export CONNECTION='{"data":{"id":"'${PRIMARY_ORG_ID}'","type":"hamr_org_connections","attributes":{"TargetOrgUuid":"'${DDR_ORG_ID}'","HamrStatus":1,"ModifiedBy":"'${USER_EMAIL}'", "IsPrimary":true}}}'
 
 curl -v -H "Content-Type: application/json" -H \
-"dd-api-key:${PRIMARY_DD_API_KEY}" -H \ 
+"dd-api-key:${PRIMARY_DD_API_KEY}" -H \
 "dd-application-key:${PRIMARY_DD_APP_KEY}" --data "${CONNECTION}" --request POST ${PRIMARY_DD_API_URL}/api/v2/hamr
 ```
 After linking your orgs, only the failover org displays this banner:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

This PR fixes DOCS-13770.

Edits are made to [Step 1 > Retrieve the public IDs and link your DDR and primary orgs](https://docs-staging.datadoghq.com/iadjivon/DOCS-13770-DDR-change/agent/guide/datadog-disaster-recovery/?tab=usingfleetautomationrecommended#:~:text=To%20link%20your%20DDR%20and%20primary%20orgs%3A)
- Modifies the code
- Adds a permission prerequisite

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [X] Ready for merge

