### PR TITLE
[DOCS-12719] Add Quartz to .NET verified OTel instrumentation libraries

### DIFF
--- a/content/en/opentelemetry/instrument/dd_sdks/instrumentation_libraries.md
+++ b/content/en/opentelemetry/instrument/dd_sdks/instrumentation_libraries.md
@@ -413,6 +413,7 @@ class Program
 | Library           | Versions | NuGet package                     | Integration Name     | Setup instructions            |
 | ----------------- | -------- | --------------------------------- | -------------------- | ----------------------------- |
 | Azure Service Bus | 7.14.0+ | [Azure.Messaging.ServiceBus][2]  | `AzureServiceBus`    | See `Azure SDK` section below |
+| Quartz            | 3.1.0+  | [Quartz][30]                     | `Quartz`             | `DD_TRACE_OTEL_ENABLED=true`  |
 
 ### Azure SDK
 
@@ -421,6 +422,7 @@ The Azure SDK provides built-in OpenTelemetry support. Enable it by setting the 
 [1]: https://opentelemetry.io/docs/languages/net/libraries/#use-natively-instrumented-libraries
 [2]: https://www.nuget.org/packages/Azure.Messaging.ServiceBus
 [3]: https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/samples/Diagnostics.md#enabling-experimental-tracing-features
+[30]: https://www.nuget.org/packages/Quartz
 {{% /tab %}}
 
 {{% tab "Ruby" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-12719

Adds the Quartz integration (v3.1.0+) to the "Verified OpenTelemetry Instrumentation Libraries" table in the .NET tab on the OTel instrumentation libraries page. This feature is already released but was missing from the docs.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes