### PR TITLE
include `mdoc` files in urlmap output

### DIFF
--- a/layouts/_default/list.urlmap.json
+++ b/layouts/_default/list.urlmap.json
@@ -5,6 +5,14 @@
     {{- if eq $page.Language.Lang "en" -}}
         {{- with $page.File -}}
             {{- $filepath := print "content/en/" .Path -}}
+            {{/* Prefer the .mdoc.md sibling when it exists. Hugo ignores
+                 .mdoc.md files via config, so $page.File.Path always points
+                 at the compiled .md companion. Phrase should pick up the
+                 Markdoc source for translation, not the compiled output. */}}
+            {{- $mdocPath := replaceRE "\\.md$" ".mdoc.md" $filepath -}}
+            {{- if and (ne $mdocPath $filepath) (os.FileExists $mdocPath) -}}
+                {{- $filepath = $mdocPath -}}
+            {{- end -}}
             {{- $urlmap = merge $urlmap (dict $page.RelPermalink $filepath) -}}
         {{- end -}}
     {{- end -}}


### PR DESCRIPTION
### What does this PR do? What is the motivation?
hugo outputs a `urlmap` that maps a url directly with it's filepath.   `mdoc` file types dont fit this definition because they are not recognized by hugo.  therefore the map needs to use the accompanying `mdoc` file path if it exists, otherwise it will try to localized the compiled version which wont work well

### Merge instructions


Merge readiness:
- [ ] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes
https://datadog-docs-preview.s3.us-east-1.amazonaws.com/brian.deutsch/url-map-with-mdoc/urlmap.json - search for `mdoc.md`
