### PR TITLE
Document user-defined dataset record IDs for LLM Observability

### DIFF
--- a/content/en/llm_observability/experiments/api.md
+++ b/content/en/llm_observability/experiments/api.md
@@ -278,13 +278,13 @@ Appends records for a given dataset.
 
 | Field | Type | Description |
 | ---- | ---- | --- |
-| `deduplicate` | bool | If `true`, deduplicates appended records. Defaults to `true`. |
 | `records` (_required_) | [][RecordReq](#object-recordreq) | List of records to create. |
 
 #### Object: RecordReq
 
 | Field | Type | Description |
 | ---- | ---- | ---- |
+| `id` | string | Optional user-provided record ID. Must be 128 characters or fewer and match `^[a-zA-Z0-9_\-\.]+$`. If not provided, the system generates one automatically. If the ID matches an existing record, the existing record is updated (upsert semantics). |
 | `input` (_required_) | any (string, number, Boolean, object, array) | Data that serves as the starting point for an experiment. |
 | `expected_output` | any (string, number, Boolean, object, array) | Expected output. |
 | `metadata` | json | Arbitrary key-value metadata associated with the record. |

--- a/content/en/llm_observability/experiments/datasets.md
+++ b/content/en/llm_observability/experiments/datasets.md
@@ -48,7 +48,6 @@ dataset = LLMObs.create_dataset_from_csv(
 - CSV files must have a header row
 - Maximum field size is 10MB
 - All columns not specified in `input_data_columns`, `expected_output_columns`, or `id_column` are automatically treated as metadata
-- If `id_column` is specified but the column is not found in the CSV header, a `ValueError` is raised
 - The dataset is automatically pushed to Datadog after creation
 
 {{% /tab %}}

--- a/content/en/llm_observability/experiments/datasets.md
+++ b/content/en/llm_observability/experiments/datasets.md
@@ -212,7 +212,7 @@ for record in dataset:
 The Dataset class provides methods to manage records: `append()`, `update()`, `delete()`. You need to `push()` changes to save the changes in Datadog.
 
 ```python
-# Add a new record (id is optional; if omitted, the SDK generates one automatically)
+# Add a new record
 dataset.append({
     "id": "switzerland-capital",
     "input_data": {"question": "What is the capital of Switzerland?"},

--- a/content/en/llm_observability/experiments/datasets.md
+++ b/content/en/llm_observability/experiments/datasets.md
@@ -214,12 +214,11 @@ The Dataset class provides methods to manage records: `append()`, `update()`, `d
 ```python
 # Add a new record (id is optional; if omitted, the SDK generates one automatically)
 dataset.append({
-    "id": "switzerland-capital",                                        # optional
+    "id": "switzerland-capital",
     "input_data": {"question": "What is the capital of Switzerland?"},
     "expected_output": "Bern",
     "metadata": {"difficulty": "easy"}
 })
-# Note: passing a duplicate id raises a ValueError
 
 # Update an existing record
 dataset.update(0, {

--- a/content/en/llm_observability/experiments/datasets.md
+++ b/content/en/llm_observability/experiments/datasets.md
@@ -9,6 +9,7 @@ Each record in a dataset contains:
 - **input** (required): Represents all the information that the agent can access in a task.
 - **expected output** (optional): Also called _ground truth_, represents the ideal answer that the agent should output. You can use _expected output_ to store the actual output of the app, as well as any intermediary results you want to assesss. 
 - **metadata** (optional): Contains any useful information to categorize the record and use for further analysis. For example: topics, tags, descriptions, notes.
+- **id** (optional): A user-defined identifier for the record. Must be 128 characters or fewer and contain only letters, numbers, `_`, `-`, or `.`. If not provided, the SDK generates one automatically.
 
 Datasets enable systematic testing and regression detection by providing consistent evaluation scenarios across experiments.
 
@@ -32,20 +33,22 @@ dataset = LLMObs.create_dataset_from_csv(
     input_data_columns=["question", "category"],  # Columns to use as input
     expected_output_columns=["answer"],           # Optional: Columns to use as expected output
     metadata_columns=["difficulty"],              # Optional: Additional columns as metadata
+    id_column="record_id",                        # Optional: Column to use as record IDs
     csv_delimiter=","                             # Optional: Defaults to comma
 )
 
 # Example "questions.csv":
-# question,category,answer,difficulty
-# What is the capital of Japan?,geography,Tokyo,medium
-# What is the capital of Brazil?,geography,Brasília,medium
+# record_id,question,category,answer,difficulty
+# japan-capital,What is the capital of Japan?,geography,Tokyo,medium
+# brazil-capital,What is the capital of Brazil?,geography,Brasília,medium
 
 ```
 
 **Notes**:
 - CSV files must have a header row
 - Maximum field size is 10MB
-- All columns not specified in `input_data_columns` or `expected_output_columns` are automatically treated as metadata
+- All columns not specified in `input_data_columns`, `expected_output_columns`, or `id_column` are automatically treated as metadata
+- If `id_column` is specified but the column is not found in the CSV header, a `ValueError` is raised
 - The dataset is automatically pushed to Datadog after creation
 
 {{% /tab %}}
@@ -63,6 +66,7 @@ dataset = LLMObs.create_dataset(
     description="Questions about world capitals",
     records=[
         {
+            "id": "china-capital",                                             # optional, user-defined record ID
             "input_data": {"question": "What is the capital of China?"},       # required, JSON or string
             "expected_output": "Beijing",                                      # optional, JSON or string
             "metadata": {"difficulty": "easy"}                                 # optional, JSON
@@ -174,10 +178,10 @@ Dataset versions start at `0`, and each new version increments the version by 1.
 
 A new dataset version is created when:
 - Adding records
-- Updating records (changes to `input` or `expected_output` fields)
+- Updating records (changes to `input`, `expected_output`, or `metadata` fields)
 - Deleting records
 
-Dataset versions are **NOT** created for changes to `metadata` fields, or when updating the dataset name or description.
+Dataset versions are **NOT** created when updating the dataset name or description.
 
 #### Version retention
 
@@ -209,12 +213,14 @@ for record in dataset:
 The Dataset class provides methods to manage records: `append()`, `update()`, `delete()`. You need to `push()` changes to save the changes in Datadog.
 
 ```python
-# Add a new record
+# Add a new record (id is optional; if omitted, the SDK generates one automatically)
 dataset.append({
+    "id": "switzerland-capital",                                        # optional
     "input_data": {"question": "What is the capital of Switzerland?"},
     "expected_output": "Bern",
     "metadata": {"difficulty": "easy"}
 })
+# Note: passing a duplicate id raises a ValueError
 
 # Update an existing record
 dataset.update(0, {


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Documents the user-defined dataset record ID feature shipped in dd-trace-py 4.7.0. Users can now supply an optional `id` when creating dataset records via `Dataset.append()`, `Dataset.extend()`, `create_dataset()`, or `create_dataset_from_csv()` (via the new `id_column` parameter). If no `id` is provided, the SDK generates one automatically.

Related PRs:
- https://github.com/DataDog/dd-trace-py/pull/17050 (SDK changes)
- https://github.com/DataDog/dd-source/pull/388116 (backend changes)

Changes:
- `datasets.md`: Add `id` to the record field list; update `create_dataset_from_csv()` example with `id_column` parameter; add optional `id` to `create_dataset()` and `append()` examples; fix incorrect statement that metadata updates do not bump the dataset version (they now do)
- `api.md`: Add optional `id` field to `RecordReq` object; remove the removed `deduplicate` request field from the POST records endpoint

### Merge instructions

Merge readiness:
- [ ] Ready for merge