### PR TITLE
docs(rum): add Browser SDK v6 to v7 upgrade guide

### DIFF
--- a/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
@@ -14,6 +14,157 @@ further_reading:
 
 Follow this guide to migrate between major versions of the Browser RUM and Browser Logs SDKs. See [the SDK documentation][26] for details on its features and capabilities.
 
+## From v6 to v7
+
+V7 improves privacy defaults, removes deprecated options, and modernizes the SDK internals. Most changes require configuration updates.
+
+Take notice of the below breaking changes as you upgrade your SDK. Changes are grouped by area of impact.
+
+### Core
+
+#### Session manager rewrite
+
+The system that tracks sessions has been rewritten to improve data reliability and reduce billing discrepancies. Depending on your setup, you may notice changes in session counts.
+
+#### Deterministic sampling decisions
+
+Previously, the sampling decision was made once at session creation and persisted. It is now computed on demand from the session ID and sample rate, making it consistent regardless of which page initializes the SDK. If you use different sampling rates across pages, those rates are now applied consistently.
+
+#### Session store key renamed
+
+The session storage key has changed from `_dd_s` to `_dd_s_v2` because the new session manager uses an incompatible storage format. On upgrade, existing sessions are automatically migrated from `_dd_s`.
+
+**Note**: Rolling back to v6 after migration starts a new session, because the v6 SDK does not read the `_dd_s_v2` key. If you have CSP or cookie policies that allowlist specific cookie names, add `_dd_s_v2`.
+
+#### CDN bundles use ESM dynamic imports
+
+CDN bundles now use ESM dynamic imports instead of CommonJS, significantly reducing webpack overhead and overall bundle size. If you use the CDN snippet, add the `crossorigin` attribute:
+
+```html
+<script src="https://www.datadoghq-browser-agent.com/..." crossorigin="anonymous"></script>
+```
+
+See the [setup documentation][26] for full snippet examples.
+
+#### ES2020 browser baseline
+
+Support for pre-ES2020 browsers has been dropped to remove compatibility shims and polyfills, reducing bundle size. Minimum supported versions are Chrome 80+, Firefox 78+, and Safari 14+. Estimated impact: ~0.048% less coverage.
+
+To continue supporting older browsers, keep using Browser SDK v6 or earlier.
+
+#### Removed options
+
+| Deprecated option (v6 or earlier) | Replacement (v7)                                       |
+| --------------------------------- | ------------------------------------------------------ |
+| `betaEncodeCookieOptions`         | Cookie encoding is always enabled.                     |
+| `allowFallbackToLocalStorage`     | Use `sessionPersistence: ['cookie', 'local-storage']`. |
+
+### RUM
+
+#### `propagateTraceBaggage` enabled by default
+
+The `propagateTraceBaggage` [initialization parameter][28] now defaults to `true`. Propagating baggage enables tail-based sampling and gives traces access to user and account context.
+
+If you use distributed tracing on cross-origin requests, either set `propagateTraceBaggage: false` or add `baggage` to your `Access-Control-Allow-Headers` response headers:
+
+```
+Access-Control-Allow-Headers: traceparent, tracestate, baggage
+```
+
+#### New default for `defaultPrivacyLevel`
+
+`defaultPrivacyLevel` now defaults to `mask-user-input` (previously `mask`). This provides better out-of-the-box privacy without the restrictions of full masking. The new default masks user input while other content is collected.
+
+To preserve full masking, explicitly set `defaultPrivacyLevel: "mask"`.
+
+#### `enablePrivacyForActionName` enabled by default
+
+`enablePrivacyForActionName` now defaults to `true`. Click action names follow the `defaultPrivacyLevel` setting by default. Use the [Datadog build plugin][36] or set `enablePrivacyForActionName: false` to opt out.
+
+#### `startDurationVital` and `stopDurationVital` API change
+
+The `DurationVitalReference` object has been replaced by a `vitalKey` string option. This aligns the API with `startResource`/`stopResource` and `startAction`/`stopAction`, and with the Mobile SDK, while still allowing multiple concurrent vitals with the same name:
+
+```js
+// Before
+const ref = datadogRum.startDurationVital('myVital')
+datadogRum.stopDurationVital(ref)
+
+// After
+datadogRum.startDurationVital('myVital', { vitalKey: 'uniqueKey' })
+datadogRum.stopDurationVital('myVital', { vitalKey: 'uniqueKey' })
+```
+
+#### New `session_renewal` view loading type
+
+When a session expires and is renewed, the new view is created with `@view.loading_type:session_renewal` instead of `route_change`. Update any dashboards or monitors that filter on `@view.loading_type` if they should also include session-renewed views.
+
+#### Document resource uses `PerformanceNavigationTiming`
+
+The initial document resource event previously used a synthetic timing entry. It now uses the browser's native `PerformanceNavigationTiming` directly, which may produce slightly different `resource.duration` values for the document resource. The `initiatorType` for the document resource changes from `initial_document` to `navigation`.
+
+If you use plugins or domain context handlers that inspect `performanceEntry` for document resources, update them to expect a `PerformanceNavigationTiming` instead of `PerformanceResourceTiming`.
+
+#### First Input Delay (FID) removed
+
+Google replaced FID with Interaction to Next Paint (INP) as a Core Web Vital. FID has been removed from the SDK to reduce bundle size. Use INP instead.
+
+#### Plugin API: `strategy` removed
+
+The `strategy` field has been removed from the plugin API. If you use `rum-react` or other integrations, upgrade them to v7 alongside the core SDK.
+
+#### Improved action name computation
+
+The SDK always uses the tree walker strategy to compute action names, including in shadow DOM and Web Components. This was required to support the privacy build plugin. Action names may change slightly. The `betaTrackActionsInShadowDom` option has been removed.
+
+#### BFCache navigations always tracked
+
+Back/Forward Cache restores are tracked as distinct views with `@view.loading_type:bf_cache`, including accurate loading time and Core Web Vitals. The `trackBfCacheViews` option has been removed.
+
+#### Early requests always collected
+
+Resources and requests that occurred before the SDK initialized are automatically captured. Some of those early resources may be missing properties such as status code. The `trackEarlyRequests` option has been removed.
+
+#### Async chunk file names prefixed with `datadog`
+
+Async chunk file names include a `datadog` prefix (for example, `datadog-rum-recorder.js`). If you have CSP or caching rules matching the old names, update them accordingly.
+
+### Logs
+
+#### Logs require a session manager
+
+Logs always use a session manager, so Logs events are consistently associated with a session ID. When neither cookies nor local storage are available, the SDK does not send data and logs a warning. Previously, Logs would still start without storage.
+
+To explicitly enable memory-backed sessions, use `sessionPersistence: 'memory'`. In worker environments, this fallback is automatic.
+
+#### `forwardErrorsToLogs` and `forwardConsoleLogs` are independent
+
+Previously, enabling `forwardErrorsToLogs` also silently forwarded `console.error` calls. These options are now fully independent, giving you precise control over what gets forwarded. `forwardErrorsToLogs` controls unhandled errors only.
+
+To preserve the previous behavior, add `error` to your `forwardConsoleLogs` array:
+
+```js
+DD_LOGS.init({
+  forwardConsoleLogs: ['error', 'warn'],
+})
+```
+
+#### Network errors for cancelled requests are dropped
+
+Requests cancelled by the application (aborted fetch or XHR) no longer generate a network error log. This reduces noise in error tracking.
+
+#### Removed options
+
+| Deprecated option (v6 or earlier) | Replacement (v7)                                                           |
+| --------------------------------- | -------------------------------------------------------------------------- |
+| `usePciIntake`                    | The standard intake is now PCI compliant. Update your [CSP][18] if needed. |
+
+### Session Replay
+
+#### New serialization algorithm
+
+The new DOM mutation serialization algorithm (Change Records) is the default. It produces more accurate recordings and significantly reduces bandwidth usage. The segment format has changed; if you depend on the raw segment format, update your integration.
+
 ## From v5 to v6
 
 The main improvement v6 offers is the bundle size reduction. By dropping support for IE11 and leveraging lazy loading, the size of the RUM bundle has been reduced by 10% and the Logs bundle by nearly 9%.
@@ -414,3 +565,4 @@ The RUM Browser SDK no longer lets you specify the source of an error collected 
 [33]: https://rollupjs.org/tutorial/#code-splitting
 [34]: https://parceljs.org/features/code-splitting
 [35]: https://developer.chrome.com/docs/web-platform/long-animation-frames#long-frames-api
+[36]: https://github.com/DataDog/build-plugins

--- a/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
@@ -87,13 +87,13 @@ Access-Control-Allow-Headers: traceparent, tracestate, baggage
 
 #### New default for `defaultPrivacyLevel`
 
-`defaultPrivacyLevel` defaults to `mask-user-input` in v7 (previously `mask`). This provides better out-of-the-box privacy without the restrictions of full masking. The new default masks user input while other content is collected.
+`defaultPrivacyLevel` defaults to `mask-user-input` in v7 (previously `mask`). This provides sensible out-of-the-box privacy without the restrictions of full masking. The new default masks user input while other content is collected.
 
 To preserve full masking, explicitly set `defaultPrivacyLevel: "mask"`.
 
 #### `enablePrivacyForActionName` enabled by default
 
-`enablePrivacyForActionName` defaults to `true` in v7. Click action names follow the `defaultPrivacyLevel` setting by default. Use the [Datadog build plugin][36] or set `enablePrivacyForActionName: false` to opt out.
+`enablePrivacyForActionName` defaults to `true` in v7. Click action names follow the `defaultPrivacyLevel` setting by default. Set `enablePrivacyForActionName: false` to opt out. New masking capabilities are planned for the [Datadog build plugin][36].
 
 #### `startDurationVital` and `stopDurationVital` API change
 

--- a/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
@@ -28,7 +28,7 @@ The system that tracks sessions has been rewritten to improve data reliability a
 
 #### Deterministic sampling decisions
 
-Previously, the sampling decision was made once at session creation and persisted. It is now computed on demand from the session ID and sample rate, making it consistent regardless of which page initializes the SDK. If you use different sampling rates across pages, those rates are now applied consistently.
+Previously, the sampling decision was made once at session creation and persisted. In v7, it is computed on demand from the session ID and sample rate, making it consistent regardless of which page initializes the SDK. If you use different sampling rates across pages, those rates are applied consistently.
 
 #### Session store key renamed
 
@@ -50,7 +50,7 @@ Replace `<SITE>` with your Datadog site (for example, `us1`, `us3`, `us5`, `eu1`
 
 #### CDN bundles use ESM dynamic imports
 
-CDN bundles now use ESM dynamic imports instead of CommonJS, significantly reducing webpack overhead and overall bundle size. If you use the CDN snippet, add the `crossorigin` attribute to the script tag:
+CDN bundles use ESM dynamic imports instead of CommonJS, significantly reducing webpack overhead and overall bundle size. If you use the CDN snippet, add the `crossorigin` attribute to the script tag:
 
 ```html
 <script src="https://www.datadoghq-browser-agent.com/..." crossorigin="anonymous"></script>
@@ -75,7 +75,7 @@ To continue supporting older browsers, keep using Browser SDK v6 or earlier.
 
 #### `propagateTraceBaggage` enabled by default
 
-The `propagateTraceBaggage` [initialization parameter][28] now defaults to `true`. Propagating baggage enables tail-based sampling and gives traces access to user and account context.
+The `propagateTraceBaggage` [initialization parameter][28] defaults to `true` in v7. Propagating baggage enables tail-based sampling and gives traces access to user and account context.
 
 If you use distributed tracing on cross-origin requests, either set `propagateTraceBaggage: false` or add `baggage` to your `Access-Control-Allow-Headers` response headers:
 
@@ -85,13 +85,13 @@ Access-Control-Allow-Headers: traceparent, tracestate, baggage
 
 #### New default for `defaultPrivacyLevel`
 
-`defaultPrivacyLevel` now defaults to `mask-user-input` (previously `mask`). This provides better out-of-the-box privacy without the restrictions of full masking. The new default masks user input while other content is collected.
+`defaultPrivacyLevel` defaults to `mask-user-input` in v7 (previously `mask`). This provides better out-of-the-box privacy without the restrictions of full masking. The new default masks user input while other content is collected.
 
 To preserve full masking, explicitly set `defaultPrivacyLevel: "mask"`.
 
 #### `enablePrivacyForActionName` enabled by default
 
-`enablePrivacyForActionName` now defaults to `true`. Click action names follow the `defaultPrivacyLevel` setting by default. Use the [Datadog build plugin][36] or set `enablePrivacyForActionName: false` to opt out.
+`enablePrivacyForActionName` defaults to `true` in v7. Click action names follow the `defaultPrivacyLevel` setting by default. Use the [Datadog build plugin][36] or set `enablePrivacyForActionName: false` to opt out.
 
 #### `startDurationVital` and `stopDurationVital` API change
 
@@ -113,7 +113,7 @@ When a session expires and is renewed, the new view is created with `@view.loadi
 
 #### Document resource uses `PerformanceNavigationTiming`
 
-The initial document resource event previously used a synthetic timing entry. It now uses the browser's native `PerformanceNavigationTiming` directly, which may produce slightly different `resource.duration` values for the document resource. The `initiatorType` for the document resource changes from `initial_document` to `navigation`.
+The initial document resource event previously used a synthetic timing entry. It uses the browser's native `PerformanceNavigationTiming` directly in v7, which may produce slightly different `resource.duration` values for the document resource. The `initiatorType` for the document resource changes from `initial_document` to `navigation`.
 
 If you use plugins or domain context handlers that inspect `performanceEntry` for document resources, update them to expect a `PerformanceNavigationTiming` instead of `PerformanceResourceTiming`.
 
@@ -127,7 +127,7 @@ The `strategy` field has been removed from the plugin API. If you use `rum-react
 
 #### Improved action name computation
 
-The SDK always uses the tree walker strategy to compute action names, including in shadow DOM and Web Components. This was required to support the privacy build plugin. Action names may change slightly. The `betaTrackActionsInShadowDom` option has been removed.
+In v7, the SDK uses a new strategy for computing action names that takes into account the structure of the DOM to apply element privacy levels more precisely and improve handling of shadow DOM content. Action names may change slightly. The `betaTrackActionsInShadowDom` option has been removed.
 
 #### BFCache navigations always tracked
 
@@ -173,9 +173,9 @@ Requests cancelled by the application (aborted fetch or XHR) no longer generate 
 
 ### Session Replay
 
-#### New serialization algorithm
+#### New data format
 
-The new DOM mutation serialization algorithm (Change Records) is the default. It produces more accurate recordings and significantly reduces bandwidth usage. The segment format has changed; if you depend on the raw segment format, update your integration.
+In v7, session replay uses a new, more compact data format which significantly reduces bandwidth usage. Session replay data is not exposed directly through browser SDK APIs, so no action is required to adopt this change.
 
 ## From v5 to v6
 

--- a/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
@@ -16,11 +16,11 @@ Follow this guide to migrate between major versions of the Browser RUM and Brows
 
 ## From v6 to v7
 
-V7 improves privacy defaults, removes deprecated options, and modernizes the SDK internals. Most changes require configuration updates.
+The v7 SDK improves privacy defaults, removes deprecated options, and modernizes the SDK internals. Most changes require configuration updates.
 
 Take notice of the below breaking changes as you upgrade your SDK. Changes are grouped by area of impact.
 
-**Tip**: If you use an AI coding assistant that supports agent skills, you can apply the [`upgrade-browser-sdk-v7` skill][37] to automate most of the migration steps below.
+<div class="alert alert-tip"> If you use an AI coding assistant that supports agent skills, you can apply the <a href="https://github.com/DataDog/browser-sdk/blob/main/.claude/skills/upgrade-browser-sdk-v7/SKILL.md"><code>upgrade-browser-sdk-v7</code> skill</a> to automate most of the migration steps below. </div>
 
 ### Core
 
@@ -36,7 +36,7 @@ Previously, the sampling decision was made once at session creation and persiste
 
 The session storage key has changed from `_dd_s` to `_dd_s_v2` because the new session manager uses an incompatible storage format. On upgrade, existing sessions are automatically migrated from `_dd_s`.
 
-**Note**: Rolling back to v6 after migration starts a new session, because the v6 SDK does not read the `_dd_s_v2` key. If you have CSP or cookie policies that allowlist specific cookie names, add `_dd_s_v2`.
+**Note**: If you roll back to v6 after upgrading, the v6 SDK starts a new session because it does not read the `_dd_s_v2` key. If you have CSP or cookie policies that allowlist specific cookie names, add `_dd_s_v2`.
 
 #### Update the CDN bundle URL
 
@@ -52,7 +52,7 @@ Replace `<SITE>` with your Datadog site (for example, `us1`, `us3`, `us5`, `eu1`
 
 #### CDN bundles use ESM dynamic imports
 
-CDN bundles use ESM dynamic imports instead of CommonJS, significantly reducing webpack overhead and overall bundle size. If you use the CDN snippet, add the `crossorigin` attribute to the script tag:
+CDN bundles use ESM dynamic imports instead of CommonJS, which reduces webpack overhead and overall bundle size. If you use the CDN snippet, add the `crossorigin` attribute to the script tag:
 
 ```html
 <script src="https://www.datadoghq-browser-agent.com/..." crossorigin="anonymous"></script>
@@ -62,7 +62,7 @@ See the [setup documentation][26] for full snippet examples.
 
 #### ES2020 browser baseline
 
-Support for pre-ES2020 browsers has been dropped to remove compatibility shims and polyfills, reducing bundle size. Minimum supported versions are Chrome 80+, Firefox 78+, and Safari 14+. Estimated impact: ~0.048% less coverage.
+Support for pre-ES2020 browsers has been dropped to remove compatibility shims and polyfills, which reduces bundle size. Minimum supported versions are Chrome 80+, Firefox 78+, and Safari 14+. Estimated impact: ~0.048% less coverage.
 
 To continue supporting older browsers, keep using Browser SDK v6 or earlier.
 
@@ -87,17 +87,17 @@ Access-Control-Allow-Headers: traceparent, tracestate, baggage
 
 #### New default for `defaultPrivacyLevel`
 
-`defaultPrivacyLevel` defaults to `mask-user-input` in v7 (previously `mask`). This provides sensible out-of-the-box privacy without the restrictions of full masking. The new default masks user input while other content is collected.
+`defaultPrivacyLevel` defaults to `mask-user-input` in v7 (previously `mask`). This provides a privacy default that masks user input without the restrictions of full masking. The new default masks user input while other content is collected.
 
 To preserve full masking, explicitly set `defaultPrivacyLevel: "mask"`.
 
 #### `enablePrivacyForActionName` enabled by default
 
-`enablePrivacyForActionName` defaults to `true` in v7. Click action names follow the `defaultPrivacyLevel` setting by default. Set `enablePrivacyForActionName: false` to opt out. New masking capabilities are planned for the [Datadog build plugin][36].
+`enablePrivacyForActionName` defaults to `true` in v7. Click action names follow the `defaultPrivacyLevel` setting by default. Set `enablePrivacyForActionName: false` to opt out.
 
 #### `startDurationVital` and `stopDurationVital` API change
 
-The `DurationVitalReference` object has been replaced by a `vitalKey` string option. This aligns the API with `startResource`/`stopResource` and `startAction`/`stopAction`, and with the Mobile SDK, while still allowing multiple concurrent vitals with the same name:
+The `DurationVitalReference` object has been replaced by a `vitalKey` string option. This aligns the API with `startResource`/`stopResource` and `startAction`/`stopAction`, and with the Mobile SDK. Multiple concurrent vitals with the same name are still supported:
 
 ```js
 // Before
@@ -129,7 +129,7 @@ The `strategy` field has been removed from the plugin API. If you use `rum-react
 
 #### Improved action name computation
 
-In v7, the SDK uses a new strategy for computing action names that takes into account the structure of the DOM to apply element privacy levels more precisely and improve handling of shadow DOM content. Action names may change slightly. The `betaTrackActionsInShadowDom` option has been removed.
+In v7, the SDK uses a new strategy for computing action names that considers the DOM structure to apply element privacy levels more precisely and improve handling of shadow DOM content. Action names may change slightly. The `betaTrackActionsInShadowDom` option has been removed.
 
 #### BFCache navigations always tracked
 
@@ -153,7 +153,7 @@ To explicitly enable memory-backed sessions, use `sessionPersistence: 'memory'`.
 
 #### `forwardErrorsToLogs` and `forwardConsoleLogs` are independent
 
-Previously, enabling `forwardErrorsToLogs` also silently forwarded `console.error` calls. These options are now fully independent, giving you precise control over what gets forwarded. `forwardErrorsToLogs` controls unhandled errors only.
+Previously, enabling `forwardErrorsToLogs` also silently forwarded `console.error` calls. These options are now fully independent. You have precise control over what gets forwarded. `forwardErrorsToLogs` controls only unhandled errors.
 
 To preserve the previous behavior, add `error` to your `forwardConsoleLogs` array:
 
@@ -163,9 +163,9 @@ DD_LOGS.init({
 })
 ```
 
-#### Network errors for cancelled requests are dropped
+#### Network errors for canceled requests are dropped
 
-Requests cancelled by the application (aborted fetch or XHR) no longer generate a network error log. This reduces noise in error tracking.
+Requests canceled by the application (aborted fetch or XHR) no longer generate a network error log. This reduces noise in error tracking.
 
 #### Removed options
 
@@ -579,5 +579,3 @@ The RUM Browser SDK no longer lets you specify the source of an error collected 
 [33]: https://rollupjs.org/tutorial/#code-splitting
 [34]: https://parceljs.org/features/code-splitting
 [35]: https://developer.chrome.com/docs/web-platform/long-animation-frames#long-frames-api
-[36]: https://github.com/DataDog/build-plugins
-[37]: https://github.com/DataDog/browser-sdk/blob/main/.claude/skills/upgrade-browser-sdk-v7/SKILL.md

--- a/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
@@ -36,9 +36,21 @@ The session storage key has changed from `_dd_s` to `_dd_s_v2` because the new s
 
 **Note**: Rolling back to v6 after migration starts a new session, because the v6 SDK does not read the `_dd_s_v2` key. If you have CSP or cookie policies that allowlist specific cookie names, add `_dd_s_v2`.
 
+#### Update the CDN bundle URL
+
+If you load the SDK from the Datadog CDN, update the version segment of the bundle URL from `v6` to `v7`. This applies to all bundles:
+
+| Bundle   | URL                                                                     |
+| -------- | ----------------------------------------------------------------------- |
+| RUM      | `https://www.datadoghq-browser-agent.com/<SITE>/v7/datadog-rum.js`      |
+| RUM Slim | `https://www.datadoghq-browser-agent.com/<SITE>/v7/datadog-rum-slim.js` |
+| Logs     | `https://www.datadoghq-browser-agent.com/<SITE>/v7/datadog-logs.js`     |
+
+Replace `<SITE>` with your Datadog site (for example, `us1`, `us3`, `us5`, `eu1`, `ap1`, or `ap2`). See the [setup documentation][26] for the URL for your site.
+
 #### CDN bundles use ESM dynamic imports
 
-CDN bundles now use ESM dynamic imports instead of CommonJS, significantly reducing webpack overhead and overall bundle size. If you use the CDN snippet, add the `crossorigin` attribute:
+CDN bundles now use ESM dynamic imports instead of CommonJS, significantly reducing webpack overhead and overall bundle size. If you use the CDN snippet, add the `crossorigin` attribute to the script tag:
 
 ```html
 <script src="https://www.datadoghq-browser-agent.com/..." crossorigin="anonymous"></script>

--- a/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
@@ -569,7 +569,7 @@ The RUM Browser SDK no longer lets you specify the source of an error collected 
 [26]: /real_user_monitoring/application_monitoring/browser/
 [25]: /real_user_monitoring/correlate_with_other_telemetry/apm#opentelemetry-support
 [27]: /real_user_monitoring/guide/proxy-rum-data
-[28]: /real_user_monitoring/application_monitoring/browser/setup/#initialization-parameters
+[28]: https://datadoghq.dev/browser-sdk/interfaces/_datadog_browser-rum.RumInitConfiguration.html
 [29]: /real_user_monitoring/correlate_with_other_telemetry/apm?tab=browserrum#:~:text=configure%20the%20traceContextInjection
 [30]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import
 [31]: https://webpack.js.org/guides/code-splitting/#dynamic-imports

--- a/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
@@ -20,6 +20,8 @@ V7 improves privacy defaults, removes deprecated options, and modernizes the SDK
 
 Take notice of the below breaking changes as you upgrade your SDK. Changes are grouped by area of impact.
 
+**Tip**: If you use an AI coding assistant that supports agent skills, you can apply the [`upgrade-browser-sdk-v7` skill][37] to automate most of the migration steps below.
+
 ### Core
 
 #### Session manager rewrite
@@ -578,3 +580,4 @@ The RUM Browser SDK no longer lets you specify the source of an error collected 
 [34]: https://parceljs.org/features/code-splitting
 [35]: https://developer.chrome.com/docs/web-platform/long-animation-frames#long-frames-api
 [36]: https://github.com/DataDog/build-plugins
+[37]: https://github.com/DataDog/browser-sdk/blob/main/.claude/skills/upgrade-browser-sdk-v7/SKILL.md

--- a/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
+++ b/content/en/real_user_monitoring/guide/browser-sdk-upgrade.md
@@ -141,7 +141,7 @@ Resources and requests that occurred before the SDK initialized are automaticall
 
 #### Async chunk file names prefixed with `datadog`
 
-Async chunk file names include a `datadog` prefix (for example, `datadog-rum-recorder.js`). If you have CSP or caching rules matching the old names, update them accordingly.
+Async chunk filenames include a `datadog` prefix (for example, `datadog-rum-recorder.js`). If you have CSP or caching rules matching the old names, update them accordingly.
 
 ### Logs
 
@@ -153,7 +153,7 @@ To explicitly enable memory-backed sessions, use `sessionPersistence: 'memory'`.
 
 #### `forwardErrorsToLogs` and `forwardConsoleLogs` are independent
 
-Previously, enabling `forwardErrorsToLogs` also silently forwarded `console.error` calls. These options are now fully independent. You have precise control over what gets forwarded. `forwardErrorsToLogs` controls only unhandled errors.
+Previously, enabling `forwardErrorsToLogs` also silently forwarded `console.error` calls. In v7, these options are fully independent. You have precise control over what gets forwarded. `forwardErrorsToLogs` controls only unhandled errors.
 
 To preserve the previous behavior, add `error` to your `forwardConsoleLogs` array:
 
@@ -171,7 +171,7 @@ Requests canceled by the application (aborted fetch or XHR) no longer generate a
 
 | Deprecated option (v6 or earlier) | Replacement (v7)                                                           |
 | --------------------------------- | -------------------------------------------------------------------------- |
-| `usePciIntake`                    | The standard intake is now PCI compliant. Update your [CSP][18] if needed. |
+| `usePciIntake`                    | The standard intake is PCI compliant. Update your [CSP][18] if needed. |
 
 ### Session Replay
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Adds a new upgrade guide covering the Browser SDK v6 to v7 migration.

- Documents breaking changes across Core, RUM, Logs, and Session Replay packages
- Covers the session manager rewrite, new privacy defaults, removed options, and updated API surface

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

Used Claude Code to draft the upgrade guide content.

### Additional notes