### PR TITLE
[DDSQL-1527] Remove ddsql toolset Preview label from MCP docs

### DIFF
--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -635,8 +635,6 @@ Searches [Database Monitoring][26] query samples, which represent individual que
 
 Tools for querying Datadog data using [DDSQL][41], a SQL dialect with support for infrastructure resources, logs, metrics, RUM, spans, and other Datadog data sources.
 
-<div class="alert alert-info">The <code>ddsql</code> toolset is in Preview.</div>
-
 ### `ddsql_get_spec`
 *Toolset: **ddsql***\
 Gets a compact DDSQL capability spec, including supported SQL functions, SQL keywords, and DDSQL-specific differences from standard PostgreSQL. Call this tool before composing queries to understand supported syntax.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DDSQL-1527

The `ddsql` toolset is now generally available. This removes the `(Preview)` label from the toolset list and the Preview alert banner that appeared before the `ddsql_get_spec` tool description in `content/en/bits_ai/mcp_server/_index.md`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes