### PR TITLE
[MLOB-7336] Document automatic user/session tagging from RUM baggage

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -2506,6 +2506,20 @@ public class MyJavaClass {
 {{% /tab %}}
 {{< /tabs >}}
 
+### Automatic tagging from RUM baggage
+
+When the [RUM Browser SDK][11] has `propagateTraceBaggage` enabled, it injects OTel baggage (`session.id`, `user.id`, `account.id`) on outbound HTTP requests. The Python and Node.js LLMObs SDKs automatically read these baggage values from the active trace context and apply them to LLMObs spans using Datadog standard attribute names:
+
+| OTel baggage key | LLMObs span tag |
+|---|---|
+| `session.id` | `session_id` |
+| `user.id` | `usr.id` |
+| `account.id` | `usr.account_id` |
+
+This links every LLMObs trace back to the originating RUM session and user without any manual tagging. Explicit values set through `LLMObs.annotate()` (or `session_id` on the root span decorator) take precedence over baggage-derived values.
+
+[11]: /real_user_monitoring/browser/
+
 ## Distributed tracing
 
 The SDK supports tracing across distributed services or hosts. Distributed tracing works by propagating span information across web requests.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes [MLOB-7336](https://datadoghq.atlassian.net/browse/MLOB-7336)

Documents the new automatic user/session tagging behavior in the Python and Node.js LLMObs SDKs. When the RUM Browser SDK's `propagateTraceBaggage` option is enabled, outgoing requests carry OTel baggage (`session.id`, `user.id`, `account.id`). The LLMObs SDKs now read those values from the active trace context and auto-apply them to LLMObs spans as Datadog standard attributes (`session_id`, `usr.id`, `usr.account_id`). Explicit `LLMObs.annotate()` values still take precedence.

Companion SDK PRs (land these first):
- [DataDog/dd-trace-py#17701](https://github.com/DataDog/dd-trace-py/pull/17701)
- [DataDog/dd-trace-js#8083](https://github.com/DataDog/dd-trace-js/pull/8083)

Parent epic: [MLOB-7330](https://datadoghq.atlassian.net/browse/MLOB-7330)

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Holding as draft until the SDK PRs ship so the docs don't describe unreleased behavior.