### PR TITLE
[synthetics] Transfer Synthetics CT team ownership to Orchestrating and Managing (SYNTH-26305)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -154,7 +154,7 @@ static/resources/yaml/observability_pipelines/                  @DataDog/observa
 # Synthetic Monitoring, Continuous Testing, Mobile Application Testing
 
 content/en/synthetics/*.md                                      @Datadog/synthetics-app @Datadog/documentation
-content/en/continuous_testing/*.md                              @Datadog/synthetics-ct @Datadog/documentation
+content/en/continuous_testing/*.md                              @Datadog/synthetics-orchestrating-managing @Datadog/documentation
 content/en/mobile_app_testing/*.md                              @Datadog/synthetics-executing-mobile @Datadog/documentation
 
 # Software Delivery


### PR DESCRIPTION
Transfer `CODEOWNERS` from `@DataDog/synthetics-ct` (team no longer exists) to `@DataDog/synthetics-orchestrating-managing`.

Part of SYNTH-26305.