### PR TITLE
[DOCS-14090] Add US1-FED banner to Decoder Processor section

### DIFF
--- a/content/en/logs/log_configuration/processors.md
+++ b/content/en/logs/log_configuration/processors.md
@@ -1048,6 +1048,10 @@ Use the [Datadog Log Pipeline API endpoint][1] with the following array processo
 
 ## Decoder processor
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">The Decoder processor is not available for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}). Contact <a href="/help/">Datadog Support</a> if you need this capability.</div>
+{{< /site-region >}}
+
 The Decoder processor translates binary-to-text encoded string fields (such as Base64 or Hex/Base16) into their original representation. This allows the data to be interpreted in its native context, whether as a UTF-8 string, ASCII command, or a numeric value (for example, an integer derived from a hex string). The Decoder processor is especially useful for analyzing encoded commands, logs from specific systems, or evasion techniques used by threat actors.
 
 **Notes**:


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14090

The Decoder processor is not available on the US1-FED site. This PR adds a `site-region` banner to the Decoder processor section of the Logs Processors page, mirroring the pattern used elsewhere for site-specific feature exclusions. The banner directs US1-FED customers to contact Datadog Support if they need this capability.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes