### PR TITLE
[SVLS-9038] Add Azure Logic Apps metrics page

### DIFF
--- a/content/en/serverless/logic_apps/_index.md
+++ b/content/en/serverless/logic_apps/_index.md
@@ -5,6 +5,9 @@ further_reading:
   - link: "/serverless/logic_apps/installation"
     tag: "Documentation"
     text: "Install Serverless Monitoring for Azure Logic Apps"
+  - link: "/serverless/logic_apps/metrics"
+    tag: "Documentation"
+    text: "Azure Logic Apps metrics"
   - link: "/serverless/logic_apps/troubleshooting"
     tag: "Documentation"
     text: "Troubleshoot Serverless Monitoring for Azure Logic Apps"
@@ -15,7 +18,7 @@ further_reading:
 Serverless Monitoring for Azure Logic Apps is in Preview. Complete the form to request access.
 {{< /callout >}}
 
-Azure Logic Apps is a serverless orchestration service that lets developers create and manage multi-step application workflows in Azure. Datadog provides Azure Logic Apps tracing and enhanced metrics through the collection of Azure diagnostic logs.
+Azure Logic Apps is a serverless orchestration service that lets developers create and manage multi-step application workflows in Azure. Datadog provides Azure Logic Apps tracing and [enhanced metrics][3] through the collection of Azure diagnostic logs.
 
 {{< img src="serverless/logic_apps/logic_apps_trace_example.png" alt="An Azure Logic Apps trace." style="width:100%;" >}}
 
@@ -33,3 +36,4 @@ To get started, follow the [installation instructions][1].
 
 [1]: /serverless/logic_apps/installation
 [2]: /logs/guide/azure-automated-log-forwarding/
+[3]: /serverless/logic_apps/metrics

--- a/content/en/serverless/logic_apps/metrics.md
+++ b/content/en/serverless/logic_apps/metrics.md
@@ -1,0 +1,66 @@
+---
+title: Azure Logic Apps metrics
+description: Reference for the enhanced metrics that Datadog generates for Azure Logic Apps workflows, including run-level and action-level metrics.
+further_reading:
+  - link: "/serverless/logic_apps/installation"
+    tag: "Documentation"
+    text: "Install Serverless Monitoring for Azure Logic Apps"
+  - link: "/serverless/logic_apps/troubleshooting"
+    tag: "Documentation"
+    text: "Troubleshoot Serverless Monitoring for Azure Logic Apps"
+---
+
+{{< callout url="https://www.datadoghq.com/product-preview/serverless-monitoring-for-azure-logic-apps/"
+ btn_hidden="false" header="Join the Preview!">}}
+Serverless Monitoring for Azure Logic Apps, including the enhanced metrics described on this page, is in Preview. Complete the form to request access.
+{{< /callout >}}
+
+This page describes the metrics available for monitoring Azure Logic Apps workflows with Datadog. There are two ways to get metrics from Azure Logic Apps:
+
+- You can get Azure Logic Apps metrics from the [Datadog Azure integration][1].
+- You can get [enhanced metrics](#enhanced-azure-logic-apps-metrics) by [installing Serverless Monitoring for Azure Logic Apps][2].
+
+## Enhanced Azure Logic Apps metrics
+
+Datadog generates enhanced metrics for Azure Logic Apps from your workflow execution data, with detailed metadata for each run and action. Enhanced metrics are distinguished by being in the `azure.logic_workflows.enhanced.*` namespace.
+
+Enhanced metrics are tagged with the workflow `run_id` along with the standard Azure Logic Apps tags, including `service` and `env`. See [Install Serverless Monitoring for Azure Logic Apps][2] for how to configure these tags.
+
+### Run-level metrics
+
+The following metrics are emitted once per workflow run.
+
+`azure.logic_workflows.enhanced.run_started`
+: Count of workflow runs that have started.
+
+`azure.logic_workflows.enhanced.run_succeeded`
+: Count of workflow runs that completed without errors.
+
+`azure.logic_workflows.enhanced.run_failed`
+: Count of workflow runs that completed with errors.
+
+`azure.logic_workflows.enhanced.run_latency`
+: Distribution of the end-to-end duration of a workflow run, in milliseconds. Supports percentile aggregations and is emitted alongside `run_succeeded` and `run_failed`.
+
+### Action-level metrics
+
+The following metrics are emitted once per action within a workflow run.
+
+`azure.logic_workflows.enhanced.actions_started`
+: Count of workflow actions that have started.
+
+`azure.logic_workflows.enhanced.actions_succeeded`
+: Count of workflow actions that completed without errors.
+
+`azure.logic_workflows.enhanced.actions_failed`
+: Count of workflow actions that completed with errors.
+
+`azure.logic_workflows.enhanced.action_latency`
+: Distribution of the duration of a workflow action, in milliseconds. Supports percentile aggregations and is emitted alongside `actions_succeeded` and `actions_failed`.
+
+## Further Reading
+
+{{< partial name="whats-next/whats-next.html" >}}
+
+[1]: /integrations/azure/
+[2]: /serverless/logic_apps/installation


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Fixes https://datadoghq.atlassian.net/browse/SVLS-9038

Adds a new `Azure Logic Apps metrics` reference page at `/serverless/logic_apps/metrics`, documenting the enhanced run-level and action-level metrics in the `azure.logic_workflows.enhanced.*` namespace. Modeled on the existing AWS Lambda metrics page.

The Logic Apps index page is updated to link to the new metrics page from the body and the further reading section.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes