### PR TITLE
[TXP-73] Fix styling for `integration-api-key-picker` shortcode

### DIFF
--- a/layouts/shortcodes/integration-api-key-picker.html
+++ b/layouts/shortcodes/integration-api-key-picker.html
@@ -13,8 +13,8 @@
 
 <div class="shortcode-wrapper shortcode-integration-api-key-picker">
 {{- if eq $type "api-key" -}}
-  <p>Copy your Datadog API key from the <strong>Configure</strong> tab on the <a href="{{ $tile_url }}">{{ $integration_title }} integration tile</a>.</p>
+  Copy your Datadog API key from the <strong>Configure</strong> tab on the <a href="{{ $tile_url }}">{{ $integration_title }} integration tile</a>.
 {{- else -}}
-  <p>Copy the generated webhook URL from the <strong>Configure</strong> tab on the <a href="{{ $tile_url }}">{{ $integration_title }} integration tile</a>.</p>
+  Copy the generated webhook URL from the <strong>Configure</strong> tab on the <a href="{{ $tile_url }}">{{ $integration_title }} integration tile</a>.
 {{- end -}}
 </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
I've now tested this out with some staging changes to docs for Incident.io ([PR here](https://github.com/DataDog/integrations-core/pull/23194)). Looks like `<p>` has margin at the bottom, removing that to ensure spacing is consistent when this shortcode is used in lists.

Example with new styling:
<img width="1194" height="715" alt="image" src="https://github.com/user-attachments/assets/24206cbc-4a71-4d7b-a564-153428c2af5c" />


### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->
Manual

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
