### PR TITLE
DSM Go: list kafka-go in automatic instrumentation section

### DIFF
--- a/content/en/data_streams/setup/language/go.md
+++ b/content/en/data_streams/setup/language/go.md
@@ -41,7 +41,7 @@ Data Streams Monitoring has not been changed between v1 and v2 of the SDK.
 
 #### Automatic Instrumentation
 
-Automatic instrumentation uses [Orchestrion][4] to install dd-trace-go and supports both the Sarama and Confluent Kafka libraries.
+Automatic instrumentation uses [Orchestrion][4] to install dd-trace-go and supports the Sarama, Confluent Kafka, and kafka-go libraries.
 
 To automatically instrument your service:
 


### PR DESCRIPTION
## Summary

- The DSM Go setup page lists `kafka-go` in the **Supported libraries** table, but the **Automatic Instrumentation** section only mentions Sarama and Confluent Kafka.
- `kafka-go` is auto-instrumented by Orchestrion via [`dd-trace-go/contrib/segmentio/kafka-go`](https://github.com/DataDog/dd-trace-go/tree/main/contrib/segmentio/kafka-go), which is registered in [`dd-trace-go/orchestrion/all`](https://github.com/DataDog/dd-trace-go/blob/main/orchestrion/all/orchestrion.tool.go) — so it's enabled out of the box for users compiling with Orchestrion.
- Updates the sentence to reflect this and avoid misleading prospects who use `segmentio/kafka-go`.

## Test plan

- [ ] Preview build renders the updated sentence on `/data_streams/setup/language/go/#automatic-instrumentation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)