### PR TITLE
Migrate imgix.net image URLs to dd-static.net

### DIFF
--- a/layouts/shortcodes/ci-itr-activation-instructions.fr.md
+++ b/layouts/shortcodes/ci-itr-activation-instructions.fr.md
@@ -2,6 +2,6 @@
 
 Pour activer la fonctionnalité Test Impact Analysis, accédez à la page [Test Service Settings][101]. Vous devez disposer de l'autorisation d'**activation d'Intelligent Test Runner** (`intelligent_test_runner_activation_write`).
 
-<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Fonctionnalité Test Impact Analysis activée dans les paramètres du service de test à la section CI de Datadog."></picture></a></figure></div>
+<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://docs.dd-static.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://docs.dd-static.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Fonctionnalité Test Impact Analysis activée dans les paramètres du service de test à la section CI de Datadog."></picture></a></figure></div>
 
 [101]: https://app.datadoghq.com/ci/settings/test-service

--- a/layouts/shortcodes/ci-itr-activation-instructions.ja.md
+++ b/layouts/shortcodes/ci-itr-activation-instructions.ja.md
@@ -2,6 +2,6 @@
 
 あなた、またはあなたの組織で **Intelligent Test Runner Activation** (`intelligent_test_runner_activation_write`) 権限を持つユーザーが、[テストサービス設定][101]ページで Test Impact Analysis を有効にする必要があります。
 
-<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Test Impact Analysis enabled in test service settings in the CI section of Datadog."></picture></a></figure></div>
+<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://docs.dd-static.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://docs.dd-static.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Test Impact Analysis enabled in test service settings in the CI section of Datadog."></picture></a></figure></div>
 
 [101]: https://app.datadoghq.com/ci/settings/test-service

--- a/layouts/shortcodes/ci-itr-activation-instructions.ko.md
+++ b/layouts/shortcodes/ci-itr-activation-instructions.ko.md
@@ -2,6 +2,6 @@
 
 **Intelligent Test Runner Activation** (`intelligent_test_runner_activation_write`) 권한이 있는 조직의 사용자는 [Test Service Settings][101] 페이지에서 Intelligent Test Runner를 활성화해야 합니다.
 
-<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://datadog-docs.imgix.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Test Impact Analysis enabled in test service settings in the CI section of Datadog."></picture></a></figure></div>
+<div class="shortcode-wrapper shortcode-img expand"><figure class="text-center"><a href="https://docs.dd-static.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?fit=max&amp;auto=format" class="pop" data-bs-toggle="modal" data-bs-target="#popupImageModal"><picture><img class="img-fluid" srcset="https://docs.dd-static.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png?auto=format" alt="Test Impact Analysis enabled in test service settings in the CI section of Datadog."></picture></a></figure></div>
 
 [101]: https://app.datadoghq.com/ci/settings/test-service


### PR DESCRIPTION
## Summary

Migrates references to legacy `*.imgix.net` hosts to their `dd-static.net` equivalents as part of the imgix → dd-static asset host migration.

### Mappings applied in this repo

- `datadog-docs.imgix.net` → `docs.dd-static.net`

### Scope

- Only the host substring of each URL changes. Paths, query strings, and schemes are preserved verbatim.
- Out-of-scope (intentionally untouched): `dd-lp-images.imgix.net`, `imgix.datadoghq.com`.

## Test plan

- [ ] CI passes
- [ ] Spot-check a rendered page / built artifact to confirm images still resolve from the new host
- [ ] Confirm no functional regressions in pages that consumed the migrated assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## URL resolution check (2026-04-28)

| URL | Status |
|---|---|
| `https://docs.dd-static.net/images/continuous_integration/itr_overview.03793aa7ffdec7d28903b5d3c9d9c32d.png` | 200 |

The migrated URL resolves correctly.