### PR TITLE
Add Kotlin support note to IAST Java compatibility page

### DIFF
--- a/content/en/security/code_security/iast/setup/compatibility/java.md
+++ b/content/en/security/code_security/iast/setup/compatibility/java.md
@@ -49,7 +49,7 @@ Datadog does not officially support any early-access versions of Java.
 
 Versions 22 and above are supported as in Preview.
 
-**Kotlin support**: Kotlin is supported via the Java tracer. Because Kotlin compiles to JVM bytecode, it runs on the same JVM runtimes listed above, with no additional configuration required beyond the standard Java setup.
+**Kotlin support**: Kotlin is supported through the Java tracer. Because Kotlin compiles to JVM bytecode, it runs on the same JVM runtimes listed above, with no additional configuration required beyond the standard Java setup.
 
 ### Web framework compatibility
 

--- a/content/en/security/code_security/iast/setup/compatibility/java.md
+++ b/content/en/security/code_security/iast/setup/compatibility/java.md
@@ -49,6 +49,8 @@ Datadog does not officially support any early-access versions of Java.
 
 Versions 22 and above are supported as in Preview.
 
+**Kotlin support**: Kotlin is supported via the Java tracer. Because Kotlin compiles to JVM bytecode, it runs on the same JVM runtimes listed above, with no additional configuration required beyond the standard Java setup.
+
 ### Web framework compatibility
 
 - Attacker source HTTP request details


### PR DESCRIPTION
## Summary
- Adds a note under the Supported Java versions section in the IAST Java compatibility page to document Kotlin support
- Kotlin is supported via the Java tracer since it compiles to JVM bytecode — no separate section or configuration needed

## Test plan
- [ ] Verify note renders correctly on the IAST setup page under the Java > Supported Java versions section

## Ready for merge
- [x] Ready for merge