### PR TITLE
Fix broken markdown reference link on push notification page

### DIFF
--- a/content/en/mobile/push_notification.md
+++ b/content/en/mobile/push_notification.md
@@ -169,6 +169,6 @@ Create [workflow automations][3] that send mobile push notifications.
 {{< partial name="whats-next/whats-next.html" >}}
 
 [1]:https://app.datadoghq.com/incidents/settings?_gl=1*334tvl*_gcl_aw*R0NMLjE3NDUwMDYwODQuQ2p3S0NBand0ZGlfQmhBQ0Vpd0E5N3k4QkxnWmU4cTdmazJtUlJoQ3o1OTZXcTNmRWJIQTk1Rzg4dnAtUmZtUHBQUGx0OVNVSjRlSk9Sb0Nwek1RQXZEX0J3RQ..*_gcl_au*MTAxODMyNDk1My4xNzQwNDk1NzA3LjExNzUxOTU1MTUuMTc0NjQ5NTU3OS4xNzQ2NDk1NTc5*_ga*MjExMzI1MjUyOS4xNzQ1ODU2NjMx*_ga_KN80RDFSQK*czE3NDY0OTQzMzYkbzU4JGcxJHQxNzQ2NDk5MzA0JGowJGwwJGg5NTQ2NTk0Ng..*_fplc*Q2V5WVJmNnRSV2R0RmljTDZyWmg3ZEVZMFZPeDNlTFhLZkxnenFCOXBvTUslMkZTWWk0a3JzVEw1cDU5YlZzTW55TE5YazY5bjdhJTJGOXpySzJ0TFMxTEozZms0WTVlOWVibEN5ZFBNNm1XYmJJQll0R0d4YnlralJ2eU1CS1NoUSUzRCUzRA..#Rules
-[2] /incident_response/incident_management/setup_and_configuration/notification_rules/
+[2]: /incident_response/incident_management/setup_and_configuration/notification_rules/
 [3]:https://docs.datadoghq.com/getting_started/workflow_automation/
 [4]: /incident_response/on-call/guides/configure-mobile-device-for-on-call


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes a broken markdown reference-link definition at the bottom of the [Set Up Push Notifications on Mobile App](https://docs.datadoghq.com/mobile/push_notification/?tab=ios) page.

The definition for `[2]` was missing its colon separator (`[2] /url` instead of `[2]: /url`). Without the colon, Hugo's markdown parser does not recognize the line as a link-reference definition, and the surrounding contiguous block falls through to the rendered output as plain text. The result is a visible block of raw text at the end of the page:

> [2] /incident_response/incident_management/setup_and_configuration/notification_rules/ [3]:https://docs.datadoghq.com/getting_started/workflow_automation/ [4]: /incident_response/on-call/guides/configure-mobile-device-for-on-call

Adding the colon restores parsing for all three definitions and re-resolves the in-text references `[2]` (Incident notifications section), `[3]` (Workflow automation notifications section), and `[4]` (Circumvent mute and Do Not Disturb mode for On-Call section).

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes


🤖 Generated with [Claude Code](https://claude.com/claude-code)