### PR TITLE
[CLOUDS-7750] feat(docs): update AWS kinesis log documentation

### DIFF
--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -159,7 +159,7 @@ To populate all logs by ARN:
 
 When logs arrive through Amazon Data Firehose, Datadog automatically determines the `source`, `service`, and tags for each log based on AWS metadata:
 
-1. **Source**: Detected from the CloudWatch Log Group name. For example, `/aws/lambda/my-function` sets `source:lambda`, `/aws/rds/...` sets `source:rds`. If the log group does not match a known AWS service pattern, the log group name itself is used as the source.
+1. **Source**: Detected from the CloudWatch log group name. For example, `/aws/lambda/my-function` sets `source:lambda`, and `/aws/rds/...` sets `source:rds`. If the log group does not match a known AWS service pattern, the log group name itself is used as the source.
 2. **Service**: Defaults to the same value as the detected source. For Lambda logs, the service is set to the function name.
 3. **Tags**: AWS metadata such as `region`, `aws_account`, and `sourcecategory:aws` are added automatically.
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -167,7 +167,7 @@ When logs arrive through Amazon Data Firehose, Datadog automatically determines 
 
 There are two ways to override these auto-detected values:
 
-#### Firehose Common Attributes
+#### Firehose common attributes
 
 You can set `source`, `service`, and arbitrary tags through the **Parameters** section (Common Attributes) of your Amazon Data Firehose delivery stream configuration. These values apply to all logs flowing through that delivery stream and take priority over the auto-detected values.
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -155,6 +155,46 @@ To populate all logs by ARN:
 
 **Note**: A single Kinesis payload must not be more than 65,000 log messages. Log messages after that limit are dropped.
 
+## How source, service, and tags are set
+
+When logs arrive through Amazon Data Firehose, Datadog automatically determines the `source`, `service`, and tags for each log based on AWS metadata:
+
+1. **Source**: Detected from the CloudWatch Log Group name. For example, `/aws/lambda/my-function` sets `source:lambda`, `/aws/rds/...` sets `source:rds`. If the log group does not match a known AWS service pattern, the log group name itself is used as the source.
+2. **Service**: Defaults to the same value as the detected source. For Lambda logs, the service is set to the function name.
+3. **Tags**: AWS metadata such as `region`, `aws_account`, and `sourcecategory:aws` are added automatically.
+
+### Overriding source, service, and tags
+
+There are two ways to override these auto-detected values:
+
+#### Firehose Common Attributes
+
+You can set `source`, `service`, and arbitrary tags through the **Parameters** section (Common Attributes) of your Amazon Data Firehose delivery stream configuration. These values apply to all logs flowing through that delivery stream and take priority over the auto-detected values.
+
+For example, setting `source: nodejs` and `env: production` in the Common Attributes adds those as the log source and as a tag, respectively.
+
+#### Reserved attributes in the log body
+
+If your application writes structured JSON logs that include `ddsource`, `service`, or `ddtags` at the top level of the JSON body, Datadog can use those values instead of the auto-detected ones. For example:
+
+```json
+{
+  "message": "request completed",
+  "ddsource": "nodejs",
+  "service": "my-app",
+  "ddtags": "env:production,version:1.2.3"
+}
+```
+
+When enabled, these fields take the highest priority, overriding both the auto-detected values and the Common Attributes:
+- `ddsource` overrides the log source.
+- `service` overrides the log service.
+- `ddtags` values are merged into the log's tags (for example, `env` and `version` become searchable tags).
+
+These fields are consumed during intake and do not appear as log attributes.
+
+<div class="alert alert-info">This behavior is not enabled by default. To enable it for your organization, <a href="/help/">contact Datadog Support</a>.</div>
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -175,6 +175,8 @@ For example, setting `source: nodejs` and `env: production` in the Common Attrib
 
 #### Reserved attributes in the log body
 
+<div class="alert alert-info">Parsing reserved attributes (<code>ddsource</code>, <code>service</code>, <code>ddtags</code>) from the log body is not enabled by default. To enable it for your organization, <a href="/help/">contact Datadog Support</a>.</div>
+
 If your application writes structured JSON logs that include `ddsource`, `service`, or `ddtags` at the top level of the JSON body, Datadog can use those values instead of the auto-detected ones. For example:
 
 ```json
@@ -192,8 +194,6 @@ When enabled, these fields take the highest priority, overriding both the auto-d
 - `ddtags` values are merged into the log's tags (for example, `env` and `version` become searchable tags).
 
 These fields are consumed during intake and do not appear as log attributes.
-
-<div class="alert alert-info">This behavior is not enabled by default. To enable it for your organization, <a href="/help/">contact Datadog Support</a>.</div>
 
 ## Further Reading
 

--- a/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
+++ b/content/en/logs/guide/send-aws-services-logs-with-the-datadog-kinesis-firehose-destination.md
@@ -155,7 +155,7 @@ To populate all logs by ARN:
 
 **Note**: A single Kinesis payload must not be more than 65,000 log messages. Log messages after that limit are dropped.
 
-## How source, service, and tags are set
+## Set the source, service, and tags
 
 When logs arrive through Amazon Data Firehose, Datadog automatically determines the `source`, `service`, and tags for each log based on AWS metadata:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Following https://datadoghq.atlassian.net/browse/CLOUDS-7750 I'm updating the docs on logs from Kinesis so customers have better expectations with regards to how the logs are parsed on the Datadog side

### Merge instructions

N/A

Merge readiness:
- [x] Ready for merge


### AI assistance

Wrote the docs with a Claude prompt and did some iterations 

