### PR TITLE
Fix JumpCloud brand name in API source attribute list

### DIFF
--- a/content/en/integrations/faq/list-of-api-source-attribute-value.md
+++ b/content/en/integrations/faq/list-of-api-source-attribute-value.md
@@ -257,7 +257,7 @@ Search for events in the event explorer using `source:<SEARCH_TERM>`.
 | Java                            | java                              | java                               |
 | Jenkins                         | jenkins                           | jenkins                            |
 | Jira                            | jira                              | jira                               |
-| Jumpcloud                       | jumpcloud                         | jumpcloud                          |
+| JumpCloud                       | jumpcloud                         | jumpcloud                          |
 | Kafka                           | kafka                             | kafka                              |
 | Knative For Anthos              | knative for anthos                | knative_for_anthos                 |
 | Kong                            | kong                              | kong                               |


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes the "Jumpcloud" → "JumpCloud" brand name typo in the English API source attribute value FAQ page.

This is part of a broader brand name typo pattern across localized integration docs. The remaining files are in `es/`, `ja/`, `ko/` directories managed by the external translation pipeline — they need upstream fixes in integrations-core manifests to propagate correctly.

#### Files still needing upstream fixes

| Brand fix | Files | Occurrences |
|-----------|-------|-------------|
| `Checkpoint` → `Check Point` | es/ja/ko `checkpoint_quantum_firewall.md` | ~40 each (~120 total) |
| `Crowdstrike` → `CrowdStrike` | es/ja/ko `crowdstrike.md` | 2 each (6 total) |
| `Crowdstrike` → `CrowdStrike` | es/ja `twingate_inc_twingate.md` | 1 each (2 total) |
| `Jumpcloud` → `JumpCloud` | es/ja/ko `jumpcloud.md` | 2-6 each (~10 total) |
| `Ping Federate` → `PingFederate` | es `ping_federate.md` | 4 |

These typos originate from integrations-core manifests and propagate through the translation pipeline. Fixing them upstream will auto-correct the localized pages on the next build/sync.

### Additional notes

The localized files (`content/{es,ja,ko}/`) are managed externally per CLAUDE.md guidelines, so only the English file is edited in this PR.