### PR TITLE
Add Flutter SDK to Operations Monitoring page

### DIFF
--- a/content/en/real_user_monitoring/operations_monitoring.md
+++ b/content/en/real_user_monitoring/operations_monitoring.md
@@ -114,7 +114,7 @@ DatadogSdk.instance.rum?.startFeatureOperation(
   }
 )
 ```
-On Flutter Web, the Browser SDK must have the `feature_operation_vital` experimental feature enabled.
+To use operations on Flutter Web, enable the `feature_operation_vital` experimental feature in the Browser SDK.
 {{% /tab %}}
 
 {{% tab "Roku" %}}
@@ -200,7 +200,7 @@ DatadogSdk.instance.rum?.succeedFeatureOperation(
   }
 )
 ```
-On Flutter Web, the Browser SDK must have the `feature_operation_vital` experimental feature enabled.
+To use operations on Flutter Web, enable the `feature_operation_vital` experimental feature in the Browser SDK.
 
 {{% /tab %}}
 

--- a/content/en/real_user_monitoring/operations_monitoring.md
+++ b/content/en/real_user_monitoring/operations_monitoring.md
@@ -303,7 +303,7 @@ DatadogSdk.instance.rum?.failFeatureOperation(
   }
 )
 ```
-On Flutter Web, the Browser SDK must have the `feature_operation_vital` experimental feature enabled.
+To use operations on Flutter Web, enable the `feature_operation_vital` experimental feature in the Browser SDK.
 
 {{% /tab %}}
 

--- a/content/en/real_user_monitoring/operations_monitoring.md
+++ b/content/en/real_user_monitoring/operations_monitoring.md
@@ -38,9 +38,12 @@ The following table shows additional example features and their associated featu
   - [Browser (6.20.0)][1]
   - [Android (3.1.0)][2]
   - [iOS (3.1.0)][3]
+  - [Flutter (3.0.0)][7]
   - [Kotlin Multiplatform (1.4.0)][4]
   - [React Native (3.0.0)][5]
   - [Roku (1.4.0)][6]
+
+On Flutter Web, operations route through the Browser SDK. Enable the `feature_operation_vital` experimental feature on the Browser SDK (see the Browser tab).
 
 ## Setup
 
@@ -101,6 +104,18 @@ DdRum.startFeatureOperation(
 )
 
 ```
+{{% /tab %}}
+
+{{% tab "Flutter" %}}
+```dart
+DatadogSdk.instance.rum?.startFeatureOperation(
+    String name, {
+    String? operationKey,
+    Map<String, Object?> attributes = const {},
+  }
+)
+```
+On Flutter Web, the underlying Browser SDK must have the `feature_operation_vital` experimental feature enabled.
 {{% /tab %}}
 
 {{% tab "Roku" %}}
@@ -173,6 +188,20 @@ DdRum.succeedFeatureOperation(
 	attributes?: Record<string, any>
 )
 ```
+
+{{% /tab %}}
+
+{{% tab "Flutter" %}}
+
+```dart
+DatadogSdk.instance.rum?.succeedFeatureOperation(
+    String name, {
+    String? operationKey,
+    Map<String, Object?> attributes = const {},
+  }
+)
+```
+On Flutter Web, the underlying Browser SDK must have the `feature_operation_vital` experimental feature enabled.
 
 {{% /tab %}}
 
@@ -263,6 +292,22 @@ DdRum.failFeatureOperation(
 ```
 {{% /tab %}}
 
+{{% tab "Flutter" %}}
+
+```dart
+DatadogSdk.instance.rum?.failFeatureOperation(
+    String name,
+    RumFeatureOperationFailureReason failureReason, // .error, .abandoned, .other
+    {
+    String? operationKey,
+    Map<String, Object?> attributes = const {},
+  }
+)
+```
+On Flutter Web, the underlying Browser SDK must have the `feature_operation_vital` experimental feature enabled.
+
+{{% /tab %}}
+
 {{< /tabs >}}
 
 ### Parallelization
@@ -317,3 +362,4 @@ Similarly to metrics, those events come with specific attributes you can use in 
 [5]: https://github.com/DataDog/dd-sdk-reactnative/releases/tag/3.0.0
 
 [6]: https://github.com/DataDog/dd-sdk-roku/releases/tag/1.4.0
+[7]: https://github.com/DataDog/dd-sdk-flutter/releases/tag/datadog_flutter_plugin%2Fv3.0.0

--- a/content/en/real_user_monitoring/operations_monitoring.md
+++ b/content/en/real_user_monitoring/operations_monitoring.md
@@ -39,11 +39,10 @@ The following table shows additional example features and their associated featu
   - [Android (3.1.0)][2]
   - [iOS (3.1.0)][3]
   - [Flutter (3.0.0)][7]
+      - On Flutter Web, operations route through the Browser SDK and require the `feature_operation_vital` experimental feature enabled.
   - [Kotlin Multiplatform (1.4.0)][4]
   - [React Native (3.0.0)][5]
   - [Roku (1.4.0)][6]
-
-On Flutter Web, operations route through the Browser SDK. Enable the `feature_operation_vital` experimental feature on the Browser SDK (see the Browser tab).
 
 ## Setup
 
@@ -115,7 +114,7 @@ DatadogSdk.instance.rum?.startFeatureOperation(
   }
 )
 ```
-On Flutter Web, the underlying Browser SDK must have the `feature_operation_vital` experimental feature enabled.
+On Flutter Web, the Browser SDK must have the `feature_operation_vital` experimental feature enabled.
 {{% /tab %}}
 
 {{% tab "Roku" %}}
@@ -201,7 +200,7 @@ DatadogSdk.instance.rum?.succeedFeatureOperation(
   }
 )
 ```
-On Flutter Web, the underlying Browser SDK must have the `feature_operation_vital` experimental feature enabled.
+On Flutter Web, the Browser SDK must have the `feature_operation_vital` experimental feature enabled.
 
 {{% /tab %}}
 
@@ -304,7 +303,7 @@ DatadogSdk.instance.rum?.failFeatureOperation(
   }
 )
 ```
-On Flutter Web, the underlying Browser SDK must have the `feature_operation_vital` experimental feature enabled.
+On Flutter Web, the Browser SDK must have the `feature_operation_vital` experimental feature enabled.
 
 {{% /tab %}}
 

--- a/content/en/real_user_monitoring/operations_monitoring.md
+++ b/content/en/real_user_monitoring/operations_monitoring.md
@@ -39,7 +39,7 @@ The following table shows additional example features and their associated featu
   - [Android (3.1.0)][2]
   - [iOS (3.1.0)][3]
   - [Flutter (3.0.0)][7]
-      - On Flutter Web, operations route through the Browser SDK and require the `feature_operation_vital` experimental feature enabled.
+      - **Note**: On Flutter Web, operations route through the Browser SDK, which requires the `feature_operation_vital` experimental feature to be enabled.
   - [Kotlin Multiplatform (1.4.0)][4]
   - [React Native (3.0.0)][5]
   - [Roku (1.4.0)][6]


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Add the Flutter SDK (`datadog_flutter_plugin` 3.0.0) to the RUM Operations Monitoring page so Flutter customers can discover the APIs and know which release introduced support.

Changes in `content/en/real_user_monitoring/operations_monitoring.md`:
- Added `Flutter (3.0.0)` to the Prerequisites SDK list, with a note that Flutter Web routes through the Browser SDK and therefore requires the `feature_operation_vital` experimental feature to be enabled on the underlying Browser SDK.
- Added a `Flutter` tab to each of the three code sample sections (Start / Stop with success / Stop with failure), each showing the Dart signature.
- Added a `[7]` link reference to the `datadog_flutter_plugin/v3.0.0` release tag.

### Merge instructions

<!--
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here.
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge