### PR TITLE
[DOCS-13085] Add enterprise environment considerations shortcode for Azure setup

### DIFF
--- a/content/en/getting_started/integrations/azure.md
+++ b/content/en/getting_started/integrations/azure.md
@@ -54,6 +54,12 @@ The `Datadog Admin Role`, or any other role with the `azure_configurations_manag
 
 {{% /collapse-content %}}
 
+{{% collapse-content title="Enterprise environment considerations" level="h4" expanded=false id="enterprise-considerations" %}}
+
+{{% azure-enterprise-prerequisites %}}
+
+{{% /collapse-content %}}
+
 {{< site-region region="us3" >}}
 
 <div class="alert alert-danger"><a href="https://docs.datadoghq.com/cloud_cost_management/setup/azure/?tab=billingaccounts&site=us3#overview">Cloud Cost Management</a> and <a href="https://docs.datadoghq.com/logs/log_configuration/archives/?tab=azurestorage">Log Archives</a> require the app registration setup method. For Datadog accounts using the Azure Native integration, follow the setup steps on this page to create an app registration. If a subscription is connected through both methods, a redundancy warning appears in the Azure integration tile. This warning can be safely ignored for Cloud Cost Management and Log Archives.

--- a/content/en/integrations/guide/azure-native-integration.md
+++ b/content/en/integrations/guide/azure-native-integration.md
@@ -29,6 +29,12 @@ This guide is for setting up and managing the Datadog Monitor resource in Azure,
 - Your Datadog account must be on the [US3 Site][1]
 - You must be an **Owner** on any Azure subscriptions you want to link, and **Admin** for the Datadog organization you are linking them to
 
+{{% collapse-content title="Enterprise environment considerations" level="h4" expanded=false id="enterprise-considerations" %}}
+
+{{% azure-enterprise-prerequisites %}}
+
+{{% /collapse-content %}}
+
 ## Overview
 
 The Datadog resource in Azure represents the connection between your Datadog organization and your Azure environment. You can configure a Datadog resource to link as many subscriptions as you wish to monitor. 

--- a/layouts/shortcodes/azure-enterprise-prerequisites.md
+++ b/layouts/shortcodes/azure-enterprise-prerequisites.md
@@ -1,0 +1,29 @@
+Some Azure environments enforce constraints that affect how the Datadog integration can be deployed. Review these considerations before starting setup if your subscription has Azure Policy enforcement, custom Marketplace plans, or other enterprise governance requirements.
+
+### Mandatory resource tags and Azure Policy
+
+The default Datadog ARM template does not accept custom tags. If your subscription enforces an Azure Policy that requires specific resource tags, the portal-based deployment fails with a `PolicyViolation` error.
+
+To deploy in environments with mandatory tag policies, use one of:
+
+- The Azure CLI, with tags injected as deployment parameters.
+- A [Terraform-based deployment][1000].
+- A customized ARM template that adds the required tags.
+
+### Azure Marketplace and pay-as-you-go eligibility
+
+ARM template-based deployments require an eligible Azure Marketplace plan and active pay-as-you-go billing. Plans in `stop sell` status produce an error during ARM template validation, similar to:
+
+`SaaS Purchase Payment Check Failed - Plan '<plan>' is defined as stop sell in offer '<offer>'`
+
+If you see this error, deploy the integration using the manual setup method. You can also contact Azure Marketplace support to confirm plan eligibility for your subscription.
+
+### Common ARM template errors
+
+| Error snippet | Likely cause | Action |
+|---|---|---|
+| `stop sell in offer` | Marketplace plan restriction | Switch to manual setup or contact Azure Marketplace support. |
+| `Forbidden` or `AuthorizationFailed` | Missing Owner role or App registration permissions | Verify the deploying principal has Owner on the subscription. |
+| `PolicyViolation` | Azure Policy blocking the deployment (commonly mandatory tags) | Use the CLI or Terraform path so required tags can be injected. |
+
+[1000]: https://github.com/DataDog/integrations-management

--- a/layouts/shortcodes/azure-enterprise-prerequisites.md
+++ b/layouts/shortcodes/azure-enterprise-prerequisites.md
@@ -23,7 +23,7 @@ If you see this error, deploy the integration using the manual setup method. You
 | Error snippet | Likely cause | Action |
 |---|---|---|
 | `stop sell in offer` | Marketplace plan restriction | Switch to manual setup or contact Azure Marketplace support. |
-| `Forbidden` or `AuthorizationFailed` | Missing Owner role or App registration permissions | Verify the deploying principal has Owner on the subscription. |
+| `Forbidden` or `AuthorizationFailed` | Missing Owner role or App registration permissions | Verify the deploying principal has the Owner role on the subscription. |
 | `PolicyViolation` | Azure Policy blocking the deployment (commonly mandatory tags) | Use the CLI or Terraform path so required tags can be injected. |
 
 [1000]: https://github.com/DataDog/integrations-management


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13085

Adds a new shortcode that surfaces enterprise-specific Azure deployment constraints (mandatory tags / Azure Policy, Marketplace plan eligibility, common ARM template errors) on both the all-sites Azure Getting Started page and the US3-only Azure native integration setup page. Customers attempting the portal-based ARM template path in enterprise environments hit hard, opaque failures that look like Datadog bugs but originate from Azure-side constraints; this content sets expectations before they hit those failures.

Changes:

- **New shortcode** `layouts/shortcodes/azure-enterprise-prerequisites.md`: contains three h3 subsections (mandatory tags / Azure Policy, Marketplace and pay-as-you-go eligibility, common ARM template errors) plus a reference-style link. The shortcode is the single source of truth for this content so it can be invoked from multiple host pages without drift.
- **`content/en/getting_started/integrations/azure.md`**: adds a `collapse-content` wrapper around the shortcode invocation, placed inside the existing Prerequisites section as a sibling to the existing "Permissions required for integration setup" collapse.
- **`content/en/integrations/guide/azure-native-integration.md`**: adds the same wrapper + invocation inside its Prerequisites section, before `## Overview`.

Design decisions:

- **Hidden behind `expanded=false` on both pages.** The content is conditional (most readers won't have these constraints), so it's wrapped in a collapsed expandable to avoid imposing reading weight on the happy path while staying discoverable for customers whose environment is affected.
- **`level="h4"` on the collapse wrapper.** Per the Datadog `collapse-content` reference, `h2` and `h3` break the right-hand TOC ([WEB-4850](https://datadoghq.atlassian.net/browse/WEB-4850)). All existing collapse blocks on these pages already use `h4`.
- **Shortcode rather than duplicated inline content.** Drift between the two host pages would be a real failure mode (the same constraint gets new error patterns or new alternative paths and only one page gets updated). The shortcode prevents that.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

This is the fourth of six planned PRs under DOCS-13085. Branched directly off master (no dependency on PRs 1, 2, or 5). PR 6 (resource deletion troubleshooting) will also touch `azure-native-integration.md` in a different section; whichever merges first will not conflict with the other content-wise.

[WEB-4850]: https://datadoghq.atlassian.net/browse/WEB-4850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ