### PR TITLE
Adding trace ID sampling to Log Index documentation

### DIFF
--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -87,7 +87,7 @@ Exclusion filters are defined by a query, a sampling rule, and an active/inactiv
 
 * Default **query** is `*`, meaning all logs flowing in the index would be excluded. Scope down exclusion filter to only a subset of logs [with a log query][12].
 * Default **sampling rule** is `Exclude 100% of logs` matching the query. Adapt sampling rate from 0% to 100%, and decide if the sampling rate applies on individual logs, or group of logs defined by the unique values of any attribute.
-  * If the sampling rate applies on individual logs, sampling will be performed on the existence of trace IDs in the logs, if present. Logs sampled will therefore have an increased chance to correlated with sampled traces, to promote unified telemetry data.
+  * If the sampling rate applies on individual logs, sampling is performed on the existence of trace IDs in the logs, if present. In this scenario, logs sampled have an increased chance to be correlated with sampled traces, to promote unified telemetry data.
   * If the unique value of a trace ID is chosen for sampling, the behavior is the same as on individual logs.
 * Default **toggle** is active, meaning logs flowing in the index are actually discarded according to the exclusion filter configuration. Toggle this to inactive to ignore this exclusion filter for new logs flowing in the index.
 

--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -88,7 +88,7 @@ Exclusion filters are defined by a query, a sampling rule, and an active/inactiv
 * Default **query** is `*`, meaning all logs flowing in the index would be excluded. Scope down exclusion filter to only a subset of logs [with a log query][12].
 * Default **sampling rule** is `Exclude 100% of logs` matching the query. Adapt sampling rate from 0% to 100%, and decide if the sampling rate applies on individual logs, or group of logs defined by the unique values of any attribute.
   * If the sampling rate applies on individual logs, sampling will be performed on the existence of trace IDs in the logs, if present. Logs sampled will therefore have an increased chance to correlated with sampled traces, to promote unified telemetry data.
-  * If the unique value of trace ID is chosen for sampling, the behaviour is the same as on individual logs.
+  * If the unique value of a trace ID is chosen for sampling, the behavior is the same as on individual logs.
 * Default **toggle** is active, meaning logs flowing in the index are actually discarded according to the exclusion filter configuration. Toggle this to inactive to ignore this exclusion filter for new logs flowing in the index.
 
 **Note**: Index filters for logs are only processed with the first **active** exclusion filter matched. If a log matches an exclusion filter (even if the log is not sampled out), it ignores all following exclusion filters in the sequence.

--- a/content/en/logs/log_configuration/indexes.md
+++ b/content/en/logs/log_configuration/indexes.md
@@ -87,6 +87,8 @@ Exclusion filters are defined by a query, a sampling rule, and an active/inactiv
 
 * Default **query** is `*`, meaning all logs flowing in the index would be excluded. Scope down exclusion filter to only a subset of logs [with a log query][12].
 * Default **sampling rule** is `Exclude 100% of logs` matching the query. Adapt sampling rate from 0% to 100%, and decide if the sampling rate applies on individual logs, or group of logs defined by the unique values of any attribute.
+  * If the sampling rate applies on individual logs, sampling will be performed on the existence of trace IDs in the logs, if present. Logs sampled will therefore have an increased chance to correlated with sampled traces, to promote unified telemetry data.
+  * If the unique value of trace ID is chosen for sampling, the behaviour is the same as on individual logs.
 * Default **toggle** is active, meaning logs flowing in the index are actually discarded according to the exclusion filter configuration. Toggle this to inactive to ignore this exclusion filter for new logs flowing in the index.
 
 **Note**: Index filters for logs are only processed with the first **active** exclusion filter matched. If a log matches an exclusion filter (even if the log is not sampled out), it ignores all following exclusion filters in the sequence.


### PR DESCRIPTION
### What does this PR do? What is the motivation?
As a result of customer reports,

We found that the customer, who was missing an intersection of logs, had been sending a large amount of logs (in some cases from checks, over 12M logs) with the same trace ID. A low number of trace IDs over several million logs, with our sampling mechanism, will cause a large number of logs to be excuded.

This is because our exclusion filter sampling mechanisms use Trace IDs to perform sampling, on the basis that Trace IDs should be a high cardinality number in the logs, and therefore, the sampling is almost but not perfectly random in this case.

### Merge instructions

Merge readiness:
- [✅ ] Ready for merge


