### PR TITLE
Update FIPS compliance documentation

### DIFF
--- a/content/en/agent/configuration/fips-compliance.md
+++ b/content/en/agent/configuration/fips-compliance.md
@@ -44,11 +44,11 @@ Supported products (Agent 7.65.0 and above):
 - Orchestrator Explorer
 - Runtime Security
 - Serverless Monitoring
+- Datadog [DDOT Collector][4]
 
 The Datadog FIPS Agent does **not** support the following:
 - Communication between Cluster Agent and Node Agents
 - Outbound communication to anything other than GovCloud
-- Datadog [DDOT Collector][4]
 
 
 ## Compliance guidelines


### PR DESCRIPTION
DDOT is now FIPS compliant

### What does this PR do? What is the motivation?

Move DDOT Collector from "not supported" to "supported", in the FIPS compliance page

[OTAGENT-1021](https://datadoghq.atlassian.net/browse/OTAGENT-1021?atlOrigin=eyJpIjoiMzIxNGRlMDg1NDk0NGIzYjg0MzYyMjIzNzgwYjQwYzYiLCJwIjoiaiJ9)

### Merge instructions

Merge readiness:
- [x] Ready for merge


### AI assistance

None

### Additional notes


[OTAGENT-1021]: https://datadoghq.atlassian.net/browse/OTAGENT-1021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ