### PR TITLE
Make AI Investigations docs platform-agnostic

### DIFF
--- a/content/en/real_user_monitoring/ai_investigations/_index.md
+++ b/content/en/real_user_monitoring/ai_investigations/_index.md
@@ -15,7 +15,7 @@ This page lists the available investigation types.
 
 ## Single-view AI investigation
 
-Run an agentic investigation on a single RUM view to investigate performance issues or identify optimization opportunities on that specific page load. Datadog's RUM agent inspects the view event and its sub-events to identify root causes from sources spanning the browser, the backend, third-party scripts, and the user's network environment.
+Run an agentic investigation on a single RUM view to investigate performance issues or identify optimization opportunities on that specific page or screen. Datadog's RUM agent inspects the view event and its sub-events to identify root causes from sources spanning the application, the backend, third-party libraries, and the user's network environment.
 
 {{< img src="real_user_monitoring/ai_investigations/single-view-ai-investigation-overview.png" alt="A Single-View AI Investigation surfacing root cause findings for a RUM view." style="width:100%;" >}}
 

--- a/content/en/real_user_monitoring/ai_investigations/single_view_ai_investigation.md
+++ b/content/en/real_user_monitoring/ai_investigations/single_view_ai_investigation.md
@@ -15,9 +15,9 @@ further_reading:
 
 ## Overview
 
-Single-View AI Investigation runs an agentic root-cause analysis on a single RUM view. When you find a session with poor performance, such as a page that loaded slowly or threw errors, click **Investigate**. Datadog's RUM agent inspects all the data attached to that view: Javascript errors, slow network requests, long tasks blocking the main thread, backend traces, CPU profiles, and device context.
+Single-View AI Investigation runs an agentic root-cause analysis on a single RUM view. When you find a session with poor performance, such as a page or screen that loaded slowly or threw errors, click **Investigate**. Datadog's RUM agent inspects all the data attached to that view: errors, slow network requests, main-thread blocking, backend traces, CPU profiles, and device context.
 
-Instead of manually combing through RUM events to figure out whether the cause was a slow API call, a Javascript bundle, or a CDN issue, you get a ranked list of findings grouped by root-cause category: App Performance, Server Side, Third Party, and Environment. From there, you can follow up through a chat interface or save the results to a [Notebook][1] to share with your team.
+Instead of manually combing through RUM events to figure out whether the cause was a slow API call, a heavy client-side computation, or a CDN issue, you get a ranked list of findings grouped by root-cause category: App Performance, Server Side, Third Party, and Environment. From there, you can follow up through a chat interface or save the results to a [Notebook][1] to share with your team.
 
 {{< img src="real_user_monitoring/ai_investigations/single-view-ai-investigation-overview.png" alt="The Single-View AI Investigation panel showing categorized findings for a RUM view." style="width:100%;" >}}
 
@@ -27,11 +27,11 @@ To investigate a view, Datadog's RUM agent inspects the data Datadog has collect
 
 - **The view event** and its sub-events: [resources][2], [long tasks][3], [errors][4], and [user actions][5].
 - **Aggregated performance signals** across the view, including auto-detected problems such as uncompressed resources, excessive script evaluation, and bandwidth inefficiencies.
-- **Device and environment context** captured by the SDK (browser, geography, connection type, and other [RUM attributes][6]).
+- **Device and environment context** captured by the SDK (browser or operating system, geography, connection type, and other [RUM attributes][6]).
 - **APM traces**, when the view's resources are correlated with backend traces. The agent uses the trace data to attribute server-side delays to specific spans and services. For more information, see [Correlate RUM with APM Traces][7].
-- **Browser profiling data**, when [Browser profiling][8] is enabled for the application. The agent uses CPU profiles to attribute App Performance findings to specific JavaScript functions in your code.
+- **Profiling data**, when [RUM profiling correlation][8] is enabled for the application. The agent uses CPU profiles to attribute App Performance findings to specific functions in your code.
 
-The richer the data available for the view, the more precise the analysis. Correlating RUM with APM and enabling Browser profiling helps the agent investigate beyond the frontend timeline.
+The richer the data available for the view, the more precise the analysis. Correlating RUM with APM and enabling profiling helps the agent investigate beyond the client-side timeline.
 
 ## Launch an investigation
 
@@ -46,9 +46,9 @@ Datadog's RUM agent looks at four sources to identify the root causes of poor pe
 
 | Source            | What is examined                                                                                              |
 |-------------------|---------------------------------------------------------------------------------------------------------------|
-| App Performance   | Client-side issues, such as long tasks, JavaScript execution, and rendering delays.               |
+| App Performance   | Client-side issues, such as main-thread contention, code execution, and rendering delays.               |
 | Server Side       | Backend latency and server-side errors that affected the view.                                                |
-| Third Party       | Performance impact from third-party scripts and libraries loaded on the page.                                 |
+| Third Party       | Performance impact from third-party scripts and libraries loaded by the application.                                 |
 | Environment       | Network and infrastructure conditions that affected the user's experience.                                    |
 
 ## Read the results


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

The AI Investigations pages added in #36350 were unintentionally browser-flavored (mentions of JavaScript, page loads, browser profiling, third-party scripts, etc.). Single-View AI Investigation actually runs on any RUM view — Browser, iOS, Android, Flutter, React Native — with no platform gating in the frontend or the backend stream API.

This PR rewords the affected sentences and table rows to be platform-agnostic:
- "page load" → "page or screen"; "the browser" → "the application"; "JavaScript bundle" → "heavy client-side computation"; "long tasks blocking the main thread" → "main-thread blocking"; etc.
- "Browser profiling" → "RUM profiling correlation" (the linked correlation page already covers Browser, iOS, and Android).
- App Performance and Third Party row descriptions reworded to drop browser-specific terminology.

No factual claims about coverage are added — only existing browser-leaning phrasings are made generic.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes