### PR TITLE
Add AAP and HTTP client IP details standard attributes

### DIFF
--- a/content/en/standard-attributes/_index.md
+++ b/content/en/standard-attributes/_index.md
@@ -1541,97 +1541,97 @@ attributes:
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.country.name
     description: The name of the country the client IP resolves to.
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.country.iso_code
-    description: "[ISO Code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) of the country (for example, `US` for the United States, `FR` for France)."
+    description: "[ISO code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) of the country (for example, `US` for the United States, `FR` for France)."
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.continent.code
-    description: ISO code of the continent (`EU`, `AS`, `NA`, `AF`, `AN`, `SA`, `OC`).
+    description: The ISO code of the continent (`EU`, `AS`, `NA`, `AF`, `AN`, `SA`, `OC`).
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.continent.name
-    description: Name of the continent the client IP resolves to.
+    description: The name of the continent the client IP resolves to.
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.subdivision.name
-    description: Name of the first-level subdivision (such as a state or region) the client IP resolves to.
+    description: The name of the first-level subdivision (such as a state or region) the client IP resolves to.
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.subdivision.iso_code
-    description: "[ISO code](https://en.wikipedia.org/wiki/ISO_3166-2) of the first-level subdivision (for example, `CA-ON` for Ontario, Canada)."
+    description: "The [ISO code](https://en.wikipedia.org/wiki/ISO_3166-2) of the first-level subdivision (for example, `CA-ON` for Ontario, Canada)."
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.city.name
     description: Name of the city the client IP resolves to.
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.location.latitude
     description: The latitude of the location the client IP resolves to.
     product_source:
       - icon-apm
     type: number
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.location.longitude
     description: The longitude of the location the client IP resolves to.
     product_source:
       - icon-apm
     type: number
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.timezone
     description: The IANA timezone identifier (for example, `America/Toronto`) associated with the client IP.
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.as.number
     description: The autonomous system number (ASN) the client IP belongs to (for example, `AS577`).
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.as.name
     description: The name of the organization that operates the autonomous system (for example, `Bell Canada`).
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.as.domain
     description: The primary domain associated with the autonomous system (for example, `bell.ca`).
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.as.route
     description: The IP prefix announced by the autonomous system (for example, `65.95.0.0/16`).
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.client_ip_details.as.type
     description: The classification of the autonomous system (for example, `isp`, `hosting`, `business`, `education`).
     product_source:
       - icon-apm
     type: string
-    domain: HTTP Client IP Details
+    domain: HTTP client IP details
   - name: http.useragent
     description: The `User-Agent` header received with the request.
     product_source:

--- a/content/en/standard-attributes/_index.md
+++ b/content/en/standard-attributes/_index.md
@@ -1536,12 +1536,6 @@ attributes:
       - icon-apm
     type: string
     domain: HTTP requests
-  - name: http.client_ip_details.ipAddress
-    description: The client IP address that was enriched. Mirrors `http.client_ip` and is populated when geolocation and network metadata lookup succeeds.
-    product_source:
-      - icon-apm
-    type: string
-    domain: HTTP Client IP Details
   - name: http.client_ip_details.type
     description: The type of IP address, such as `public`, `private`, or `reserved`.
     product_source:

--- a/content/en/standard-attributes/_index.md
+++ b/content/en/standard-attributes/_index.md
@@ -1536,6 +1536,108 @@ attributes:
       - icon-apm
     type: string
     domain: HTTP requests
+  - name: http.client_ip_details.ipAddress
+    description: The client IP address that was enriched. Mirrors `http.client_ip` and is populated when geolocation and network metadata lookup succeeds.
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.type
+    description: The type of IP address, such as `public`, `private`, or `reserved`.
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.country.name
+    description: The name of the country the client IP resolves to.
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.country.iso_code
+    description: "[ISO Code](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes) of the country (for example, `US` for the United States, `FR` for France)."
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.continent.code
+    description: ISO code of the continent (`EU`, `AS`, `NA`, `AF`, `AN`, `SA`, `OC`).
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.continent.name
+    description: Name of the continent the client IP resolves to.
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.subdivision.name
+    description: Name of the first-level subdivision (such as a state or region) the client IP resolves to.
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.subdivision.iso_code
+    description: "[ISO code](https://en.wikipedia.org/wiki/ISO_3166-2) of the first-level subdivision (for example, `CA-ON` for Ontario, Canada)."
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.city.name
+    description: Name of the city the client IP resolves to.
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.location.latitude
+    description: The latitude of the location the client IP resolves to.
+    product_source:
+      - icon-apm
+    type: number
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.location.longitude
+    description: The longitude of the location the client IP resolves to.
+    product_source:
+      - icon-apm
+    type: number
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.timezone
+    description: The IANA timezone identifier (for example, `America/Toronto`) associated with the client IP.
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.as.number
+    description: The autonomous system number (ASN) the client IP belongs to (for example, `AS577`).
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.as.name
+    description: The name of the organization that operates the autonomous system (for example, `Bell Canada`).
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.as.domain
+    description: The primary domain associated with the autonomous system (for example, `bell.ca`).
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.as.route
+    description: The IP prefix announced by the autonomous system (for example, `65.95.0.0/16`).
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
+  - name: http.client_ip_details.as.type
+    description: The classification of the autonomous system (for example, `isp`, `hosting`, `business`, `education`).
+    product_source:
+      - icon-apm
+    type: string
+    domain: HTTP Client IP Details
   - name: http.useragent
     description: The `User-Agent` header received with the request.
     product_source:
@@ -1712,7 +1814,38 @@ attributes:
       - icon-apm
     type: string
     domain: Remote procedure calls
-  
+
+  - name: appsec.security_activity
+    description: The kind of security activity detected on the request, expressed as `<category>.<type>` (for example, `attack_attempt.sql_injection`, `business_logic.users.login.failure`). A span can have more than one value when multiple rules match.
+    product_source:
+      - icon-apm
+    type: string
+    domain: Application & API Protection (AAP)
+  - name: appsec.category
+    description: The top-level classification of the detected security activity (for example, `attack_attempt`, `business_logic`).
+    product_source:
+      - icon-apm
+    type: string
+    domain: Application & API Protection (AAP)
+  - name: appsec.type
+    description: The specific threat or event type within the category (for example, `sql_injection`, `xss`, `users.login.failure`).
+    product_source:
+      - icon-apm
+    type: string
+    domain: Application & API Protection (AAP)
+  - name: appsec.rule_id
+    description: The identifier of the AAP rule that matched the request (for example, `crs-942-100`). A span can have multiple values when more than one rule triggers.
+    product_source:
+      - icon-apm
+    type: string
+    domain: Application & API Protection (AAP)
+  - name: appsec.blocked
+    description: Whether the request was blocked by AAP. `true` if the request was blocked, `false` otherwise.
+    product_source:
+      - icon-apm
+    type: string
+    domain: Application & API Protection (AAP)
+
 ---
 
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds new standard attribute documentation for APM spans:

- **Application & API Protection (AAP)** domain: `appsec.category`, `appsec.security_activity`, `appsec.type`, `appsec.rule_id`, and `appsec.blocked`.
- **HTTP Client IP Details** domain: `http.client_ip_details.*` attributes (17 total) covering the IP address, type, geolocation (country, continent, subdivision, city, location, timezone), and autonomous system metadata (AS number, name, domain, route, type) that enrich `http.client_ip`.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes