### PR TITLE
Improve LLM Observability instrumentation docs for agents and humans

### DIFF
--- a/content/en/llm_observability/instrumentation/_index.md
+++ b/content/en/llm_observability/instrumentation/_index.md
@@ -50,6 +50,91 @@ All supported SDKs provide advanced capabilities for custom instrumentation of y
 
 To learn more, see the [SDK Reference Documentation][2].
 
+##### Decorator quick-reference
+
+The following examples show how to add LLM Observability instrumentation to your functions. The `@workflow`, `@agent`, `@tool`, and `@task` decorators automatically capture function inputs and outputs. For full arguments and options, see the [SDK Reference Documentation][2].
+
+{{< tabs >}}
+{{% tab "Python" %}}
+{{< code-block lang="python" >}}
+from ddtrace.llmobs.decorators import workflow, agent, tool, task, llm, retrieval
+
+@workflow
+def my_pipeline(input_data):
+    # Top-level entry point for a static sequence of operations
+    ...
+
+@agent
+def my_agent(user_message):
+    # Autonomous agent with dynamic decision-making
+    ...
+
+@tool
+def call_external_api(query):
+    # Calls to external services, APIs, or databases
+    ...
+
+@task
+def preprocess_data(raw_input):
+    # Internal processing steps (no external calls)
+    ...
+
+@llm(model_name="gpt-4o", model_provider="openai")
+def invoke_llm(prompt):
+    # Direct LLM call (only needed if not using auto-instrumentation)
+    ...
+{{< /code-block >}}
+{{% /tab %}}
+
+{{% tab "Node.js" %}}
+{{< code-block lang="javascript" >}}
+const tracer = require('dd-trace').init({ llmobs: { mlApp: '<ML_APP>' } })
+const llmobs = tracer.llmobs
+
+// Top-level entry point for a static sequence of operations
+myPipeline = llmobs.wrap({ kind: 'workflow' }, myPipeline)
+
+// Autonomous agent with dynamic decision-making
+myAgent = llmobs.wrap({ kind: 'agent' }, myAgent)
+
+// Calls to external services, APIs, or databases
+callExternalApi = llmobs.wrap({ kind: 'tool' }, callExternalApi)
+
+// Internal processing steps (no external calls)
+preprocessData = llmobs.wrap({ kind: 'task' }, preprocessData)
+
+// Direct LLM call (only needed if not using auto-instrumentation)
+invokeLlm = llmobs.wrap({ kind: 'llm', modelName: 'gpt-4o', modelProvider: 'openai' }, invokeLlm)
+{{< /code-block >}}
+{{% /tab %}}
+
+{{% tab "Java" %}}
+{{< code-block lang="java" >}}
+import datadog.trace.api.llmobs.LLMObs;
+import datadog.trace.api.llmobs.LLMObsSpan;
+
+// Top-level entry point for a static sequence of operations
+LLMObsSpan workflowSpan = LLMObs.startWorkflowSpan("my-pipeline", null, null);
+
+// Autonomous agent with dynamic decision-making
+LLMObsSpan agentSpan = LLMObs.startAgentSpan("my-agent", null, null);
+
+// Calls to external services, APIs, or databases
+LLMObsSpan toolSpan = LLMObs.startToolSpan("call-external-api", null, null);
+
+// Internal processing steps (no external calls)
+LLMObsSpan taskSpan = LLMObs.startTaskSpan("preprocess-data", null, null);
+
+// Direct LLM call (only needed if not using auto-instrumentation)
+LLMObsSpan llmSpan = LLMObs.startLLMSpan("invoke-llm", "gpt-4o", "openai", null, null);
+
+// Call span.finish() after each operation completes
+{{< /code-block >}}
+{{% /tab %}}
+{{< /tabs >}}
+
+<div class="alert alert-info">Instrumentation is additive. Add imports and decorators to your existing functions without modifying their signatures, return values, or internal logic. Do not restructure or refactor code to accommodate instrumentation.</div>
+
 ### HTTP API instrumentation
 If your language is not supported by the SDKs or you are using custom integrations, you can instrument your application using Datadog's HTTP API.
 

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -917,6 +917,21 @@ LLMObs.startToolSpan(spanName, mlApp, sessionID);
 {{% /tab %}}
 {{< /tabs >}}
 
+### Choosing between tool and retrieval spans
+
+Retrieval spans are a specialized subcategory of tool spans. Use the following table to determine which span kind to apply:
+
+| Use `@tool` when | Use `@retrieval` when |
+|---|---|
+| The function calls an external API (web search, calculator, code interpreter) | The function performs a vector similarity search against an embedding store |
+| The function queries a traditional database (SQL, key-value, graph) | The function fetches ranked documents from a knowledge base for RAG |
+| The function reads or writes files, or makes HTTP requests | The function returns a list of documents with relevance scores |
+| The function name contains "retrieve" or "fetch" but does not search a vector database | The function is part of a retrieval-augmented generation (RAG) pipeline performing the document retrieval step |
+
+<div class="alert alert-info"><code>@retrieval</code> is only for vector search operations that return ranked documents from a knowledge base. For all other external calls — including traditional database queries and API requests — use <code>@tool</code>. When in doubt, use <code>@tool</code>.</div>
+
+Retrieval spans also expect document-structured output with a required `text` field and optional `name`, `id`, and `score` fields (see [Enriching spans](#enriching-spans)), while tool spans accept any JSON-serializable input and output.
+
 ### Tasks
 
 {{< tabs >}}
@@ -1190,6 +1205,31 @@ getRelevantDocs = llmobs.wrap({ kind: 'retrieval' }, getRelevantDocs)
 
 Starting a new span before the current span is finished automatically traces a parent-child relationship between the two spans. The parent span represents the larger operation, while the child span represents a smaller nested sub-operation within it.
 
+### Trace hierarchy
+
+The following diagrams show common parent-child relationships between span kinds:
+
+```
+agent (root)                        workflow (root)
+├── llm        ← reasoning step     ├── task       ← input validation
+├── tool       ← external API call  ├── retrieval  ← fetch relevant docs
+│   └── task   ← postprocessing     ├── llm        ← generate response
+├── workflow   ← static sub-pipeline└── task       ← format output
+│   ├── task   ← preprocessing
+│   ├── llm    ← LLM call
+│   └── retrieval ← vector search
+└── llm        ← final response
+```
+
+**Key nesting rules:**
+
+- **Agent** and **workflow** spans are typically root spans. They contain child spans representing the steps they orchestrate.
+- Any span kind can have children. Nesting is determined by the execution context, not by the span kind. For example, a `@tool` span can contain child `@task` or `@llm` spans if the tool function calls other decorated functions.
+- Nesting is automatic: calling a decorated function inside another decorated function creates a parent-child relationship. No explicit parent parameter is required.
+- A function decorated with `@workflow` that calls a function decorated with `@tool` produces a `workflow → tool` trace.
+
+### Basic example
+
 {{< tabs >}}
 {{% tab "Python" %}}
 {{< code-block lang="python" >}}
@@ -1249,12 +1289,170 @@ public class MyJavaClass {
 {{% /tab %}}
 {{< /tabs >}}
 
+### Multi-level nesting example
+
+The following example demonstrates a realistic agent trace with multiple nested span kinds:
+
+{{< tabs >}}
+{{% tab "Python" %}}
+{{< code-block lang="python" >}}
+from ddtrace.llmobs.decorators import agent, llm, tool, task
+
+@agent
+def customer_support_agent(user_message):
+    clean_message = sanitize_input(user_message)
+    intent = classify_intent(clean_message)
+    if intent == "order_status":
+        result = lookup_order(clean_message)
+    response = generate_response(clean_message, result)
+    return response
+
+@task
+def sanitize_input(message):
+    ... # clean and validate user input
+    return cleaned
+
+@llm(model_name="gpt-4o", model_provider="openai")
+def classify_intent(message):
+    ... # LLM call to classify intent
+    return intent
+
+@tool
+def lookup_order(message):
+    order_data = db.query(...)  # external database call
+    return order_data
+
+@llm(model_name="gpt-4o", model_provider="openai")
+def generate_response(message, context):
+    ... # LLM call to generate final response
+    return response
+{{< /code-block >}}
+
+This produces the following trace:
+
+```
+customer_support_agent (agent)
+├── sanitize_input (task)
+├── classify_intent (llm)       ← auto-instrumented OpenAI call
+├── lookup_order (tool)
+└── generate_response (llm)     ← auto-instrumented OpenAI call
+```
+{{% /tab %}}
+{{% tab "Node.js" %}}
+{{< code-block lang="javascript" >}}
+function sanitizeInput (message) {
+  ... // clean and validate user input
+  return cleaned
+}
+sanitizeInput = llmobs.wrap({ kind: 'task' }, sanitizeInput)
+
+function classifyIntent (message) {
+  ... // LLM call to classify intent
+  return intent
+}
+classifyIntent = llmobs.wrap({ kind: 'llm', modelName: 'gpt-4o', modelProvider: 'openai' }, classifyIntent)
+
+function lookupOrder (message) {
+  const orderData = ... // external database call
+  return orderData
+}
+lookupOrder = llmobs.wrap({ kind: 'tool' }, lookupOrder)
+
+function generateResponse (message, context) {
+  ... // LLM call to generate final response
+  return response
+}
+generateResponse = llmobs.wrap({ kind: 'llm', modelName: 'gpt-4o', modelProvider: 'openai' }, generateResponse)
+
+function customerSupportAgent (userMessage) {
+  const cleaned = sanitizeInput(userMessage)
+  const intent = classifyIntent(cleaned)
+  let result
+  if (intent === 'order_status') {
+    result = lookupOrder(cleaned)
+  }
+  return generateResponse(cleaned, result)
+}
+customerSupportAgent = llmobs.wrap({ kind: 'agent' }, customerSupportAgent)
+{{< /code-block >}}
+{{% /tab %}}
+{{% tab "Java" %}}
+{{< code-block lang="java" >}}
+import datadog.trace.api.llmobs.LLMObs;
+import datadog.trace.api.llmobs.LLMObsSpan;
+
+public class CustomerSupport {
+  public String handleRequest(String userMessage) {
+    LLMObsSpan agentSpan = LLMObs.startAgentSpan("customer-support-agent", null, null);
+    try {
+      LLMObsSpan taskSpan = LLMObs.startTaskSpan("sanitize-input", null, null);
+      String cleaned = sanitize(userMessage);
+      taskSpan.finish();
+
+      LLMObsSpan classifySpan = LLMObs.startLLMSpan("classify-intent", "gpt-4o", "openai", null, null);
+      String intent = classifyIntent(cleaned);
+      classifySpan.finish();
+
+      LLMObsSpan toolSpan = LLMObs.startToolSpan("lookup-order", null, null);
+      String orderData = lookupOrder(cleaned);
+      toolSpan.finish();
+
+      LLMObsSpan responseSpan = LLMObs.startLLMSpan("generate-response", "gpt-4o", "openai", null, null);
+      String response = generateResponse(cleaned, orderData);
+      responseSpan.finish();
+
+      return response;
+    } finally {
+      agentSpan.finish();
+    }
+  }
+}
+{{< /code-block >}}
+{{% /tab %}}
+{{< /tabs >}}
+
 
 ## Enriching spans
 
 <div class="alert alert-info">
 The <code>metrics</code> parameter here refers to numeric values attached as attributes on individual spans — not <a href="/llm_observability/monitoring/metrics/">Datadog platform metrics</a>. For certain recognized keys such as <code>input_tokens</code>, <code>output_tokens</code>, and <code>total_tokens</code>, Datadog uses these span attributes to generate corresponding platform metrics (such as <code>ml_obs.span.llm.input.tokens</code>) for use in dashboards and monitors.
 </div>
+
+<div class="alert alert-info">The <code>@workflow</code>, <code>@agent</code>, <code>@tool</code>, and <code>@task</code> decorators automatically capture function inputs and outputs. You only need to call <code>annotate()</code> to add metadata, metrics, tags, or to override the auto-captured values.</div>
+
+### Safe annotation pattern
+
+If your application initializes LLM Observability conditionally (for example, only in certain environments), wrap `annotate()` calls to avoid errors when LLM Observability is not enabled or when the span has already finished:
+
+{{< tabs >}}
+{{% tab "Python" %}}
+{{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
+
+def safe_annotate(**kwargs):
+    try:
+        LLMObs.annotate(**kwargs)
+    except Exception:
+        pass  # LLM Observability is not enabled or span is not active
+{{< /code-block >}}
+{{% /tab %}}
+
+{{% tab "Node.js" %}}
+{{< code-block lang="javascript" >}}
+function safeAnnotate (options) {
+  try {
+    llmobs.annotate(options)
+  } catch (e) {
+    // LLM Observability is not enabled or span is not active
+  }
+}
+{{< /code-block >}}
+{{% /tab %}}
+
+{{% tab "Java" %}}
+In Java, `LLMObsSpan` annotation methods are no-ops after `finish()` is called, so no safe wrapper is needed.
+{{% /tab %}}
+{{< /tabs >}}
 
 {{< tabs >}}
 {{% tab "Python" %}}

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -1209,16 +1209,26 @@ Starting a new span before the current span is finished automatically traces a p
 
 The following diagrams show common parent-child relationships between span kinds:
 
+**Agent-rooted trace:**
 ```
-agent (root)                        workflow (root)
-├── llm        ← reasoning step     ├── task       ← input validation
-├── tool       ← external API call  ├── retrieval  ← fetch relevant docs
-│   └── task   ← postprocessing     ├── llm        ← generate response
-├── workflow   ← static sub-pipeline└── task       ← format output
-│   ├── task   ← preprocessing
-│   ├── llm    ← LLM call
-│   └── retrieval ← vector search
-└── llm        ← final response
+agent (root)
+├── llm              ← reasoning step
+├── tool             ← external API call
+│   └── task         ← postprocessing
+├── workflow         ← static sub-pipeline
+│   ├── task         ← preprocessing
+│   ├── llm          ← LLM call
+│   └── retrieval    ← vector search
+└── llm              ← final response
+```
+
+**Workflow-rooted trace:**
+```
+workflow (root)
+├── task             ← input validation
+├── retrieval        ← fetch relevant docs
+├── llm              ← generate response
+└── task             ← format output
 ```
 
 **Key nesting rules:**

--- a/content/en/llm_observability/terms/_index.md
+++ b/content/en/llm_observability/terms/_index.md
@@ -54,6 +54,24 @@ LLM Observability supports the following span kinds:
 
 For instructions on creating spans from your application, including code examples, see [Tracing spans][2] in the LLM Observability SDK for Python documentation.
 
+### Span hierarchy
+
+Span kinds follow a natural hierarchy. Agent and workflow spans act as containers for other span kinds:
+
+```
+agent or workflow (root span)
+├── llm         ← Calls to language models
+├── tool        ← Calls to external services or APIs
+├── task        ← Internal processing steps (no external calls)
+├── embedding   ← Calls to embedding models
+├── retrieval   ← Vector search operations (subcategory of tool)
+└── workflow    ← Nested static sub-pipelines
+```
+
+- **Root spans**: `agent`, `workflow`, and `llm` spans can be root spans. Agent spans represent dynamic decision-making; workflow spans represent static sequences.
+- **Nesting**: Any span kind can have children. Nesting is determined by the execution context, not the span kind. In practice, `agent` and `workflow` spans are the most common parent spans, but `tool` and `task` spans can also contain children when needed.
+- **Retrieval vs. tool**: Retrieval spans are a specialized subcategory of tool spans, used only for vector search operations that return ranked documents from a knowledge base. For all other external calls, including traditional database queries and API requests, use tool spans.
+
 #### LLM span
 
 LLM spans represent a call to an LLM where input and outputs are represented as text.


### PR DESCRIPTION
## Summary

Improves the LLM Observability instrumentation documentation based on findings from a baseline experiment that measured how well coding agents (Claude Code) could follow the docs to instrument a Python codebase. Changes are validated against all three SDK implementations (Python, Node.js, Java) and informed by competitive research (Langfuse, LangSmith, Braintrust, Arize Phoenix).

**Key changes:**
- Add decorator quick-reference with tabbed Python/Node.js/Java examples to the high-level instrumentation page — eliminates a failure mode where agents with no code examples scored 0.0 on decorator accuracy
- Add `@tool` vs `@retrieval` decision table to SDK reference — all 6 test agents confused these two because docs didn't distinguish them
- Expand the "Nesting spans" section with ASCII trace hierarchy diagrams, nesting rules, and a realistic multi-level example across all 3 languages
- Add span hierarchy diagram to the Terms and Concepts page
- Add safe annotation pattern for Python/Node.js (all 6 test agents independently invented this pattern)
- Add note that `@workflow`/`@agent`/`@tool`/`@task` decorators auto-capture function inputs and outputs
- Add additive-only instrumentation guidance

Fixes DOCS-XXXXX

## Test plan

- [ ] Run Vale linter on all 3 modified files
- [ ] Verify Hugo rendering on branch preview
- [ ] Cross-reference all code examples against SDK source (done — see verification table in plan)
- [ ] Re-run baseline experiment to measure metric improvements

🤖 Generated with [Claude Code](https://claude.com/claude-code)