### PR TITLE
Remove misleading EKS Fargate/GKE Autopilot note from DDOT DaemonSet page

### DIFF
--- a/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_daemonset.md
+++ b/content/en/opentelemetry/setup/ddot_collector/install/kubernetes_daemonset.md
@@ -32,7 +32,6 @@ To complete this guide, you need the following:
 Install and set up the following on your machine:
 
 - A Kubernetes cluster (v1.29+)
-  - **Note**: EKS Fargate and GKE Autopilot environments are not supported
 - [Helm (v3+)][54]
 - [kubectl][5]
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes the note "EKS Fargate and GKE Autopilot environments are not supported" from the DDOT Collector Kubernetes DaemonSet requirements section.

The note is ambiguous. It reads as if DDOT itself is unsupported on those environments, when the actual constraint is that DaemonSets don't exist in EKS Fargate and GKE Autopilot. The note is unnecessary and creates a maintenance burden.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes