### PR TITLE
Rename "AI Agents Console" to "Agent Console" in nav

### DIFF
--- a/config/_default/menus/main.en.yaml
+++ b/config/_default/menus/main.en.yaml
@@ -5488,7 +5488,7 @@ menu:
       parent: gpu_monitoring
       identifier: gpu_monitoring_fleet
       weight: 3
-    - name: AI Agents Console
+    - name: Agent Console
       url: ai_agents_console/
       pre: llm-observability
       identifier: ai_agents_console


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Renames the side nav entry from "AI Agents Console" to "Agent Console" in `config/_default/menus/main.en.yaml`.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes