### PR TITLE
[OTAGENT-1025] Update Datadog Extension Setup and Configuration options

### DIFF
--- a/content/en/opentelemetry/integrations/datadog_extension.md
+++ b/content/en/opentelemetry/integrations/datadog_extension.md
@@ -78,19 +78,38 @@ service:
       exporters: [datadog/exporter]
 ```
 
+### 4. (Optional) Add custom resource attributes
+
+The Datadog Extension automatically collects resource attributes from the Collector's internal telemetry and includes them in the metadata payload it sends to Datadog. To attach custom attributes such as deployment environment, team, or Kubernetes cluster name, set them under `service.telemetry.resource`:
+
+```yaml
+service:
+  telemetry:
+    resource:
+      deployment.environment.name: production
+      team.name: platform
+      k8s.cluster.name: prod-us-east1-cluster-a
+```
+
+The Collector automatically attaches `service.name`, `service.version`, and `service.instance.id` (a randomly generated UUID) to its internal telemetry. You don't need to set these manually.
+
 ## Configuration options
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `api.key` | Datadog API key (required) | - |
-| `api.site` | Datadog site (for example, `us5.datadoghq.com`) | `datadoghq.com` |
-| `hostname` | Custom hostname for the Collector | Auto-detected |
-| `http.endpoint` | Local HTTP server endpoint | `localhost:9875` |
-| `http.path` | HTTP server path for metadata | `/metadata` |
+| `api.key` | Datadog API key (required). | - |
+| `api.site` | Datadog site (for example, `us5.datadoghq.com`). | `datadoghq.com` |
+| `api.fail_on_invalid_key` | Exit at startup if the API key is invalid. | `true` |
+| `hostname` | Custom hostname for the Collector. | Auto-detected |
+| `http.endpoint` | Local HTTP server endpoint. | `localhost:9875` |
+| `http.path` | HTTP server path for metadata. | `/metadata` |
 | `deployment_type` | Deployment type for the Collector. One of: `gateway`, `daemonset`, or `unknown`. | `unknown` |
-| `proxy_url` | HTTP proxy URL for outbound requests | - |
-| `timeout` | Timeout for HTTP requests | `30s` |
-| `tls.insecure_skip_verify` | Skip TLS certificate verification | `false` |
+| `installation_method` | How the Collector was installed. One of: `kubernetes`, `bare-metal`, `docker`, `ecs-fargate`, `eks-fargate`, or unset. Available in Collector v0.148.0 and later. | unset |
+| `gateway_service` | Set on **gateway** Collectors only. The Kubernetes Service fronting the gateway Collector pods. Format: `service` or `namespace/service`. Available in Collector v0.150.0 and later. | - |
+| `gateway_destination` | Set on **agent or DaemonSet** Collectors only. The Kubernetes Service that this Collector forwards telemetry to. Must match `gateway_service` on the receiving gateway Collector. Format: `service` or `namespace/service`. Available in Collector v0.150.0 and later. | - |
+| `proxy_url` | HTTP proxy URL for outbound requests. | - |
+| `timeout` | Timeout for HTTP requests. | `30s` |
+| `tls.insecure_skip_verify` | Skip TLS certificate verification. | `false` |
 
 <div class="alert alert-danger">
 <strong>Hostname Matching</strong>: If you specify a custom <code>hostname</code> in the Datadog Extension, it <strong>must</strong> match the <code>hostname</code> value in the Datadog Exporter configuration. The Datadog Extension does not have access to pipeline telemetry and cannot infer hostnames from incoming spans. It only obtains hostnames from system/cloud provider APIs or manual configuration. If telemetry has different <a href="/opentelemetry/config/hostname_tagging/?tab=host">hostname attributes</a> than the hostname reported by the extension, the telemetry will not be correlated to the correct host, and you may see duplicate hosts in Datadog.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes OTAGENT-1025

Sync the Datadog Extension docs with the upstream `extension/datadogextension` code in `opentelemetry-collector-contrib`:

- **Configuration options table**: add `api.fail_on_invalid_key`, `installation_method` (Collector v0.148.0+), `gateway_service` (v0.150.0+), and `gateway_destination` (v0.150.0+).
- **Setup**: add a new optional step covering custom resource attributes via `service.telemetry.resource`, mirroring the upstream README. Note the `service.name`, `service.version`, and `service.instance.id` attributes that the Collector attaches automatically.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes