### PR TITLE
[DOCS-14068] Add US1-FED banner to SSI instrumentation rules sections

### DIFF
--- a/content/en/tracing/trace_collection/single-step-apm/linux.md
+++ b/content/en/tracing/trace_collection/single-step-apm/linux.md
@@ -118,7 +118,7 @@ To update the SDK versions:
 ### Define instrumentation rules
 
 {{< site-region region="gov" >}}
-<div class="alert alert-warning">Instrumentation rules are not available on the US1-FED site.</div>
+<div class="alert alert-warning">Instrumentation rules are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 Instrumentation rules (available for Agent v7.73+) let you control which processes are automatically instrumented by SSI on Linux hosts.

--- a/content/en/tracing/trace_collection/single-step-apm/linux.md
+++ b/content/en/tracing/trace_collection/single-step-apm/linux.md
@@ -117,6 +117,10 @@ To update the SDK versions:
 
 ### Define instrumentation rules
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Instrumentation rules are not available on the US1-FED site.</div>
+{{< /site-region >}}
+
 Instrumentation rules (available for Agent v7.73+) let you control which processes are automatically instrumented by SSI on Linux hosts.
 
 To configure instrumentation rules:

--- a/content/en/tracing/trace_collection/single-step-apm/windows.md
+++ b/content/en/tracing/trace_collection/single-step-apm/windows.md
@@ -94,7 +94,9 @@ To enable products, [set environment variables][3] in your application configura
 <div class="alert alert-warning">Instrumentation rules are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
+{{< site-region region="us,us3,us5,eu,ap1,ap2" >}}
 <div class="alert alert-info">Instrumentation rules (available for Agent v7.73+) apply only to host-wide instrumentation. They are not supported for IIS-only installation.</div>
+{{< /site-region >}}
 
 Instrumentation rules let you control which processes are automatically instrumented by SSI on Windows hosts.
 

--- a/content/en/tracing/trace_collection/single-step-apm/windows.md
+++ b/content/en/tracing/trace_collection/single-step-apm/windows.md
@@ -90,6 +90,10 @@ To enable products, [set environment variables][3] in your application configura
 
 ### Define instrumentation rules
 
+{{< site-region region="gov" >}}
+<div class="alert alert-warning">Instrumentation rules are not available on the US1-FED site.</div>
+{{< /site-region >}}
+
 <div class="alert alert-info">Instrumentation rules (available for Agent v7.73+) apply only to host-wide instrumentation. They are not supported for IIS-only installation.</div>
 
 Instrumentation rules let you control which processes are automatically instrumented by SSI on Windows hosts.

--- a/content/en/tracing/trace_collection/single-step-apm/windows.md
+++ b/content/en/tracing/trace_collection/single-step-apm/windows.md
@@ -91,7 +91,7 @@ To enable products, [set environment variables][3] in your application configura
 ### Define instrumentation rules
 
 {{< site-region region="gov" >}}
-<div class="alert alert-warning">Instrumentation rules are not available on the US1-FED site.</div>
+<div class="alert alert-warning">Instrumentation rules are not supported for your selected <a href="/getting_started/site">Datadog site</a> ({{< region-param key="dd_site_name" >}}).</div>
 {{< /site-region >}}
 
 <div class="alert alert-info">Instrumentation rules (available for Agent v7.73+) apply only to host-wide instrumentation. They are not supported for IIS-only installation.</div>


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14068

Adds a US1-FED warning banner to the "Define instrumentation rules" section on the SSI Linux and Windows pages.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes