### PR TITLE
Fix aiguard-sdk-setup partial markdown not rendering

### DIFF
--- a/content/en/security/ai_guard/setup/automatic_integrations.md
+++ b/content/en/security/ai_guard/setup/automatic_integrations.md
@@ -31,7 +31,7 @@ AI Guard can automatically evaluate LLM calls made through supported AI ecosyste
 {{% /tab %}}
 {{< /tabs >}}
 
-{{< partial name="security-platform/aiguard-sdk-setup.md" target="automatic" >}}
+{{% partial name="security-platform/aiguard-sdk-setup.md" target="automatic" %}}
 
 ## Integrations
 

--- a/content/en/security/ai_guard/setup/manual_integrations.md
+++ b/content/en/security/ai_guard/setup/manual_integrations.md
@@ -22,7 +22,7 @@ Manual integrations require additional configuration to enable AI Guard protecti
 | [Amazon Strands](#amazon-strands) | >= 1.29.0          | >= 4.7.0       |
 | [LiteLLM Proxy](#litellm-proxy)   | >= 1.78.5          | >= 4.8.0       |
 
-{{< partial name="security-platform/aiguard-sdk-setup.md" target="manual" >}}
+{{% partial name="security-platform/aiguard-sdk-setup.md" target="manual" %}}
 
 ## Integrations
 

--- a/content/en/security/ai_guard/setup/sdk.md
+++ b/content/en/security/ai_guard/setup/sdk.md
@@ -14,7 +14,7 @@ further_reading:
 
 Use an SDK to call the AI Guard REST API and monitor AI Guard activity in real time in Datadog.
 
-{{< partial name="security-platform/aiguard-sdk-setup.md" target="manual" >}}
+{{% partial name="security-platform/aiguard-sdk-setup.md" target="manual" %}}
 
 ## Install the SDK
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Switches the `aiguard-sdk-setup.md` partial shortcode calls from `{{< >}}` to `{{% %}}` delimiter syntax in three AI Guard setup pages.

The `{{< >}}` (angle-bracket) syntax inserts shortcode output verbatim as HTML, bypassing Hugo's markdown renderer. Since `aiguard-sdk-setup.md` outputs markdown (headings, tables, paragraphs), those elements were rendering as raw text on the page. The `{{% %}}` (percent) syntax runs the shortcode output through the markdown renderer, fixing the display.

Affected pages:
- `content/en/security/ai_guard/setup/sdk.md`
- `content/en/security/ai_guard/setup/manual_integrations.md`
- `content/en/security/ai_guard/setup/automatic_integrations.md`

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes