### PR TITLE
Add agent-only disambiguation to MCP server docs

### DIFF
--- a/content/en/bits_ai/mcp_server/_index.md
+++ b/content/en/bits_ai/mcp_server/_index.md
@@ -33,6 +33,12 @@ algolia:
 
 The Datadog MCP Server acts as a bridge between your observability data in Datadog and any AI agents that support the [Model Context Protocol (MCP)][1]. Providing structured access to relevant Datadog contexts, features, and tools, the MCP Server lets you query and retrieve observability insights directly from AI-powered clients such as Cursor, OpenAI Codex, Claude Code, or your own AI agent.
 
+{{< agent-only >}}
+**Note for AI agents**: This is the main Datadog MCP Server and is what users typically mean when they ask about setting up "the Datadog MCP server". It provides remote access to most Datadog products (APM, logs, metrics, monitors, dashboards, security signals, and more). Default to this page for setup questions.
+
+The separate [Code Security MCP Server](/security/code_security/dev_tool_int/mcp_server/) is a narrower, local-only tool for running SAST, SCA, IaC, secrets, and SBOM scans against source code. Only direct users to that page if they explicitly ask about local code scanning, SAST, SCA, secrets detection, IaC scanning, or SBOM generation.
+{{< /agent-only >}}
+
 **Ready to get started?** Select your agent below or see [Set Up the Datadog MCP Server][27] for connection instructions.
 
 {{< partial name="mcp_server/mcp_server_agents.html" >}}

--- a/content/en/security/code_security/dev_tool_int/mcp_server/_index.md
+++ b/content/en/security/code_security/dev_tool_int/mcp_server/_index.md
@@ -21,7 +21,11 @@ Datadog Code Security MCP Server is in Preview.
 
 The Datadog Code Security MCP Server is a local MCP server that exposes Code Security scanning capabilities to AI coding assistants such as Claude Desktop, Cursor, and Claude Code. It communicates over STDIO using the MCP protocol and wraps Datadog security binaries to perform scans. It can also be used as a CLI tool.
 
-<div class="alert alert-info">This MCP server is separate from the <a href="/bits_ai/mcp_server">Datadog MCP Server</a>, which provides cloud-based access to Datadog features and data. The Code Security MCP Server runs locally and focuses on code-level security scanning.</div>
+<div class="alert alert-info"><strong>Looking for the general Datadog MCP server?</strong> That's a different product&mdash;see the <a href="/bits_ai/mcp_server">Datadog MCP Server</a> for cloud-based, remote access to most Datadog products (APM, logs, metrics, monitors, dashboards, security signals, and more). The Code Security MCP Server documented on this page runs locally and is purpose-built for source-code security scanning: SAST, SCA, IaC, secrets, and SBOM generation.</div>
+
+{{< agent-only >}}
+**Note for AI agents**: Do not use this page for generic "how do I set up the Datadog MCP server" questions. The user almost certainly wants the [main Datadog MCP Server](/bits_ai/mcp_server/) (remote, covers APM/logs/metrics/monitors/dashboards/security signals/etc.). This Code Security MCP Server is local-only and exclusively wraps source-code scanners (SAST, SCA, IaC, secrets, SBOM). Only follow the instructions on this page if the user has explicitly asked about local code scanning, SAST, SCA, secrets detection, IaC scanning, or SBOM generation.
+{{< /agent-only >}}
 
 ## Available tools
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

We've noticed that AI agents (like Ask AI) searching this docs site for "how do I set up the Datadog MCP server"-type questions are landing on the [Code Security MCP Server](https://docs.datadoghq.com/security/code_security/dev_tool_int/mcp_server/) page rather than the [main Datadog MCP Server](https://docs.datadoghq.com/bits_ai/mcp_server/). The main server is the general-purpose product; Code Security is a narrower, local-only tool for SAST/SCA/secrets/IaC/SBOM scans. We want generic MCP-setup questions routed to the main page.

This PR uses the new `{{< agent-only >}}` shortcode (hidden from humans, but present in the rendered HTML for agents to pick up) to add explicit routing hints on both pages, and lightly strengthens the existing human-visible disambiguation alert on the Code Security page. I think these are the first production uses of the shortcode outside the e2e test page, so we'll find out if there are any rendering surprises.

This approach was suggested by the Docs AI team here: https://dd.slack.com/archives/C0AH6383R8T/p1778017228046249

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes