### PR TITLE
[WEB-8804] Generate search.json in preview environment

### DIFF
--- a/layouts/_default/list.search.json
+++ b/layouts/_default/list.search.json
@@ -1,4 +1,4 @@
-{{- if (or (eq hugo.Environment "live") (in (slice "typesense_sync_preview:manual" "algolia_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
+{{- if (or (eq hugo.Environment "live") (eq hugo.Environment "preview") (in (slice "typesense_sync_preview:manual" "algolia_sync_preview:manual") (os.Getenv "CI_JOB_NAME" | default "" ))) -}}
     {{ $.Scratch.Add "algoliaindex" slice }}
     {{ $section := $.Site.GetPage "section" .Section }}
     {{ $hugo_context := . }}


### PR DESCRIPTION
   ### What does this PR do? What is the motivation?

   Fixes WEB-8804

   The `typesense_sync_preview:manual` CI job was failing with a 404 on `search.json` in preview builds.

   The root cause: Hugo was upgraded from 0.126.0 to 0.149.0 in the CI Docker image (September 2025). Hugo 0.128+ no longer writes output files when a template renders to empty content. The search template
   only generates content when `hugo.Environment == "live"` or `CI_JOB_NAME` matches one of the sync jobs. In regular preview builds neither condition is true, so the template rendered empty and Hugo 0.149.0
    skipped writing `search.json` entirely. The sync job then couldn't find the file.

   Fix: add `(eq hugo.Environment "preview")` to the condition so preview builds always generate the full search index, the same as production.

   ### Merge instructions

   Merge readiness:
   - [ ] Ready for merge
