### PR TITLE
[DOCS-14201] Fix typos in Product Analytics docs

### DIFF
--- a/content/en/product_analytics/charts/analytics_explorer/_index.md
+++ b/content/en/product_analytics/charts/analytics_explorer/_index.md
@@ -37,7 +37,7 @@ With Analytics visualizations, you can:
 * Dive deeper into subsets of the events list depending on the interactions that the visualization enables.
 
 ## Using the analytics chart
-{{< whatsnext desc="Follow these links here to learn how to use the analytics search syntax, view events, and vizualise, group, and export views. " >}}
+{{< whatsnext desc="Follow these links here to learn how to use the analytics search syntax, view events, and visualize, group, and export views. " >}}
     {{< nextlink href="product_analytics/charts/analytics_explorer/search_syntax" >}}Search syntax{{< /nextlink >}}
     {{< nextlink href="product_analytics/charts/analytics_explorer/events" >}} Events {{< /nextlink >}}
     {{< nextlink href="product_analytics/charts/analytics_explorer/visualize" >}}Visualize{{< /nextlink >}}

--- a/content/en/product_analytics/guide/action_management.md
+++ b/content/en/product_analytics/guide/action_management.md
@@ -30,7 +30,7 @@ Action Management requires [The Datadog test recorder Chrome extension][1]. If y
 
 2. Use the **Navigate Site** mode to browse to the location of the actions you want to label.
 
-{{< img src="product_analytics/action_management/pana-point-click-interface.png" alt="The point and click interface used to locate and labed your action " style="width:90%;">}}
+{{< img src="product_analytics/action_management/pana-point-click-interface.png" alt="The point and click interface used to locate and label your action " style="width:90%;">}}
 
 
 3. To add an action, first, switch to **Label Actions** mode.

--- a/content/en/product_analytics/guide/monitor-utm-campaigns-in-product-analytics.md
+++ b/content/en/product_analytics/guide/monitor-utm-campaigns-in-product-analytics.md
@@ -16,7 +16,7 @@ UTM campaigns are connected to [View][1] events in Product Analytics. The campai
 |-------------------------------|--------|---------------------------------------------------------------|
 | `view.url_query.utm_source`     | string | The parameter in the URL tracking the source of traffic. |
 | `view.url_query.utm_medium`        | string | The parameter in the URL tracking the channel where the traffic is coming from.    |
-| `view.url_query.utm_campaign`  | string | The paramter in the URL identifying the specific marketing campaign tied to that view.              |
+| `view.url_query.utm_campaign`  | string | The parameter in the URL identifying the specific marketing campaign tied to that view.              |
 | `view.url_query.utm_content`  | string | The parameter in the URL identifying the specific element a user clicked within a marketing campaign.           |
 | `view.url_query.utm_term` | string | The parameter in the URL tracking the keyword a user searched to trigger a given campaign.             |
 

--- a/content/en/product_analytics/profiles.md
+++ b/content/en/product_analytics/profiles.md
@@ -147,7 +147,7 @@ On this same page, you can select the [Custom Attributes][5] tab to view importe
 
 {{< img src="product_analytics/integration_page5.png" alt="See the integrations that are compatible with Product Analytics." style="width:80%;" >}}
 
-To import attibutes from a reference table or from an integration such as Salesforce or Snowflake, select the **Add Attributes** button and choose whether the attributes are for user or account profiles. Then, follow the prompts to:
+To import attributes from a reference table or from an integration such as Salesforce or Snowflake, select the **Add Attributes** button and choose whether the attributes are for user or account profiles. Then, follow the prompts to:
 
 
 {{< img src="product_analytics/add_attribute2_button.png" alt="Add new attributes using to enrich your profiles." style="width:80%;" >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14201

Fixes four typos found by codespell in Product Analytics pages. Experiments docs were clean.

| File | Typo | Fix |
|---|---|---|
| `profiles.md` | `attibutes` | `attributes` |
| `guide/action_management.md` | `labed` | `label` |
| `guide/monitor-utm-campaigns-in-product-analytics.md` | `paramter` | `parameter` |
| `charts/analytics_explorer/_index.md` | `vizualise` | `visualize` (American English) |

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Claude Code to run codespell and apply the fixes. Manually reviewed each match in context before commit.

### Additional notes

Codespell suggested `visualise` (British) for `vizualise`; corrected to `visualize` to match Datadog's American English convention.