### PR TITLE
[NETUI-4088] Add supported device profiles section to NCM page

### DIFF
--- a/content/en/network_monitoring/devices/config_management.md
+++ b/content/en/network_monitoring/devices/config_management.md
@@ -146,43 +146,22 @@ When you compare two configuration versions, the AI summary automatically:
 
 ## Supported device profiles
 
-NCM uses device profiles to collect configurations from network devices through SSH. Each profile defines how to connect to a specific device operating system, what configurations to collect, and how to parse the output. Profiles are included in the Datadog Agent and matched automatically based on your device's operating system.
+NCM uses device profiles to collect configurations from network devices over SSH. Profiles are bundled with the Datadog Agent and matched automatically based on your device's operating system.
 
 For the profile source files, see the [NCM default profiles directory][8] in the `datadog-agent` repository.
 
-### Available profiles
-
-The following table lists the NCM device profiles and the minimum Datadog Agent version required for each:
-
-| Profile | Min. Agent Version | OS | Vendor | Running Config | Startup Config |
+| Vendor | Profile | Example Devices | Minimal Agent version | Running | Startup |
 |---|---|---|---|---|---|
-| `cisco-ios` | 7.73.0 | IOS | Cisco | {{< X >}} | {{< X >}} |
-| `junos` | 7.74.0 | JunOS | Juniper | {{< X >}} | |
-| `pan-os` | 7.75.0 | PAN-OS | Palo Alto | {{< X >}} | |
-| `aosw` | 7.75.0 | AOS-W | Aruba | {{< X >}} | |
-| `aoscx` | 7.76.0 | AOS-CX | Aruba | {{< X >}} | {{< X >}} |
-| `nxos` | 7.76.0 | NX-OS | Cisco | {{< X >}} | {{< X >}} |
-| `tmos` | 7.76.0 | TMOS | F5 | {{< X >}} | |
-| `fortios` | 7.77.0 | FortiOS | FortiGate | {{< X >}} | |
-| `eos` | 7.77.0 | EOS | Arista | {{< X >}} | {{< X >}} |
-| `dellos10` | 7.77.0 | DellOS10 | Dell | {{< X >}} | {{< X >}} |
-
-### Device profile support matrix
-
-The following matrix provides more detail on the devices, configuration types, and metadata each profile supports:
-
-| Vendor | Profile | Example Devices | Running | Startup | Metadata |
-|---|---|---|---|---|---|
-| Cisco | `cisco-ios` | Catalyst switches, ISR/ASR routers | {{< X >}} | {{< X >}} | Timestamp, config size |
-| Cisco | `nxos` | Nexus data center switches | {{< X >}} | {{< X >}} | Timestamp |
-| Juniper | `junos` | EX/QFX/MX/SRX devices | {{< X >}} | | Timestamp, author |
-| Palo Alto | `pan-os` | Palo Alto firewalls | {{< X >}} | | |
-| Aruba | `aosw` | Aruba switches and controllers | {{< X >}} | | |
-| Aruba | `aoscx` | Aruba CX switches | {{< X >}} | {{< X >}} | |
-| F5 | `tmos` | BIG-IP load balancers | {{< X >}} | | |
-| FortiGate | `fortios` | FortiGate firewalls | {{< X >}} | | |
-| Arista | `eos` | Arista switches | {{< X >}} | {{< X >}} | Timestamp, author |
-| Dell | `dellos10` | Dell EMC data center switches | {{< X >}} | {{< X >}} | |
+| Arista | `eos` | Arista switches | 7.77.0 | {{< X >}} | {{< X >}} |
+| Aruba | `aoscx` | Aruba CX switches | 7.76.0 | {{< X >}} | {{< X >}} |
+| Aruba | `aosw` | Aruba switches and controllers | 7.75.0 | {{< X >}} | |
+| Cisco | `cisco-ios` | Catalyst switches, ISR/ASR routers | 7.73.0 | {{< X >}} | {{< X >}} |
+| Cisco | `nxos` | Nexus data center switches | 7.76.0 | {{< X >}} | {{< X >}} |
+| Dell | `dellos10` | Dell EMC data center switches | 7.77.0 | {{< X >}} | {{< X >}} |
+| F5 | `tmos` | BIG-IP load balancers | 7.76.0 | {{< X >}} | |
+| FortiGate | `fortios` | FortiGate firewalls | 7.77.0 | {{< X >}} | |
+| Juniper | `junos` | EX/QFX/MX/SRX devices | 7.74.0 | {{< X >}} | |
+| Palo Alto | `pan-os` | Palo Alto firewalls | 7.75.0 | {{< X >}} | |
 
 ## Further Reading
 

--- a/content/en/network_monitoring/devices/config_management.md
+++ b/content/en/network_monitoring/devices/config_management.md
@@ -148,9 +148,11 @@ When you compare two configuration versions, the AI summary automatically:
 
 NCM uses device profiles to collect configurations from network devices over SSH. Profiles are bundled with the Datadog Agent and matched automatically based on your device's operating system.
 
+NCM profiles are managed and updated automatically through Agent releases, so new device support and improvements are included without any manual configuration.
+
 For the profile source files, see the [NCM default profiles directory][8] in the `datadog-agent` repository.
 
-| Vendor | OS | Profile | Minimal Agent version | Running | Startup |
+| Vendor | OS | Profile | Min. Agent version | Running | Startup |
 |---|---|---|---|---|---|
 | Arista | EOS | `eos` | 7.77.0 | {{< X >}} | {{< X >}} |
 | Aruba | AOS-CX | `aoscx` | 7.76.0 | {{< X >}} | {{< X >}} |

--- a/content/en/network_monitoring/devices/config_management.md
+++ b/content/en/network_monitoring/devices/config_management.md
@@ -150,18 +150,18 @@ NCM uses device profiles to collect configurations from network devices over SSH
 
 For the profile source files, see the [NCM default profiles directory][8] in the `datadog-agent` repository.
 
-| Vendor | Profile | Example Devices | Minimal Agent version | Running | Startup |
+| Vendor | OS | Profile | Minimal Agent version | Running | Startup |
 |---|---|---|---|---|---|
-| Arista | `eos` | Arista switches | 7.77.0 | {{< X >}} | {{< X >}} |
-| Aruba | `aoscx` | Aruba CX switches | 7.76.0 | {{< X >}} | {{< X >}} |
-| Aruba | `aosw` | Aruba switches and controllers | 7.75.0 | {{< X >}} | |
-| Cisco | `cisco-ios` | Catalyst switches, ISR/ASR routers | 7.73.0 | {{< X >}} | {{< X >}} |
-| Cisco | `nxos` | Nexus data center switches | 7.76.0 | {{< X >}} | {{< X >}} |
-| Dell | `dellos10` | Dell EMC data center switches | 7.77.0 | {{< X >}} | {{< X >}} |
-| F5 | `tmos` | BIG-IP load balancers | 7.76.0 | {{< X >}} | |
-| FortiGate | `fortios` | FortiGate firewalls | 7.77.0 | {{< X >}} | |
-| Juniper | `junos` | EX/QFX/MX/SRX devices | 7.74.0 | {{< X >}} | |
-| Palo Alto | `pan-os` | Palo Alto firewalls | 7.75.0 | {{< X >}} | |
+| Arista | EOS | `eos` | 7.77.0 | {{< X >}} | {{< X >}} |
+| Aruba | AOS-CX | `aoscx` | 7.76.0 | {{< X >}} | {{< X >}} |
+| Aruba | AOS-W | `aosw` | 7.75.0 | {{< X >}} | |
+| Cisco | IOS | `cisco-ios` | 7.73.0 | {{< X >}} | {{< X >}} |
+| Cisco | NX-OS | `nxos` | 7.76.0 | {{< X >}} | {{< X >}} |
+| Dell | DellOS10 | `dellos10` | 7.77.0 | {{< X >}} | {{< X >}} |
+| F5 | TMOS | `tmos` | 7.76.0 | {{< X >}} | |
+| FortiGate | FortiOS | `fortios` | 7.77.0 | {{< X >}} | |
+| Juniper | JunOS | `junos` | 7.74.0 | {{< X >}} | |
+| Palo Alto | PAN-OS | `pan-os` | 7.75.0 | {{< X >}} | |
 
 ## Further Reading
 

--- a/content/en/network_monitoring/devices/config_management.md
+++ b/content/en/network_monitoring/devices/config_management.md
@@ -146,9 +146,7 @@ When you compare two configuration versions, the AI summary automatically:
 
 ## Supported device profiles
 
-NCM uses device profiles to collect configurations from network devices over SSH. Profiles are bundled with the Datadog Agent and matched automatically based on your device's operating system.
-
-NCM profiles are managed and updated automatically through Agent releases, so new device support and improvements are included without any manual configuration.
+NCM uses device profiles to collect configurations from network devices over SSH. Profiles are bundled with the Datadog Agent, matched automatically based on your device's operating system, and updated through Agent releases.
 
 For the profile source files, see the [NCM default profiles directory][8] in the `datadog-agent` repository.
 

--- a/content/en/network_monitoring/devices/config_management.md
+++ b/content/en/network_monitoring/devices/config_management.md
@@ -144,6 +144,46 @@ When you compare two configuration versions, the AI summary automatically:
 - Describes changes in human-readable terms
 - Highlights changes that may be relevant for incident investigation or risk analysis
 
+## Supported device profiles
+
+NCM uses device profiles to collect configurations from network devices through SSH. Each profile defines how to connect to a specific device operating system, what configurations to collect, and how to parse the output. Profiles are included in the Datadog Agent and matched automatically based on your device's operating system.
+
+For the profile source files, see the [NCM default profiles directory][8] in the `datadog-agent` repository.
+
+### Available profiles
+
+The following table lists the NCM device profiles and the minimum Datadog Agent version required for each:
+
+| Profile | Min. Agent Version | OS | Vendor | Running Config | Startup Config |
+|---|---|---|---|---|---|
+| `cisco-ios` | 7.73.0 | IOS | Cisco | {{< X >}} | {{< X >}} |
+| `junos` | 7.74.0 | JunOS | Juniper | {{< X >}} | |
+| `pan-os` | 7.75.0 | PAN-OS | Palo Alto | {{< X >}} | |
+| `aosw` | 7.75.0 | AOS-W | Aruba | {{< X >}} | |
+| `aoscx` | 7.76.0 | AOS-CX | Aruba | {{< X >}} | {{< X >}} |
+| `nxos` | 7.76.0 | NX-OS | Cisco | {{< X >}} | {{< X >}} |
+| `tmos` | 7.76.0 | TMOS | F5 | {{< X >}} | |
+| `fortios` | 7.77.0 | FortiOS | FortiGate | {{< X >}} | |
+| `eos` | 7.77.0 | EOS | Arista | {{< X >}} | {{< X >}} |
+| `dellos10` | 7.77.0 | DellOS10 | Dell | {{< X >}} | {{< X >}} |
+
+### Device profile support matrix
+
+The following matrix provides more detail on the devices, configuration types, and metadata each profile supports:
+
+| Vendor | Profile | Example Devices | Running | Startup | Metadata |
+|---|---|---|---|---|---|
+| Cisco | `cisco-ios` | Catalyst switches, ISR/ASR routers | {{< X >}} | {{< X >}} | Timestamp, config size |
+| Cisco | `nxos` | Nexus data center switches | {{< X >}} | {{< X >}} | Timestamp |
+| Juniper | `junos` | EX/QFX/MX/SRX devices | {{< X >}} | | Timestamp, author |
+| Palo Alto | `pan-os` | Palo Alto firewalls | {{< X >}} | | |
+| Aruba | `aosw` | Aruba switches and controllers | {{< X >}} | | |
+| Aruba | `aoscx` | Aruba CX switches | {{< X >}} | {{< X >}} | |
+| F5 | `tmos` | BIG-IP load balancers | {{< X >}} | | |
+| FortiGate | `fortios` | FortiGate firewalls | {{< X >}} | | |
+| Arista | `eos` | Arista switches | {{< X >}} | {{< X >}} | Timestamp, author |
+| Dell | `dellos10` | Dell EMC data center switches | {{< X >}} | {{< X >}} | |
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -155,3 +195,4 @@ When you compare two configuration versions, the AI summary automatically:
 [5]: /network_monitoring/devices/topology
 [6]: /network_monitoring/devices/supported_devices#vendor-profiles
 [7]: https://github.com/DataDog/datadog-agent/tree/main/cmd/agent/dist/conf.d/network_config_management.d/
+[8]: https://github.com/DataDog/datadog-agent/tree/main/pkg/networkconfigmanagement/profile/default_profiles


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes NETUI-4088 and adds section in [NCM doc](https://docs-staging.datadoghq.com/dan.chiniara/add-device-profile-sections/network_monitoring/devices/config_management/#supported-device-profiles)

Adds a "Supported device profiles" section to the Network Configuration Management page. This documents the 10 NCM device profiles that are available, including which vendors and devices are supported, minimum Agent versions, and whether running and startup configurations are collected. This information was not previously documented for users.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Claude Code to consolidate tables and refine column naming.

### Additional notes

Sources:
- [Oxidized vendors and models](https://datadoghq.atlassian.net/wiki/spaces/II/pages/5705203846/Oxidized+vendors+and+models)
- [NCM default profiles (datadog-agent)](https://github.com/DataDog/datadog-agent/tree/main/pkg/networkconfigmanagement/profile/default_profiles)
