### PR TITLE
Fix missing quotes in Go struct tags in SDK code sample

### DIFF
--- a/content/en/security/application_security/setup/go/sdk.md
+++ b/content/en/security/application_security/setup/go/sdk.md
@@ -76,9 +76,9 @@ type LoginRequest struct {
 }
 
 type User struct {
-	Name     string `json:name`
-	Username string `json:username`
-	Email    string `json:email`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
 	password string
 }
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds missing double quotes around JSON field names in Go struct tags.
Unquoted tag values are not valid Go; all three fields (Name, Username,
Email) are corrected.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes