### PR TITLE
Add integrations security section to Kubernetes page

### DIFF
--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -36,7 +36,7 @@ If you are using Docker or Amazon ECS, see [Docker and Integrations][1].
 
 <div class="alert alert-info">
 Some Datadog integrations don't work with Autodiscovery because they require either process tree data or filesystem access: <a href="/integrations/ceph">Ceph</a>, <a href="/integrations/varnish">Varnish</a>, <a href="/integrations/postfix">Postfix</a>, <a href="/integrations/cassandra/#agent-check-cassandra-nodetool">Cassandra Nodetool</a>, and <a href="/integrations/gunicorn">Gunicorn</a>.<br/><br/>
-To monitor integrations that are not compatible with Autodiscovery, you can use a Prometheus exporter in the pod to expose an HTTP endpoint, and then use the <a href="/integrations/openmetrics/">OpenMetrics integration</a> (which supports Autodiscovery) to find the pod and query the endpoint. 
+To monitor integrations that are not compatible with Autodiscovery, you can use a Prometheus exporter in the pod to expose an HTTP endpoint, and then use the <a href="/integrations/openmetrics/">OpenMetrics integration</a> (which supports Autodiscovery) to find the pod and query the endpoint.
 </div>
 
 ## Set up your integration
@@ -85,7 +85,7 @@ spec:
 # (...)
 ```
 
-**Autodiscovery annotations v1** 
+**Autodiscovery annotations v1**
 
 ```yaml
 apiVersion: v1
@@ -137,7 +137,7 @@ You can store Autodiscovery templates as local files inside the mounted `conf.d`
          volumes:
            - hostPath:
                path: <PATH_TO_LOCAL_FOLDER>/conf.d
-             name: confd 
+             name: confd
    ```
 
    For Helm:
@@ -268,7 +268,7 @@ spec:
 ```
 <div class="alert alert-info">When multiple deployed <code>DatadogAgent</code> CRDs use <code>configDataMap</code>, each CRD writes to a shared ConfigMap named <code>nodeagent-extra-confd</code>. This can cause configurations to override each other. </div>
 
-To monitor a [Cluster Check][1], add an override `extraConfd.configDataMap` to the `clusterAgent` component. You must also enable cluster checks by setting `features.clusterChecks.enabled: true`. 
+To monitor a [Cluster Check][1], add an override `extraConfd.configDataMap` to the `clusterAgent` component. You must also enable cluster checks by setting `features.clusterChecks.enabled: true`.
 
 ```yaml
 apiVersion: datadoghq.com/v2alpha1
@@ -323,7 +323,7 @@ datadog:
         <LOGS_CONFIG>
 ```
 
-To monitor a [Cluster Check][3], define your template under `clusterAgent.confd`. You can find inline examples in the sample [values.yaml][2]. You must also enable the Cluster Agent by setting `clusterAgent.enabled: true` and enable cluster checks by setting `datadog.clusterChecks.enabled: true`. 
+To monitor a [Cluster Check][3], define your template under `clusterAgent.confd`. You can find inline examples in the sample [values.yaml][2]. You must also enable the Cluster Agent by setting `clusterAgent.enabled: true` and enable cluster checks by setting `datadog.clusterChecks.enabled: true`.
 
 ```yaml
 datadog:
@@ -424,7 +424,7 @@ Starting with Datadog Agent version 7.78.0, you can set the following parameters
 |-----------|------|---------|-------------|
 | `integration_ignore_untrusted_file_params` | bool | `false` | When enabled, integrations ignore configuration parameters that refer to file paths if the configuration provider is not trusted. |
 | `integration_file_paths_allowlist` | list | `[]` | List of file paths that integrations are allowed to access, even when provided by an untrusted configuration provider. An empty list means all file paths are allowed. |
-| `integration_trusted_providers` | list | `["file", "remote-config"]` | List of configuration providers considered trusted. Any provider not in this list is considered untrusted. By default, local configuration files (`file`) and Datadog Remote Configuration (`remote-config`) are trusted. For the full list of supported providers, see [datadog-agent provider names](https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/providers/names/provider_names.go#L10-L38). |
+| `integration_trusted_providers` | list | `["file", "remote-config"]` | List of configuration providers considered trusted. Any provider not in this list is considered untrusted. By default, local configuration files (`file`) and Datadog Remote Configuration (`remote-config`) are trusted. For the full list of supported providers, see [Datadog Agent provider names][28]. |
 | `integration_security_excluded_checks` | list | `[]` | List of integration names that are excluded from the above security restrictions. |
 
 These options are backwards compatible: the default values preserve existing behavior. To opt in, enable `integration_ignore_untrusted_file_params` and adjust the remaining parameters to match your environment.
@@ -511,7 +511,7 @@ spec:
     - name: postgres
 ```
 
-**Autodiscovery annotations v1** 
+**Autodiscovery annotations v1**
 
 ```yaml
 apiVersion: v1
@@ -574,7 +574,7 @@ spec:
          volumes:
            - hostPath:
                path: <PATH_TO_LOCAL_FOLDER>/conf.d
-             name: confd 
+             name: confd
    ```
 
    For Helm:
@@ -742,3 +742,4 @@ For more examples, including how to configure multiple checks for multiple sets 
 [25]: /integrations/istio/
 [26]: /integrations/postgres
 [27]: /getting_started/integrations/#per-check-tag-configuration
+[28]: https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/providers/names/provider_names.go#L10-L38

--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -414,6 +414,37 @@ The Datadog Agent automatically recognizes and supplies basic configuration for 
 
 Configurations set with Kubernetes annotations take precedence over auto-configuration, but auto-configuration takes precedence over configurations set with Datadog Operator or Helm. To use Datadog Operator or Helm to configure an integration in the [Autodiscovery auto-configuration][20] list, you must [disable auto-configuration][22].
 
+## Integrations security
+
+Integrations often need to read configuration files, certificates, or other resources from the filesystem. When file paths come from untrusted configuration providers (for example, pod annotations or external service autodiscovery), there is a risk of path traversal or unauthorized file access.
+
+To control filesystem access based on the trust level of a configuration provider, set the following parameters in the Agent's `datadog.yaml`:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `integration_ignore_untrusted_file_params` | bool | `false` | When enabled, integrations ignore configuration parameters that refer to file paths if the configuration provider is not trusted. |
+| `integration_file_paths_allowlist` | list | `[]` | List of file paths that integrations are allowed to access, even when provided by an untrusted configuration provider. An empty list means all file paths are allowed. |
+| `integration_trusted_providers` | list | `["file", "remote-config"]` | List of configuration providers considered trusted. Any provider not in this list is considered untrusted. By default, local configuration files (`file`) and Datadog Remote Configuration (`remote-config`) are trusted. |
+| `integration_security_excluded_checks` | list | `[]` | List of integration names that are excluded from the above security restrictions. |
+
+These options are backwards compatible: the default values preserve existing behavior. To opt in, enable `integration_ignore_untrusted_file_params` and adjust the remaining parameters to match your environment.
+
+Example `datadog.yaml`:
+
+```yaml
+integration_ignore_untrusted_file_params: true
+integration_file_paths_allowlist:
+  - /etc/datadog-agent/certs
+  - /var/run/secrets
+integration_trusted_providers:
+  - file
+  - remote-config
+integration_security_excluded_checks:
+  - <INTEGRATION_NAME>
+```
+
+With this configuration, an integration configured through pod annotations (an untrusted provider) cannot reference file paths outside `/etc/datadog-agent/certs` or `/var/run/secrets`, unless the integration name is listed in `integration_security_excluded_checks`.
+
 ## Example: Postgres integration
 
 In this example scenario, you deployed Postgres on Kubernetes. You want to set up and configure the [Datadog-Postgres integration][26]. All of your Postgres containers have container names that contain the string `postgres`.

--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -424,7 +424,7 @@ To control filesystem access based on the trust level of a configuration provide
 |-----------|------|---------|-------------|
 | `integration_ignore_untrusted_file_params` | bool | `false` | When enabled, integrations ignore configuration parameters that refer to file paths if the configuration provider is not trusted. |
 | `integration_file_paths_allowlist` | list | `[]` | List of file paths that integrations are allowed to access, even when provided by an untrusted configuration provider. An empty list means all file paths are allowed. |
-| `integration_trusted_providers` | list | `["file", "remote-config"]` | List of configuration providers considered trusted. Any provider not in this list is considered untrusted. By default, local configuration files (`file`) and Datadog Remote Configuration (`remote-config`) are trusted. |
+| `integration_trusted_providers` | list | `["file", "remote-config"]` | List of configuration providers considered trusted. Any provider not in this list is considered untrusted. By default, local configuration files (`file`) and Datadog Remote Configuration (`remote-config`) are trusted. For the full list of supported providers, see [datadog-agent provider names](https://github.com/DataDog/datadog-agent/blob/main/comp/core/autodiscovery/providers/names/provider_names.go#L10-L38). |
 | `integration_security_excluded_checks` | list | `[]` | List of integration names that are excluded from the above security restrictions. |
 
 These options are backwards compatible: the default values preserve existing behavior. To opt in, enable `integration_ignore_untrusted_file_params` and adjust the remaining parameters to match your environment.

--- a/content/en/containers/kubernetes/integrations.md
+++ b/content/en/containers/kubernetes/integrations.md
@@ -418,7 +418,7 @@ Configurations set with Kubernetes annotations take precedence over auto-configu
 
 Integrations often need to read configuration files, certificates, or other resources from the filesystem. When file paths come from untrusted configuration providers (for example, pod annotations or external service autodiscovery), there is a risk of path traversal or unauthorized file access.
 
-To control filesystem access based on the trust level of a configuration provider, set the following parameters in the Agent's `datadog.yaml`:
+Starting with Datadog Agent version 7.78.0, you can set the following parameters in the Agent's `datadog.yaml` to control filesystem access based on the trust level of a configuration provider.
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds an "Integrations security" section to the Kubernetes integrations page documenting four new `datadog.yaml` parameters that control filesystem access based on the trust level of the configuration provider:

- `integration_ignore_untrusted_file_params`
- `integration_file_paths_allowlist`
- `integration_trusted_providers`
- `integration_security_excluded_checks`

These options help prevent path traversal and unauthorized file access when file paths come from untrusted providers (such as pod annotations).

https://datadoghq.atlassian.net/browse/AI-6780

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes