### PR TITLE
fix: correct typos in App and API Protection documentation

### DIFF
--- a/content/en/security/application_security/how-it-works/add-user-info.md
+++ b/content/en/security/application_security/how-it-works/add-user-info.md
@@ -889,7 +889,7 @@ Available since dd-trace-py v3.7, `track_user_sdk` provides 5 functions:
 
 Available since dd-trace-py v3.17, `track_user_sdk` provides this additional function:
 
-- `tracker_user_id`
+- `track_user_id`
 
 
 ```python

--- a/content/en/security/application_security/setup/dotnet/compatibility.md
+++ b/content/en/security/application_security/setup/dotnet/compatibility.md
@@ -49,7 +49,7 @@ These are supported on the following architectures:
 - macOS (Darwin) x86-64, ARM64
 - Windows (msvc) x86, x86-64
 
-For a complete list of supported versions abd operating systems, see the [.NET Core tracer documentation][3] and [.NET Framework tracer documentation][4].
+For a complete list of supported versions and operating systems, see the [.NET Core tracer documentation][3] and [.NET Framework tracer documentation][4].
 
 You must be running Datadog Agent v7.41.1+ for App and API Protection features.
 

--- a/content/en/security/application_security/setup/go/sdk.md
+++ b/content/en/security/application_security/setup/go/sdk.md
@@ -138,7 +138,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 
 func authMiddleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		user := "<username>" // Do real authentification here
+		user := "<username>" // Do real authentication here
 
 		// Set user context on all authenticated requests
 		if err := appsec.SetUser(r.Context(), user); err != nil && events.IsSecurityError(err) {

--- a/content/en/security/application_security/setup/go/setup.md
+++ b/content/en/security/application_security/setup/go/setup.md
@@ -8,7 +8,7 @@ aliases:
 further_reading:
 - link: "/security/application_security/setup/go/sdk"
   tag: "Documentation"
-  text: "App & API Protecion SDK for Go"
+  text: "App & API Protection SDK for Go"
 - link: "/security/application_security/add-user-info/"
   tag: "Documentation"
   text: "Adding user information to traces"

--- a/content/en/security/application_security/setup/php/compatibility.md
+++ b/content/en/security/application_security/setup/php/compatibility.md
@@ -47,7 +47,7 @@ It's recommended to use <a href="https://www.php.net/supported-versions">officia
 | 7.1.x          | General Availability                  | All             |
 | 7.0.x          | General Availability                  | All             |
 
-App and API Protection capabililties for PHP support the following SAPI's:
+App and API Protection capabilities for PHP support the following SAPI's:
 
 | SAPI           | Support type    |
 |:---------------|:----------------|
@@ -59,7 +59,7 @@ App and API Protection capabililties for PHP support the following SAPI's:
 
 ## Supported processor architectures
 
-App and API Protection capabililties for PHP support the following architectures:
+App and API Protection capabilities for PHP support the following architectures:
 
 | Processor architectures                   | Support level         | Package version                        |
 | ------------------------------------------|-----------------------|----------------------------------------|

--- a/content/en/security/application_security/troubleshooting.md
+++ b/content/en/security/application_security/troubleshooting.md
@@ -540,7 +540,7 @@ AAP data is sent with APM traces. See [APM troubleshooting][4] to [confirm APM s
 
 ### Confirm tracer versions are updated
 
-See the App and API Protection product set up documentation to validate you you are using the right version of the tracer. These minimum versions are required to start sending telemetry data that includes library information.
+See the App and API Protection product set up documentation to validate you are using the right version of the tracer. These minimum versions are required to start sending telemetry data that includes library information.
 
 ### Ensure the communication of telemetry data
 

--- a/content/en/security/code_security/iast/setup/_index.md
+++ b/content/en/security/code_security/iast/setup/_index.md
@@ -341,7 +341,7 @@ DD_ENV=<YOUR_ENVIRONMENT>
 
 {{% collapse-content title="Python" level="h4" %}}
 
-You can detect code-level vulnerabilities and monitor application security in Python applicationss running in Docker, Kubernetes, Amazon ECS, and AWS Fargate.
+You can detect code-level vulnerabilities and monitor application security in Python applications running in Docker, Kubernetes, Amazon ECS, and AWS Fargate.
 
 Follow these steps to enable Runtime Code Analysis (IAST) in your service:
 

--- a/content/en/security/code_security/software_composition_analysis/setup_runtime/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_runtime/_index.md
@@ -145,7 +145,7 @@ java -javaagent:dd-java-agent.jar \
 
 ## Data Retention
 
-Datadog stores findings in accordance with our [Data Rentention Periods](https://docs.datadoghq.com/data_security/data_retention_periods/). Datadog does not store or retain customer source code.
+Datadog stores findings in accordance with our [Data Retention Periods](https://docs.datadoghq.com/data_security/data_retention_periods/). Datadog does not store or retain customer source code.
 
 [1]: /security/code_security/software_composition_analysis/setup_runtime/compatibility/java
 [2]: /security/code_security/software_composition_analysis/setup_runtime/compatibility/

--- a/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -202,7 +202,7 @@ Static reachability analysis is available for the following advisories:
 
 ## Data Retention
 
-Datadog stores findings in accordance with our [Data Rentention Periods](https://docs.datadoghq.com/data_security/data_retention_periods/). Datadog does not store or retain customer source code.
+Datadog stores findings in accordance with our [Data Retention Periods](https://docs.datadoghq.com/data_security/data_retention_periods/). Datadog does not store or retain customer source code.
 
 ## Further Reading
 

--- a/content/en/security/code_security/troubleshooting/_index.md
+++ b/content/en/security/code_security/troubleshooting/_index.md
@@ -49,7 +49,7 @@ When uploading results from third-party static analysis tools to Datadog, ensure
 To upload a SARIF report, follow the steps below:
 
 1. Ensure the [`DD_API_KEY` and `DD_APP_KEY` variables are defined][4].
-2. Optionally, set a [`DD_SITE` variable][7] (this default to `datadoghq.com`).
+2. Optionally, set a [`DD_SITE` variable][7] (this defaults to `datadoghq.com`).
 3. Install the `datadog-ci` utility:
 
    ```bash

--- a/content/en/security/guide/byoti_guide.md
+++ b/content/en/security/guide/byoti_guide.md
@@ -82,7 +82,7 @@ If the reference tables are not refreshing, select the **View Change Events** li
 
 **View Change Events** opens a page in **Event Management** showing potential error events for the ingestion. You can also filter in **Event Management** using the reference table name.
 
-<div class="alert alert-info">In Datadog Event Management, it can look like the data is fetched from the cloud, but it can take a few more minutes to propagate those changes to Threat Intellegence.</div>
+<div class="alert alert-info">In Datadog Event Management, it can look like the data is fetched from the cloud, but it can take a few more minutes to propagate those changes to Threat Intelligence.</div>
 
 Other useful cloud import details to remember:
 

--- a/layouts/shortcodes/aap/aap_and_api_protection_dotnet_overview.md
+++ b/layouts/shortcodes/aap/aap_and_api_protection_dotnet_overview.md
@@ -3,7 +3,7 @@
 ## Overview
 App and API Protection leverages the [Datadog .NET library](https://github.com/DataDog/dd-trace-dotnet/) to monitor and secure your .NET service. The library integrates seamlessly with your existing application without requiring code changes.
 
-For detailed compatibility information, including supported DOTNET versions, frameworks, and deployment environments, see [.NET Compatibility Requirements](/security/application_security/setup/dotnet/compatibility).
+For detailed compatibility information, including supported .NET versions, frameworks, and deployment environments, see [.NET Compatibility Requirements](/security/application_security/setup/dotnet/compatibility).
 
 {{ if $showSetup }}
 This guide explains how to set up App and API Protection (AAP) for .NET applications. The setup involves:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes a set of typos identified across the App and API Protection documentation:

| File | Typo | Fix |
|------|------|-----|
| `setup/go/sdk.md` | `authentification` | `authentication` |
| `setup/go/setup.md` | `App & API Protecion SDK for Go` | `App & API Protection SDK for Go` |
| `setup/php/compatibility.md` | `capabililties` (×2) | `capabilities` |
| `setup/dotnet/compatibility.md` | `supported versions abd operating systems` | `supported versions and operating systems` |
| `layouts/shortcodes/aap/aap_and_api_protection_dotnet_overview.md` | `supported DOTNET versions` | `supported .NET versions` |
| `code_security/iast/setup/_index.md` | `Python applicationss` | `Python applications` |
| `code_security/software_composition_analysis/setup_runtime/_index.md` | `Data Rentention Periods` | `Data Retention Periods` |
| `code_security/software_composition_analysis/setup_static/_index.md` | `Data Rentention Periods` | `Data Retention Periods` |
| `security/guide/byoti_guide.md` | `Threat Intellegence` | `Threat Intelligence` |
| `application_security/troubleshooting.md` | `validate you you are using` | `validate you are using` |
| `code_security/troubleshooting/_index.md` | `this default to` | `this defaults to` |
| `how-it-works/add-user-info.md` | `tracker_user_id` (Python function name) | `track_user_id` |

For the Python SDK function name: the correct name is `track_user_id` (not `tracker_user_id`), as defined in [`ddtrace/appsec/track_user_sdk.py`](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/appsec/track_user_sdk.py) in the dd-trace-py repository. The function has been available since dd-trace-py v3.17.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes