### PR TITLE
[DOCS-14246] Add API links to downtime, mobile app, and network path pages

### DIFF
--- a/content/en/synthetics/mobile_app_testing/_index.md
+++ b/content/en/synthetics/mobile_app_testing/_index.md
@@ -27,6 +27,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/mobile-apps-synthetic-tests/"
   tag: "Blog"
   text: "How to build reliable and accurate synthetic tests for your mobile apps"
+- link: "/api/latest/synthetics/#create-or-clone-a-test"
+  tag: "API"
+  text: "Synthetics API"
 cascade:
   algolia:
     tags: ['mobile_testing']

--- a/content/en/synthetics/network_path_tests/_index.md
+++ b/content/en/synthetics/network_path_tests/_index.md
@@ -18,6 +18,9 @@ further_reading:
 - link: "https://www.datadoghq.com/blog/synthetic-monitoring-network-path/"
   tag: "Blog"
   text: "Understand user experience through network performance with Datadog Synthetic Monitoring"
+- link: "/api/latest/synthetics/#create-or-clone-a-test"
+  tag: "API"
+  text: "Synthetics API"
 ---
 
 ## Overview

--- a/content/en/synthetics/platform/downtime.md
+++ b/content/en/synthetics/platform/downtime.md
@@ -14,6 +14,9 @@ further_reading:
 - link: "/synthetics/test_suites/"
   tag: "Documentation"
   text: "Test Suites"
+- link: "/api/latest/synthetics/#list-synthetics-downtimes"
+  tag: "API"
+  text: "Synthetics Downtimes API"
 ---
 
 ## Overview
@@ -91,6 +94,10 @@ To apply an existing downtime to multiple tests or test suites at once:
 - When viewing the calendar with multiple downtimes configured, filter by a specific downtime to avoid a crowded view.
 - For complex recurrence patterns, split requirements into multiple time slots within the same downtime.
 
+## Manage downtimes programmatically
+
+You can create, update, list, and delete Synthetic Monitoring downtimes through the [Synthetics API][4]. Use the API to integrate downtime management into your deployment pipelines or automation scripts.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -98,3 +105,4 @@ To apply an existing downtime to multiple tests or test suites at once:
 [1]: /monitors/downtimes/
 [2]: https://app.datadoghq.com/synthetics/settings/downtimes
 [3]: https://app.datadoghq.com/synthetics/tests
+[4]: /api/latest/synthetics/#list-synthetics-downtimes


### PR DESCRIPTION
### What does this PR do? What is the motivation?

Fixes DOCS-14246

Improves visibility of API availability across Synthetics pages:

- **Downtime page**: Adds a "Manage downtimes programmatically" section linking to the Synthetics Downtimes API, plus a further_reading link.
- **Mobile App Testing**: Adds Synthetics API further_reading link (was missing).
- **Network Path Tests**: Adds Synthetics API further_reading link (was missing).

**Audit notes**: API tests, browser tests, and multistep API tests already had API and Terraform links — no changes needed. The Terraform export guide covers the UI "Copy Terraform Snippet" feature for tests only; downtimes use the API instead, so no changes to that guide.

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes