### PR TITLE
Remove blank Developers tile from homepage

### DIFF
--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -278,8 +278,6 @@ nav_sections:
         link: client_sdks/
         icon: building-block
         desc: Install and configure the Datadog SDK for your platform
-      - title: Developers
-        link: developers/
       - title: Extend Datadog
         link: extend/
         icon: dev-code


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Removes the "Developers" tile under the "Platform Capabilities and Extending Datadog" section of the docs homepage. The tile was rendering completely blank because its entry in `data/partials/home.yaml` is missing the `icon` and `desc` fields that every other tile in the section has.

The tile was re-added in #34948 with only `title` and `link`, and its `link: developers/` is an alias of `/extend/`, which is already the destination of the "Extend Datadog" tile directly beneath it. Removing the incomplete tile eliminates the blank render and the duplicate destination.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes