### PR TITLE
[DOCS-13900] Add GovCloud availability notes to Metrics Summary

### DIFF
--- a/content/en/metrics/summary.md
+++ b/content/en/metrics/summary.md
@@ -129,6 +129,10 @@ The metric description helps you understand what a metric represents, why it exi
 
 #### AI-generated description
 
+{{< site-region region="gov" >}}
+<div class="alert alert-info">AI-generated metric descriptions are not available for your selected Datadog site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
 For custom metrics with connected source code, Datadog can automatically create AI-generated descriptions to provide additional context. These descriptions are fully editable, and human edits always take precedence.
 
 To enable auto-generated descriptions from source code, ensure that you've installed Datadog's [GitHub][36], [GitLab][37], or [Azure DevOps][38] integration and that all your [repositories][39] are connected.
@@ -137,6 +141,10 @@ To enable auto-generated descriptions from source code, ensure that you've insta
 
 
 ## Source Code
+
+{{< site-region region="gov" >}}
+<div class="alert alert-info">Metric Source Code is not available for your selected Datadog site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
 
 The Source Code section in the metric side panel provides a centralized view of every custom metric and its underlying context.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13900

Adds site-region banners to two sections of the Metrics Summary page indicating that the following features are not available for the US1-FED site:
- AI-generated metric descriptions
- Metric Source Code

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes