### PR TITLE
[MLOB-7396] docs(llm): promote forward-only automation caveat to a callout

### DIFF
--- a/content/en/llm_observability/evaluations/annotation_queues.md
+++ b/content/en/llm_observability/evaluations/annotation_queues.md
@@ -65,16 +65,18 @@ Add traces to a queue manually from the Trace Explorer:
 {{% tab "Using Automation Rules" %}}
 Instead of manually selecting traces, use Automation Rules to route traces into annotation queues automatically based on filters and sampling criteria. This enables continuous, hands-off queue population without requiring manual trace selection.
 
+<div class="alert alert-info">Automations apply going forward: new traces matching your rule are routed to the queue as they arrive. Existing traces matching the filter are not added retroactively.</div>
+
 To add an annotation queue action to an Automation Rule:
 1. Navigate to  [**AI Observability > Traces**][1]
 2. Apply filters to identify traces you want to route (evaluation failures, latency thresholds, specific applications). See the example queries in [Search Syntax](https://docs.datadoghq.com/logs/explorer/search_syntax/).
 3. Click **Automate Query**
-4. Configure sampling rate (for example, 10% of matching traces).
+4. Configure sampling rate (up to 5% for annotation queues; for example, 2% of matching traces).
 5. Under **Actions**, select **Add to Annotation Queue**.
 6. Choose the target queue.
 7. Save the rule.
 
-Traces matching the rule's filters are added to the queue automatically as they arrive.
+Traces matching the rule's filters are added to the queue as they arrive. Annotation queues hold up to 1,000 records; the automation pauses when the queue reaches that limit.
 
 [1]: https://app.datadoghq.com/llm/traces
 {{% /tab %}}

--- a/content/en/llm_observability/experiments/datasets.md
+++ b/content/en/llm_observability/experiments/datasets.md
@@ -94,7 +94,9 @@ Add production traces to datasets manually through the UI or automatically with 
 
 **Automatic routing (Automations)**:
 
-Automations enable you to continuously route production traces to datasets based on configurable rules, keeping your datasets current with production behavior without manual intervention. Automation rules apply only to new traces generated after the rule is created, not to existing historical traces. 
+<div class="alert alert-info">Automations apply going forward: new traces matching your rule are routed to the dataset as they arrive. Existing traces matching the filter are not added retroactively.</div>
+
+Automations enable you to continuously route production traces to datasets based on configurable rules, keeping your datasets current with production behavior without manual intervention.
 
 To set up automatic dataset updates:
 1. Navigate to [**AI Observability > Traces**][2].


### PR DESCRIPTION
Tracks: [MLOB-7396](https://datadoghq.atlassian.net/browse/MLOB-7396)

### What does this PR do?

The dataset page already mentioned that automations apply only to new traces (not historical), but the line was buried at the end of a 60-word run-on sentence under **Adding to datasets > Automatic routing (Automations)**. Easy to skim past — and users routinely do, then file support tickets when matching past traces don't show up in the dataset.

Promote that caveat into its own `alert-info` callout placed at the top of the section, so the forward-only semantics are the first thing readers see.

### Before / After

**Before** (line 97):
> Automations enable you to continuously route production traces to datasets based on configurable rules, keeping your datasets current with production behavior without manual intervention. Automation rules apply only to new traces generated after the rule is created, not to existing historical traces.

**After**:
> **Automatic routing (Automations)**:
>
> *(alert-info callout)* Automations apply going forward: new traces matching your rule are routed to the dataset as they arrive. Existing traces matching the filter are not added retroactively.
>
> Automations enable you to continuously route production traces to datasets based on configurable rules, keeping your datasets current with production behavior without manual intervention.

### Motivation

User-reported confusion: a customer setting up an automation expected past matches to get backfilled into the dataset, then thought the rule was broken when nothing showed up. The doc had the answer, but it wasn't where their eyes landed.

Wording aligns with the in-product copy that's shipping in [web-ui#302078](https://github.com/DataDog/web-ui/pull/302078) — "Automations apply going forward" — so doc and product reinforce each other.

### Review checklist

- [ ] `alert-info` callout renders correctly on the staging preview.
- [ ] No other references to "applies to historical traces" anywhere on the page that contradict the callout.

### Additional notes

Companion in-product copy PR: https://github.com/DataDog/web-ui/pull/302078 (also draft).

[MLOB-7396]: https://datadoghq.atlassian.net/browse/MLOB-7396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ