### PR TITLE
Update SCA vulnerability database timing to include malicious packages

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/_index.md
@@ -46,7 +46,7 @@ When Datadog ingests a new advisory, it is matched against your last known libra
 
 Datadog SCA draws from multiple public and private sources to build a curated proprietary database. These sources include the [National Vulnerability Database (NVD)][21], the [GitHub Advisory Database][22], [osv.dev][23], ecosystem-specific advisories such as [PyPA's Advisory Database][24] and the [Global Security Database][25], [Datadog GuardDog][26], and Datadog Security Research. 
 
-Datadog uses these sources to identify known vulnerabilities, malicious packages, and emerging supply chain threats across supported ecosystems. There is a maximum of 1 hour between when a new vulnerability is published and when it appears in Datadog, with emerging vulnerabilities typically appearing in Datadog within minutes.
+Datadog uses these sources to identify known vulnerabilities, malicious packages, and emerging supply chain threats across supported ecosystems. There is a maximum of 1 hour between when a new vulnerability is published and when it appears in Datadog, with emerging vulnerabilities typically appearing in Datadog within minutes. Malicious packages are reported in Datadog within 6 hours.
 
 ## Key capabilities
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the Vulnerability database section of the Software Composition Analysis page to include information about the reporting time for malicious packages.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes