### PR TITLE
[SEC-24729][docs] clarify that suppressions are evaluated at signal creation time

### DIFF
--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -23,6 +23,10 @@ products:
 
 Suppressions are specific conditions for when a signal should not be generated, which can improve the accuracy and relevance of the signals that are generated.
 
+{{< callout btn_hidden="true" header="Suppression timing" >}}
+Suppressions are evaluated at signal creation time and are not applied retroactively to existing signals. To suppress activity, apply suppression queries against **log or event attributes** before a signal is generated, rather than against an already-created signal.
+{{< /callout >}}
+
 ## Suppression routes
 
 You can set up a suppression query within an individual [detection rule](#detection-rules), or define a separate [suppression rule](#suppression-rules) to suppress signals across one or more detection rules.

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -24,7 +24,7 @@ products:
 Suppressions are specific conditions for when a signal should not be generated, which can improve the accuracy and relevance of the signals that are generated.
 
 {{< callout btn_hidden="true" header="Suppression timing" >}}
-Suppressions are evaluated at signal creation time and are not applied retroactively to existing signals. To suppress activity, apply suppression queries against **log or event attributes** before a signal is generated, rather than against an already-created signal.
+There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created—they are not re-evaluated when a signal is updated. To reliably exclude specific activity, use log or event attribute suppressions, which prevent signals from being generated in the first place.
 {{< /callout >}}
 
 ## Suppression routes

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -24,7 +24,7 @@ products:
 Suppressions are specific conditions for when a signal should not be generated, which can improve the accuracy and relevance of the signals that are generated.
 
 {{< callout btn_hidden="true" header="Suppression evaluation" >}}
-There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created—they are not re-evaluated when a signal is updated. Log or event attribute suppressions prevent matching events from both generating new signals and updating existing ones, making them the recommended approach to reliably exclude specific activity.
+There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created. They are not re-evaluated when a signal is updated. Log or event attribute suppressions prevent matching events from new signals and updated existing signals, making this approach the recommended one to reliably exclude specific activity.
 {{< /callout >}}
 
 ## Suppression routes

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -24,7 +24,7 @@ products:
 Suppressions are specific conditions for when a signal should not be generated, which can improve the accuracy and relevance of the signals that are generated.
 
 {{< callout btn_hidden="true" header="Suppression evaluation" >}}
-There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created. They are not re-evaluated when a signal is updated. Log or event attribute suppressions prevent matching events from new signals and updated existing signals, making this approach the recommended one to reliably exclude specific activity.
+There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created. They are not re-evaluated when a signal is updated. Log and event attribute suppressions prevent matching events from new signals and updated existing signals. Datadog recommends using log and event attribute suppressions to reliably exclude specific activity.
 {{< /callout >}}
 
 ## Suppression routes

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -23,7 +23,7 @@ products:
 
 Suppressions are specific conditions for when a signal should not be generated, which can improve the accuracy and relevance of the signals that are generated.
 
-{{< callout btn_hidden="true" header="Suppression timing" >}}
+{{< callout btn_hidden="true" header="Suppression evaluation" >}}
 There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created—they are not re-evaluated when a signal is updated. Log or event attribute suppressions prevent matching events from both generating new signals and updating existing ones, making them the recommended approach to reliably exclude specific activity.
 {{< /callout >}}
 

--- a/content/en/security/suppressions.md
+++ b/content/en/security/suppressions.md
@@ -24,7 +24,7 @@ products:
 Suppressions are specific conditions for when a signal should not be generated, which can improve the accuracy and relevance of the signals that are generated.
 
 {{< callout btn_hidden="true" header="Suppression timing" >}}
-There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created—they are not re-evaluated when a signal is updated. To reliably exclude specific activity, use log or event attribute suppressions, which prevent signals from being generated in the first place.
+There are two types of suppression queries: suppression on **signal attributes** and suppression on **log or event attributes**. Signal-based suppressions are only evaluated at the time a signal is created—they are not re-evaluated when a signal is updated. Log or event attribute suppressions prevent matching events from both generating new signals and updating existing ones, making them the recommended approach to reliably exclude specific activity.
 {{< /callout >}}
 
 ## Suppression routes


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes SEC-24729

Adds a callout banner to the Suppressions page clarifying the two types of suppression queries (signal attributes vs. log/event attributes), and that signal-based suppressions are only evaluated at signal creation time—not on updates. Recommends log/event suppressions to reliably exclude specific activity.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes