### PR TITLE
Limit OTEL integration data collected table columns - [WEB-8985]

### DIFF
--- a/layouts/shortcodes/mapping-table.html
+++ b/layouts/shortcodes/mapping-table.html
@@ -11,6 +11,8 @@
 
 {{ $resource_path := print "_data/semantic-core/" (.Get "resource")}}
 {{ $resource := resources.Get $resource_path}}
+
+{{/* Only render otel metric name and description */}}
 {{ $allowed_cols := slice "otel" "description" }}
 
 {{ if $resource }}
@@ -28,15 +30,31 @@
             </tr>
         </thead>
         <tbody>
+        {{/* Get column indices of "otel" and "description" — both form the composite dedupe key */}}
+        {{ $otel_idx := 0 }}
+        {{ $desc_idx := 0 }}
+        {{ range $i, $h := $headers }}
+            {{ if eq $h "otel" }}{{ $otel_idx = $i }}{{ end }}
+            {{ if eq $h "description" }}{{ $desc_idx = $i }}{{ end }}
+        {{ end }}
+
+        {{ $unique_vals := newScratch }}
         {{ range $index, $row := $rows }}
             {{ if $index }}
-                <tr>
-                {{ range $i, $cell := $row }}
-                    {{ if in $allowed_cols (index $headers $i) }}
-                        <td>{{ $cell | markdownify }}</td>
+                {{/* Build a composite key from otel+description vals so rows with the same metric name
+                     but different descriptions are treated as distinct */}}
+                {{ $dedupe_key := print (index $row $otel_idx) "|" (index $row $desc_idx) }}
+                {{/* Deduplicate: skips the row if $unique_vals already recorded this $dedupe_key */}}
+                {{ if not ($unique_vals.Get $dedupe_key) }}
+                    {{ $unique_vals.Set $dedupe_key true }}
+                    <tr>
+                    {{ range $i, $cell := $row }}
+                        {{ if in $allowed_cols (index $headers $i) }}
+                            <td>{{ $cell | markdownify }}</td>
+                        {{ end }}
                     {{ end }}
+                    </tr>
                 {{ end }}
-                </tr>
             {{ end }}
         {{ end }}
         </tbody>

--- a/layouts/shortcodes/mapping-table.html
+++ b/layouts/shortcodes/mapping-table.html
@@ -12,8 +12,8 @@
 {{ $resource_path := print "_data/semantic-core/" (.Get "resource")}}
 {{ $resource := resources.Get $resource_path}}
 
-{{/* Only render otel metric name and description */}}
-{{ $allowed_cols := slice "otel" "description" }}
+{{/* Only render these columns from the csv */}}
+{{ $allowed_cols := slice "otel" "description" "filter"}}
 
 {{ if $resource }}
 {{ $rows := unmarshal $resource }}
@@ -30,21 +30,21 @@
             </tr>
         </thead>
         <tbody>
-        {{/* Get column indices of "otel" and "description" — both form the composite dedupe key */}}
+        {{/* Get column indices of "otel" and "filter" to form the composite dedupe key */}}
         {{ $otel_idx := 0 }}
-        {{ $desc_idx := 0 }}
+        {{ $filter_idx := 0 }}
         {{ range $i, $h := $headers }}
             {{ if eq $h "otel" }}{{ $otel_idx = $i }}{{ end }}
-            {{ if eq $h "description" }}{{ $desc_idx = $i }}{{ end }}
+            {{ if eq $h "filter" }}{{ $filter_idx = $i }}{{ end }}
         {{ end }}
 
         {{ $unique_vals := newScratch }}
         {{ range $index, $row := $rows }}
             {{ if $index }}
-                {{/* Build a composite key from otel+description vals so rows with the same metric name
-                     but different descriptions are treated as distinct */}}
-                {{ $dedupe_key := print (index $row $otel_idx) "|" (index $row $desc_idx) }}
-                {{/* Deduplicate: skips the row if $unique_vals already recorded this $dedupe_key */}}
+                {{/* Build a composite key from otel+filter vals so rows with the same metric name
+                     but different filter are treated as distinct */}}
+                {{ $dedupe_key := print (index $row $otel_idx) "|" (index $row $filter_idx) }}
+                {{/* Deduplicate: skips the row if $unique_vals already recorded the $dedupe_key */}}
                 {{ if not ($unique_vals.Get $dedupe_key) }}
                     {{ $unique_vals.Set $dedupe_key true }}
                     <tr>

--- a/layouts/shortcodes/mapping-table.html
+++ b/layouts/shortcodes/mapping-table.html
@@ -1,8 +1,8 @@
-{{/*  
+{{/*
     Render a HTML table from a CSV file located in the assets/_data/semantic-core directory (Global resource).
-    CSV file should be a 2D array with the first array/row as the header. 
+    CSV file should be a 2D array with the first array/row as the header.
 
-    Note: 
+    Note:
     - csv files mounted from websites-sources: https://github.com/DataDog/websites-sources/tree/main/assets/_data/semantic-core
     - csv files cannot be mounted to the ./data directory (https://gohugo.io/content-management/data-sources/)
 
@@ -11,24 +11,30 @@
 
 {{ $resource_path := print "_data/semantic-core/" (.Get "resource")}}
 {{ $resource := resources.Get $resource_path}}
+{{ $allowed_cols := slice "otel" "description" }}
 
 {{ if $resource }}
+{{ $rows := unmarshal $resource }}
+{{ $headers := index $rows 0 }}
 <div class="table-wrapper">
     <table class="table-fixed">
         <thead>
             <tr>
-            {{ range (index (unmarshal $resource) 0) }}
-                {{ $header := cond (eq . "dd") "Datadog" .}}
-                <th>{{ $header | upper }}</th>
+            {{ range $headers }}
+                {{ if in $allowed_cols . }}
+                    <th>{{ . | upper }}</th>
+                {{ end }}
             {{ end }}
             </tr>
         </thead>
         <tbody>
-        {{ range $index, $row := (unmarshal $resource) }}
+        {{ range $index, $row := $rows }}
             {{ if $index }}
                 <tr>
-                {{ range $row }}
-                    <td>{{ . | markdownify }}</td>
+                {{ range $i, $cell := $row }}
+                    {{ if in $allowed_cols (index $headers $i) }}
+                        <td>{{ $cell | markdownify }}</td>
+                    {{ end }}
                 {{ end }}
                 </tr>
             {{ end }}


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Updates the `mapping-table` shortcode to only render the **OTel metric name**, **Description** and **Filter** columns
- table only contains unique rows

**motivation**: https://datadoghq.atlassian.net/browse/WEB-8985

### Merge instructions

**preview**: a few otel integration pages using the shortcode. Check **Data Collected** table has no duplicate rows and only the 3 mentioned fields:
- https://docs-staging.datadoghq.com/stefon.simmons/web-8985/opentelemetry/integrations/spark_metrics/
- https://docs-staging.datadoghq.com/stefon.simmons/web-8985/opentelemetry/integrations/apache_metrics/
- https://docs-staging.datadoghq.com/stefon.simmons/web-8985/opentelemetry/integrations/kubernetes_metrics/

FYI the full mapping still uses all fields: https://docs-staging.datadoghq.com/stefon.simmons/web-8985/opentelemetry/mapping/metrics_mapping/ 

Merge readiness:
- [x] Ready for merge

### AI assistance

Used Claude Code for research, implementation, and commit.

### Additional notes

The `mapping-table` shortcode is used exclusively by the 26 OTel integration pages. The consolidated Metrics Mapping page uses the `multifilter-search` shortcode with a separate JSON file, so it is unaffected by this change.