### PR TITLE
Feature Flags .NET SDK package/namespace update

### DIFF
--- a/content/en/feature_flags/server/dotnet.md
+++ b/content/en/feature_flags/server/dotnet.md
@@ -38,10 +38,10 @@ DD_ENV=<YOUR_ENVIRONMENT>
 
 ## Installation
 
-Install the Datadog .NET tracer and OpenFeature SDK using NuGet:
+Install the Datadog [.NET tracer][3] and [OpenFeature SDK][4] using NuGet:
 
 {{< code-block lang="bash" >}}
-dotnet add package Datadog.Trace
+dotnet add package Datadog.FeatureFlags.OpenFeature
 dotnet add package OpenFeature
 {{< /code-block >}}
 
@@ -49,8 +49,8 @@ Or add them to your `.csproj` file:
 
 {{< code-block lang="xml" filename="MyProject.csproj" >}}
 <ItemGroup>
-  <PackageReference Include="Datadog.Trace" Version="3.36.0" />
-  <PackageReference Include="OpenFeature" Version="2.0.0" />
+  <PackageReference Include="Datadog.FeatureFlags.OpenFeature" />
+  <PackageReference Include="OpenFeature" />
 </ItemGroup>
 {{< /code-block >}}
 
@@ -64,7 +64,7 @@ Use `SetProviderAsync` with `await` to block evaluation until the initial flag c
 
 {{< code-block lang="csharp" >}}
 using OpenFeature;
-using Datadog.Trace.FeatureFlags.OpenFeature;
+using Datadog.FeatureFlags.OpenFeature;
 
 // Create and register the Datadog provider
 var provider = new DatadogProvider();
@@ -82,7 +82,7 @@ Use `SetProvider` to register the provider without waiting. Flag evaluations ret
 
 {{< code-block lang="csharp" >}}
 using OpenFeature;
-using Datadog.Trace.FeatureFlags.OpenFeature;
+using Datadog.FeatureFlags.OpenFeature;
 
 // Create and register the Datadog provider
 var provider = new DatadogProvider();
@@ -303,6 +303,8 @@ var enabled = client.GetBooleanValueAsync("flag-key", false, context);
 
 [1]: https://openfeature.dev/
 [2]: /agent/remote_config/
+[3]: https://www.nuget.org/packages/Datadog.Trace
+[4]: https://www.nuget.org/packages/Datadog.FeatureFlags.OpenFeature
 
 ## Further reading
 


### PR DESCRIPTION

### What does this PR do? What is the motivation?
On the [.NET Feature Flags](https://docs.datadoghq.com/feature_flags/server/dotnet) page, updates the name of the Feature Flags OpenFeature NuGet package and namespace, prompted by @CarsonHui 's feedback [here](https://dd.slack.com/archives/C0DESMBQU/p1774865883248679)

### Merge instructions

Merge readiness:
- [ ] Ready for merge


### AI assistance
n/a

### Additional notes
n/a
