### PR TITLE
[DOCS-14243] Add US1-FED unsupported banner to Product Analytics pages

### DIFF
--- a/config/_default/params.yaml
+++ b/config/_default/params.yaml
@@ -351,6 +351,7 @@ unsupported_sites:
   oracle_fusion_integration_setup: [gov,gov2]
   overview_pages: [gov,gov2]
   pr_gates: [gov,gov2]
+  product_analytics: [gov,gov2]
   resource_based_sampling: [gov,gov2]
   remote_config: [gov,gov2]
   remote_config_for_fa: [gov,gov2] #For the Guides page


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14243

Adds a US1-FED unsupported site banner to all Product Analytics doc pages. Product Analytics is not supported on GovCloud. This adds `product_analytics: [gov,gov2]` to the `unsupported_sites` config so the banner displays automatically on all pages under `/product_analytics/`.

US1-FED
<img width="1061" height="411" alt="image" src="https://github.com/user-attachments/assets/1cf369e2-bd5e-4397-9c34-6687a6bcc8e2" />

US2-FED
<img width="1048" height="398" alt="image" src="https://github.com/user-attachments/assets/aa9ae6f8-797b-4112-99c6-e48fdebed9b6" />

Staging
https://docs-staging.datadoghq.com/ida.adjivon/DOCS-14243-add-us-fed-banner-product-analytics/product_analytics/?site=gov2

### Merge instructions

Merge readiness:
- [X] Ready for merge
