### PR TITLE
[DOCS-13085] Clarify Azure VM extension version vs. Datadog Agent version

### DIFF
--- a/content/en/integrations/guide/azure-advanced-configuration.md
+++ b/content/en/integrations/guide/azure-advanced-configuration.md
@@ -100,6 +100,10 @@ An alternative to the GUI installation is the command line.
 To run the Datadog Agent in your Azure instances as an extension, use the command that matches your environment. Replace `<SITE_PARAMETER>` with your Datadog account **site parameter** value in the [Datadog sites page][33], and `<DATADOG_API_KEY>` with your [Datadog API key][9].
    **Note**: Python 3.9+ is required for installing Agent version 7+.
 
+<div class="alert alert-info">
+The Azure VM extension version (visible in the Azure portal as <code>5.0.0.0</code> or similar) is not the same as the Datadog Agent version. The portal may continue to display the extension version after the Agent is installed or upgraded. To confirm which Agent version is running, follow the <strong>Verify the installed Agent version</strong> steps in the tab below. You can also check the host on the <a href="https://app.datadoghq.com/infrastructure">Datadog Infrastructure list</a>. Manage the Agent version using PowerShell, the Azure CLI, or an ARM template rather than the Azure portal extension UI.
+</div>
+
 {{< tabs >}}
 {{% tab "Windows" %}}
 
@@ -168,8 +172,19 @@ This example shows how to specify a version of the Agent to install. By default 
 Set-AzVMExtension -Name "DatadogAgent" -Publisher "Datadog.Agent" -Type "DatadogWindowsAgent" -TypeHandlerVersion "7.0" -Settings @{"site" = "<SITE_PARAMETER>"; "agentVersion" = "latest"} -ProtectedSettings @{"api_key" = "<DATADOG_API_KEY>"} -DisableAutoUpgradeMinorVersion
 {{< /code-block >}}
 
+### Verify the installed Agent version
+
+To check which Datadog Agent version is running on a Windows VM, run this PowerShell command on the host:
+
+{{< code-block lang="powershell" >}}
+& "$env:ProgramFiles\Datadog\Datadog Agent\bin\agent.exe" version
+{{< /code-block >}}
+
+You can also confirm the running version on the host's entry in the [Datadog Infrastructure list][102].
+
 [100]: https://learn.microsoft.com/powershell/module/az.compute/set-azvmextension
 [101]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
+[102]: https://app.datadoghq.com/infrastructure
 {{% /tab %}}
 {{% tab "Linux" %}}
 
@@ -226,8 +241,19 @@ az vm extension set --publisher "Datadog.Agent" --name "DatadogLinuxAgent" --ver
 {{< /code-block >}}
 
 
+### Verify the installed Agent version
+
+To check which Datadog Agent version is running on a Linux VM, run this command on the host:
+
+{{< code-block lang="shell" >}}
+datadog-agent version
+{{< /code-block >}}
+
+You can also confirm the running version on the host's entry in the [Datadog Infrastructure list][202].
+
 [200]: https://learn.microsoft.com/cli/azure/vm/extension
 [201]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
+[202]: https://app.datadoghq.com/infrastructure
 {{% /tab %}}
 {{< /tabs >}}
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-13085

The Azure VM extension and the Datadog Agent are two different things with two different version numbers, and the Azure portal can keep displaying the extension version (for example, `5.0.0.0`) long after a newer Agent has been installed and is running on the VM. Customers reasonably interpret the portal display as the Agent version, conclude something is wrong, and escalate. This PR sets that expectation explicitly and gives customers a verification path on the VM itself.

Changes in `content/en/integrations/guide/azure-advanced-configuration.md`:

- Adds a callout above the Windows/Linux tabs in the "Commands to install the Azure Datadog Extension" section: extension version is not the Agent version; the portal may continue to display the extension version after Agent install/upgrade; verify with the steps in each tab; manage Agent version via PowerShell / Azure CLI / ARM rather than the portal extension UI.
- Adds a `### Verify the installed Agent version` subsection inside the Windows tab with a PowerShell command using the Agent's executable.
- Adds a `### Verify the installed Agent version` subsection inside the Linux tab with `datadog-agent version`.
- Both verify subsections cross-link to the Datadog Infrastructure list as a UI alternative for confirming the running Agent version.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

This is the fifth of six planned PRs under DOCS-13085. Branched directly off master (no overlap with other PRs in the project).

The "Install on Azure Arc" section in the same file has the same versioning concerns but is not in scope here — CLOUDS-5729 was specifically about the VM extension. If Arc-related escalations surface, a follow-up can extend the same callout pattern there.