### PR TITLE
[DOCS-13085] Add per-permission rationale and security FAQ to Azure Graph API permissions doc

### DIFF
--- a/content/en/integrations/guide/azure-graph-api-permissions.md
+++ b/content/en/integrations/guide/azure-graph-api-permissions.md
@@ -11,21 +11,52 @@ To fetch Azure app registration details, the [Datadog-Azure integration][1] requ
 
 **Note**: On the Azure integration tile in Datadog, if there are several app registrations (client IDs) used for the same tenant, you only need permissions on one app registration.
 
+## Required permissions
+
+The Datadog-Azure integration requires the following Application permissions on Microsoft Graph:
+
+| Permission | What Datadog reads |
+|---|---|
+| `Application.Read.All` | App registration metadata (display names and IDs) used to associate Azure resources with their owning applications. |
+| `Directory.Read.All` | Tenant directory metadata, including organization details and read-only access to directory objects (users, groups, applications). Used for tenant-level discovery context. |
+| `Group.Read.All` | Group identifiers and display names used to associate Azure resources with the groups that own them. |
+| `Policy.Read.All` | Identity-related policies in the tenant, such as Conditional Access and sign-in policies. Used for security and compliance context. |
+| `User.Read.All` | User identifiers and display names used to associate Azure resources with the users that created or own them. |
+
+## What Datadog does not access
+
+Microsoft Graph permissions such as `Group.Read.All` and `User.Read.All` technically grant access to a wider scope of data than the Datadog-Azure integration uses. The integration does not read:
+
+- Mailbox content, including Office 365 group conversations, email bodies, and calendar items
+- Files in OneDrive, SharePoint, or Microsoft Teams
+- Message attachments
+
 ## Setup
 
 1. In your Azure portal, go to the **App registrations** page. Click on the app registration you want to modify.
-2. In the left sidebar, under the _Manage_ section, click on **API permissions**. 
+2. In the left sidebar, under the _Manage_ section, click on **API permissions**.
 3. Click **+ Add a permission**.
 4. In the panel that opens, select **Microsoft Graph**.
-5. On the next page, select **Application permissions**. Then, under _Select permissions_, search for and enable each of the following permissions. 
-   - `Application.Read.All`
-   - `Directory.Read.All`
-   - `Group.Read.All`
-   - `Policy.Read.All`
-   - `User.Read.All`
-     
+5. On the next page, select **Application permissions**. Under _Select permissions_, search for and enable each permission listed in [Required permissions](#required-permissions).
+
    Click the checkbox on the left, and click the **Add permissions** button at the bottom to add each permission.
    {{< img src="integrations/guide/azure-graph-api-permissions/permission-select-1.png" alt="Panel for adding Microsoft Graph API permissions. 'Application permissions' is selected. Under the 'Select permissions' section, a user has typed in 'Application.Read.All'. In the section below, under 'Application (1)', the Application.Read.All permission appears next to a selected checkbox.">}}
+
+## Reviewing for security teams
+
+The questions below address topics that come up during security review of the Datadog-Azure integration.
+
+### Does Datadog read emails or chat content?
+
+No. `Group.Read.All` technically grants access to Microsoft 365 group conversations and shared mailboxes, but the Datadog integration only reads group identifiers and display names. See [What Datadog does not access](#what-datadog-does-not-access) for the full list of data the integration does not read.
+
+### Why is `Group.Read.All` required?
+
+Datadog uses group identifiers to associate Azure resources with the groups that own them, which surfaces ownership context in Datadog dashboards and tags. Microsoft Graph does not provide a more narrowly scoped read-only permission for group identifiers alone.
+
+### Can these permissions be reduced?
+
+The five permissions in [Required permissions](#required-permissions) are the minimum set required for the integration's tenant-level resource discovery and ownership attribution. Removing any permission disables the corresponding feature in Datadog.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13085

Expands `azure-graph-api-permissions.md` to address security-team escalations on the Datadog-Azure integration's Microsoft Graph permission requirements. The previous doc listed five required permissions with no rationale, no scoping information, and no statement of what data the integration does not access. Security reviewers (notably regulated-customer security teams) have escalated concerns about `Group.Read.All` granting access to Microsoft 365 group conversations and shared mailboxes; the existing doc gives them no answer.

Changes in `content/en/integrations/guide/azure-graph-api-permissions.md`:

- Adds a new `## Required permissions` section with a rationale table for each of the five Application permissions. The Setup section now references this table instead of inlining the bare permission list.
- Adds a new `## What Datadog does not access` section that explicitly states the integration does not read mailbox content, Office 365 group conversations, email bodies, calendar items, OneDrive/SharePoint/Teams files, or message attachments — addressing the most common security-review concern head-on.
- Adds a new `## Reviewing for security teams` FAQ section with three entries: "Does Datadog read emails or chat content?", "Why is `Group.Read.All` required?", "Can these permissions be reduced?".

### **REQUIRES SME REVIEW BEFORE MERGE**

The per-permission rationale table is a starting draft for SME correction, not a verified reference. Each row claims something about what the Datadog-Azure integration reads and uses. I do not have first-hand knowledge of the integration's data-access logic; the rationales are my best inference from public scope documentation.

Specifically, please verify or correct each of the following before merging:

- **`Application.Read.All`** — claim: app registration metadata used to associate Azure resources with their owning applications.
- **`Directory.Read.All`** — claim: tenant directory metadata (organization details, read-only access to directory objects) used for tenant-level discovery context. (Revised from an earlier draft that incorrectly mentioned subscriptions/resource groups, which are in Azure Resource Manager, not Microsoft Graph.)
- **`Group.Read.All`** — claim: group identifiers and display names used for resource ownership context.
- **`Policy.Read.All`** — claim: identity-related policies in the tenant (Conditional Access, sign-in policies) used for security and compliance context. (Revised from an earlier draft that conflated Microsoft Graph identity policies with Azure cloud policies — these are different concepts.)
- **`User.Read.All`** — claim: user identifiers and display names used for resource ownership context.

In addition, please verify the claims in the "What Datadog does not access" section, the "Why is `Group.Read.All` required?" answer (specifically, whether Microsoft Graph really has no narrower read-only permission for the integration's group-metadata use case), and the "Can these permissions be reduced?" claim that all five permissions are individually load-bearing.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

This is the third of six planned PRs under DOCS-13085. Marked WORK IN PROGRESS pending the SME review noted above. Branched directly off master (no dependency on PRs 1 or 2).