### PR TITLE
[DOCS-11179] Fix instruction order in browser tracking user actions doc

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/tracking_user_actions.md
@@ -32,9 +32,22 @@ You can accomplish the following objectives:
 
 While there is no explicit cap on the total number of actions that can be collected by the RUM Browser SDK during a session, there are technical limitations on individual event sizes and the payload sent. For further details about limitations on actions, see [RUM Browser Troubleshooting documentation][1].
 
+## Track user interactions
+
+To enable automatic click tracking, set `trackUserInteractions: true` in your SDK initialization:
+
+```javascript
+window.DD_RUM.init({
+    ...
+    trackUserInteractions: true,
+});
+```
+
+The RUM Browser SDK automatically tracks clicks to generate click actions. A one-click action generally represents one user click, except when the same element is clicked multiple times in a row, which is considered a single action (see [Frustration Signals "rage clicks"][4]).
+
 ## Manage information being collected
 
-The `trackUserInteractions` initialization parameter enables the collection of user clicks in your application, which means sensitive and private data contained in your pages may be included to identify elements that a user interacted with.
+When user interaction tracking is enabled, sensitive and private data contained in your pages may be included to identify elements that a user interacted with.
 
 To control which information is sent to Datadog, you can [mask action names with privacy options][2], [manually set an action name](#declare-a-name-for-click-actions), or [implement a global scrubbing rule in the Datadog Browser SDK for RUM][3].
 
@@ -53,10 +66,6 @@ window.DD_RUM.init({
 When enabled, all action names are replaced with `Masked Element`. Action names explicitly set with the `data-dd-action-name` attribute are still displayed, allowing you to selectively expose specific action names while keeping others masked.
 
 <div class="alert alert-info">If your application uses a JavaScript bundler, the <a href="/real_user_monitoring/application_monitoring/browser/build_plugins/action_name_deobfuscation">Action Name Deobfuscation build plugin</a> automatically restores readable action names in minified builds.</div>
-
-## Track user interactions
-
-The RUM Browser SDK automatically tracks clicks to generate click actions. A one-click action generally represents one user click, except when the same element is clicked multiple times in a row, which is considered a single action (see [Frustration Signals "rage clicks"][4]).
 
 ## Action timing telemetry
 

--- a/content/en/real_user_monitoring/application_monitoring/browser/tracking_user_actions.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/tracking_user_actions.md
@@ -47,7 +47,7 @@ The RUM Browser SDK automatically tracks clicks to generate click actions. A one
 
 ## Manage information being collected
 
-When user interaction tracking is enabled, sensitive and private data contained in your pages may be included to identify elements that a user interacted with.
+When user interaction tracking is enabled, sensitive, and private data contained in your pages may be included to identify elements that a user interacted with.
 
 To control which information is sent to Datadog, you can [mask action names with privacy options][2], [manually set an action name](#declare-a-name-for-click-actions), or [implement a global scrubbing rule in the Datadog Browser SDK for RUM][3].
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-11179

Addresses user feedback that `trackUserInteractions: true` wasn't clearly identified as a required setup step before the customization instructions.

- Moved "Track user interactions" section before "Manage information being collected" so setup comes before customization
- Added a code example showing `trackUserInteractions: true` must be set in the SDK init

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes