### PR TITLE
Add SBOM export documentation to SCA and Library Inventory pages

### DIFF
--- a/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/_index.md
@@ -117,9 +117,9 @@ Use the Library Inventory to understand which dependencies you rely on, where th
 
 To learn more about how the inventory is generated, how Static and Runtime data differ, and how to interpret the library details (usage, vulnerabilities, licenses, versions, and OpenSSF score), see [Library Inventory][14].
 
-### Export a Software Bill of Materials (SBOM)
+### Export a Software Bill of Materials
 
-Export a Software Bill of Materials (SBOM) of your third-party libraries directly from the [Library Inventory][8]. The exported SBOM includes libraries detected both statically (via Static SCA) and at runtime (via Runtime SCA), giving you a single, comprehensive view of your software supply chain.
+Export a SBOM of your third-party libraries directly from the [Library Inventory][8]. The exported SBOM includes libraries detected both statically (with Static SCA) and at runtime (with Runtime SCA), giving you a single, comprehensive view of your software supply chain.
 
 Datadog supports the following SBOM formats:
 

--- a/content/en/security/code_security/software_composition_analysis/_index.md
+++ b/content/en/security/code_security/software_composition_analysis/_index.md
@@ -39,6 +39,7 @@ Using Software Composition Analysis provides organizations with the following be
 - Identification of emerging and known vulnerabilities affecting open source libraries
 - Risk-based prioritization and remediation based on runtime detection of vulnerabilities
 - Identification of malicious packages, end-of-life libraries, and library riskiness based on OpenSSF standards
+- Export a Software Bill of Materials (SBOM) of detected libraries in CycloneDX 1.6 or SPDX 2.3 format
 
 ## How it works
 
@@ -115,6 +116,19 @@ The [Library Inventory][8] provides visibility into the third-party libraries de
 Use the Library Inventory to understand which dependencies you rely on, where they are used, and whether they contain known vulnerabilities or license risks.
 
 To learn more about how the inventory is generated, how Static and Runtime data differ, and how to interpret the library details (usage, vulnerabilities, licenses, versions, and OpenSSF score), see [Library Inventory][14].
+
+### Export a Software Bill of Materials (SBOM)
+
+Export a Software Bill of Materials (SBOM) of your third-party libraries directly from the [Library Inventory][8]. The exported SBOM includes libraries detected both statically (via Static SCA) and at runtime (via Runtime SCA), giving you a single, comprehensive view of your software supply chain.
+
+Datadog supports the following SBOM formats:
+
+- **CycloneDX 1.6**
+- **SPDX 2.3**
+
+Use the exported SBOM to share dependency data with downstream consumers, satisfy compliance and regulatory requirements, or feed into other supply chain tooling.
+
+For details on how to generate and download an SBOM, see [Library Inventory][29].
 
 ### Create tickets from findings
 
@@ -210,3 +224,4 @@ You can exclude paths from Static SCA analysis by configuring `ignore-paths` in 
 [26]: https://github.com/DataDog/guarddog
 [27]: /security/code_security/software_composition_analysis/configuration/
 [28]: /security/code_security/guides/configuration/
+[29]: /security/code_security/software_composition_analysis/library_inventory/#export-a-software-bill-of-materials-sbom

--- a/content/en/security/code_security/software_composition_analysis/library_inventory.md
+++ b/content/en/security/code_security/software_composition_analysis/library_inventory.md
@@ -151,9 +151,9 @@ The score ranges from **0 to 10**, where 10 indicates best practices.
 {{< img src="/security/code_security/openSSF_Score_1.png" alt="OpenSSF Scorecard results for the upstream project" style="width:100%;" >}}
 
 
-## Export a Software Bill of Materials (SBOM)
+## Export a Software Bill of Materials
 
-From the [Library Inventory][1], you can export a Software Bill of Materials (SBOM) of all libraries detected across your environment, both statically (via Static SCA) and at runtime (via Runtime SCA). This gives you a single, authoritative inventory of the open source components your organization depends on, regardless of where they were observed.
+From the [Library Inventory][1], you can export a Software Bill of Materials (SBOM) of all libraries detected across your environment, both statically (with Static SCA) and at runtime (with Runtime SCA). This gives you a single, authoritative inventory of the open source components your organization depends on, regardless of where they were observed.
 
 Datadog supports the following SBOM formats:
 

--- a/content/en/security/code_security/software_composition_analysis/library_inventory.md
+++ b/content/en/security/code_security/software_composition_analysis/library_inventory.md
@@ -151,13 +151,32 @@ The score ranges from **0 to 10**, where 10 indicates best practices.
 {{< img src="/security/code_security/openSSF_Score_1.png" alt="OpenSSF Scorecard results for the upstream project" style="width:100%;" >}}
 
 
+## Export a Software Bill of Materials (SBOM)
+
+From the [Library Inventory][1], you can export a Software Bill of Materials (SBOM) of all libraries detected across your environment, both statically (via Static SCA) and at runtime (via Runtime SCA). This gives you a single, authoritative inventory of the open source components your organization depends on, regardless of where they were observed.
+
+Datadog supports the following SBOM formats:
+
+- **CycloneDX 1.6**
+- **SPDX 2.3**
+
+To export an SBOM:
+
+1. Navigate to [**Code Security > Inventory > Libraries**][1].
+1. (Optional) Apply filters to scope the export to a subset of libraries (for example, by repository, service, or environment).
+1. Click **Export SBOM** and choose **CycloneDX 1.6** or **SPDX 2.3**.
+1. Download the generated file.
+
+<div class="alert alert-info">The exported SBOM reflects the libraries currently visible in the inventory, including any active filters. Adjust your filters before exporting to scope the SBOM to the libraries you want to include.</div>
+
 ## Next steps
 
 To get started with Library Inventory:
 
-1. Enable **Static SCA** to detect libraries in your repositories. See [static setup][2] to get started.  
-2. Enable **Runtime SCA** to identify libraries actually used during execution. See [runtime setup][3] to get started.  
+1. Enable **Static SCA** to detect libraries in your repositories. See [static setup][2] to get started.
+2. Enable **Runtime SCA** to identify libraries actually used during execution. See [runtime setup][3] to get started.
 3. Use both views together to understand both your full dependency footprint and your real runtime exposure.
+4. (Optional) [Export an SBOM](#export-a-software-bill-of-materials-sbom) of your libraries in CycloneDX 1.6 or SPDX 2.3 format.
 
 [1]: https://app.datadoghq.com/security/code-security/inventory/libraries
 [2]: /security/code_security/software_composition_analysis/setup_static/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Adds documentation for the SBOM export feature across two SCA pages.

**Changes:**
- `software_composition_analysis/_index.md`: Added SBOM export bullet to the overview benefits list and a new "Export a Software Bill of Materials (SBOM)" section under Key capabilities
- `software_composition_analysis/library_inventory.md`: Added a new "Export a Software Bill of Materials (SBOM)" H2 section with step-by-step export instructions, and updated Next steps to include SBOM export as an optional step

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

