### PR TITLE
Fix invalid Ruby hash syntax in user tracking code sample

### DIFF
--- a/content/en/security/application_security/how-it-works/add-user-info.md
+++ b/content/en/security/application_security/how-it-works/add-user-info.md
@@ -157,8 +157,8 @@ Datadog::Kit::Identity.set_user(
 
   # optional tags with known semantics
   name: 'Jean Example',
-  email:, 'jean.example@example.com',
-  session_id:, '987654321',
+  email: 'jean.example@example.com',
+  session_id: '987654321',
   role: 'admin',
   scope: 'read:message, write:files',
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes spurious commas between symbol keys and their values in the Ruby
hash literal used as the user tracking example, making the sample valid Ruby.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes