### PR TITLE
Added documentation for new repo datadog-custom-rules-template

### DIFF
--- a/content/en/security/code_security/static_analysis/custom_rules/_index.md
+++ b/content/en/security/code_security/static_analysis/custom_rules/_index.md
@@ -51,7 +51,7 @@ On every push to `main`, the GitHub Action runs `upload.py`, which:
 - **Updates** rulesets and rules whose content has changed
 - **Deletes** rulesets and rules that have been removed from disk
 
-Only changed rules trigger API calls — unchanged rules are skipped.
+Only changed rules trigger API calls—unchanged rules are skipped.
 
 To trigger a sync without pushing a commit, go to the **Actions** tab and click **Upload Custom Rules → Run workflow**.
 
@@ -76,9 +76,9 @@ description: Detailed description.
 category: BEST_PRACTICES     # SECURITY | BEST_PRACTICES | CODE_STYLE | ERROR_PRONE | PERFORMANCE
 severity: ERROR              # ERROR | WARNING | NOTICE | INFO
 language: JAVASCRIPT
-tree_sitter_query: ...       # See Anatomy of a custom rule
-code: |-                     # See Anatomy of a custom rule
-  function visit(node, filename, code) { ... }
+tree_sitter_query: <TREE_SITTER_QUERY>    # See Anatomy of a custom rule
+code: |-                                  # See Anatomy of a custom rule
+  function visit(node, filename, code) { <RULE_LOGIC> }
 tests: []
 is_published: false          # Set to true when the rule is ready for scans
 ```

--- a/content/en/security/code_security/static_analysis/custom_rules/_index.md
+++ b/content/en/security/code_security/static_analysis/custom_rules/_index.md
@@ -47,7 +47,7 @@ As an alternative to managing custom rules in Datadog, the [datadog-custom-rules
 ### How sync works
 
 On every push to `main`, the GitHub Action runs `upload.py`, which:
-- **Creates** rulesets and rules that are new on disk
+- **Creates** rulesets and rules that are new in the repository
 - **Updates** rulesets and rules whose content has changed
 - **Deletes** rulesets and rules that have been removed the repository
 

--- a/content/en/security/code_security/static_analysis/custom_rules/_index.md
+++ b/content/en/security/code_security/static_analysis/custom_rules/_index.md
@@ -27,7 +27,7 @@ ruleset names are `python-security`, `cobra-team-checks`, or `my-company-securit
 
 ## Manage rules with the template repository
 
-As an alternative to managing custom rules in Datadog, the [datadog-custom-rules-template][5] GitHub repository provides a Git-based workflow for managing custom rules as code. On every push to `main`, a GitHub Action automatically creates, updates, or deletes rulesets and rules to match what's on disk.
+As an alternative to managing custom rules in Datadog, the [datadog-custom-rules-template][5] GitHub repository provides a Git-based workflow for managing custom rules as code. On every push to `main`, a GitHub Action automatically creates, updates, or deletes rulesets and rules to match what's in the repository.
 
 ### Get started
 

--- a/content/en/security/code_security/static_analysis/custom_rules/_index.md
+++ b/content/en/security/code_security/static_analysis/custom_rules/_index.md
@@ -25,6 +25,64 @@ on how rules are organized within a ruleset. For example, some users might want 
 A ruleset must have a unique name with only letters, numbers, and hyphens (`-`). Examples of valid
 ruleset names are `python-security`, `cobra-team-checks`, or `my-company-security-checks`.
 
+## Manage rules with the template repository
+
+The [datadog-custom-rules-template][5] GitHub repository provides a Git-based workflow for managing custom rules. On every push to `main`, a GitHub Action automatically creates, updates, or deletes rulesets and rules to match what's on disk.
+
+### Get started
+
+1. Click **Use this template** on the [datadog-custom-rules-template][5] repository to create your own copy.
+2. Add your Datadog credentials as GitHub secrets. See [Authentication](#authentication).
+3. Rename `rulesets/my-custom-rules/` or add new ruleset directories under `rulesets/`.
+4. Push to `main`. The GitHub Action uploads your rules automatically.
+
+### Authentication
+
+1. In your GitHub repository, go to **Settings → Secrets and variables → Actions**.
+2. Add three secrets:
+   - `DD_API_KEY` — your Datadog API key
+   - `DD_APP_KEY` — your Datadog Application key
+   - `DD_SITE` — your Datadog site hostname (for example, `datadoghq.com`, `datadoghq.eu`, or `us3.datadoghq.com`)
+
+### How sync works
+
+On every push to `main`, the GitHub Action runs `upload.py`, which:
+- **Creates** rulesets and rules that are new on disk
+- **Updates** rulesets and rules whose content has changed
+- **Deletes** rulesets and rules that have been removed from disk
+
+Only changed rules trigger API calls — unchanged rules are skipped.
+
+To trigger a sync without pushing a commit, go to the **Actions** tab and click **Upload Custom Rules → Run workflow**.
+
+### Rule file format
+
+Each ruleset directory contains a `ruleset.yaml` and a separate `.yaml` file for each rule.
+
+**`ruleset.yaml`**
+
+```yaml
+name: my-org-custom-rules
+short_description: One-line summary
+description: Longer description of what this ruleset covers.
+```
+
+**Rule file**
+
+```yaml
+name: your-rule-name
+short_description: One-line summary
+description: Detailed description.
+category: BEST_PRACTICES     # SECURITY | BEST_PRACTICES | CODE_STYLE | ERROR_PRONE | PERFORMANCE
+severity: ERROR              # ERROR | WARNING | NOTICE | INFO
+language: JAVASCRIPT
+tree_sitter_query: ...       # See Anatomy of a custom rule
+code: |-                     # See Anatomy of a custom rule
+  function visit(node, filename, code) { ... }
+tests: []
+is_published: false          # Set to true when the rule is ready for scans
+```
+
 ## Anatomy of a custom rule
 
 A custom rule is composed of three main components:
@@ -85,3 +143,4 @@ All Datadog default rules are available in [Code Security][4]. You can easily an
 [2]: https://tree-sitter.github.io/
 [3]: https://tree-sitter.github.io/tree-sitter/using-parsers/queries/index.html
 [4]: https://app.datadoghq.com/ci/code-analysis/static-analysis/default-rulesets
+[5]: https://github.com/DataDog/datadog-custom-rules-template

--- a/content/en/security/code_security/static_analysis/custom_rules/_index.md
+++ b/content/en/security/code_security/static_analysis/custom_rules/_index.md
@@ -53,7 +53,7 @@ On every push to `main`, the GitHub Action runs `upload.py`, which:
 
 Only changed rules trigger API calls—unchanged rules are skipped.
 
-To trigger a sync without pushing a commit, go to the **Actions** tab and click **Upload Custom Rules → Run workflow**.
+To run a sync manually, in to your GitHub repository, go to the **Actions** tab, select **Upload Custom Rules**, and click **Run workflow**.
 
 ### Rule file format
 

--- a/content/en/security/code_security/static_analysis/custom_rules/_index.md
+++ b/content/en/security/code_security/static_analysis/custom_rules/_index.md
@@ -49,7 +49,7 @@ As an alternative to managing custom rules in Datadog, the [datadog-custom-rules
 On every push to `main`, the GitHub Action runs `upload.py`, which:
 - **Creates** rulesets and rules that are new on disk
 - **Updates** rulesets and rules whose content has changed
-- **Deletes** rulesets and rules that have been removed from disk
+- **Deletes** rulesets and rules that have been removed the repository
 
 Only changed rules trigger API calls—unchanged rules are skipped.
 

--- a/content/en/security/code_security/static_analysis/custom_rules/_index.md
+++ b/content/en/security/code_security/static_analysis/custom_rules/_index.md
@@ -27,7 +27,7 @@ ruleset names are `python-security`, `cobra-team-checks`, or `my-company-securit
 
 ## Manage rules with the template repository
 
-The [datadog-custom-rules-template][5] GitHub repository provides a Git-based workflow for managing custom rules. On every push to `main`, a GitHub Action automatically creates, updates, or deletes rulesets and rules to match what's on disk.
+As an alternative to managing custom rules in Datadog, the [datadog-custom-rules-template][5] GitHub repository provides a Git-based workflow for managing custom rules as code. On every push to `main`, a GitHub Action automatically creates, updates, or deletes rulesets and rules to match what's on disk.
 
 ### Get started
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Add a "Manager rules with the template repository" section to the SAST custom rules page. This documents [datadog-custom-rules-template](https://github.com/DataDog/datadog-custom-rules-template) GitHub template for managing custom rules as code

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge