### PR TITLE
Update agent metrics descriptions to match integrations-core/agent_metrics/metadata.csv

### DIFF
--- a/content/en/getting_started/agent/_index.md
+++ b/content/en/getting_started/agent/_index.md
@@ -73,9 +73,9 @@ The Agent reports the following metrics to Datadog about itself. These metrics p
 
 | Metric                           | Description                                      |
 | -------------------------------- |------------------------------------------------- |
-| `datadog.agent.running`        | Shows a value of `1` if the Agent is reporting to Datadog.                    |
-| `datadog.agent.started`        | A count sent with a value of `1` when the Agent starts (available in v6.12+).    |
-| `datadog.agent.python.version` | The metric is tagged with the `python_version`.     |
+| `datadog.agent.running`        | A value of `1` if the Agent is running and reporting to Datadog, tagged with the Agent version.  |
+| `datadog.agent.started`        | A count of `1` each time the Agent starts.    |
+| `datadog.agent.python.version` | A value of `1`, tagged with the Python version.     |
 
 
 See the [Agent Metrics][3] integration for a full list of Agent metrics.


### PR DESCRIPTION
### What does this PR do? 

Updates the agent metrics table in the [Getting Started with the Agent](https://docs.datadoghq.com/getting_started/agent/#agent-metrics) to match the descriptions in [integrations-core/agent_metrics/metadata.csv](https://github.com/DataDog/integrations-core/blob/master/agent_metrics/metadata.csv).


### What is the motivation?

[integrations-core/agent_metrics/metadata.csv](https://github.com/DataDog/integrations-core/blob/master/agent_metrics/metadata.csv) was updated and this PR syncs the docs to reflect those changes.

### Companion PR (DataDog/integrations-core)
https://github.com/DataDog/integrations-core/pull/23571
