### PR TITLE
docs(browser-sdk): bump CDN bundle URLs from v6 to v7

### DIFF
--- a/content/en/error_tracking/frontend/browser.md
+++ b/content/en/error_tracking/frontend/browser.md
@@ -80,7 +80,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js','DD_RUM')
   window.DD_RUM.onReady(function() {
     window.DD_RUM.init({
       clientToken: '<CLIENT_TOKEN>',
@@ -107,7 +107,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js"
+    src="https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js"
     type="text/javascript"
     crossorigin>
 </script>

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -139,7 +139,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-logs-v6.js','DD_LOGS')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-logs-v7.js','DD_LOGS')
 </script>
 ```
 
@@ -222,7 +222,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/datadog-logs-v6.js"
+    src="https://www.datadoghq-browser-agent.com/datadog-logs-v7.js"
     type="text/javascript"
     crossorigin>
 </script>

--- a/content/en/logs/log_collection/javascript.md
+++ b/content/en/logs/log_collection/javascript.md
@@ -61,7 +61,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js','DD_LOGS')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v7/datadog-logs.js','DD_LOGS')
 </script>
 ```
 
@@ -74,7 +74,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/eu/v6/datadog-logs.js','DD_LOGS')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/eu/v7/datadog-logs.js','DD_LOGS')
 </script>
 ```
 
@@ -87,7 +87,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/ap1/v6/datadog-logs.js','DD_LOGS')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/ap1/v7/datadog-logs.js','DD_LOGS')
 </script>
 ```
 
@@ -100,7 +100,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/ap2/v6/datadog-logs.js','DD_LOGS')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/ap2/v7/datadog-logs.js','DD_LOGS')
 </script>
 ```
 
@@ -113,7 +113,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v6/datadog-logs.js','DD_LOGS')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v7/datadog-logs.js','DD_LOGS')
 </script>
 ```
 
@@ -126,7 +126,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v6/datadog-logs.js','DD_LOGS')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v7/datadog-logs.js','DD_LOGS')
 </script>
 ```
 
@@ -156,7 +156,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-logs.js"
+    src="https://www.datadoghq-browser-agent.com/us1/v7/datadog-logs.js"
     type="text/javascript"
     crossorigin>
 </script>
@@ -167,7 +167,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/eu/v6/datadog-logs.js"
+    src="https://www.datadoghq-browser-agent.com/eu/v7/datadog-logs.js"
     type="text/javascript"
     crossorigin>
 </script>
@@ -178,7 +178,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/ap1/v6/datadog-logs.js"
+    src="https://www.datadoghq-browser-agent.com/ap1/v7/datadog-logs.js"
     type="text/javascript"
     crossorigin>
 </script>
@@ -189,7 +189,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/ap2/v6/datadog-logs.js"
+    src="https://www.datadoghq-browser-agent.com/ap2/v7/datadog-logs.js"
     type="text/javascript"
     crossorigin>
 </script>
@@ -200,7 +200,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/us3/v6/datadog-logs.js"
+    src="https://www.datadoghq-browser-agent.com/us3/v7/datadog-logs.js"
     type="text/javascript"
     crossorigin>
 </script>
@@ -211,7 +211,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/us5/v6/datadog-logs.js"
+    src="https://www.datadoghq-browser-agent.com/us5/v7/datadog-logs.js"
     type="text/javascript"
     crossorigin>
 </script>

--- a/content/en/real_user_monitoring/guide/monitor-your-nextjs-app-with-rum.md
+++ b/content/en/real_user_monitoring/guide/monitor-your-nextjs-app-with-rum.md
@@ -103,7 +103,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
             d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
             n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-          })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM')
+          })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js','DD_RUM')
           window.DD_RUM.onReady(function() {
             window.DD_RUM.init({
               clientToken: '<CLIENT_TOKEN>',
@@ -137,7 +137,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body>
         <Script
           id="dd-rum-sync"
-          src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js"
+          src="https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js"
           crossOrigin=""
           type="text/javascript"
           strategy="beforeInteractive"
@@ -220,7 +220,7 @@ export default function App({ Component, pageProps }: AppProps) {
             h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
             d=o.createElement(u);d.async=1;d.src=n;d.crossOrigin=''
             n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-          })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM')
+          })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js','DD_RUM')
           window.DD_RUM.onReady(function() {
             window.DD_RUM.init({
               clientToken: '<CLIENT_TOKEN>',
@@ -254,7 +254,7 @@ export default function App({ Component, pageProps }: AppProps) {
     <>
       <Script
         id="dd-rum-sync"
-        src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js"
+        src="https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js"
         crossOrigin=""
         type="text/javascript"
         strategy="beforeInteractive"

--- a/layouts/shortcodes/mdoc/en/sdk/setup/browser.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/setup/browser.mdoc.md
@@ -53,9 +53,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 <script>
   (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n
+    d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js','DD_RUM')
 </script>
 ```
 
@@ -66,9 +66,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 <script>
   (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n
+    d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/eu/v6/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/eu/v7/datadog-rum.js','DD_RUM')
 </script>
 ```
 
@@ -79,9 +79,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 <script>
   (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n
+    d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/ap1/v6/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/ap1/v7/datadog-rum.js','DD_RUM')
 </script>
 ```
 
@@ -92,9 +92,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 <script>
   (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n
+    d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/ap2/v6/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/ap2/v7/datadog-rum.js','DD_RUM')
 </script>
 ```
 
@@ -105,9 +105,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 <script>
   (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n
+    d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us3/v7/datadog-rum.js','DD_RUM')
 </script>
 ```
 
@@ -118,9 +118,9 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 <script>
   (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n
+    d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v6/datadog-rum.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/us5/v7/datadog-rum.js','DD_RUM')
 </script>
 ```
 
@@ -131,7 +131,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
 <script>
   (function(h,o,u,n,d) {
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
-    d=o.createElement(u);d.async=1;d.src=n
+    d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
   })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v6.js','DD_RUM')
 </script>
@@ -150,8 +150,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/us1/v6/datadog-rum.js"
-    type="text/javascript">
+    src="https://www.datadoghq-browser-agent.com/us1/v7/datadog-rum.js"
+    type="text/javascript"
+    crossorigin>
 </script>
 ```
 
@@ -160,8 +161,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/eu/v6/datadog-rum.js"
-    type="text/javascript">
+    src="https://www.datadoghq-browser-agent.com/eu/v7/datadog-rum.js"
+    type="text/javascript"
+    crossorigin>
 </script>
 ```
 
@@ -170,8 +172,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/ap1/v6/datadog-rum.js"
-    type="text/javascript">
+    src="https://www.datadoghq-browser-agent.com/ap1/v7/datadog-rum.js"
+    type="text/javascript"
+    crossorigin>
 </script>
 ```
 
@@ -180,8 +183,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/ap2/v6/datadog-rum.js"
-    type="text/javascript">
+    src="https://www.datadoghq-browser-agent.com/ap2/v7/datadog-rum.js"
+    type="text/javascript"
+    crossorigin>
 </script>
 ```
 
@@ -190,8 +194,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/us3/v6/datadog-rum.js"
-    type="text/javascript">
+    src="https://www.datadoghq-browser-agent.com/us3/v7/datadog-rum.js"
+    type="text/javascript"
+    crossorigin>
 </script>
 ```
 
@@ -200,8 +205,9 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/us5/v6/datadog-rum.js"
-    type="text/javascript">
+    src="https://www.datadoghq-browser-agent.com/us5/v7/datadog-rum.js"
+    type="text/javascript"
+    crossorigin>
 </script>
 ```
 

--- a/layouts/shortcodes/mdoc/en/sdk/setup/browser.mdoc.md
+++ b/layouts/shortcodes/mdoc/en/sdk/setup/browser.mdoc.md
@@ -133,7 +133,7 @@ Add the generated code snippet to the head tag of every HTML page you want to mo
     h=h[d]=h[d]||{q:[],onReady:function(c){h.q.push(c)}}
     d=o.createElement(u);d.async=1;d.src=n,d.crossOrigin=''
     n=o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n)
-  })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v6.js','DD_RUM')
+  })(window,document,'script','https://www.datadoghq-browser-agent.com/datadog-rum-v7.js','DD_RUM')
 </script>
 ```
 
@@ -216,7 +216,7 @@ Add the generated code snippet to the head tag (in front of any other script tag
 
 ```javascript
 <script
-    src="https://www.datadoghq-browser-agent.com/datadog-rum-v6.js"
+    src="https://www.datadoghq-browser-agent.com/datadog-rum-v7.js"
     type="text/javascript">
 </script>
 ```


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates Browser SDK CDN bundle URLs from v6 to v7 across RUM, Logs, and Error Tracking setup docs so customers copying snippets get the latest major version.

- Bumps `datadog-rum-v6.js` / `datadog-logs-v6.js` references to `-v7.js` in setup snippets
- Affects browser setup shortcode and the JS logs, frontend error tracking, and Next.js RUM guides

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

Used Claude Code to draft and edit the changes.

### Additional notes