### PR TITLE
[DOCS-14069] Link Tag Enrichment preview callout to form

### DIFF
--- a/content/en/tracing/services/tag_enrichment.md
+++ b/content/en/tracing/services/tag_enrichment.md
@@ -10,7 +10,7 @@ further_reading:
   text: "Software Catalog"
 ---
 
-{{< callout btn_hidden="true" >}}
+{{< callout url="https://www.datadoghq.com/product-preview/tag-enrichment/" btn_hidden="false" header="Join the Preview!" >}}
 Tag enrichment is in Preview.
 {{< /callout >}}
 

--- a/content/en/tracing/services/tag_enrichment.md
+++ b/content/en/tracing/services/tag_enrichment.md
@@ -10,8 +10,8 @@ further_reading:
   text: "Software Catalog"
 ---
 
-{{< callout url="https://www.datadoghq.com/product-preview/tag-enrichment/" btn_hidden="false" header="Join the Preview!" >}}
-Tag enrichment is in Preview.
+{{< callout url="https://www.datadoghq.com/product-preview/tag-enrichment/" >}}
+Tag enrichment is in Preview. To request access, fill out this form.
 {{< /callout >}}
 
 ## Overview


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14069

The preview signup form for Tag Enrichment is now live. This PR updates the preview callout on the Tag Enrichment page to show the "Request Access" button and link it to https://www.datadoghq.com/product-preview/tag-enrichment/, matching the pattern used on the sibling Service remapping rules page.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes