### PR TITLE
[DOCS-14199] Trim trailing whitespace in Product Analytics docs

### DIFF
--- a/content/en/product_analytics/charts/chart_basics.md
+++ b/content/en/product_analytics/charts/chart_basics.md
@@ -19,24 +19,24 @@ further_reading:
 
 ## Overview
 
-Charts help you turn user data into actionable insights by visualizing trends, funnels, and key product metrics. Use charts to answer common product questions, such as how users move through a funnel, how engagement changes over time, and how adoption varies across segments. 
+Charts help you turn user data into actionable insights by visualizing trends, funnels, and key product metrics. Use charts to answer common product questions, such as how users move through a funnel, how engagement changes over time, and how adoption varies across segments.
 
 This page introduces the core charting capabilities available across Product Analytics, including:
 
-- [Creating charts](#create-a-chart) 
+- [Creating charts](#create-a-chart)
 - [Saving individual charts](#save-a-chart)
 - [Sharing charts internally and externally](#share-a-chart)
 - [Using prebuilt chart templates](#start-from-a-template)
 
-## Create a chart 
+## Create a chart
 Create charts to explore user behavior and visualize product metrics. For example, use a funnel chart to understand where users drop off during onboarding.
 
-To create a chart, click **New Chart** on the [Chart List page][1] and select the chart type you want to build. For guidance on choosing the right option for your use case, see [Deciding which chart to use][2]. 
+To create a chart, click **New Chart** on the [Chart List page][1] and select the chart type you want to build. For guidance on choosing the right option for your use case, see [Deciding which chart to use][2].
 
 {{< img src="product_analytics/chart_basics/pana_chart_basics_new2.png" alt="Chart List page showing the New Chart button with options to select a chart type." style="width:100%;" >}}
 
 
-## Save a chart 
+## Save a chart
 Save charts to track key product metrics over time and return to your analyses as the data evolves. For example, you can use a saved chart to follow weekly conversion rates or feature adoption.
 
 Use the pencil icon to **edit** the name of the chart. Then, click **Save** at the top-right corner to save the chart. You can view your saved chart on the [Chart List page][1].
@@ -47,16 +47,16 @@ Use the pencil icon to **edit** the name of the chart. Then, click **Save** at t
 ## Share a chart
 Share charts to make product insights available across dashboards, notebooks, and your teams. For example, you can add a conversion funnel to a weekly product dashboard to align stakeholders on product performance.
 
-To add a chart to a dashboard or a notebook, click **+ Add To** in the top-right corner of the chart. Then, select whether to add it to an existing dashboard or notebook, or to a new one. 
+To add a chart to a dashboard or a notebook, click **+ Add To** in the top-right corner of the chart. Then, select whether to add it to an existing dashboard or notebook, or to a new one.
 
 
-To share a link to a chart, click **Share** to copy the link to your clipboard. Then paste and share this link through the method of your choice. Team members with Datadog access are directed to the live chart in Product Analytics, while users without Datadog access see a static snapshot of the chart. 
+To share a link to a chart, click **Share** to copy the link to your clipboard. Then paste and share this link through the method of your choice. Team members with Datadog access are directed to the live chart in Product Analytics, while users without Datadog access see a static snapshot of the chart.
 
 {{< img src="product_analytics/chart_basics/pana_chart_basics_share_add.png" alt="Chart editor view showing the Add To button for sharing charts to a dashboard or to a notebook." style="width:100%;" >}}
 
 
-## Start from a template 
-Start from a template to explore user behavior and product performance using pre-built chart configurations. For example, you can understand users' average time to convert, or see their conversion breakdown by country with a few clicks. 
+## Start from a template
+Start from a template to explore user behavior and product performance using pre-built chart configurations. For example, you can understand users' average time to convert, or see their conversion breakdown by country with a few clicks.
 
 To see the available templates, click **Explore all templates** on the [Chart List page][1]. Hover over your choice and click **Create Chart** to edit and save your chart.
 

--- a/content/en/product_analytics/charts/retention_analysis.md
+++ b/content/en/product_analytics/charts/retention_analysis.md
@@ -16,7 +16,7 @@ further_reading:
 ## Overview
 Retention Analysis measures how often users are successfully returning to a page or action helping you assess the ongoing value of your products and features.
 
-User retention is measured within a given cohort of users that you define. A cohort is a group of users who performed the start event, such as clicking a link. A user in the cohort is considered retained if they subsequently complete the configured return event, such as clicking the same link again or clicking a **Proceed to Payment** button. 
+User retention is measured within a given cohort of users that you define. A cohort is a group of users who performed the start event, such as clicking a link. A user in the cohort is considered retained if they subsequently complete the configured return event, such as clicking the same link again or clicking a **Proceed to Payment** button.
 
 Only views and actions can act as events.
 
@@ -41,11 +41,11 @@ For each cohort and return period, `Return on or after` calculates the percentag
 
 `Return on or after` highlights users who either fully leave your product or stop using key functionalities, which is helpful when assessing the effectiveness of onboarding experiences.
 
-## Calculating retention events 
+## Calculating retention events
 ### What is a weighted average cohort
 The weighted average cohort summarizes overall cohort behavior by accounting for cohort size. Larger cohorts have more influence on the final value, making the result more representative than an average.
 
-This weighted average calculation is applied across all [visualization types](#visualization-types). For example, in the retention grid, the weighted average is used to populate the summary cell for each time interval. 
+This weighted average calculation is applied across all [visualization types](#visualization-types). For example, in the retention grid, the weighted average is used to populate the summary cell for each time interval.
 
 ### How to calculate a weighted average cohort
 To compute the value for a specific interval (such as Week 1 in the retention grid), multiply each cohort's value by its size, sum the results, and divide by the total cohort size. The formula is:
@@ -83,9 +83,9 @@ To build a retention graph, navigate to **[Product Analytics > Charts][1]**, cli
 2. Select the view or action to act as the return event.
 
 ### 2. Define the measures
-1. Select `Retention rate` to see the data in percentages, or `Unique users` to see the absolute number of users. 
+1. Select `Retention rate` to see the data in percentages, or `Unique users` to see the absolute number of users.
 2. Scope the retention measure `Return on or after` or `Return on` based on when the return event occurs.
-3. Choose the time frame for which you want to analyze user retention. Select a period size (day, week, or month) to define how return events are grouped in the analysis. Consider the following when selecting a period size: 
+3. Choose the time frame for which you want to analyze user retention. Select a period size (day, week, or month) to define how return events are grouped in the analysis. Consider the following when selecting a period size:
 - **Daily retention**: Can be applied for up to a month.
 - **Weekly retention**: Can be applied for up to a year.
 - **Monthly retention**: Can be applied for up to 16 months.
@@ -97,11 +97,11 @@ To build a retention graph, navigate to **[Product Analytics > Charts][1]**, cli
 Optionally, select a specific [segment][6] to measure the retention of its users. This defaults to all users. You can also add any desired filter criteria, such as `user country`, `device type`, or `operating system`.
 
 
-### 4. Group by 
-Optionally, `group by` event attributes to compare retention by device type, for example. 
+### 4. Group by
+Optionally, `group by` event attributes to compare retention by device type, for example.
 
 ## Analyze the graph
-For insights on user retention week over week, read each row of the graph horizontally from left to right. 
+For insights on user retention week over week, read each row of the graph horizontally from left to right.
 
 You can click on an individual diagram cell to view a list of users, and export the list as a CSV:
 
@@ -109,7 +109,7 @@ You can click on an individual diagram cell to view a list of users, and export 
 
 The graph displays slightly different information depending on whether the initial and return events match.
 
-### Matching events 
+### Matching events
 If the starting and returning events match:
 - **Week 0** is always 100%, since it represents all of the users who completed the initial event.
 - The other cells compare the viewers in a given week to **Week 0**, displaying the percentage of the cohort who completed the event in that week.
@@ -151,8 +151,8 @@ Timeseries
 {{< img src="product_analytics/retention/pana_retention_viz_timeseries.png" alt="Timeseries visualization graph" style="width:90%;" >}}
 
 
-Query value 
-: Displays a single value that highlights the retention rate of a time period and cohort. 
+Query value
+: Displays a single value that highlights the retention rate of a time period and cohort.
 {{< img src="product_analytics/retention/pana_retention_viz_query_value.png" alt="Query value visualization graph" style="width:90%;" >}}
 
 

--- a/content/en/product_analytics/dashboards.md
+++ b/content/en/product_analytics/dashboards.md
@@ -7,7 +7,7 @@ further_reading:
   text: "Product Analytics"
 ---
 
-## Overview 
+## Overview
 
 The key to getting started with dashboards is knowing what kind of questions you ask yourself regularly. What are common issues your customers face? When a problem occurs, what questions help you find a solution?
 
@@ -17,7 +17,7 @@ This guide gets you started on a path to creating dashboards. These basic dashbo
 
 ## Create a dashboard
 
-To create a dashboard, click **+New Dashboard** on the [Dashboard List][1] page. 
+To create a dashboard, click **+New Dashboard** on the [Dashboard List][1] page.
 
 {{< img src="product_analytics/dashboard/pana_dashboard_overview.png" alt="Adding a new dashboard" style="width:70%;">}}
 
@@ -26,7 +26,7 @@ Enter a dashboard name and choose a layout option.
 
 {{< img src="dashboards/create-dashboard.png" alt="Adding a new dashboard" style="width:70%;">}}
 
-Dashboards 
+Dashboards
 : A grid-based layout, which can include a variety of objects such as images, graphs, and logs. They are commonly used as status boards or storytelling views which update in real time, and can represent fixed points in the past. They have a maximum width of 12 grid squares and also work well for debugging.
 
 Timeboards

--- a/content/en/product_analytics/guide/action_management.md
+++ b/content/en/product_analytics/guide/action_management.md
@@ -15,13 +15,13 @@ further_reading:
 ## Overview
 Action Management is a no-code way to label autocaptured actions from your website. Action Management helps to improve trust in your Product Analytics dataset and enhance efficiency in your analysis. This page describes how to get started with Action Management.
 
-## Setup 
+## Setup
 
-### Step 1 - Install the browser extension 
+### Step 1 - Install the browser extension
 
-Action Management requires [The Datadog test recorder Chrome extension][1]. If you are unable to add the extension through the Chrome web store, see the [manual instructions][2]. 
+Action Management requires [The Datadog test recorder Chrome extension][1]. If you are unable to add the extension through the Chrome web store, see the [manual instructions][2].
 
-### Step 2 - Label your actions 
+### Step 2 - Label your actions
 
 1. Go to the [Actions][3] page in the Datadog UI, and click on **Label New Action**. This takes you to the point-and-click interface where you can select your actions.
 
@@ -48,7 +48,7 @@ Action Management requires [The Datadog test recorder Chrome extension][1]. If y
 {{< img src="product_analytics/action_management/pana-name-action.png" alt="Give a name and description to your action." style="width:90%;">}}
 
 
-### Step 3 - Retrieve your actions 
+### Step 3 - Retrieve your actions
 
 After you define an action, you can find it in the [list of labeled actions][4]. From this list, you can:
 - Filter to only see your actions
@@ -59,9 +59,9 @@ After you define an action, you can find it in the [list of labeled actions][4].
 
 
 
-## Known limitations 
+## Known limitations
 - Action Management only works for web pages at this time.
-- You cannot label Actions that are hidden behind a hover. If this limitation impacts your use cases, share examples of these with your Customer Success Manager to inform future improvements. 
+- You cannot label Actions that are hidden behind a hover. If this limitation impacts your use cases, share examples of these with your Customer Success Manager to inform future improvements.
 - Labeled actions can only be used in Funnels and Retention graphs at this time.
 - Deleting a labeled action also deletes it from the dashboards where it is being used.
 

--- a/content/en/product_analytics/profiles.md
+++ b/content/en/product_analytics/profiles.md
@@ -9,11 +9,11 @@ further_reading:
 
 ## Overview
 
-The [User Profiles][7] and [Account Profiles][8] pages contain enriched data on the users and accounts interacting with your product. 
+The [User Profiles][7] and [Account Profiles][8] pages contain enriched data on the users and accounts interacting with your product.
 
 These profile pages integrate attributes extracted from collected events with information from third-party sources. Examples of these attributes include a user’s `first_seen` timestamp or the ISO code of the user's `last_seen_country`. Together, they help create comprehensive, centralized profiles.
 
-These enriched profiles enable more precise segmentation and deeper analysis of user behavior, helping you identify patterns over time, track key cohorts (for example, users active after six months), and guide product decisions and engagement strategies. 
+These enriched profiles enable more precise segmentation and deeper analysis of user behavior, helping you identify patterns over time, track key cohorts (for example, users active after six months), and guide product decisions and engagement strategies.
 
 ## Profiles
 
@@ -21,23 +21,23 @@ User and account profiles are generated from RUM events collected through the RU
 
 User profiles are grouped by the `user_id` attribute, while account profiles are grouped by `account_id`.
 
-You can also customize these pages by adding attributes that matter most to your team. See the [Custom Attributes section](#use-custom-attributes-to-enrich-profiles) to learn how to tailor profile data to your needs. 
+You can also customize these pages by adding attributes that matter most to your team. See the [Custom Attributes section](#use-custom-attributes-to-enrich-profiles) to learn how to tailor profile data to your needs.
 
 
-### User profiles 
+### User profiles
 
 The [User Profiles][7] page lists the users who are interacting with your application. You can select a user to view detailed insights into their activity, including their most visited pages, frequent actions, and session history.
 
 {{< img src="product_analytics/user_profile2ui.png" alt="A view of the User profiles page." style="width:80%;" >}}
 
-Each profile has attributes to help you better segment your users. You can conduct a full-text search or sort and filter based on any of these attributes. You can also customize this page with attributes relevant to your analytic needs. See the [Custom Attributes section](#use-custom-attributes-to-enrich-profiles) to learn how.  
+Each profile has attributes to help you better segment your users. You can conduct a full-text search or sort and filter based on any of these attributes. You can also customize this page with attributes relevant to your analytic needs. See the [Custom Attributes section](#use-custom-attributes-to-enrich-profiles) to learn how.
 
 
 {{% collapse-content title="List of user profile attributes" level="h5" expanded=true id="id-for-anchoring" %}}
 
 <!-- #### User attributes  -->
 User ID `REQUIRED`
-: `type:string` <br> A unique user identifier.<br> 
+: `type:string` <br> A unique user identifier.<br>
 
 User Email
 : `type:string` <br> The user's email address.
@@ -68,7 +68,7 @@ First City
 Last City
 : `type:string` <br> The city of the user's last session.
 
-First Seen Country 
+First Seen Country
 : `type:string` <br> The ISO code of the country for the user's first session. The country's code is saved in the backend and the country's name is displayed in the UI.
 
 Last Seen Country
@@ -116,11 +116,11 @@ First Browser Version
 Last Browser Version
 : `type:string` <br> The browser version from the user's last session.
 
-{{% /collapse-content %}} 
+{{% /collapse-content %}}
 <br>
 
 
-### Account profiles 
+### Account profiles
 The Account Profiles page surfaces a list of the organizations interacting with your application.
 
 {{< img src="product_analytics/account_profile_ui3.png" alt="A view of the User profiles page." style="width:80%;" >}}
@@ -129,7 +129,7 @@ Each profile includes four default attributes to help you identify and track acc
 - `account_id`
 - `account_name`
 - `first_seen`
-- `last_seen` 
+- `last_seen`
 
 You can customize the Account Profiles page to include additional attributes, giving you the flexibility to tailor the view to your observability and product analysis needs.
 
@@ -137,7 +137,7 @@ You can customize the Account Profiles page to include additional attributes, gi
 
 ## Use custom attributes to enrich profiles
 
-### How to configure custom attributes using integrations 
+### How to configure custom attributes using integrations
 
 Use integrations or reference tables to automatically import custom attribute data into profiles. This data is synced on a regular schedule, reflecting the latest values from the source system to ensure that profiles remain up-to-date and accurate.
 
@@ -147,7 +147,7 @@ On this same page, you can select the [Custom Attributes][5] tab to view importe
 
 {{< img src="product_analytics/integration_page5.png" alt="See the integrations that are compatible with Product Analytics." style="width:80%;" >}}
 
-To import attibutes from a reference table or from an integration such as Salesforce or Snowflake, select the **Add Attributes** button and choose whether the attributes are for user or account profiles. Then, follow the prompts to: 
+To import attibutes from a reference table or from an integration such as Salesforce or Snowflake, select the **Add Attributes** button and choose whether the attributes are for user or account profiles. Then, follow the prompts to:
 
 
 {{< img src="product_analytics/add_attribute2_button.png" alt="Add new attributes using to enrich your profiles." style="width:80%;" >}}
@@ -172,7 +172,7 @@ To import attibutes from a reference table or from an integration such as Salesf
 
 ## How to query your custom attributes
 
-You can filter these custom attributes throughout the product analytics platform without needing to first add them to a [segment][6]. For example, you can create an analytics chart to view the volume of sessions for users that spent more than $100. 
+You can filter these custom attributes throughout the product analytics platform without needing to first add them to a [segment][6]. For example, you can create an analytics chart to view the volume of sessions for users that spent more than $100.
 
 {{< img src="product_analytics/query_custom_attribute_analytics3.png" alt="Query your custom attributes in an analytics chart." style="width:80%;" >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14199

Strips trailing whitespace from 43 lines across five Product Analytics pages. No content changes — purely a Vale/style cleanup. `git diff --ignore-all-space` is empty.

Files touched:
- `content/en/product_analytics/dashboards.md`
- `content/en/product_analytics/charts/chart_basics.md`
- `content/en/product_analytics/charts/retention_analysis.md`
- `content/en/product_analytics/profiles.md`
- `content/en/product_analytics/guide/action_management.md`

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code to scan the pages for trailing whitespace and apply the fixes. Manually reviewed the diff before commit.

### Additional notes

Out of scope for this PR (separate cards if pursued):
- Structural cleanup in `retention_analysis.md` (numbered procedural headings, "How to" → imperative).
