### PR TITLE
(maint) Add a build warning for non main script branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,13 @@ setup-build-scripts: $(PY_PATH) backup-config clean-build-scripts
 		echo -e "\033[0;31mone or more build-script env vars are undefined, check your makefile.config \033[0m"; \
 		exit 1; \
 	fi;
+	@if [ "$(BUILD_SCRIPT_BRANCH)" != "main" ]; then \
+		echo -e "\n\033[0;31m##########################################################################"; \
+		echo -e "# WARNING: BUILD_SCRIPT_BRANCH is set to '$(BUILD_SCRIPT_BRANCH)'"; \
+		echo -e "# You are NOT using the main branch for build scripts."; \
+		echo -e "# If this is unintentional, update BUILD_SCRIPT_BRANCH in Makefile.config"; \
+		echo -e "##########################################################################\033[0m\n"; \
+	fi;
 	@tmp_dir=$$(mktemp -d) && \
 	git clone --depth 1 -b $(BUILD_SCRIPT_BRANCH) $(BUILD_SCRIPT_REPO_URL) $$tmp_dir && \
 	if [ -d "$$tmp_dir/$(BUILD_SCRIPT_SOURCE_DIR)" ]; then \


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

I was having some weird build issues and figured out I was sourcing a really old feature branch in my Makefile.config. This adds a warning to the build output when branch isn't set to `main`.