### PR TITLE
Move Cribl Stream troubleshooting guide to Cloud SIEM guides

### DIFF
--- a/content/en/security/cloud_siem/guide/_index.md
+++ b/content/en/security/cloud_siem/guide/_index.md
@@ -18,4 +18,5 @@ disable_toc: true
     {{< nextlink href="/security/cloud_siem/guide/oci-config-guide-for-cloud-siem/" >}}OCI Configuration Guide for Cloud SIEM{{< /nextlink >}}
     {{< nextlink href="security/cloud_siem/guide/monitor-authentication-logs-for-security-threats" >}}Monitor Authentication Logs for Security Threats{{< /nextlink >}}
     {{< nextlink href="/security/cloud_siem/guide/how-to-setup-security-filters-using-cloud-siem-api" >}}Security Filters with the Cloud SIEM API{{< /nextlink >}}
+    {{< nextlink href="/security/cloud_siem/guide/troubleshoot-cribl-stream-cloud-siem" >}}Troubleshoot using Cribl Stream with Cloud SIEM{{< /nextlink >}}
 {{< /whatsnext >}}

--- a/content/en/security/cloud_siem/guide/troubleshoot-cribl-stream-cloud-siem.md
+++ b/content/en/security/cloud_siem/guide/troubleshoot-cribl-stream-cloud-siem.md
@@ -1,6 +1,8 @@
 ---
-title: Troubleshoot the Cribl Stream integration with Cloud SIEM
+title: Troubleshoot using Cribl Stream with Cloud SIEM
 description: Investigate issues with sending out-of-the-box Cloud SIEM content with Cribl, and explore options on how to fix your configuration so your dashboards and detection rules work as expected.
+aliases:
+  - /security/guide/troubleshoot-cribl-stream-cloud-siem/
 further_reading:
 - link: "/security/cloud_siem/"
   tag: "Documentation"

--- a/content/en/security/guide/_index.md
+++ b/content/en/security/guide/_index.md
@@ -57,6 +57,3 @@ disable_toc: true
    {{< nextlink href="security/sensitive_data_scanner/guide/investigate_sensitive_data_findings" >}}Investigate Sensitive Data Findings{{< /nextlink >}}
 {{< /whatsnext >}}
 
-{{< whatsnext desc="Troubleshooting Guides:" >}}
-   {{< nextlink href="/security/guide/troubleshoot-cribl-stream-cloud-siem" >}}Troubleshoot the Cribl Stream integration with Cloud SIEM{{< /nextlink >}}
-{{< /whatsnext >}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Moves the Cribl Stream troubleshooting guide from the general Security guides section to the Cloud SIEM guides section, where it more appropriately belongs.

Changes:
- Moved `troubleshoot-cribl-stream-cloud-siem.md` from `security/guide/` to `security/cloud_siem/guide/`
- Renamed page title to "Troubleshoot using Cribl Stream with Cloud SIEM"
- Added alias for the old URL (`/security/guide/troubleshoot-cribl-stream-cloud-siem/`) to preserve existing links
- Added entry to the Cloud SIEM guides index (`security/cloud_siem/guide/_index.md`)
- Removed the Troubleshooting Guides section from the general Security guides index (`security/guide/_index.md`)

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes