### PR TITLE
RUM: document source map resolution limit for cross-micro-frontend stacks

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
@@ -1784,9 +1784,9 @@ Some events cannot be attributed to an origin because they do not have an associ
 
 #### Source map resolution across micro frontends
 
-When a stack trace contains frames from multiple micro frontends (for example, an error thrown in one micro frontend that bubbles through code from another), the event is attributed to a single `service` and `version`: those of the throw-site (top) frame. Source maps are resolved for the entire event under that single service, so frames belonging to other micro frontends in the same stack remain minified, even when their source maps were correctly uploaded under their own `service`.
+Stack traces can contain frames from multiple micro frontends. For example, an error thrown in one micro frontend may bubble through code from another. In that case, the event receives a single `service` and `version` from the throw-site (top) frame. Source maps are resolved for the event under that single service. Frames from other micro frontends remain minified, even when their source maps were correctly uploaded under their own `service`.
 
-To choose which micro frontend's source maps are used for unminification (for example, to attribute the event to the host application instead of the throw-site frame), use the [manual attribution](#manual-service-and-version-attribution) approach with `beforeSend` to set `event.service` and `event.version`. This still applies a single service per event: only frames belonging to the chosen micro frontend are unminified.
+To control which micro frontend's source maps are used, use the [manual attribution](#manual-service-and-version-attribution) approach with `beforeSend` to set `event.service` and `event.version`. For example, you can attribute the event to the host application rather than to the throw-site frame. This still applies a single service per event: only frames belonging to the chosen micro frontend are unminified.
 
 ### Explore micro frontend data in Datadog
 

--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
@@ -1773,12 +1773,20 @@ The regular expression must match your application's file path structure. Adjust
 
 ### Limitations
 
+#### Events without an attributed origin
+
 Some events cannot be attributed to an origin because they do not have an associated handling stack:
 
 -   Action events collected automatically
 -   Resource events other than XHR and Fetch
 -   View events collected automatically
 -   CORS and CSP violations
+
+#### Source map resolution across micro frontends
+
+When a stack trace contains frames from multiple micro frontends (for example, an error thrown in one micro frontend that bubbles through code from another), the event is attributed to a single `service` and `version`: those of the throw-site (top) frame. Source maps are resolved for the entire event under that single service, so frames belonging to other micro frontends in the same stack remain minified, even when their source maps were correctly uploaded under their own `service`.
+
+To choose which micro frontend's source maps are used for unminification (for example, to attribute the event to the host application instead of the throw-site frame), use the [manual attribution](#manual-service-and-version-attribution) approach with `beforeSend` to set `event.service` and `event.version`. This still applies a single service per event: only frames belonging to the chosen micro frontend are unminified.
 
 ### Explore micro frontend data in Datadog
 

--- a/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/advanced_configuration.mdoc.md
@@ -1784,9 +1784,9 @@ Some events cannot be attributed to an origin because they do not have an associ
 
 #### Source map resolution across micro frontends
 
-Stack traces can contain frames from multiple micro frontends. For example, an error thrown in one micro frontend may bubble through code from another. In that case, the event receives a single `service` and `version` from the throw-site (top) frame. Source maps are resolved for the event under that single service. Frames from other micro frontends remain minified, even when their source maps were correctly uploaded under their own `service`.
+When a stack trace contains frames from multiple micro frontends, the event receives a single `service` and `version` from the topmost frame (where the error was thrown). Source maps are resolved for the event under that single service, so frames from other micro frontends remain minified, even when their source maps were correctly uploaded under their own `service`.
 
-To control which micro frontend's source maps are used, use the [manual attribution](#manual-service-and-version-attribution) approach with `beforeSend` to set `event.service` and `event.version`. For example, you can attribute the event to the host application rather than to the throw-site frame. This still applies a single service per event: only frames belonging to the chosen micro frontend are unminified.
+To control which micro frontend's source maps are used, use the [manual attribution](#manual-service-and-version-attribution) approach with `beforeSend` to set `event.service` and `event.version`. Only frames belonging to the chosen micro frontend are unminified.
 
 ### Explore micro frontend data in Datadog
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents a missing limitation in the [Micro-frontend section of the Browser RUM advanced configuration](https://docs.datadoghq.com/real_user_monitoring/application_monitoring/browser/advanced_configuration/#micro-frontend).

When a stack trace spans multiple micro frontends, a single `service` / `version` is attributed to the event (the throw-site frame's). Source maps are resolved per-event under that single service, so frames from other micro frontends in the same stack remain minified, even when their source maps were correctly uploaded. 

The existing `beforeSend` manual-attribution workaround can shift *which* micro frontend gets unminified, but does not enable cross-MFE unminification.

### Merge instructions

Merge readiness:
- [x] Ready for merge

