### PR TITLE
Update MCP tool call metric name and add query example

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -66,20 +66,14 @@ All tool calls are recorded in the Datadog [Audit Trail][16] with metadata ident
 Datadog also emits two standard metrics that you can use to monitor MCP Server activity:
 
 - `datadog.mcp.session.starts`: Emitted on each session initialization.
-- `datadog.mcp.tool.usage`: A distribution metric emitted on each tool call, tagged with `tool_name`.
+- `datadog.mcp.tool.usage`: A distribution metric emitted on each tool call.
 
-Both metrics are tagged with `user_id`, `user_email`, and `client` (the MCP client name, such as `claude` or `cursor`).
+Both metrics are tagged with attributes such as `user_id`, `user_email`, and `client` (the MCP client name, such as `claude` or `cursor`).
 
-Because `datadog.mcp.tool.usage` is a distribution metric, use `count` (not `sum`) with `.as_count()` to get the number of tool calls. For example, to query the total number of tool calls:
-
-```
-count:datadog.mcp.tool.usage{*}.as_count()
-```
-
-To break down tool calls by tool name, group by the `tool_name` tag:
+Because `datadog.mcp.tool.usage` is a distribution metric, use `count` (not `sum`) with `.as_count()` to get the number of tool calls. For example, to query the total number of tool calls grouped by user email:
 
 ```
-count:datadog.mcp.tool.usage{*} by {tool_name}.as_count()
+count:datadog.mcp.tool.usage{*} by {user_email}.as_count()
 ```
 
 ## Available tools

--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -66,9 +66,21 @@ All tool calls are recorded in the Datadog [Audit Trail][16] with metadata ident
 Datadog also emits two standard metrics that you can use to monitor MCP Server activity:
 
 - `datadog.mcp.session.starts`: Emitted on each session initialization.
-- `datadog.mcp.tool.calls`: Emitted on each tool call, tagged with `tool_name`.
+- `datadog.mcp.tool.usage`: A distribution metric emitted on each tool call, tagged with `tool_name`.
 
 Both metrics are tagged with `user_id`, `user_email`, and `client` (the MCP client name, such as `claude` or `cursor`).
+
+Because `datadog.mcp.tool.usage` is a distribution metric, use `count` (not `sum`) with `.as_count()` to get the number of tool calls. For example, to query the total number of tool calls:
+
+```
+count:datadog.mcp.tool.usage{*}.as_count()
+```
+
+To break down tool calls by tool name, group by the `tool_name` tag:
+
+```
+count:datadog.mcp.tool.usage{*} by {tool_name}.as_count()
+```
 
 ## Available tools
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the Datadog MCP Server docs to reflect the correct metric name for tracking tool calls:

- Renames `datadog.mcp.tool.calls` to `datadog.mcp.tool.usage`.
- Clarifies that `datadog.mcp.tool.usage` is a distribution metric.
- Adds an example showing how to query it using `count` (not `sum`) with `.as_count()`:

  ```
  count:datadog.mcp.tool.usage{*}.as_count()
  ```

- Adds a second example grouping by `tool_name`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes