### PR TITLE
Add Redshift to Quality Monitoring landing page

### DIFF
--- a/content/en/data_observability/quality_monitoring/_index.md
+++ b/content/en/data_observability/quality_monitoring/_index.md
@@ -30,6 +30,7 @@ With Quality Monitoring, you can:
    {{< nextlink href="data_observability/quality_monitoring/data_warehouses/snowflake" >}}Snowflake{{< /nextlink >}}
    {{< nextlink href="data_observability/quality_monitoring/data_warehouses/databricks" >}}Databricks{{< /nextlink >}}
    {{< nextlink href="data_observability/quality_monitoring/data_warehouses/bigquery" >}}BigQuery{{< /nextlink >}}
+   {{< nextlink href="data_observability/quality_monitoring/data_warehouses/redshift" >}}Redshift{{< /nextlink >}}
 {{< /whatsnext >}}
 
 {{< whatsnext desc="Connect to these data lake catalogs:" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds Redshift to the list of supported data warehouses on the Quality Monitoring landing page (`/data_observability/quality_monitoring/`).

Redshift was added to the data warehouses sub-page ([`/data_observability/quality_monitoring/data_warehouses/`](https://docs.datadoghq.com/data_observability/quality_monitoring/data_warehouses/)) in #35474, but the parent Quality Monitoring landing page was missed — so users browsing the top-level page don't currently see Redshift in the supported warehouses list.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

One-line change mirroring the entry that's already on the data warehouses sub-page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)