### PR TITLE
[web-7879] adds a url map

### DIFF
--- a/config/_default/config.yaml
+++ b/config/_default/config.yaml
@@ -238,6 +238,11 @@ outputFormats:
     isPlainText: true
     mediaType: "text/plain"
     notAlternative: true
+  URLMap:
+    baseName: "urlmap"
+    isPlainText: true
+    mediaType: "application/json"
+    notAlternative: true
 
 timeout: 300s
 

--- a/config/_default/languages.yaml
+++ b/config/_default/languages.yaml
@@ -8,6 +8,7 @@ en:
       - Search
       - Partners
       - Redirects
+      - URLMap
     page:
       - HTML
 

--- a/layouts/_default/list.urlmap.json
+++ b/layouts/_default/list.urlmap.json
@@ -1,4 +1,4 @@
-{{- if ne hugo.Environment "development" -}}
+{{- if eq hugo.Environment "live" -}}
 {{- $urlmap := dict -}}
 {{- range where .Site.AllPages "Kind" "!=" "home" -}}
     {{- $page := . -}}

--- a/layouts/_default/list.urlmap.json
+++ b/layouts/_default/list.urlmap.json
@@ -1,0 +1,13 @@
+{{- if ne hugo.Environment "development" -}}
+{{- $urlmap := dict -}}
+{{- range where .Site.AllPages "Kind" "!=" "home" -}}
+    {{- $page := . -}}
+    {{- if eq $page.Language.Lang "en" -}}
+        {{- with $page.File -}}
+            {{- $filepath := print "content/en/" .Path -}}
+            {{- $urlmap = merge $urlmap (dict $filepath $page.RelPermalink) -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+{{- $urlmap | jsonify -}}
+{{- end -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
adds a simple map linking a url with it's relative file path in hugo.   this will be used in the translation pipeline to link popular docs URLs with the file path we need to prioritize in phrase.

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

claude made it

### Additional notes
https://docs-staging.datadoghq.com/brian.deutsch/web-7879-url-map/urlmap.json
