### PR TITLE
[CAP-3442] Add Kubernetes toolset to MCP Server documentation

### DIFF
--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -463,6 +463,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `ddsql`: Tools for querying Datadog data using [DDSQL][44], a SQL dialect with support for infrastructure resources, logs, metrics, RUM, spans, and other Datadog data sources
 - `error-tracking`: Tools for interacting with Datadog [Error Tracking][32]
 - `feature-flags`: Tools for managing [feature flags][35], including creating, listing, and updating flags and their environments
+- `kubernetes`: Tools for searching and describing [Kubernetes][51] resources and retrieving manifests across all clusters
 - `llmobs`: Tools for searching and analyzing [LLM Observability][36] spans and experiments
 - `networks`: Tools for [Cloud Network Monitoring][37] analysis and [Network Device Monitoring][38]
 - `onboarding`: Agentic onboarding tools for guided Datadog setup and configuration
@@ -650,3 +651,4 @@ Local authentication is recommended for Cline and when remote authentication is 
 [48]: /reference_tables/
 [49]: /bits_ai/mcp_server/tools
 [50]: https://github.com/google-gemini/gemini-cli
+[51]: /containers/monitoring/kubernetes_explorer/

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -775,7 +775,7 @@ Tools for searching and describing [Kubernetes][55] resources and retrieving man
 ### `search_datadog_k8s_resources`
 *Toolset: **kubernetes***\
 *Permissions Required: `Hosts Read` and `Teams Read`*\
-Searches for [Kubernetes][55] resources across all clusters. Use this tool instead of `kubectl` to determine the state of Kubernetes resources such as deployments, pods, nodes, etc. This tool does not require local cluster access, works across all clusters, and returns enriched data with tags.
+Searches for [Kubernetes][55] resources across all clusters. Use this tool instead of `kubectl` to determine the state of Kubernetes resources such as deployments, pods, nodes, etc. This tool does not require local cluster access, works across all clusters, and returns enriched data with tags. You can include specific tag keys (or all tags) on each result, and include parent resource names to investigate relationships between resources (for example, the deployment a pod belongs to).
 
 - Show me all pods in the `production` namespace with `CrashLoopBackOff` status.
 - Find deployments with in-progress rollouts in the `general2` cluster.

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -775,16 +775,17 @@ Tools for searching and describing [Kubernetes][55] resources and retrieving man
 ### `search_datadog_k8s_resources`
 *Toolset: **kubernetes***\
 *Permissions Required: `Hosts Read` and `Teams Read`*\
-Searches for [Kubernetes][55] resources across all clusters. Use this tool instead of `kubectl` to determine the state of Kubernetes resources such as deployments, pods, nodes, etc. This tool does not require local cluster access, works across all clusters, and returns enriched data with tags. You can include specific tag keys (or all tags) on each result, and include parent resource names to investigate relationships between resources (for example, the deployment a pod belongs to).
+Searches for [Kubernetes][55] resources across all clusters. Use this tool instead of `kubectl` to determine the state of Kubernetes resources such as deployments, pods, nodes, etc. This tool does not require local cluster access, works across all clusters, and returns enriched data with tags. You can include specific tag keys on each result, and include parent resource names to investigate relationships between resources (for example, the deployment a pod belongs to).
 
 - Show me all pods in the `production` namespace with `CrashLoopBackOff` status.
 - Find deployments with in-progress rollouts in the `general2` cluster.
 - List all nodes in my cluster sorted by CPU usage.
+- Group deployments by `service` and `env` to see how my services are distributed across environments.
 
 ### `describe_datadog_k8s_resource`
 *Toolset: **kubernetes***\
 *Permissions Required: `Hosts Read`*\
-Gets detailed information about a specific [Kubernetes][55] resource, including `kubectl`-style tabular fields, resource-specific details (such as CPU and memory requests and limits), tags, labels, annotations, and optionally manifest history, parent resources, and a deep link to the [Kubernetes Explorer][55]. Use this tool instead of `kubectl describe`. Identify a resource by its UID from a previous search or by providing resource identifiers (cluster, namespace, and resource name). For the full raw manifest, use `get_datadog_k8s_manifest`.
+Gets detailed information about a specific [Kubernetes][55] resource, including resource-specific details such as CPU and memory requests and limits, and optionally tags, labels, annotations, manifest history, parent resources, and a deep link to the [Kubernetes Explorer][55]. Use this tool instead of `kubectl describe`. Identify a resource by its UID from a previous search or by providing resource identifiers (cluster, namespace, and resource name). For the full raw manifest, use `get_datadog_k8s_manifest`.
 
 - Describe pod `my-app` in cluster `prod`, namespace `default`.
 - Get details for deployment `api-server` in namespace `default`, cluster `staging`.

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -768,6 +768,37 @@ Syncs feature flag allocations for a specific environment.
 
 - Sync the allocations for flag `new-checkout-flow` in production.
 
+## Kubernetes
+
+Tools for searching and describing [Kubernetes][55] resources and retrieving manifests across all clusters.
+
+### `search_datadog_k8s_resources`
+*Toolset: **kubernetes***\
+*Permissions Required: `Hosts Read` and `Teams Read`*\
+Searches for [Kubernetes][55] resources across all clusters. Use this tool instead of `kubectl` to determine the state of Kubernetes resources such as deployments, pods, nodes, etc. This tool does not require local cluster access, works across all clusters, and returns enriched data with tags.
+
+- Show me all pods in the `production` namespace with `CrashLoopBackOff` status.
+- Find deployments with in-progress rollouts in the `general2` cluster.
+- List all nodes in my cluster sorted by CPU usage.
+
+### `describe_datadog_k8s_resource`
+*Toolset: **kubernetes***\
+*Permissions Required: `Hosts Read`*\
+Gets detailed information about a specific [Kubernetes][55] resource, including `kubectl`-style tabular fields, resource-specific details (such as CPU and memory requests and limits), tags, labels, annotations, and optionally manifest history, parent resources, and a deep link to the [Kubernetes Explorer][55]. Use this tool instead of `kubectl describe`. Identify a resource by its UID from a previous search or by providing resource identifiers (cluster, namespace, and resource name). For the full raw manifest, use `get_datadog_k8s_manifest`.
+
+- Describe pod `my-app` in cluster `prod`, namespace `default`.
+- Get details for deployment `api-server` in namespace `default`, cluster `staging`.
+- Show me the tags and annotations for this Kubernetes resource.
+
+### `get_datadog_k8s_manifest`
+*Toolset: **kubernetes***\
+*Permissions Required: `Hosts Read`*\
+Retrieves the YAML manifest for a specific [Kubernetes][55] resource. Use this tool instead of `kubectl get -o yaml`. Supports extracting specific subtrees with a `kubectl` JSONPath expression and a concise mode that omits `status` and `managedFields` to reduce response size.
+
+- Get the manifest for pod `my-app` in cluster `prod`, namespace `default`.
+- Show me the container ports for deployment `api-server` in namespace `default`, cluster `staging`.
+- Get the container images from the manifest of pod `my-app`.
+
 ## Networks
 
 Tools for [Cloud Network Monitoring][31] analysis and [Network Device Monitoring][32].
@@ -1105,3 +1136,4 @@ Adds an agent trigger to a workflow and publishes it, enabling the workflow to b
 [51]: /feature_flags/
 [53]: /security/threats/security_signals/
 [54]: /security/misconfigurations/findings/
+[55]: /containers/monitoring/kubernetes_explorer/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds the `kubernetes` toolset to the Datadog MCP Server documentation page. This toolset includes three tools:

- **`search_datadog_k8s_resources`**: Search for Kubernetes resources across all clusters (replaces `kubectl` for search use cases)
- **`describe_datadog_k8s_resource`**: Get detailed information about a specific Kubernetes resource (replaces `kubectl describe`)
- **`get_datadog_k8s_manifest`**: Retrieve the YAML manifest for a Kubernetes resource (replaces `kubectl get -o yaml`)

These tools work across all clusters without requiring local cluster access and return enriched data with tags and metrics.

### Merge instructions

Merge readiness:

Ready to be merged
