### PR TITLE
Add missing newly introduced sane RDS configuration

### DIFF
--- a/content/en/database_monitoring/setup_postgres/aurora.md
+++ b/content/en/database_monitoring/setup_postgres/aurora.md
@@ -212,6 +212,7 @@ To configure collecting Database Monitoring metrics for an Agent running on a ho
    instances:
      - dbm: true
        host: '<AWS_INSTANCE_ENDPOINT>'
+       ssl: allow
        port: 5432
        username: datadog
        password: 'ENC[datadog_user_database_password]'


### PR DESCRIPTION
What does this PR do? What is the motivation?
Documents configuration needed for the Database Monitoring Agent against PostgreSQL on Amazon RDS when SSL is enforced.

Background: New RDS instances use rds.force_ssl = 1 by default. Agent versions prior to 7.49 may fail to connect without an explicit SSL setting. When the Agent runs queries, PostgreSQL can return:

FATAL: no pg_hba.conf entry for host "HOSTNAME", user "datadog", database "postgres", no encryption

Change: For each instance config where host and port are set, document adding:

ssl: allow

so the Agent can connect using SSL. This aligns with guidance for PostgreSQL 15 / RDS upgrades and forced SSL; see [Upgrade to PostgreSQL 15](https://docs.datadoghq.com/database_monitoring/guide/pg15_upgrade/?tab=rds).

Merge instructions
Merge readiness:


 Ready for merge
For Datadog employees:

Your branch name MUST follow the <name>/<description> convention and include the forward slash (/). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the Squash and Merge button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

AI assistance
Additional notes
Targets readers on RDS + PostgreSQL who hit no encryption / pg_hba errors after SSL-related defaults changed; complements the existing pg15 upgrade guide rather than replacing it.