### PR TITLE
Add RUM event for every chatbot open

### DIFF
--- a/assets/scripts/components/conversational-search/index.js
+++ b/assets/scripts/components/conversational-search/index.js
@@ -315,6 +315,10 @@ class ConversationalSearch {
             this.hasLoggedFirstOpen = true;
         }
 
+        this.log('Conversational Search Open', {
+            conversational_search: { action: 'open', trigger, provider: this.provider }
+        });
+
         this.isOpen = true;
         this.sidebar.classList.add('open');
         this.overlay.classList.add('open');


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a new `open` action event that fires every time the chatbot is opened, complementing the existing `open_first_time` event which only fires once per page load.

This enables accurate open count tracking for the Docs AI dashboard engagement rate metrics (total opens vs. impressions).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

The existing `open_first_time` event is unchanged. The new `open` event fires on every open, including the first one, so both events coexist.