### PR TITLE
[DOCS-14301] Note Azure Gov and Azure China are not supported for automated log forwarding

### DIFF
--- a/content/en/logs/guide/azure-automated-log-forwarding.md
+++ b/content/en/logs/guide/azure-automated-log-forwarding.md
@@ -17,7 +17,7 @@ The ARM template deploys resources from a series of Azure services (storage acco
 
 **All sites**: Automated log forwarding is available to use on all [Datadog sites][4].
 
-**Supported Azure environments**: Automated log forwarding supports the Azure commercial (public) cloud only. Azure Government and Azure China are not supported.
+**Supported Azure environments**: Automated log forwarding supports the Azure commercial (public) cloud only. Azure Government and Azure China are not supported. Customers on Datadog government sites can use this feature only with workloads in Azure commercial cloud.
 
 ## How to choose between automated and manual setup
 

--- a/content/en/logs/guide/azure-automated-log-forwarding.md
+++ b/content/en/logs/guide/azure-automated-log-forwarding.md
@@ -17,7 +17,7 @@ The ARM template deploys resources from a series of Azure services (storage acco
 
 **All sites**: Automated log forwarding is available to use on all [Datadog sites][4].
 
-**Supported Azure environments**: Automated log forwarding supports the Azure commercial (public) cloud only. Azure Government and Azure China are not supported. Customers on Datadog government sites can use this feature only with workloads in Azure commercial cloud.
+**Supported Azure environments**: Automated log forwarding supports the Azure commercial (public) cloud only. Azure Government and Azure China are not supported.
 
 ## How to choose between automated and manual setup
 

--- a/content/en/logs/guide/azure-automated-log-forwarding.md
+++ b/content/en/logs/guide/azure-automated-log-forwarding.md
@@ -17,6 +17,8 @@ The ARM template deploys resources from a series of Azure services (storage acco
 
 **All sites**: Automated log forwarding is available to use on all [Datadog sites][4].
 
+**Supported Azure environments**: Automated log forwarding supports the Azure commercial (public) cloud only. Azure Government and Azure China are not supported.
+
 ## How to choose between automated and manual setup
 
 Choose the manual setup method if you want to:
@@ -45,12 +47,7 @@ Use the **Configure Log Forwarding** flow to set up new or manage existing log f
 
 ### ARM template
 
-Alternatively, you can deploy automated log forwarding with an Azure Resource Manager (ARM) template. Open the ARM template corresponding to your Azure environment:
-
-  - [Azure Public][1]
-  - [Azure China][7]
-
-The sections below provide instructions for completing each page of the template.
+Alternatively, you can deploy automated log forwarding with an [Azure Public ARM template][1]. The sections below provide instructions for completing each page of the template.
 
 #### Basics
 
@@ -205,7 +202,6 @@ The script first discovers any instances running in each subscription, then prom
 [2]: https://app.datadoghq.com/organization-settings/api-keys
 [4]: /getting_started/site/
 [5]: https://learn.microsoft.com/en-us/azure/cloud-shell/overview
-[7]: https://portal.azure.cn/#create/Microsoft.Template/uri/CustomDeploymentBlade/uri/https%3A%2F%2Fraw.githubusercontent.com%2FDataDog%2Fintegrations-management%2Fmain%2Fazure%2Flogging_install%2Fdist%2Fazuredeploy.json/createUIDefinitionUri/https%3A%2F%2Fraw.githubusercontent.com%2FDataDog%2Fintegrations-management%2Fmain%2Fazure%2Flogging_install%2Fdist%2FcreateUiDefinition.json
 [8]: https://azure.microsoft.com/products/container-apps
 [9]: https://learn.microsoft.com/azure/storage/common/storage-account-overview
 [10]: https://learn.microsoft.com/azure/azure-monitor/roles-permissions-security#monitoring-contributor


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes DOCS-14301

Clarifies that Datadog's Automated Azure Log Forwarding supports the Azure commercial (public) cloud only, and removes the Azure China ARM template deployment link. Per the feature team, deployments do not work in Azure Government or Azure China today.

Changes to `content/en/logs/guide/azure-automated-log-forwarding.md`:

- Add a "Supported Azure environments" callout to the Overview stating that Azure Government and Azure China are not supported.
- Replace the bulleted ARM-template list (which offered an Azure China deployment) with a single Azure Public ARM template link.
- Remove the now-orphaned reference link to the Azure China deployment URL.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes