### PR TITLE
Fix duplicate step numbering in AWS manual setup Access Keys tab

### DIFF
--- a/content/en/integrations/guide/aws-manual-setup.md
+++ b/content/en/integrations/guide/aws-manual-setup.md
@@ -149,10 +149,10 @@ This policy defines the permissions necessary for the Datadog integration role t
 3. In the [AWS integration tile][1], click **Add AWS Account**, and then select **Manually**.
 4. Select the **Access Keys** tab.
 5. Choose which AWS partition your AWS account is scoped to. The partition is either `aws` for commercial regions, `aws-cn` for China*, or `aws-us-gov` for GovCloud. See [Partitions][9] in the AWS documentation for more information.
-5. Click the **I confirm that the IAM User for the Datadog Integration has been added to the AWS Account** checkbox.
-6. Enter your `Account ID`, `AWS Access Key` and `AWS Secret Key`.
-7. Click **Save**.
-8. Wait up to 10 minutes for data to start being collected, and then view the out-of-the-box <a href="https://app.datadoghq.com/screen/integration/7/aws-overview" target="_blank">AWS Overview Dashboard</a> to see metrics sent by your AWS services and infrastructure.
+6. Click the **I confirm that the IAM User for the Datadog Integration has been added to the AWS Account** checkbox.
+7. Enter your `Account ID`, `AWS Access Key` and `AWS Secret Key`.
+8. Click **Save**.
+9. Wait up to 10 minutes for data to start being collected, and then view the out-of-the-box <a href="https://app.datadoghq.com/screen/integration/7/aws-overview" target="_blank">AWS Overview Dashboard</a> to see metrics sent by your AWS services and infrastructure.
 
 \*{{% mainland-china-disclaimer %}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes a pre-existing source-level numbering bug in the **Access Keys** tab of the [AWS manual setup guide](https://docs.datadoghq.com/integrations/guide/aws-manual-setup/?tab=accesskeys). The partition-selection step and the confirm-checkbox step were both numbered `5.`; the subsequent `6.`, `7.`, `8.` were off by one.

Renumbered the last four steps to `6.`, `7.`, `8.`, `9.` so the source matches the rendered sequence.

No visible change in the rendered docs (Markdown auto-numbers ordered lists) — this is a source-readability cleanup.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes