### PR TITLE
docs(mcp-server): Add Goose setup tab with OAuth instructions [GRAPHAI-417]

### DIFF
--- a/assets/scripts/config/regions.config.js
+++ b/assets/scripts/config/regions.config.js
@@ -673,6 +673,15 @@ export default {
     ap2: 'cursor://anysphere.cursor-deeplink/mcp/install?name=datadog-onboarding-ap2&config=eyJ1cmwiOiJodHRwczovL21jcC5hcDIuZGF0YWRvZ2hxLmNvbS9hcGkvdW5zdGFibGUvbWNwLXNlcnZlci9tY3A/dG9vbHNldHM9b25ib2FyZGluZyIsInR5cGUiOiJvYXV0aCJ9',
     gov: 'N/A'
   },
+  goose_mcp_install_deeplink: {
+    us: 'goose://extension?url=https://mcp.datadoghq.com/api/unstable/mcp-server/mcp&type=streamable_http&id=Datadog&name=Datadog&description=Datadog%20MCP%20Server',
+    us3: 'goose://extension?url=https://mcp.us3.datadoghq.com/api/unstable/mcp-server/mcp&type=streamable_http&id=Datadog&name=Datadog&description=Datadog%20MCP%20Server',
+    us5: 'goose://extension?url=https://mcp.us5.datadoghq.com/api/unstable/mcp-server/mcp&type=streamable_http&id=Datadog&name=Datadog&description=Datadog%20MCP%20Server',
+    eu: 'goose://extension?url=https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp&type=streamable_http&id=Datadog&name=Datadog&description=Datadog%20MCP%20Server',
+    ap1: 'goose://extension?url=https://mcp.ap1.datadoghq.com/api/unstable/mcp-server/mcp&type=streamable_http&id=Datadog&name=Datadog&description=Datadog%20MCP%20Server',
+    ap2: 'goose://extension?url=https://mcp.ap2.datadoghq.com/api/unstable/mcp-server/mcp&type=streamable_http&id=Datadog&name=Datadog&description=Datadog%20MCP%20Server',
+    gov: 'N/A'
+  },
   microsoft_teams_app_name: {
     us: 'Datadog',
     us3: 'Datadog',

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -397,7 +397,7 @@ Point your AI agent to the MCP Server endpoint for your regional [Datadog site][
 {{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
 Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
 
-1. One-click install (recommended): Use this [deeplink](goose://extension?url={{< region-param key="mcp_server_endpoint" >}}&type=streamable_http&id=Datadog&name=Datadog&description=Datadog%20MCP%20Server) to add the Datadog MCP Server to Goose.
+1. One-click install (recommended): Use this <a href="goose://extension?url={{< region-param key="mcp_server_endpoint" >}}&amp;type=streamable_http&amp;id=Datadog&amp;name=Datadog&amp;description=Datadog%20MCP%20Server">deeplink</a> to add the Datadog MCP Server to Goose.
 
 1. Alternatively, follow Goose's [Add an MCP server][2] instructions. Use the selected endpoint shown above as the remote Streamable HTTP server URL. You can also modify Goose's config directly for future updates at `~/.config/goose/config.yaml`.
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -397,7 +397,7 @@ Point your AI agent to the MCP Server endpoint for your regional [Datadog site][
 {{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
 Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
 
-1. One-click install (recommended): Use this <a href="goose://extension?url={{< region-param key="mcp_server_endpoint" >}}&amp;type=streamable_http&amp;id=Datadog&amp;name=Datadog&amp;description=Datadog%20MCP%20Server">deeplink</a> to add the Datadog MCP Server to Goose.
+1. One-click install (recommended): Use this {{< region-param key="goose_mcp_install_deeplink" link="true" text="deeplink" >}} to add the Datadog MCP Server to Goose.
 
 1. Alternatively, follow Goose's [Add an MCP server][2] instructions. Use the selected endpoint shown above as the remote Streamable HTTP server URL. You can also modify Goose's config directly for future updates at `~/.config/goose/config.yaml`.
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -409,7 +409,7 @@ Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-pa
 
     <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=apm,llmobs</code></pre>
 
-1. The first time you open a session with this extension activated, you'll be prompted to choose your Datadog account.
+1. The first time you open a session with this extension activated, you are prompted to choose your Datadog account.
 
 [1]: /bits_ai/mcp_server#toolsets
 [2]: https://goose-docs.ai/docs/getting-started/using-extensions/#mcp-servers

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -399,7 +399,7 @@ Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-pa
 
 1. One-click install (recommended): Use this deeplink to add the Datadog MCP Server to Goose:
 
-   <pre><code>goose://extension?url={{< region-param key="mcp_server_endpoint" >}}&type=streamable_http&id=datadog&name=Datadog&description=Datadog%20MCP%20Server</code></pre>
+   [Install Datadog MCP Server in Goose](goose://extension?url={{< region-param key="mcp_server_endpoint" >}}&type=streamable_http&id=datadog&name=Datadog&description=Datadog%20MCP%20Server)
 
    To tune extension response wait time, include the optional `timeout` query parameter (seconds).
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -392,12 +392,14 @@ Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-pa
 
 {{% tab "Goose" %}}
 
-Point your AI agent to the MCP Server endpoint for your regional [Datadog site][3]. For the correct instructions, use the **Datadog Site** selector on the right side of this documentation page to select your site.
+Point your AI agent to the MCP Server endpoint for your regional [Datadog site][3]. For the correct instructions, use the {{< ui >}}Datadog Site{{< /ui >}} selector on the right side of this documentation page to select your site.
 
 {{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
 Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
 
-1. One-click install (recommended): Use this {{< region-param key="goose_mcp_install_deeplink" link="true" text="deeplink" >}} to add the Datadog MCP Server to Goose.
+1. Add the Datadog MCP Server to Goose using one of the following methods:
+   - **One-click install (recommended):** Use the Datadog MCP Server {{< region-param key="goose_mcp_install_deeplink" link="true" text="install deeplink" >}}.
+   - **Manual configuration:** Follow Goose's [Add an MCP server][2] instructions, using the endpoint listed in this section as the Streamable HTTP server URL. To edit the configuration directly, modify `~/.config/goose/config.yaml`.
 
 1. Alternatively, follow Goose's [Add an MCP server][2] instructions. Use the selected endpoint shown above as the remote Streamable HTTP server URL. You can also modify Goose's config directly for future updates at `~/.config/goose/config.yaml`.
 
@@ -405,7 +407,7 @@ Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-pa
 
     <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=apm,llmobs</code></pre>
 
-1. The first time you open a session with this extension activated, you are prompted to choose your Datadog account.
+1. On first session launch, choose your Datadog account when prompted to authenticate.
 
 [1]: /bits_ai/mcp_server#toolsets
 [2]: https://goose-docs.ai/docs/getting-started/using-extensions/#mcp-servers

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -401,13 +401,13 @@ Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-pa
    - **One-click install (recommended):** Use the Datadog MCP Server {{< region-param key="goose_mcp_install_deeplink" link="true" text="install deeplink" >}}.
    - **Manual configuration:** Follow Goose's [Add an MCP server][2] instructions, using the endpoint listed in this section as the Streamable HTTP server URL. To edit the configuration directly, modify `~/.config/goose/config.yaml`.
 
-1. Alternatively, follow Goose's [Add an MCP server][2] instructions. Use the selected endpoint shown above as the remote Streamable HTTP server URL. You can also modify Goose's config directly for future updates at `~/.config/goose/config.yaml`.
-
 1. To enable [product-specific tools][1], include the `toolsets` query parameter at the end of the endpoint URL. For example, this URL enables _only_ APM and LLM Observability tools (use `toolsets=all` to enable all generally available toolsets, best for clients that support tool filtering):
 
     <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=apm,llmobs</code></pre>
 
 1. On first session launch, choose your Datadog account when prompted to authenticate.
+
+1. Verify that you have the required [permissions](#required-permissions) for the Datadog resources you want to access.
 
 [1]: /bits_ai/mcp_server#toolsets
 [2]: https://goose-docs.ai/docs/getting-started/using-extensions/#mcp-servers

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -397,11 +397,7 @@ Point your AI agent to the MCP Server endpoint for your regional [Datadog site][
 {{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
 Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
 
-1. One-click install (recommended): Use this deeplink to add the Datadog MCP Server to Goose:
-
-   [Install Datadog MCP Server in Goose](goose://extension?url={{< region-param key="mcp_server_endpoint" >}}&type=streamable_http&id=datadog&name=Datadog&description=Datadog%20MCP%20Server)
-
-   To tune extension response wait time, include the optional `timeout` query parameter (seconds).
+1. One-click install (recommended): Use this [deeplink](goose://extension?url={{< region-param key="mcp_server_endpoint" >}}&type=streamable_http&id=Datadog&name=Datadog&description=Datadog%20MCP%20Server) to add the Datadog MCP Server to Goose.
 
 1. Alternatively, follow Goose's [Add an MCP server][2] instructions. Use the selected endpoint shown above as the remote Streamable HTTP server URL. You can also modify Goose's config directly for future updates at `~/.config/goose/config.yaml`.
 

--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -390,6 +390,38 @@ Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-pa
 [3]: /getting_started/site/
 {{% /tab %}}
 
+{{% tab "Goose" %}}
+
+Point your AI agent to the MCP Server endpoint for your regional [Datadog site][3]. For the correct instructions, use the **Datadog Site** selector on the right side of this documentation page to select your site.
+
+{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
+Selected endpoint ({{< region-param key="dd_site_name" >}}): <code>{{< region-param key="mcp_server_endpoint" >}}</code>.
+
+1. One-click install (recommended): Use this deeplink to add the Datadog MCP Server to Goose:
+
+   <pre><code>goose://extension?url={{< region-param key="mcp_server_endpoint" >}}&type=streamable_http&id=datadog&name=Datadog&description=Datadog%20MCP%20Server</code></pre>
+
+   To tune extension response wait time, include the optional `timeout` query parameter (seconds).
+
+1. Alternatively, follow Goose's [Add an MCP server][2] instructions. Use the selected endpoint shown above as the remote Streamable HTTP server URL. You can also modify Goose's config directly for future updates at `~/.config/goose/config.yaml`.
+
+1. To enable [product-specific tools][1], include the `toolsets` query parameter at the end of the endpoint URL. For example, this URL enables _only_ APM and LLM Observability tools (use `toolsets=all` to enable all generally available toolsets, best for clients that support tool filtering):
+
+    <pre><code>{{< region-param key="mcp_server_endpoint" >}}?toolsets=apm,llmobs</code></pre>
+
+1. The first time you open a session with this extension activated, you'll be prompted to choose your Datadog account.
+
+[1]: /bits_ai/mcp_server#toolsets
+[2]: https://goose-docs.ai/docs/getting-started/using-extensions/#mcp-servers
+{{< /site-region >}}
+
+{{< site-region region="gov" >}}
+<div class="alert alert-danger">Datadog MCP Server is not supported for your selected site ({{< region-param key="dd_site_name" >}}).</div>
+{{< /site-region >}}
+
+[3]: /getting_started/site/
+{{% /tab %}}
+
 {{% tab "Other" %}}
 
 For most other [supported clients](#supported-clients), use these instructions for remote authentication. For Cline or when remote authentication is unreliable or not available, use [local binary authentication](#local-binary-authentication).
@@ -491,7 +523,8 @@ These toolsets are in Preview. Sign up for a toolset by completing the Product P
 | [VS Code][7] | Microsoft | Datadog [Cursor & VS Code extension][16] recommended. |
 | [JetBrains IDEs][18] | JetBrains | [Datadog plugin][18] recommended. |
 | [Kiro][9], [Kiro CLI][10] | Amazon Web Services | |
-| [Goose][8], [Cline][11] | Various | See the {{< ui >}}Other{{< /ui >}} tab above. Use local binary authentication for Cline if remote authentication is unreliable. |
+| [Goose][8] | Agentic AI Foundation | |
+| [Cline][11] | Various | See the {{< ui >}}Other{{< /ui >}} tab above. Use local binary authentication for Cline if remote authentication is unreliable. |
 
 <div class="alert alert-info">The Datadog MCP Server is under significant development, and additional supported clients may become available.</div>
 

--- a/layouts/partials/mcp_server/mcp_server_agents.html
+++ b/layouts/partials/mcp_server/mcp_server_agents.html
@@ -68,7 +68,7 @@
                 </a>
             </div>
             <div class="col">
-                <a class="card h-100" href="{{ absURL `bits_ai/mcp_server/setup/` }}?tab=other" title="Goose" data-bs-toggle="tooltip" data-bs-placement="top">
+                <a class="card h-100" href="{{ absURL `bits_ai/mcp_server/setup/` }}?tab=goose" title="Goose" data-bs-toggle="tooltip" data-bs-placement="top">
                     <div class="card-body text-center py-2 px-1">
                         {{ partial "img.html" (dict "root" . "src" "integrations_logos/goose.svg" "class" "img-fluid" "alt" "Goose" "width" "150") }}
                     </div>


### PR DESCRIPTION
<!-- dd-meta {"pullId":"37e8b088-6fad-4e2c-b9f1-2abc5acbfebf","source":"chat","resourceId":"28aca013-5a4d-4a44-8b98-4ca861aada34","workflowId":"4e0ec9f4-eeca-4c36-82f4-e0aa5e4ee954","codeChangeId":"4e0ec9f4-eeca-4c36-82f4-e0aa5e4ee954","sourceType":"chat"} -->
### Motivation

This PR updates the [Goose](https://goose-docs.ai/) integration documentation to include a dedicated setup tab with current and accurate instructions. Previously, Goose was grouped with other clients under the "Other" tab with outdated setup guidance (suggesting it needed API keys, when OAuth is enough after I shipped https://github.com/aaif-goose/goose/pull/8148 )

### Changes

- Add a new "Goose" tab with step-by-step MCP server setup instructions based on the Kiro tab structure
- Direct users to Goose's official "Add an MCP server" documentation
- Include instructions for enabling product-specific tools via the `toolsets` query parameter
- Clarify that OAuth authentication occurs on first session launch
- Update the supported clients table to give Goose its own row with the [Agentic AI Foundation ](https://aaif.io/)as the project sponsor (which Datadog is part of).

<img width="786" height="948" alt="image" src="https://github.com/user-attachments/assets/1423cb95-f0a4-4963-8a93-65c0b85c750f" />

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Bits Dev agent for initial draft of the documentation content and structure.

### Additional notes

The Goose tab follows the same regional endpoint selection pattern as Kiro and includes appropriate alerts for unsupported regions (gov). The deeplink format and configuration instructions are based on Goose's current extension system. 


---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/28aca013-5a4d-4a44-8b98-4ca861aada34)

Comment @datadog to request changes