### PR TITLE
[OMG-1350] Add Startup plan to SCIM availability in Okta and Entra docs

### DIFF
--- a/content/en/account_management/scim/entra.md
+++ b/content/en/account_management/scim/entra.md
@@ -8,7 +8,7 @@ algolia:
 ---
 
 <div class="alert alert-info">
-SCIM is available with the Infrastructure Pro and Infrastructure Enterprise plans.
+SCIM is available with the Infrastructure Pro, Infrastructure Enterprise, and Startup plans.
 </div>
 
 <div class="alert alert-danger">
@@ -25,7 +25,7 @@ For capabilities and limitations of this feature, see [SCIM][1].
 
 ## Prerequisites
 
-SCIM in Datadog is an advanced feature available with the Infrastructure Pro and Infrastructure Enterprise plans.
+SCIM in Datadog is an advanced feature available with the Infrastructure Pro, Infrastructure Enterprise, and Startup plans.
 
 This documentation assumes your organization manages user identities using an identity provider.
 

--- a/content/en/account_management/scim/okta.md
+++ b/content/en/account_management/scim/okta.md
@@ -13,7 +13,7 @@ further_reading:
 ---
 
 <div class="alert alert-info">
-SCIM is available with the Infrastructure Pro and Infrastructure Enterprise plans.
+SCIM is available with the Infrastructure Pro, Infrastructure Enterprise, and Startup plans.
 </div>
 
 See the following instructions to synchronize your Datadog users with Okta using SCIM.
@@ -22,7 +22,7 @@ For the capabilities and limitations of this feature, see [SCIM][1].
 
 ## Prerequisites
 
-SCIM in Datadog is an advanced feature available with the Infrastructure Pro and Infrastructure Enterprise plans
+SCIM in Datadog is an advanced feature available with the Infrastructure Pro, Infrastructure Enterprise, and Startup plans
 
 This documentation assumes your organization manages user identities using an identity provider.
 


### PR DESCRIPTION
## What does this PR do? What is the motivation?

Fixes OMG-1350

Follow-up to #36419 — updates the remaining SCIM docs pages (Okta and Entra) to include the Startup plan in the availability notice. The previous PR only updated `_index.md`.

**Files changed:**
- `content/en/account_management/scim/entra.md` — 2 occurrences (banner + prerequisites)
- `content/en/account_management/scim/okta.md` — 2 occurrences (banner + prerequisites)

## Merge instructions

Merge readiness:
- [ ] Ready for merge

## Additional notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)