### PR TITLE
Add AI Agents Console to nav and make page public

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -5437,6 +5437,12 @@ menu:
       parent: gpu_monitoring
       identifier: gpu_monitoring_fleet
       weight: 3
+    - name: AI Agents Console
+      url: ai_agents_console/
+      pre: llm-observability
+      identifier: ai_agents_console
+      parent: ai_observability_heading
+      weight: 30000
     - name: CI Visibility
       url: continuous_integration/
       pre: ci

--- a/content/en/ai_agents_console/_index.md
+++ b/content/en/ai_agents_console/_index.md
@@ -1,6 +1,5 @@
 ---
 title: AI Agents Console
-private: true
 further_reading:
   - link: '/integrations/anthropic-usage-and-costs/'
     tag: 'Documentation'


### PR DESCRIPTION
### What does this PR do? What is the motivation?

- Adds AI Agents Console to the left nav under AI Observability
- Removes `private: true` from the page frontmatter so the page is visible to all customers

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes