### PR TITLE
Update RUM Managed Archive permissions table

### DIFF
--- a/content/en/real_user_monitoring/managed_archive.md
+++ b/content/en/real_user_monitoring/managed_archive.md
@@ -59,9 +59,9 @@ Access to Managed Archive and Recovery is controlled through role-based access c
 
 | Permission | Capability | Default Role |
 |---|---|---|
-| `rum_recovery_read` | View the Managed Archive configuration and stored sessions, but cannot edit the configuration or recover sessions | Standard |
-| `rum_recovery_write` | Turn session storage on or off for an application | Admin |
-| `rum_recovery_index` | Recover sessions | Admin |
+| RUM Managed Archive Read | View the Managed Archive configuration and stored sessions, but cannot edit the configuration or recover sessions | Standard |
+| RUM Managed Archive Config Write | Turn session storage on or off for an application | Admin |
+| RUM Recovery Index | Recover sessions | Admin |
 
 ## Setup
 

--- a/content/en/real_user_monitoring/managed_archive.md
+++ b/content/en/real_user_monitoring/managed_archive.md
@@ -59,7 +59,7 @@ Access to Managed Archive and Recovery is controlled through role-based access c
 
 | Permission | Capability | Default Role |
 |---|---|---|
-| `rum_recovery_read` | View the Managed Archive configuration and stored sessions, but cannot edit the configuration or recover sessions | Admin |
+| `rum_recovery_read` | View the Managed Archive configuration and stored sessions, but cannot edit the configuration or recover sessions | Standard |
 | `rum_recovery_write` | Turn session storage on or off for an application | Admin |
 | `rum_recovery_index` | Recover sessions | Admin |
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the RUM Managed Archive permissions table to reflect the current product behavior:

- Changes the default role for `rum_recovery_read` from **Admin** to **Standard**
- Replaces the raw permission identifiers with their display names: **RUM Managed Archive Read**, **RUM Managed Archive Config Write**, **RUM Recovery Index**

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes