### PR TITLE
CloudPrem: Document supported ingestion formats and additional ingestion paths

### DIFF
--- a/content/en/cloudprem/ingest/_index.md
+++ b/content/en/cloudprem/ingest/_index.md
@@ -11,6 +11,21 @@ description: Configure log sources to send data to your CloudPrem deployment
 
 After installing and configuring CloudPrem, you need to set up log ingestion to start sending log data from your applications and infrastructure. CloudPrem supports multiple ingestion methods to accommodate different architectures and requirements.
 
+## Supported log format
+
+CloudPrem accepts logs as **JSON objects** sent to the `/api/v2/logs` endpoint. Each request body must be a JSON array of log objects:
+
+```json
+[
+  {"message": "First log entry", "service": "my-app", "level": "info"},
+  {"message": "Second log entry", "service": "my-app", "level": "error"}
+]
+```
+
+<div class="alert alert-info">
+<strong>NDJSON (newline-delimited JSON) is not supported.</strong> If your log source sends one JSON object per line without array wrapping, use Observability Pipelines to reformat the payload before sending to CloudPrem.
+</div>
+
 ## Log ingestion methods
 
 {{< whatsnext desc="Choose the appropriate ingestion method based on your infrastructure and requirements:">}}
@@ -18,3 +33,22 @@ After installing and configuring CloudPrem, you need to set up log ingestion to 
    {{< nextlink href="/cloudprem/ingest/observability_pipelines/" >}}Observability Pipelines{{< /nextlink >}}
    {{< nextlink href="/cloudprem/ingest/api/" >}}REST API Integration{{< /nextlink >}}
 {{< /whatsnext >}}
+
+## Additional ingestion paths
+
+### Datadog Lambda Forwarder
+
+The [Datadog Lambda Forwarder][1] can send AWS CloudWatch Logs to CloudPrem by setting the `DD_URL` environment variable to your CloudPrem endpoint:
+
+```
+DD_URL=<CLOUDPREM_HOST>
+```
+
+The forwarder sends logs to `https://<DD_URL>:443/api/v2/logs`. Note that API key validation (`/api/v1/validate`) is sent to Datadog SaaS (controlled by `DD_API_URL`), not to CloudPrem. This means you need a valid Datadog API key even when forwarding to CloudPrem.
+
+### OpenTelemetry
+
+CloudPrem can receive logs from OpenTelemetry collectors through Observability Pipelines. See [Send OTel logs to CloudPrem with Observability Pipelines][2] for setup instructions.
+
+[1]: /serverless/libraries_integrations/forwarder/
+[2]: /cloudprem/guides/send_otel_logs_observability_pipelines/

--- a/content/en/cloudprem/ingest/_index.md
+++ b/content/en/cloudprem/ingest/_index.md
@@ -44,7 +44,9 @@ The [Datadog Lambda Forwarder][1] can send AWS CloudWatch Logs to CloudPrem by s
 DD_URL=<CLOUDPREM_HOST>
 ```
 
-The forwarder sends logs to `https://<DD_URL>:443/api/v2/logs`. Note that API key validation (`/api/v1/validate`) is sent to Datadog SaaS (controlled by `DD_API_URL`), not to CloudPrem. This means you need a valid Datadog API key even when forwarding to CloudPrem.
+The forwarder sends logs to `https://<DD_URL>:443/api/v2/logs`. 
+
+**Note:** API key validation (`/api/v1/validate`) is sent to Datadog SaaS (controlled by `DD_API_URL`), not to CloudPrem. This means you need a valid Datadog API key even when forwarding to CloudPrem.
 
 ### OpenTelemetry
 


### PR DESCRIPTION
## Summary
- Document supported log format (JSON array on /api/v2/logs, NDJSON not supported)
- Add Lambda Forwarder integration guide (DD_URL setup, API key validation behavior)
- Add OpenTelemetry ingestion path with link to existing guide

## Test plan
- [ ] Verify ingest index page renders correctly
- [ ] Review with CloudPrem engineering for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)