### PR TITLE
CloudPrem: Document data flow and reverse connection architecture

### DIFF
--- a/content/en/cloudprem/introduction/architecture.md
+++ b/content/en/cloudprem/introduction/architecture.md
@@ -42,7 +42,7 @@ The CloudPrem cluster, typically deployed on Kubernetes (EKS), consists of sever
 
 ### Ingestion path (logs entering CloudPrem)
 
-Logs are ingested into CloudPrem entirely within your infrastructure. The typical flow is:
+Logs are ingested into CloudPrem within your infrastructure. The typical flow is:
 
 1. Your applications emit logs to the **Datadog Agent** or **Observability Pipelines Worker**.
 2. Logs are forwarded to CloudPrem **indexers** running in your cluster.
@@ -52,7 +52,7 @@ Logs are ingested into CloudPrem entirely within your infrastructure. The typica
 
 ### Query path (searching logs from Datadog UI)
 
-When you search CloudPrem logs from the Datadog UI (for example, Log Explorer), the query flows through a secure connection between Datadog and your cluster:
+When you search CloudPrem logs from the Datadog UI (for example, in the Log Explorer), the query flows through a secure connection between Datadog and your cluster:
 
 1. The Datadog UI sends the search query to Datadog's backend.
 2. Datadog's backend forwards the query to your CloudPrem cluster through the established connection (reverse connection or ingress).

--- a/content/en/cloudprem/introduction/architecture.md
+++ b/content/en/cloudprem/introduction/architecture.md
@@ -38,6 +38,29 @@ The CloudPrem cluster, typically deployed on Kubernetes (EKS), consists of sever
 : Performs maintenance tasks, applying retention policies, garbage collecting expired splits, and running delete query jobs.
 
 
+## Data flow
+
+### Ingestion path (logs entering CloudPrem)
+
+Logs are ingested into CloudPrem entirely within your infrastructure. The typical flow is:
+
+1. Your applications emit logs to the **Datadog Agent** or **Observability Pipelines Worker**.
+2. Logs are forwarded to CloudPrem **indexers** running in your cluster.
+3. Indexers process and store logs as splits in your **object storage** (for example, Amazon S3 or Google Cloud Storage).
+
+**No log data leaves your environment during ingestion.** Logs are stored exclusively in your own object storage.
+
+### Query path (searching logs from Datadog UI)
+
+When you search CloudPrem logs from the Datadog UI (for example, Log Explorer), the query flows through a secure connection between Datadog and your cluster:
+
+1. The Datadog UI sends the search query to Datadog's backend.
+2. Datadog's backend forwards the query to your CloudPrem cluster through the established connection (reverse connection or ingress).
+3. **Searchers** in your cluster execute the query against your object storage.
+4. Only the **matching log results** are sent back to Datadog for display in the UI.
+
+**Only query results travel between your cluster and Datadog.** The full dataset remains in your object storage and is never transferred to Datadog.
+
 ## Connection to Datadog UI
 
 There are two ways to connect the Datadog UI to CloudPrem:

--- a/content/en/cloudprem/introduction/network.md
+++ b/content/en/cloudprem/introduction/network.md
@@ -12,18 +12,39 @@ further_reading:
 
 This document provides an overview of how CloudPrem and Datadog communicate with each other.
 
-### Default behavior: CloudPrem initiates the connection
+## Reverse connection (default)
 
-By default, CloudPrem initiates a WebSocket connection with Datadog using your API key, without requiring you to add a DNS record and configure a public ingress. This setup is useful for environments with strict network policies that do not allow inbound requests.
+By default, CloudPrem **searcher** pods initiate an outbound WebSocket connection to Datadog using your API key. Each searcher pod maintains its own connection to `wss://<DD_SITE>/api/unstable/cloudprem-connection-gateway/connect`.
 
+This is the recommended setup because:
+- **No inbound ports need to be opened** in your network.
+- **No DNS record or public ingress is required.**
+- The connection is initiated from your infrastructure, which simplifies firewall and security policies.
 
-### Optional behavior: using a public Ingress
+### What flows through the reverse connection
 
-It's possible to configure CloudPrem to deploy a public ingress so Datadog can establish a connection. 
+| Data | Direction | Description |
+|------|-----------|-------------|
+| Search queries | Datadog → CloudPrem | Queries from Log Explorer, dashboards, monitors |
+| Query results | CloudPrem → Datadog | Matching log entries returned for display |
+| Index management | Datadog → CloudPrem | Index creation, updates, deletion |
+
+### Network requirements
+
+Searcher pods require **outbound HTTPS (port 443)** access to your Datadog site (for example, `app.datadoghq.com`). No inbound connectivity is required.
+
+If your environment uses an HTTP proxy, CloudPrem supports standard proxy configuration via `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` environment variables.
+
+### Which pods connect to Datadog
+
+Only **searcher** pods establish the reverse connection. Indexers, the control plane, the metastore, and the janitor do not initiate any connection to Datadog.
+
+## Public ingress (optional)
+
+It is also possible to configure CloudPrem to deploy a public ingress so Datadog can establish the connection in the other direction.
 
 The public ingress enables Datadog's control plane and query service to manage and query CloudPrem clusters over the public internet. It provides secure access to the CloudPrem gRPC API using mTLS authentication. You can find more information about CloudPrem ingress in its [configuration page](/cloudprem/configure/ingress/).
 
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
-

--- a/content/en/cloudprem/introduction/network.md
+++ b/content/en/cloudprem/introduction/network.md
@@ -16,7 +16,7 @@ This document provides an overview of how CloudPrem and Datadog communicate with
 
 By default, CloudPrem **searcher** pods initiate an outbound WebSocket connection to Datadog using your API key. Each searcher pod maintains its own connection to `wss://<DD_SITE>/api/unstable/cloudprem-connection-gateway/connect`.
 
-This is the recommended setup because:
+Datadog recommends this setup because:
 - **No inbound ports need to be opened** in your network.
 - **No DNS record or public ingress is required.**
 - The connection is initiated from your infrastructure, which simplifies firewall and security policies.
@@ -33,7 +33,7 @@ This is the recommended setup because:
 
 Searcher pods require **outbound HTTPS (port 443)** access to your Datadog site (for example, `app.datadoghq.com`). No inbound connectivity is required.
 
-If your environment uses an HTTP proxy, CloudPrem supports standard proxy configuration via `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` environment variables.
+If your environment uses an HTTP proxy, CloudPrem supports standard proxy configuration with `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY` environment variables.
 
 ### Which pods connect to Datadog
 


### PR DESCRIPTION
## Summary
- Add a **Data flow** section to the architecture page explaining the ingestion and query paths
- Expand the **network** page with reverse connection details: which pods connect, what data flows through, network requirements, and proxy support

## Test plan
- [ ] Verify architecture page renders correctly with new Data flow section
- [ ] Verify network page renders correctly with tables and new sections
- [ ] Review with CloudPrem engineering for technical accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)