### PR TITLE
[CCT-1240] Update forecasting data requirements to 64 days

### DIFF
--- a/content/en/cloud_cost_management/planning/forecasting.md
+++ b/content/en/cloud_cost_management/planning/forecasting.md
@@ -47,8 +47,8 @@ You can generate forecasts for various time horizons and rollup intervals to mat
 
 To generate accurate forecasts, CCM requires:
 
-- **At least 31 *consecutive* days of cost data**: This helps ensure the model has sufficient information to identify meaningful patterns. If fewer days are available, the model pads the remaining days with zeros to generate a forecast.
-- **Recent data**: The model uses up to the last 100 days of your cost history to generate predictions.
+- **At least 64 consecutive days of cost data**: This helps ensure the model has sufficient information to identify meaningful patterns. If fewer days are available, the model pads the remaining days with zeros to generate a forecast.
+- **Recent data**: The model uses up to the last 64 days of your cost history to generate predictions.
 
 ## View forecasts in reports
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the forecasting data requirements section to reflect the current model parameters post Toto GA:
- Minimum consecutive days of cost data: 31 → **64**
- Historical data window: 100 → **64** days

Jira: https://datadoghq.atlassian.net/browse/CCT-1240

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Claude Code to create the PR.

### Additional notes

Follow-up to #35257 which added the original forecasting documentation.