### PR TITLE
Add Startup plan to SCIM availability notice

### DIFF
--- a/content/en/account_management/scim/_index.md
+++ b/content/en/account_management/scim/_index.md
@@ -13,7 +13,7 @@ algolia:
 ---
 
 <div class="alert alert-info">
-SCIM is available with the Infrastructure Pro and Infrastructure Enterprise plans.
+SCIM is available with the Infrastructure Pro, Infrastructure Enterprise, and Startup plans.
 </div>
 
 ## Overview


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Updates the SCIM documentation to reflect that SCIM is now available for Startup plan customers, not just Pro and Enterprise.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes

Companion PRs enabling SCIM for Startup plan:
- DataDog/dogweb#165870 (SCIM Users)
- DataDog/dd-source#427953 (SCIM Groups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)