### PR TITLE
Add RUM events for Docs AI dashboard

### DIFF
--- a/assets/scripts/components/conversational-search/index.js
+++ b/assets/scripts/components/conversational-search/index.js
@@ -53,6 +53,9 @@ initializeFeatureFlags().then(async (client) => {
 
     if (IS_CONVERSATIONAL_SEARCH_ENABLED) {
         document.body.classList.add('conv-search-enabled');
+        logAction('Conversational Search Impression', {
+            conversational_search: { action: 'impression', page: window.location.pathname }
+        });
         initConversationalSearch();
     }
 });
@@ -322,6 +325,14 @@ class ConversationalSearch {
     }
 
     close() {
+        const messageCount = this.chatHistory.filter(m => m.role === 'user').length;
+        if (messageCount > 0) {
+            this.logInteraction('conversation_close', {
+                messages_sent: messageCount,
+                responses_received: this.chatHistory.filter(m => m.role === 'assistant').length
+            });
+        }
+
         this.isOpen = false;
         this.sidebar.classList.remove('open');
         this.overlay.classList.remove('open');

--- a/assets/scripts/components/instantsearch.js
+++ b/assets/scripts/components/instantsearch.js
@@ -358,7 +358,7 @@ function loadInstantSearch(currentPageWasAsyncLoaded) {
             if (selectedItem?.classList.contains('ais-Hits-ai-suggestion')) {
                 const query = selectedItem.dataset.query || aisSearchBoxInput.value;
                 if (window.askDocsAI) {
-                    window.askDocsAI(query);
+                    window.askDocsAI(query, { source: 'search_suggestion' });
                     // Hide the search dropdown
                     hitsContainerContainer.classList.add('d-none');
                     searchBoxContainerContainer.classList.remove('active-search');


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds two new RUM events to the Docs AI conversational search chatbot to support more dashboard tracking adoption and engagement:

1. **Impression event** (`action: impression`): fires once per page load when the chatbot UI renders, enabling "saw vs engaged" funnel analysis.
2. **Conversation close event** (`action: conversation_close`): fires when a user closes the chat after sending messages, capturing `messages_sent` and `responses_received` for conversation depth metrics.

These events complement the existing instrumentation (open, feedback, copy, source clicks, response latency) to provide the full picture for reporting.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Existing events already cover thumbs up/down counts, entry points, source clicks, copy actions, and response latency. These two new events fill the gaps for impression tracking and session-level engagement.