### PR TITLE
fix: remove concatenated text in callout boxes

### DIFF
--- a/content/en/security/application_security/how-it-works/_index.md
+++ b/content/en/security/application_security/how-it-works/_index.md
@@ -28,7 +28,7 @@ Services exposed to application attacks are highlighted directly in the security
 
 Datadog Threat Monitoring and Detection identifies bad actors by collecting client IP addresses, login account info (for example, user account/ID), and manually-added user tags on all requests.
 
-<div class="alert alert-info"><strong>1-Click Enablement</strong><br>
+<div class="alert alert-info"><strong>1-Click Enablement:</strong> <br>
 If your service is running with <a href="/agent/remote_config/#enabling-remote-configuration">an Agent with Remote Configuration enabled and a tracing library version that supports it</a>, you can <a href="https://app.datadoghq.com/security/configuration/asm/setup">enable App and API Protection</a> from the Datadog UI without additional configuration of the Agent or tracing libraries.</div>
 
 ## Compatibility

--- a/content/en/security/application_security/setup/_index.md
+++ b/content/en/security/application_security/setup/_index.md
@@ -14,8 +14,7 @@ disable_sidebar: true
 Learn how to enable App and API Protection on all the following supported platforms and environments.
 
 <div class="alert alert-info">
-  <p class="fs-bold m-0">Are you missing your environment?</p>
-  <span>Send us a request for your missing environment <a href="https://forms.gle/nMGq2Hhe7Z4sCKdy6">here</a>.</span>
+<strong>Are you missing your environment?</strong> Send us a request for your missing environment <a href="https://forms.gle/nMGq2Hhe7Z4sCKdy6">here</a>.
 </div>
 
 ## Languages

--- a/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/setup_static/_index.md
@@ -53,8 +53,7 @@ You can run Datadog Static SCA scans directly on Datadog infrastructure. Support
 To get started, navigate to the [**Code Security** page][2].
 
 <div class="alert alert-info">
-Datadog-hosted SCA scanning is not supported for repositories that contain file names longer than 255 characters. <br>
-For these cases, scan using CI pipelines.
+Datadog-hosted SCA scanning is not supported for repositories that contain file names longer than 255 characters. For these cases, scan using CI pipelines.
 </div>
 
 ### Scan in CI pipelines


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes three callout boxes where adjacent text nodes were being concatenated without spaces when rendered (visible in text extraction / accessibility tools):

- `setup/_index.md`: Merged `<p class="fs-bold m-0">` + `<span>` into a single inline text flow with `<strong>`.
- `how-it-works/_index.md`: Added a colon after the bold "1-Click Enablement" title so there is visible text separation before the `<br>`.
- `software_composition_analysis/setup_static/_index.md`: Removed the mid-sentence `<br>` tag and joined the two sentences into one paragraph.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes