### PR TITLE
Update logpoint expiry time in JetBrains IDE plugin docs

### DIFF
--- a/content/en/ide_plugins/idea/live_debugger.md
+++ b/content/en/ide_plugins/idea/live_debugger.md
@@ -13,7 +13,7 @@ further_reading:
 ---
 
 ## Overview
-The Live Debugger enables you to add logpoints—auto-expiring, non-breaking breakpoints—to your runtime code to collect information for debugging. The logpoints are set dynamically in running systems, so there is no need to redeploy your code to investigate and resolve issues. Logpoints are grouped into sessions and you can activate, edit, deactivate, or delete sessions (or individual logpoints) at any time. All sessions and logpoints automatically deactivate after 48 hours.
+The Live Debugger enables you to add logpoints—auto-expiring, non-breaking breakpoints—to your runtime code to collect information for debugging. The logpoints are set dynamically in running systems, so there is no need to redeploy your code to investigate and resolve issues. Logpoints are grouped into sessions and you can activate, edit, deactivate, or delete sessions (or individual logpoints) at any time. All sessions and logpoints automatically deactivate after 60 minutes.
 
 ## Live Debugger tab
 The **Live Debugger** tab in the Datadog tool window shows the current session, its logpoints, and the data captured by the selected logpoint:
@@ -69,7 +69,7 @@ When a condition is defined, log events are generated only when the condition ev
 
 The *Capture variables depth* controls how deeply hierarchical data structures are traversed when capturing runtime values. Higher values provide more useful information but require more capacity.
 
-Logpoints expire automatically after 48 hours. Logpoint events are rate-limited to 1 execution per second.
+Logpoints expire automatically after 60 minutes. Logpoint events are rate-limited to 1 execution per second.
 
 #### Local and remote versions
 Notice that the remote code may be a different version compared to the source code in the IDE. The **New Logpoint** dialog displays the version of the code that is deployed remotely, if it can be detected, so that you can see exactly where the logpoint is being placed. This requires that your application or service is [tagged with Git information][4].
@@ -83,7 +83,7 @@ To modify the log message for a logpoint, right-click the logpoint and select **
 
 You can update the log message, the logpoint condition, and the capture depth. Changing the service or environment requires deleting the logpoint and creating a new one.
 
-Applying changes to the logpoint also extends the expiration time to 48 hours.
+Applying changes to the logpoint also extends the expiration time to 60 minutes.
 
 ### Delete a logpoint
 You can delete logpoints by right-clicking the icon in the gutter of the source editor, or the entry in the tool window, and selecting **Delete** from the context menu.
@@ -102,7 +102,7 @@ You can enable or disable logpoints by right-clicking and selecting the appropri
 | {{< img src="/ide_plugins/idea/live_debugger/probeError.svg.png" alt="Error icon" width="24px" >}}        | **Error**: The logpoint is not generating log events due to an error. |
 | {{< img src="/ide_plugins/idea/live_debugger/probeWarning.svg.png" alt="Warning icon" width="24px" >}}    | **Warning**: The logpoint may not be generating log events. |
 
-Disabling then re-enabling a logpoint extends its expiry time to 48 hours.
+Disabling then re-enabling a logpoint extends its expiry time to 60 minutes.
 
 ## Prerequisites
 The Live Debugger feature in the IDE supports Java and Python and is subject to the same setup requirements as [Live Debugger][1].


### PR DESCRIPTION
### What does this PR do? What is the motivation?
The docs state that the logpoint expiry is after 48 hours but this was changed to 60 minutes by the Live Debugger product.

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

<!-- If you used AI tools (Claude Code, GitHub Copilot, Cursor, etc.) while working on this PR, briefly note how. This helps reviewers understand the contribution. Examples: "Used Claude Code for initial draft", "Copilot autocomplete for code examples", "AI-assisted research, manually written". Leave blank if not applicable. -->

### Additional notes
<!-- Anything else we should know when reviewing?-->

<!-- Previewing the PR: Assuming you are a Datadog employee and named your branch `<yourname>/<description>`, a preview build will run and links to the preview output will be auto-generated and posted in the PR comments. The links will 404 until the preview build is finished running. -->
