### PR TITLE
Rename Bits AI to Bits AI SRE in API page headers

### DIFF
--- a/content/en/api/latest/bits-ai/_index.md
+++ b/content/en/api/latest/bits-ai/_index.md
@@ -1,3 +1,3 @@
 ---
-title: Bits AI
+title: Bits AI SRE
 ---

--- a/content/en/api/v2/bits-ai/_index.md
+++ b/content/en/api/v2/bits-ai/_index.md
@@ -1,4 +1,4 @@
 ---
-title: Bits AI
+title: Bits AI SRE
 headless: true
 ---


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the page title on [docs.datadoghq.com/api/latest/bits-ai/](https://docs.datadoghq.com/api/latest/bits-ai/) from "Bits AI" to "Bits AI SRE" to reflect the correct product name.

**Note:** The operation section headers (Trigger / List / Get) are driven by `full_spec.yaml`, which is auto-generated from `datadog-api-spec`. Those changes are tracked in the companion spec PR below.

### Companion spec PR

https://github.com/DataDog/datadog-api-spec/pull/5522

Once that spec PR is merged by `#api-platform`, the pipeline bot will auto-update `full_spec.yaml` here, completing the rename on the live page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Claude Code to find and update the relevant files, and to identify that `full_spec.yaml` is auto-generated.

### Additional notes

Files changed:
- `content/en/api/latest/bits-ai/_index.md` — page title: Bits AI → Bits AI SRE
- `content/en/api/v2/bits-ai/_index.md` — page title: Bits AI → Bits AI SRE