### PR TITLE
Documentation update - API support table

### DIFF
--- a/content/en/opentelemetry/compatibility.md
+++ b/content/en/opentelemetry/compatibility.md
@@ -57,10 +57,10 @@ Datadog SDKs provide support for the OpenTelemetry Traces, Metrics, and Logs API
 | [.NET][31] | {{< X >}} | {{< X >}} | {{< X >}} |
 | [Python][32] | {{< X >}} | {{< X >}} | {{< X >}} |
 | [Node.js][33] | {{< X >}} | {{< X >}} | {{< X >}} |
-| [Java][34] | {{< X >}} | *Not Yet Supported* | *Not Yet Supported* |
-| [Go][35] | {{< X >}} | *Not Yet Supported* | *Not Yet Supported* |
+| [Java][34] | {{< X >}} | {{< X >}} | *Not Yet Supported* |
+| [Go][35] | {{< X >}} | {{< X >}} | {{< X >}} |
 | [Ruby][36] | {{< X >}} | Alpha | *Not Yet Supported* |
-| [PHP][37] | {{< X >}} | *Not Yet Supported* | *Not Yet Supported* |
+| [PHP][37] | {{< X >}} | {{< X >}} | *Not Yet Supported* |
 
 ## More details
 


### PR DESCRIPTION
Updating docs to ensure consistency between these two:

1- https://docs.datadoghq.com/opentelemetry/instrument/dd_sdks/api_support/?platform=metrics&prog_lang=php

2- https://docs.datadoghq.com/opentelemetry/compatibility/#api-support