### PR TITLE
Update AI Agents Console: Preview open to all, add GitHub Copilot

### DIFF
--- a/content/en/ai_agents_console/_index.md
+++ b/content/en/ai_agents_console/_index.md
@@ -13,8 +13,8 @@ further_reading:
     text: "Monitor Claude Code adoption in your organization with Datadog's AI Agents Console"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/ai-agents-console/" btn_hidden="false" header="Join the Preview!">}}
-AI Agents Console is in Preview. Complete the form to request access.
+{{< callout url="#" btn_hidden="true" header="Preview">}}
+AI Agents Console is in Preview and is available to all Datadog customers.
 {{< /callout >}}
 
 The [AI Agents Console][1] provides centralized monitoring for agentic developer tools. It collects logs and metrics from developer environments and surfaces them in real time within Datadog, giving you visibility into usage, cost, latency, and errors across your organization.
@@ -25,7 +25,7 @@ AI Agents Console supports the following integrations:
 |------|-------------|
 | [Claude Code][2] | Anthropic's agentic coding tool |
 | [Cursor][3] | AI-powered code editor |
-| GitHub Copilot | Coming soon |
+| [GitHub Copilot][10] | GitHub's AI-powered code completion tool |
 
 ## Set up an integration
 
@@ -108,6 +108,12 @@ To monitor Cursor with AI Agents Console, set up the [Cursor][5] integration usi
 
 After setup, navigate to the [AI Agents Console][1] and click the {{< ui >}}Cursor{{< /ui >}} tile to view metrics.
 
+### GitHub Copilot
+
+To monitor GitHub Copilot with AI Agents Console, set up the [GitHub Copilot][10] integration.
+
+After setup, navigate to the [AI Agents Console][1] and click the {{< ui >}}GitHub Copilot{{< /ui >}} tile to view metrics.
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -121,3 +127,4 @@ After setup, navigate to the [AI Agents Console][1] and click the {{< ui >}}Curs
 [7]: /logs/log_configuration/indexes/
 [8]: https://app.datadoghq.com/organization-settings/api-keys
 [9]: /agent/?tab=Host-based
+[10]: /integrations/github-copilot/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

[Brief description of changes]

- Updates the Preview callout to reflect that AI Agents Console is now available to all Datadog customers (removes form signup button)
- Adds GitHub Copilot as a supported integration in the table and adds a setup section linking to `/integrations/github-copilot/`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes