### PR TITLE
[DOCS-13085] Add Azure log ingestion decision framework and VNet/NSG flow logs subsection

### DIFF
--- a/content/en/logs/guide/azure-automated-log-forwarding.md
+++ b/content/en/logs/guide/azure-automated-log-forwarding.md
@@ -17,17 +17,36 @@ The ARM template deploys resources from a series of Azure services (storage acco
 
 **All sites**: Automated log forwarding is available to use on all [Datadog sites][4].
 
-## How to choose between automated and manual setup
+## Choose your Azure log ingestion method
 
-Choose the manual setup method if you want to:
-   - apply custom tags to your resources
+Selecting the right ingestion method depends on the type of Azure log you want to forward. It also depends on how you prefer to manage the forwarder infrastructure.
 
-Use the automated setup method if you want to:
+### Log type to ingestion path
+
+Different Azure log types support different ingestion paths. Use this table to identify a path that works for your source before choosing a setup method.
+
+| Azure log source | Supported ingestion paths | Notes |
+|---|---|---|
+| Activity logs | Diagnostic settings to the automated forwarder, Event Hub, or Blob Storage | |
+| Resource (diagnostic) logs | Diagnostic settings to the automated forwarder, Event Hub, or Blob Storage | |
+| Log Analytics Workspace tables | Data export rule to the automated forwarder Storage Account | See the [Log Analytics Workspaces](#log-analytics-workspaces) section below. |
+| VNet flow logs | **Blob Storage only** | Network Watcher writes flow logs directly to a Storage Account. Event Hub is not a supported destination. See [Forward VNet flow logs or NSG flow logs][23]. |
+| NSG flow logs | **Blob Storage only** | Same destination constraint as VNet flow logs. See [Forward VNet flow logs or NSG flow logs][23]. |
+| Microsoft Defender for Cloud | Continuous export to Event Hub, then to a Function App | Use the manual Event Hub setup. |
+| Microsoft Entra ID logs | Diagnostic settings to the Datadog Monitor resource (US3 native integration) or to Event Hub | For US3, see [Microsoft Entra ID logs in the Azure native integration guide][22]. |
+
+### Setup method
+
+Use the automated setup method (this guide) if you want to:
    - automate deployment through the Azure portal
    - manage your infrastructure through declarative templates
    - centrally control access, tags, and billing
    - redeploy your resources in the correct order and in a consistent way
    - save costs by using a storage account rather than an event hub
+
+Choose the [manual setup method][24] if you want to:
+   - apply custom tags to your resources
+   - forward logs from sources that only write to Blob Storage, such as VNet flow logs or NSG flow logs
 
 ## Setup
 
@@ -220,3 +239,6 @@ The script first discovers any instances running in each subscription, then prom
 [19]: https://portal.azure.com
 [20]: https://learn.microsoft.com/troubleshoot/azure/azure-monitor/log-analytics/workspaces/workspace-data-export-faq
 [21]: /getting_started/integrations/azure/#resource-tag-filtering-for-logs
+[22]: /integrations/guide/azure-native-integration/#microsoft-entra-id-logs
+[23]: /logs/guide/azure-manual-log-forwarding/?tab=blobstorage#forward-vnet-flow-logs-or-nsg-flow-logs
+[24]: /logs/guide/azure-manual-log-forwarding/

--- a/content/en/logs/guide/azure-manual-log-forwarding.md
+++ b/content/en/logs/guide/azure-manual-log-forwarding.md
@@ -136,6 +136,26 @@ az functionapp deployment source config-zip \
 
 8. Verify the setup by checking the [Datadog Log Explorer][108] for logs from the source Storage Account.
 
+##### Forward VNet flow logs or NSG flow logs
+
+VNet flow logs and NSG flow logs cannot stream to Event Hub. Network Watcher writes them directly to a Storage Account, which the Datadog Blob log forwarder then polls.
+
+To enable the pipeline:
+
+1. Set up the Datadog Blob log forwarder using the steps above. Use a Storage Account that you intend Network Watcher to write to.
+2. In the Azure portal, navigate to **Network Watcher**, then **Flow logs**.
+3. Click **Create**, then select the virtual network or network security group you want to monitor.
+4. For **Target Storage Account**, select the source Storage Account from step 1.
+5. Configure the log version, retention, and traffic analytics settings as needed for your environment. For VNet flow logs, version 2 is recommended.
+6. Save the flow log configuration.
+
+The Function App's connection string for the source Storage Account must grant at least the **Storage Blob Data Reader** role on the source container. Network Watcher writes flow log blobs to predictable container paths:
+
+- VNet flow logs (version 2): `insights-logs-flowlogflowevent`
+- NSG flow logs: `insights-logs-networksecuritygroupflowevent`
+
+Update the `path` value in `function.json` to match the container that Network Watcher writes to, then redeploy the function. For more information, see [Manage VNet flow logs][111] and [Manage NSG flow logs][112].
+
 ##### Logs not appearing in Datadog
 
 If you completed the setup but do not see logs in Datadog:
@@ -171,6 +191,8 @@ The Azure portal Function App UI changes frequently. Use this path only if the C
 [108]: https://app.datadoghq.com/logs
 [109]: https://learn.microsoft.com/azure/azure-functions/create-first-function-vs-code-node
 [110]: https://learn.microsoft.com/azure/azure-functions/functions-run-local
+[111]: https://learn.microsoft.com/azure/network-watcher/vnet-flow-logs-overview
+[112]: https://learn.microsoft.com/azure/network-watcher/nsg-flow-logs-overview
 {{% /tab %}}
 
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13085

Adds a log-type-to-ingestion-path decision framework to `azure-automated-log-forwarding.md`, and a VNet/NSG flow logs setup subsection to `azure-manual-log-forwarding.md`. Customers repeatedly choose the wrong Azure log ingestion path (Event Hub vs. Blob Storage vs. Log Analytics Workspace) and fail silently — most acutely when the source is VNet flow logs or NSG flow logs, which only support Storage Account destinations.

Changes in `content/en/logs/guide/azure-automated-log-forwarding.md`:

- Renames `## How to choose between automated and manual setup` to `## Choose your Azure log ingestion method` (verified no inbound anchor links to the old heading exist in the repo).
- Splits the section into two subsections: "Log type to ingestion path" (new) and "Setup method" (existing bullets, retained).
- Adds a new decision table mapping seven Azure log sources to their supported ingestion paths, with notes calling out Blob-Storage-only sources (VNet flow logs, NSG flow logs) and the cross-link to the new VNet/NSG subsection in the manual guide.
- Adds an additional "manual setup method" reason: forwarding sources that only write to Blob Storage.
- Adds three new link references: `[22]` Microsoft Entra ID logs section in the Azure native integration guide; `[23]` deep link to the new VNet/NSG flow logs subsection (with `?tab=blobstorage` query param so the Blob Storage tab opens automatically); `[24]` manual log forwarding page.

Changes in `content/en/logs/guide/azure-manual-log-forwarding.md`:

- Adds an `##### Forward VNet flow logs or NSG flow logs` subsection in the Blob Storage tab between step 8 (verify) and "Logs not appearing in Datadog."
- Documents the Network Watcher → Storage Account → Datadog Blob log forwarder pipeline, including the required Storage Blob Data Reader role on the source container and the predictable container path structure (`insights-logs-flowlogflowevent` for VNet flow logs v2; `insights-logs-networksecuritygroupflowevent` for NSG flow logs).
- Adds two new link references for the Microsoft Network Watcher overview pages.

This is the second of six planned PRs under DOCS-13085. PR 2 is branched off PR 1 (`docs13085/azure-log-forwarding-cli-first`), so this PR is targeted against PR 1's branch as base while PR 1 is in flight. After PR 1 merges, GitHub auto-rebases PR 2 against master.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Marked as WORK IN PROGRESS pending follow-up review.

Three rows of the decision table (Microsoft Defender for Cloud, Microsoft Entra ID logs, and the multi-destination rows for Activity / Resource logs) would benefit from an Azure SME fact-check during review. The VNet/NSG flow logs Blob-Storage-only constraint and Log Analytics Workspace data-export-rule path are confirmed against Microsoft documentation.