### PR TITLE
[DOCS-11784] Add guidance for tracking third-party library network calls on iOS

### DIFF
--- a/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/advanced_config/ios.mdoc.md
@@ -110,7 +110,7 @@ For more details and available options, see [`RUMMonitorProtocol` in GitHub][4].
 
 ### Custom resources
 
-In addition to [tracking resources automatically](#automatically-track-network-requests), you can also track specific custom resources such as network requests or third-party provider APIs. Use the following methods on `RUMMonitor.shared()` to manually collect RUM resources:
+In addition to [tracking resources automatically](#automatically-track-network-requests), you can also track specific custom resources such as network requests or third-party provider APIs. This is the recommended approach for third-party libraries that don't expose a `URLSession` delegate. Use the following methods on `RUMMonitor.shared()` to manually collect RUM resources:
 
 - `.startResource(resourceKey:request:)`
 - `.stopResource(resourceKey:response:)`

--- a/layouts/shortcodes/mdoc/en/sdk/setup/ios.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/setup/ios.mdoc.md
@@ -486,6 +486,8 @@ NSURLSession *session = [NSURLSession sessionWithConfiguration:[NSURLSessionConf
 {% /tab %}
 {% /tabs %}
 
+**Note**: `URLSessionInstrumentation` requires access to a `URLSession` delegate class. For third-party libraries that don't expose a session delegate, use the [Custom Resources API][17] to manually track those network calls.
+
 ### Instrument views
 
 The Datadog iOS SDK allows you to instrument views of `SwiftUI` applications. The instrumentation also works with hybrid `UIKit` and `SwiftUI` applications.
@@ -580,4 +582,5 @@ See [Supported versions][9] for a list of operating system versions and platform
 [14]: /error_tracking/
 [15]: /real_user_monitoring/application_monitoring/ios/advanced_configuration#custom-actions
 [16]: /real_user_monitoring/application_monitoring/agentic_onboarding/?tab=realusermonitoring
+[17]: /real_user_monitoring/application_monitoring/ios/advanced_configuration#custom-resources
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-11784

Addresses user feedback asking how to track network calls from third-party libraries that don't expose a session delegate. Users can now see clearly that `URLSessionInstrumentation` requires a delegate class, and that the Custom Resources API is the right path forward when a delegate isn't available.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes