### PR TITLE
[OTAGENT-1027] Expand Collector health metrics setup with Prometheus and OTLP tabs

### DIFF
--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -208,7 +208,7 @@ Datadog maps these attributes to tags and host metadata. For the full list of su
 
 ### `service.telemetry.metrics` fields
 
-The following top-level fields apply to both setups:
+The following top-level fields apply to both Prometheus and OTLP setups:
 
 `level`
 : Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. Set `level: detailed` to enable `views`.

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -52,7 +52,7 @@ exporters:
 service:
   telemetry:
     metrics:
-      level: detailed
+      level: normal
       readers:
         - pull:
             exporter:
@@ -136,7 +136,7 @@ Configure the Collector's internal telemetry to push metrics directly to the [Da
 service:
   telemetry:
     metrics:
-      level: detailed
+      level: normal
       readers:
         - periodic:
             interval: 10000
@@ -152,7 +152,7 @@ service:
                   - name: dd-api-key
                     value: ${env:DD_API_KEY}
                   - name: dd-otel-metric-config
-                    value: '{"resource_attributes_as_tags": true}'
+                    value: '{"resource_attributes_as_tags": true, "instrumentation_scope_metadata_as_tags": true}'
                 # default_histogram_aggregation: explicit_bucket_histogram
                 # headers_list: "dd-api-key=${env:DD_API_KEY}"
                 # insecure: false
@@ -170,6 +170,10 @@ service:
 Replace `<OTLP_METRICS_ENDPOINT>` with the [Datadog OTLP metrics intake endpoint][201] for your [Datadog site][202]. Your endpoint is {{< region-param key="otlp_metrics_endpoint" code="true" >}}.
 
 The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `temporality_preference: delta` is required. The `dd-api-key` header authenticates the request. For configuration options (including the `dd-otel-metric-config` header for customizing metric translation) and troubleshooting, see [Datadog OTLP Metrics Intake Endpoint][201].
+
+<div class="alert alert-warning">
+This setup pushes metrics directly to the OTLP intake endpoint, bypassing any enrichment that pipeline processors (such as <code>resourcedetection</code> or <code>k8sattributes</code>) would otherwise apply. To populate Datadog tags and host metadata (which are needed for hostname resolution and the default Collector dashboard), set the relevant attributes explicitly under <a href="#optional-tag-with-resource-attributes"><code>service.telemetry.resource</code></a>. If you need automatic hostname and cloud-attribute detection, use the Prometheus tab instead.
+</div>
 
 **`periodic` reader options:**
 
@@ -243,7 +247,7 @@ service:
       deployment.environment: prod
 ```
 
-The declarative `attributes` format supports explicit typing and a `schema_url`:
+Alternatively, use the declarative `attributes` format, which supports explicit typing and a `schema_url`. This format requires Collector v0.151.0 or later:
 
 ```yaml
 service:
@@ -255,13 +259,9 @@ service:
           value: my-cluster
         - name: k8s.pod.name
           value: ${env:HOSTNAME}
-      detectors:
-        attributes:
-          included: [host.id, host.name, cloud.provider, cloud.region]
-          excluded: []
 ```
 
-Use `detectors.attributes.included` and `detectors.attributes.excluded` to allowlist or denylist attributes contributed by SDK-side resource detectors. To suppress a default attribute such as `service.version`, specify it with a null value in the legacy inline format.
+To suppress a default attribute such as `service.version`, specify it with a null value in the legacy inline format.
 
 These attributes are mapped to Datadog tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][6] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][7].
 

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -79,7 +79,7 @@ service:
 
 Replace `<DATADOG_SITE>` with your [Datadog site][106]. Your site is {{< region-param key="dd_site" code="true" >}}.
 
-The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint and the metrics pipeline forwards them to Datadog.
+The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint, and the metrics pipeline forwards them to Datadog.
 
 **`pull.exporter.prometheus` options:**
 
@@ -87,7 +87,7 @@ The `service.telemetry.metrics` block exposes the Collector's internal metrics o
 : Address to expose the Prometheus endpoint on. Defaults to `localhost:8888`. Use `0.0.0.0` to expose outside the loopback interface.
 
 `without_type_suffix`
-: When `true`, drops the type suffix (for example, `_total` for counters) from metric names. The Collector defaults to `true`, which produces names such as `otelcol_exporter_sent_metric_points` instead of `otelcol_exporter_sent_metric_points_total`.
+: When `true` (the Collector default), drops the type suffix (for example, `_total` for counters) from metric names. Names appear as `otelcol_exporter_sent_metric_points` instead of `otelcol_exporter_sent_metric_points_total`.
 
 `without_units`
 : When `true`, drops the unit suffix (for example, `_seconds`, `_bytes`) from metric names.
@@ -100,7 +100,7 @@ The `service.telemetry.metrics` block exposes the Collector's internal metrics o
 
 #### Optional: enrich with processors
 
-Add the [resource detection processor][103] to the metrics pipeline to automatically populate cloud and host resource attributes (for example, `host.id`, `cloud.provider`, `cloud.region`). Other processors such as [`transform`][104] or [`k8sattributes`][105] can also be added to the pipeline to further enrich or transform Collector health metrics before they are exported.
+Add the [resource detection processor][103] to the metrics pipeline to automatically populate cloud and host resource attributes (for example, `host.id`, `cloud.provider`, `cloud.region`). You can also add other processors such as [`transform`][104] or [`k8sattributes`][105] to enrich or transform Collector health metrics before export.
 
 ```yaml
 processors:
@@ -210,7 +210,7 @@ This setup pushes metrics directly to the OTLP intake endpoint, bypassing any en
 : When `true`, disables TLS. Defaults to `false`.
 
 `certificate`, `client_certificate`, `client_key`
-: Paths to PEM files for custom CA verification and mTLS client authentication.
+: Paths to PEM files for custom CA verification and mutual TLS (mTLS) client authentication.
 
 [201]: /opentelemetry/setup/otlp_ingest/metrics/
 [202]: /getting_started/site
@@ -223,7 +223,7 @@ This setup pushes metrics directly to the OTLP intake endpoint, bypassing any en
 The following top-level fields apply to both setups:
 
 `level`
-: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. `detailed` is required to enable `views`.
+: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. Set `level: detailed` to enable `views`.
 
 `readers`
 : List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
@@ -263,7 +263,7 @@ service:
 
 To suppress a default attribute such as `service.version`, specify it with a null value in the legacy inline format.
 
-These attributes are mapped to Datadog tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][6] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][7].
+Datadog maps these attributes to tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][6] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][7].
 
 ## Data collected
 

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -154,7 +154,7 @@ service:
       #         drop: {}
 ```
 
-Replace `<OTLP_METRICS_ENDPOINT>` with the [Datadog OTLP metrics intake endpoint][201] for your [Datadog site][202]. Your endpoint is {{< region-param key="otlp_metrics_endpoint" code="true" >}}.
+Replace `<OTLP_METRICS_ENDPOINT>` with the [Datadog OTLP metrics intake endpoint][201] for your [Datadog site][202]: {{< region-param key="otlp_metrics_endpoint" code="true" >}}.
 
 The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `temporality_preference: delta` is required. The `dd-api-key` header authenticates the request. For configuration options (including the `dd-otel-metric-config` header for customizing metric translation) and troubleshooting, see [Datadog OTLP Metrics Intake Endpoint][201].
 

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -42,7 +42,7 @@ exporters:
   datadog:
     api:
       key: ${env:DD_API_KEY}
-      site: {{< region-param key="dd_site" >}}
+      site: <DATADOG_SITE>
     metrics:
       resource_attributes_as_tags: true
     sending_queue:
@@ -76,6 +76,8 @@ service:
       receivers: [prometheus/internal]
       exporters: [datadog]
 ```
+
+Replace `<DATADOG_SITE>` with your [Datadog site][106]. Your site is {{< region-param key="dd_site" code="true" >}}.
 
 The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint and the metrics pipeline forwards them to Datadog.
 
@@ -123,6 +125,7 @@ If you have a Datadog Agent running on the same host as an OpenTelemetry Collect
 [103]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
 [104]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor
 [105]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor
+[106]: /getting_started/site
 
 {{% /tab %}}
 {{% tab "OTLP" %}}
@@ -141,7 +144,7 @@ service:
             exporter:
               otlp:
                 protocol: http/protobuf
-                endpoint: {{< region-param key="otlp_metrics_endpoint" >}}
+                endpoint: <OTLP_METRICS_ENDPOINT>
                 temporality_preference: delta
                 compression: gzip
                 timeout: 5000
@@ -163,6 +166,8 @@ service:
       #       aggregation:
       #         drop: {}
 ```
+
+Replace `<OTLP_METRICS_ENDPOINT>` with the [Datadog OTLP metrics intake endpoint][201] for your [Datadog site][202]. Your endpoint is {{< region-param key="otlp_metrics_endpoint" code="true" >}}.
 
 The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `temporality_preference: delta` is required. The `dd-api-key` header authenticates the request. For configuration options (including the `dd-otel-metric-config` header for customizing metric translation) and troubleshooting, see [Datadog OTLP Metrics Intake Endpoint][201].
 
@@ -204,6 +209,7 @@ The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `tempora
 : Paths to PEM files for custom CA verification and mTLS client authentication.
 
 [201]: /opentelemetry/setup/otlp_ingest/metrics/
+[202]: /getting_started/site
 
 {{% /tab %}}
 {{< /tabs >}}

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -156,13 +156,12 @@ service:
 
 Replace `<OTLP_METRICS_ENDPOINT>` with the [Datadog OTLP metrics intake endpoint][201] for your [Datadog site][202]: {{< region-param key="otlp_metrics_endpoint" code="true" >}}.
 
-The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `temporality_preference: delta` is required. The `dd-api-key` header authenticates the request. For configuration options (including the `dd-otel-metric-config` header for customizing metric translation) and troubleshooting, see [Datadog OTLP Metrics Intake Endpoint][201].
+The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `temporality_preference: delta` is required. The `dd-api-key` header authenticates the request, and the `dd-otel-metric-config` header customizes how metrics are translated to Datadog. For all the YAML fields available under the `periodic` reader, see [`periodic.exporter.otlp` options](#periodicexporterotlp-options); for the full list of metric-translation options and troubleshooting, see [Datadog OTLP Metrics Intake Endpoint][201].
 
 <div class="alert alert-warning">
 This setup pushes metrics directly to the OTLP intake endpoint, bypassing any enrichment that pipeline processors (such as <code>resourcedetection</code> or <code>k8sattributes</code>) would otherwise apply. To populate Datadog tags and host metadata (which are needed for hostname resolution and the default Collector dashboard), set the relevant attributes explicitly under <a href="#tag-with-resource-attributes-optional"><code>service.telemetry.resource</code></a>. If you need automatic hostname and cloud-attribute detection, use the Prometheus tab instead.
 </div>
 
-For all available options, see [`periodic.exporter.otlp` options](#periodicexporterotlp-options).
 
 [201]: /opentelemetry/setup/otlp_ingest/metrics/
 [202]: /getting_started/site

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -21,6 +21,8 @@ You can collect Collector health metrics in two ways:
 
 ## Setup
 
+The two tabs below show alternative ways to configure the pipeline. Pick one based on whether you want a Prometheus-style scrape or a direct OTLP push. The [`service.telemetry.metrics` fields](#servicetelemetrymetrics-fields) and [resource attribute](#optional-tag-with-resource-attributes) sections that follow apply to both setups.
+
 {{< tabs >}}
 {{% tab "Prometheus" %}}
 
@@ -77,17 +79,6 @@ service:
 
 The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint and the metrics pipeline forwards them to Datadog.
 
-**Top-level fields under `service.telemetry.metrics`:**
-
-`level`
-: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. `detailed` is required to enable `views`.
-
-`readers`
-: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
-
-`views`
-: Optional list of [SDK views][109] that drop, rename, filter, or re-aggregate specific instruments. Only available when `level: detailed`.
-
 **`pull.exporter.prometheus` options:**
 
 `host` / `port`
@@ -105,47 +96,9 @@ The `service.telemetry.metrics` block exposes the Collector's internal metrics o
 `with_resource_constant_labels.included` / `with_resource_constant_labels.excluded`
 : Allowlist and denylist of resource attributes to copy onto every exported metric as constant labels.
 
-#### Optional: tag with resource attributes
-
-Use `service.telemetry.resource` to attach resource attributes (such as `k8s.cluster.name`, `service.instance.id`, or any [Datadog-mapped semantic convention][103]) to all telemetry the Collector emits about itself.
-
-Use the legacy inline map format for a concise definition:
-
-```yaml
-service:
-  telemetry:
-    resource:
-      k8s.cluster.name: my-cluster
-      k8s.pod.name: ${env:HOSTNAME}
-      service.instance.id: ${env:HOSTNAME}
-      deployment.environment: prod
-```
-
-The declarative `attributes` format supports explicit typing and a `schema_url`:
-
-```yaml
-service:
-  telemetry:
-    resource:
-      schema_url: https://opentelemetry.io/schemas/1.27.0
-      attributes:
-        - name: k8s.cluster.name
-          value: my-cluster
-        - name: k8s.pod.name
-          value: ${env:HOSTNAME}
-      detectors:
-        attributes:
-          included: [host.id, host.name, cloud.provider, cloud.region]
-          excluded: []
-```
-
-Use `detectors.attributes.included` and `detectors.attributes.excluded` to allowlist or denylist attributes contributed by SDK-side resource detectors. To suppress a default attribute such as `service.version`, specify it with a null value in the legacy inline format.
-
-These attributes are mapped to Datadog tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][103] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][104].
-
 #### Optional: enrich with processors
 
-Add the [resource detection processor][105] to the metrics pipeline to automatically populate cloud and host resource attributes (for example, `host.id`, `cloud.provider`, `cloud.region`). Other processors such as [`transform`][106] or [`k8sattributes`][107] can also be added to the pipeline to further enrich or transform Collector health metrics before they are exported.
+Add the [resource detection processor][103] to the metrics pipeline to automatically populate cloud and host resource attributes (for example, `host.id`, `cloud.provider`, `cloud.region`). Other processors such as [`transform`][104] or [`k8sattributes`][105] can also be added to the pipeline to further enrich or transform Collector health metrics before they are exported.
 
 ```yaml
 processors:
@@ -167,12 +120,9 @@ If you have a Datadog Agent running on the same host as an OpenTelemetry Collect
 
 [101]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
 [102]: /opentelemetry/setup/collector_exporter/
-[103]: /opentelemetry/mapping/semantic_mapping/
-[104]: /opentelemetry/mapping/hostname/
-[105]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
-[106]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor
-[107]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor
-[109]: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view
+[103]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+[104]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor
+[105]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor
 
 {{% /tab %}}
 {{% tab "OTLP" %}}
@@ -216,17 +166,6 @@ service:
 
 The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `temporality_preference: delta` is required. The `dd-api-key` header authenticates the request. For configuration options (including the `dd-otel-metric-config` header for customizing metric translation) and troubleshooting, see [Datadog OTLP Metrics Intake Endpoint][201].
 
-**Top-level fields under `service.telemetry.metrics`:**
-
-`level`
-: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. `detailed` is required to enable `views`.
-
-`readers`
-: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
-
-`views`
-: Optional list of [SDK views][204] to drop, rename, filter attributes on, or change the aggregation of specific instruments. Only available when `level: detailed`.
-
 **`periodic` reader options:**
 
 `interval`
@@ -264,11 +203,29 @@ The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `tempora
 `certificate`, `client_certificate`, `client_key`
 : Paths to PEM files for custom CA verification and mTLS client authentication.
 
-#### Optional: tag with resource attributes
+[201]: /opentelemetry/setup/otlp_ingest/metrics/
 
-Use `service.telemetry.resource` to attach resource attributes (such as `k8s.cluster.name`, `service.instance.id`, or any [Datadog-mapped semantic convention][202]) to all telemetry the Collector emits about itself.
+{{% /tab %}}
+{{< /tabs >}}
 
-The legacy inline map format is concise:
+### `service.telemetry.metrics` fields
+
+The following top-level fields apply to both setups:
+
+`level`
+: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. `detailed` is required to enable `views`.
+
+`readers`
+: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
+
+`views`
+: Optional list of [SDK views][5] that drop, rename, filter, or re-aggregate specific instruments. Only available when `level: detailed`.
+
+### Optional: tag with resource attributes
+
+Use `service.telemetry.resource` to attach resource attributes (such as `k8s.cluster.name`, `service.instance.id`, or any [Datadog-mapped semantic convention][6]) to all telemetry the Collector emits about itself.
+
+Use the legacy inline map format for a concise definition:
 
 ```yaml
 service:
@@ -298,17 +255,9 @@ service:
           excluded: []
 ```
 
-`detectors.attributes.included` and `detectors.attributes.excluded` allow- or deny-list attributes contributed by SDK-side resource detectors. To set an attribute to a null value (suppressing a default such as `service.version`), specify it with a null value in the legacy inline format.
+Use `detectors.attributes.included` and `detectors.attributes.excluded` to allowlist or denylist attributes contributed by SDK-side resource detectors. To suppress a default attribute such as `service.version`, specify it with a null value in the legacy inline format.
 
-These attributes are mapped to Datadog tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][202] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][203].
-
-[201]: /opentelemetry/setup/otlp_ingest/metrics/
-[202]: /opentelemetry/mapping/semantic_mapping/
-[203]: /opentelemetry/mapping/hostname/
-[204]: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view
-
-{{% /tab %}}
-{{< /tabs >}}
+These attributes are mapped to Datadog tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][6] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][7].
 
 ## Data collected
 
@@ -406,3 +355,6 @@ Descriptor:
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
 [3]: https://pkg.go.dev/runtime#MemStats.Sys
 [4]: /opentelemetry/setup/otlp_ingest/metrics/
+[5]: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view
+[6]: /opentelemetry/mapping/semantic_mapping/
+[7]: /opentelemetry/mapping/hostname/

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -14,7 +14,7 @@ further_reading:
 
 The OpenTelemetry Collector exposes internal telemetry as metrics. You can collect these metrics and send them to Datadog to monitor Collector health and pipeline throughput.
 
-You can collect Collector health metrics in two ways:
+You can send the Collector's health metrics to Datadog with two approaches:
 
 - **Prometheus**: Scrape the Collector's internal Prometheus endpoint with the [Prometheus receiver][1] and forward the metrics through a metrics pipeline to the Datadog Exporter.
 - **OTLP**: Configure the Collector's internal telemetry to export metrics directly to the [Datadog OTLP metrics intake endpoint][4] over OTLP HTTP.
@@ -23,12 +23,12 @@ You can collect Collector health metrics in two ways:
 
 ### Configure the pipeline
 
-Pick a tab based on whether you want a Prometheus-style scrape or a direct OTLP push. After configuring the pipeline, see the [Configuration reference](#configuration-reference) for all available options.
+The following tabs cover two approaches: a Prometheus-style scrape and a direct OTLP push. After configuring the pipeline, see the [Configuration reference](#configuration-reference) for all available options.
 
 {{< tabs >}}
 {{% tab "Prometheus" %}}
 
-Configure the Collector to expose its internal metrics on a Prometheus pull endpoint. Then scrape that endpoint with the [Prometheus receiver][101] and route the data through a metrics pipeline to the [Datadog Exporter][102].
+Configure the Collector to expose its internal metrics on a Prometheus pull endpoint. Scrape that endpoint with the [Prometheus receiver][101] and route the data through a metrics pipeline to the [Datadog Exporter][102].
 
 ```yaml
 receivers:
@@ -81,11 +81,11 @@ service:
 
 Replace `<DATADOG_SITE>` with your [Datadog site][106]: {{< region-param key="dd_site" code="true" >}}.
 
-The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint, and the metrics pipeline forwards them to Datadog.
+The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint, and the metrics pipeline forwards the scraped metrics to Datadog.
 
-For all available options, see [`pull.exporter.prometheus` options](#pullexporterprometheus-options) in the [Configuration reference](#configuration-reference).
+For all available options, see [`pull.exporter.prometheus` options](#pullexporterprometheus-options).
 
-#### Optional: enrich with processors
+#### Enrich with processors (optional)
 
 Add the [resource detection processor][103] to the metrics pipeline to automatically populate cloud and host resource attributes (for example, `host.id`, `cloud.provider`, `cloud.region`). You can also add other processors such as [`transform`][104] or [`k8sattributes`][105] to enrich or transform Collector health metrics before export.
 
@@ -162,7 +162,7 @@ The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `tempora
 This setup pushes metrics directly to the OTLP intake endpoint, bypassing any enrichment that pipeline processors (such as <code>resourcedetection</code> or <code>k8sattributes</code>) would otherwise apply. To populate Datadog tags and host metadata (which are needed for hostname resolution and the default Collector dashboard), set the relevant attributes explicitly under <a href="#tag-with-resource-attributes-optional"><code>service.telemetry.resource</code></a>. If you need automatic hostname and cloud-attribute detection, use the Prometheus tab instead.
 </div>
 
-For all available options, see [`periodic.exporter.otlp` options](#periodicexporterotlp-options) in the [Configuration reference](#configuration-reference).
+For all available options, see [`periodic.exporter.otlp` options](#periodicexporterotlp-options).
 
 [201]: /opentelemetry/setup/otlp_ingest/metrics/
 [202]: /getting_started/site
@@ -214,7 +214,7 @@ The following top-level fields apply to both Prometheus and OTLP setups:
 : Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. Set `level: detailed` to enable `views`.
 
 `readers`
-: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
+: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP or console).
 
 `views`
 : Optional list of [SDK views][5] that drop, rename, filter, or re-aggregate specific instruments. Only available when `level: detailed`.

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -12,28 +12,303 @@ further_reading:
 
 {{< img src="/opentelemetry/collector_exporter/collector_health_metrics.png" alt="OpenTelemetry Collector health metrics dashboard" style="width:100%;" >}}
 
-To collect health metrics from the OpenTelemetry Collector itself, configure the [Prometheus receiver][1] in your Datadog Exporter.
+The OpenTelemetry Collector exposes its own internal telemetry as metrics, which you can collect and send to Datadog to monitor Collector health and pipeline throughput.
 
-For more information, see the OpenTelemetry project documentation for the [Prometheus receiver][1].
+You can collect Collector health metrics two ways:
+
+- **Prometheus**: Scrape the Collector's internal Prometheus endpoint with the [Prometheus receiver][1] and forward the metrics through a metrics pipeline to the Datadog Exporter.
+- **OTLP**: Configure the Collector's internal telemetry to export metrics directly to the [Datadog OTLP metrics intake endpoint][4] over OTLP HTTP.
 
 ## Setup
 
-Add the following lines to your Collector configuration:
+{{< tabs >}}
+{{% tab "Prometheus" %}}
+
+Configure the Collector to expose its internal metrics on a Prometheus pull endpoint, then scrape that endpoint with the [Prometheus receiver][101] and route the data through a metrics pipeline to the [Datadog Exporter][102].
 
 ```yaml
 receivers:
-  prometheus:
+  prometheus/internal:
     config:
       scrape_configs:
-      - job_name: 'otelcol'
-        scrape_interval: 10s
-        static_configs:
-        - targets: ['0.0.0.0:8888']
+        - job_name: 'otelcol'
+          scrape_interval: 10s
+          static_configs:
+            - targets: ['0.0.0.0:8888']
+
+exporters:
+  datadog:
+    api:
+      key: ${env:DD_API_KEY}
+      site: {{< region-param key="dd_site" >}}
+    metrics:
+      resource_attributes_as_tags: true
+    sending_queue:
+      batch:
+        flush_timeout: 10s
+
+service:
+  telemetry:
+    metrics:
+      level: detailed
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: 0.0.0.0
+                port: 8888
+                without_type_suffix: true
+                without_units: true
+                without_scope_info: true
+                # with_resource_constant_labels:
+                #   included: ["service.name", "service.instance.id"]
+                #   excluded: []
+      # views:
+      #   - selector:
+      #       instrument_name: otelcol_processor_*
+      #     stream:
+      #       aggregation:
+      #         drop: {}
+  pipelines:
+    metrics:
+      receivers: [prometheus/internal]
+      exporters: [datadog]
+```
+
+The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint and the metrics pipeline forwards them to Datadog.
+
+**Top-level fields under `service.telemetry.metrics`:**
+
+`level`
+: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. `detailed` is required to enable `views`.
+
+`readers`
+: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
+
+`views`
+: Optional list of [SDK views][109] to drop, rename, filter attributes on, or change the aggregation of specific instruments. Only available when `level: detailed`.
+
+**`pull.exporter.prometheus` options:**
+
+`host` / `port`
+: Address to expose the Prometheus endpoint on. Defaults to `localhost:8888`. Use `0.0.0.0` to expose outside the loopback interface.
+
+`without_type_suffix`
+: When `true`, drops the type suffix (for example, `_total` for counters) from metric names. The Collector defaults to `true`, which produces names such as `otelcol_exporter_sent_metric_points` instead of `otelcol_exporter_sent_metric_points_total`.
+
+`without_units`
+: When `true`, drops the unit suffix (for example, `_seconds`, `_bytes`) from metric names.
+
+`without_scope_info`
+: When `true`, suppresses the `otel_scope_info` metric and `otel_scope_*` labels.
+
+`with_resource_constant_labels.included` / `with_resource_constant_labels.excluded`
+: Allow- and deny-lists of resource attributes to copy onto every exported metric as constant labels.
+
+#### Optional: tag with resource attributes
+
+Use `service.telemetry.resource` to attach resource attributes (such as `k8s.cluster.name`, `service.instance.id`, or any [Datadog-mapped semantic convention][103]) to all telemetry the Collector emits about itself.
+
+The legacy inline map format is concise:
+
+```yaml
+service:
+  telemetry:
+    resource:
+      k8s.cluster.name: my-cluster
+      k8s.pod.name: ${env:HOSTNAME}
+      service.instance.id: ${env:HOSTNAME}
+      deployment.environment: prod
+```
+
+The declarative `attributes` format supports explicit typing and a `schema_url`:
+
+```yaml
+service:
+  telemetry:
+    resource:
+      schema_url: https://opentelemetry.io/schemas/1.27.0
+      attributes:
+        - name: k8s.cluster.name
+          value: my-cluster
+        - name: k8s.pod.name
+          value: ${env:HOSTNAME}
+      detectors:
+        attributes:
+          included: [host.id, host.name, cloud.provider, cloud.region]
+          excluded: []
+```
+
+`detectors.attributes.included` and `detectors.attributes.excluded` allow- or deny-list attributes contributed by SDK-side resource detectors. To set an attribute to a null value (suppressing a default such as `service.version`), specify it with a null value in the legacy inline format.
+
+These attributes are mapped to Datadog tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][103] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][104].
+
+#### Optional: enrich with processors
+
+Add the [resource detection processor][105] to the metrics pipeline to automatically populate cloud and host resource attributes (for example, `host.id`, `cloud.provider`, `cloud.region`). Other processors such as [`transform`][106] or [`k8sattributes`][107] can also be added to the pipeline to further enrich or transform Collector health metrics before they are exported.
+
+```yaml
+processors:
+  resourcedetection:
+    detectors: [env, system, ec2]
+    override: false
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus/internal]
+      processors: [resourcedetection]
+      exporters: [datadog]
 ```
 
 <div class="alert alert-warning">
 If you have a Datadog Agent running on the same host as an OpenTelemetry Collector or DDOT Collector that uses a Prometheus receiver to scrape Collector health metrics, make sure the Agent's <a href="/integrations/openmetrics/">OpenMetrics integration</a> is either turned off or scraping a different endpoint than the Collector health metrics endpoint. Otherwise, both the Agent and Collector scrape the same endpoint, resulting in duplicate Collector health metrics.
 </div>
+
+[101]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
+[102]: /opentelemetry/setup/collector_exporter/
+[103]: /opentelemetry/mapping/semantic_mapping/
+[104]: /opentelemetry/mapping/hostname/
+[105]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/resourcedetectionprocessor
+[106]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor
+[107]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/k8sattributesprocessor
+[109]: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view
+
+{{% /tab %}}
+{{% tab "OTLP" %}}
+
+Configure the Collector's internal telemetry to push metrics directly to the [Datadog OTLP metrics intake endpoint][201] using a periodic OTLP HTTP reader. This approach does not require a Prometheus receiver or a metrics pipeline for Collector health metrics.
+
+```yaml
+service:
+  telemetry:
+    metrics:
+      level: detailed
+      readers:
+        - periodic:
+            interval: 10000
+            timeout: 5000
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: {{< region-param key="otlp_metrics_endpoint" >}}
+                temporality_preference: delta
+                compression: gzip
+                timeout: 5000
+                headers:
+                  - name: dd-api-key
+                    value: ${env:DD_API_KEY}
+                  - name: dd-otel-metric-config
+                    value: '{"resource_attributes_as_tags": true}'
+                # default_histogram_aggregation: explicit_bucket_histogram
+                # headers_list: "dd-api-key=${env:DD_API_KEY}"
+                # insecure: false
+                # certificate: /path/to/ca.pem
+                # client_certificate: /path/to/client.pem
+                # client_key: /path/to/client.key
+      # views:
+      #   - selector:
+      #       instrument_name: otelcol_processor_*
+      #     stream:
+      #       aggregation:
+      #         drop: {}
+```
+
+The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `temporality_preference: delta` is required. The `dd-api-key` header authenticates the request. For configuration options (including the `dd-otel-metric-config` header for customizing metric translation) and troubleshooting, see [Datadog OTLP Metrics Intake Endpoint][201].
+
+**Top-level fields under `service.telemetry.metrics`:**
+
+`level`
+: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. `detailed` is required to enable `views`.
+
+`readers`
+: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
+
+`views`
+: Optional list of [SDK views][204] to drop, rename, filter attributes on, or change the aggregation of specific instruments. Only available when `level: detailed`.
+
+**`periodic` reader options:**
+
+`interval`
+: Time in milliseconds between exports. Defaults to `60000` (60 seconds).
+
+`timeout`
+: Maximum time in milliseconds to wait for an export to complete. Defaults to `30000` (30 seconds).
+
+**`periodic.exporter.otlp` options:**
+
+`protocol`
+: One of `grpc`, `http/protobuf`, or `http/json`. Use `http/protobuf` for the Datadog OTLP metrics intake endpoint.
+
+`endpoint`
+: URL of the OTLP receiver. For Datadog, use {{< region-param key="otlp_metrics_endpoint" code="true" >}}.
+
+`headers` / `headers_list`
+: Headers to add to every export request. Use the structured `headers` list (each entry is a `{name, value}` pair) or `headers_list` as a URL-encoded string (for example, `dd-api-key=${env:DD_API_KEY}`).
+
+`compression`
+: Compression algorithm. One of `gzip` or `none`.
+
+`timeout`
+: Per-request timeout in milliseconds. Distinct from the reader-level `timeout`.
+
+`temporality_preference`
+: One of `cumulative`, `delta`, or `lowmemory`. The Datadog OTLP metrics intake endpoint requires `delta`.
+
+`default_histogram_aggregation`
+: One of `explicit_bucket_histogram` (default) or `base2_exponential_bucket_histogram`.
+
+`insecure`
+: When `true`, disables TLS. Defaults to `false`.
+
+`certificate`, `client_certificate`, `client_key`
+: Paths to PEM files for custom CA verification and mTLS client authentication.
+
+#### Optional: tag with resource attributes
+
+Use `service.telemetry.resource` to attach resource attributes (such as `k8s.cluster.name`, `service.instance.id`, or any [Datadog-mapped semantic convention][202]) to all telemetry the Collector emits about itself.
+
+The legacy inline map format is concise:
+
+```yaml
+service:
+  telemetry:
+    resource:
+      k8s.cluster.name: my-cluster
+      k8s.pod.name: ${env:HOSTNAME}
+      service.instance.id: ${env:HOSTNAME}
+      deployment.environment: prod
+```
+
+The declarative `attributes` format supports explicit typing and a `schema_url`:
+
+```yaml
+service:
+  telemetry:
+    resource:
+      schema_url: https://opentelemetry.io/schemas/1.27.0
+      attributes:
+        - name: k8s.cluster.name
+          value: my-cluster
+        - name: k8s.pod.name
+          value: ${env:HOSTNAME}
+      detectors:
+        attributes:
+          included: [host.id, host.name, cloud.provider, cloud.region]
+          excluded: []
+```
+
+`detectors.attributes.included` and `detectors.attributes.excluded` allow- or deny-list attributes contributed by SDK-side resource detectors. To set an attribute to a null value (suppressing a default such as `service.version`), specify it with a null value in the legacy inline format.
+
+These attributes are mapped to Datadog tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][202] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][203].
+
+[201]: /opentelemetry/setup/otlp_ingest/metrics/
+[202]: /opentelemetry/mapping/semantic_mapping/
+[203]: /opentelemetry/mapping/hostname/
+[204]: https://opentelemetry.io/docs/specs/otel/metrics/sdk/#view
+
+{{% /tab %}}
+{{< /tabs >}}
 
 ## Data collected
 
@@ -66,10 +341,6 @@ If you have a Datadog Agent running on the same host as an OpenTelemetry Collect
 | `otelcol_receiver_refused_log_records` | Number of log records that could not be pushed into the pipeline |
 | `otelcol_receiver_accepted_log_records` | Number of log records successfully pushed into the pipeline |
 
-
-## Full example configuration
-
-For a full working example configuration with the Datadog exporter, see [`collector-metrics.yaml`][2].
 
 ## Example logging output
 
@@ -133,5 +404,5 @@ Descriptor:
 
 
 [1]: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver
-[2]: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/examples/collector-metrics.yaml
 [3]: https://pkg.go.dev/runtime#MemStats.Sys
+[4]: /opentelemetry/setup/otlp_ingest/metrics/

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -12,9 +12,9 @@ further_reading:
 
 {{< img src="/opentelemetry/collector_exporter/collector_health_metrics.png" alt="OpenTelemetry Collector health metrics dashboard" style="width:100%;" >}}
 
-The OpenTelemetry Collector exposes its own internal telemetry as metrics, which you can collect and send to Datadog to monitor Collector health and pipeline throughput.
+The OpenTelemetry Collector exposes internal telemetry as metrics. You can collect these metrics and send them to Datadog to monitor Collector health and pipeline throughput.
 
-You can collect Collector health metrics two ways:
+You can collect Collector health metrics in two ways:
 
 - **Prometheus**: Scrape the Collector's internal Prometheus endpoint with the [Prometheus receiver][1] and forward the metrics through a metrics pipeline to the Datadog Exporter.
 - **OTLP**: Configure the Collector's internal telemetry to export metrics directly to the [Datadog OTLP metrics intake endpoint][4] over OTLP HTTP.
@@ -24,7 +24,7 @@ You can collect Collector health metrics two ways:
 {{< tabs >}}
 {{% tab "Prometheus" %}}
 
-Configure the Collector to expose its internal metrics on a Prometheus pull endpoint, then scrape that endpoint with the [Prometheus receiver][101] and route the data through a metrics pipeline to the [Datadog Exporter][102].
+Configure the Collector to expose its internal metrics on a Prometheus pull endpoint. Then scrape that endpoint with the [Prometheus receiver][101] and route the data through a metrics pipeline to the [Datadog Exporter][102].
 
 ```yaml
 receivers:
@@ -86,7 +86,7 @@ The `service.telemetry.metrics` block exposes the Collector's internal metrics o
 : List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
 
 `views`
-: Optional list of [SDK views][109] to drop, rename, filter attributes on, or change the aggregation of specific instruments. Only available when `level: detailed`.
+: Optional list of [SDK views][109] that drop, rename, filter, or re-aggregate specific instruments. Only available when `level: detailed`.
 
 **`pull.exporter.prometheus` options:**
 
@@ -103,13 +103,13 @@ The `service.telemetry.metrics` block exposes the Collector's internal metrics o
 : When `true`, suppresses the `otel_scope_info` metric and `otel_scope_*` labels.
 
 `with_resource_constant_labels.included` / `with_resource_constant_labels.excluded`
-: Allow- and deny-lists of resource attributes to copy onto every exported metric as constant labels.
+: Allowlist and denylist of resource attributes to copy onto every exported metric as constant labels.
 
 #### Optional: tag with resource attributes
 
 Use `service.telemetry.resource` to attach resource attributes (such as `k8s.cluster.name`, `service.instance.id`, or any [Datadog-mapped semantic convention][103]) to all telemetry the Collector emits about itself.
 
-The legacy inline map format is concise:
+Use the legacy inline map format for a concise definition:
 
 ```yaml
 service:
@@ -139,7 +139,7 @@ service:
           excluded: []
 ```
 
-`detectors.attributes.included` and `detectors.attributes.excluded` allow- or deny-list attributes contributed by SDK-side resource detectors. To set an attribute to a null value (suppressing a default such as `service.version`), specify it with a null value in the legacy inline format.
+Use `detectors.attributes.included` and `detectors.attributes.excluded` to allowlist or denylist attributes contributed by SDK-side resource detectors. To suppress a default attribute such as `service.version`, specify it with a null value in the legacy inline format.
 
 These attributes are mapped to Datadog tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][103] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][104].
 

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -79,7 +79,7 @@ service:
       exporters: [datadog]
 ```
 
-Replace `<DATADOG_SITE>` with your [Datadog site][106]. Your site is {{< region-param key="dd_site" code="true" >}}.
+Replace `<DATADOG_SITE>` with your [Datadog site][106]: {{< region-param key="dd_site" code="true" >}}.
 
 The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint, and the metrics pipeline forwards them to Datadog.
 

--- a/content/en/opentelemetry/integrations/collector_health_metrics.md
+++ b/content/en/opentelemetry/integrations/collector_health_metrics.md
@@ -21,7 +21,9 @@ You can collect Collector health metrics in two ways:
 
 ## Setup
 
-The two tabs below show alternative ways to configure the pipeline. Pick one based on whether you want a Prometheus-style scrape or a direct OTLP push. The [`service.telemetry.metrics` fields](#servicetelemetrymetrics-fields) and [resource attribute](#optional-tag-with-resource-attributes) sections that follow apply to both setups.
+### Configure the pipeline
+
+Pick a tab based on whether you want a Prometheus-style scrape or a direct OTLP push. After configuring the pipeline, see the [Configuration reference](#configuration-reference) for all available options.
 
 {{< tabs >}}
 {{% tab "Prometheus" %}}
@@ -81,22 +83,7 @@ Replace `<DATADOG_SITE>` with your [Datadog site][106]. Your site is {{< region-
 
 The `service.telemetry.metrics` block exposes the Collector's internal metrics on `0.0.0.0:8888`. The `prometheus/internal` receiver scrapes that same endpoint, and the metrics pipeline forwards them to Datadog.
 
-**`pull.exporter.prometheus` options:**
-
-`host` / `port`
-: Address to expose the Prometheus endpoint on. Defaults to `localhost:8888`. Use `0.0.0.0` to expose outside the loopback interface.
-
-`without_type_suffix`
-: When `true` (the Collector default), drops the type suffix (for example, `_total` for counters) from metric names. Names appear as `otelcol_exporter_sent_metric_points` instead of `otelcol_exporter_sent_metric_points_total`.
-
-`without_units`
-: When `true`, drops the unit suffix (for example, `_seconds`, `_bytes`) from metric names.
-
-`without_scope_info`
-: When `true`, suppresses the `otel_scope_info` metric and `otel_scope_*` labels.
-
-`with_resource_constant_labels.included` / `with_resource_constant_labels.excluded`
-: Allowlist and denylist of resource attributes to copy onto every exported metric as constant labels.
+For all available options, see [`pull.exporter.prometheus` options](#pullexporterprometheus-options) in the [Configuration reference](#configuration-reference).
 
 #### Optional: enrich with processors
 
@@ -172,45 +159,10 @@ Replace `<OTLP_METRICS_ENDPOINT>` with the [Datadog OTLP metrics intake endpoint
 The Datadog OTLP metrics intake endpoint accepts only delta metrics, so `temporality_preference: delta` is required. The `dd-api-key` header authenticates the request. For configuration options (including the `dd-otel-metric-config` header for customizing metric translation) and troubleshooting, see [Datadog OTLP Metrics Intake Endpoint][201].
 
 <div class="alert alert-warning">
-This setup pushes metrics directly to the OTLP intake endpoint, bypassing any enrichment that pipeline processors (such as <code>resourcedetection</code> or <code>k8sattributes</code>) would otherwise apply. To populate Datadog tags and host metadata (which are needed for hostname resolution and the default Collector dashboard), set the relevant attributes explicitly under <a href="#optional-tag-with-resource-attributes"><code>service.telemetry.resource</code></a>. If you need automatic hostname and cloud-attribute detection, use the Prometheus tab instead.
+This setup pushes metrics directly to the OTLP intake endpoint, bypassing any enrichment that pipeline processors (such as <code>resourcedetection</code> or <code>k8sattributes</code>) would otherwise apply. To populate Datadog tags and host metadata (which are needed for hostname resolution and the default Collector dashboard), set the relevant attributes explicitly under <a href="#tag-with-resource-attributes-optional"><code>service.telemetry.resource</code></a>. If you need automatic hostname and cloud-attribute detection, use the Prometheus tab instead.
 </div>
 
-**`periodic` reader options:**
-
-`interval`
-: Time in milliseconds between exports. Defaults to `60000` (60 seconds).
-
-`timeout`
-: Maximum time in milliseconds to wait for an export to complete. Defaults to `30000` (30 seconds).
-
-**`periodic.exporter.otlp` options:**
-
-`protocol`
-: One of `grpc`, `http/protobuf`, or `http/json`. Use `http/protobuf` for the Datadog OTLP metrics intake endpoint.
-
-`endpoint`
-: URL of the OTLP receiver. For Datadog, use {{< region-param key="otlp_metrics_endpoint" code="true" >}}.
-
-`headers` / `headers_list`
-: Headers to add to every export request. Use the structured `headers` list (each entry is a `{name, value}` pair) or `headers_list` as a URL-encoded string (for example, `dd-api-key=${env:DD_API_KEY}`).
-
-`compression`
-: Compression algorithm. One of `gzip` or `none`.
-
-`timeout`
-: Per-request timeout in milliseconds. Distinct from the reader-level `timeout`.
-
-`temporality_preference`
-: One of `cumulative`, `delta`, or `lowmemory`. The Datadog OTLP metrics intake endpoint requires `delta`.
-
-`default_histogram_aggregation`
-: One of `explicit_bucket_histogram` (default) or `base2_exponential_bucket_histogram`.
-
-`insecure`
-: When `true`, disables TLS. Defaults to `false`.
-
-`certificate`, `client_certificate`, `client_key`
-: Paths to PEM files for custom CA verification and mutual TLS (mTLS) client authentication.
+For all available options, see [`periodic.exporter.otlp` options](#periodicexporterotlp-options) in the [Configuration reference](#configuration-reference).
 
 [201]: /opentelemetry/setup/otlp_ingest/metrics/
 [202]: /getting_started/site
@@ -218,20 +170,7 @@ This setup pushes metrics directly to the OTLP intake endpoint, bypassing any en
 {{% /tab %}}
 {{< /tabs >}}
 
-### `service.telemetry.metrics` fields
-
-The following top-level fields apply to both setups:
-
-`level`
-: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. Set `level: detailed` to enable `views`.
-
-`readers`
-: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
-
-`views`
-: Optional list of [SDK views][5] that drop, rename, filter, or re-aggregate specific instruments. Only available when `level: detailed`.
-
-### Optional: tag with resource attributes
+### Tag with resource attributes (optional)
 
 Use `service.telemetry.resource` to attach resource attributes (such as `k8s.cluster.name`, `service.instance.id`, or any [Datadog-mapped semantic convention][6]) to all telemetry the Collector emits about itself.
 
@@ -264,6 +203,77 @@ service:
 To suppress a default attribute such as `service.version`, specify it with a null value in the legacy inline format.
 
 Datadog maps these attributes to tags and host metadata. For the full list of supported mappings, see [OpenTelemetry Semantic Conventions and Datadog Conventions][6] and [Mapping OpenTelemetry Semantic Conventions to Hostnames][7].
+
+## Configuration reference
+
+### `service.telemetry.metrics` fields
+
+The following top-level fields apply to both setups:
+
+`level`
+: Verbosity of the Collector's internal metrics. One of `none`, `basic`, `normal` (default), or `detailed`. Set `level: detailed` to enable `views`.
+
+`readers`
+: List of metric readers. At least one is required when `level` is not `none`. Each reader is either a `pull` reader (Prometheus) or a `periodic` reader (OTLP, console).
+
+`views`
+: Optional list of [SDK views][5] that drop, rename, filter, or re-aggregate specific instruments. Only available when `level: detailed`.
+
+### `pull.exporter.prometheus` options
+
+`host` / `port`
+: Address to expose the Prometheus endpoint on. Defaults to `localhost:8888`. Use `0.0.0.0` to expose outside the loopback interface.
+
+`without_type_suffix`
+: When `true` (the Collector default), drops the type suffix (for example, `_total` for counters) from metric names. Names appear as `otelcol_exporter_sent_metric_points` instead of `otelcol_exporter_sent_metric_points_total`.
+
+`without_units`
+: When `true`, drops the unit suffix (for example, `_seconds`, `_bytes`) from metric names.
+
+`without_scope_info`
+: When `true`, suppresses the `otel_scope_info` metric and `otel_scope_*` labels.
+
+`with_resource_constant_labels.included` / `with_resource_constant_labels.excluded`
+: Allowlist and denylist of resource attributes to copy onto every exported metric as constant labels.
+
+### `periodic.exporter.otlp` options
+
+The `periodic` reader (which contains the OTLP exporter) accepts these top-level options:
+
+`interval`
+: Time in milliseconds between exports. Defaults to `60000` (60 seconds).
+
+`timeout`
+: Maximum time in milliseconds to wait for an export to complete. Defaults to `30000` (30 seconds).
+
+The `otlp` block inside `periodic.exporter` accepts these options:
+
+`protocol`
+: One of `grpc`, `http/protobuf`, or `http/json`. Use `http/protobuf` for the Datadog OTLP metrics intake endpoint.
+
+`endpoint`
+: URL of the OTLP receiver. For Datadog, use {{< region-param key="otlp_metrics_endpoint" code="true" >}}.
+
+`headers` / `headers_list`
+: Headers to add to every export request. Use the structured `headers` list (each entry is a `{name, value}` pair) or `headers_list` as a URL-encoded string (for example, `dd-api-key=${env:DD_API_KEY}`).
+
+`compression`
+: Compression algorithm. One of `gzip` or `none`.
+
+`timeout`
+: Per-request timeout in milliseconds. Distinct from the reader-level `timeout`.
+
+`temporality_preference`
+: One of `cumulative`, `delta`, or `lowmemory`. The Datadog OTLP metrics intake endpoint requires `delta`.
+
+`default_histogram_aggregation`
+: One of `explicit_bucket_histogram` (default) or `base2_exponential_bucket_histogram`.
+
+`insecure`
+: When `true`, disables TLS. Defaults to `false`.
+
+`certificate`, `client_certificate`, `client_key`
+: Paths to PEM files for custom CA verification and mutual TLS (mTLS) client authentication.
 
 ## Data collected
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes OTAGENT-1027

Expands the Setup section of the OpenTelemetry Collector Health Metrics page so readers see complete, working pipeline configurations rather than a single receiver snippet:

- Splits Setup into two tabs: **Prometheus** (scrape the Collector's `:8888` endpoint and route through a metrics pipeline to the Datadog Exporter) and **OTLP** (configure `service.telemetry.metrics` to push directly to the Datadog OTLP metrics intake endpoint).
- Documents the full applicable surface of `service.telemetry.metrics` (`level`, `readers`, `views`) and the per-reader options for both `pull.exporter.prometheus` and `periodic.exporter.otlp`.
- Adds an "Optional: tag with resource attributes" subsection covering `service.telemetry.resource` in both legacy inline and declarative `attributes`/`detectors`/`schema_url` formats, with cross-links to the semantic-mapping and hostname-mapping pages.
- For the Prometheus tab, adds an "Optional: enrich with processors" subsection pointing to the resource detection, transform, and k8sattributes processors.
- Sets `resource_attributes_as_tags: true` in both setups (Datadog Exporter `metrics` block in Prometheus tab; `dd-otel-metric-config` header in OTLP tab) and uses `sending_queue.batch.flush_timeout` on the Datadog Exporter instead of a `batch` processor.
- Removes the external "Full example configuration" link section.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes