### PR TITLE
Add Learning Center course cross-reference: Getting Started with Notebooks

### DIFF
--- a/content/en/notebooks/_index.md
+++ b/content/en/notebooks/_index.md
@@ -24,6 +24,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/finops-at-datadog/"
   tag: "Blog"
   text: "How we've created a successful FinOps practice at Datadog"
+- link: "https://learn.datadoghq.com/courses/getting-started-with-notebooks"
+  tag: "Learning Center"
+  text: "Getting Started with Notebooks"
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

Adds a `further_reading` link to the [Getting Started with Notebooks](https://learn.datadoghq.com/courses/getting-started-with-notebooks) Learning Center course on the following documentation page:

- **Notebooks** — `content/en/notebooks/_index.md`

## Motivation

Cross-linking the Learning Center course from the most relevant documentation page helps readers find hands-on practice resources for creating notebooks, adding data sources, collaborating, and sharing investigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)