### PR TITLE
docs(users): add warning callout about key revocation when disabling users

### DIFF
--- a/content/en/account_management/users/_index.md
+++ b/content/en/account_management/users/_index.md
@@ -72,7 +72,9 @@ To edit a user's login methods:
 
 ## Disable existing members
 
-Only users with the Access Management permission, such as users with the Datadog Admin Role, can disable members. You cannot permanently remove users, as they might have authored dashboards or monitors, and their user ID is used to keep a record of their actions. When a user is disabled, any application keys they had generated are automatically revoked.
+Only users with the Access Management permission, such as users with the Datadog Admin Role, can disable members. You cannot permanently remove users, as they might have authored dashboards or monitors, and their user ID is used to keep a record of their actions. When a user is disabled, any application keys and personal access tokens (PATs) they had generated are automatically revoked.
+
+<div class="alert alert-warning">Disabling a user revokes all of their application keys and personal access tokens (PATs). Any workflows or integrations that rely on these keys stop working immediately. To avoid disruptions, use keys that belong to <a href="/account_management/org_settings/service_accounts/">service accounts</a> for long-running integrations and automated workflows.</div>
 
 1. Go to the {{< ui >}}Users{{< /ui >}} tab of {{< ui >}}Organization Settings{{< /ui >}}.
 2. Select the {{< ui >}}Edit{{< /ui >}} button on the right of the user line.

--- a/content/en/account_management/users/_index.md
+++ b/content/en/account_management/users/_index.md
@@ -72,7 +72,7 @@ To edit a user's login methods:
 
 ## Disable existing members
 
-Only users with the Access Management permission, such as users with the Datadog Admin Role, can disable members. You cannot permanently remove users, as they might have authored dashboards or monitors, and their user ID is used to keep a record of their actions. When a user is disabled, any application keys and personal access tokens (PATs) they had generated are automatically revoked.
+Only users with the Access Management permission, such as users with the Datadog Admin Role, can disable members. You cannot permanently remove users, as they might have authored dashboards or monitors, and their user ID is used to keep a record of their actions.
 
 <div class="alert alert-warning">Disabling a user revokes all of their application keys and personal access tokens (PATs). Any workflows or integrations that rely on these keys stop working immediately. To avoid disruptions, use keys that belong to <a href="/account_management/org_settings/service_accounts/">service accounts</a> for long-running integrations and automated workflows.</div>
 
@@ -90,3 +90,4 @@ Only users with the Access Management permission, such as users with the Datadog
 
 [1]: /account_management/users/default_roles/
 [2]: /account_management/rbac/
+


### PR DESCRIPTION
## What does this PR do?

Adds a warning callout to the **Disable existing members** section of the User Management page.

The current text mentions that application keys are revoked, but doesn't surface the impact clearly. This update:

- Explicitly mentions **personal access tokens (PATs)** alongside application keys (both are revoked)
- Adds a visible `alert-warning` callout so the consequence isn't buried in paragraph text
- Links to the Service Accounts docs and strongly recommends using service account keys for long-running integrations and automated workflows

## Motivation

Users (and admins) are frequently surprised when disabling an account breaks automated pipelines. Making this consequence more prominent — and surfacing the service account recommendation — reduces operational incidents.

## Checklist

- [x] Content follows Datadog docs style guide (no banned words, imperative voice, present tense)
- [x] Warning callout uses existing `alert alert-warning` HTML pattern consistent with the page
- [x] Service accounts link uses a relative path
- [ ] Vale linter output reviewed in Files changed tab

/cc @docs