### PR TITLE
Add blog post to Further Reading in Code Security MCP Server page

### DIFF
--- a/content/en/security/code_security/dev_tool_int/mcp_server/_index.md
+++ b/content/en/security/code_security/dev_tool_int/mcp_server/_index.md
@@ -4,6 +4,9 @@ description: Use the Datadog Code Security MCP server to run SAST, secrets detec
 is_beta: true
 disable_toc: false
 further_reading:
+- link: "https://www.datadoghq.com/blog/introducing-datadog-code-security-mcp/"
+  tag: "Blog"
+  text: "Introducing the Datadog Code Security MCP Server"
 - link: "https://www.datadoghq.com/blog/monitor-mcp-servers/"
   tag: "Blog"
   text: "Identify common security risks in MCP servers"


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds the Datadog Code Security MCP Server blog post to the Further Reading section of the Code Security MCP Server documentation page.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes