### PR TITLE
Esther.kim/google workspace doc edits

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -2956,7 +2956,12 @@ menu:
       url: actions/connections/aws_integration/
       parent: actions_connections
       identifier: actions_aws_integration
-      weight: 101
+      weight: 102
+    - name: Google Workspace
+      url: actions/connections/google_workspace/
+      parent: actions_connections
+      identifier: actions_google_workspace
+      weight: 103
     - name: Private Actions
       url: actions/private_actions/
       parent: action_catalog

--- a/content/en/actions/connections/google_workspace.md
+++ b/content/en/actions/connections/google_workspace.md
@@ -1,6 +1,6 @@
 ---
 title: Google Workspace
-description: Connect Datadog Actions to Google Workspace services using OAuth2 to automate tasks in Gmail, Calendar, Drive, Docs, Sheets, Forms, and Chat.
+description: Connect Datadog Actions to Google Workspace services using OAuth 2.0 to automate tasks in Gmail, Calendar, Drive, Docs, Sheets, Forms, and Chat.
 disable_toc: false
 further_reading:
 - link: "/actions/connections/"
@@ -12,7 +12,7 @@ Use a Google Workspace connection to authenticate Datadog Actions against Google
 
 ## Prerequisites
 
-Before creating the connection in Datadog, you must set up an OAuth2 client in Google Cloud.
+Before creating the connection in Datadog, you must set up an OAuth 2.0 client in Google Cloud.
 
 ### Create a Google Cloud project
 
@@ -49,7 +49,7 @@ Enable the Google APIs you plan to use in your workflows:
 1. Under **Scopes**, add the OAuth scopes required for the actions you intend to use. See the [scopes reference](#scopes-reference).
 1. Complete the remaining steps and click **Back to Dashboard**.
 
-### Create OAuth2 credentials
+### Create OAuth 2.0 credentials
 
 1. Navigate to [**APIs & Services** > **Credentials**][5] in the Google Cloud Console.
 1. Click **Create Credentials** > **OAuth client ID**.
@@ -65,9 +65,9 @@ Enable the Google APIs you plan to use in your workflows:
 1. Click {{< ui >}}New Connection{{< /ui >}}.
 1. Select the {{< ui >}}Google Workspace{{< /ui >}} icon.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}.
-1. Enter the {{< ui >}}Client ID{{< /ui >}} and {{< ui >}}Client Secret{{< /ui >}} from your Google Cloud OAuth2 credentials.
+1. Enter the {{< ui >}}Client ID{{< /ui >}} and {{< ui >}}Client Secret{{< /ui >}} from your Google Cloud OAuth 2.0 credentials.
 1. Select the {{< ui >}}Scopes{{< /ui >}} required for the actions you plan to use. See the [scopes reference](#scopes-reference).
-1. The {{< ui >}}Authorize URL{{< /ui >}} and {{< ui >}}Token URL{{< /ui >}} fields are pre-populated with Google's default OAuth2 endpoints. Leave these as-is unless you have a specific reason to change them.
+1. The {{< ui >}}Authorize URL{{< /ui >}} and {{< ui >}}Token URL{{< /ui >}} fields are pre-populated with Google's default OAuth 2.0 endpoints. Leave these as-is unless you have a specific reason to change them.
 1. Click {{< ui >}}Create{{< /ui >}}.
 1. In the authorization window that opens, sign in with the Google account you want to use and grant the requested permissions.
 

--- a/content/en/actions/connections/google_workspace.md
+++ b/content/en/actions/connections/google_workspace.md
@@ -14,7 +14,7 @@ Use a Google Workspace connection to authenticate Datadog Actions against Google
 
 Before creating the connection in Datadog, you must set up an OAuth2 client in Google Cloud.
 
-### 1. Create a Google Cloud project
+### Create a Google Cloud project
 
 If you don't already have a Google Cloud project:
 
@@ -22,12 +22,12 @@ If you don't already have a Google Cloud project:
 1. Click **Select a project** > **New Project**.
 1. Enter a project name and click **Create**.
 
-### 2. Enable the required APIs
+### Enable the required APIs
 
 Enable the Google APIs you plan to use in your workflows:
 
-1. Navigate to [**APIs & Services** > **Library**][5] in the Google Cloud Console.
-1. Search for and enable the APIs for the Google Workspace services you intend to use:
+1. Navigate to [**APIs & Services** > **Library**][3] in the Google Cloud Console.
+1. Search for and enable the APIs for the Google Workspace services you intend to use, listed in the following table.
 
 | Google Workspace service | API to enable |
 |---|---|
@@ -39,36 +39,36 @@ Enable the Google APIs you plan to use in your workflows:
 | Google Forms | Google Forms API |
 | Google Chat | Google Chat API |
 
-### 3. Configure the OAuth consent screen
+### Configure the OAuth consent screen
 
-1. Navigate to [**APIs & Services** > **OAuth consent screen**][6] in the Google Cloud Console.
+1. Navigate to [**APIs & Services** > **OAuth consent screen**][4] in the Google Cloud Console.
 1. Select a user type:
    - **Internal**: Limits access to users in your Google Workspace organization. Recommended for most enterprise use cases.
    - **External**: Allows any Google account to authorize. Requires app verification for production use.
 1. Fill in the required app information fields and click **Save and Continue**.
-1. Under **Scopes**, add the OAuth scopes required for the actions you intend to use. See the [scopes reference](#scopes-reference) below.
+1. Under **Scopes**, add the OAuth scopes required for the actions you intend to use. See the [scopes reference](#scopes-reference).
 1. Complete the remaining steps and click **Back to Dashboard**.
 
-### 4. Create OAuth2 credentials
+### Create OAuth2 credentials
 
-1. Navigate to [**APIs & Services** > **Credentials**][7] in the Google Cloud Console.
+1. Navigate to [**APIs & Services** > **Credentials**][5] in the Google Cloud Console.
 1. Click **Create Credentials** > **OAuth client ID**.
 1. For **Application type**, select **Web application**.
 1. Under **Authorized JavaScript origins**, add the Datadog origin URL. This URL is displayed in the Datadog connection creation dialog when you select **Google Workspace**.
 1. Under **Authorized redirect URIs**, add the Datadog OAuth callback URL. This URL is also displayed in the Datadog connection creation dialog when you select **Google Workspace**.
 1. Click **Create**.
-1. Copy the **Client ID** and **Client Secret** — you need these when creating the connection in Datadog.
+1. Copy the **Client ID** and **Client Secret**—you need these when creating the connection in Datadog.
 
 ## Create the connection in Datadog
 
-1. From the [Action Catalog page][2], click the **Connections** tab.
-1. Click **New Connection**.
-1. Select the **Google Workspace** icon.
-1. Enter a **Connection Name**.
-1. Enter the **Client ID** and **Client Secret** from your Google Cloud OAuth2 credentials.
-1. Select the **Scopes** required for the actions you plan to use. See the [scopes reference](#scopes-reference) below.
-1. The **Authorize URL** and **Token URL** fields are pre-populated with Google's default OAuth2 endpoints. Leave these as-is unless you have a specific reason to change them.
-1. Click **Create**.
+1. From the [Action Catalog page][2], click the {{< ui >}}Connections{{< /ui >}} tab.
+1. Click {{< ui >}}New Connection{{< /ui >}}.
+1. Select the {{< ui >}}Google Workspace{{< /ui >}} icon.
+1. Enter a {{< ui >}}Connection Name{{< /ui >}}.
+1. Enter the {{< ui >}}Client ID{{< /ui >}} and {{< ui >}}Client Secret{{< /ui >}} from your Google Cloud OAuth2 credentials.
+1. Select the {{< ui >}}Scopes{{< /ui >}} required for the actions you plan to use. See the [scopes reference](#scopes-reference).
+1. The {{< ui >}}Authorize URL{{< /ui >}} and {{< ui >}}Token URL{{< /ui >}} fields are pre-populated with Google's default OAuth2 endpoints. Leave these as-is unless you have a specific reason to change them.
+1. Click {{< ui >}}Create{{< /ui >}}.
 1. In the authorization window that opens, sign in with the Google account you want to use and grant the requested permissions.
 
 ## Scopes reference
@@ -111,15 +111,15 @@ Select only the scopes required by the actions you intend to use.
 
 | Scope label | Scope value | Description |
 |---|---|---|
-| Docs: Full Access | `https://www.googleapis.com/auth/documents` | View and manage Google Docs documents |
-| Docs: Read Only | `https://www.googleapis.com/auth/documents.readonly` | View Google Docs documents |
+| Docs: Full Access | `https://www.googleapis.com/auth/documents` | View and manage documents in Google Docs |
+| Docs: Read Only | `https://www.googleapis.com/auth/documents.readonly` | View documents in Google Docs |
 
 ### Google Sheets
 
 | Scope label | Scope value | Description |
 |---|---|---|
-| Sheets: Full Access | `https://www.googleapis.com/auth/spreadsheets` | View and manage Google Sheets spreadsheets |
-| Sheets: Read Only | `https://www.googleapis.com/auth/spreadsheets.readonly` | View Google Sheets spreadsheets |
+| Sheets: Full Access | `https://www.googleapis.com/auth/spreadsheets` | View and manage spreadsheets in Google Sheets |
+| Sheets: Read Only | `https://www.googleapis.com/auth/spreadsheets.readonly` | View spreadsheets in Google Sheets |
 
 ### Google Forms
 
@@ -145,7 +145,7 @@ Select only the scopes required by the actions you intend to use.
 | Scope label | Scope value | Description |
 |---|---|---|
 | User Info: Email Address | `https://www.googleapis.com/auth/userinfo.email` | View the user's email address |
-| User Info: Basic Profile | `https://www.googleapis.com/auth/userinfo.profile` | View the user's basic profile info |
+| User Info: Basic Profile | `https://www.googleapis.com/auth/userinfo.profile` | View the user's basic profile information |
 | OpenID Connect | `openid` | Authenticate using OpenID Connect |
 
 ### Google Workspace Admin
@@ -161,11 +161,11 @@ Select only the scopes required by the actions you intend to use.
 
 {{< partial name="whats-next/whats-next.html" >}}
 
-<br>Do you have questions or feedback? Join the **#workflows** or **#app-builder** channel on the [Datadog Community Slack][4].
+<br>Do you have questions or feedback? Join the **#workflows** or **#app-builder** channel on the [Datadog Community Slack][6].
 
 [1]: https://console.cloud.google.com/
 [2]: https://app.datadoghq.com/actions/action-catalog
-[4]: https://chat.datadoghq.com/
-[5]: https://console.cloud.google.com/apis/library
-[6]: https://console.cloud.google.com/apis/credentials/consent
-[7]: https://console.cloud.google.com/apis/credentials
+[3]: https://console.cloud.google.com/apis/library
+[4]: https://console.cloud.google.com/apis/credentials/consent
+[5]: https://console.cloud.google.com/apis/credentials
+[6]: https://chat.datadoghq.com/

--- a/content/en/actions/connections/http.md
+++ b/content/en/actions/connections/http.md
@@ -52,7 +52,7 @@ If you need to authenticate your request, use the action's {{< ui >}}Connection{
 1. In the {{< ui >}}Connection{{< /ui >}} section, click the plus icon ({{< ui >}}+{{< /ui >}}).
 1. Select {{< ui >}}Azure{{< /ui >}}.
 1. Enter a {{< ui >}}Connection Name{{< /ui >}}, {{< ui >}}Tenant ID{{< /ui >}}, {{< ui >}}Client ID{{< /ui >}}, and {{< ui >}}Client Secret{{< /ui >}}.
-1. Optionally, enter the {{< ui >}}Custom Scope{{< /ui >}} to be requested from Microsoft when acquiring an OAuth 2 access token. A resource's scope is constructed using the identifier URI for the resource and `.default`, separated by a forward slash (`/`). For example, `{identifierURI}/.default`. For more information, see [the Microsoft documentation on .default scope][3].
+1. Optionally, enter the {{< ui >}}Custom Scope{{< /ui >}} to be requested from Microsoft when acquiring an OAuth 2.0 access token. A resource's scope is constructed using the identifier URI for the resource and `.default`, separated by a forward slash (`/`). For example, `{identifierURI}/.default`. For more information, see [the Microsoft documentation on .default scope][3].
 1. Click {{< ui >}}Create{{< /ui >}}.
 
 ### Create an HTTP token authentication connection


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Docs specific formatting fixes for the editorial review:

<!-- A brief description of the change being made with this pull request. What is your motivation for the PR? -->
  content/en/actions/connections/google_workspace.md
  - Removed the directional "below" from references to the scopes reference anchor.
  - Combined the duplicated "This URL is displayed in the Datadog connection creation dialog…" sentence into a single
  shared note covering both the Authorized JavaScript origins and Authorized redirect URIs steps.
  - Updated the lead-in for "Enable the required APIs" from "in your workflows" to "in your workflows and apps" for
  consistency with the introduction.
  - Standardized OAuth terminology to OAuth 2.0 throughout (description, prerequisites, "Create OAuth 2.0 credentials"
  heading, and references in the Datadog setup steps).
  - Cleaned up minor wording: "authenticate against" → "authenticate with", trimmed "This allows you to interact
  with…", and tightened repeated phrasing like "the actions you intend to use."
  - Refined a scope description ("View the user's basic profile info" → "…basic profile information") and adjusted the
  Gmail "All access except deleting permanently" row for parallelism.
  - Renumbered reference-style links to remove the gap (formerly skipped [3]).

  content/en/actions/connections/http.md
  - Updated OAuth 2 → OAuth 2.0 in the Azure connection step to match the new convention used in the Google Workspace
  doc.
### Merge instructions

<!-- 
If you're waiting for a release or there are other considerations that you want us to be aware of, list them here. 
If the PR is ready to be merged once it receives the required reviews, check the box below after you've created the PR.
-->

Merge readiness:
- [x] Ready for merge
