### PR TITLE
[DOCS-9945] Fix Istio service name default and add DD_SERVICE override

### DIFF
--- a/content/en/tracing/trace_collection/proxy_setup/istio.md
+++ b/content/en/tracing/trace_collection/proxy_setup/istio.md
@@ -58,14 +58,26 @@ Traces are generated when Istio is able to determine the traffic is using an HTT
 By default, Istio tries to automatically detect this. It can be manually configured by naming the ports in your
 application's deployment and service. More information can be found in Istio's documentation for [Protocol Selection][7]
 
-By default, the service name used when creating traces is generated from the deployment name and namespace. This can be
-set manually by adding an `app` label to the deployment's pod template:
+By default, the service name used when creating traces is derived from the `app` label on the pod and the pod's namespace. If the `app` label is not set, the service name defaults to `istio-proxy`.
+
+To set a custom service name, add an `app` label to the deployment's pod template:
 
 ```yaml
 template:
   metadata:
     labels:
       app: <SERVICE_NAME>
+```
+
+Alternatively, override the service name with the `DD_SERVICE` environment variable through the [`proxy.istio.io/config` annotation](#environment-variables):
+
+```yaml
+template:
+  metadata:
+    annotations:
+      proxy.istio.io/config: |
+        proxyMetadata:
+          "DD_SERVICE": "<SERVICE_NAME>"
 ```
 
 For [CronJobs][8], the `app` label should be added to the job template, as the generated name comes from the `Job` instead


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-9945

Corrects the Istio proxy setup documentation for service naming:

- **Fixes inaccurate default description**: The docs stated the default service name is "generated from the deployment name and namespace." The actual default (per Istio's `APP_LABEL_AND_NAMESPACE` TracingServiceName mode) is derived from the `app` label on the pod and the pod's namespace. If the `app` label is not set, the service name defaults to `istio-proxy`.
- **Adds `DD_SERVICE` override**: Documents how to override the service name using the `DD_SERVICE` environment variable through the `proxy.istio.io/config` annotation, which is the Datadog-native approach.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes