### PR TITLE
[DOCS-13994] Add individual GCS IAM permissions to log archive docs

### DIFF
--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -194,6 +194,15 @@ Only Datadog users with the [`logs_write_archive` permission][5] can create, mod
 
    {{< img src="logs/archives/gcp_role_storage_object_admin-2.png" alt="Add the Storage Object Admin role to your Datadog Google Cloud Service Account." style="width:75%;">}}
 
+The **Storage Object Admin** role is Datadog's recommended configuration. If your organization requires a least-privilege custom role, the following individual permissions are required for archive uploads:
+
+- `storage.objects.create`
+- `storage.objects.get`
+- `storage.objects.list`
+- `storage.objects.delete`
+
+`storage.objects.delete` is required to support archive write retries, where Datadog overwrites an existing object in the bucket. Multipart upload permissions (`storage.multipartUploads.*`) are not required, although future product changes might add them.
+
 [1]: https://console.cloud.google.com/iam-admin/iam
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -201,7 +201,7 @@ The **Storage Object Admin** role is Datadog's recommended configuration. If you
 - `storage.objects.list`
 - `storage.objects.delete`
 
-`storage.objects.delete` is required to support archive write retries, where Datadog overwrites an existing object in the bucket. Multipart upload permissions (`storage.multipartUploads.*`) are not required, although future product changes might add them.
+`storage.objects.delete` is required to support archive write retries, where Datadog overwrites an existing object in the bucket. Multipart upload permissions (`storage.multipartUploads.*`) are not required.
 
 [1]: https://console.cloud.google.com/iam-admin/iam
 {{% /tab %}}

--- a/content/en/logs/log_configuration/rehydrating.md
+++ b/content/en/logs/log_configuration/rehydrating.md
@@ -178,7 +178,7 @@ In order to rehydrate log events from your archives, Datadog uses a service acco
 
 {{< img src="logs/archives/log_archives_gcs_role.png" alt="Rehydration from GCS requires the Storage Object Viewer role" style="width:75%;">}}
 
-The **Storage Object Viewer** role is Datadog's recommended configuration. If your organization requires a least-privilege custom role, rehydration requires the following individual permissions:
+The **Storage Object Viewer** role is Datadog's recommended configuration. If your organization requires a least-privilege custom role, the following individual permissions are required for rehydration:
 
 - `storage.objects.get`
 - `storage.objects.list`

--- a/content/en/logs/log_configuration/rehydrating.md
+++ b/content/en/logs/log_configuration/rehydrating.md
@@ -178,6 +178,11 @@ In order to rehydrate log events from your archives, Datadog uses a service acco
 
 {{< img src="logs/archives/log_archives_gcs_role.png" alt="Rehydration from GCS requires the Storage Object Viewer role" style="width:75%;">}}
 
+The **Storage Object Viewer** role is Datadog's recommended configuration. If your organization requires a least-privilege custom role, rehydration requires the following individual permissions:
+
+- `storage.objects.get`
+- `storage.objects.list`
+
 [1]: https://console.cloud.google.com/iam-admin/iam
 {{% /tab %}}
 {{< /tabs >}}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13994

Adds individual IAM permissions to the GCS tabs on the Log Archives setup and Rehydrating from Archives pages, alongside the existing Storage Object Admin / Storage Object Viewer recommendations. Customers building least-privilege custom roles (for example, to satisfy CSPM tooling that flags `roles/storage.objectAdmin` as overly permissive) now have the underlying permission list documented.

- `logs/log_configuration/archives.md` (GCS tab): lists `storage.objects.create`, `.get`, `.list`, `.delete` for archive uploads, with a note explaining why `delete` is required (overwrite-on-retry) and that `storage.multipartUploads.*` is not used today.
- `logs/log_configuration/rehydrating.md` (GCS tab): lists `storage.objects.get`, `.list` for rehydration.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

References: engineering escalation LOGSS-10126.