### PR TITLE
[DOCS-14099, DOCS-13997] Fix broken guide link and update nav for integration override removal

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -4449,8 +4449,8 @@ menu:
       parent: tracing_services
       identifier: tracing_service_remapping_rules
       weight: 908
-    - name: Service Override Removal
-      url: tracing/services/service_override_removal
+    - name: Integration Override Removal
+      url: tracing/services/integration_override_removal
       parent: tracing_services
       identifier: tracing_service_override_removal
       weight: 909

--- a/content/en/tracing/guide/_index.md
+++ b/content/en/tracing/guide/_index.md
@@ -21,7 +21,7 @@ cascade:
     {{< nextlink href="tracing/guide/apm_dashboard" >}}3. Create a Dashboard to track and correlate APM metrics{{< /nextlink >}}
     {{< nextlink href="tracing/guide/slowest_request_daily" >}}4. Debug the slowest trace on the slowest endpoint of a web service{{< /nextlink >}}
     <a id="enabling-tracing-tutorials">
-    {{< nextlink href="tracing/guide/add_span_md_and_graph_it" >}}5. Add span tags and filter and group your application performance{{< /nextlink >}}
+    {{< nextlink href="tracing/trace_collection/custom_instrumentation" >}}5. Add span tags and filter and group your application performance{{< /nextlink >}}
     {{< nextlink href="tracing/guide/instrument_custom_method" >}}6. Instrument a custom method to get deep visibility into your business logic.{{< /nextlink >}}
 {{< /whatsnext >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14099, DOCS-13997

Two quick fixes:
- **Broken link** (`tracing/guide/_index.md`): The "Add span tags" guide link pointed to `add_span_md_and_graph_it`, a page removed in #22038. Updated to point to `tracing/trace_collection/custom_instrumentation`.
- **Nav rename** (`menus/main.en.yaml`): The side nav still said "Service Override Removal" with the old URL. Updated to "Integration Override Removal" with the canonical URL, matching the page title renamed in #34455.

### References

- #22038 — removed `add_span_md_and_graph_it` guide
- #34455 — renamed page from `service_override_removal` to `integration_override_removal`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes