### PR TITLE
Add Learning Center course cross-reference: Monitoring a Postgres Database with Datadog DBM

### DIFF
--- a/content/en/database_monitoring/_index.md
+++ b/content/en/database_monitoring/_index.md
@@ -26,6 +26,9 @@ further_reading:
 - link: "https://dtdg.co/fe"
   tag: "Foundation Enablement"
   text: "Join an interactive session to level up your Database Monitoring"
+- link: "https://learn.datadoghq.com/courses/database-monitoring"
+  tag: "Learning Center"
+  text: "Monitoring a Postgres Database with Datadog DBM"
 algolia:
   tags: ['database monitoring', 'dbm']
 cascade:

--- a/content/en/getting_started/database_monitoring/_index.md
+++ b/content/en/getting_started/database_monitoring/_index.md
@@ -14,6 +14,9 @@ further_reading:
     - link: 'https://dtdg.co/fe'
       tag: 'Foundation Enablement'
       text: 'Join an interactive session to level up your Database Monitoring'
+    - link: 'https://learn.datadoghq.com/courses/database-monitoring'
+      tag: 'Learning Center'
+      text: 'Monitoring a Postgres Database with Datadog DBM'
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

Adds `further_reading` links to the [Monitoring a Postgres Database with Datadog DBM](https://learn.datadoghq.com/courses/database-monitoring) Learning Center course on the following documentation pages:

- Database Monitoring (`database_monitoring/_index.md`)
- Getting Started with Database Monitoring (`getting_started/database_monitoring/_index.md`)

## Motivation

Cross-linking the Learning Center course from the most relevant documentation pages helps readers find hands-on practice resources to complement the reference documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)