### PR TITLE
[CCM] Document the new ccm_budget_write permission

### DIFF
--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -112,7 +112,7 @@ Use [Container Cost Allocation metrics][4] to discover costs associated with clu
 
 ## Permissions
 
-Cloud Cost Management uses two permissions to control access: `cloud_cost_management_read` for viewing cost data and `cloud_cost_management_write` for modifying configurations. See the [Permissions documentation][9] for a detailed breakdown of requirements by page.
+Cloud Cost Management uses two main permissions, `cloud_cost_management_read` and `cloud_cost_management_write`, to control access to cost data and most CCM configurations. Additional permissions are available for specific use cases, such as editing budgets (`ccm_budget_write`) and managing report schedules. See the [Permissions documentation][9] for a detailed breakdown of requirements by page.
 
 ## Review data history
 

--- a/content/en/cloud_cost_management/_index.md
+++ b/content/en/cloud_cost_management/_index.md
@@ -112,7 +112,11 @@ Use [Container Cost Allocation metrics][4] to discover costs associated with clu
 
 ## Permissions
 
-Cloud Cost Management uses two main permissions, `cloud_cost_management_read` and `cloud_cost_management_write`, to control access to cost data and most CCM configurations. Additional permissions are available for specific use cases, such as editing budgets (`ccm_budget_write`) and managing report schedules. See the [Permissions documentation][9] for a detailed breakdown of requirements by page.
+Cloud Cost Management uses the following permissions to control access to cost data and most CCM configurations:
+- `cloud_cost_management_read`
+- `cloud_cost_management_write`
+
+For a detailed breakdown of requirements by page, see [Permissions][9].
 
 ## Review data history
 

--- a/content/en/cloud_cost_management/planning/budgets.md
+++ b/content/en/cloud_cost_management/planning/budgets.md
@@ -139,9 +139,19 @@ To view detailed forecast information in a budget, click {{< ui >}}View Performa
 
 Learn more about how [forecasting][3] works and data requirements.
 
+## Permissions
+
+| Action | Required Permission |
+|--------|---------------------|
+| View budgets | `cloud_cost_management_read` |
+| Create, edit, or delete a budget | `ccm_budget_write` |
+
+For the full list of CCM permissions, see the [Permissions documentation][4].
+
 ## Further Reading
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]: https://app.datadoghq.com/cost/plan/budgets
 [2]: /cloud_cost_management/cost_changes/monitors/
 [3]: /cloud_cost_management/planning/forecasting
+[4]: /cloud_cost_management/setup/permissions

--- a/content/en/cloud_cost_management/setup/permissions.md
+++ b/content/en/cloud_cost_management/setup/permissions.md
@@ -16,7 +16,7 @@ further_reading:
 
 Permissions control what actions a user can take in Datadog. Users are assigned to roles, and each role has a set of permissions that determines what that user can see and do.
 
-Cloud Cost Management (CCM) uses two permissions to control access to cost data and settings. Assign these permissions to roles through [Role Based Access Control (RBAC)][1] to manage who can view cost data and who can modify CCM configurations.
+Cloud Cost Management (CCM) uses two main permissions, `cloud_cost_management_read` and `cloud_cost_management_write`, to control access to cost data and most CCM configurations. Additional product-level permissions are available for specific features, such as editing budgets (`ccm_budget_write`) and managing report schedules (`generate_ccm_report_schedules`, `manage_ccm_report_schedules`). Assign these permissions to roles through [Role Based Access Control (RBAC)][1].
 
 CCM also supports [Data Access Control](#data-access-control) to further restrict cost data by tags.
 
@@ -25,7 +25,10 @@ CCM also supports [Data Access Control](#data-access-control) to further restric
 | Permission | Description |
 |------------|-------------|
 | `cloud_cost_management_read` | Grants read-only access to view cost data, budgets, recommendations, and settings across CCM pages and external integrations. |
-| `cloud_cost_management_write` | Grants access to modify CCM configurations, including creating budgets, uploading custom costs, and managing cloud accounts. Requires the read permission to access pages. |
+| `cloud_cost_management_write` | Grants access to modify CCM configurations, including uploading custom costs and managing cloud accounts. Does not grant access to create, edit, or delete budgets; see `ccm_budget_write`. |
+| `ccm_budget_write` | Grants access to create, update, and delete Cloud Cost Management budgets, including budget metadata and budgeted amounts per entry. Requires the read permission to access pages. |
+| `generate_ccm_report_schedules` | View all report schedules and manage only the ones the user has created. |
+| `manage_ccm_report_schedules` | View, create, and fully manage all report schedules across the organization. |
 
 ## Permission requirements by page
 
@@ -37,7 +40,7 @@ The table below shows the required permissions for each CCM page and related fea
 | CCM Containers Page                           | Required to view container cost allocation data  | N/A                                               |
 | CCM Recommendations Page                      | Required to view cost recommendations            | N/A                                               |
 | CCM Explorer Page                             | Required to query and view cost data             | N/A                                               |
-| CCM Plan Page                                 | Required to view budgets                         | Required to modify or create budgets              |
+| CCM Plan Page                                 | Required to view budgets                         | `ccm_budget_write` required to create, edit, or delete budgets |
 | CCM Settings Page - Custom Costs              | Required to view custom costs settings           | Required to upload custom costs                   |
 | CCM Settings Page - Tag Pipelines             | Required to view tag pipelines                   | Required to create tag pipelines                  |
 | CCM Settings Page - SaaS Integrations         | Required to view SaaS integration settings       | Required to enable integration for CCM            |

--- a/content/en/cloud_cost_management/setup/permissions.md
+++ b/content/en/cloud_cost_management/setup/permissions.md
@@ -27,8 +27,8 @@ CCM also supports [Data Access Control](#data-access-control) to further restric
 | `cloud_cost_management_read` | Grants read-only access to view cost data, budgets, recommendations, and settings across CCM pages and external integrations. |
 | `cloud_cost_management_write` | Grants access to modify CCM configurations, including uploading custom costs and managing cloud accounts. Does not grant access to create, edit, or delete budgets; see `ccm_budget_write`. |
 | `ccm_budget_write` | Grants access to create, update, and delete Cloud Cost Management budgets, including budget metadata and budgeted amounts per entry. Requires the read permission to access pages. |
-| `generate_ccm_report_schedules` | View all report schedules and manage only the ones the user has created. |
-| `manage_ccm_report_schedules` | View, create, and fully manage all report schedules across the organization. |
+| `generate_ccm_report_schedules` | Grants access to view all report schedules and manage only the ones the user has created. |
+| `manage_ccm_report_schedules` | Grants access to view, create, and fully manage all report schedules across the organization. |
 
 ## Permission requirements by page
 


### PR DESCRIPTION
## Context

Cloud Cost Management is introducing a new product-level permission `ccm_budget_write` that narrows the scope of budget edits previously gated by the broader `cloud_cost_management_write`. Once the migration ships, all Budgets write routes will require `ccm_budget_write`, and `cloud_cost_management_write` will no longer cover budget create/edit/delete.

This PR updates the public CCM documentation to reflect the new permission and to formalize the existing CCM Report Schedule permissions, which were not previously listed in the Permissions reference.

## Changes

### Preview

- [CCM Budgets](https://docs-staging.datadoghq.com/georges.bergossi/update_ccm_budget_forecast_permissions/cloud_cost_management/planning/budgets) => New 'Permissions' section. 2 new links in 'Further Reading'
- [CCM permissions](https://docs-staging.datadoghq.com/georges.bergossi/update_ccm_budget_forecast_permissions/cloud_cost_management/setup/permissions) => Updated 'Overview' section. Updated table in 'Available permissions' section. Updated CCM Plan row in 'Permission requirements by page' table
- [CCM index](https://docs-staging.datadoghq.com/georges.bergossi/update_ccm_budget_forecast_permissions/cloud_cost_management/) => Updated 'Permissions' section.

### In details

- `content/en/cloud_cost_management/setup/permissions.md`
  - Reworked the Overview section.
  - Expanded the Available permissions table with three new rows: `ccm_budget_write`, `generate_ccm_report_schedules`, and `manage_ccm_report_schedules`.
  - Updated the `cloud_cost_management_write` description to call out that it no longer covers budget create/edit/delete.
  - Updated the CCM Plan Page row in the requirements-by-page table to reference `ccm_budget_write`.
- `content/en/cloud_cost_management/_index.md`
  - Updated the Permissions section summary so it mentions `ccm_budget_write` and report-schedule permissions in addition to the two main read/write permissions.
- `content/en/cloud_cost_management/planning/budgets.md`
  - Added a new `## Permissions` section with an action / required permission table, modeled on the pattern in `cloud_cost_management/reporting/scheduled_reports.md`.
  - Added a reference link to `/cloud_cost_management/setup/permissions`.

The auto-generated `account_management/rbac/permissions/` page is intentionally not modified; new permissions are picked up automatically.

## Tests

- Ran Vale on the modified files: 0 errors. Remaining warnings/suggestions are pre-existing in unmodified content.
