### PR TITLE
[AAP] Fix dotnet troubleshooting page

### DIFF
--- a/content/en/security/application_security/setup/dotnet/troubleshooting.md
+++ b/content/en/security/application_security/setup/dotnet/troubleshooting.md
@@ -7,34 +7,34 @@ title: Troubleshooting .NET App and API Protection
 ### No security signals appearing
 
 1. Verify Agent version:
-   - Ensure you're running Datadog Agent v7.41.1 or higher.
-   - Check Agent status: `datadog-agent status`.
+    - Ensure you're running Datadog Agent v7.41.1 or higher.
+    - Check Agent status: `datadog-agent status`.
 2. Check .NET tracer version:
-   - Confirm you're using .NET tracer v2.42.0 or higher.
+    - Confirm you're using .NET tracer v2.42.0 or higher.
 3. Verify environment variables:
-   - Ensure `DD_APPSEC_ENABLED=true` is set.
-   - Check `DD_SERVICE` and `DD_ENV` are properly configured.
-   - Verify `DD_APM_ENABLED=true` if using APM features.
+    - Ensure `DD_APPSEC_ENABLED=true` is set.
+    - Check `DD_SERVICE` and `DD_ENV` are properly configured.
+    - Verify `DD_APM_ENABLED=true` if using APM features.
 4. Check file system permissions:
-   - Ensure the application has write access to `/tmp`.
-   - Verify the Java agent JAR is readable.
+    - Verify the Datadog .NET tracer installation directory exists and that the native tracer library is readable.
+    - Verify the tracer log directory is writable (`/var/log/datadog/dotnet/` on Linux or `%PROGRAMDATA%\Datadog .NET Tracer\logs\` on Windows).
 
 ### Application fails to start
 
 1. Check logs for errors:
-   - Logs are located at
-     - Linux: `/var/log/datadog/dotnet/`
-     - Windows: `%PROGRAMDATA%\Datadog .NET Tracer\logs\`
+    - Logs are located at
+        - Linux: `/var/log/datadog/dotnet/`
+        - Windows: `%PROGRAMDATA%\Datadog .NET Tracer\logs\`
 
 ### Performance impact
 
 1. High latency:
-   - Check Agent resource usage.
-   - Verify network connectivity between Agent and Datadog.
-   - Consider adjusting sampling rates.
+    - Check Agent resource usage.
+    - Verify network connectivity between Agent and Datadog.
+    - Consider adjusting sampling rates.
 2. High memory usage:
-   - Monitor memory usage.
-   - Adjust Agent resource limits if needed
+    - Monitor memory usage.
+    - Adjust Agent resource limits if needed
 
 ### Still having issues?
 

--- a/content/en/security/application_security/setup/dotnet/troubleshooting.md
+++ b/content/en/security/application_security/setup/dotnet/troubleshooting.md
@@ -4,15 +4,15 @@ title: Troubleshooting .NET App and API Protection
 
 ## Common Issues
 
-### No security signals appearing
+### No Security Signals appear
 
 1. Verify Agent version:
-    - Ensure you're running Datadog Agent v7.41.1 or higher.
+    - Confirm you're running Datadog Agent v7.41.1 or higher.
     - Check Agent status: `datadog-agent status`.
 2. Check .NET tracer version:
     - Confirm you're using .NET tracer v2.42.0 or higher.
 3. Verify environment variables:
-    - Ensure `DD_APPSEC_ENABLED=true` is set.
+    - Confirm `DD_APPSEC_ENABLED=true` is set.
     - Check `DD_SERVICE` and `DD_ENV` are properly configured.
     - Verify `DD_APM_ENABLED=true` if using APM features.
 4. Check file system permissions:
@@ -39,6 +39,7 @@ title: Troubleshooting .NET App and API Protection
 ### Still having issues?
 
 If you're still experiencing problems:
+
 1. Check the [Application Security Monitoring troubleshooting guide][1]
 2. Review the [.NET tracer documentation][2]
 3. Contact [Datadog support][3]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->

The dotnet troubleshooting page referenced Java instructions instead of .NET ones.
(Suspicion of a copy paste issue).

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

Fix proposed via gpt-5.4.

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
