### PR TITLE
Remove JRuby from Test Optimization docs

### DIFF
--- a/content/en/tests/setup/ruby.md
+++ b/content/en/tests/setup/ruby.md
@@ -26,7 +26,6 @@ Supported languages:
 | Language | Version |
 | -------- | ------- |
 | Ruby     | >= 2.7  |
-| JRuby    | >= 9.4  |
 
 Supported test frameworks:
 

--- a/content/en/tests/test_impact_analysis/setup/ruby.md
+++ b/content/en/tests/test_impact_analysis/setup/ruby.md
@@ -20,7 +20,6 @@ Test Impact Analysis is only supported in the following versions and testing fra
 
 * `datadog-ci >= 1.0`
 * `Ruby >= 2.7`
-  * JRuby is not supported.
 * `rspec >= 3.0.0`
 * `minitest >= 5.0.0`
 * `cucumber >= 3.0.0`


### PR DESCRIPTION
### What does this PR do? What is the motivation?
Recently we dropped JRuby support from our Ruby SDKs. 

This PR removes JRuby from Test Optimization docs

### Merge instructions

Merge readiness:
- [x] Ready for merge
