### PR TITLE
Fix concatenated list items in library inventory page

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/library_inventory.md
+++ b/content/en/security/code_security/software_composition_analysis/library_inventory.md
@@ -107,7 +107,7 @@ The license table in this section is based on the **Choose a License Appendix**:
 It summarizes the license's:
 
 * **Permissions**  
-  **Conditions**  
+* **Conditions**  
 * **Limitations**
 
 Additionally, Datadog identifies **license risks**, including:


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Two consecutive bold-text list items were written on a single line without
any separator, causing them to render as a single run-together term. Split
them into distinct list items.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes