### PR TITLE
Fix incorrect RUM attribute names in standard attributes page

### DIFF
--- a/content/en/standard-attributes/_index.md
+++ b/content/en/standard-attributes/_index.md
@@ -412,6 +412,15 @@ attributes:
     type: string
     domain: RUM core attributes
 
+  - name: application.name
+    description: The Datadog application name.
+    product_source:
+      - icon-rum
+      - android
+      - browser
+      - ios
+    type: string
+    domain: RUM core attributes
 
   - name: device.type
     description: The device type as reported by the device (System User-Agent).

--- a/content/en/standard-attributes/_index.md
+++ b/content/en/standard-attributes/_index.md
@@ -412,15 +412,6 @@ attributes:
     type: string
     domain: RUM core attributes
 
-  - name: application.name
-    description: The Datadog application name.
-    product_source:
-      - icon-rum
-      - android
-      - browser
-      - ios
-    type: string
-    domain: RUM core attributes
 
   - name: device.type
     description: The device type as reported by the device (System User-Agent).
@@ -594,22 +585,16 @@ attributes:
     type: string
     domain: Geolocation
   
-  - name: user.id
-    description: Identifier of the user.
-    product_source:
-      - icon-rum
-      - android
-      - roku
-    type: string
-    domain: RUM user attributes (Android, Roku)
   - name: usr.id
     description: Identifier of the user.
     product_source:
       - icon-rum
+      - android
       - ios
       - browser
+      - roku
     type: string
-    domain: RUM user attributes (iOS, Browser)
+    domain: RUM user attributes
   - name: usr.name
     description: Name of the user.
     product_source:
@@ -873,8 +858,8 @@ attributes:
     type: string
     domain: Error (Browser events, Android events, iOS events, Roku events)
   
-  - name: error.issue_id
-    description: The stack trace or complementary information about the error.
+  - name: error.id
+    description: UUID of the error.
     product_source:
       - icon-rum
       - android
@@ -963,18 +948,8 @@ attributes:
       - roku
     type: string
     domain: Action (Browser events, Android events, iOS events, Roku events)
-  - name: action.name
-    description: A user-friendly name (for example, `Click on checkout`). For [Custom Browser User Actions](/real_user_monitoring/application_monitoring/browser/tracking_user_actions/?tab=npm#custom-actions), the action name given in the API call.
-    product_source:
-      - icon-rum
-      - android
-      - browser
-      - ios
-      - roku
-    type: string
-    domain: Action (Browser events, Android events, iOS events, Roku events)
   - name: action.target.name
-    description: Element that the user interacted with. Only for automatically collected actions.
+    description: The name of the element the user interacted with (for automatically collected actions) or the name provided in the API call (for custom actions, for example `Click on checkout`).
     product_source:
       - icon-rum
       - android
@@ -1342,24 +1317,8 @@ attributes:
     type: string
     domain: Resource (Browser events)
 
-  - name: action.frustration.type:dead_click
-    description: The dead clicks detected by the RUM Browser SDK.
-    product_source:
-      - icon-rum
-      - browser
-    type: string
-    domain: Frustration signals (Browser events)
-  
-  - name: action.frustration.type:rage_click
-    description: The rage clicks detected by the RUM Browser SDK.
-    product_source:
-      - icon-rum
-      - browser
-    type: string
-    domain: Frustration signals (Browser events)
-  
-  - name: action.frustration.type:error_click
-    description: The error clicks detected by the RUM Browser SDK.
+  - name: action.frustration.type
+    description: The type of frustration signal detected by the RUM Browser SDK (`rage_click`, `dead_click`, or `error_click`).
     product_source:
       - icon-rum
       - browser

--- a/content/en/standard-attributes/_index.md
+++ b/content/en/standard-attributes/_index.md
@@ -958,7 +958,7 @@ attributes:
     type: string
     domain: Action (Browser events, Android events, iOS events, Roku events)
   - name: action.target.name
-    description: The name of the element the user interacted with (for automatically collected actions) or the name provided in the API call (for custom actions, for example `Click on checkout`).
+    description: For automatically collected actions, the name of the element the user interacted with. For custom actions, the name provided in the API call (for example, `Click on checkout`).
     product_source:
       - icon-rum
       - android


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes 4 incorrect RUM attribute entries in the standard attributes page. Each was verified against the [`rum-events-format`](https://github.com/DataDog/rum-events-format) JSON schemas and SDK source code:

- **`user.id` removed, `usr.id` expanded to all platforms** — All SDKs use `usr.id`; the `user.id` entry was incorrect. The existing `usr.id` entry was updated to include Android and Roku.
- **`error.issue_id` removed, `error.id` added** — `error.issue_id` doesn't exist in any SDK or schema. The correct attribute is `error.id` (consistent with `resource.id` and `action.id`), which was missing from the page.
- **`action.name` removed, `action.target.name` description updated** — `action.name` doesn't exist in the schema or any SDK event payload. The description of `action.target.name` was updated to cover both automatically collected and custom actions.
- **`action.frustration.type:rage_click/dead_click/error_click` replaced with a single `action.frustration.type` entry** — The `attribute:value` naming convention used here is inconsistent with the rest of the page. Replaced with one entry listing the possible values in the description, following the same pattern as other enum attributes (e.g. `resource.provider.type`).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code to cross-reference attribute names against `rum-events-format` schemas and SDK source code (browser, iOS, Android).