### PR TITLE
Fix Go SDK code sample errors

### DIFF
--- a/content/en/security/application_security/setup/go/sdk.md
+++ b/content/en/security/application_security/setup/go/sdk.md
@@ -132,7 +132,7 @@ func loginHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Track failed login
-	appsec.TrackUserLoginFailure(r.Context(), req.Username, true, metadata)
+	appsec.TrackUserLoginFailure(r.Context(), req.Username, true, nil)
 	http.Error(w, "Invalid credentials", http.StatusUnauthorized)
 }
 
@@ -155,7 +155,7 @@ func profileHandler(w http.ResponseWriter, r *http.Request) {
 		"data_type": "personal_info",
 	})
 
-	userAsked := r.Query().Get("user")
+	userAsked := r.URL.Query().Get("user")
 	user := users[0] // Search for the user
 
 	// Monitor response body


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes two errors in the Go SDK code sample:
- Corrects `r.Query()` to `r.URL.Query()` (`http.Request` has no `.Query()` method).
- Replaces an out-of-scope `metadata` variable reference in the login failure
  tracking call with `nil`.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes