### PR TITLE
Format Browser RUM subparts SDK version notes as info callouts

### DIFF
--- a/content/en/real_user_monitoring/application_monitoring/browser/monitoring_page_performance.md
+++ b/content/en/real_user_monitoring/application_monitoring/browser/monitoring_page_performance.md
@@ -76,7 +76,7 @@ Largest Contentful Paint and Interaction to Next Paint break down into subparts,
 
 #### Largest Contentful Paint subparts
 
-**Note**: These attributes require Browser SDK v6.32.0 or later.
+<div class="alert alert-info">These attributes require Browser SDK v6.32.0 or later.</div>
 
 LCP breaks down into four phases. Time to First Byte is collected separately as `view.first_byte`. The remaining three subparts are collected under `view.performance.lcp.sub_parts`:
 
@@ -89,7 +89,7 @@ LCP breaks down into four phases. Time to First Byte is collected separately as 
 
 #### Interaction to Next Paint subparts
 
-**Note**: These attributes require Browser SDK v6.33.0 or later.
+<div class="alert alert-info">These attributes require Browser SDK v6.33.0 or later.</div>
 
 INP breaks down into three phases, collected under `view.performance.inp.sub_parts`:
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The two SDK version notes added in #36286 (under `#### Largest Contentful Paint subparts` and `#### Interaction to Next Paint subparts`) currently render as plain bold text. Switch them to `<div class="alert alert-info">` so they render as the styled info callout, matching the pattern used elsewhere in the RUM docs (e.g. `real_user_monitoring/rum_without_limits/retention_filters`).

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes