### PR TITLE
LLM Observability: use public ddtrace.llmobs.evaluators import path

### DIFF
--- a/content/en/llm_observability/guide/evaluation_developer_guide.md
+++ b/content/en/llm_observability/guide/evaluation_developer_guide.md
@@ -285,8 +285,7 @@ Use `LLMObs.publish_evaluator()` to push a locally-defined `LLMJudge` configurat
 | `variable_mapping` | `dict[str, str]` | No | Remaps variable names in `user_prompt` to Datadog span field paths in the published evaluator. |
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs import LLMObs
-from ddtrace.llmobs._evaluators import BooleanStructuredOutput, LLMJudge
+from ddtrace.llmobs import BooleanStructuredOutput, LLMJudge, LLMObs
 
 LLMObs.enable(
     ml_app="my-ml-app",

--- a/content/en/llm_observability/guide/evaluation_developer_guide.md
+++ b/content/en/llm_observability/guide/evaluation_developer_guide.md
@@ -335,7 +335,7 @@ Performs string comparison operations between `output_data` and `expected_output
 | `icontains` | `output_data` contains `expected_output` (case-insensitive) |
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs._evaluators import StringCheckEvaluator
+from ddtrace.llmobs.evaluators import StringCheckEvaluator
 
 # Perform an exact match (default)
 evaluator = StringCheckEvaluator(operation="eq", case_sensitive=True)
@@ -361,7 +361,7 @@ Validates output against a regex pattern.
 | `fullmatch` | Match entire string |
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs._evaluators import RegexMatchEvaluator
+from ddtrace.llmobs.evaluators import RegexMatchEvaluator
 import re
 
 # Validate email format
@@ -388,7 +388,7 @@ Validates output length constraints.
 | `lines` | Count lines |
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs._evaluators import LengthEvaluator
+from ddtrace.llmobs.evaluators import LengthEvaluator
 
 # Ensure response is 50-200 characters
 evaluator = LengthEvaluator(min_length=50, max_length=200, count_type="characters")
@@ -402,7 +402,7 @@ evaluator = LengthEvaluator(min_length=10, max_length=100, count_type="words")
 Validates that output is valid JSON, and optionally checks for required keys.
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs._evaluators import JSONEvaluator
+from ddtrace.llmobs.evaluators import JSONEvaluator
 
 # Validate JSON syntax
 evaluator = JSONEvaluator()
@@ -416,7 +416,7 @@ evaluator = JSONEvaluator(required_keys=["name", "status", "data"])
 Measures semantic similarity between `output_data` and `expected_output` using embeddings. Returns a similarity score between 0.0 and 1.0.
 
 {{< code-block lang="python" >}}
-from ddtrace.llmobs._evaluators import SemanticSimilarityEvaluator
+from ddtrace.llmobs.evaluators import SemanticSimilarityEvaluator
 from openai import OpenAI
 
 client = OpenAI()


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the LLM Observability evaluation developer guide to import evaluator classes from their public modules instead of the private `ddtrace.llmobs._evaluators` module:

- `StringCheckEvaluator`, `RegexMatchEvaluator`, `LengthEvaluator`, `JSONEvaluator`, `SemanticSimilarityEvaluator` → `from ddtrace.llmobs.evaluators import ...`
- `LLMJudge`, `BooleanStructuredOutput` → `from ddtrace.llmobs import ...`

The built-in evaluators module has been available since [ddtrace v4.5.0](https://github.com/DataDog/dd-trace-py/pull/16157), and `LLMJudge` / `BooleanStructuredOutput` are re-exported directly from `ddtrace.llmobs`. Documenting the private path discourages users from relying on the supported public API.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

For merge readiness, see [CONTRIBUTING](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md#merging-prs).

Merge queue is enabled in this repo. Your PR will be merged automatically after it's reviewed and approved.