### PR TITLE
Fix SCA reachability description to reflect static analysis scope

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/_index.md
@@ -61,7 +61,7 @@ To assist in prioritizing remediation, Datadog modifies the base CVSS score into
 | Risk factor                       | How it is evaluated                                                  | Impact on the score                                    |
 |-----------------------------------|----------------------------------------------------------------------|--------------------------------------------------------|
 | Base CVSS score                   | Published CVSS score for the vulnerability.                          | Starting point for the severity score.                 |
-| Reachability                      | Whether the vulnerable code path is actually executed.               | Increased when the vulnerable code is invoked.         |
+| Reachability                      | Whether the vulnerable function is referenced in the source code (detected statically at the repository level). | Increased when the vulnerable function is found to be reachable in the code. |
 | Production runtime context        | Whether the affected service is running in a production environment. | Decreased if the service is not running in production. |
 | Under attack                      | Evidence of active attack activity targeting the service.            | Decreased if there is no observed attack activity.     |
 | Exploit availability              | Availability of public exploits for the vulnerability.               | Decreased if no exploit is available.                  |


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the reachability row in the Datadog severity score table to accurately reflect that reachability is detected statically at the repository level (source code reference), not at runtime. The previous wording implied runtime invocation confirmation, which is misleading.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes