### PR TITLE
docs(experiments): document table customization and quick actions [MLOB-7078]

### DIFF
--- a/content/en/llm_observability/experiments/analyzing_results.md
+++ b/content/en/llm_observability/experiments/analyzing_results.md
@@ -22,6 +22,42 @@ The **Records** section contains traces related to the execution of your task on
 
 You can use the facets (on the left-hand side) to filter the records based on their evaluation results to uncover patterns.
 
+### Customizing the results table
+
+You can customize the experiment results table to surface the fields that matter most to you without opening each trace individually.
+
+#### Column picker
+
+Use the column picker to toggle columns on or off and drag to reorder them. By default, raw JSON blob columns (Input, Output, Expected Output) are hidden to keep the table scannable. You can toggle them back on at any time.
+
+The table includes a **Record ID** column that shows which dataset record each experiment run was executed against. For experiments with multiple runs per record, expand a record to see all runs underneath.
+
+#### Custom columns
+
+Extract specific fields from your top-level experiment span — such as an input key, output key, or metadata key — and display them as dedicated table columns. This lets you compare key properties across records at a glance.
+
+To add a custom column, type a field path in the **Add Column** input at the top of the table:
+
+| Source          | Path format                    | Example                          |
+| --------------- | ------------------------------ | -------------------------------- |
+| Input           | `@meta.input.<key>`           | `@meta.input.user_query`        |
+| Output          | `@meta.output.<key>`          | `@meta.output.result.status`    |
+| Expected output | `@meta.expected_output.<key>` | `@meta.expected_output.answer`  |
+| Metadata        | `@meta.metadata.<key>`        | `@meta.metadata.scenario_type`  |
+| Tag             | `<tag_key>`                    | `env`                            |
+
+You can add multiple custom columns and reorder them with drag-and-drop. Column configuration persists per project.
+
+#### Quick actions from the span detail
+
+When viewing the root span in the span detail side panel, you can act on any field in **Input**, **Output**, **Expected Output**, **Metadata**, or **Tags** directly from the context menu:
+
+- **Copy key path**: Copies the field's full path (for example, `@meta.input.user_query`) so you can paste it into the custom column input, search bar, or a dashboard widget query.
+- **Add column**: Adds the field as a custom column in the results table in one click — no typing or copy-pasting required.
+- **Filter by / Exclude**: Adds the field's key-value pair to the search query to narrow down or exclude matching records. Available on leaf values (strings, numbers, booleans) only.
+
+<div class="alert alert-info">These actions are only available on the root span of a trace. Array indices are automatically stripped from paths so queries and columns resolve correctly.</div>
+
 ### Searching for specific records
 
 You can use the search bar to find specific records, based on their properties (dataset records data) or on the result of the experiment (output and evaluations). The search is executed at trace level.

--- a/content/en/llm_observability/experiments/analyzing_results.md
+++ b/content/en/llm_observability/experiments/analyzing_results.md
@@ -58,7 +58,7 @@ The following options are available on JSON fields (Input, Output, Expected Outp
 - **Add column**: Adds the field as a custom column in the results table in one click.
 - **Filter by / Exclude**: Adds the field's key-value pair to the search query to narrow down or exclude matching records. Available on leaf values (strings, numbers, booleans) only.
 
-**On tags**:
+The following options are available on tags:
 
 - **Copy key**: Copies the tag key (for example, `env`).
 - **Copy to clipboard**: Copies the full tag including its value (for example, `env:prod`).

--- a/content/en/llm_observability/experiments/analyzing_results.md
+++ b/content/en/llm_observability/experiments/analyzing_results.md
@@ -34,7 +34,7 @@ The table includes a **Record ID** column that shows which dataset record each e
 
 #### Custom columns
 
-Extract specific fields from your top-level experiment span — such as an input key, output key, or metadata key — and display them as dedicated table columns. This lets you compare key properties across records at a glance.
+Extract specific fields from your top-level experiment span, such as an input key, output key, or metadata key, and display them as dedicated table columns. This lets you compare key properties across records at a glance.
 
 To add a custom column, type a field path in the **Add Column** input at the top of the table:
 

--- a/content/en/llm_observability/experiments/analyzing_results.md
+++ b/content/en/llm_observability/experiments/analyzing_results.md
@@ -46,17 +46,26 @@ To add a custom column, type a field path in the **Add Column** input at the top
 | Metadata        | `@meta.metadata.<key>`        | `@meta.metadata.scenario_type`  |
 | Tag             | `<tag_key>`                    | `env`                            |
 
-You can add multiple custom columns and reorder them with drag-and-drop. Column configuration persists per project.
+You can add multiple custom columns and reorder them with drag-and-drop. Column configuration is saved to your browser's local storage per project.
 
 #### Quick actions from the span detail
 
-When viewing the root span in the span detail side panel, you can act on any field in **Input**, **Output**, **Expected Output**, **Metadata**, or **Tags** directly from the context menu:
+When viewing the root span in the span detail side panel, you can act on fields directly from the context menu instead of manually typing paths.
+
+**On JSON fields** (Input, Output, Expected Output, Metadata):
 
 - **Copy key path**: Copies the field's full path (for example, `@meta.input.user_query`) so you can paste it into the custom column input, search bar, or a dashboard widget query.
-- **Add column**: Adds the field as a custom column in the results table in one click — no typing or copy-pasting required.
+- **Add column**: Adds the field as a custom column in the results table in one click.
 - **Filter by / Exclude**: Adds the field's key-value pair to the search query to narrow down or exclude matching records. Available on leaf values (strings, numbers, booleans) only.
 
-<div class="alert alert-info">These actions are only available on the root span of a trace. Array indices are automatically stripped from paths so queries and columns resolve correctly.</div>
+**On tags**:
+
+- **Copy key**: Copies the tag key (for example, `env`).
+- **Copy to clipboard**: Copies the full tag including its value (for example, `env:prod`).
+- **Add column**: Adds the tag key as a custom column in the results table.
+- **Filter by / Exclude**: Adds the tag's key-value pair to the search query.
+
+<div class="alert alert-info">These actions are available on the root span of a trace.</div>
 
 ### Searching for specific records
 

--- a/content/en/llm_observability/experiments/analyzing_results.md
+++ b/content/en/llm_observability/experiments/analyzing_results.md
@@ -52,7 +52,7 @@ You can add multiple custom columns and reorder them with drag-and-drop. Column 
 
 When viewing the root span in the span detail side panel, you can act on fields directly from the context menu instead of manually typing paths.
 
-**On JSON fields** (Input, Output, Expected Output, Metadata):
+The following options are available on JSON fields (Input, Output, Expected Output, Metadata):
 
 - **Copy key path**: Copies the field's full path (for example, `@meta.input.user_query`) so you can paste it into the custom column input, search bar, or a dashboard widget query.
 - **Add column**: Adds the field as a custom column in the results table in one click.

--- a/content/en/llm_observability/experiments/datasets.md
+++ b/content/en/llm_observability/experiments/datasets.md
@@ -236,7 +236,7 @@ When viewing a dataset's records, you can customize the table to quickly scan an
 
 #### Column picker
 
-Use the column picker to toggle columns on or off and drag to reorder them. By default, raw JSON blob columns are hidden to keep the table scannable. You can toggle them back on at any time.
+Use the column picker to toggle columns on or off and drag to reorder them.
 
 #### Custom columns
 

--- a/content/en/llm_observability/experiments/datasets.md
+++ b/content/en/llm_observability/experiments/datasets.md
@@ -240,16 +240,7 @@ Use the column picker to toggle columns on or off and drag to reorder them. By d
 
 #### Custom columns
 
-Extract specific fields from your dataset records and display them as dedicated table columns. To add a custom column, type a field path in the **Add Column** input at the top of the table:
-
-| Source          | Path format                    | Example                          |
-| --------------- | ------------------------------ | -------------------------------- |
-| Input           | `@meta.input.<key>`           | `@meta.input.user_query`        |
-| Expected output | `@meta.expected_output.<key>` | `@meta.expected_output.answer`  |
-| Metadata        | `@meta.metadata.<key>`        | `@meta.metadata.scenario_type`  |
-| Tag             | `<tag_key>`                    | `env`                            |
-
-You can add multiple custom columns and reorder them with drag-and-drop. Column configuration persists per dataset.
+Extract specific fields from your dataset records and display them as dedicated table columns. To add a custom column, type a field path in the **Add Column** input at the top of the table. You can add multiple custom columns and reorder them with drag-and-drop. Column configuration is saved to your browser's local storage per project.
 
 [1]: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html
 

--- a/content/en/llm_observability/experiments/datasets.md
+++ b/content/en/llm_observability/experiments/datasets.md
@@ -230,5 +230,26 @@ dataset.delete(1)  # Deletes the second record
 dataset.push()
 ```
 
+### Customizing the dataset table
+
+When viewing a dataset's records, you can customize the table to quickly scan and compare records without expanding each one individually.
+
+#### Column picker
+
+Use the column picker to toggle columns on or off and drag to reorder them. By default, raw JSON blob columns are hidden to keep the table scannable. You can toggle them back on at any time.
+
+#### Custom columns
+
+Extract specific fields from your dataset records and display them as dedicated table columns. To add a custom column, type a field path in the **Add Column** input at the top of the table:
+
+| Source          | Path format                    | Example                          |
+| --------------- | ------------------------------ | -------------------------------- |
+| Input           | `@meta.input.<key>`           | `@meta.input.user_query`        |
+| Expected output | `@meta.expected_output.<key>` | `@meta.expected_output.answer`  |
+| Metadata        | `@meta.metadata.<key>`        | `@meta.metadata.scenario_type`  |
+| Tag             | `<tag_key>`                    | `env`                            |
+
+You can add multiple custom columns and reorder them with drag-and-drop. Column configuration persists per dataset.
+
 [1]: https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents the experiment detail and dataset table redesign features (MLOB-5851, MLOB-6697, MLOB-6699, MLOB-7081, MLOB-7082, MLOB-7084).

**Changes to `analyzing_results.md`** — new "Customizing the results table" section covering:
- **Column picker**: toggle and reorder columns, JSON blobs hidden by default, Record ID column
- **Custom columns**: extract nested fields from Input/Output/Expected Output/Metadata/Tags into dedicated table columns
- **Quick actions from span detail**: Copy key path, Add column, and Filter by / Exclude directly from the root span context menu

**Changes to `datasets.md`** — new "Customizing the dataset table" section covering:
- **Column picker**: same toggle and reorder behavior
- **Custom columns**: extract fields from Input/Expected Output/Metadata/Tags into table columns

### Merge instructions

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Feature PRs:
- https://github.com/DataDog/web-ui/pull/293725 (Filter by / Exclude on I/O/EO fields)
- MLOB-7081 branch (Add column from span detail, custom column improvements)
- MLOB-5851 / MLOB-6697 / MLOB-6699 (table redesign, custom columns, column picker)

### AI assistance

Used Claude Code for initial draft based on feature implementation code and demo notes.

### Additional notes

Screenshots/images TBD — will add once the feature is fully deployed.