### PR TITLE
Use Permalink in tile partials for absolute hrefs

### DIFF
--- a/layouts/partials/actions/expressions.html
+++ b/layouts/partials/actions/expressions.html
@@ -3,14 +3,14 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-3 justify-content-center">
       <div class="col">
-        <a class="card h-100" href="javascript">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}javascript/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/javascript.png" "class" "img-fluid" "alt" "JavaScript" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="python">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>

--- a/layouts/partials/actions/expressions.html
+++ b/layouts/partials/actions/expressions.html
@@ -3,14 +3,14 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-3 justify-content-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}javascript/">
+        <a class="card h-100" href="{{ .Page.Permalink }}javascript/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/javascript.png" "class" "img-fluid" "alt" "JavaScript" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
+        <a class="card h-100" href="{{ .Page.Permalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-compatibility.html
+++ b/layouts/partials/apm/apm-compatibility.html
@@ -3,70 +3,70 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-3 justify-content-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
+        <a class="card h-100" href="{{ .Page.Permalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
+        <a class="card h-100" href="{{ .Page.Permalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
+        <a class="card h-100" href="{{ .Page.Permalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "Go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
+        <a class="card h-100" href="{{ .Page.Permalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}cpp/">
+        <a class="card h-100" href="{{ .Page.Permalink }}cpp/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/cpp.png" "class" "img-fluid" "alt" "C++" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet-core/">
+        <a class="card h-100" href="{{ .Page.Permalink }}dotnet-core/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet-core.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet-framework/">
+        <a class="card h-100" href="{{ .Page.Permalink }}dotnet-framework/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet-framework.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}rust/">
+        <a class="card h-100" href="{{ .Page.Permalink }}rust/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/rust.png" "class" "img-fluid" "alt" "Rust" "width" "400") }}
           </div>
@@ -76,14 +76,14 @@
       {{ $currentURL := .Page.Permalink }}
       {{ if and (not (in $currentURL "/compatibility/")) (not (in $currentURL "/library_config/")) }}
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}android/">
+        <a class="card h-100" href="{{ .Page.Permalink }}android/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/android.png" "class" "img-fluid" "alt" "Android" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ios/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ios/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ios_large.svg" "class" "img-fluid" "alt" "iOS" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-compatibility.html
+++ b/layouts/partials/apm/apm-compatibility.html
@@ -3,70 +3,70 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-3 justify-content-center">
       <div class="col">
-        <a class="card h-100" href="java">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="python">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ruby">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="go">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "Go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="nodejs">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="php">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="cpp">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}cpp/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/cpp.png" "class" "img-fluid" "alt" "C++" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="dotnet-core">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet-core/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet-core.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="dotnet-framework">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet-framework/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet-framework.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="rust">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}rust/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/rust.png" "class" "img-fluid" "alt" "Rust" "width" "400") }}
           </div>
@@ -76,14 +76,14 @@
       {{ $currentURL := .Page.Permalink }}
       {{ if and (not (in $currentURL "/compatibility/")) (not (in $currentURL "/library_config/")) }}
       <div class="col">
-        <a class="card h-100" href="android">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}android/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/android.png" "class" "img-fluid" "alt" "Android" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ios">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ios/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ios_large.svg" "class" "img-fluid" "alt" "iOS" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-connect-logs-and-traces.html
+++ b/layouts/partials/apm/apm-connect-logs-and-traces.html
@@ -3,56 +3,56 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}java/" >
+        <a class="card h-100" href="{{ .Page.Permalink }}java/" >
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}python/" >
+        <a class="card h-100" href="{{ .Page.Permalink }}python/" >
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}go/" >
+        <a class="card h-100" href="{{ .Page.Permalink }}go/" >
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
+        <a class="card h-100" href="{{ .Page.Permalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
+        <a class="card h-100" href="{{ .Page.Permalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}opentelemetry/">
+        <a class="card h-100" href="{{ .Page.Permalink }}opentelemetry/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/otel.png" "class" "img-fluid" "alt" "OpenTelemetry" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-connect-logs-and-traces.html
+++ b/layouts/partials/apm/apm-connect-logs-and-traces.html
@@ -3,56 +3,56 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="java" >
+        <a class="card h-100" href="{{ .Page.RelPermalink }}java/" >
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="python" >
+        <a class="card h-100" href="{{ .Page.RelPermalink }}python/" >
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="go" >
+        <a class="card h-100" href="{{ .Page.RelPermalink }}go/" >
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ruby">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="nodejs">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="dotnet">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="php">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="opentelemetry">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}opentelemetry/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/otel.png" "class" "img-fluid" "alt" "OpenTelemetry" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-opentracing-custom.html
+++ b/layouts/partials/apm/apm-opentracing-custom.html
@@ -3,21 +3,21 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/java/">
+        <a class="card h-100" href="{{ .Page.Permalink }}opentracing/java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/python/">
+        <a class="card h-100" href="{{ .Page.Permalink }}opentracing/python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/nodejs/">
+        <a class="card h-100" href="{{ .Page.Permalink }}opentracing/nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
@@ -27,28 +27,28 @@
     </br>
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/ruby/">
+        <a class="card h-100" href="{{ .Page.Permalink }}opentracing/ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/dotnet/">
+        <a class="card h-100" href="{{ .Page.Permalink }}opentracing/dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/php/">
+        <a class="card h-100" href="{{ .Page.Permalink }}opentracing/php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/android/">
+        <a class="card h-100" href="{{ .Page.Permalink }}opentracing/android/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/android_large.svg" "class" "img-fluid" "alt" "Android" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-opentracing-custom.html
+++ b/layouts/partials/apm/apm-opentracing-custom.html
@@ -3,21 +3,21 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="opentracing/java">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="opentracing/python">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="opentracing/nodejs">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
@@ -27,28 +27,28 @@
     </br>
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="opentracing/ruby">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="opentracing/dotnet">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="opentracing/php">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="opentracing/android">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}opentracing/android/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/android_large.svg" "class" "img-fluid" "alt" "Android" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-otel-instrumentation.html
+++ b/layouts/partials/apm/apm-otel-instrumentation.html
@@ -3,49 +3,49 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="java">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="python">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ruby">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="go">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="nodejs">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="php">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="dotnet">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-otel-instrumentation.html
+++ b/layouts/partials/apm/apm-otel-instrumentation.html
@@ -3,49 +3,49 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
+        <a class="card h-100" href="{{ .Page.Permalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
+        <a class="card h-100" href="{{ .Page.Permalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
+        <a class="card h-100" href="{{ .Page.Permalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
+        <a class="card h-100" href="{{ .Page.Permalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
+        <a class="card h-100" href="{{ .Page.Permalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-proxies.html
+++ b/layouts/partials/apm/apm-proxies.html
@@ -3,49 +3,49 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-3 justify-content-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}httpd/">
+        <a class="card h-100" href="{{ .Page.Permalink }}httpd/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/apache.png" "class" "img-fluid" "alt" "httpd" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}envoy/">
+        <a class="card h-100" href="{{ .Page.Permalink }}envoy/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/envoy.png" "class" "img-fluid" "alt" "envoy" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}istio/">
+        <a class="card h-100" href="{{ .Page.Permalink }}istio/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/istio.png" "class" "img-fluid" "alt" "istio" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}kong/">
+        <a class="card h-100" href="{{ .Page.Permalink }}kong/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/kong.png" "class" "img-fluid" "alt" "kong" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nginx/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nginx/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nginx.png" "class" "img-fluid" "alt" "nginx" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-       <a class="card h-100" href="{{ .Page.RelPermalink }}apigateway/">
+       <a class="card h-100" href="{{ .Page.Permalink }}apigateway/">
          <div class="card-body text-center py-2 px-1">
            {{ partial "img.html" (dict "root" . "src" "integrations_logos/amazon_api_gateway.png" "class" "img-fluid" "alt" "apigateway" "width" "400") }}
          </div>
        </a>
      </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}azure_apim/">
+        <a class="card h-100" href="{{ .Page.Permalink }}azure_apim/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/azure_api_management.png" "class" "img-fluid" "alt" "Azure API Management" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-proxies.html
+++ b/layouts/partials/apm/apm-proxies.html
@@ -3,49 +3,49 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-3 justify-content-center">
       <div class="col">
-        <a class="card h-100" href="httpd">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}httpd/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/apache.png" "class" "img-fluid" "alt" "httpd" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="envoy">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}envoy/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/envoy.png" "class" "img-fluid" "alt" "envoy" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="istio">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}istio/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/istio.png" "class" "img-fluid" "alt" "istio" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="kong">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}kong/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/kong.png" "class" "img-fluid" "alt" "kong" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="nginx">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nginx/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nginx.png" "class" "img-fluid" "alt" "nginx" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-       <a class="card h-100" href="apigateway">
+       <a class="card h-100" href="{{ .Page.RelPermalink }}apigateway/">
          <div class="card-body text-center py-2 px-1">
            {{ partial "img.html" (dict "root" . "src" "integrations_logos/amazon_api_gateway.png" "class" "img-fluid" "alt" "apigateway" "width" "400") }}
          </div>
        </a>
      </div>
       <div class="col">
-        <a class="card h-100" href="azure_apim">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}azure_apim/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/azure_api_management.png" "class" "img-fluid" "alt" "Azure API Management" "width" "400") }}
           </div>

--- a/layouts/partials/apm/apm-single-step.html
+++ b/layouts/partials/apm/apm-single-step.html
@@ -3,28 +3,28 @@
   <div class="container cards-dd">
     <div class="row row-cols-1 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}linux/">
+        <a class="card h-100" href="{{ .Page.Permalink }}linux/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/linux.png" "class" "img-fluid" "alt" "linux" "width" "200") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}docker/">
+        <a class="card h-100" href="{{ .Page.Permalink }}docker/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/docker.png" "class" "img-fluid" "alt" "docker" "width" "200") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}kubernetes/">
+        <a class="card h-100" href="{{ .Page.Permalink }}kubernetes/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/kubernetes.png" "class" "img-fluid" "alt" "kubernetes" "width" "200") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}windows/">
+        <a class="card h-100" href="{{ .Page.Permalink }}windows/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/windows.png" "class" "img-fluid" "alt" "windows" "width" "200") }}
           </div>

--- a/layouts/partials/apm/apm-single-step.html
+++ b/layouts/partials/apm/apm-single-step.html
@@ -3,28 +3,28 @@
   <div class="container cards-dd">
     <div class="row row-cols-1 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="linux">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}linux/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/linux.png" "class" "img-fluid" "alt" "linux" "width" "200") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="docker">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}docker/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/docker.png" "class" "img-fluid" "alt" "docker" "width" "200") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="kubernetes">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}kubernetes/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/kubernetes.png" "class" "img-fluid" "alt" "kubernetes" "width" "200") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="windows">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}windows/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/windows.png" "class" "img-fluid" "alt" "windows" "width" "200") }}
           </div>

--- a/layouts/partials/observability_pipelines/use_cases.html
+++ b/layouts/partials/observability_pipelines/use_cases.html
@@ -2,7 +2,7 @@
 <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-3 justify-content-center">
         <div class="col">
-            <a class="card h-100" href="datadog">
+            <a class="card h-100" href="{{ .Page.RelPermalink }}datadog/">
                 <div class="card-body text-center py-2 px-1">
                     {{ partial "img.html" (dict "root" . "src" "integrations_logos/datadog.png" "class" "img-fluid"
                     "alt" "Datadog" "width" "150") }}
@@ -10,7 +10,7 @@
             </a>
         </div>
         <div class="col">
-            <a class="card h-100" href="splunk">
+            <a class="card h-100" href="{{ .Page.RelPermalink }}splunk/">
                 <div class="card-body text-center py-2 px-1">
                     {{ partial "img.html" (dict "root" . "src" "integrations_logos/splunk.png" "class" "img-fluid"
                     "alt" "Splunk" "width" "175") }}

--- a/layouts/partials/observability_pipelines/use_cases.html
+++ b/layouts/partials/observability_pipelines/use_cases.html
@@ -2,7 +2,7 @@
 <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-3 justify-content-center">
         <div class="col">
-            <a class="card h-100" href="{{ .Page.RelPermalink }}datadog/">
+            <a class="card h-100" href="{{ .Page.Permalink }}datadog/">
                 <div class="card-body text-center py-2 px-1">
                     {{ partial "img.html" (dict "root" . "src" "integrations_logos/datadog.png" "class" "img-fluid"
                     "alt" "Datadog" "width" "150") }}
@@ -10,7 +10,7 @@
             </a>
         </div>
         <div class="col">
-            <a class="card h-100" href="{{ .Page.RelPermalink }}splunk/">
+            <a class="card h-100" href="{{ .Page.Permalink }}splunk/">
                 <div class="card-body text-center py-2 px-1">
                     {{ partial "img.html" (dict "root" . "src" "integrations_logos/splunk.png" "class" "img-fluid"
                     "alt" "Splunk" "width" "175") }}

--- a/layouts/partials/profiling/profiling-troubleshooting.html
+++ b/layouts/partials/profiling/profiling-troubleshooting.html
@@ -3,70 +3,70 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
+        <a class="card h-100" href="{{ .Page.Permalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
+        <a class="card h-100" href="{{ .Page.Permalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
      <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
+        <a class="card h-100" href="{{ .Page.Permalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
+        <a class="card h-100" href="{{ .Page.Permalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
+        <a class="card h-100" href="{{ .Page.Permalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ddprof/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ddprof/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/rust.png" "class" "img-fluid" "alt" "Rust" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ddprof/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ddprof/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/c.png" "class" "img-fluid" "alt" "C" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ddprof/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ddprof/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/cpp.png" "class" "img-fluid" "alt" "C++" "width" "400") }}
           </div>

--- a/layouts/partials/profiling/profiling-troubleshooting.html
+++ b/layouts/partials/profiling/profiling-troubleshooting.html
@@ -3,70 +3,70 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-4 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="go">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="java">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
      <div class="col">
-        <a class="card h-100" href="nodejs">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="php">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="python">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ruby">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="dotnet">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".NET" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ddprof">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ddprof/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/rust.png" "class" "img-fluid" "alt" "Rust" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ddprof">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ddprof/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/c.png" "class" "img-fluid" "alt" "C" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ddprof">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ddprof/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/cpp.png" "class" "img-fluid" "alt" "C++" "width" "400") }}
           </div>

--- a/layouts/partials/security-platform/appsec-languages-code-security.html
+++ b/layouts/partials/security-platform/appsec-languages-code-security.html
@@ -3,33 +3,33 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="java">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="dotnet">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="nodejs">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="python">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
-      </div>      
+      </div>
     </div>
   </div>
 </div>

--- a/layouts/partials/security-platform/appsec-languages-code-security.html
+++ b/layouts/partials/security-platform/appsec-languages-code-security.html
@@ -3,28 +3,28 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
+        <a class="card h-100" href="{{ .Page.Permalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
+        <a class="card h-100" href="{{ .Page.Permalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
+        <a class="card h-100" href="{{ .Page.Permalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>

--- a/layouts/partials/security-platform/appsec-languages-sca.html
+++ b/layouts/partials/security-platform/appsec-languages-sca.html
@@ -3,49 +3,49 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
+        <a class="card h-100" href="{{ .Page.Permalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
+        <a class="card h-100" href="{{ .Page.Permalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
+        <a class="card h-100" href="{{ .Page.Permalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
+        <a class="card h-100" href="{{ .Page.Permalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
+        <a class="card h-100" href="{{ .Page.Permalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>

--- a/layouts/partials/security-platform/appsec-languages-sca.html
+++ b/layouts/partials/security-platform/appsec-languages-sca.html
@@ -3,49 +3,49 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="java">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="dotnet">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="go">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ruby">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="php">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="nodejs">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="python">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>

--- a/layouts/partials/security-platform/appsec-languages.html
+++ b/layouts/partials/security-platform/appsec-languages.html
@@ -3,84 +3,84 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="java">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="dotnet">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="go">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="ruby">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="php">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="nodejs">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="python">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="nginx">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}nginx/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nginx.png" "class" "img-fluid" "alt" "nginx" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="envoy">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}envoy/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/envoy.png" "class" "img-fluid" "alt" "envoy" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="istio">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}istio/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/istio.png" "class" "img-fluid" "alt" "istio" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="gcp-service-extensions">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}gcp-service-extensions/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/google_cloud_platform.png" "class" "img-fluid" "alt" "GCP Service Extensions" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="haproxy">
+        <a class="card h-100" href="{{ .Page.RelPermalink }}haproxy/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/haproxy.png" "class" "img-fluid" "alt" "HAProxy" "width" "400") }}
           </div>

--- a/layouts/partials/security-platform/appsec-languages.html
+++ b/layouts/partials/security-platform/appsec-languages.html
@@ -3,84 +3,84 @@
   <div class="container cards-dd">
     <div class="row row-cols-2 row-cols-sm-3 g-2 g-xl-3 justify-content-sm-center">
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}java/">
+        <a class="card h-100" href="{{ .Page.Permalink }}java/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/java.png" "class" "img-fluid" "alt" "Java" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}dotnet/">
+        <a class="card h-100" href="{{ .Page.Permalink }}dotnet/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/dotnet_text.png" "class" "img-fluid" "alt" ".Net" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}go/">
+        <a class="card h-100" href="{{ .Page.Permalink }}go/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/go-metro.png" "class" "img-fluid" "alt" "go" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}ruby/">
+        <a class="card h-100" href="{{ .Page.Permalink }}ruby/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/ruby.png" "class" "img-fluid" "alt" "Ruby" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}php/">
+        <a class="card h-100" href="{{ .Page.Permalink }}php/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/php.png" "class" "img-fluid" "alt" "PHP" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nodejs/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nodejs/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nodejs.png" "class" "img-fluid" "alt" "Node.js" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}python/">
+        <a class="card h-100" href="{{ .Page.Permalink }}python/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/python.png" "class" "img-fluid" "alt" "Python" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}nginx/">
+        <a class="card h-100" href="{{ .Page.Permalink }}nginx/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/nginx.png" "class" "img-fluid" "alt" "nginx" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}envoy/">
+        <a class="card h-100" href="{{ .Page.Permalink }}envoy/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/envoy.png" "class" "img-fluid" "alt" "envoy" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}istio/">
+        <a class="card h-100" href="{{ .Page.Permalink }}istio/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/istio.png" "class" "img-fluid" "alt" "istio" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}gcp-service-extensions/">
+        <a class="card h-100" href="{{ .Page.Permalink }}gcp-service-extensions/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/google_cloud_platform.png" "class" "img-fluid" "alt" "GCP Service Extensions" "width" "400") }}
           </div>
         </a>
       </div>
       <div class="col">
-        <a class="card h-100" href="{{ .Page.RelPermalink }}haproxy/">
+        <a class="card h-100" href="{{ .Page.Permalink }}haproxy/">
           <div class="card-body text-center py-2 px-1">
             {{ partial "img.html" (dict "root" . "src" "integrations_logos/haproxy.png" "class" "img-fluid" "alt" "HAProxy" "width" "400") }}
           </div>


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates 12 tile partials under `layouts/partials/` so each `<a class="card">` href resolves to a full `docs.datadoghq.com` URL at build time. This is an interim improvement to how tiles appear in the nightly [plaintext build](https://datadoghq.atlassian.net/wiki/x/ZwTpawE), which serves `<page>.md` versions of every docs page for LLM/chatbot ingestion.

#### Symptom

The `.md` version of a page with tiles using relative hrefs (for example, `/tracing/trace_collection/single-step-apm.md`) produces broken-looking link syntax:

```
- [linux](linux)
- [docker](docker)
- [kubernetes](kubernetes)
- [windows](windows)
```

Pages with tiles using absolute hrefs (for example, `/tracing/trace_collection/custom_instrumentation.md`) produce usable links:

```
- [Java](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/server-side/?api_type=dd_api&prog_lang=java)
```

#### Root cause

The plaintext build runs `html-to-mdoc` against the rendered HTML. 

The card processor takes the href attribute **verbatim** with no URL validation, no normalization, no resolution against a base URL.

#### Fix

Each href is prefixed with `{{ .Page.Permalink }}`, which Hugo expands to the full URL of the including page. For example:

- Before: `<a class="card" href="java">`
- After: `<a class="card" href="{{ .Page.Permalink }}java/">`

#### Partials updated

Single-parent partials:

- `layouts/partials/actions/expressions.html`
- `layouts/partials/apm/apm-connect-logs-and-traces.html`
- `layouts/partials/apm/apm-opentracing-custom.html`
- `layouts/partials/apm/apm-otel-instrumentation.html`
- `layouts/partials/apm/apm-proxies.html`
- `layouts/partials/apm/apm-single-step.html`
- `layouts/partials/observability_pipelines/use_cases.html`
- `layouts/partials/profiling/profiling-troubleshooting.html`

Multi-parent partials (the same partial is embedded from multiple parent pages that each have their own child pages, so a hardcoded absolute path wouldn't work):

- `layouts/partials/apm/apm-compatibility.html`
- `layouts/partials/security-platform/appsec-languages.html`
- `layouts/partials/security-platform/appsec-languages-sca.html`
- `layouts/partials/security-platform/appsec-languages-code-security.html`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes
