### PR TITLE
docs(annotations): document annotation aggregation in Add to Dataset [MLOB-7392]

### DIFF
--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -216,7 +216,7 @@ Transfer annotated traces to datasets for experiment evaluation:
 4. Click **Add to Dataset**.
 5. Set the dataset's **expected output**:
    - **From interaction**: use each trace's actual output (or, if you're working from experiment traces, the original expected output).
-   - **From annotation label**: use the values annotators applied. Pick one or more labels — the record's `expected_output` is built from your selection.
+   - **From annotation label**: use the values annotators applied. Pick one or more labels; the record's `expected_output` is built from your selection.
 6. Choose an existing dataset, or create a dataset.
 
 #### How annotation values are aggregated
@@ -248,16 +248,16 @@ Aggregated: `"polite"` (2 of 3 votes).
 - Annotator B: `["safety", "billing"]`
 - Annotator C: `["safety", "policy"]`
 
-Aggregated: `["safety", "policy"]` — `safety` (3 of 3) and `policy` (2 of 3) clear the majority; `billing` (1 of 3) is dropped.
+Aggregated: `["safety", "policy"]`. `safety` (3 of 3) and `policy` (2 of 3) clear the majority; `billing` (1 of 3) is dropped.
 
 **Example: text.** Two annotators leave notes:
 
 - Annotator A: `"Confusing phrasing"`
 - Annotator B: `"Tone too casual"`
 
-Aggregated: `["Confusing phrasing", "Tone too casual"]` — every annotator's value is preserved.
+Aggregated: `["Confusing phrasing", "Tone too casual"]`. Every annotator's value is preserved.
 
-Raw per-annotator values are preserved in each record's metadata, along with annotator identity, so you can recompute with a different strategy (for example, median, weighted vote, or reviewer pick) if the default consensus doesn't fit your workflow.
+Raw per-annotator values are preserved in each record's metadata, along with annotator identity. If the default consensus doesn't fit your workflow, you can recompute with a different strategy (for example, median, weighted vote, or reviewer pick).
 
 Labels not selected as expected output are also included with each trace as metadata.
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -232,6 +232,31 @@ When multiple annotators have annotated the same trace, the value for each label
 | Score       | Average                                             |
 | Text        | List of responses                                   |
 
+When a single-select categorical label ties (multiple options receive the same number of votes), the option that comes first alphabetically wins.
+
+**Example: categorical (single-select).** Three annotators rate `tone`:
+
+- Annotator A: `polite`
+- Annotator B: `rude`
+- Annotator C: `polite`
+
+Aggregated: `"polite"` (2 of 3 votes).
+
+**Example: categorical (multi-select).** Three annotators tag `topics`:
+
+- Annotator A: `["safety", "policy"]`
+- Annotator B: `["safety", "billing"]`
+- Annotator C: `["safety", "policy"]`
+
+Aggregated: `["safety", "policy"]` — `safety` (3 of 3) and `policy` (2 of 3) clear the majority; `billing` (1 of 3) is dropped.
+
+**Example: text.** Two annotators leave notes:
+
+- Annotator A: `"Confusing phrasing"`
+- Annotator B: `"Tone too casual"`
+
+Aggregated: `["Confusing phrasing", "Tone too casual"]` — every annotator's value is preserved.
+
 Raw per-annotator values are preserved in each record's metadata, along with annotator identity, so you can recompute with a different strategy (for example, median, weighted vote, or reviewer pick) if the default consensus doesn't fit your workflow.
 
 Labels not selected as expected output are also included with each trace as metadata.

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -214,9 +214,27 @@ Transfer annotated traces to datasets for experiment evaluation:
 2. Open the queue.
 3. Select traces to transfer.
 4. Click **Add to Dataset**.
-5. Choose an existing dataset, or create a dataset.
+5. Set the dataset's **expected output**:
+   - **From interaction**: use each trace's actual output (or, if you're working from experiment traces, the original expected output).
+   - **From annotation label**: use the values annotators applied. Pick one or more labels — the record's `expected_output` is built from your selection.
+6. Choose an existing dataset, or create a dataset.
 
-Labels are included with each trace as metadata.
+#### How annotation values are aggregated
+
+When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": ["neutral"] }`. The same shape applies whether you select one label or many.
+
+When multiple annotators have annotated the same trace, the value for each label is aggregated across them by consensus:
+
+| Label type  | Aggregation                                         |
+| ----------- | --------------------------------------------------- |
+| Boolean     | Majority vote                                       |
+| Categorical | Per-option majority vote (a list when multi-select) |
+| Score       | Average                                             |
+| Text        | List of responses                                   |
+
+Raw per-annotator values are preserved in each record's metadata, along with annotator identity, so you can recompute with a different strategy (for example, median, weighted vote, or reviewer pick) if the default consensus doesn't fit your workflow.
+
+Labels not selected as expected output are also included with each trace as metadata.
 
 See [Datasets][3] for more information about using datasets in experiments.
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -232,7 +232,7 @@ When multiple annotators have annotated the same trace, the value for each label
 | Score       | Average                                   |
 | Text        | List of responses                         |
 
-For single-select categorical labels, the option with the most votes wins, even without a strict majority. Ties break alphabetically (the option that comes first wins). For multi-select, the resulting list is sorted alphabetically.
+For single-select categorical labels, the option with the most votes wins, even without a strict majority. Ties break alphabetically (the option that comes first wins). For multi-select, the resulting list is sorted alphabetically. For boolean labels, ties break in favor of `true`.
 
 **Example: categorical (single-select).** Three annotators rate `tone`:
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -232,7 +232,7 @@ When multiple annotators have annotated the same trace, the value for each label
 | Score       | Average                                   |
 | Text        | List of responses                         |
 
-For single-select categorical labels, the option with the most votes wins, even without a strict majority. Ties break alphabetically (the option that comes first wins).
+For single-select categorical labels, the option with the most votes wins, even without a strict majority. Ties break alphabetically (the option that comes first wins). For multi-select, the resulting list is sorted alphabetically.
 
 **Example: categorical (single-select).** Three annotators rate `tone`:
 
@@ -248,7 +248,7 @@ Aggregated: `"polite"` (2 of 3 votes).
 - Annotator B: `["safety", "billing"]`
 - Annotator C: `["safety", "policy"]`
 
-Aggregated: `["safety", "policy"]`. `safety` (3 of 3) and `policy` (2 of 3) make it in; `billing` (1 of 3) does not.
+Aggregated: `["policy", "safety"]`. `safety` (3 of 3) and `policy` (2 of 3) make it in; `billing` (1 of 3) does not. The list is sorted alphabetically.
 
 **Example: text.** Two annotators leave notes:
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -215,7 +215,7 @@ Transfer annotated traces to datasets for experiment evaluation:
 3. Select traces to transfer.
 4. Click **Add to Dataset**.
 5. Set the dataset's **expected output**:
-   - **From interaction**: use each trace's actual output (or, if you're working from experiment traces, the original expected output).
+   - **From interaction**: use each trace's actual output. For experiment traces, you can also pick **Expected output** to use the original expected output from the experiment's source dataset.
    - **From annotation label**: use the values annotators applied. Pick one or more labels; the record's `expected_output` is built from your selection.
 6. Choose an existing dataset, or create a dataset.
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -225,14 +225,14 @@ When **expected output** is built from annotation labels, the exported value is 
 
 When multiple annotators have annotated the same trace, the value for each label is aggregated across them by consensus:
 
-| Label type  | Aggregation                               |
-| ----------- | ----------------------------------------- |
-| Boolean     | Majority vote                             |
-| Categorical | Plurality vote (a list when multi-select) |
-| Score       | Average                                   |
-| Text        | List of responses                         |
+| Label type  | Aggregation                              |
+| ----------- | ---------------------------------------- |
+| Boolean     | Majority vote                            |
+| Categorical | Plurality vote (most-picked option wins) |
+| Score       | Average                                  |
+| Text        | List of responses                        |
 
-For single-select categorical labels, the option with the most votes wins, even without a strict majority. Ties break alphabetically (the option that comes first wins). For multi-select, the resulting list is sorted alphabetically. For boolean labels, ties break in favor of `true`.
+For categorical labels (both single-select and multi-select), the option picked by the most annotators wins. With multi-select, each option an annotator selects counts as one vote. Ties break alphabetically. For boolean labels, ties break in favor of `true`.
 
 **Example: categorical (single-select).** Three annotators rate `tone`:
 
@@ -242,13 +242,13 @@ For single-select categorical labels, the option with the most votes wins, even 
 
 Aggregated: `"polite"` (2 of 3 votes).
 
-**Example: categorical (multi-select).** Three annotators tag `topics`:
+**Example: categorical (multi-select).** Three annotators tag `topics` (each can pick multiple options):
 
 - Annotator A: `["safety", "policy"]`
 - Annotator B: `["safety", "billing"]`
 - Annotator C: `["safety", "policy"]`
 
-Aggregated: `["policy", "safety"]`. `safety` (3 of 3) and `policy` (2 of 3) make it in; `billing` (1 of 3) does not. The list is sorted alphabetically.
+Each option an annotator selects counts as one vote: `safety` gets 3, `policy` gets 2, `billing` gets 1. Aggregated: `"safety"` (most votes).
 
 **Example: text.** Two annotators leave notes:
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -219,20 +219,20 @@ Transfer annotated traces to datasets for experiment evaluation:
    - **From annotation label**: use the values annotators applied. Pick one or more labels; the record's `expected_output` is built from your selection.
 6. Choose an existing dataset, or create a dataset.
 
-#### How annotation values are aggregated
+When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": "neutral" }`. The same shape applies whether you select one label or many.
 
-When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": ["neutral"] }`. The same shape applies whether you select one label or many.
+{{% collapse-content title="How annotation values are aggregated across annotators" level="h4" expanded=false id="annotation-aggregation" %}}
 
 When multiple annotators have annotated the same trace, the value for each label is aggregated across them by consensus:
 
-| Label type  | Aggregation                                         |
-| ----------- | --------------------------------------------------- |
-| Boolean     | Majority vote                                       |
-| Categorical | Per-option majority vote (a list when multi-select) |
-| Score       | Average                                             |
-| Text        | List of responses                                   |
+| Label type  | Aggregation                               |
+| ----------- | ----------------------------------------- |
+| Boolean     | Majority vote                             |
+| Categorical | Plurality vote (a list when multi-select) |
+| Score       | Average                                   |
+| Text        | List of responses                         |
 
-When a single-select categorical label ties (multiple options receive the same number of votes), the option that comes first alphabetically wins.
+For single-select categorical labels, the option with the most votes wins, even without a strict majority. Ties break alphabetically (the option that comes first wins).
 
 **Example: categorical (single-select).** Three annotators rate `tone`:
 
@@ -248,7 +248,7 @@ Aggregated: `"polite"` (2 of 3 votes).
 - Annotator B: `["safety", "billing"]`
 - Annotator C: `["safety", "policy"]`
 
-Aggregated: `["safety", "policy"]`. `safety` (3 of 3) and `policy` (2 of 3) clear the majority; `billing` (1 of 3) is dropped.
+Aggregated: `["safety", "policy"]`. `safety` (3 of 3) and `policy` (2 of 3) make it in; `billing` (1 of 3) does not.
 
 **Example: text.** Two annotators leave notes:
 
@@ -258,6 +258,8 @@ Aggregated: `["safety", "policy"]`. `safety` (3 of 3) and `policy` (2 of 3) clea
 Aggregated: `["Confusing phrasing", "Tone too casual"]`. Every annotator's value is preserved.
 
 Raw per-annotator values are preserved in each record's metadata, along with annotator identity. If the default consensus doesn't fit your workflow, you can recompute with a different strategy (for example, median, weighted vote, or reviewer pick).
+
+{{% /collapse-content %}}
 
 Labels not selected as expected output are also included with each trace as metadata.
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -235,7 +235,7 @@ When multiple annotators have annotated the same trace, the value for each label
 
 For Boolean labels, ties break in favor of `true`. For categorical single-select, ties break alphabetically.
 
-For categorical multi-select, each option is treated as an independent yes/no vote: keep the option if the number of annotators who selected it is greater than or equal to the number who did not. The aggregated value is the array of options that meet this threshold (and may be empty if no option does — in which case the value falls back to a plurality vote and a single option is picked, with alphabetical tie-break).
+For categorical multi-select, each option is treated as an independent yes/no vote. Keep the option if the number of annotators who selected it is greater than or equal to the number who did not. The aggregated value is the array of options that meet this threshold. If no option meets the threshold, the value falls back to a plurality vote, and a single option is picked with alphabetical tie-break.
 
 **Example: categorical (single-select).** Three annotators rate `tone`:
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -259,7 +259,7 @@ Per-option counts: `safety` 3 yes / 0 no (kept), `policy` 2 yes / 1 no (kept), `
 - Annotator B: `["billing"]`
 - Annotator C: `["safety"]`
 
-Each option has 1 yes / 2 no — none meets the threshold, so the aggregated set would be empty. The value falls back to a plurality vote: all three options are tied at 1 vote, so alphabetical tie-break picks `["billing"]`.
+Each option has 1 yes / 2 no: none meet the threshold, so the aggregated set would be empty. The value falls back to a plurality vote: all three options are tied at 1 vote, so alphabetical tie-break picks `["billing"]`.
 
 **Example: text.** Two annotators leave notes:
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -219,20 +219,23 @@ Transfer annotated traces to datasets for experiment evaluation:
    - **From annotation label**: use the values the annotators applied. Pick one or more labels. The record's `expected_output` is built from your selection.
 6. Choose an existing dataset, or create a dataset.
 
-When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": "neutral" }`. The same shape applies whether you select one label or multiple labels.
+When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": "neutral", "topics": ["safety", "policy"] }`. The same shape applies whether you select one label or multiple labels. Multi-select categorical labels are exported as arrays.
 
 {{% collapse-content title="How annotation values are aggregated across annotators" level="h4" expanded=false id="annotation-aggregation" %}}
 
 When multiple annotators have annotated the same trace, the value for each label is aggregated across them by consensus:
 
-| Label type  | Aggregation                              |
-| ----------- | ---------------------------------------- |
-| Boolean     | Majority vote                            |
-| Categorical | Plurality vote (most-picked option wins) |
-| Score       | Average                                  |
-| Text        | List of responses                        |
+| Label type                 | Aggregation                                                                                  |
+| -------------------------- | -------------------------------------------------------------------------------------------- |
+| Boolean                    | Majority vote                                                                                |
+| Categorical (single-select)| Plurality vote (most-picked option wins)                                                     |
+| Categorical (multi-select) | Per-option majority (keep options where at least half the annotators selected it)            |
+| Score                      | Average                                                                                      |
+| Text                       | List of responses                                                                            |
 
-For categorical labels (both single-select and multi-select), the option picked by the most annotators wins. With multi-select, each option an annotator selects counts as one vote. Ties break alphabetically. For Boolean labels, ties break in favor of `true`.
+For Boolean labels, ties break in favor of `true`. For categorical single-select, ties break alphabetically.
+
+For categorical multi-select, each option is treated as an independent yes/no vote: keep the option if the number of annotators who selected it is greater than or equal to the number who did not. The aggregated value is the array of options that meet this threshold (and may be empty if no option does — in which case the value falls back to a plurality vote and a single option is picked, with alphabetical tie-break).
 
 **Example: categorical (single-select).** Three annotators rate `tone`:
 
@@ -248,7 +251,15 @@ Aggregated: `"polite"` (2 of 3 votes).
 - Annotator B: `["safety", "billing"]`
 - Annotator C: `["safety", "policy"]`
 
-Each option an annotator selects counts as one vote: `safety` gets 3, `policy` gets 2, `billing` gets 1. Aggregated: `"safety"` (most votes).
+Per-option counts: `safety` 3 yes / 0 no (kept), `policy` 2 yes / 1 no (kept), `billing` 1 yes / 2 no (dropped). Aggregated: `["safety", "policy"]`.
+
+**Example: categorical (multi-select), fallback.** Three annotators tag `topics` with no option appearing in more than one annotator's set:
+
+- Annotator A: `["policy"]`
+- Annotator B: `["billing"]`
+- Annotator C: `["safety"]`
+
+Each option has 1 yes / 2 no — none meets the threshold, so the aggregated set would be empty. The value falls back to a plurality vote: all three options are tied at 1 vote, so alphabetical tie-break picks `["billing"]`.
 
 **Example: text.** Two annotators leave notes:
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -216,10 +216,10 @@ Transfer annotated traces to datasets for experiment evaluation:
 4. Click **Add to Dataset**.
 5. Set the dataset's **expected output**:
    - **From interaction**: use each trace's actual output. For experiment traces, you can also pick **Expected output** to use the original expected output from the experiment's source dataset.
-   - **From annotation label**: use the values annotators applied. Pick one or more labels; the record's `expected_output` is built from your selection.
+   - **From annotation label**: use the values the annotators applied. Pick one or more labels. The record's `expected_output` is built from your selection.
 6. Choose an existing dataset, or create a dataset.
 
-When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": "neutral" }`. The same shape applies whether you select one label or many.
+When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": "neutral" }`. The same shape applies whether you select one label or multiple labels.
 
 {{% collapse-content title="How annotation values are aggregated across annotators" level="h4" expanded=false id="annotation-aggregation" %}}
 
@@ -232,7 +232,7 @@ When multiple annotators have annotated the same trace, the value for each label
 | Score       | Average                                  |
 | Text        | List of responses                        |
 
-For categorical labels (both single-select and multi-select), the option picked by the most annotators wins. With multi-select, each option an annotator selects counts as one vote. Ties break alphabetically. For boolean labels, ties break in favor of `true`.
+For categorical labels (both single-select and multi-select), the option picked by the most annotators wins. With multi-select, each option an annotator selects counts as one vote. Ties break alphabetically. For Boolean labels, ties break in favor of `true`.
 
 **Example: categorical (single-select).** Three annotators rate `tone`:
 

--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -219,31 +219,36 @@ Transfer annotated traces to datasets for experiment evaluation:
    - **From annotation label**: use the values the annotators applied. Pick one or more labels. The record's `expected_output` is built from your selection.
 6. Choose an existing dataset, or create a dataset.
 
-When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": "neutral", "topics": ["safety", "policy"] }`. The same shape applies whether you select one label or multiple labels. Multi-select categorical labels are exported as arrays.
+When **expected output** is built from annotation labels, the exported value is a JSON object keyed by label name, for example `{ "is_harmful": false, "tone": ["neutral"], "topics": ["safety", "policy"] }`. The same shape applies whether you select one label or multiple labels. Categorical labels are always exported as arrays of selected options, whether the label is single-select or multi-select.
 
 {{% collapse-content title="How annotation values are aggregated across annotators" level="h4" expanded=false id="annotation-aggregation" %}}
 
 When multiple annotators have annotated the same trace, the value for each label is aggregated across them by consensus:
 
-| Label type                 | Aggregation                                                                                  |
-| -------------------------- | -------------------------------------------------------------------------------------------- |
-| Boolean                    | Majority vote                                                                                |
-| Categorical (single-select)| Plurality vote (most-picked option wins)                                                     |
-| Categorical (multi-select) | Per-option majority (keep options where at least half the annotators selected it)            |
-| Score                      | Average                                                                                      |
-| Text                       | List of responses                                                                            |
+| Label type   | Aggregation                                                                |
+| ------------ | -------------------------------------------------------------------------- |
+| Boolean      | Majority vote (ties break in favor of `true`)                              |
+| Categorical  | Intersection: the sorted set of options that every annotator selected      |
+| Score        | Average                                                                    |
+| Text         | List of responses                                                          |
 
-For Boolean labels, ties break in favor of `true`. For categorical single-select, ties break alphabetically.
+For categorical labels (single-select or multi-select), the aggregated value is the sorted array of options that *every* annotator selected. If any annotator's selection differs, the value is an empty array. The result is always an array, even when only one annotator has annotated the trace.
 
-For categorical multi-select, each option is treated as an independent yes/no vote. Keep the option if the number of annotators who selected it is greater than or equal to the number who did not. The aggregated value is the array of options that meet this threshold. If no option meets the threshold, the value falls back to a plurality vote, and a single option is picked with alphabetical tie-break.
+**Example: categorical (consensus).** Three annotators rate `tone` and all agree:
 
-**Example: categorical (single-select).** Three annotators rate `tone`:
+- Annotator A: `polite`
+- Annotator B: `polite`
+- Annotator C: `polite`
+
+Aggregated: `["polite"]`.
+
+**Example: categorical (disagreement).** Three annotators rate `tone` and one differs:
 
 - Annotator A: `polite`
 - Annotator B: `rude`
 - Annotator C: `polite`
 
-Aggregated: `"polite"` (2 of 3 votes).
+Aggregated: `[]`. The intersection is empty because `rude` is not in every annotator's set.
 
 **Example: categorical (multi-select).** Three annotators tag `topics` (each can pick multiple options):
 
@@ -251,15 +256,7 @@ Aggregated: `"polite"` (2 of 3 votes).
 - Annotator B: `["safety", "billing"]`
 - Annotator C: `["safety", "policy"]`
 
-Per-option counts: `safety` 3 yes / 0 no (kept), `policy` 2 yes / 1 no (kept), `billing` 1 yes / 2 no (dropped). Aggregated: `["safety", "policy"]`.
-
-**Example: categorical (multi-select), fallback.** Three annotators tag `topics` with no option appearing in more than one annotator's set:
-
-- Annotator A: `["policy"]`
-- Annotator B: `["billing"]`
-- Annotator C: `["safety"]`
-
-Each option has 1 yes / 2 no: none meet the threshold, so the aggregated set would be empty. The value falls back to a plurality vote: all three options are tied at 1 vote, so alphabetical tie-break picks `["billing"]`.
+Aggregated: `["safety"]`. Only `safety` appears in every annotator's set; `policy` is missing from B's selection and `billing` is missing from A's and C's.
 
 **Example: text.** Two annotators leave notes:
 


### PR DESCRIPTION
### What does this PR do?

Documents the expected-output picker behavior in the **Adding to datasets** flow on the [Annotation queues page](https://docs.datadoghq.com/llm_observability/evaluations/annotation_queues/?tab=manuallyfromtraceexplorer#adding-to-datasets):

- New step in the workflow to set the dataset's **expected output** (from interaction or from annotation label), placed before dataset selection to match the UI flow.
- New collapsible "How annotation values are aggregated" subsection covering:
  - The exported value's JSON object shape (`{ "<label_name>": <value>, ... }`), consistent whether one or many labels are selected.
  - Per-type consensus aggregation across multiple annotators: boolean → majority vote, categorical → intersection, score → average, text → list of responses.
  - Categorical (single-select or multi-select) returns the sorted array of options that every annotator selected; empty array when any annotator disagrees. Always an array, even for single-select labels and single-annotator traces.
  - Boolean tie-break: `true` wins.
  - Concrete examples for categorical consensus, disagreement, multi-select intersection, and text aggregation.
  - Raw per-annotator values preserved in metadata, so users can recompute with a different strategy.

### Motivation

Tracks [MLOB-7392](https://datadoghq.atlassian.net/browse/MLOB-7392). The annotation export v2 (FF `llm-annotation-dataset-export-v2`) ships per-type aggregation and a multi-label JSON shape, but the public docs page hadn't been updated. Users hit the modal without context for what their dataset record will actually contain.

Backend aggregation rules verified against [dd-source#430490](https://github.com/DataDog/dd-source/pull/430490), which switched categorical aggregation from plurality voting to set intersection.

### Follow-up (separate ticket / PR)

- The in-product `MessageBox` copy in `AnnotationExpectedOutputPanel.tsx:255–258` says **"Categorical: majority vote (a list when multi-select)"**, but the actual BE behavior is intersection — the value is the sorted array of options every annotator selected (empty when annotators disagree), and it's always an array regardless of single-select vs multi-select. The UI copy should be updated to match.

### Merge instructions

Merge readiness:

- [x] Ready for merge

### Additional notes

- Companion FE PR (still draft): https://github.com/DataDog/web-ui/pull/302319 (single-label preview shape). The docs change is independent — the BE already emits the documented shape.
- Drafted with help from Claude Code.

[MLOB-7392]: https://datadoghq.atlassian.net/browse/MLOB-7392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
