### PR TITLE
[DOCS-10142] Clarify OTLP exporter configuration in application

### DIFF
--- a/content/en/opentelemetry/setup/otlp_ingest_in_the_agent.md
+++ b/content/en/opentelemetry/setup/otlp_ingest_in_the_agent.md
@@ -321,7 +321,23 @@ There are many other environment variables and settings supported in the Datadog
 
 ## Sending OpenTelemetry traces, metrics, and logs to Datadog Agent
 
+After enabling OTLP ingestion on the Datadog Agent, configure your OpenTelemetry-instrumented application to export telemetry data to the Agent's OTLP endpoint. Set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable in your **application** environment to direct data to the Agent. Without this configuration, your application does not send telemetry data to the Agent, even if the Agent's OTLP receiver is enabled.
+
 {{< tabs >}}
+{{% tab "Host" %}}
+Set the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable in your application's environment:
+
+For gRPC:
+```shell
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4317"
+```
+
+For HTTP:
+```shell
+export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318"
+```
+{{% /tab %}}
+
 {{% tab "Docker" %}}
 1. For the application container, set `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable to point to the Datadog Agent container. For example:
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-10142

Adds a clarifying intro paragraph to the "Sending OpenTelemetry traces, metrics, and logs to Datadog Agent" section, explicitly stating that the application must be configured to export telemetry data via OTLP. Also adds a missing Host tab with `OTEL_EXPORTER_OTLP_ENDPOINT` examples for gRPC and HTTP.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes