### PR TITLE
Fix broken link to injector guide on SSI Kubernetes page

### DIFF
--- a/content/en/tracing/trace_collection/single-step-apm/kubernetes.md
+++ b/content/en/tracing/trace_collection/single-step-apm/kubernetes.md
@@ -891,3 +891,4 @@ If you encounter problems enabling APM with SSI, see the [SSI troubleshooting gu
 [35]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/troubleshooting
 [36]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/compatibility/
 [37]: /containers/kubernetes/csi_driver/
+[41]: /tracing/guide/injectors/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes a broken link on the SSI Kubernetes page. Reference `[41]` (used in the "Configure injection modes" section to link to "Injector Behavior with Single Step Instrumentation") was missing from the reference list at the bottom of the file.

Added: `[41]: /tracing/guide/injectors/`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes