### PR TITLE
[DOCS-14035] Add Python preforking WSGI Known issues entry to SSI compatibility

### DIFF
--- a/content/en/tracing/trace_collection/single-step-apm/compatibility.md
+++ b/content/en/tracing/trace_collection/single-step-apm/compatibility.md
@@ -177,11 +177,12 @@ Recent Python SDK releases include partial fixes. See the [dd-trace-py releases 
 To mitigate:
 - Disable SSI for the affected service. See [your platform's SSI setup page][3] for removal steps.
 - Switch to a lazy-loading deployment pattern (for example, gunicorn without `--preload`, or uWSGI with lazy-apps mode).
-- Use manual tracer installation (`pip install ddtrace` + `ddtrace-run`) instead of SSI.
+- Install the [Python SDK][4] manually (`pip install ddtrace` + `ddtrace-run`) instead of using SSI.
 
 [1]: /tracing/trace_collection/compatibility/python
 [2]: https://github.com/DataDog/dd-trace-py/releases
 [3]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/#instrument-sdks-across-applications
+[4]: /tracing/trace_collection/dd_libraries/python/
 
 {{< /programming-lang >}}
 

--- a/content/en/tracing/trace_collection/single-step-apm/compatibility.md
+++ b/content/en/tracing/trace_collection/single-step-apm/compatibility.md
@@ -170,7 +170,7 @@ For other distributions, you may need to install Python 3.7+ separately.
 
 ### Known issues
 
-**Preforking WSGI servers**: Python applications running under preforking WSGI servers can experience worker process crashes (SIGSEGV) on startup when SSI is enabled. This affects uWSGI in preforking mode, gunicorn with `--preload`, and Apache mod_wsgi in daemon mode with preload.
+**Preforking WSGI servers**: Python applications running under preforking WSGI servers can experience worker process crashes (SIGSEGV) on startup when SSI is enabled. This affects uWSGI in preforking mode, gunicorn with `--preload`, and Apache `mod_wsgi` in daemon mode with preload.
 
 Recent Python SDK releases include partial fixes. See the [dd-trace-py releases page][2] for the latest status.
 

--- a/content/en/tracing/trace_collection/single-step-apm/compatibility.md
+++ b/content/en/tracing/trace_collection/single-step-apm/compatibility.md
@@ -168,7 +168,20 @@ Python 3.7+ is available by default only on:
 
 For other distributions, you may need to install Python 3.7+ separately.
 
+### Known issues
+
+**Preforking WSGI servers**: Python applications running under preforking WSGI servers can experience worker process crashes (SIGSEGV) on startup when SSI is enabled. This affects uWSGI in preforking mode, gunicorn with `--preload`, and Apache mod_wsgi in daemon mode with preload.
+
+Recent Python SDK releases include partial fixes. See the [dd-trace-py releases page][2] for the latest status.
+
+To mitigate:
+- Disable SSI for the affected service. See [your platform's SSI setup page][3] for removal steps.
+- Switch to a lazy-loading deployment pattern (for example, gunicorn without `--preload`, or uWSGI with lazy-apps mode).
+- Use manual tracer installation (`pip install ddtrace` + `ddtrace-run`) instead of SSI.
+
 [1]: /tracing/trace_collection/compatibility/python
+[2]: https://github.com/DataDog/dd-trace-py/releases
+[3]: /tracing/trace_collection/automatic_instrumentation/single-step-apm/#instrument-sdks-across-applications
 
 {{< /programming-lang >}}
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14035

Adds a Known issues entry to the Python tab of the SSI compatibility page documenting that Python applications running under preforking WSGI servers can experience worker process crashes on startup when SSI is enabled. Includes mitigation steps.

This brings the Python tab in line with Java, Ruby, and Node.js, which already have Known issues subsections.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes