### PR TITLE
Add Learning Center course cross-reference: Log Analytics with Notebooks

### DIFF
--- a/content/en/notebooks/advanced_analysis/_index.md
+++ b/content/en/notebooks/advanced_analysis/_index.md
@@ -12,6 +12,9 @@ further_reading:
 - link: "/notebooks/advanced_analysis/getting_started"
   tag: "Documentation"
   text: "Getting Started with Analysis Features"
+- link: https://learn.datadoghq.com/courses/log-analytics-with-notebooks
+  tag: Learning Center
+  text: Log Analytics with Notebooks
 ---
 
 {{< callout url="https://www.datadoghq.com/product-preview/additional-advanced-querying-data-sources/" header="Advanced Data Sources">}}

--- a/content/en/notebooks/advanced_analysis/getting_started.md
+++ b/content/en/notebooks/advanced_analysis/getting_started.md
@@ -5,6 +5,9 @@ further_reading:
 - link: "/notebooks/advanced_analysis"
   tag: "Documentation"
   text: "Analysis Features"
+- link: https://learn.datadoghq.com/courses/log-analytics-with-notebooks
+  tag: Learning Center
+  text: Log Analytics with Notebooks
 ---
 
 ## Overview


### PR DESCRIPTION
## Summary

Adds `further_reading` links to the [Log Analytics with Notebooks](https://learn.datadoghq.com/courses/log-analytics-with-notebooks) Learning Center course on the following documentation pages:

- **Analysis Features** — `content/en/notebooks/advanced_analysis/_index.md`
- **Getting Started with Notebooks Analysis Features** — `content/en/notebooks/advanced_analysis/getting_started.md`

## Motivation

Cross-linking the Learning Center course from the most relevant documentation pages helps readers find resources for hands-on practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)