### PR TITLE
[DBM] Add work_mem troubleshooting section for Postgres

### DIFF
--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -250,6 +250,37 @@ The default Agent configuration for Database Monitoring is conservative, but you
 The recommended value for `pg_stat_statements.max` is `10000`. Setting this configuration to a higher value
 may cause the collection query to take longer to run, which can lead to query timeouts and gaps in query metric collection. If the Agent reports this warning, make sure that `pg_stat_statements.max` is set to `10000` on the database.
 
+#### Agent queries writing temporary files to disk {#agent-queries-temp-files}
+
+DBM collection queries perform sort and hash-join operations against `pg_stat_statements` and catalog tables such as `pg_attribute` and `pg_index`. On databases with high query diversity or large schemas, these operations can exceed the Datadog user's [`work_mem`][26] limit and spill to temporary disk files, causing elevated write IOPS on the database host. This symptom typically appears gradually after enabling DBM and temporarily resolves after a database restart, which resets `pg_stat_statements`.
+
+To confirm, open [Metrics Explorer][27] and query:
+
+```
+sum:postgresql.queries.temp_blks_written{user:datadog} by {database_instance,query}.as_count()
+```
+
+If the metric returns data, run the following query as a superuser on the affected database to estimate the minimum `work_mem` value needed:
+
+```sql
+SELECT pg_size_pretty(
+  ((SELECT count(*) FROM pg_attribute WHERE attnum > 0 AND NOT attisdropped) * 500
+  + (SELECT count(*) FROM pg_index) * 600
+  + (SELECT count(*) FROM pg_stat_statements) *
+      (SELECT setting::int FROM pg_settings WHERE name = 'track_activity_query_size')
+  + (SELECT count(*) FROM pg_inherits) * 200
+  ) * 2
+) AS recommended_min_work_mem;
+```
+
+Round the result up to the next power of 2 and apply it as a role-level default for the `datadog` user:
+
+```sql
+ALTER ROLE datadog SET work_mem = '<value>';
+```
+
+This setting applies only to the Datadog user's sessions and does not affect application queries. No database restart is required. The setting takes effect on the next Agent connection.
+
 
 [1]: /database_monitoring/setup_postgres/
 [2]: /agent/troubleshooting/
@@ -276,3 +307,5 @@ may cause the collection query to take longer to run, which can lead to query ti
 [23]: https://github.com/DataDog/integrations-core/blob/master/postgres/datadog_checks/postgres/data/conf.yaml.example#L281
 [24]: https://pkg.go.dev/github.com/jackc/pgx/v4#QuerySimpleProtocol
 [25]: https://www.postgresql.org/docs/current/predefined-roles.html#:~:text=a%20long%20time.-,pg_monitor,-Read/execute%20various
+[26]: https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-WORK-MEM
+[27]: https://app.datadoghq.com/metric/explorer

--- a/content/en/database_monitoring/setup_postgres/troubleshooting.md
+++ b/content/en/database_monitoring/setup_postgres/troubleshooting.md
@@ -279,7 +279,7 @@ Round the result up to the next power of 2 and apply it as a role-level default 
 ALTER ROLE datadog SET work_mem = '<value>';
 ```
 
-This setting applies only to the Datadog user's sessions and does not affect application queries. No database restart is required. The setting takes effect on the next Agent connection.
+This setting applies only to the Datadog user's sessions and does not affect application queries. No database restart is required. Restart the Datadog Agent to open new connections with the updated setting.
 
 
 [1]: /database_monitoring/setup_postgres/
@@ -308,4 +308,4 @@ This setting applies only to the Datadog user's sessions and does not affect app
 [24]: https://pkg.go.dev/github.com/jackc/pgx/v4#QuerySimpleProtocol
 [25]: https://www.postgresql.org/docs/current/predefined-roles.html#:~:text=a%20long%20time.-,pg_monitor,-Read/execute%20various
 [26]: https://www.postgresql.org/docs/current/runtime-config-resource.html#GUC-WORK-MEM
-[27]: https://app.datadoghq.com/metric/explorer
+[27]: /metrics/explorer/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a new subsection under "Queries from Agent are slow and/or have a high impact on the database" in the Postgres DBM troubleshooting doc.

Covers the case where DBM collection queries spill to temporary disk files because the `work_mem` for the `datadog` user is too low. This manifests as elevated write IOPS on the database host, gradually worsening after DBM is enabled and temporarily resolving after a database restart.

The new section provides:
- A Metrics Explorer query to confirm the issue (`postgresql.queries.temp_blks_written` filtered by `user:datadog`)
- A SQL estimation query to size the correct `work_mem` value based on actual schema and `pg_stat_statements` state
- The `ALTER ROLE` command to apply the fix without a database restart

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

New section is inserted after the existing `#### High value for pg_stat_statements.max` subsection.