### PR TITLE
Fix incorrect permission name on Governance Console page

### DIFF
--- a/content/en/account_management/governance_console/_index.md
+++ b/content/en/account_management/governance_console/_index.md
@@ -27,7 +27,7 @@ Governance Console provides centralized configuration and governance for multi-t
 
 The `governance_console_read` permission controls access to the Governance Console. Users with `governance_console_read` assigned to their role can view the Governance Console UI and associated reporting and insights.
 
-Product-specific permissions restrict users' ability to change product-specific settings. For example, modifying or automating metrics configuration requires the `metrics_write` permission.
+Product-specific permissions restrict users' ability to change product-specific settings. For example, modifying or automating metrics configuration requires the `metrics_metadata_write` permission.
 
 ## Using Governance Console
 


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes an incorrect permission name on the Governance Console page. Changes `metrics_write` to `metrics_metadata_write` — the `metrics_write` permission does not exist in the Datadog permissions model.

Verified via:
- The [Permissions API](https://docs.datadoghq.com/api/v2/roles/#list-permissions) (`GET /api/v2/permissions`)
- The Datadog app (Organization Settings > Roles)
- The [RBAC Permissions docs page](https://docs.datadoghq.com/account_management/rbac/permissions/)

Flagged by a customer in #documentation.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes