### PR TITLE
[DOCS-14094] Add DDSQL skill to Bits Assistant page

### DIFF
--- a/content/en/bits_ai/bits_assistant.md
+++ b/content/en/bits_ai/bits_assistant.md
@@ -68,7 +68,7 @@ Example prompts:
 - `Which teams are responsible for the highest S3 storage costs this month?`
 
 #### DDSQL
-Generate and run [DDSQL][7] queries against Datadog telemetry data—including logs, metrics, spans, RUM events, and cloud resources—using natural language.
+Generate and run [DDSQL][7] queries against Datadog [telemetry data][8] using natural language. 
 
 Example prompts:
 - `Write a DDSQL query that shows the top 10 services by error count in the last hour`
@@ -114,3 +114,4 @@ After setup is completed, you can send queries to `@Datadog` in natural language
 [5]: /dashboards/
 [6]: /notebooks/
 [7]: /ddsql_editor/
+[8]: /ddsql_reference/data_directory/

--- a/content/en/bits_ai/bits_assistant.md
+++ b/content/en/bits_ai/bits_assistant.md
@@ -67,6 +67,14 @@ Example prompts:
 - `Investigate why EC2 costs changed between January and February`
 - `Which teams are responsible for the highest S3 storage costs this month?`
 
+#### DDSQL
+Generate and run [DDSQL][7] queries against Datadog telemetry data—including logs, metrics, spans, RUM events, and cloud resources—using natural language.
+
+Example prompts:
+- `Write a DDSQL query that shows the top 10 services by error count in the last hour`
+- `Query average request latency for the payments service broken down by status code`
+- `Show me a DDSQL query for the number of RUM sessions by country over the past day`
+
 ### Web application
 There are multiple ways to open Bits Assistant in the Datadog web application:
 - In the top-right of the navigation bar, click {{< ui >}}Ask Bits{{< /ui >}}
@@ -105,3 +113,4 @@ After setup is completed, you can send queries to `@Datadog` in natural language
 [4]: /cloud_cost_management/
 [5]: /dashboards/
 [6]: /notebooks/
+[7]: /ddsql_editor/


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes [DOCS-14094](https://datadoghq.atlassian.net/browse/DOCS-14094)

Adds a DDSQL section to the Skills section of the Bits Assistant page. The DDSQL skill allows users to ask Bits Assistant to generate and run DDSQL queries against Datadog telemetry data using natural language.

### Merge instructions

Merge readiness:
- [x] Ready for merge

### Additional notes

[DOCS-14094]: https://datadoghq.atlassian.net/browse/DOCS-14094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ