### PR TITLE
[Code Gen] Add Ubuntu repos to default allowlist & update description

### DIFF
--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -77,7 +77,7 @@ Configure the Dev Agent's runtime environment, including network access policies
 
 By default, the Dev Agent has **no internet access** during agent execution. To configure which external domains agents can reach, navigate to **Bits AI Dev** > **Settings** > [**General**][6], and find the **Internet Access** section. Choose from the following access policies: **No Internet Access**, **Default Allowlist**, **Custom + Default Allowlist**, or **Custom Allowlist**.
 
-The default allowlist includes the following domains:
+The default allowlist includes the following domains. This list will evolve over time based on user feedback and ecosystem changes. To avoid changes, configure a custom allowlist.
 
 | Language | Domains |
 |---|---|

--- a/content/en/bits_ai/bits_ai_dev_agent/setup.md
+++ b/content/en/bits_ai/bits_ai_dev_agent/setup.md
@@ -89,6 +89,7 @@ The default allowlist includes the following domains:
 | PHP | `packagist.org`, `repo.packagist.org` |
 | Python | `files.pythonhosted.org`, `pypi.org`, `pypi.python.org`, `pythonhosted.org` |
 | Rust | `index.crates.io`, `static.crates.io` |
+| Ubuntu | `archive.ubuntu.com`, `ports.ubuntu.com`, `security.ubuntu.com` |
 
 ### Configure repository environment
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"452abd91-0339-49b0-a842-4c9518aba481","source":"chat","resourceId":"1d46ce72-fc6d-4df5-8323-afd38191b8c7","workflowId":"b9145457-a1cd-4b12-89df-870ab3e77f2e","codeChangeId":"b9145457-a1cd-4b12-89df-870ab3e77f2e","sourceType":"slack"} -->
### What does this PR do? What is the motivation?

This PR updates the documentation for the Bits AI Dev Agent setup guide to reflect the addition of Ubuntu package repositories to the default allowlist. It also adds a clarifying note that the default allowlist may evolve over time based on user feedback and ecosystem changes, helping users understand when they should configure a custom allowlist if they need stability.

The backend allowlist has been updated to include `archive.ubuntu.com`, `security.ubuntu.com`, and `ports.ubuntu.com` to support Ubuntu package installations in generated code environments (CODEGEN-621).

### Merge instructions

Merge readiness:
- [x] Ready for merge

**For Datadog employees**:

Your branch name MUST follow the `<name>/<description>` convention and include the forward slash (`/`). Without this format, your pull request will not pass CI, the GitLab pipeline will not run, and you won't get a branch preview. Getting a branch preview makes it easier for us to check any issues with your PR, such as broken links.

If your branch doesn't follow this format, rename it or create a new branch and PR.

[6/5/2025] Merge queue has been disabled on the documentation repo. If you have write access to the repo, the PR has been reviewed by a Documentation team member, and all of the required checks have passed, you can use the **Squash and Merge** button to merge the PR. If you don't have write access, or you need help, reach out in the #documentation channel in Slack.

### AI assistance

Manual documentation update to clarify allowlist behavior and reflect backend changes.

### Additional notes

This documentation update complements the backend changes in CODEGEN-621 and the corresponding backend PR #8457. The change adds context about the dynamic nature of the default allowlist and guides users on when to use custom allowlists for stability.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/1d46ce72-fc6d-4df5-8323-afd38191b8c7)

Comment @datadog to request changes