### PR TITLE
Clarify collecting_browser_errors Overview

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/collecting_browser_errors.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/collecting_browser_errors.md
@@ -18,7 +18,7 @@ further_reading:
 ---
 ## Overview
 
-The Browser SDK collects front-end errors. The error message and stack trace are included when available.
+The Browser SDK collects frontend errors, including the error message and stack trace when available. For triaging and managing these errors in the Error Tracking product, see [Browser Error Tracking][4].
 
 When the Browser SDK collects an error:
 
@@ -30,7 +30,7 @@ When the Browser SDK collects an error:
 [Error Tracking rules][17] do not apply to _Error events_, and RUM still records Error events that match [Ignored and Excluded issues][18] in Error Tracking. To prevent errors from being recorded as Error events, you must discard them before they are sent to Datadog [using the `beforeSend` callback][19].
 
 ## Error sources
-Front-end errors come from several different sources:
+Frontend errors come from several different sources:
 
 - **agent**: From the SDK execution
 - **console**: From `console.error()` API calls
@@ -72,7 +72,7 @@ addError(
 **Note**: [Error Tracking][4] processes errors that are sent with the source set to `custom`, `source`, `report` or `console`, and contain a stack trace. Errors sent with any other source (such as `network`) or sent from browser extensions are not processed by Error Tracking.
 
 {{< tabs >}}
-{{% tab "NPM" %}}
+{{% tab "npm" %}}
 
 ```javascript
 import { datadogRum } from '@datadog/browser-rum';
@@ -160,7 +160,7 @@ The collected rendering errors contain a component stack, which is unminified li
 To instrument React error boundaries for monitoring, use the following:
 
 {{< tabs >}}
-{{% tab "NPM" %}}
+{{% tab "npm" %}}
 
 ```javascript
 import { datadogRum } from '@datadog/browser-rum';


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Rewrites the Overview opening to remove repetition and adds a pointer to Browser Error Tracking. Also fixes `front-end` → `frontend` and `NPM` → `npm`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge