### PR TITLE
[MOPU-446] Add missing alerting MCP tools documentation

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -68,7 +68,7 @@ Both metrics are tagged with `user_id`, `user_email`, and `client` (the MCP clie
 The Datadog MCP Server supports _toolsets_, which allow you to use only the tools you need, saving valuable context window space. These toolsets are available:
 
 - `core`: The default toolset for logs, metrics, traces, dashboards, monitors, incidents, hosts, services, events, and notebooks
-- `alerting`: Tools for validating monitors, searching monitor groups, and retrieving monitor templates
+- `alerting`: Tools for validating and creating monitors, searching monitor groups, retrieving monitor templates, analyzing monitor coverage, and searching SLOs
 - `apm`: ([Preview][43]) Tools for in-depth [APM][28] trace analysis, span search, Watchdog insights, and performance investigation
 - `cases`: Tools for [Case Management][38], including creating, searching, and updating cases; managing projects; and linking Jira issues
 - `dashboards`: Tools for retrieving, creating, updating, and deleting [dashboards][44], plus widget schema reference and validation
@@ -374,6 +374,33 @@ Searches monitor groups by name or criteria.
 
 - Show me all monitor groups in an alerting state.
 - Find monitor groups related to the checkout service.
+
+### `search_datadog_slos`
+*Toolset: **alerting***\
+*Permissions Required: `SLOs Read`*\
+Searches Datadog SLOs by name, tags, or type. Supports query syntax for filtering by service, team, or other attributes.
+
+- Search for SLOs related to `service:checkout`.
+- List all SLOs tagged with `team:backend`.
+- List SLOs for the payments service.
+
+### `create_datadog_monitor`
+*Toolset: **alerting***\
+*Permissions Required: `Monitors Write`*\
+Creates a Datadog monitor in draft mode. Monitors created with this tool do not send notifications and are set to priority 5 (low). Use `validate_datadog_monitor` to check the definition before creating and `get_datadog_monitor_templates` for query syntax examples. After creation, publish the monitor in the Datadog UI.
+
+- Create a metric alert monitor for high CPU usage on the web service.
+- Set up a log alert monitor for error spikes in the payments service.
+- Create a monitor to track p95 latency for the checkout endpoint.
+
+### `get_monitor_coverage`
+*Toolset: **alerting***\
+*Permissions Required: `Monitors Read`*\
+Finds monitoring gaps and coverage for services or hosts. Returns which signals (such as error rate, latency, and request rate) are covered by existing monitors and which are missing. Use with `create_datadog_monitor` to fill gaps.
+
+- Get monitoring coverage for `service:checkout`.
+- What monitoring gaps exist for `host:web-01`?
+- Find services that are missing error rate monitors.
 
 <div class="alert alert-info">The <code>apm</code> toolset is in Preview. <a href="https://www.datadoghq.com/product-preview/apm-mcp-toolset/">Sign up for access.</a></div>
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for three alerting-mcp-server MCP tools that were missing from the [Datadog MCP Server](https://docs.datadoghq.com/bits_ai/mcp_server/) page:

- **`search_datadog_slos`** — Search SLOs by name, tags, or type with query syntax filtering
- **`create_datadog_monitor`** — Create monitors in draft mode (no notifications, priority 5) with validation and template support
- **`get_monitor_coverage`** — Analyze monitoring gaps for services/hosts, showing covered and missing signals

Also updates the `alerting` toolset description to reflect the full set of capabilities (SLOs, monitor creation, coverage analysis).

### Additional notes

The three new tools match the implementations in `dd-source/domains/alerting/apps/apis/alerting-mcp-server/tools/`. The existing three tools (`validate_datadog_monitor`, `get_datadog_monitor_templates`, `search_datadog_monitor_groups`) were already documented and remain unchanged.