### PR TITLE
[DOCS-12757] Add required service account permissions for SCIM

### DIFF
--- a/content/en/account_management/scim/_index.md
+++ b/content/en/account_management/scim/_index.md
@@ -52,7 +52,7 @@ If you use an application key tied to a user to enable SCIM and that user leaves
 
 To avoid losing access to your data, Datadog strongly recommends that you create a [service account][6] dedicated to SCIM. Within that service account, create an application key to use in the SCIM integration.
 
-The service account must have at minimum the `user_access_invite` and `user_access_manage` permissions. For the full list of required permissions, see the [SCIM API documentation][10].
+The service account requires at minimum the `user_access_invite` and `user_access_manage` permissions. For the full list of required permissions, see the [SCIM API documentation][10].
 
 ## Further Reading
 

--- a/content/en/account_management/scim/_index.md
+++ b/content/en/account_management/scim/_index.md
@@ -52,6 +52,8 @@ If you use an application key tied to a user to enable SCIM and that user leaves
 
 To avoid losing access to your data, Datadog strongly recommends that you create a [service account][6] dedicated to SCIM. Within that service account, create an application key to use in the SCIM integration.
 
+The service account must have at minimum the `user_access_invite` and `user_access_manage` permissions. For the full list of required permissions, see the [SCIM API documentation][10].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -65,3 +67,4 @@ To avoid losing access to your data, Datadog strongly recommends that you create
 [7]: https://app.datadoghq.com/organization-settings/users
 [8]: /help/
 [9]: https://scim.cloud/
+[10]: /api/latest/scim/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes [DOCS-12757](https://datadoghq.atlassian.net/browse/DOCS-12757)

Adds a note to the "Using a service account with SCIM" section clarifying that the service account must have at minimum the `user_access_invite` and `user_access_manage` permissions, with a link to the SCIM API docs for the full list. This info was already in the API reference but not surfaced in the feature docs.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Sonnet 4.6 to make this PR 

[DOCS-12757]: https://datadoghq.atlassian.net/browse/DOCS-12757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ