### PR TITLE
Update GPU Fleet metrics inventory table to match UI

### DIFF
--- a/content/en/gpu_monitoring/fleet.md
+++ b/content/en/gpu_monitoring/fleet.md
@@ -115,27 +115,20 @@ You can click on the gear icon to customize which metrics are displayed within t
 {{% collapse-content title="See the full list of available metrics" level="h4" expanded=false id="metric-full-list" %}}
 | Metric                | Definition                                                              | Metric Name                                    |
 | ----------------------| ------------------------------------------------------------------------| ---------------------------------------------  |
-| CPU Utilization       | The percent of time the CPU spent running user space processes. Shown as percent. | `system.cpu.user`
 | Device Type           | Type of GPU device. | `gpu_device`
-| Total Devices         | Count of all devices sending data during this time frame. | `gpu.device.total`
+| Graphics Engine Activity| Percentage of time that the graphics engine was active. | `gpu.gr_engine_active`
+| SM Activity           | Percentage of time the streaming multiprocessor was active. | `gpu.sm_active`
+| Core Utilization      | (Only available if System Probe enabled) `Cores Used/Cores Limit` for GPU processes. Measure of Temporal Core Utilization. | `gpu_core_utilization`
+| Idle Cost             | (Only nonzero for time frames longer than 2 days) The cost of GPU resources that are reserved and allocated, but not used.
 | Allocated Devices     | (only available if using Kubernetes) Count of devices that have been allocated to a workload. | `gpu.device.total`
 | Active Devices        | Count of devices that are actively used for a workload / busy. If using Kubernetes: count of allocated devices that are actively used for a workload. | `gpu.gr_engine_active`
 | Effective Devices     | Count of devices that are used and working for more than 50% of their lifespan. | `gpu.sm_active`
-| Graphics Engine Activity| Percentage of time that the graphics engine was active. | `gpu.gr_engine_active`
-| SM Activity           | Percentage of time the streaming multiprocessor was active. | `gpu.sm_active`
+| CPU Utilization       | The percent of time the CPU spent running user space processes. Shown as percent. | `system.cpu.user`
+| Power                 | Power usage for the GPU device.<br>**Note**: On GA100 and previous architectures, this represents the instantaneous power at that moment.<br>For newer architectures, it represents the average power draw (Watts) over one second. | `gpu.power.usage`
+| Temperature           | Temperature of a GPU device. | `gpu.temperature`
 | SM Clock              | SM clock frequency in MHz. | `gpu.clock_speed.sm`
 | PCIe RX Throughput    | Bytes received through PCI from the GPU device per second. | `gpu.pci.throughput.rx`
 | PCIe TX Throughput    | Bytes transmitted through PCI to the GPU device per second. | `gpu.pci.throughput.tx`
-| Power                 | Power usage for the GPU device.<br>**Note**: On GA100 and previous architectures, this represents the instantaneous power at that moment.<br>For newer architectures, it represents the average power draw (Watts) over one second. | `gpu.power.usage`
-| Temperature           | Temperature of a GPU device. | `gpu.temperature`
-| Cores Used            | (Only emitted if processes are active) Average number of GPU cores that a process was using in the interval.  | `gpu.core.usage`
-| Cores Limit           | Number of GPU cores that the process, container, or device has available. | `gpu.core.limit`
-| Memory Used           | (Only emitted if processes are active) The memory used by this process at the point the metric was submitted. | `gpu.memory.usage`
-| Memory Limit          | The maximum amount of memory a process, container, or device could allocate. | `gpu.memory.limit`
-| Metric Tons CO2       | Metric tons of carbon dioxide equivalent (MTCO2e) is a unit of measurement that compares the emissions of greenhouse gases based on their global warming potential (GWP). It's calculated by multiplying the amount of a gas by its GWP. For example, if methane has a GWP of 21, then 1 million metric tons of methane is equivalent to 21 million metric tons of carbon dioxide. | Formula based on `gpu.power.usage`
-| Core Utilization      | (Only available if System Probe enabled) `Cores Used/Cores Limit` for GPU processes. Measure of Temporal Core Utilization. | `gpu_core_utilization`  
-| Memory Utilization    | GPU Memory used / GPU Memory limit for GPU processes. | `gpu_memory_utilization`
-| Idle Cost             | (Only nonzero for time frames longer than 2 days) The cost of GPU resources that are reserved and allocated, but not used.
 {{% /collapse-content %}} 
 
 ## Details side panel 

--- a/content/en/gpu_monitoring/fleet.md
+++ b/content/en/gpu_monitoring/fleet.md
@@ -82,16 +82,12 @@ After toggling Cluster, Host, or Device, the **Summary Graph** displays key reso
 {{% collapse-content title="See the full list of GPU metrics" level="h4" expanded=false id="gpu-metrics-table" %}}
 | Metric                | Definition                                                              | Metric Name                                    |
 | ----------------------| ------------------------------------------------------------------------| --------------------------------------------- |
-| Core Utilization      | (Only available with System Probe enabled for advanced eBPF metrics) `Cores Used/Cores Limit` for GPU processes. Measure of Temporal Core Utilization.| `gpu_core_utilization`  
-| Memory Utilization    | GPU Memory used / GPU Memory limit for GPU processes. | `gpu_memory_utilization`
-| PCIe Throughput       | Bytes received and bytes transmitted through PCI from the GPU device per second. | `gpu.pci.throughput.rx`,`gpu.pci.throughput.tx` 
+| Core Utilization      | (Only available with System Probe enabled for advanced eBPF metrics) `Cores Used/Cores Limit` for GPU processes. Measure of Temporal Core Utilization.| `gpu_core_utilization`
+| PCIe Throughput       | Bytes received and bytes transmitted through PCI from the GPU device per second. | `gpu.pci.throughput.rx`,`gpu.pci.throughput.tx`
 | Graphics Activity     | Percentage of time that the graphics engine was active. | `gpu.gr_engine_active`
 | SM Activity           | Percentage of time the streaming multiprocessor was active. | `gpu.sm_active`
 | Power                 | Power usage for the GPU device.<br>**Note**: On GA100 and previous architectures, this represents the instantaneous power at that moment.<br>For newer architectures, it represents the average power draw (Watts) over one second. | `gpu.power.usage`
 | Temperature           | Temperature of a GPU device. | `gpu.temperature`
-| Cores Used            | (Only emitted if processes are active) Average number of GPU cores that a process was using in the interval.  | `gpu.core.usage`
-| Memory Used           | (Only emitted if processes are active) The memory used by this process at the point the metric was queried. | `gpu.memory.usage`
-| Device Total          | Count of all devices sending data during this time frame. | `gpu.device.total`
 {{% /collapse-content %}} 
 
 If you've selected an additional tag to group by---for example, _team_---every unique timeseries in the Summary Graph corresponds to a team's value for the selected metric.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Updates the "Inventory of your GPU-powered infrastructure" metrics table on the GPU Monitoring Fleet page to reflect the current product UI.

- Reordered the rows to match the order shown in the column-customization menu
- Removed metrics no longer surfaced in the UI: Total Devices, Cores Used, Cores Limit, Memory Used, Memory Limit, Metric Tons CO2, Memory Utilization

No new metrics were added in this PR — follow-up work can document the new ones (Total/ECC/XID Errors, GPU Saturation, GPU Memory, GPU Idle, Unallocated Devices, Host Uptime/IO/Memory, GPU Util, NVLink RX/TX/Active Links) along with section headers (Hardware Health, Utilization, Provisioning, Performance).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### AI assistance

Used Claude Code to fetch the file via the GitHub API, reorder the table, and open this PR. Edits reviewed by me.