### PR TITLE
[DEBUG-5524] Document high-entropy scanner in Exception Replay Targeted Mode

### DIFF
--- a/content/en/error_tracking/backend/exception_replay.md
+++ b/content/en/error_tracking/backend/exception_replay.md
@@ -101,7 +101,7 @@ snapshots becomes available.
 Exception Replay has two redaction modes:
 
 - **Strict Mode:** Redacts all values except numbers and Booleans.
-- **Targeted Mode:** Redacts known sensitive patterns such as credit card numbers, API keys, IPs, and other PII.
+- **Targeted Mode:** Redacts known sensitive patterns such as credit card numbers, API keys, IPs, and other PII. Targeted Mode also includes a high-entropy secrets scanner that automatically redacts strings detected as having high entropy. These values appear as `[REDACTED:HIGH_ENTROPY]` in snapshots.
 
 These redaction modes cannot be disabled, only switched, and Targeted Mode is applied automatically in common
 pre-production environments like `staging` or `preprod`.

--- a/content/en/error_tracking/backend/exception_replay.md
+++ b/content/en/error_tracking/backend/exception_replay.md
@@ -94,14 +94,14 @@ their captured values.
 ## Sensitive data redaction
 
 Exception Replay applies automatic mode- and identifier-based redaction to ensure sensitive data is protected before
-snapshots becomes available.
+snapshots become available.
 
 ### Mode-based redaction
 
 Exception Replay has two redaction modes:
 
 - **Strict Mode:** Redacts all values except numbers and Booleans.
-- **Targeted Mode:** Redacts known sensitive patterns such as credit card numbers, API keys, IPs, and other PII. Targeted Mode also includes a high-entropy secrets scanner that automatically redacts strings detected as having high entropy. These values appear as `[REDACTED:HIGH_ENTROPY]` in snapshots.
+- **Targeted Mode:** Redacts known sensitive patterns such as credit card numbers, API keys, IPs, and other PII. It also runs a high-entropy secrets scanner that automatically redacts likely secrets, which appear as `[REDACTED:HIGH_ENTROPY]` in snapshots.
 
 These redaction modes cannot be disabled, only switched, and Targeted Mode is applied automatically in common
 pre-production environments like `staging` or `preprod`.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DEBUG-5524

Updates the Exception Replay sensitive data redaction section to note that Targeted Mode includes a high-entropy secrets scanner. Strings detected as having high entropy are automatically redacted and appear as `[REDACTED:HIGH_ENTROPY]` in snapshots.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes