### PR TITLE
Fix Java feature flags doc: API key belongs on Agent, not application

### DIFF
--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -10,7 +10,7 @@ further_reading:
   text: "Java APM and Distributed Tracing"
 ---
 
-<div class="alert alert-info">The Java Feature Flags provider is enabled by setting <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code>. The <code>EXPERIMENTAL_</code> prefix in the variable name is preserved for backwards compatibility — the provider itself is no longer experimental. See the <a href="#configuration">Configuration section</a> for details.</div>
+<div class="alert alert-info">Java Feature Flags support is enabled by setting <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code>. (Note: the provider itself is no longer experimental. The <code>EXPERIMENTAL_</code> prefix in the variable name is there for backwards compatibility reasons.) See the <a href="#configuration">Configuration section</a> for details.</div>
 
 ## Overview
 

--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -10,7 +10,7 @@ further_reading:
   text: "Java APM and Distributed Tracing"
 ---
 
-<div class="alert alert-warning">Java Feature Flags support is experimental and requires enabling an experimental flag in the SDK. See the <a href="#configuration">Configuration section</a> for details.</div>
+<div class="alert alert-info">The Java Feature Flags provider is enabled by setting <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code>. The <code>EXPERIMENTAL_</code> prefix in the variable name is preserved for backwards compatibility — the provider itself is no longer experimental. See the <a href="#configuration">Configuration section</a> for details.</div>
 
 ## Overview
 
@@ -110,7 +110,7 @@ api_key: <YOUR_API_KEY>
 
 ### Application configuration
 
-If your application already runs with `-javaagent:dd-java-agent.jar` and has Remote Configuration enabled (`DD_REMOTE_CONFIG_ENABLED=true`), you only need to add the experimental feature flag (`DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`). Skip the SDK download and JVM configuration steps.
+If your application already runs with `-javaagent:dd-java-agent.jar` and has Remote Configuration enabled (`DD_REMOTE_CONFIG_ENABLED=true`), you only need to add the feature flagging variable (`DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`). Skip the SDK download and JVM configuration steps.
 
 Configure your Java application with the required environment variables or system properties:
 
@@ -120,7 +120,8 @@ Configure your Java application with the required environment variables or syste
 # Required: Enable Remote Configuration in the SDK
 export DD_REMOTE_CONFIG_ENABLED=true
 
-# Required: Enable experimental feature flagging support
+# Required: Enable the feature flagging provider
+# (The EXPERIMENTAL_ prefix is historical — the provider is no longer experimental.)
 export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
 # Required: Service name
@@ -150,9 +151,9 @@ java -javaagent:path/to/dd-java-agent.jar \
 {{% /tab %}}
 {{< /tabs >}}
 
-The Datadog feature flagging system starts automatically when the tracer is initialized with both Remote Configuration and the experimental flagging provider enabled. No additional initialization code is required in your application.
+The Datadog feature flagging system starts automatically when the tracer is initialized with both Remote Configuration and the feature flagging provider enabled. No additional initialization code is required in your application.
 
-<div class="alert alert-danger">Feature flagging requires both <code>DD_REMOTE_CONFIG_ENABLED=true</code> and <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code>. Without the experimental flag, the feature flagging system does not start and the <code>Provider</code> returns the programmatic default.</div>
+<div class="alert alert-danger">Feature flagging requires both <code>DD_REMOTE_CONFIG_ENABLED=true</code> and <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code>. Without these settings, the feature flagging system does not start and the <code>Provider</code> returns the programmatic default.</div>
 
 ### Add the Java tracer to the JVM
 
@@ -547,7 +548,7 @@ Before investigating specific errors, confirm these prerequisites are in place:
 
 1. **The Datadog Agent is healthy and reachable**: See [APM Connection Errors][2] to verify Agent connectivity.
 2. **Required Agent environment variables are set**: `DD_API_KEY`.
-3. **The experimental flagging provider is enabled on the tracer**: Set `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`.
+3. **The flagging provider is enabled on the tracer**: Set `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`.
 4. **Required tracer environment variables are set**: `DD_ENV` and `DD_SITE`.
 5. **Your `DD_ENV` value appears in the Feature Flag environments list**: Confirm your environment is visible in the [Feature Flag Environments][5] settings.
 

--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -10,7 +10,7 @@ further_reading:
   text: "Java APM and Distributed Tracing"
 ---
 
-<div class="alert alert-info">Java Feature Flags support is enabled by setting <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code>. (Note: the provider itself is no longer experimental. The <code>EXPERIMENTAL_</code> prefix in the variable name is there for backwards compatibility reasons.) See the <a href="#configuration">Configuration section</a> for details.</div>
+<div class="alert alert-info">Enable Java Feature Flags by setting <code>DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true</code>. The <code>EXPERIMENTAL_</code> prefix is kept for backwards compatibility; the provider is stable. See the <a href="#configuration">Configuration section</a> for details.</div>
 
 ## Overview
 
@@ -121,7 +121,7 @@ Configure your Java application with the required environment variables or syste
 export DD_REMOTE_CONFIG_ENABLED=true
 
 # Required: Enable the feature flagging provider
-# (The EXPERIMENTAL_ prefix is historical — the provider is no longer experimental.)
+# The EXPERIMENTAL_ prefix is historical; the provider is no longer experimental.
 export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
 # Required: Service name
@@ -547,7 +547,7 @@ In Spring Boot tests, register the `InMemoryProvider` through a `@TestConfigurat
 Before investigating specific errors, confirm these prerequisites are in place:
 
 1. **The Datadog Agent is healthy and reachable**: See [APM Connection Errors][2] to verify Agent connectivity.
-2. **Required Agent environment variables are set**: `DD_API_KEY`.
+2. **The Agent has a valid API key configured**: Confirm `DD_API_KEY` is set on the Agent.
 3. **The flagging provider is enabled on the tracer**: Set `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`.
 4. **Required tracer environment variables are set**: `DD_ENV` and `DD_SITE`.
 5. **Your `DD_ENV` value appears in the Feature Flag environments list**: Confirm your environment is visible in the [Feature Flag Environments][5] settings.

--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -546,9 +546,10 @@ In Spring Boot tests, register the `InMemoryProvider` through a `@TestConfigurat
 Before investigating specific errors, confirm these prerequisites are in place:
 
 1. **The Datadog Agent is healthy and reachable**: See [APM Connection Errors][2] to verify Agent connectivity.
-2. **The experimental flagging provider is enabled on the tracer**: Set `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`.
-3. **Required application environment variables are set**: `DD_SERVICE` and `DD_ENV`. (`DD_API_KEY` and `DD_SITE` belong on the Agent, not the application.)
-4. **Your `DD_ENV` value appears in the Feature Flag environments list**: Confirm your environment is visible in the [Feature Flag Environments][5] settings.
+2. **Required Agent environment variables are set**: `DD_API_KEY`.
+3. **The experimental flagging provider is enabled on the tracer**: Set `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`.
+4. **Required tracer environment variables are set**: `DD_ENV` and `DD_SITE`.
+5. **Your `DD_ENV` value appears in the Feature Flag environments list**: Confirm your environment is visible in the [Feature Flag Environments][5] settings.
 
 After confirming all prerequisites, continue with the following sections if feature flags still aren't working.
 

--- a/content/en/feature_flags/server/java.md
+++ b/content/en/feature_flags/server/java.md
@@ -27,7 +27,7 @@ The Datadog Feature Flags SDK for Java requires:
 - **Datadog Java SDK**: Version **1.57.0** or later
 - **OpenFeature SDK**: Version **1.18.2** or later
 - **Datadog Agent**: Version **7.x or later** with [Remote Configuration][1] enabled
-- **Datadog [API Key][6]**: Required for Remote Configuration
+- **Datadog [API key][6]**: Configured on the Agent (not the application) for Remote Configuration
 
 For a full list of Datadog's Java version and framework support, read [Compatibility Requirements](/tracing/trace_collection/compatibility/java/).
 
@@ -123,9 +123,6 @@ export DD_REMOTE_CONFIG_ENABLED=true
 # Required: Enable experimental feature flagging support
 export DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true
 
-# Required: Your Datadog API key
-export DD_API_KEY=<YOUR_API_KEY>
-
 # Required: Service name
 export DD_SERVICE=<YOUR_SERVICE_NAME>
 
@@ -145,7 +142,6 @@ java -javaagent:path/to/dd-java-agent.jar -jar your-application.jar
 java -javaagent:path/to/dd-java-agent.jar \
   -Ddd.remote.config.enabled=true \
   -Ddd.experimental.flagging.provider.enabled=true \
-  -Ddd.api.key=<YOUR_API_KEY> \
   -Ddd.service=<YOUR_SERVICE_NAME> \
   -Ddd.env=<YOUR_ENVIRONMENT> \
   -Ddd.version=<YOUR_APP_VERSION> \
@@ -551,7 +547,7 @@ Before investigating specific errors, confirm these prerequisites are in place:
 
 1. **The Datadog Agent is healthy and reachable**: See [APM Connection Errors][2] to verify Agent connectivity.
 2. **The experimental flagging provider is enabled on the tracer**: Set `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED=true`.
-3. **Required tracer environment variables are set**: `DD_API_KEY`, `DD_ENV`, and `DD_SITE`.
+3. **Required application environment variables are set**: `DD_SERVICE` and `DD_ENV`. (`DD_API_KEY` and `DD_SITE` belong on the Agent, not the application.)
 4. **Your `DD_ENV` value appears in the Feature Flag environments list**: Confirm your environment is visible in the [Feature Flag Environments][5] settings.
 
 After confirming all prerequisites, continue with the following sections if feature flags still aren't working.


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Two fixes to `content/en/feature_flags/server/java.md`:

**1. `DD_API_KEY` does not belong on the application.**

The page lists `DD_API_KEY` as a required application-level environment variable. It is not — the Java SDK reaches Datadog only through the local Agent for feature flagging:
- Flag config flows over the standard Agent-mediated Remote Configuration poller.
- Exposures route through the Agent's EVP proxy. `EVENT_PLATFORM` in [`Intake.java`](https://github.com/DataDog/dd-trace-java/blob/master/internal-api/src/main/java/datadog/trace/api/intake/Intake.java) is constructed with agentless mode hardcoded to `false`, so the API-key code path in `BackendApiFactory` is unreachable.
- Evaluation metrics export to the Agent's OTLP receiver at `http://localhost:4318` by default ([dd-openfeature README](https://github.com/DataDog/dd-trace-java/blob/master/products/feature-flagging/feature-flagging-api/README.md)).

Removed `DD_API_KEY` / `-Ddd.api.key` from the application env vars and system properties tabs, clarified the compatibility requirement that the API key goes on the Agent, and added an Agent-side prerequisite to the troubleshooting checklist (so the key still appears, in the right place).

**2. The provider is no longer experimental — only the env var name is.**

The page reads as if Java Feature Flags is still an experimental feature. It isn't; the `EXPERIMENTAL_` prefix on `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED` is kept for backwards compatibility. Updated the top-of-page banner from a yellow warning to an info note that explains the prefix is historical, and dropped "experimental" from descriptive prose throughout (env-var comments, the auto-start sentence, the red alert, and the troubleshooting prereq). The actual variable and system property names are unchanged.

Translated content (`content/es/...`) is not edited per the contributing guidelines; it will re-sync from the English source.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes