### PR TITLE
Include get and upsert dashboard tools in core MCP toolset

### DIFF
--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -476,7 +476,7 @@ Searches for Datadog users by email, name, or handle. Useful for finding the rig
 Tools for retrieving, creating, updating, and deleting [dashboards][46], plus widget schema reference and validation.
 
 ### `get_datadog_dashboard`
-*Toolset: **core***\
+*Toolset: **core**, **dashboards***\
 *Permissions Required: `Dashboards Read` and `User Access Read`*\
 Retrieves a Datadog [dashboard][46] by ID, returning its title, description, tags, and widgets. Use `search_datadog_dashboards` first to find dashboard IDs.
 
@@ -485,7 +485,7 @@ Retrieves a Datadog [dashboard][46] by ID, returning its title, description, tag
 - Retrieve the template variables configured on this dashboard.
 
 ### `upsert_datadog_dashboard`
-*Toolset: **core***\
+*Toolset: **core**, **dashboards***\
 *Permissions Required: `Dashboards Read` and `Dashboards Write`*\
 Creates or updates a Datadog [dashboard][46]. To update an existing dashboard, provide the dashboard ID; omit it to create a new one. Call `get_widget_reference` for widget schemas before building widgets.
 

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -476,7 +476,7 @@ Searches for Datadog users by email, name, or handle. Useful for finding the rig
 Tools for retrieving, creating, updating, and deleting [dashboards][46], plus widget schema reference and validation.
 
 ### `get_datadog_dashboard`
-*Toolset: **dashboards***\
+*Toolset: **core***\
 *Permissions Required: `Dashboards Read` and `User Access Read`*\
 Retrieves a Datadog [dashboard][46] by ID, returning its title, description, tags, and widgets. Use `search_datadog_dashboards` first to find dashboard IDs.
 
@@ -485,7 +485,7 @@ Retrieves a Datadog [dashboard][46] by ID, returning its title, description, tag
 - Retrieve the template variables configured on this dashboard.
 
 ### `upsert_datadog_dashboard`
-*Toolset: **dashboards***\
+*Toolset: **core***\
 *Permissions Required: `Dashboards Read` and `Dashboards Write`*\
 Creates or updates a Datadog [dashboard][46]. To update an existing dashboard, provide the dashboard ID; omit it to create a new one. Call `get_widget_reference` for widget schemas before building widgets.
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes CRP-2164

Moves `get_datadog_dashboard` and `upsert_datadog_dashboard` from the **dashboards** toolset to the **core** toolset so they are available by default without enabling an additional toolset.

### Merge instructions
Don't merge until https://github.com/DataDog/dd-source/pull/413528 merges and deploys.

Merge readiness:
- [x] Ready for merge

### Additional notes

🤖 Generated with [Claude Code](https://claude.ai/code)