### PR TITLE
[DOCS-13620] Document trace ID visibility in Log Explorer and trace sampling mismatch

### DIFF
--- a/content/en/logs/explorer/side_panel.md
+++ b/content/en/logs/explorer/side_panel.md
@@ -55,11 +55,13 @@ When logs come from a serverless source, the Host Section is replaced with a Ser
 
 Make sure you enable [trace injection in logs][9] and follow the [Unified Service Tagging][10] best practices to benefit from all the capabilities of Logs and APM correlation.
 
+The log side panel displays the trace ID directly in the log event when a trace ID is present. You can use this trace ID to filter logs in the Log Explorer.
+
 Click on the **Trace tab** and see a log in the context of its entire trace, with upstream and downstream services running. Deep dive into the corresponding APM data by clicking on [View Trace Details][11].
 
-Interact with the **Service** section to highlight the part of the trace that corresponds with the selected service. Use this information to refocus your query in the Log Explorer and view other logs from the same trace.
+If a log has a trace ID but the associated trace was not ingested or not retained due to sampling, the side panel displays a message indicating the trace is missing. Because traces and logs are sampled independently, a log can reference a trace that was sampled out. This does not indicate a configuration error. For more information, see [Log has a trace ID but the associated trace is missing][15].
 
-{{< img src="logs/explorer/side_panel/trace.mp4" alt="Hub to APM" video=true style="width:100%;">}}
+Interact with the **Service** section to highlight the part of the trace that corresponds with the selected service. Use this information to refocus your query in the Log Explorer and view other logs from the same trace.
 
 ## Configure your troubleshooting context
 
@@ -98,3 +100,4 @@ Use the **Share** button to share the log opened in side panel to other contexts
 [12]: /logs/explorer/facets/#overview
 [13]: /integrations/#cat-notification
 [14]: /logs/explorer/calculated_fields/
+[15]: /logs/troubleshooting/#log-has-a-trace-id-but-the-associated-trace-is-missing

--- a/content/en/logs/guide/ease-troubleshooting-with-cross-product-correlation.md
+++ b/content/en/logs/guide/ease-troubleshooting-with-cross-product-correlation.md
@@ -38,7 +38,7 @@ This guide walks you through how to correlate your full stack data. Depending on
 
 When your users are encountering errors or high latency in your application, viewing the specific logs from a problematic request can reveal exactly what went wrong. By pulling together all the logs pertaining to a given request, you can see in rich detail how it was handled from beginning to end so you can quickly diagnose the issue.
 
-Correlating your logs with traces also eases [aggressive sampling strategy without losing entity-level consistency][2] with the use of `trace_id`.
+Correlating your logs with traces also eases [aggressive sampling strategy without losing entity-level consistency][2] with the use of `trace_id`. Because traces and logs are sampled independently, a log may contain a trace ID that refers to a trace that was not retained. For more information, see [Log has a trace ID but the associated trace is missing][21].
 
 [Correlating application logs](#correlate-application-logs) offers extensive visibility across your stack, but some specific use cases require correlation deeper into your stack. Follow the links to complete setup per use case:
 
@@ -214,3 +214,4 @@ For more information, see [Connect Synthetic Tests and Traces][19].
 [18]: https://app.datadoghq.com/synthetics/tests
 [19]: /synthetics/apm
 [20]: /tracing/trace_collection/proxy_setup/nginx
+[21]: /logs/troubleshooting/#log-has-a-trace-id-but-the-associated-trace-is-missing

--- a/content/en/logs/troubleshooting/_index.md
+++ b/content/en/logs/troubleshooting/_index.md
@@ -1,5 +1,6 @@
 ---
 title: Logs Troubleshooting
+description: "Troubleshooting common log ingestion and processing issues in Datadog Logs, including missing logs, data access problems, and timestamp misalignment."
 ---
 
 If you experience unexpected behavior with Datadog Logs, there are a few common issues you can investigate and this guide may help resolve issues quickly. If you continue to have trouble, reach out to [Datadog support][1] for further assistance.
@@ -98,6 +99,19 @@ If the `datadog_index` tag is set to `N/A` for a metric datapoint, the correspon
 
 **Note**: Estimated Usage Metrics do not respect [Daily Quotas][13].
 
+## Log has a trace ID but the associated trace is missing
+
+A log in the [Log Explorer][2] shows a trace ID, but when you click through to view the trace, you see a message that the associated trace is missing. The linked trace was either not ingested or not retained.
+
+This happens because logs and traces are sampled independently:
+
+- **Traces** can be sampled at the tracer level, the Agent level, and at ingestion through [ingestion controls][21].
+- **Logs** can be sampled through [index exclusion filters][22] and quotas.
+
+Because these sampling decisions are not coordinated, a log can retain a trace ID that refers to a trace that was sampled out at any of these stages, or vice versa.
+
+This does not indicate a configuration error. The trace ID was correctly injected by the tracer, but the trace itself was dropped during sampling. To reduce the likelihood of this mismatch, align your trace and log retention strategies. For more information, see [Correlate Logs and Traces][23] and [Trace Ingestion Controls][21].
+
 ## Create a support ticket
 If the above troubleshooting steps do not resolve your issues with missing logs in Datadog, create a [support ticket][15]. If possible, include the following information:
 
@@ -129,3 +143,6 @@ If the above troubleshooting steps do not resolve your issues with missing logs 
 [18]: /agent/troubleshooting/send_a_flare/?tab=agent
 [19]: /logs/log_configuration/processors/?tab=ui#grok-parser
 [20]: https://app.datadoghq.com/dashboard/lists/preset/3?q=Log%20Management%20estimated%20usage&p=1
+[21]: /tracing/trace_pipeline/ingestion_controls/
+[22]: /logs/log_configuration/indexes/#exclusion-filters
+[23]: /tracing/other_telemetry/connect_logs_and_traces/

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/_index.md
@@ -17,6 +17,8 @@ It is recommended to configure your application's tracer with `DD_ENV`, `DD_SERV
 
 Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][3]. Your language level logs _must_ be turned into Datadog attributes in order for traces and logs correlation to work.
 
+**Note:** Traces and logs are sampled independently. Even after correlation is configured, a log may contain a trace ID that refers to a trace that was not ingested or not retained due to [trace sampling][4]. This does not indicate a configuration error. For more information, see [Log has a trace ID but the associated trace is missing][5].
+
 To learn more about automatically or manually connecting your logs to your traces, select your language below:
 
 {{< partial name="apm/apm-connect-logs-and-traces.html" >}}
@@ -24,3 +26,5 @@ To learn more about automatically or manually connecting your logs to your trace
 [1]: /tracing/glossary/#trace
 [2]: /getting_started/tagging/unified_service_tagging
 [3]: /agent/logs/#enabling-log-collection-from-integrations
+[4]: /tracing/trace_pipeline/ingestion_controls/
+[5]: /logs/troubleshooting/#log-has-a-trace-id-but-the-associated-trace-is-missing

--- a/content/en/tracing/other_telemetry/connect_logs_and_traces/_index.md
+++ b/content/en/tracing/other_telemetry/connect_logs_and_traces/_index.md
@@ -17,7 +17,7 @@ It is recommended to configure your application's tracer with `DD_ENV`, `DD_SERV
 
 Before correlating traces with logs, ensure your logs are either sent as JSON, or [parsed by the proper language level log processor][3]. Your language level logs _must_ be turned into Datadog attributes in order for traces and logs correlation to work.
 
-**Note:** Traces and logs are sampled independently. Even after correlation is configured, a log may contain a trace ID that refers to a trace that was not ingested or not retained due to [trace sampling][4]. This does not indicate a configuration error. For more information, see [Log has a trace ID but the associated trace is missing][5].
+**Note**: Traces and logs are sampled independently. Even after correlation is configured, a log may contain a trace ID that refers to a trace that was not ingested or not retained due to [trace sampling][4]. This does not indicate a configuration error. For more information, see [Log has a trace ID but the associated trace is missing][5].
 
 To learn more about automatically or manually connecting your logs to your traces, select your language below:
 

--- a/content/en/tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel.md
+++ b/content/en/tracing/troubleshooting/correlated-logs-not-showing-up-in-the-trace-id-panel.md
@@ -92,7 +92,7 @@ Once the IDs are properly injected and remapped to your logs, you can see the lo
 
 {{< img src="tracing/troubleshooting/trace_id_injection.png" alt="A trace page showing the logs section with correlated logs" style="width:90%;">}}
 
-**Note**: Trace IDs and span IDs are not displayed in your logs or log attributes in the UI.
+**Note**: Trace IDs are displayed in the log side panel. If a log has a trace ID but the associated trace was sampled out, the panel displays a message indicating the trace is missing. For more information, see [Log has a trace ID but the associated trace is missing][5].
 
 ## Further Reading
 
@@ -102,3 +102,4 @@ Once the IDs are properly injected and remapped to your logs, you can see the lo
 [2]: https://app.datadoghq.com/logs
 [3]: /logs/guide/logs-not-showing-expected-timestamp/
 [4]: /tracing/other_telemetry/connect_logs_and_traces/
+[5]: /logs/troubleshooting/#log-has-a-trace-id-but-the-associated-trace-is-missing


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

[DOCS-13620](https://datadoghq.atlassian.net/browse/DOCS-13620)

Documents the new trace ID visibility in the Log Explorer side panel and explains why a log may have a trace ID but no associated trace (due to independent sampling of logs and traces).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DOCS-13620]: https://datadoghq.atlassian.net/browse/DOCS-13620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ