### PR TITLE
Document zstd compression support for log archives

### DIFF
--- a/content/en/logs/log_configuration/archive_search.md
+++ b/content/en/logs/log_configuration/archive_search.md
@@ -125,6 +125,7 @@ To optimize performance and reduce costs:
 * **Set Scan Limits:** Admins with `Logs Write Archives` permissions can set a maximum scan size per Archive in the settings.
 * **Use Partition Attributes (Preview):** The most effective way to accelerate searches on low-cardinality data like `service`, `env`, or `status`. Datadog skips entire partitions that don't match your query.
 * **Use Lookup Attributes (Preview):** The most effective way to accelerate searches on high-cardinality data like `trace_id` or `user_id`.
+* **Use zstd compression:** Configure your archives to use zstd compression instead of gzip. Zstd offers better compression ratios, which reduces the volume of data scanned and lowers cloud egress costs. See [Log Archives][9] to configure compression.
 
 **Note**: Only logs archived after you configure Partition or Lookup attributes benefit from accelerated searches. Logs archived before this configuration are not affected.
 
@@ -233,3 +234,4 @@ In order to search log events from your archives, Datadog uses a service account
 [6]: /logs/guide/logs-rbac/?tab=ui#restrict-access-to-logs
 [7]: /logs/log_configuration/archives/?tab=awss3#archive-search-lookup-attribute
 [8]: /logs/log_configuration/archives/?tab=awss3#archive-search-partition-attribute
+[9]: /logs/log_configuration/archives/?tab=awss3#compression

--- a/content/en/logs/log_configuration/archive_search.md
+++ b/content/en/logs/log_configuration/archive_search.md
@@ -125,7 +125,7 @@ To optimize performance and reduce costs:
 * **Set Scan Limits:** Admins with `Logs Write Archives` permissions can set a maximum scan size per Archive in the settings.
 * **Use Partition Attributes (Preview):** The most effective way to accelerate searches on low-cardinality data like `service`, `env`, or `status`. Datadog skips entire partitions that don't match your query.
 * **Use Lookup Attributes (Preview):** The most effective way to accelerate searches on high-cardinality data like `trace_id` or `user_id`.
-* **Use zstd compression:** Configure your archives to use zstd compression instead of gzip. Zstd offers better compression ratios, which reduces the volume of data scanned and lowers cloud egress costs. See [Log Archives][9] to configure compression.
+* **Use zstd compression:** Archives use zstd compression by default, which offers better compression ratios than gzip and reduces the volume of data scanned, lowering cloud egress costs. If your archive is configured to use gzip, consider switching to zstd. See [Log Archives][9] to configure compression.
 
 **Note**: Only logs archived after you configure Partition or Lookup attributes benefit from accelerated searches. Logs archived before this configuration are not affected.
 

--- a/content/en/logs/log_configuration/archive_search.md
+++ b/content/en/logs/log_configuration/archive_search.md
@@ -125,7 +125,7 @@ To optimize performance and reduce costs:
 * **Set Scan Limits:** Admins with `Logs Write Archives` permissions can set a maximum scan size per Archive in the settings.
 * **Use Partition Attributes (Preview):** The most effective way to accelerate searches on low-cardinality data like `service`, `env`, or `status`. Datadog skips entire partitions that don't match your query.
 * **Use Lookup Attributes (Preview):** The most effective way to accelerate searches on high-cardinality data like `trace_id` or `user_id`.
-* **Use zstd compression:** Archives use zstd compression by default, which offers better compression ratios than gzip and reduces the volume of data scanned, lowering cloud egress costs. If your archive is configured to use gzip, consider switching to zstd. See [Log Archives][9] to configure compression.
+* **Use zstd compression:** Archives use zstd compression by default, which reduces scan volume and cloud egress costs compared to gzip. If your archive uses gzip, see [Log Archives][9] to switch to zstd.
 
 **Note**: Only logs archived after you configure Partition or Lookup attributes benefit from accelerated searches. Logs archived before this configuration are not affected.
 

--- a/content/en/logs/log_configuration/archive_search.md
+++ b/content/en/logs/log_configuration/archive_search.md
@@ -13,9 +13,6 @@ further_reading:
   text: "Manage log retention and indexing"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/flex-frozen-archive-search/" btn_hidden="false" >}}
-Archive Search is in Preview. Request access to search archived logs in real time. No rehydrating, no delays. Instantly access years of data when you need it.
-{{< /callout >}}
 
 ## Overview
 

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -247,7 +247,7 @@ To optimize how your archived logs are physically organized in storage (and acce
 * **Partition Attributes**: Add low-cardinality attributes such as `service`, `source`, `env`, or `status` that you frequently use as search filters.
 * **Benefit**: Logs sharing the same partition attribute values are co-located in storage. When searching, Datadog can skip entire partitions that don't match your query, drastically reducing the volume of data scanned.
 
-#### Archive Lookup Attribute (Preview) {#archive-search-lookup-attribute}
+#### Archive Lookup Attribute
 
 To accelerate searches and investigations in your archives (with [Archive Search][16]), configure lookup attributes in your Datadog Archive.
 
@@ -278,16 +278,16 @@ Firewall rules are not supported.
 {{< /tabs >}}
 
 {{< /site-region >}}
+
 #### Compression
 
-By default, Datadog archives logs using **zstd** (Zstandard) compression (`.json.zst`), which offers better compression ratios and faster decompression speeds compared to gzip. You can also configure **gzip** compression (`.json.gz`) if needed.
+By default, Datadog archives logs using **zstd** (Zstandard) compression (`.json.zst`), which offers better compression ratios and faster decompression speeds compared to gzip. You can also configure **gzip** compression (`.json.gz`).
 
-Zstd compression reduces the size of your archived files, which lowers storage costs and reduces the volume of data scanned during [Archive Search][16], resulting in faster queries and lower cloud egress costs.
 
-To configure compression, select **Compression Type** when creating or editing an archive in the [Log Archiving & Forwarding page][6]:
+To configure compression, select **Compression Type** when creating or editing an archive on the [Log Archiving & Forwarding page][6]:
 
-- **Zstd** (default): Better compression ratio and decompression speed; recommended for new archives, especially if you plan to use [Archive Search][16].
-- **Gzip**: Widely supported and compatible with most tools.
+- **zstd** (default): Better compression ratio and decompression speed. Recommended for new archives, especially if you plan to use [Archive Search][16].
+- **gzip**: Widely supported and compatible with most tools.
 
 **Note**: Changing the compression format of an existing archive only affects new archive files. Files already stored in your bucket remain in their original format.
 

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -278,6 +278,19 @@ Firewall rules are not supported.
 {{< /tabs >}}
 
 {{< /site-region >}}
+#### Compression
+
+By default, Datadog archives logs using **gzip** compression (`.json.gz`). You can also configure **zstd** (Zstandard) compression (`.json.zst`), which offers better compression ratios and faster decompression speeds compared to gzip.
+
+Zstd compression reduces the size of your archived files, which lowers storage costs and reduces the volume of data scanned during [Archive Search][16], resulting in faster queries and lower cloud egress costs.
+
+To configure compression, select **Compression Type** when creating or editing an archive in the [Log Archiving & Forwarding page][6]:
+
+- **Gzip** (default): Widely supported and compatible with most tools.
+- **Zstd**: Better compression ratio and decompression speed; recommended for new archives, especially if you plan to use [Archive Search][16].
+
+**Note**: Changing the compression format of an existing archive only affects new archive files. Files already stored in your bucket remain in their original format.
+
 #### Storage class
 
 {{< tabs >}}
@@ -441,7 +454,7 @@ It is important to order your archives carefully. For example, if you create a f
 
 ## Format of the archives
 
-The log archives that Datadog forwards to your storage bucket are in compressed JSON format (`.json.gz`). Using the prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, such as the following:
+The log archives that Datadog forwards to your storage bucket are in compressed JSON format. Depending on your [compression configuration](#compression), archive files use either gzip (`.json.gz`) or zstd (`.json.zst`) compression. Using the prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, such as the following:
 
 ```
 /my/bucket/prefix/dt=20180515/hour=14/archive_143201.1234.02aafad5-f525-4592-905e-e962d1a5b2f7.json.gz

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -280,14 +280,14 @@ Firewall rules are not supported.
 {{< /site-region >}}
 #### Compression
 
-By default, Datadog archives logs using **gzip** compression (`.json.gz`). You can also configure **zstd** (Zstandard) compression (`.json.zst`), which offers better compression ratios and faster decompression speeds compared to gzip.
+By default, Datadog archives logs using **zstd** (Zstandard) compression (`.json.zst`), which offers better compression ratios and faster decompression speeds compared to gzip. You can also configure **gzip** compression (`.json.gz`) if needed.
 
 Zstd compression reduces the size of your archived files, which lowers storage costs and reduces the volume of data scanned during [Archive Search][16], resulting in faster queries and lower cloud egress costs.
 
 To configure compression, select **Compression Type** when creating or editing an archive in the [Log Archiving & Forwarding page][6]:
 
-- **Gzip** (default): Widely supported and compatible with most tools.
-- **Zstd**: Better compression ratio and decompression speed; recommended for new archives, especially if you plan to use [Archive Search][16].
+- **Zstd** (default): Better compression ratio and decompression speed; recommended for new archives, especially if you plan to use [Archive Search][16].
+- **Gzip**: Widely supported and compatible with most tools.
 
 **Note**: Changing the compression format of an existing archive only affects new archive files. Files already stored in your bucket remain in their original format.
 
@@ -454,7 +454,7 @@ It is important to order your archives carefully. For example, if you create a f
 
 ## Format of the archives
 
-The log archives that Datadog forwards to your storage bucket are in compressed JSON format. Depending on your [compression configuration](#compression), archive files use either gzip (`.json.gz`) or zstd (`.json.zst`) compression. Using the prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, such as the following:
+The log archives that Datadog forwards to your storage bucket are in compressed JSON format. Depending on your [compression configuration](#compression), archive files use either zstd (`.json.zst`, default) or gzip (`.json.gz`) compression. Using the prefix you indicate (or `/` if there is none), the archives are stored in a directory structure that indicates on what date and at what time the archive files were generated, such as the following:
 
 ```
 /my/bucket/prefix/dt=20180515/hour=14/archive_143201.1234.02aafad5-f525-4592-905e-e962d1a5b2f7.json.gz

--- a/content/en/logs/log_configuration/archives.md
+++ b/content/en/logs/log_configuration/archives.md
@@ -242,20 +242,12 @@ For Archives with a maximum scan size defined, all users need to estimate the sc
 
 #### Archive Partition Attribute (Preview) {#archive-search-partition-attribute}
 
-{{< callout url="https://www.datadoghq.com/product-preview/flex-frozen-archive-search/" btn_hidden="false" header="Join the Preview!" >}}
-Archive Search is in Preview. Request access to search archived logs in real time. No rehydrating, no delays. Instantly access years of data when you need it.
-{{< /callout >}}
-
 To optimize how your archived logs are physically organized in storage (and accelerate [Archive Search][16]), configure partition attributes in your Datadog Archive.
 
 * **Partition Attributes**: Add low-cardinality attributes such as `service`, `source`, `env`, or `status` that you frequently use as search filters.
 * **Benefit**: Logs sharing the same partition attribute values are co-located in storage. When searching, Datadog can skip entire partitions that don't match your query, drastically reducing the volume of data scanned.
 
 #### Archive Lookup Attribute (Preview) {#archive-search-lookup-attribute}
-
-{{< callout url="https://www.datadoghq.com/product-preview/flex-frozen-archive-search/" btn_hidden="false" header="Join the Preview!" >}}
-Archive Search is in Preview. Request access to search archived logs in real time. No rehydrating, no delays. Instantly access years of data when you need it.
-{{< /callout >}}
 
 To accelerate searches and investigations in your archives (with [Archive Search][16]), configure lookup attributes in your Datadog Archive.
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Documents zstd (Zstandard) compression support for Datadog Log Archives, which is now available alongside the existing gzip option.

**Changes:**
- **Log Archives page** (`archives.md`): Added a new **Compression** subsection under Advanced Settings documenting both gzip (default) and zstd options. Updated the "Format of the archives" section to mention both `.json.gz` and `.json.zst` file formats.
- **Archive Search page** (`archive_search.md`): Added a zstd compression tip in the "Search performance and optimization" section, noting that zstd reduces scan volume and cloud egress costs, with a link to the compression configuration in the archives doc.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

Used Claude Code for drafting and editing.