### PR TITLE
[DOCS-13808] Add multi-tenancy section to secure embedded dashboards docs

### DIFF
--- a/content/en/dashboards/sharing/secure_embedded_dashboards.md
+++ b/content/en/dashboards/sharing/secure_embedded_dashboards.md
@@ -277,6 +277,8 @@ Before using this code, implement the following helper functions for your enviro
 - `save_tenant_credentials(tenant_id, token, base_url, credential)`: stores the tenant's share token, base URL, and credential in your secret store
 - `get_secure_embed_token_for_tenant(tenant_id)`: retrieves the share token for a tenant from your secret store
 - `get_base_url_for_tenant(tenant_id)`: retrieves the base URL for a tenant from your secret store
+- `get_credential_for_tenant(tenant_id)`: retrieves the credential for a tenant from your secret store
+- `get_tenant_id_for_user(user_id)`: maps an authenticated user to their tenant ID
 - `delete_tenant_credentials(tenant_id)`: removes the tenant's credentials from your secret store
 
 ```python
@@ -387,8 +389,9 @@ The iFrame URL generation follows the same pattern as single-tenant setups. The 
 @cross_origin(origins="*", methods=["GET", "OPTIONS"], allow_headers=["Content-Type"])
 def embed_url():
     user_id = get_authenticated_user_id()
-    credential = get_credential_from_secure_store_for_user_id(user_id)
-    base_url = get_base_url_for_user_id(user_id)
+    tenant_id = get_tenant_id_for_user(user_id)
+    credential = get_credential_for_tenant(tenant_id)
+    base_url = get_base_url_for_tenant(tenant_id)
     iframe_url = generate_secure_embed_url(credential, base_url)
     return jsonify({"iframeUrl": iframe_url})
 ```

--- a/content/en/dashboards/sharing/secure_embedded_dashboards.md
+++ b/content/en/dashboards/sharing/secure_embedded_dashboards.md
@@ -194,7 +194,8 @@ Backend API endpoint (Python/Flask example):
 @cross_origin(origins="*", methods=["GET", "OPTIONS"], allow_headers=["Content-Type"])
 def embed_url():
     credential = get_credential_from_secure_store()
-    iframe_url = generate_secure_embed_url(credential, BASE_URL)
+    base_url = get_base_url_from_secure_store()
+    iframe_url = generate_secure_embed_url(credential, base_url)
     return jsonify({"iframeUrl": iframe_url})
 ```
 
@@ -237,7 +238,8 @@ Backend (Python/Flask example):
 @app.get("/dashboard")
 def dashboard():
     credential = get_credential_from_secure_store()
-    iframe_url = generate_secure_embed_url(credential, BASE_URL)
+    base_url = get_base_url_from_secure_store()
+    iframe_url = generate_secure_embed_url(credential, base_url)
     return render_template("dashboard.html", iframe_url=iframe_url)
 ```
 
@@ -251,6 +253,147 @@ HTML template:
   allow="fullscreen"
 ></iframe>
 ```
+
+## Multi-tenancy
+
+To serve multiple tenants from a single source dashboard, create one secure embed per tenant. Set `selectable_template_vars` with `visible_tags` scoped to each tenant's resources. Each tenant gets a unique credential and base URL, which your backend stores and retrieves when generating iFrame URLs.
+
+```text
+Dashboard
+  └── Secure Embed 1: Tenant A  →  visible_tags scoped to Tenant A
+  └── Secure Embed 2: Tenant B  →  visible_tags scoped to Tenant B
+  └── Secure Embed 3: Tenant C  →  visible_tags scoped to Tenant C
+```
+
+### Manage tenant embeds
+
+The following example uses the [Secure Embed API][5] to create, update, and delete embeds per tenant.
+
+Before using this code, implement the following helper functions for your environment:
+
+- `get_org_id_for_tenant(tenant_id)`: returns the org ID for the tenant
+- `get_hosts_for_tenant(tenant_id)`: returns the list of hosts for the tenant
+- `is_new_tenant(tenant_id)`, `is_existing_tenant(tenant_id)`, `is_offboarding_tenant(tenant_id)`: tenant lifecycle checks
+- `save_tenant_credentials(tenant_id, token, base_url, credential)`: stores the tenant's share token, base URL, and credential in your secret store
+- `get_secure_embed_token_for_tenant(tenant_id)`: retrieves the share token for a tenant from your secret store
+- `get_base_url_for_tenant(tenant_id)`: retrieves the base URL for a tenant from your secret store
+- `delete_tenant_credentials(tenant_id)`: removes the tenant's credentials from your secret store
+
+```python
+import requests
+
+DD_API_URL = "https://api.datadoghq.com"
+DASHBOARD_ID = "abc-def-ghi"
+HEADERS = {
+    "Content-Type": "application/vnd.api+json",
+    "DD-API-KEY": DD_API_KEY,
+    "DD-APPLICATION-KEY": DD_APP_KEY,
+}
+
+
+def build_selectable_template_vars(tenant_id: str) -> list[dict]:
+    return [
+        {
+            "name": "org_id",
+            "prefix": "org_id",
+            "default_values": [get_org_id_for_tenant(tenant_id)],
+            "visible_tags": [get_org_id_for_tenant(tenant_id)],
+        },
+        {
+            "name": "host",
+            "prefix": "host",
+            "default_values": get_hosts_for_tenant(tenant_id),
+            "visible_tags": get_hosts_for_tenant(tenant_id),
+        },
+    ]
+
+
+def onboard_tenant(tenant_id: str) -> dict:
+    resp = requests.post(
+        f"{DD_API_URL}/api/v2/dashboard/{DASHBOARD_ID}/shared/secure-embed",
+        headers=HEADERS,
+        json={
+            "data": {
+                "type": "secure_embed_request",
+                "attributes": {
+                    "status": "active",
+                    "title": f"Dashboard - Tenant {tenant_id}",
+                    "global_time_selectable": False,
+                    "selectable_template_vars": build_selectable_template_vars(tenant_id),
+                    "viewing_preferences": {"high_density": False, "theme": "system"},
+                    "global_time": {"live_span": "1h"},
+                },
+            }
+        },
+    )
+    resp.raise_for_status()
+    data = resp.json()["data"]["attributes"]
+
+    # The credential is only returned on creation. Store it in a secret store.
+    return {
+        "token": data["token"],
+        "base_url": data["url"],
+        "credential": data["credential"],
+    }
+
+
+def update_tenant(tenant_id: str, share_token: str):
+    resp = requests.patch(
+        f"{DD_API_URL}/api/v2/dashboard/{DASHBOARD_ID}/shared/secure-embed/{share_token}",
+        headers=HEADERS,
+        json={
+            "data": {
+                "type": "secure_embed_update_request",
+                "attributes": {
+                    "selectable_template_vars": build_selectable_template_vars(tenant_id),
+                },
+            }
+        },
+    )
+    resp.raise_for_status()
+
+
+def offboard_tenant(share_token: str):
+    resp = requests.delete(
+        f"{DD_API_URL}/api/v2/dashboard/{DASHBOARD_ID}/shared/secure-embed/{share_token}",
+        headers=HEADERS,
+    )
+    resp.raise_for_status()
+
+
+def manage_tenant(tenant_id: str):
+    if is_new_tenant(tenant_id):
+        result = onboard_tenant(tenant_id)
+        save_tenant_credentials(
+            tenant_id, result["token"], result["base_url"], result["credential"]
+        )
+
+    elif is_existing_tenant(tenant_id):
+        token = get_secure_embed_token_for_tenant(tenant_id)
+        update_tenant(tenant_id, token)
+
+    elif is_offboarding_tenant(tenant_id):
+        token = get_secure_embed_token_for_tenant(tenant_id)
+        offboard_tenant(token)
+        delete_tenant_credentials(tenant_id)
+```
+
+### Generate the iFrame URL
+
+The iFrame URL generation follows the same pattern as single-tenant setups. The difference is that your backend looks up the correct credential and base URL for the requesting user's tenant.
+
+```python
+@app.get("/api/embed-url")
+@cross_origin(origins="*", methods=["GET", "OPTIONS"], allow_headers=["Content-Type"])
+def embed_url():
+    user_id = get_authenticated_user_id()
+    credential = get_credential_from_secure_store_for_user_id(user_id)
+    base_url = get_base_url_for_user_id(user_id)
+    iframe_url = generate_secure_embed_url(credential, base_url)
+    return jsonify({"iframeUrl": iframe_url})
+```
+
+Because `visible_tags` is scoped to each tenant at embed creation time, the URL enforces data isolation: each tenant can only see the template variable values assigned to them.
 
 ## Limitations
 
@@ -280,3 +423,4 @@ If you are using client-side rendering and see CORS errors when your frontend fe
 [2]: https://app.datadoghq.com/organization-settings/public-sharing
 [3]: https://app.datadoghq.com/organization-settings/public-sharing/settings
 [4]: https://app.datadoghq.com/organization-settings/roles
+[5]: /api/latest/dashboard-secure-embed/

--- a/content/en/dashboards/sharing/secure_embedded_dashboards.md
+++ b/content/en/dashboards/sharing/secure_embedded_dashboards.md
@@ -256,13 +256,13 @@ HTML template:
 
 ## Multi-tenancy
 
-To serve multiple tenants from a single source dashboard, create one secure embed per tenant. Set `selectable_template_vars` with `visible_tags` scoped to each tenant's resources. Each tenant gets a unique credential and base URL, which your backend stores and retrieves when generating iFrame URLs.
+To serve multiple tenants from a single source dashboard, create one secure embed per tenant. Use `selectable_template_vars` to scope each tenant's default template variable values to their own resources. Each tenant gets a unique credential and base URL, which your backend stores and retrieves when generating iFrame URLs.
 
 ```text
 Dashboard
-  └── Secure Embed 1: Tenant A  →  visible_tags scoped to Tenant A
-  └── Secure Embed 2: Tenant B  →  visible_tags scoped to Tenant B
-  └── Secure Embed 3: Tenant C  →  visible_tags scoped to Tenant C
+  └── Secure Embed 1: Tenant A  →  default_values scoped to Tenant A
+  └── Secure Embed 2: Tenant B  →  default_values scoped to Tenant B
+  └── Secure Embed 3: Tenant C  →  default_values scoped to Tenant C
 ```
 
 ### Manage tenant embeds
@@ -271,9 +271,8 @@ The following example uses the [Secure Embed API][5] to create, update, and dele
 
 Before using this code, implement the following helper functions for your environment:
 
-- `get_org_id_for_tenant(tenant_id)`: returns the org ID for the tenant
-- `get_hosts_for_tenant(tenant_id)`: returns the list of hosts for the tenant
-- `is_new_tenant(tenant_id)`, `is_existing_tenant(tenant_id)`, `is_offboarding_tenant(tenant_id)`: tenant lifecycle checks
+- `get_template_var_value_for_tenant(tenant_id)`: returns the template variable values for the tenant
+- `is_new_tenant(tenant_id)`, `is_existing_tenant(tenant_id)`, `is_offboarding_tenant(tenant_id)`: tenant life cycle checks
 - `save_tenant_credentials(tenant_id, token, base_url, credential)`: stores the tenant's share token, base URL, and credential in your secret store
 - `get_secure_embed_token_for_tenant(tenant_id)`: retrieves the share token for a tenant from your secret store
 - `get_base_url_for_tenant(tenant_id)`: retrieves the base URL for a tenant from your secret store
@@ -286,6 +285,8 @@ import requests
 
 DD_API_URL = "https://api.datadoghq.com"
 DASHBOARD_ID = "abc-def-ghi"
+TEMPLATE_VAR_NAME = "<TEMPLATE_VAR_NAME>"      # Template variable name as defined on the dashboard
+TEMPLATE_VAR_PREFIX = "<TEMPLATE_VAR_PREFIX>"  # Template variable prefix as defined on the dashboard
 HEADERS = {
     "Content-Type": "application/vnd.api+json",
     "DD-API-KEY": DD_API_KEY,
@@ -296,16 +297,9 @@ HEADERS = {
 def build_selectable_template_vars(tenant_id: str) -> list[dict]:
     return [
         {
-            "name": "org_id",
-            "prefix": "org_id",
-            "default_values": [get_org_id_for_tenant(tenant_id)],
-            "visible_tags": [get_org_id_for_tenant(tenant_id)],
-        },
-        {
-            "name": "host",
-            "prefix": "host",
-            "default_values": get_hosts_for_tenant(tenant_id),
-            "visible_tags": get_hosts_for_tenant(tenant_id),
+            "name": TEMPLATE_VAR_NAME,
+            "prefix": TEMPLATE_VAR_PREFIX,
+            "default_values": get_template_var_value_for_tenant(tenant_id),
         },
     ]
 
@@ -396,7 +390,7 @@ def embed_url():
     return jsonify({"iframeUrl": iframe_url})
 ```
 
-Because `visible_tags` is scoped to each tenant at embed creation time, the URL enforces data isolation: each tenant can only see the template variable values assigned to them.
+Because `default_values` are scoped to each tenant at embed creation time, each tenant sees only their own data when the dashboard loads.
 
 ## Limitations
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a multi-tenancy section to the secure embedded dashboards page, based on @michlee1337's draft and example code. It explains how to serve multiple customers from a single dashboard by creating one secure embed per tenant and using `selectable_template_vars` to scope each tenant's default template variable values to their own data. Uses the new [Dashboard Secure Embed API](https://docs.datadoghq.com/api/latest/dashboard-secure-embed/) (note: I have a [PR open](https://github.com/DataDog/datadog-api-spec/pull/5470) to fix some formatting issues on the API doc).

Also makes a small update to the existing single-tenant iFrame examples, replacing the hardcoded `BASE_URL` constant with a call to retrieve the base URL from a secret store.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes
