### PR TITLE
Migrate RUM SDK integrated libraries pages to Cdocs pattern

### DIFF
--- a/content/en/client_sdks/integrated_libraries.mdoc.md
+++ b/content/en/client_sdks/integrated_libraries.mdoc.md
@@ -1,0 +1,42 @@
+---
+title: Integrated Libraries
+content_filters:
+  - trait_id: platform
+    option_group_id: client_sdk_platform_options
+    label: "SDK"
+---
+
+## Overview
+
+Select a platform below to see the libraries available for integration with the Datadog SDK.
+
+<!-- Browser: no integrated libraries page -->
+
+<!-- Android -->
+{% if equals($platform, "android") %}
+{% partial file="sdk/integrated_libraries/android.mdoc.md" /%}
+{% /if %}
+
+<!-- iOS -->
+{% if equals($platform, "ios") %}
+{% partial file="sdk/integrated_libraries/ios.mdoc.md" /%}
+{% /if %}
+
+<!-- Flutter -->
+{% if equals($platform, "flutter") %}
+{% partial file="sdk/integrated_libraries/flutter.mdoc.md" /%}
+{% /if %}
+
+<!-- React Native -->
+{% if equals($platform, "react_native") %}
+{% partial file="sdk/integrated_libraries/react_native.mdoc.md" /%}
+{% /if %}
+
+<!-- Kotlin Multiplatform -->
+{% if equals($platform, "kotlin_multiplatform") %}
+{% partial file="sdk/integrated_libraries/kotlin_multiplatform.mdoc.md" /%}
+{% /if %}
+
+<!-- Roku: no integrated libraries page -->
+
+<!-- Unity: no integrated libraries page -->

--- a/content/en/real_user_monitoring/application_monitoring/android/integrated_libraries.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/android/integrated_libraries.mdoc.md
@@ -1,0 +1,13 @@
+---
+title: Android and Android TV Libraries for RUM
+description: "Integrate popular Android libraries like Coil, OkHttp, and Retrofit with RUM for automatic monitoring of network requests and image loading."
+aliases:
+- /real_user_monitoring/android/integrated_libraries/
+- /real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/android
+- /real_user_monitoring/mobile_and_tv_monitoring/android/integrated_libraries
+further_reading:
+- link: https://github.com/DataDog/dd-sdk-android
+  tag: "Source Code"
+  text: Source code for dd-sdk-android
+---
+{% partial file="sdk/integrated_libraries/android.mdoc.md" /%}

--- a/content/en/real_user_monitoring/application_monitoring/flutter/integrated_libraries.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/flutter/integrated_libraries.mdoc.md
@@ -1,0 +1,13 @@
+---
+title: Flutter Libraries for RUM
+description: "Integrate popular Flutter libraries with RUM SDK for automatic monitoring of HTTP requests, navigation, and other app functionality."
+aliases:
+- /real_user_monitoring/flutter/integrated_libraries/
+- /real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/flutter
+- /real_user_monitoring/mobile_and_tv_monitoring/flutter/integrated_libraries
+further_reading:
+- link: https://github.com/DataDog/dd-sdk-flutter
+  tag: "Source Code"
+  text: Source code for dd-sdk-flutter
+---
+{% partial file="sdk/integrated_libraries/flutter.mdoc.md" /%}

--- a/content/en/real_user_monitoring/application_monitoring/ios/integrated_libraries.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/ios/integrated_libraries.mdoc.md
@@ -1,0 +1,13 @@
+---
+title: iOS and tvOS Libraries for RUM
+description: "Integrate popular iOS libraries like URLSession, Alamofire, Apollo GraphQL and image loaders with RUM for automatic monitoring and tracking."
+aliases:
+- /real_user_monitoring/ios/integrated_libraries/
+- /real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/ios/
+- /real_user_monitoring/mobile_and_tv_monitoring/ios/integrated_libraries/
+further_reading:
+- link: https://github.com/DataDog/dd-sdk-ios
+  tag: "Source Code"
+  text: Source code for dd-sdk-ios
+---
+{% partial file="sdk/integrated_libraries/ios.mdoc.md" /%}

--- a/content/en/real_user_monitoring/application_monitoring/kotlin_multiplatform/integrated_libraries.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/kotlin_multiplatform/integrated_libraries.mdoc.md
@@ -1,0 +1,14 @@
+---
+title: Kotlin Multiplatform Libraries for RUM
+description: "Integrate Kotlin Multiplatform libraries with RUM SDK for automatic monitoring of network requests and cross-platform functionality."
+aliases:
+- /real_user_monitoring/kotlin-multiplatform/integrated_libraries/
+- /real_user_monitoring/kotlin_multiplatform/integrated_libraries/
+- /real_user_monitoring/mobile_and_tv_monitoring/kotlin-multiplatform/integrated_libraries/
+- /real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/integrated_libraries
+further_reading:
+- link: https://github.com/DataDog/dd-sdk-kotlin-multiplatform
+  tag: "Source Code"
+  text: Source code for dd-sdk-kotlin-multiplatform
+---
+{% partial file="sdk/integrated_libraries/kotlin_multiplatform.mdoc.md" /%}

--- a/content/en/real_user_monitoring/application_monitoring/react_native/integrated_libraries.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/react_native/integrated_libraries.mdoc.md
@@ -1,0 +1,13 @@
+---
+title: React Native Libraries for RUM
+description: "Integrate React Native libraries with RUM SDK for automatic monitoring of navigation, network requests, and other app functionality."
+aliases:
+- /real_user_monitoring/reactnative/integrated_libraries/
+- /real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/reactnative
+- /real_user_monitoring/mobile_and_tv_monitoring/react_native/integrated_libraries
+further_reading:
+- link: https://github.com/DataDog/dd-sdk-reactnative
+  tag: "Source Code"
+  text: Source code for dd-sdk-reactnative
+---
+{% partial file="sdk/integrated_libraries/react_native.mdoc.md" /%}

--- a/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/android.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/android.mdoc.md
@@ -1,15 +1,7 @@
----
-title: Android and Android TV Libraries for RUM
-description: "Integrate popular Android libraries like Coil, OkHttp, and Retrofit with RUM for automatic monitoring of network requests and image loading."
-aliases:
-- /real_user_monitoring/android/integrated_libraries/
-- /real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/android
-- /real_user_monitoring/mobile_and_tv_monitoring/android/integrated_libraries
-further_reading:
-- link: https://github.com/DataDog/dd-sdk-android
-  tag: "Source Code"
-  text: Source code for dd-sdk-android
----
+<!--
+This partial contains integrated libraries content for the Android SDK.
+It can be included in the Android SDK integrated libraries page or in the unified client_sdks view.
+-->
 
 This page lists integrated libraries you can use for Android and Android TV applications.
 
@@ -37,8 +29,8 @@ If you use RxJava in your application, see Datadog's [dedicated RxJava library][
 
 If you use Picasso, use it with the `OkHttpClient` that's been instrumented with the Datadog SDK for RUM and APM information about network requests made by Picasso.
 
-{{< tabs >}}
-{{% tab "Kotlin" %}}
+{% tabs %}
+{% tab label="Kotlin" %}
    ```kotlin
    val picasso = Picasso.Builder(context)
       .downloader(OkHttp3Downloader(okHttpClient))
@@ -46,8 +38,8 @@ If you use Picasso, use it with the `OkHttpClient` that's been instrumented with
       .build()
    Picasso.setSingletonInstance(picasso)
    ```
-{{% /tab %}}
-{{% tab "Java" %}}
+{% /tab %}
+{% tab label="Java" %}
    ```java
    final Picasso picasso = new Picasso.Builder(context)
       .downloader(new OkHttp3Downloader(okHttpClient))
@@ -55,31 +47,31 @@ If you use Picasso, use it with the `OkHttpClient` that's been instrumented with
       .build();
    Picasso.setSingletonInstance(picasso);
    ```
-{{% /tab %}}
-{{< /tabs >}}
+{% /tab %}
+{% /tabs %}
 
 ## Retrofit
 
 If you use Retrofit, use it with the `OkHttpClient` that's been instrumented with the Datadog SDK for RUM and APM information about network requests made with Retrofit.
 
-{{< tabs >}}
-{{% tab "Kotlin" %}}
+{% tabs %}
+{% tab label="Kotlin" %}
    ```kotlin
    val retrofitClient = Retrofit.Builder()
       .client(okHttpClient)
       // …
       .build()
    ```
-{{% /tab %}}
-{{% tab "Java" %}}
+{% /tab %}
+{% tab label="Java" %}
    ```java
    final Retrofit retrofitClient = new Retrofit.Builder()
       .client(okHttpClient)
       // …
       .build();
    ```
-{{% /tab %}}
-{{< /tabs >}}
+{% /tab %}
+{% /tabs %}
 
 ## SQLDelight
 
@@ -93,8 +85,8 @@ Following SQLiteOpenHelper's [generated API documentation][5], you only have to 
 Doing this detects whenever a database is corrupted and sends a relevant
 RUM error event for it.
 
-{{< tabs >}}
-{{% tab "Kotlin" %}}
+{% tabs %}
+{% tab label="Kotlin" %}
    ```kotlin
    class <YourOwnSqliteOpenHelper>: SqliteOpenHelper(
                                     <Context>,
@@ -106,8 +98,8 @@ RUM error event for it.
 
    }
    ```
-{{% /tab %}}
-{{% tab "Java" %}}
+{% /tab %}
+{% tab label="Java" %}
    ```java
    public class <YourOwnSqliteOpenHelper> extends SqliteOpenHelper {
       public <YourOwnSqliteOpenHelper>(){
@@ -119,8 +111,8 @@ RUM error event for it.
       }
    }
    ```
-{{% /tab %}}
-{{< /tabs >}}
+{% /tab %}
+{% /tabs %}
 
 ## Apollo (GraphQL)
 
@@ -133,10 +125,6 @@ If you use the Leanback API to add actions into your Android TV application, see
 ## Kotlin Coroutines
 
 If you use Kotlin Coroutines, see Datadog's [dedicated library with extensions for RUM][9] and with [extensions for Trace][10].
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://github.com/DataDog/dd-sdk-android/tree/develop/integrations/dd-sdk-android-coil
 [2]: https://github.com/DataDog/dd-sdk-android/tree/develop/integrations/dd-sdk-android-fresco

--- a/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/flutter.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/flutter.mdoc.md
@@ -1,15 +1,7 @@
----
-title: Flutter Libraries for RUM
-description: "Integrate popular Flutter libraries with RUM SDK for automatic monitoring of HTTP requests, navigation, and other app functionality."
-aliases:
-- /real_user_monitoring/flutter/integrated_libraries/
-- /real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/flutter
-- /real_user_monitoring/mobile_and_tv_monitoring/flutter/integrated_libraries
-further_reading:
-- link: https://github.com/DataDog/dd-sdk-flutter
-  tag: "Source Code"
-  text: Source code for dd-sdk-flutter
----
+<!--
+This partial contains integrated libraries content for the Flutter SDK.
+It can be included in the Flutter SDK integrated libraries page or in the unified client_sdks view.
+-->
 
 This page lists integrated libraries you can use for Flutter applications.
 
@@ -59,7 +51,7 @@ MaterialApp.router(
 );
 ```
 
-Additionally, if you are using `GoRoute`'s `pageBuilder` parameter over its `builder` parameter, ensure that you are passing on the `state.pageKey` value and the `name` value to your `MaterialPage`.
+Additionally, if you are using `GoRoute`'s `pageBuilder` parameter over its `builder` parameter, make sure you are passing on the `state.pageKey` value and the `name` value to your `MaterialPage`.
 
 ```dart
 GoRoute(
@@ -135,7 +127,7 @@ final routerDelegate = BeamerDelegate(
 
 Real User Monitoring allows you to monitor web views and eliminate blind spots in your hybrid mobile applications.
 
-The Datadog Flutter SDK has packages for working with both [`webview_flutter`][8] and [`flutter_inappwebview`][9]. For more information, refer to the [Web View Tracking documentation page][10].
+The Datadog Flutter SDK has packages for working with both [`webview_flutter`][8] and [`flutter_inappwebview`][9]. For more information, see the [Web View Tracking documentation page][10].
 
 ## gRPC
 
@@ -222,7 +214,7 @@ final datadogConfig = DatadogConfiguration(
 For most Dio setups, use Datadog Tracking Http Client instead of the specialized Dio interceptor. Only use the Dio interceptor if you're using a non-standard Dio <code>HttpClientAdapter</code> that cannot be tracked by Datadog Tracking Http Client.
 </div>
 
-Datadog provides [`datadog_dio`][6] for use with the [Dio Flutter package][7]. The Dio interceptor automatically tracks requests from a given Dio client as RUM Resources and enables distributed tracing with APM.
+Datadog provides [`datadog_dio`][11] for use with the [Dio Flutter package][7]. The Dio interceptor automatically tracks requests from a given Dio client as RUM Resources and enables distributed tracing with APM.
 
 ### Setup
 
@@ -252,17 +244,13 @@ final dio = Dio()
   ..addDatadogInterceptor(DatadogSdk.instance);
 ```
 
-Calling `addDatadogInterceptor` adds the Datadog interceptor as the first interceptor in your list. This ensures all network requests from Dio are sent to Datadog, since other interceptors may not forward information down the chain. Call `addDatadogInterceptor` after completing all other Dio configuration.
+Calling `addDatadogInterceptor` adds the Datadog interceptor as the first interceptor in your list, so all network requests from Dio are sent to Datadog, since other interceptors may not forward information down the chain. Call `addDatadogInterceptor` after completing all other Dio configuration.
 
-### Use with other Datadog Network Tracking
+### Use with other Datadog network tracking
 
 To track all network requests, including those made by `dart:io` and widgets like `NetworkImage`, use `datadog_tracking_http_client` to capture these requests. However, depending on your setup, the global override method used in `enableHttpTracking` may cause resources to be double reported (once by the global override and once by the Dio interceptor)
 
 To avoid this, use the `ignoreUrlPatterns` parameter when calling `enableHttpTracking` to ignore requests made by your Dio client.
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://pub.dev/packages/datadog_gql_link
 [2]: https://pub.dev/packages?q=go_router

--- a/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/ios.mdoc.md
@@ -1,15 +1,7 @@
----
-title: iOS and tvOS Libraries for RUM
-description: "Integrate popular iOS libraries like URLSession, Alamofire, Apollo GraphQL and image loaders with RUM for automatic monitoring and tracking."
-aliases:
-- /real_user_monitoring/ios/integrated_libraries/
-- /real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/ios/
-- /real_user_monitoring/mobile_and_tv_monitoring/ios/integrated_libraries/
-further_reading:
-- link: https://github.com/DataDog/dd-sdk-ios
-  tag: "Source Code"
-  text: Source code for dd-sdk-ios
----
+<!--
+This partial contains integrated libraries content for the iOS SDK.
+It can be included in the iOS SDK integrated libraries page or in the unified client_sdks view.
+-->
 
 This page lists integrated libraries you can use for iOS and tvOS applications.
 
@@ -26,7 +18,7 @@ import DatadogRUM
 
 URLSessionInstrumentation.enableDurationBreakdown(with: .init(delegateClass: Alamofire.SessionDelegate.self))
 ```
-For additional information on sampling rate, distributed tracing, and adding custom attributes to tracked RUM resources, refer to [Advanced Configuration > Automatically track network requests][4].
+For additional information on sampling rate, distributed tracing, and adding custom attributes to tracked RUM resources, see [Advanced Configuration > Automatically track network requests][4].
 
 ## Apollo GraphQL
 

--- a/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/kotlin_multiplatform.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/kotlin_multiplatform.mdoc.md
@@ -1,16 +1,7 @@
----
-title: Kotlin Multiplatform Libraries for RUM
-description: "Integrate Kotlin Multiplatform libraries with RUM SDK for automatic monitoring of network requests and cross-platform functionality."
-aliases:
-- /real_user_monitoring/kotlin-multiplatform/integrated_libraries/
-- /real_user_monitoring/kotlin_multiplatform/integrated_libraries/
-- /real_user_monitoring/mobile_and_tv_monitoring/kotlin-multiplatform/integrated_libraries/
-- /real_user_monitoring/mobile_and_tv_monitoring/kotlin_multiplatform/integrated_libraries
-further_reading:
-- link: https://github.com/DataDog/dd-sdk-kotlin-multiplatform
-  tag: "Source Code"
-  text: Source code for dd-sdk-kotlin-multiplatform
----
+<!--
+This partial contains integrated libraries content for the Kotlin Multiplatform SDK.
+It can be included in the Kotlin Multiplatform SDK integrated libraries page or in the unified client_sdks view.
+-->
 
 This page lists integrated libraries you can use for Kotlin Multiplatform applications.
 
@@ -50,9 +41,5 @@ val ktorClient = HttpClient {
     )
 }
 ```
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: /real_user_monitoring/application_monitoring/kotlin_multiplatform/

--- a/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/react_native.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/integrated_libraries/react_native.mdoc.md
@@ -1,15 +1,7 @@
----
-title: React Native Libraries for RUM
-description: "Integrate React Native libraries with RUM SDK for automatic monitoring of navigation, network requests, and other app functionality."
-aliases:
-- /real_user_monitoring/reactnative/integrated_libraries/
-- /real_user_monitoring/mobile_and_tv_monitoring/integrated_libraries/reactnative
-- /real_user_monitoring/mobile_and_tv_monitoring/react_native/integrated_libraries
-further_reading:
-- link: https://github.com/DataDog/dd-sdk-reactnative
-  tag: "Source Code"
-  text: Source code for dd-sdk-reactnative
----
+<!--
+This partial contains integrated libraries content for the React Native SDK.
+It can be included in the React Native SDK integrated libraries page or in the unified client_sdks view.
+-->
 
 This page lists integrated libraries you can use for React Native applications.
 
@@ -17,9 +9,9 @@ This page lists integrated libraries you can use for React Native applications.
 
 ### Setup
 
-**Note**: This package is an integration for [`react-navigation`][1] library, please make sure you first install and setup the core `mobile-react-native` SDK.
+**Note**: This package is an integration for [`react-navigation`][1] library. Make sure you first install and setup the core `mobile-react-native` SDK.
 
-To install with NPM, run:
+To install with npm, run:
 
 ```sh
 npm install @datadog/mobile-react-navigation
@@ -63,11 +55,11 @@ function App() {
 
 ## React Native Navigation
 
-**Note**: This package is an integration for `react-native-navigation` library. Please make sure you first install and setup the core `mobile-react-native` SDK.
+**Note**: This package is an integration for `react-native-navigation` library. Make sure you first install and setup the core `mobile-react-native` SDK.
 
 ### Setup
 
-To install with NPM, run:
+To install with npm, run:
 
 ```sh
 npm install @datadog/mobile-react-native-navigation
@@ -98,11 +90,11 @@ DdRumReactNativeNavigationTracking.startTracking(viewNamePredicate);
 
 ## Apollo Client
 
-**Note**: This package is an integration for the `@apollo/client` library. Please make sure you first install and set up the core `mobile-react-native` SDK.
+**Note**: This package is an integration for the `@apollo/client` library. Make sure you first install and set up the core `mobile-react-native` SDK.
 
 ### Setup
 
-To install with NPM, run:
+To install with npm, run:
 
 ```sh
 npm install @datadog/mobile-react-native-apollo-client
@@ -179,10 +171,6 @@ const datadogConfiguration = new DatadogProviderConfiguration(
     }
 );
 ```
-
-## Further Reading
-
-{{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://reactnavigation.org/
 [2]: https://wix.github.io/react-native-navigation/api/events/#componentdidappear


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Converts all 5 RUM SDK integrated libraries pages (Android, iOS, Flutter, Kotlin Multiplatform, React Native) to the same Cdocs `.mdoc.md` structure used by the setup, advanced configuration, and data collected pages.

- Extracts content into shared partials under `layouts/shortcodes/mdoc/en/sdk/integrated_libraries/`
- Replaces individual SDK `integrated_libraries.md` files with `.mdoc.md` wrapper pages
- Adds a unified view at `client_sdks/integrated_libraries.mdoc.md` with `content_filters` for per-SDK content
- Browser, Roku, and Unity excluded (no integrated libraries pages)

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes