### PR TITLE
Remove Client SDKs and Developers tiles from landing page nav

### DIFF
--- a/data/partials/home.yaml
+++ b/data/partials/home.yaml
@@ -274,10 +274,10 @@ nav_sections:
         link: data_security/
         icon: security-lock
         desc: Learn how Datadog protects your data
-      - title: Client SDKs
-        link: client_sdks/
-        icon: building-block
-        desc: Install and configure the Datadog SDK for your platform
+      # - title: Client SDKs
+      #   link: client_sdks/
+      #   icon: building-block
+      #   desc: Install and configure the Datadog SDK for your platform
       - title: Extend Datadog
         link: extend/
         icon: dev-code


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Removes the Client SDKs and Developers tiles from the landing page navigation.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes