### PR TITLE
[OE-587] Expand Infrastructure Monitoring tab to include Kubernetes and Docker prompts

### DIFF
--- a/content/en/agentic_onboarding/setup.md
+++ b/content/en/agentic_onboarding/setup.md
@@ -125,7 +125,11 @@ To get started:
    {{% /tab %}}
 
    {{% tab "Infrastructure Monitoring" %}}
+   **Kubernetes**
    {{< code-block lang="text" >}}Add Datadog for Kubernetes to my project{{< /code-block >}}
+
+   **Docker**
+   {{< code-block lang="text" >}}Add Datadog for Docker to my project{{< /code-block >}}
    {{% /tab %}}
 
    {{% tab "Serverless Monitoring" %}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Restructures the "Infrastructure Monitoring" tab in the Agentic Onboarding setup page to include two sub-sections — **Kubernetes** and **Docker** — each with their respective setup prompt, rather than having a separate tab per platform.

### Motivation
https://datadoghq.atlassian.net/browse/OE-587