### PR TITLE
[DBM][Oracle] Add Multi-tenant/Non-CDB tabs to RAC setup page

### DIFF
--- a/content/en/database_monitoring/setup_oracle/rac.md
+++ b/content/en/database_monitoring/setup_oracle/rac.md
@@ -40,7 +40,27 @@ Complete the following to enable Database Monitoring with your Oracle database:
 
 ### Create the Datadog user
 
-{{% dbm-create-oracle-user %}}
+{{< tabs >}}
+{{% tab "Multi-tenant" %}}
+```SQL
+CREATE USER c##datadog IDENTIFIED BY &password CONTAINER = ALL ;
+
+ALTER USER c##datadog SET CONTAINER_DATA=ALL CONTAINER=CURRENT;
+```
+{{% /tab %}}
+
+{{% tab "Non-CDB" %}}
+```SQL
+CREATE USER datadog IDENTIFIED BY &password ;
+```
+{{% /tab %}}
+
+{{% tab "Oracle 11" %}}
+```SQL
+CREATE USER datadog IDENTIFIED BY &password ;
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 ### Securely store your password
 {{% dbm-secret %}}
@@ -53,10 +73,12 @@ For installation steps, see the [Agent installation instructions][9].
 
 ### Configure the Agent
 
-Configure the Agent for each RAC node by following the instructions for [self-hosted Oracle databases][3].
+Configure the Agent for each RAC node. Use the tab that matches your Oracle deployment type (the `username` value must match the user created above).
 
 You must configure the Agent for each Real Application Cluster (RAC) node, because the Agent collects information from every node separately by querying `V$` views. The Agent doesn't query any `GV$` views to avoid generating interconnect traffic. The collected data from each RAC node is aggregated in the frontend.
 
+{{< tabs >}}
+{{% tab "Multi-tenant" %}}
 ```yaml
 init_config:
 instances:
@@ -81,6 +103,58 @@ instances:
 ```
 
 The Agent connects only to CDB. It queries the information about PDBs while connected to CDB. Don't create connections to individual PDBs.
+{{% /tab %}}
+
+{{% tab "Non-CDB" %}}
+```yaml
+init_config:
+instances:
+  - server: '<RAC_NODE_1>:<PORT>'
+    service_name: "<SERVICE_NAME>"
+    username: 'datadog'
+    password: 'ENC[datadog_user_database_password]'
+    dbm: true
+    tags:  # Optional
+      - rac_cluster:<CLUSTER_NAME>
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
+  - server: '<RAC_NODE_2>:<PORT>'
+    service_name: "<SERVICE_NAME>"
+    username: 'datadog'
+    password: 'ENC[datadog_user_database_password]'
+    dbm: true
+    tags:  # Optional
+      - rac_cluster:<CLUSTER_NAME>
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
+```
+{{% /tab %}}
+
+{{% tab "Oracle 11" %}}
+```yaml
+init_config:
+instances:
+  - server: '<RAC_NODE_1>:<PORT>'
+    service_name: "<SERVICE_NAME>"
+    username: 'datadog'
+    password: 'ENC[datadog_user_database_password]'
+    dbm: true
+    tags:  # Optional
+      - rac_cluster:<CLUSTER_NAME>
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
+  - server: '<RAC_NODE_2>:<PORT>'
+    service_name: "<SERVICE_NAME>"
+    username: 'datadog'
+    password: 'ENC[datadog_user_database_password]'
+    dbm: true
+    tags:  # Optional
+      - rac_cluster:<CLUSTER_NAME>
+      - 'service:<CUSTOM_SERVICE>'
+      - 'env:<CUSTOM_ENV>'
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 Set the `rac_cluster` configuration parameter to the name of your RAC cluster or some user friendly alias. The `rac_cluster` filter helps you select all RAC nodes in the [DBM Oracle Database Overview dashboard][4]. You can set an additional filter for the database of interest.
 

--- a/content/en/database_monitoring/setup_oracle/rac.md
+++ b/content/en/database_monitoring/setup_oracle/rac.md
@@ -40,6 +40,10 @@ Complete the following to enable Database Monitoring with your Oracle database:
 
 ### Create the Datadog user
 
+If you already have the legacy Oracle integration installed, skip this step, because the user already exists.
+
+Create a read-only login to connect to your server and grant the required permissions:
+
 {{< tabs >}}
 {{% tab "Multi-tenant" %}}
 ```SQL
@@ -73,7 +77,7 @@ For installation steps, see the [Agent installation instructions][9].
 
 ### Configure the Agent
 
-Configure the Agent for each RAC node. Use the tab that matches your Oracle deployment type (the `username` value must match the user created above).
+Configure the Agent for each RAC node. Use the tab that matches your Oracle deployment type. The `username` value must match the user you created previously.
 
 You must configure the Agent for each Real Application Cluster (RAC) node, because the Agent collects information from every node separately by querying `V$` views. The Agent doesn't query any `GV$` views to avoid generating interconnect traffic. The collected data from each RAC node is aggregated in the frontend.
 

--- a/content/en/database_monitoring/setup_oracle/rac.md
+++ b/content/en/database_monitoring/setup_oracle/rac.md
@@ -40,8 +40,6 @@ Complete the following to enable Database Monitoring with your Oracle database:
 
 ### Create the Datadog user
 
-If you already have the legacy Oracle integration installed, skip this step, because the user already exists.
-
 Create a read-only login to connect to your server and grant the required permissions:
 
 {{< tabs >}}

--- a/content/en/database_monitoring/setup_oracle/rac.md
+++ b/content/en/database_monitoring/setup_oracle/rac.md
@@ -35,7 +35,7 @@ Complete the following to enable Database Monitoring with your Oracle database:
 1. [Create the Datadog user](#create-the-datadog-user)
 1. [Install the Agent](#install-the-agent)
 1. [Configure the Agent](#configure-the-agent)
-1. [Install or verify the Oracle integration](#install-or-verify-the-oracle-integration)
+1. Install or verify the Oracle integration
 1. [Validate the setup](#validate-the-setup)
 
 ### Create the Datadog user


### PR DESCRIPTION
## What

Added Multi-tenant, Non-CDB, and Oracle 11 tab structure to the Oracle RAC setup page, matching the pattern already used on the self-hosted Oracle setup page. The `Create the Datadog user` section now shows the correct `CREATE USER` statement per deployment type, and the `Configure the Agent` section now shows the correct `username` value (`c##datadog` for CDB, `datadog` for Non-CDB/Oracle 11) in each tab. A note ties the two sections together: "the `username` value must match the user created above."

## Why

The RAC page previously used a generic shortcode for user creation while hardcoding `username: 'c##datadog'` in the YAML example. Users on non-CDB or Oracle 11 RAC deployments would create a `datadog` user but copy a config with `c##datadog`, causing authentication failures. Making the username choice explicit per deployment type prevents this mismatch.

## Docs preview

https://docs.datadoghq.com/database_monitoring/setup_oracle/rac/