### PR TITLE
[DOCS-13132] Add Google Cloud collection scope decision support

### DIFF
--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -74,7 +74,7 @@ Use this guide to get started with monitoring your Google Cloud environment. Thi
 
 ### Metric collection
 
-{{% google-cloud-metric-collection-scope %}}
+{{% google-cloud-collection-scope %}}
 
 <div class="alert alert-info">If your Google Cloud organization uses <a href="https://cloud.google.com/vpc-service-controls/docs/overview">VPC Service Controls</a>, you must explicitly allow Datadog service accounts to access protected resources. If these service accounts are not permitted within your service perimeter, metric, resource, and metadata collection may fail. Contact <a href="/help/">Datadog Support</a> for the service account identifiers for your site or region.</div>
 

--- a/content/en/getting_started/integrations/google_cloud.md
+++ b/content/en/getting_started/integrations/google_cloud.md
@@ -74,6 +74,8 @@ Use this guide to get started with monitoring your Google Cloud environment. Thi
 
 ### Metric collection
 
+{{% google-cloud-metric-collection-scope %}}
+
 <div class="alert alert-info">If your Google Cloud organization uses <a href="https://cloud.google.com/vpc-service-controls/docs/overview">VPC Service Controls</a>, you must explicitly allow Datadog service accounts to access protected resources. If these service accounts are not permitted within your service perimeter, metric, resource, and metadata collection may fail. Contact <a href="/help/">Datadog Support</a> for the service account identifiers for your site or region.</div>
 
 {{< tabs >}}
@@ -370,9 +372,7 @@ In the below example, only Google Cloud hosts with the label `datadog:true` are 
 
 {{< img src="integrations/google_cloud_platform/limit_metric_collection.png" alt="The fields to limit metric collection in the Google Cloud integration tile" style="width:100%;" >}}
 
-#### Best practices for monitoring multiple projects
-
-##### Enable per-project cost and API quota attribution
+#### Enable per-project cost and API quota attribution
 
 By default, Google Cloud attributes the cost of monitoring API calls, as well as API quota usage, to the project containing the service account for this integration. As a best practice for Google Cloud environments with multiple projects, enable per-project cost attribution of monitoring API calls and API quota usage. With this enabled, costs and quota usage are attributed to the project being *queried*, rather than the project containing the service account. This provides visibility into the monitoring costs incurred by each project, and also helps to prevent reaching API rate limits.
 

--- a/layouts/shortcodes/google-cloud-collection-scope.md
+++ b/layouts/shortcodes/google-cloud-collection-scope.md
@@ -1,4 +1,4 @@
-Datadog supports two metric collection approaches:
+Datadog supports two collection approaches for metrics and resources:
 
 - **Automatic project discovery (recommended)**: Assign IAM roles at the organization or folder level. Datadog automatically discovers and monitors all current and future projects in scope. Requires the corresponding Admin role at the chosen scope.
 - **Manual per-project setup**: Assign IAM roles to specific projects. Use this approach when org- or folder-level admin access is not available, or to limit Datadog's monitoring scope.

--- a/layouts/shortcodes/google-cloud-metric-collection-scope.md
+++ b/layouts/shortcodes/google-cloud-metric-collection-scope.md
@@ -1,0 +1,4 @@
+Datadog supports two metric collection approaches:
+
+- **Automatic project discovery (recommended)**: Assign IAM roles at the organization or folder level. Datadog automatically discovers and monitors all current and future projects in scope. Requires the corresponding Admin role at the chosen scope.
+- **Manual per-project setup**: Assign IAM roles to specific projects. Use this approach when org- or folder-level admin access is not available, or to limit Datadog's monitoring scope.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13132

Adds decision support for choosing between Google Cloud's two collection approaches (automatic project discovery vs. manual per-project setup), which are currently buried inside two setup tabs without an upfront comparison. This addresses the cluster of escalated multi-project / org-level support tickets analyzed under DOCS-13132 — customers were picking the wrong scope because the trade-offs weren't surfaced before the setup steps.

Two changes:

1. **New shortcode `layouts/shortcodes/google-cloud-collection-scope.md`** — five-line "Choose your scope" intro covering automatic project discovery (recommended) and manual per-project setup, framed by mechanism so folder-level customers find their term explicitly. Covers both metric and resource collection. Referenced from `getting_started/integrations/google_cloud.md` between `### Metric collection` and the existing VPC Service Controls alert.

2. **Heading flatten on the per-project cost and API quota attribution section** — removes the misleading plural `#### Best practices for monitoring multiple projects` H4 wrapper and promotes the inner H5 ("Enable per-project cost and API quota attribution") to H4. The existing `#enable-per-project-cost-and-api-quota-attribution` anchor is preserved (text-based slug, level-independent), so the two inbound callers (`google_cloud.md:107` and `_vendor/.../google-cloud-platform.md:231`) keep working unchanged.

A companion change in `integrations-internal-core` will apply both edits to the integration tile page (`google_cloud_platform/README.md`); that PR will be opened after this one merges so the new shortcode is available before the upstream reference goes live.

Follow-up work tracked in DOCS-14219: decision rubric (org vs. folder vs. project tier choice), project-discovery mechanism (re-scan cadence, triggers, removal behavior), and architecture diagram. SME-blocked.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes