### PR TITLE
Add LLM Observability API reference to annotation queues doc

### DIFF
--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -11,6 +11,9 @@ further_reading:
   - link: "https://www.datadoghq.com/blog/automations-annotation-queues"
     tag: "Blog"
     text: "Annotate traces to improve LLM quality with Datadog LLM Observability"
+  - link: /api/latest/llm-observability/
+    tag: API
+    text: LLM Observability API reference
 ---
 
 ## Overview
@@ -172,6 +175,16 @@ To delete a queue:
 
 <div class="alert alert-info">Deleting a queue removes the queue and label associations, but does not delete the underlying traces from LLM Observability. Traces remain accessible in Trace Explorer.</div>
 
+## Using the API
+
+You can manage annotation queues programmatically with the LLM Observability API. Use the API to:
+
+- Create, list, update, and delete annotation queues
+- Add interactions to a queue
+- Retrieve annotated interactions from a queue
+
+For endpoints, request schemas, and examples, see the [LLM Observability API reference][4].
+
 ## Data retention
 
 
@@ -242,3 +255,4 @@ Build benchmark datasets with human-verified labels for regression testing and c
 [1]: https://app.datadoghq.com/llm/traces
 [2]: https://app.datadoghq.com/llm/annotations/queues
 [3]: /llm_observability/experiments/datasets
+[4]: /api/latest/llm-observability/


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a "Using the API" section to the LLM Observability Annotation Queues doc pointing users to the public [LLM Observability API](https://docs.datadoghq.com/api/latest/llm-observability/). Calls out that the API supports creating, listing, updating, and deleting annotation queues, adding interactions to a queue, and retrieving annotated interactions. Also adds the API reference to Further Reading.


### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes


### QA
*Preview link*: https://docs-staging.datadoghq.com/anis.amar/docs-llm-obs-annotation-queues-api-reference/llm_observability/evaluations/annotation_queues/?tab=manuallyfromtraceexplorer#using-the-api 


Made with [Cursor](https://cursor.com)