### PR TITLE
Update unsupported widget types list for shared dashboards

### DIFF
--- a/content/en/dashboards/sharing/shared_dashboards.md
+++ b/content/en/dashboards/sharing/shared_dashboards.md
@@ -159,6 +159,12 @@ The following widget types are not supported on shared dashboards. Widgets of th
 * Topology Map
 * List Widget (all data sources)
 * Legacy treemap widget
+* SLO Summary
+* Event Stream
+* Log Stream
+* Flame Graph
+* Uptime
+* Service Map
 
 ### Limited timeframe options
 


### PR DESCRIPTION
## What does this PR do?

Updates the unsupported widget types list in the shared dashboards docs to reflect the actual set of widget types that do not display data.

**Added:**
- SLO Summary
- Event Stream
- Log Stream
- Flame Graph
- Uptime
- Service Map

These are all present in the `MORPHEUS_UNSUPPORTED_WIDGETS` list in the shared dashboard query backend service and are absent from the MPDQ widget type allowlist, meaning they silently return empty data in all shared dashboard flavors (public, invite-only, embed).

The additions were identified by cross-referencing:
- `MORPHEUS_UNSUPPORTED_WIDGETS` in `domains/dashboardsnotebooks_backend/sharing/public_dashboard_lib/morpheus_query.py` (dd-source)
- The `type` enum in `services/public-dashboard-query/schemas/definitions.schema.ts` (web-ui)

A companion dd-source PR adds `slo_summary` to the backend unsupported list: https://github.com/DataDog/dd-source/pull/431047

## Motivation

Support ticket: customer reported SLO Summary widgets are empty in a shared dashboard. Investigation revealed the docs unsupported list was incomplete.