### PR TITLE
[DOCS-13902] Add GovCloud availability note to NLQ section

### DIFF
--- a/content/en/metrics/explorer.md
+++ b/content/en/metrics/explorer.md
@@ -25,6 +25,10 @@ The [Metrics Explorer][1] is a basic interface for examining your metrics in Dat
 
 ## Natural language queries
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">Natural Language Queries for Metrics Explorer are not available for your selected Datadog site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 Use Natural Language Queries (NLQ) to describe what you're looking for in plain English. Datadog automatically translates your request into a structured metric query, understanding context such as your services, attributes, and tags. This makes it easier to explore metrics without needing to write complex syntax.
 
 To access this feature, click **Ask** in the search field and type your query.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13902

Adds a site-region banner to the Natural Language Queries section of the Metrics Explorer page indicating that NLQ is not available for the US1-FED site.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes