### PR TITLE
Document Custom alias URLs field on Snowflake integration

### DIFF
--- a/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
@@ -161,7 +161,21 @@ To configure the Snowflake integration in Datadog:
 
 3. Follow the flow to enter your account details and upload a private key.
 4. Turn on {{< ui >}}Enable Data Observability for Snowflake tables{{< /ui >}}.
-5. Click {{< ui >}}Save & Test{{< /ui >}}.
+5. (Optional) Under {{< ui >}}Custom alias URLs{{< /ui >}}, register any additional names used to reference this Snowflake account from other tools — for example, the account identifier configured in dbt, the connection string used by a BI tool, or an AWS PrivateLink URL. See [Custom alias URLs](#custom-alias-urls) below for when this is needed.
+6. Click {{< ui >}}Save & Test{{< /ui >}}.
+
+### Custom alias URLs
+
+This field is optional. Use it when the Snowflake account name Datadog connects to does not match how other tools reference the same account.
+
+Lineage events arriving from sources outside Datadog — OpenLineage emitters, dbt manifests, query history from other tools — identify the warehouse using whichever name was configured upstream. If those names differ from the canonical account URL Datadog uses, lineage from those sources is not stitched to this Snowflake integration.
+
+Registering each alternative name as a {{< ui >}}Custom alias URL{{< /ui >}} tells Datadog to treat them as references to the same Snowflake account, so cross-tool lineage resolves correctly. Common cases include:
+
+- The account is reached through an AWS PrivateLink URL.
+- A dbt project, BI tool, or other connector is configured with an account identifier that does not match the canonical URL.
+
+To add an alias, expand {{< ui >}}Configure Data Observability{{< /ui >}} during integration setup and click {{< ui >}}+ Add Alias{{< /ui >}} under {{< ui >}}Custom alias URLs{{< /ui >}}. Add one entry per alternative name. Aliases apply only to the Snowflake account being configured; each Snowflake integration manages its own alias list.
 
 ## Snowflake tasks and Snowpipes
 

--- a/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
@@ -168,9 +168,9 @@ To configure the Snowflake integration in Datadog:
 
 This field is optional. Use it when the Snowflake account name Datadog connects to does not match how other tools reference the same account.
 
-Lineage events arriving from sources outside Datadog (OpenLineage emitters, dbt manifests, query history from other tools) identify the warehouse using whichever name was configured upstream. If those names differ from the canonical account URL Datadog uses, lineage from those sources is not stitched to this Snowflake integration.
+Lineage events from outside Datadog include OpenLineage emitters, dbt manifests, and query history from other tools. These events identify the warehouse using whatever name the upstream tool was configured with. If those names differ from the canonical account URL Datadog uses, lineage from those sources is not stitched to this Snowflake integration.
 
-Registering each alternative name as a {{< ui >}}Custom alias URL{{< /ui >}} tells Datadog to treat them as references to the same Snowflake account, so cross-tool lineage resolves correctly. Common cases include:
+Registering each alternative name as a {{< ui >}}Custom alias URL{{< /ui >}} tells Datadog to treat them as references to the same Snowflake account. Cross-tool lineage then resolves correctly. Common cases include:
 
 - The account is reached through an AWS PrivateLink URL.
 - A dbt project, BI tool, or other connector is configured with an account identifier that does not match the canonical URL.

--- a/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
+++ b/content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md
@@ -161,14 +161,14 @@ To configure the Snowflake integration in Datadog:
 
 3. Follow the flow to enter your account details and upload a private key.
 4. Turn on {{< ui >}}Enable Data Observability for Snowflake tables{{< /ui >}}.
-5. (Optional) Under {{< ui >}}Custom alias URLs{{< /ui >}}, register any additional names used to reference this Snowflake account from other tools — for example, the account identifier configured in dbt, the connection string used by a BI tool, or an AWS PrivateLink URL. See [Custom alias URLs](#custom-alias-urls) below for when this is needed.
+5. (Optional) Under {{< ui >}}Custom alias URLs{{< /ui >}}, register any additional names other tools use to reference this Snowflake account. Examples include the account identifier configured in dbt, the connection string used by a BI tool, or an AWS PrivateLink URL. See [Custom alias URLs](#custom-alias-urls) below for when this is needed.
 6. Click {{< ui >}}Save & Test{{< /ui >}}.
 
 ### Custom alias URLs
 
 This field is optional. Use it when the Snowflake account name Datadog connects to does not match how other tools reference the same account.
 
-Lineage events arriving from sources outside Datadog — OpenLineage emitters, dbt manifests, query history from other tools — identify the warehouse using whichever name was configured upstream. If those names differ from the canonical account URL Datadog uses, lineage from those sources is not stitched to this Snowflake integration.
+Lineage events arriving from sources outside Datadog (OpenLineage emitters, dbt manifests, query history from other tools) identify the warehouse using whichever name was configured upstream. If those names differ from the canonical account URL Datadog uses, lineage from those sources is not stitched to this Snowflake integration.
 
 Registering each alternative name as a {{< ui >}}Custom alias URL{{< /ui >}} tells Datadog to treat them as references to the same Snowflake account, so cross-tool lineage resolves correctly. Common cases include:
 


### PR DESCRIPTION
## Summary
- Documents the **Custom alias URLs** field that now appears in step 3 (**Configure Data Observability**) of the Snowflake integration setup.
- Explains *when* the field is needed: when the Snowflake account name Datadog connects to does not match how other tools (dbt, BI tools, PrivateLink, etc.) reference the same account, so cross-tool lineage stitches correctly.
- Field is optional; copy makes that explicit.

## Test plan
- [ ] Render preview of `content/en/data_observability/quality_monitoring/data_warehouses/snowflake.md` and confirm:
  - [ ] New step 5 renders with the `(Optional)` prefix and links to the `#custom-alias-urls` anchor
  - [ ] New `### Custom alias URLs` subsection renders below the numbered list, before `## Snowflake tasks and Snowpipes`
  - [ ] Hugo `{{< ui >}}` shortcodes resolve correctly for `Custom alias URLs`, `+ Add Alias`, and `Configure Data Observability`
- [ ] Spot-check that the anchor link `[Custom alias URLs](#custom-alias-urls)` resolves to the new heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)