### PR TITLE
[test optimization] Add known limitation and workaround for vitest

### DIFF
--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -770,9 +770,10 @@ Mocha's [--exit][16] option may cause data loss. Datadog tries to send data imme
 Vitest's [browser mode][17] is not supported.
 
 ### Vitest's test duration overhead
+
 By default, Vitest's [`isolate`][21] option is `true`, so each test file runs in its own fork or thread. Vitest is ESM-first and relies on [import-in-the-middle][20] for instrumentation, which incurs a setup cost every time a suite starts. With isolation, that setup cost is repeated for every file. The effect is largest when you have many small, fast suites, because setup time can dominate wall-clock time.
 
-To lower overhead, set `isolate: false` in your `vitest.config` file, or pass `--no-isolate` to the test command.
+To lower overhead, set `isolate: false` in your Vitest config file, or pass `--no-isolate` to the test command.
 
 ## Best practices
 

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -769,6 +769,11 @@ Mocha's [--exit][16] option may cause data loss. Datadog tries to send data imme
 ### Vitest's browser mode
 Vitest's [browser mode][17] is not supported.
 
+### Vitest's test duration overhead
+By default, Vitest uses `isolate: true` (see [Vitest configuration][21]), so each test file runs in its own fork or thread. Vitest is ESM-first and relies on [import-in-the-middle][20] for instrumentation. That library pays a setup cost every time a suite starts; with isolation, that cost is repeated for every file. The effect is largest when you have many small, fast suites, because setup time can dominate wall-clock time.
+
+To lower overhead, set `isolate: false` in your `vitest.config` file, or pass `--no-isolate` to the test command.
+
 ## Best practices
 
 Follow these practices to take full advantage of the testing framework and Test Optimization.
@@ -859,3 +864,5 @@ Datadog recommends using `DD_TEST_SESSION_NAME` if your test commands vary betwe
 [17]: https://vitest.dev/guide/browser/
 [18]: https://jestjs.io/docs/api#testeachtablename-fn-timeout
 [19]: https://www.npmjs.com/package/mocha-each
+[20]: https://github.com/nodejs/import-in-the-middle
+[21]: https://vitest.dev/config/isolate

--- a/content/en/tests/setup/javascript.md
+++ b/content/en/tests/setup/javascript.md
@@ -770,7 +770,7 @@ Mocha's [--exit][16] option may cause data loss. Datadog tries to send data imme
 Vitest's [browser mode][17] is not supported.
 
 ### Vitest's test duration overhead
-By default, Vitest uses `isolate: true` (see [Vitest configuration][21]), so each test file runs in its own fork or thread. Vitest is ESM-first and relies on [import-in-the-middle][20] for instrumentation. That library pays a setup cost every time a suite starts; with isolation, that cost is repeated for every file. The effect is largest when you have many small, fast suites, because setup time can dominate wall-clock time.
+By default, Vitest's [`isolate`][21] option is `true`, so each test file runs in its own fork or thread. Vitest is ESM-first and relies on [import-in-the-middle][20] for instrumentation, which incurs a setup cost every time a suite starts. With isolation, that setup cost is repeated for every file. The effect is largest when you have many small, fast suites, because setup time can dominate wall-clock time.
 
 To lower overhead, set `isolate: false` in your `vitest.config` file, or pass `--no-isolate` to the test command.
 

--- a/content/en/tests/troubleshooting/_index.md
+++ b/content/en/tests/troubleshooting/_index.md
@@ -177,7 +177,7 @@ When retrying a flaky test multiple times within a short span of time (less than
 
 ## Vitest test duration overhead is high
 
-Wall-clock time is often dominated by Vitest's default suite isolation (`isolate: true`) and repeated ESM instrumentation startup, not only by how long the tests themselves take. For that interaction and when it matters most, read [Vitest's test duration overhead][18] in the JavaScript test setup guide.
+High wall-clock time can show up when you have many small, fast suites: Vitest uses suite isolation by default (`isolate: true`), so ESM instrumentation startup repeats for every test file and that fixed cost adds up across files. Read [Vitest's test duration overhead][18] in the JavaScript test setup guide for the full explanation.
 
 To reduce overhead, pass `--no-isolate` to your test command or set `isolate: false` in your `vitest.config` file. For Vitest's reference on the setting, see the [`isolate` option][17].
 

--- a/content/en/tests/troubleshooting/_index.md
+++ b/content/en/tests/troubleshooting/_index.md
@@ -179,7 +179,7 @@ When retrying a flaky test multiple times within a short span of time (less than
 
 By default, Vitest's [`isolate`][17] option is `true`, so each test file runs in its own fork or thread. Vitest is ESM-first and relies on [import-in-the-middle][18] for instrumentation, which incurs a setup cost every time a suite starts. With isolation, that setup cost is repeated for every file. The effect is largest when you have many small, fast suites, because setup time can dominate wall-clock time.
 
-To lower overhead, set `isolate: false` in your `vitest.config` file, or pass `--no-isolate` to the test command.
+To lower overhead, set `isolate: false` in your Vitest config file, or pass `--no-isolate` to the test command.
 
 ## Further reading
 

--- a/content/en/tests/troubleshooting/_index.md
+++ b/content/en/tests/troubleshooting/_index.md
@@ -177,9 +177,9 @@ When retrying a flaky test multiple times within a short span of time (less than
 
 ## Vitest test duration overhead is high
 
-High wall-clock time can show up when you have many small, fast suites: Vitest uses suite isolation by default (`isolate: true`), so ESM instrumentation startup repeats for every test file and that fixed cost adds up across files. Read [Vitest's test duration overhead][18] in the JavaScript test setup guide for the full explanation.
+High wall-clock time can show up when you have many small, fast suites. Vitest uses suite isolation by default (`isolate: true`), so ESM instrumentation startup repeats for every test file, and that fixed cost adds up across files.
 
-To reduce overhead, pass `--no-isolate` to your test command or set `isolate: false` in your `vitest.config` file. For Vitest's reference on the setting, see the [`isolate` option][17].
+For Vitest's documentation on the setting, see [`isolate`][17].
 
 ## Further reading
 

--- a/content/en/tests/troubleshooting/_index.md
+++ b/content/en/tests/troubleshooting/_index.md
@@ -175,6 +175,12 @@ This is also caused by an unstable test session fingerprint. See the [Session hi
 
 When retrying a flaky test multiple times within a short span of time (less than a second), test run events might contain unexpected `@test.is_flaky`, `@test.is_known_flaky`, or `@test.is_new_flaky` tags. This is a known limitation that occurs due to a race condition in the flaky test detection system. In some cases, test run events might be processed out of order, causing the tags to not follow the logical order of events.
 
+## Vitest test duration overhead is high
+
+Wall-clock time is often dominated by Vitest's default suite isolation (`isolate: true`) and repeated ESM instrumentation startup, not only by how long the tests themselves take. For that interaction and when it matters most, read [Vitest's test duration overhead][18] in the JavaScript test setup guide.
+
+To reduce overhead, pass `--no-isolate` to your test command or set `isolate: false` in your `vitest.config` file. For Vitest's reference on the setting, see the [`isolate` option][17].
+
 ## Further reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -195,3 +201,5 @@ When retrying a flaky test multiple times within a short span of time (less than
 [14]: /tests/#supported-features
 [15]: /agent/configuration/network/
 [16]: /tests/network/
+[17]: https://vitest.dev/config/isolate
+[18]: /tests/setup/javascript/#vitests-test-duration-overhead

--- a/content/en/tests/troubleshooting/_index.md
+++ b/content/en/tests/troubleshooting/_index.md
@@ -177,9 +177,9 @@ When retrying a flaky test multiple times within a short span of time (less than
 
 ## Vitest test duration overhead is high
 
-High wall-clock time can show up when you have many small, fast suites. Vitest uses suite isolation by default (`isolate: true`), so ESM instrumentation startup repeats for every test file, and that fixed cost adds up across files.
+By default, Vitest's [`isolate`][17] option is `true`, so each test file runs in its own fork or thread. Vitest is ESM-first and relies on [import-in-the-middle][18] for instrumentation, which incurs a setup cost every time a suite starts. With isolation, that setup cost is repeated for every file. The effect is largest when you have many small, fast suites, because setup time can dominate wall-clock time.
 
-For Vitest's documentation on the setting, see [`isolate`][17].
+To lower overhead, set `isolate: false` in your `vitest.config` file, or pass `--no-isolate` to the test command.
 
 ## Further reading
 
@@ -202,4 +202,4 @@ For Vitest's documentation on the setting, see [`isolate`][17].
 [15]: /agent/configuration/network/
 [16]: /tests/network/
 [17]: https://vitest.dev/config/isolate
-[18]: /tests/setup/javascript/#vitests-test-duration-overhead
+[18]: https://github.com/nodejs/import-in-the-middle


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Reporting tests run by `vitest` to Test Optimization can have significant test duration overhead if test files run with `isolate:true` and are quick and plentiful. This PR helps identify the issue and provides a workaround. 

https://docs-staging.datadoghq.com/juan-fernandez/add-known-limitation-and-workaround/tests/troubleshooting/#vitest-test-duration-overhead-is-high

https://docs-staging.datadoghq.com/juan-fernandez/add-known-limitation-and-workaround/tests/setup/javascript/?tab=ciproviderwithautoinstrumentationsupport#vitests-test-duration-overhead

### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge

