### PR TITLE
[WEB-8784] Enforce max image width via Fastly IO params in img shortcode

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -2,10 +2,10 @@ environment: default
 # do not delete repo_name, used by websites-modules as context
 repo_name: "documentation"
 integrations_img_url: "https://static.datadoghq.com/static/images/logos/"
-imgix:
-  header_jpg: "?ch=Width&fit=max&fm=jpg&auto=format&lossless=true"
-  header_png: "?ch=Width&fit=max&fm=png&auto=format&lossless=1"
-  header_gif: "?ch=Width,Save-Data&fm=gif"
+img:
+  header_jpg: "?fit=max&fm=jpg&auto=format&lossless=true"
+  header_png: "?fit=max&fm=png&auto=format&lossless=1"
+  header_gif: "?fm=gif"
   jpg: "?fm=jpg&auto=format&lossless=true"
   png: "?fm=png&auto=format&lossless=1"
   gif: ""

--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -3,11 +3,11 @@ environment: default
 repo_name: "documentation"
 integrations_img_url: "https://static.datadoghq.com/static/images/logos/"
 img:
-  header_jpg: "?fit=max&fm=jpg&auto=format&lossless=true"
-  header_png: "?fit=max&fm=png&auto=format&lossless=1"
+  header_jpg: "?fit=max&fm=jpg&auto=format"
+  header_png: "?fit=max&fm=png&auto=format"
   header_gif: "?fm=gif"
-  jpg: "?fm=jpg&auto=format&lossless=true"
-  png: "?fm=png&auto=format&lossless=1"
+  jpg: "?fm=jpg&auto=format"
+  png: "?fm=png&auto=format"
   gif: ""
 code_languages:
   'py':

--- a/layouts/partials/img.html
+++ b/layouts/partials/img.html
@@ -4,7 +4,7 @@ there MUST NOT be an empty line at the end of this file */}}
 {{ if .img_param }}
     {{ .root.Scratch.Set "img_param" .img_param }}
 {{ else }}
-    {{ .root.Scratch.Set "img_param" "?ch=Width,DPR&fit=max" }}
+    {{ .root.Scratch.Set "img_param" "?fit=max" }}
 {{ end }}
 {{ $img_param := .root.Scratch.Get "img_param" }}
 

--- a/layouts/partials/nav/left-nav.html
+++ b/layouts/partials/nav/left-nav.html
@@ -47,8 +47,8 @@
                                 {{ $url_without_anchor = (index (split .URL "#") 0) }}
                                 <a href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}" data-skip="{{ .Params.skip | not | not }}">
                                     {{ if .Pre }}
-                                    {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
-                                    {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                    {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?fit=max&auto=format&w=21") -}}
+                                    {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?fit=max&auto=format&w=21" "disable_lazy" "true") -}}
                                     {{ end }}
                                     <span>{{ .Name }}</span>
                                 </a>
@@ -60,8 +60,8 @@
                                         {{ $url_without_anchor = (index (split .URL "#") 0) }}
                                         <a href="{{ .URL | relLangURL }}" data-type="{{- with site.GetPage .URL -}}{{- .Type -}}{{- end -}}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}" data-skip="{{ .Params.skip | not | not }}">
                                             {{ if .Pre }}
-                                            {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
-                                            {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                            {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?fit=max&auto=format&w=21") -}}
+                                            {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?fit=max&auto=format&w=21" "disable_lazy" "true") -}}
                                             {{ end }}
                                             <span>{{ .Name }}</span>
                                         </a>
@@ -77,8 +77,8 @@
                                                     {{ $url_without_anchor = (index (split .URL "#") 0) }}
                                                     <a data-name="{{- delimit (last 1 (split (strings.TrimSuffix "/" .URL) "/")) "" -}}" href="{{ .URL | relLangURL }}" data-path="{{ trim (print $branchPath ((print $url_without_anchor) | relLangURL)) "/" }}" data-skip="{{ .Params.skip | not | not }}">
                                                         {{ if .Pre }}
-                                                        {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21") -}}
-                                                        {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?ch=Width,DPR&fit=max&auto=format&w=21" "disable_lazy" "true") -}}
+                                                        {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) ".png") "class" "static" "alt" "icon" "width" "21" "img_param" "?fit=max&auto=format&w=21") -}}
+                                                        {{- partial "img.html" (dict "root" $ctx "src" (print "icons/" (.Pre) "_p.png") "class" "hover" "alt" "icon" "width" "21" "img_param" "?fit=max&auto=format&w=21" "disable_lazy" "true") -}}
                                                         {{ end }}
                                                         <span>{{ .Name }}</span>
                                                     </a>

--- a/layouts/partials/platforms/platforms.html
+++ b/layouts/partials/platforms/platforms.html
@@ -66,7 +66,7 @@
                                 <a class="card" href="{{ .link | absLangURL }}">
                                     <div class="card-body text-center">
                                         {{ $src := (print "icons/" .image)}}
-                                        {{ $url := (print ($dot.Site.Params.img_url) "images/" $src "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                                        {{ $url := (print ($dot.Site.Params.img_url) "images/" $src "?fit=max&auto=format") | safeURL }}
                                         <picture class="mx-auto">
                                             <source srcset="{{ $url }}&w=138 1x, {{ $url }}&w=138&dpr=2 2x" media="(min-width: 1200px)">
                                             <source srcset="{{ $url }}&w=108 1x, {{ $url }}&w=108&dpr=2 2x" media="(min-width: 992px)">

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -42,7 +42,8 @@
 {{- $img_param := $.Scratch.Get "img_param" -}}
 {{- $pop_param := $.Scratch.Get "pop_param" -}}
 {{- $figure_class :=  .Get "figure_class" -}}
-{{ $e := (print $img_resource "?auto=format&w=" $img_w | safeURL) }}
+{{- $e := (print $img_resource "?auto=format&fit=max&w=" $img_w | safeURL) -}}
+{{- $e2x := (print $img_resource "?auto=format&fit=max&w=" $img_w "&dpr=2" | safeURL) -}}
 {{- if not (eq $img_inline "true")}}
   <div class="shortcode-wrapper shortcode-img expand {{- if $wide -}}wide-parent{{- end -}}"><figure class="text-center {{- if $wide -}}wide {{- end -}}{{ $figure_class -}}" {{- if .Get "figure_style" -}}style="{{- with .Get "figure_style" -}}{{- . | safeCSS -}}{{- end -}}"{{- end -}}>
     {{- if $video -}}
@@ -66,23 +67,21 @@
       {{- if .Get "target" -}}target="{{- with .Get "target" -}}{{- . -}}{{- end -}}"{{- end -}} >
   {{- end -}}
   {{- if $wide -}}
-    {{ $e := (print $img_resource "?auto=format&w=" $img_w | safeURL) }}
     {{- if eq $image_ext "gif" -}}
       <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
     {{- else -}}
       <picture {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }}>
-        <img class="img-fluid" srcset="{{ $e }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
+        <img class="img-fluid" srcset="{{ $e }} 1x, {{ $e2x }} 2x" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
       </picture>
     {{- end -}}
   {{- else -}}
-      {{ $e := (print $img_resource "?auto=format&w=" $img_w | safeURL) }}
       {{- if eq $image_ext "gif" -}}
           <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{ . | safeCSS }}{{- end -}}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
       {{- else -}}
         <picture class="" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{- . | safeCSS -}}{{- end -}}" {{ end }} >
           <img 
               class="img-fluid" 
-              srcset="{{ $e }}" 
+              srcset="{{ $e }} 1x, {{ $e2x }} 2x"
               {{ if .Get "style" }}style="{{ with .Get "style" }}{{ . | safeCSS }}{{ end }}" {{ end }} 
               {{- with $img_width -}} width="{{ . }}" {{- end -}}
               {{- with $img_height -}} height="{{ . }}" {{- end -}}
@@ -104,8 +103,8 @@
     </figure>
   </div>
   {{- else -}}
-  <img 
-    srcset="{{ $e }}" 
+  <img
+    srcset="{{ $e }} 1x, {{ $e2x }} 2x"
     {{ if .Get "style" }}style="{{ with .Get "style" }}{{ . | safeCSS }}{{ end }}" {{ end }} 
     {{- with $img_width -}} width="{{ . }}" {{- end -}}
     {{- with $img_height -}} height="{{ . }}" {{- end -}} />

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -20,11 +20,11 @@
 {{- $image_type_arr := split (.Get "src") "." -}}
 {{- $image_ext := index $image_type_arr 1 -}}
 {{- if $wide -}}
-    {{- $.Scratch.Set "imgix_w" "1170" -}}
+    {{- $.Scratch.Set "img_w" "1170" -}}
 {{- else -}}
-    {{- $.Scratch.Set "imgix_w" "850" -}}
+    {{- $.Scratch.Set "img_w" "850" -}}
 {{- end -}}
-{{- $imgix_w := $.Scratch.Get "imgix_w" -}}
+{{- $img_w := $.Scratch.Get "img_w" -}}
 {{- if .Get "img_param" | len -}}
   {{- .Get "img_param" | $.Scratch.Add "img_param" -}}
 {{- else -}}
@@ -42,7 +42,7 @@
 {{- $img_param := $.Scratch.Get "img_param" -}}
 {{- $pop_param := $.Scratch.Get "pop_param" -}}
 {{- $figure_class :=  .Get "figure_class" -}}
-{{ $e := (print $img_resource "?auto=format" | safeURL) }}
+{{ $e := (print $img_resource "?auto=format&w=" $img_w | safeURL) }}
 {{- if not (eq $img_inline "true")}}
   <div class="shortcode-wrapper shortcode-img expand {{- if $wide -}}wide-parent{{- end -}}"><figure class="text-center {{- if $wide -}}wide {{- end -}}{{ $figure_class -}}" {{- if .Get "figure_style" -}}style="{{- with .Get "figure_style" -}}{{- . | safeCSS -}}{{- end -}}"{{- end -}}>
     {{- if $video -}}
@@ -66,7 +66,7 @@
       {{- if .Get "target" -}}target="{{- with .Get "target" -}}{{- . -}}{{- end -}}"{{- end -}} >
   {{- end -}}
   {{- if $wide -}}
-    {{ $e := (print $img_resource "?auto=format" safeURL) }}
+    {{ $e := (print $img_resource "?auto=format&w=" $img_w | safeURL) }}
     {{- if eq $image_ext "gif" -}}
       <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{ with .Get "style" }}{{ . | safeCSS }}{{end}}" {{ end }} {{ if .Get "alt" }} alt="{{ with .Get "alt"}}{{ . }}{{ end }}" {{ end }} />
     {{- else -}}
@@ -75,7 +75,7 @@
       </picture>
     {{- end -}}
   {{- else -}}
-      {{ $e := (print $img_resource "?auto=format" | safeURL) }}
+      {{ $e := (print $img_resource "?auto=format&w=" $img_w | safeURL) }}
       {{- if eq $image_ext "gif" -}}
           <img class="img-fluid" src="{{ (print $img_resource | safeURL) }}" {{ if .Get "style" }} style="{{- with .Get "style" -}}{{ . | safeCSS }}{{- end -}}" {{ end }} {{ if .Get "alt" }} alt="{{- with .Get "alt" -}}{{.}}{{- end -}}" {{ end }} />
       {{- else -}}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -28,7 +28,7 @@
 {{- if .Get "img_param" | len -}}
   {{- .Get "img_param" | $.Scratch.Add "img_param" -}}
 {{- else -}}
-  {{- $.Scratch.Add "img_param" (printf "?ch=Width,DPR&fit=max") -}}
+  {{- $.Scratch.Add "img_param" (printf "?fit=max") -}}
 {{- end -}}
 {{- if .Get "pop_param" | len -}}
   {{- .Get "pop_param" | $.Scratch.Add "pop_param" -}}

--- a/layouts/shortcodes/tile-nav.html
+++ b/layouts/shortcodes/tile-nav.html
@@ -3,7 +3,7 @@
     <div class="card-deck">
         <a class="card agent" href="{{ "agent/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/agent.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (.Site.Params.img_url) "images/icons/agent.png"  "?fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -15,7 +15,7 @@
         </a>
         <a class="card integrations" href="{{ "integrations/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url)  "images/icons/integrations.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (.Site.Params.img_url)  "images/icons/integrations.png"  "?fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -28,7 +28,7 @@
         <div class="w-100 d-none d-sm-block d-md-none"><!-- wrap every 2 on sm--></div>
         <a class="card graphing" href="{{ "graphing/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/graphing.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (.Site.Params.img_url) "images/icons/graphing.png"  "?fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -43,7 +43,7 @@
         <div class="w-100 d-none d-xl-block"><!-- wrap every 3 on xl--></div>
         <a class="card alerting" href="{{ "monitoring/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/alerting.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (.Site.Params.img_url) "images/icons/alerting.png"  "?fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -56,7 +56,7 @@
         <div class="w-100 d-none d-sm-block d-md-none"><!-- wrap every 2 on sm--></div>
         <a class="card tracing" href="{{ "tracing/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/tracing_apm.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (.Site.Params.img_url) "images/icons/tracing_apm.png"  "?fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">
@@ -68,7 +68,7 @@
         </a>
         <a class="card developers" href="{{ "developers/" | absLangURL }}">
             <div class="card-body text-center">
-                {{ $url := (print (.Site.Params.img_url) "images/icons/developers.png"  "?ch=Width,DPR&fit=max&auto=format") | safeURL }}
+                {{ $url := (print (.Site.Params.img_url) "images/icons/developers.png"  "?fit=max&auto=format") | safeURL }}
                 <picture class="mx-auto">
                     <source srcset="{{ $url }}&w=80 1x, {{ $url }}&w=80&dpr=2 2x" media="(min-width: 576px)">
                     <source srcset="{{ $url }}&w=47 1x, {{ $url }}&w=47&dpr=2 2x" media="(min-width: 0px)">

--- a/layouts/shortcodes/vimeo.html
+++ b/layouts/shortcodes/vimeo.html
@@ -1,7 +1,7 @@
 {{ $posterImg := "" }}
 
 {{- if .Get "poster" -}}
-  {{ $posterImg = (print (.Site.Params.img_url) (.Get "poster")  "?ch=Width,DPR,Save-Data&auto=format,compress&fit=clip&w=1200") | safeURL }}
+  {{ $posterImg = (print (.Site.Params.img_url) (.Get "poster")  "?auto=format,compress&fit=clip&w=1200") | safeURL }}
 {{ else }}
   {{ $posterImg = "/images/poster/tracing.png" }}
 {{ end }}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes WEB-8784: https://datadoghq.atlassian.net/browse/WEB-8784

The `img.html` shortcode computed a max display width (`$img_w`: 850px standard, 1170px wide) but never applied it to the Fastly IO image URL. Every image was served at full resolution via `?auto=format` only, regardless of actual display size.

This change appends `&w=$img_w` to the Fastly IO URL in all three `$e` assignment branches, capping image downloads to the content column constraints. Also renames `$imgix_w` → `$img_w` for CDN-agnostic naming.

Noticeable difference in larger-asset sizes. Validate downloaded file sizes on the /logs page compared with live: https://docs-staging.datadoghq.com/nsollecito/img-max-width/logs/

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Content column is `col-lg-7` of a 1170px container (~682px rendered width). The 850px cap for standard images provides ~1.25x retina headroom; 1170px for wide images matches the full container width.