### PR TITLE
Refactor date version selector to Bootstrap dropdown

### DIFF
--- a/assets/scripts/components/api.js
+++ b/assets/scripts/components/api.js
@@ -171,28 +171,41 @@ if (dataVersionToggles.length) {
     });
 }
 
-// Date-based API version selector (x-datadog-api-versioning / x-datadog-api-versioned)
+// Date-based API version selector dropdown (x-datadog-api-versioning / x-datadog-api-versioned)
 // Uses event delegation so it works regardless of DOM load order or collapsed sections.
 document.addEventListener('click', (e) => {
-    const tab = e.target.closest('.js-api-date-version-tab');
-    if (!tab) return;
+    const item = e.target.closest('.js-api-date-version-item');
+    if (!item) return;
 
     e.preventDefault();
-    e.stopPropagation();
 
-    const selectedVersion = tab.dataset.apiDateVersion;
-    const operationId = tab.dataset.operationId;
+    const selectedVersion = item.dataset.apiDateVersion;
+    const operationId = item.dataset.operationId;
 
     if (!selectedVersion || !operationId) return;
 
-    // Update active state on all tabs for this operation
-    document.querySelectorAll(`.js-api-date-version-tab[data-operation-id="${operationId}"]`).forEach((t) => {
-        t.classList.toggle('active', t === tab);
+    // Update active state on dropdown items
+    document.querySelectorAll(`.js-api-date-version-item[data-operation-id="${operationId}"]`).forEach((i) => {
+        i.classList.toggle('active', i === item);
     });
+
+    // Update the dropdown button label to show the selected version
+    const dropdown = item.closest('.js-api-date-version-dropdown');
+    if (dropdown) {
+        const label = dropdown.querySelector('.js-api-date-version-label');
+        if (label) {
+            label.textContent = selectedVersion;
+        }
+    }
 
     // Show the matching version pane, hide all others for this operation
     document.querySelectorAll(`.api-versioned-schema-pane[data-operation-id="${operationId}"]`).forEach((pane) => {
         pane.classList.toggle('d-none', pane.dataset.apiDateVersion !== selectedVersion);
+    });
+
+    // Update DD-API-VERSION header values in curl examples and SDK notes
+    document.querySelectorAll(`.api-version-header-value[data-operation-id="${operationId}"]`).forEach((el) => {
+        el.textContent = selectedVersion;
     });
 });
 

--- a/assets/styles/pages/_api.scss
+++ b/assets/styles/pages/_api.scss
@@ -262,3 +262,41 @@ $ddpurple: #632ca6;
         }
     }
 }
+
+// Date-based API version selector dropdown
+.js-api-date-version-dropdown {
+    .dropdown-toggle {
+        color: #333;
+        background: #fff;
+        border: 1px solid #c4c4c4;
+
+        &:hover,
+        &:focus,
+        &.show {
+            color: #fff;
+            background: $ddpurple;
+            border-color: $ddpurple;
+        }
+    }
+
+    .dropdown-item {
+        &:hover,
+        &:focus {
+            color: #fff;
+            background: $ddpurple;
+
+            .text-muted {
+                color: rgba(255, 255, 255, 0.7) !important;
+            }
+        }
+
+        &.active {
+            color: #fff;
+            background: $ddpurple;
+
+            .text-muted {
+                color: rgba(255, 255, 255, 0.7) !important;
+            }
+        }
+    }
+}

--- a/layouts/api/list.html
+++ b/layouts/api/list.html
@@ -72,6 +72,71 @@
 
     {{ $anchorStr := $menuChild.Name }}
     {{ $versionCount := (len $menuChild.Params.versions) }}
+
+    {{/* ---- Pre-scan: detect date-based API versioning for this operation ---- */}}
+    {{ $topDvScratch := newScratch }}
+    {{ $topDvScratch.Set "isDateVersioned" false }}
+    {{ $topDvScratch.Set "apiVersionsList" slice }}
+    {{ $topDvScratch.Set "baseVersion" "" }}
+    {{ $topDvScratch.Set "dateVersionOperationId" "" }}
+    {{ range $versionNum := $menuChild.Params.versions }}
+      {{ $specData := partial "api/load-specs.html" (dict "version" $versionNum) }}
+      {{ if $specData }}
+        {{ $gr := partial "api/regions.html" (dict "servers" $specData.servers) }}
+        {{ $ep := partial "api/get-endpoint.html" (dict "lang" $.Page.Lang "operationids" $menuChild.Params.operationids "spec" $specData "generalRegions" $gr) }}
+        {{ if $ep }}
+          {{ range $respCode, $resp := $ep.action.responses }}
+            {{ range $mt, $content := $resp.content }}
+              {{ if index $content.schema "x-datadog-api-versioned" }}
+                {{ $topDvScratch.Set "isDateVersioned" true }}
+                {{ $topDvScratch.Set "dateVersionOperationId" $ep.action.operationId }}
+              {{ end }}
+            {{ end }}
+          {{ end }}
+          {{ with $ep.action.requestBody }}
+            {{ range $mt, $content := .content }}
+              {{ if index $content.schema "x-datadog-api-versioned" }}
+                {{ $topDvScratch.Set "isDateVersioned" true }}
+                {{ $topDvScratch.Set "dateVersionOperationId" $ep.action.operationId }}
+              {{ end }}
+            {{ end }}
+          {{ end }}
+          {{ if $topDvScratch.Get "isDateVersioned" }}
+            {{ $apiVersioningData := index $specData "x-datadog-api-versioning" | default dict }}
+            {{ $versionMap := $apiVersioningData.versions | default dict }}
+            {{ $dateKeys := slice }}
+            {{ range $dk, $_ := $versionMap }}
+              {{ $dateKeys = append $dk $dateKeys }}
+            {{ end }}
+            {{ $dateKeys = sort $dateKeys }}
+            {{ $bvs := newScratch }}
+            {{ $bvs.Set "bv" "" }}
+            {{ range $dateKeys }}
+              {{ if (index $versionMap .).base }}
+                {{ $bvs.Set "bv" . }}
+              {{ end }}
+            {{ end }}
+            {{ $bv := $bvs.Get "bv" }}
+            {{ if and (eq $bv "") (gt (len $dateKeys) 0) }}
+              {{ $bv = index $dateKeys 0 }}
+            {{ end }}
+            {{ $topDvScratch.Set "baseVersion" $bv }}
+            {{ $vList := slice }}
+            {{ range $dateKeys }}
+              {{ $vd := index $versionMap . }}
+              {{ $vList = append (dict "date" . "isBase" ($vd.base | default false)) $vList }}
+            {{ end }}
+            {{ $topDvScratch.Set "apiVersionsList" $vList }}
+          {{ end }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+    {{ $topIsDateVersioned := $topDvScratch.Get "isDateVersioned" }}
+    {{ $topApiVersionsList := $topDvScratch.Get "apiVersionsList" }}
+    {{ $topBaseVersion := $topDvScratch.Get "baseVersion" }}
+    {{ $topDateVersionOpId := $topDvScratch.Get "dateVersionOperationId" }}
+    {{/* ---- End pre-scan ---- */}}
+
     <div class="row">
       <div class="col-12 {{ if gt (len $menuChild.Params.versions) 0 }}col-md-6{{ end }}">
           <h2 class="mb-2 api-task-description" id="{{ $anchorStr | anchorize }}">
@@ -82,6 +147,12 @@
       </div>
       {{ if gt (len $menuChild.Params.versions) 0 }}
       <div class="col-12 col-md-6 api-version-label-wrapper">
+          {{/* If date-versioned, show a dropdown instead of v1/v2 tabs */}}
+          {{ if $topIsDateVersioned }}
+            <div class="d-flex justify-content-md-end align-items-center gap-2">
+              {{ partial "api/date-version-selector.html" (dict "operationId" $topDateVersionOpId "versions" $topApiVersionsList "baseVersion" $topBaseVersion) }}
+            </div>
+          {{ else }}
           <ul class="nav nav-tabs response-toggle border-none justify-content-md-end">
             {{ range $versionIndex, $versionNum := $menuChild.Params.versions }}
               {{ $adat := cond (eq $versionNum "v1") $d $d2 }}
@@ -93,6 +164,7 @@
               </li>
             {{ end }}
           </ul>
+          {{ end }}
       </div>
       {{ end }}
     </div>
@@ -110,7 +182,7 @@
         {{ $endpoint := partial "api/get-endpoint.html" (dict "lang" $.Page.Lang "operationids" $menuChild.Params.operationids "spec" $adat "generalRegions" $generalRegions ) }}
         {{ $endpointVisibility := partial "api/endpoint-visibility.html" (dict "versionCount" $versionCount "versionNum" $versionNum "menuChild" $menuChild "endpoint" $endpoint) }}
 
-        <div data-title="{{ $versionNum }}" id="{{ (print $anchorStr "-" $versionNum) | anchorize }}" class="{{- if and (eq (len $menuChild.Params.versions) 1) ($endpoint.action.deprecated | default false) -}}collapse{{- else -}}tab-pane{{- end -}} {{ if $endpointVisibility.isVisibleVersion }} active{{ end }}" role="tabpanel">
+        <div data-title="{{ $versionNum }}" id="{{ (print $anchorStr "-" $versionNum) | anchorize }}" class="{{- if $topIsDateVersioned -}}{{/* no tab-pane — content always visible when date-versioned */}}{{- else if and (eq (len $menuChild.Params.versions) 1) ($endpoint.action.deprecated | default false) -}}collapse{{- else -}}tab-pane{{- end -}} {{ if or $topIsDateVersioned $endpointVisibility.isVisibleVersion }} active{{ end }}" {{ if not $topIsDateVersioned }}role="tabpanel"{{ end }}>
 
         <!-- for accessing v1/v2 resources from latest -->
         {{ $resourcePage := $dot.Site.GetPage (print "/api/" $versionNum "/" $baseDir "") }}
@@ -208,13 +280,7 @@
                         {{- end -}}
                       </p>
 
-                      {{ if $isDateVersioned }}
-                      <!-- Date-based API version selector -->
-                      <div class="d-flex justify-content-end align-items-center gap-2 mt-1 mb-2">
-                        <small class="text-muted fw-semibold">API version:</small>
-                        {{ partial "api/date-version-selector.html" (dict "operationId" $endpoint.action.operationId "versions" $apiVersionsList "baseVersion" $baseVersion) }}
-                      </div>
-                      {{ end }}
+                      {{/* Date-based API version dropdown is rendered in the top-level version label area */}}
 
                       <h3 class="mt-2">{{ i18n "overview" }}</h3>
                       <p>
@@ -233,7 +299,7 @@
                       {{ partial "api/response.html" (dict "responses" $endpoint.action.responses "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "translate_action" $translate_action "version" $versionNum "isDateVersioned" $isDateVersioned "apiVersionsList" $apiVersionsList "baseVersion" $baseVersion "spec" $adat) }}
 
                       <!-- code example -->
-                      {{ partial "api/code-example.html" (dict "context" $dot "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "securitySchemes" $adat.components.securitySchemes "endpoint" $endpoint "version" $versionNum) }}
+                      {{ partial "api/code-example.html" (dict "context" $dot "resourcePage" $resourcePage "operationid" $endpoint.action.operationId "securitySchemes" $adat.components.securitySchemes "endpoint" $endpoint "version" $versionNum "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion) }}
                   </div>
               </div>
           </div>

--- a/layouts/partials/api/code-example.html
+++ b/layouts/partials/api/code-example.html
@@ -5,6 +5,8 @@
 {{ $endpoint := .endpoint }}
 {{ $version := .version }}
 {{ $securitySchemes := .securitySchemes }}
+{{ $isDateVersioned := .isDateVersioned | default false }}
+{{ $baseVersion := .baseVersion | default "" }}
 {{- $codeExampleLookup := (index (index $context.Site.Data.api $version) "CodeExamples") -}}
 
 <h3 class="mb-2">{{ i18n "code_example" }}</h3>
@@ -157,15 +159,15 @@
                                                   {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
                                               {{- end -}}
                                             {{- end -}}
-                                            {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                                            {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                                           {{- end -}}
                                       {{- else -}}
-                                        {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                                        {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                                       {{- end -}}
                                   {{- end -}}
                               {{- end -}}
                           {{- else -}}
-                            {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description) }}
+                            {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "body" $body "title" $item.description "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                           {{- end -}}
                           </code>
                         </pre>
@@ -214,15 +216,15 @@
                                             {{- $exampleValue = $exampleValue | jsonify (dict "indent" "  ") -}}
                                         {{- end -}}
                                       {{- end -}}
-                  {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                  {{ partial "api/curl.html" (dict "contentType" $contentType "exampleValue" $exampleValue "exampleId" $exampleId "exampleDefinition" $exampleDefinition "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                                   {{- end -}}
                               {{- else -}}
-                  {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                  {{ partial "api/curl.html" (dict "contentType" $contentType "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                               {{- end -}}
                           {{- end -}}
                       {{- end -}}
                   {{- else -}}
-                  {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary) }}
+                  {{ partial "api/curl.html" (dict "context" $context "securitySchemes" $securitySchemes "dollarScratch" $context.Scratch "endpoint" $endpoint "title" $endpoint.action.summary "isDateVersioned" $isDateVersioned "baseVersion" $baseVersion "operationId" $operationid) }}
                   {{- end -}}
                   </code>
                 </pre>
@@ -261,6 +263,11 @@
     {{ $myItems := (index ($s.Get "items") $lang.name) }}
     {{ if gt $numOfCodeExamples 0 }}
     <div class="code-snippet-wrapper js-code-block append-copy-btn" data-code-lang-block="{{ $lang.name }}">
+      {{ if $isDateVersioned }}
+      <div class="alert alert-info py-2 px-3 mb-2 small api-version-sdk-note" data-operation-id="{{ $operationid }}">
+        Include the header <code>DD-API-VERSION: <span class="api-version-header-value" data-operation-id="{{ $operationid }}">{{ $baseVersion }}</span></code> in your request.
+      </div>
+      {{ end }}
       {{ if gt $numOfCodeExamples 1 }}<div class="example-accordion" id="accordion-{{ $operationid | lower }}-{{ $version }}-{{ $lang.name }}">{{ end }}
         {{ range $i, $item := $myItems | first 3 }}
             {{ $fileStr := (printf "%s%s.%s" $operationid $item.suffix $file_extension) }}

--- a/layouts/partials/api/curl.html
+++ b/layouts/partials/api/curl.html
@@ -162,6 +162,11 @@
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.apiKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.apiKeyAuth "x-env-name" -}} }</span>"</span> \
 <span class="o">-H</span> <span class="s1">"{{ $securitySchemes.appKeyAuth.name }}: <span class="n">${ {{- index $securitySchemes.appKeyAuth "x-env-name" -}} }</span>"</span>
 {{- end -}}
+{{- /* DD-API-VERSION header for date-versioned operations */ -}}
+{{- if .isDateVersioned -}}
+{{ " \\" }}
+<span class="o">-H</span> <span class="s1">"DD-API-VERSION: <span class="api-version-header-value" data-operation-id="{{ .operationId }}">{{ .baseVersion }}</span>"</span>
+{{- end -}}
 {{- /* Render binary data (usually compressed) */ -}}
 {{- if gt (len $contentEncoding) 0 -}}
 {{- if eq $contentEncoding "gzip" -}}

--- a/layouts/partials/api/date-version-selector.html
+++ b/layouts/partials/api/date-version-selector.html
@@ -1,5 +1,5 @@
 {{/*
-  Renders date-based API version selector tabs for a versioned operation.
+  Renders a date-based API version selector dropdown for a versioned operation.
   Params:
     operationId  - string, the endpoint's operationId
     versions     - slice of dicts: {date string, isBase bool}
@@ -9,21 +9,27 @@
 {{ $versions    := .versions }}
 {{ $baseVersion := .baseVersion }}
 
-<ul class="nav nav-tabs response-toggle border-none justify-content-md-end mb-0"
-    role="tablist"
-    aria-label="API date version">
-  {{ range $versions }}
-    <li class="nav-item">
-      <button type="button"
-              class="nav-link me-1 js-api-date-version-tab {{ if eq .date $baseVersion }}active{{ end }}"
-              data-api-date-version="{{ .date }}"
-              data-operation-id="{{ $operationId }}">
+<div class="dropdown d-inline-block js-api-date-version-dropdown"
+     data-operation-id="{{ $operationId }}">
+  <button class="btn btn-sm dropdown-toggle"
+          type="button"
+          data-bs-toggle="dropdown"
+          aria-haspopup="true"
+          aria-expanded="false"
+          style="min-width: 130px;">
+    <span class="js-api-date-version-label">{{ $baseVersion }}</span>
+  </button>
+  <div class="dropdown-menu dropdown-menu-end" style="min-width: 130px;">
+    {{ range $versions }}
+      <a class="dropdown-item js-api-date-version-item {{ if eq .date $baseVersion }}active{{ end }}"
+         href="#"
+         data-api-date-version="{{ .date }}"
+         data-operation-id="{{ $operationId }}">
         {{- .date -}}
         {{- if .isBase }}
-          <span class="badge bg-secondary ms-1 api-version-default-badge"
-                title="Default — non-versioned requests use this version">default</span>
+          <small class="text-muted ms-1">(default)</small>
         {{- end }}
-      </button>
-    </li>
-  {{ end }}
-</ul>
+      </a>
+    {{ end }}
+  </div>
+</div>


### PR DESCRIPTION
## Summary
- Replace nav-tabs with a Bootstrap dropdown for the date-based API version selector, placed in the top-level version label area (replacing v1/v2 tabs when date-versioned)
- Add `DD-API-VERSION` header to curl examples and an SDK note banner, both updating dynamically when the user switches versions
- Move inline `<style>` block to `_api.scss` using the existing `$ddpurple` variable

## Test plan
- [ ] Verify the dropdown appears in place of v1/v2 tabs for date-versioned operations
- [ ] Verify selecting a version updates the dropdown label, schema pane, curl header, and SDK note
- [ ] Verify non-date-versioned operations still show v1/v2 tabs as before
- [ ] Verify hover/focus/active states on the dropdown button and items

🤖 Generated with [Claude Code](https://claude.com/claude-code)