### PR TITLE
CloudPrem: Clarify deployment requirements and supported platforms

### DIFF
--- a/content/en/cloudprem/install/_index.md
+++ b/content/en/cloudprem/install/_index.md
@@ -9,7 +9,11 @@ description: Learn how to deploy CloudPrem on various platforms and environments
 
 ## Overview
 
-CloudPrem can be deployed in various environments, from cloud-managed Kubernetes services to bare metal servers. The provided installation instructions are specific to **Kubernetes distributions**.
+CloudPrem requires **Kubernetes** for production deployments. It is supported on cloud-managed Kubernetes services (EKS, GKE, AKS) and self-managed Kubernetes clusters. A [Docker installation][2] is also available for local evaluation and testing only.
+
+<div class="alert alert-warning">
+<strong>Docker is for evaluation only.</strong> The Docker installation method is designed for exploring CloudPrem features locally. For production workloads, deploy on a supported Kubernetes platform.
+</div>
 
 ## Prerequisites
 
@@ -22,7 +26,7 @@ If you don't see the CloudPrem entry in the Logs menu, it means CloudPrem is not
 | Requirement            | Details                                                                                  |
 |------------------------|------------------------------------------------------------------------------------------|
 | **Kubernetes Version** | 1.25 or higher                                                                           |
-| **Recommended Platforms** | - AWS EKS<br>- Google GKE<br>- Azure AKS<br>- Self-managed Kubernetes (Nginx controller) |
+| **Supported Platforms** | - AWS EKS<br>- Google GKE<br>- Azure AKS<br>- Self-managed Kubernetes (Nginx controller)<br><br>OpenShift and OCI (Oracle Cloud) are not currently tested or supported. |
 | **Metadata Storage**   | PostgreSQL database                                                                      |
 | **Recommended PostgreSQL Options** | - AWS: RDS PostgreSQL<br>- GCP: Cloud SQL for PostgreSQL<br>- Azure: Azure Database for PostgreSQL<br>- Self-hosted: PostgreSQL with persistent storage |
 
@@ -46,3 +50,4 @@ CloudPrem supports the following object storage types:
 {{< /whatsnext >}}
 
 [1]: https://www.datadoghq.com/product-preview/cloudprem/
+[2]: /cloudprem/install/docker/

--- a/content/en/cloudprem/install/docker.md
+++ b/content/en/cloudprem/install/docker.md
@@ -17,7 +17,11 @@ further_reading:
 
 ## Overview
 
-This installation guide shows you how to run Datadog CloudPrem locally using either standalone Docker containers or Docker Compose. Follow these steps to deploy a minimal CloudPrem environment on your machine, ideal for exploring CloudPrem features and testing log ingestion with Datadog before deploying to production.
+<div class="alert alert-warning">
+<strong>This installation method is for local evaluation only.</strong> Docker is not supported for production deployments. For production workloads, deploy CloudPrem on a <a href="/cloudprem/install/">supported Kubernetes platform</a> (EKS, GKE, AKS, or self-managed Kubernetes).
+</div>
+
+This installation guide shows you how to run Datadog CloudPrem locally using either standalone Docker containers or Docker Compose. Follow these steps to deploy a minimal CloudPrem environment on your machine, ideal for exploring CloudPrem features and testing log ingestion with Datadog.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- State Kubernetes as a hard requirement for production deployments
- Add warning callouts on the install index and Docker pages flagging Docker as evaluation-only
- Change "Recommended Platforms" to "Supported Platforms" and explicitly note OpenShift and OCI are not currently supported

## Test plan
- [ ] Verify install index page renders correctly with warning callout
- [ ] Verify Docker page renders correctly with warning callout
- [ ] Review with CloudPrem engineering for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)