### PR TITLE
Add data-streams toolset to Datadog MCP Server documentation

### DIFF
--- a/content/en/bits_ai/mcp_server/setup.md
+++ b/content/en/bits_ai/mcp_server/setup.md
@@ -545,6 +545,7 @@ These toolsets are generally available. See [Datadog MCP Server Tools][49] for a
 - `alerting`: Tools for validating and creating monitors, searching monitor groups, retrieving monitor templates, analyzing monitor coverage, and searching SLOs
 - `cases`: Tools for [Case Management][42], including creating, searching, and updating cases; managing projects; and linking Jira issues
 - `dashboards`: Tools for retrieving, creating, updating, and deleting [dashboards][46], plus widget schema reference and validation
+- `data-streams`: Tools for investigating Kafka workloads with [Data Streams Monitoring][52], including topic, broker, and client configuration inspection, Schema Registry browsing, and on-demand reads of Kafka messages through the Datadog Agent
 - `dbm`: Tools for interacting with [Database Monitoring][33]
 - `ddsql`: Tools for querying Datadog data using [DDSQL][44], a SQL dialect with support for infrastructure resources, logs, metrics, RUM, spans, and other Datadog data sources
 - `error-tracking`: Tools for interacting with Datadog [Error Tracking][32]
@@ -739,3 +740,4 @@ Local authentication is recommended for Cline and when remote authentication is 
 [49]: /bits_ai/mcp_server/tools
 [50]: https://github.com/google-gemini/gemini-cli
 [51]: /containers/monitoring/kubernetes_explorer/
+[52]: /data_streams/

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -537,7 +537,7 @@ Tools for investigating Kafka workloads with [Data Streams Monitoring][27], incl
 ### `list_kafka_topic_configs`
 *Toolset: **data-streams***\
 *Permissions Required: `APM Read`*\
-Lists Kafka topic configuration overrides for a cluster, such as `cleanup.policy`, `retention.ms`, and `max.message.bytes`. Optionally filtered to a single topic. Use this to check whether topic-level settings explain producer or consumer behavior.
+Lists Kafka topic configuration overrides for a cluster, such as `cleanup.policy`, `retention.ms`, and `max.message.bytes`. You can optionally filter to a single topic. Use this to check whether topic-level settings explain producer or consumer behavior.
 
 - Show me the topic config for `checkout-orders`.
 - What is the retention setting on the orders Kafka topic?

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -537,7 +537,7 @@ Tools for investigating Kafka workloads with [Data Streams Monitoring][27], incl
 *Permissions Required: `APM Read`*\
 Lists Kafka topic configuration overrides for a cluster, such as `cleanup.policy`, `retention.ms`, and `max.message.bytes`. Optionally filtered to a single topic. Use this to check whether topic-level settings explain producer or consumer behavior.
 
-- Show me the topic config for `checkout-orders` on cluster `prod-east-1`.
+- Show me the topic config for `checkout-orders`.
 - What is the retention setting on the orders Kafka topic?
 - Compare `max.message.bytes` across all topics in the payments cluster.
 
@@ -546,7 +546,7 @@ Lists Kafka topic configuration overrides for a cluster, such as `cleanup.policy
 *Permissions Required: `APM Read`*\
 Lists Kafka broker-level configuration for a cluster, optionally filtered to a single broker. Use this to inspect broker tuning when consumers across multiple topics are affected.
 
-- Show broker configs for cluster `prod-east-1`.
+- Show me the broker configs for my Kafka cluster.
 - What's the `num.io.threads` setting on broker 3?
 - Compare broker configs between two clusters.
 
@@ -557,14 +557,14 @@ Returns Kafka client (producer and consumer) configurations for a cluster, inclu
 
 - Show me the consumer config for service `checkout-api` on the payments cluster.
 - What's the `session.timeout.ms` for consumer group `orders-processor`?
-- Compare producer configs across services on cluster `prod-east-1`.
+- Compare producer configs across services on my Kafka cluster.
 
 ### `list_all_kafka_schemas`
 *Toolset: **data-streams***\
 *Permissions Required: `APM Read`*\
 Lists all Schema Registry subjects for a cluster's schema registry. Use this when you don't know the subject name to inspect.
 
-- List all Schema Registry subjects on cluster `prod-east-1`.
+- List all Schema Registry subjects.
 - What schemas are registered for the orders topic?
 
 ### `get_subject_kafka_schemas`

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -532,6 +532,8 @@ Ask a Datadog widget expert a question about widget configuration, schemas, quer
 
 Tools for investigating Kafka workloads with [Data Streams Monitoring][27], including topic, broker, and client configuration inspection, Schema Registry browsing, and on-demand reads of Kafka messages through the Datadog Agent.
 
+**Note**: All tools in this toolset require the [Kafka integration][28] to be configured for your Kafka clusters. If a call returns a setup error or an empty result, follow the [Kafka setup guide][28] to enable Data Streams Monitoring on your Agent before retrying.
+
 ### `list_kafka_topic_configs`
 *Toolset: **data-streams***\
 *Permissions Required: `APM Read`*\
@@ -584,8 +586,6 @@ Reads messages from a given Kafka cluster, topic, and partition through the Data
 - What are the last messages on topic `checkout-orders`?
 - Show me the most recent payloads produced to the orders Kafka topic.
 - Read the message at offset 12345 on partition 3 of the `payments` topic.
-
-**Note**: This tool requires the [Kafka integration][28] to be configured for your Kafka clusters. If the call returns a setup error, follow the [Kafka setup guide][28] to enable Data Streams Monitoring on your Agent before retrying.
 
 ## Database Monitoring
 

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -528,6 +528,65 @@ Ask a Datadog widget expert a question about widget configuration, schemas, quer
 - Help me debug why this widget is showing fractional values when it should be a count.
 - How do I configure a timeseries to show both bars and lines?
 
+## Data Streams
+
+Tools for investigating Kafka workloads with [Data Streams Monitoring][27], including topic, broker, and client configuration inspection, Schema Registry browsing, and on-demand reads of Kafka messages through the Datadog Agent.
+
+### `list_kafka_topic_configs`
+*Toolset: **data-streams***\
+*Permissions Required: `APM Read`*\
+Lists Kafka topic configuration overrides for a cluster, such as `cleanup.policy`, `retention.ms`, and `max.message.bytes`. Optionally filtered to a single topic. Use this to check whether topic-level settings explain producer or consumer behavior.
+
+- Show me the topic config for `dbm-events` on cluster `prod-east-1`.
+- What is the retention setting on the orders Kafka topic?
+- Compare `max.message.bytes` across all topics in the payments cluster.
+
+### `list_kafka_broker_configs`
+*Toolset: **data-streams***\
+*Permissions Required: `APM Read`*\
+Lists Kafka broker-level configuration for a cluster, optionally filtered to a single broker. Use this to inspect broker tuning when consumers across multiple topics are affected.
+
+- Show broker configs for cluster `prod-east-1`.
+- What's the `num.io.threads` setting on broker 3?
+- Compare broker configs between two clusters.
+
+### `get_kafka_client_configs`
+*Toolset: **data-streams***\
+*Permissions Required: `APM Read`*\
+Returns Kafka client (producer and consumer) configurations for a cluster, including consumer-group settings and client-side tuning.
+
+- Show me the consumer config for service `checkout-api` on the payments cluster.
+- What's the `session.timeout.ms` for consumer group `orders-processor`?
+- Compare producer configs across services on cluster `prod-east-1`.
+
+### `list_all_kafka_schemas`
+*Toolset: **data-streams***\
+*Permissions Required: `APM Read`*\
+Lists all Schema Registry subjects for a cluster's schema registry. Use this when you don't know the subject name to inspect.
+
+- List all Schema Registry subjects on cluster `prod-east-1`.
+- What schemas are registered for the orders topic?
+
+### `get_subject_kafka_schemas`
+*Toolset: **data-streams***\
+*Permissions Required: `APM Read`*\
+Returns all schema versions for a single Schema Registry subject (schema body, ID, version, and references). Use this after `list_all_kafka_schemas` to inspect the version history of a specific subject.
+
+- Show every version of the `orders-value` schema.
+- What changed in the latest version of the `payments-key` schema?
+- Get the schema body for `dbm-events-value` version 7.
+
+### `read_kafka_messages`
+*Toolset: **data-streams***\
+*Permissions Required: `APM Read` and `Data Streams Monitoring Capture Messages`*\
+Reads messages from a given Kafka cluster, topic, and partition through the Datadog Agent by dispatching a Remote Config action and polling for the agent's response. Rate-limited to 10 calls per minute per organization. Useful for inspecting message payloads when investigating poison messages or stuck consumer offsets.
+
+- What are the last messages on topic `dbm-events`?
+- Show me the most recent payloads produced to the orders Kafka topic.
+- Read the message at offset 12345 on partition 3 of the `payments` topic.
+
+**Note**: This tool requires the [Kafka integration][28] to be configured for your Kafka clusters. If the call returns a setup error, follow the [Kafka setup guide][28] to enable Data Streams Monitoring on your Agent before retrying.
+
 ## Database Monitoring
 
 Tools for interacting with [Database Monitoring][26].
@@ -1139,6 +1198,8 @@ Adds an agent trigger to a workflow and publishes it, enabling the workflow to b
 [15]: /api/latest/events/
 [24]: /tests/
 [26]: /database_monitoring/
+[27]: /data_streams/
+[28]: /data_streams/kafka/setup/
 [31]: /network_monitoring/cloud_network_monitoring/
 [32]: /network_monitoring/devices/
 [38]: /service_management/case_management/

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -581,7 +581,7 @@ Returns all schema versions for a single Schema Registry subject (schema body, I
 ### `read_kafka_messages`
 *Toolset: **data-streams***\
 *Permissions Required: `APM Read` and `Data Streams Monitoring Capture Messages`*\
-Reads messages from a given Kafka cluster, topic, and partition through the Datadog Agent by dispatching a Remote Config action and polling for the agent's response. Rate-limited to 10 calls per minute per organization. Useful for inspecting message payloads when investigating poison messages or stuck consumer offsets.
+Reads messages from a given Kafka cluster, topic, and partition through the Datadog Agent by dispatching a Remote Config action and polling for the Agent's response. This tool is rate-limited to 10 calls per minute per organization, and is useful for inspecting message payloads when investigating poison messages or stuck consumer offsets.
 
 - What are the last messages on topic `checkout-orders`?
 - Show me the most recent payloads produced to the orders Kafka topic.

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -537,7 +537,7 @@ Tools for investigating Kafka workloads with [Data Streams Monitoring][27], incl
 *Permissions Required: `APM Read`*\
 Lists Kafka topic configuration overrides for a cluster, such as `cleanup.policy`, `retention.ms`, and `max.message.bytes`. Optionally filtered to a single topic. Use this to check whether topic-level settings explain producer or consumer behavior.
 
-- Show me the topic config for `dbm-events` on cluster `prod-east-1`.
+- Show me the topic config for `checkout-orders` on cluster `prod-east-1`.
 - What is the retention setting on the orders Kafka topic?
 - Compare `max.message.bytes` across all topics in the payments cluster.
 
@@ -574,14 +574,14 @@ Returns all schema versions for a single Schema Registry subject (schema body, I
 
 - Show every version of the `orders-value` schema.
 - What changed in the latest version of the `payments-key` schema?
-- Get the schema body for `dbm-events-value` version 7.
+- Get the schema body for `checkout-orders-value` version 7.
 
 ### `read_kafka_messages`
 *Toolset: **data-streams***\
 *Permissions Required: `APM Read` and `Data Streams Monitoring Capture Messages`*\
 Reads messages from a given Kafka cluster, topic, and partition through the Datadog Agent by dispatching a Remote Config action and polling for the agent's response. Rate-limited to 10 calls per minute per organization. Useful for inspecting message payloads when investigating poison messages or stuck consumer offsets.
 
-- What are the last messages on topic `dbm-events`?
+- What are the last messages on topic `checkout-orders`?
 - Show me the most recent payloads produced to the orders Kafka topic.
 - Read the message at offset 12345 on partition 3 of the `payments` topic.
 

--- a/content/en/bits_ai/mcp_server/tools.md
+++ b/content/en/bits_ai/mcp_server/tools.md
@@ -564,7 +564,7 @@ Returns Kafka client (producer and consumer) configurations for a cluster, inclu
 ### `list_all_kafka_schemas`
 *Toolset: **data-streams***\
 *Permissions Required: `APM Read`*\
-Lists all Schema Registry subjects for a cluster's schema registry. Use this when you don't know the subject name to inspect.
+Lists all subjects for a cluster's schema registry. Use this when you don't know which subject name to inspect.
 
 - List all Schema Registry subjects.
 - What schemas are registered for the orders topic?


### PR DESCRIPTION
## Summary

Adds the `data-streams` toolset to the public Datadog MCP Server docs, mirroring the structure used for other GA-d toolsets (DDSQL, DBM, Dashboards, etc.).

- `setup.md` — adds `data-streams` to the *Available toolsets* list (alphabetical, between `dashboards` and `dbm`).
- `tools.md` — adds a *Data Streams* section describing the six tools, their toolset membership, required permissions, and example prompts:
  - `list_kafka_topic_configs`
  - `list_kafka_broker_configs`
  - `get_kafka_client_configs`
  - `list_all_kafka_schemas`
  - `get_subject_kafka_schemas`
  - `read_kafka_messages` (additionally requires the `Data Streams Monitoring Capture Messages` permission; rate-limited to 10 calls/min per org; routes the caller to the [Kafka setup guide](https://docs.datadoghq.com/data_streams/kafka/setup/) when monitoring is not configured)

## Companion PRs (DataDog/dd-source)

- [#432166 — Graduate data-streams toolset and Kafka tools out of preview](https://github.com/DataDog/dd-source/pull/432166)
- [#429642 — Setup-docs redirect, prompt → marketplace skill, eager loading, acceptance tests](https://github.com/DataDog/dd-source/pull/429642)

## Test plan

- [ ] Hugo build is green in CI.
- [ ] Section renders with the expected headers, toolset badges, permissions, and example prompts.
- [ ] Internal cross-links `[27]` (`/data_streams/`), `[28]` (`/data_streams/kafka/setup/`), and `[52]` (`/data_streams/`) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)