### PR TITLE
LLMObs SDK docs: clarify manual token instrumentation

### DIFF
--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -493,7 +493,7 @@ To finish a span, call `finish()` on a span object instance. If possible, wrap t
 
 <div class="alert alert-info">If you are using any LLM providers or frameworks that are supported by <a href="/llm_observability/instrumentation/auto_instrumentation/">Datadog's LLM integrations</a>, you do not need to manually start an LLM span to trace these operations.</div>
 
-<div class="alert alert-info">When manually instrumenting an LLM span, token counts (<code>input_tokens</code>, <code>output_tokens</code>, <code>total_tokens</code>) are not captured automatically — you must record them yourself by annotating the span. See <a href="#enriching-spans">Enriching spans</a> for the full annotation API. The examples below show the typical pattern.</div>
+<div class="alert alert-info">If you are manually instrumenting an LLM span, you must record token counts (such as <code>input_tokens</code>, <code>output_tokens</code>, and <code>total_tokens</code>) yourself by annotating the span. See <a href="#enriching-spans">Enriching spans</a> for more information.</div>
 
 {{< tabs >}}
 {{% tab "Python" %}}
@@ -576,8 +576,8 @@ To trace an LLM call, specify the span kind as `llm`, and optionally specify the
 function llmCall (prompt) {
   const completion = ... // user application logic to invoke LLM
   llmobs.annotate({
-    inputData: [{ role: 'user', content: prompt }],
-    outputData: [{ role: 'assistant', content: completion }],
+    inputData: [{ role: "user", content: prompt }],
+    outputData: [{ role: "assistant", content: completion }],
     metrics: { input_tokens: 4, output_tokens: 6, total_tokens: 10 }
   })
   return completion

--- a/content/en/llm_observability/instrumentation/sdk.md
+++ b/content/en/llm_observability/instrumentation/sdk.md
@@ -493,6 +493,8 @@ To finish a span, call `finish()` on a span object instance. If possible, wrap t
 
 <div class="alert alert-info">If you are using any LLM providers or frameworks that are supported by <a href="/llm_observability/instrumentation/auto_instrumentation/">Datadog's LLM integrations</a>, you do not need to manually start an LLM span to trace these operations.</div>
 
+<div class="alert alert-info">When manually instrumenting an LLM span, token counts (<code>input_tokens</code>, <code>output_tokens</code>, <code>total_tokens</code>) are not captured automatically — you must record them yourself by annotating the span. See <a href="#enriching-spans">Enriching spans</a> for the full annotation API. The examples below show the typical pattern.</div>
+
 {{< tabs >}}
 {{% tab "Python" %}}
 To trace an LLM call, use the function decorator `ddtrace.llmobs.decorators.llm()`.
@@ -525,11 +527,17 @@ To trace an LLM call, use the function decorator `ddtrace.llmobs.decorators.llm(
 #### Example
 
 {{< code-block lang="python" >}}
+from ddtrace.llmobs import LLMObs
 from ddtrace.llmobs.decorators import llm
 
 @llm(model_name="claude", name="invoke_llm", model_provider="anthropic")
-def llm_call():
+def llm_call(prompt):
     completion = ... # user application logic to invoke LLM
+    LLMObs.annotate(
+        input_data=[{"role": "user", "content": prompt}],
+        output_data=[{"role": "assistant", "content": completion}],
+        metrics={"input_tokens": 4, "output_tokens": 6, "total_tokens": 10},
+    )
     return completion
 {{< /code-block >}}
 {{% /tab %}}
@@ -565,8 +573,13 @@ To trace an LLM call, specify the span kind as `llm`, and optionally specify the
 #### Example
 
 {{< code-block lang="javascript" >}}
-function llmCall () {
+function llmCall (prompt) {
   const completion = ... // user application logic to invoke LLM
+  llmobs.annotate({
+    inputData: [{ role: 'user', content: prompt }],
+    outputData: [{ role: 'assistant', content: completion }],
+    metrics: { input_tokens: 4, output_tokens: 6, total_tokens: 10 }
+  })
   return completion
 }
 llmCall = llmobs.wrap({ kind: 'llm', name: 'invokeLLM', modelName: 'claude', modelProvider: 'anthropic' }, llmCall)
@@ -616,6 +629,11 @@ public class MyJavaClass {
     LLMObsSpan llmSpan = LLMObs.startLLMSpan("my-llm-span-name", "my-llm-model", "my-company", "maybe-ml-app-override", "session-141");
     String inference = ... // user application logic to invoke LLM
     llmSpan.annotateIO(...); // record the input and output
+    llmSpan.setMetrics(Map.of(
+      "input_tokens", 617,
+      "output_tokens", 338,
+      "total_tokens", 955
+    ));
     llmSpan.finish();
     return inference;
   }


### PR DESCRIPTION
## Summary

The manual instrumentation examples in `content/en/llm_observability/instrumentation/sdk.md` under **LLM calls** did not show how to record token counts, even though token counts must be supplied manually when not relying on auto-instrumentation. This might create confusion since the *context-manager* example earlier on the same page does demonstrate token annotation, but the `@llm` decorator / `llmobs.wrap` / `startLLMSpan` examples did not.

Changes:
- Added an info callout under `### LLM calls` pointing to **Enriching spans** and explicitly stating that token counts (`input_tokens`, `output_tokens`, `total_tokens`) are not captured automatically for manually-started LLM spans.
- Updated the Python (`@llm` decorator), Node.js (`llmobs.wrap`), and Java (`LLMObs.startLLMSpan`) examples to show the typical token-annotation pattern inline.

---

Claude session: `9884a19c-97fb-4141-97cb-760fbcaa9f39`
Resume: `claude --resume 9884a19c-97fb-4141-97cb-760fbcaa9f39`

🤖 Generated with [Claude Code](https://claude.com/claude-code)