### PR TITLE
Add Docker Monitoring tab to Agentic Onboarding setup page

### DIFF
--- a/content/en/agentic_onboarding/setup.md
+++ b/content/en/agentic_onboarding/setup.md
@@ -131,6 +131,10 @@ To get started:
    {{% tab "Serverless Monitoring" %}}
    {{< code-block lang="text" >}}Instrument my AWS Lambda functions with Datadog{{< /code-block >}}
    {{% /tab %}}
+
+   {{% tab "Docker Monitoring" %}}
+   {{< code-block lang="text" >}}Add Datadog for Docker to my project{{< /code-block >}}
+   {{% /tab %}}
    {{< /tabs >}}
 
 2. Review and accept each action your AI agent proposes to complete the setup process.


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds a "Docker Monitoring" tab to the "Set up your project" section of the Agentic Onboarding setup page, with the prompt copy "Add Datadog for Docker to my project".

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes