### PR TITLE
Update OTel integration content to match simplified data collected tables

### DIFF
--- a/content/en/opentelemetry/integrations/apache_metrics.md
+++ b/content/en/opentelemetry/integrations/apache_metrics.md
@@ -27,7 +27,7 @@ See the [Apache receiver documentation][1] for detailed configuration options an
 
 {{< mapping-table resource="apache.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 ## Further reading
 

--- a/content/en/opentelemetry/integrations/docker_metrics.md
+++ b/content/en/opentelemetry/integrations/docker_metrics.md
@@ -150,11 +150,11 @@ The Docker Stats receiver generates container metrics for the OpenTelemetry Coll
 
 Learn more about [mapping between OpenTelemetry and Datadog semantic conventions for resource attributes][5].
 
-The following table shows the Datadog container metric names that correspond to OpenTelemetry container metric names:
+The following table lists the OpenTelemetry container metrics collected for Datadog's out-of-the-box in-app experiences.
 
 {{< mapping-table resource="dockerstats.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 ## Full example configuration
 

--- a/content/en/opentelemetry/integrations/haproxy_metrics.md
+++ b/content/en/opentelemetry/integrations/haproxy_metrics.md
@@ -27,7 +27,7 @@ See the [HAProxy receiver documentation][1] for detailed configuration options a
 
 {{< mapping-table resource="haproxy.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 ## Further reading
 

--- a/content/en/opentelemetry/integrations/host_metrics.md
+++ b/content/en/opentelemetry/integrations/host_metrics.md
@@ -116,11 +116,11 @@ The metrics, mapped to Datadog metrics, are used in the following views:
 
 **Note**: To correlate trace and host metrics, configure [Unified Service Tagging attributes][10] for each service, and set the `host.name` resource attribute to the corresponding underlying host for both service and collector instances. 
 
-The following table shows which Datadog host metric names are associated with corresponding OpenTelemetry host metric names, and, if applicable, what math is applied to the OTel host metric to transform it to Datadog units during the mapping.
+The following table lists the OpenTelemetry host metrics collected for Datadog's out-of-the-box in-app experiences.
 
 {{< mapping-table resource="host.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 
 ## Full example configuration

--- a/content/en/opentelemetry/integrations/iis_metrics.md
+++ b/content/en/opentelemetry/integrations/iis_metrics.md
@@ -27,7 +27,7 @@ See the [IIS receiver documentation][1] for detailed configuration options and r
 
 {{< mapping-table resource="iis.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 ## Further reading
 

--- a/content/en/opentelemetry/integrations/kafka_metrics.md
+++ b/content/en/opentelemetry/integrations/kafka_metrics.md
@@ -271,7 +271,7 @@ In order to ensure this attribute only gets added to your Kafka logs, use [inclu
 
 **Note:** In Datadog `-` gets translated to `_`. For example, `kafka.producer.request-rate` becomes `kafka.producer.request_rate`.
 
-See [OpenTelemetry Metrics Mapping][9] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][9].
 
 ## Full example configuration
 

--- a/content/en/opentelemetry/integrations/mysql_metrics.md
+++ b/content/en/opentelemetry/integrations/mysql_metrics.md
@@ -130,7 +130,7 @@ Add `hostmetrics` and `filelog` receiver if you configured them, for example:
 
 {{< mapping-table resource="mysql.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 ## Further reading
 

--- a/content/en/opentelemetry/integrations/nginx_metrics.md
+++ b/content/en/opentelemetry/integrations/nginx_metrics.md
@@ -27,7 +27,7 @@ See the [NGINX receiver documentation][1] for detailed configuration options and
 
 {{< mapping-table resource="nginx.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 ## Further reading
 

--- a/content/en/opentelemetry/integrations/podman_metrics.md
+++ b/content/en/opentelemetry/integrations/podman_metrics.md
@@ -29,7 +29,7 @@ See the [Podman receiver documentation][1] for detailed configuration options an
 
 {{< mapping-table resource="podman.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 ## Further reading
 

--- a/content/en/opentelemetry/integrations/postgres_metrics.md
+++ b/content/en/opentelemetry/integrations/postgres_metrics.md
@@ -168,7 +168,7 @@ If you configured the file log receiver, add a logs pipeline:
 
 {{< mapping-table resource="postgresql.csv">}}
 
-See [OpenTelemetry Metrics Mapping][5] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][5].
 
 ## Further reading
 

--- a/content/en/opentelemetry/integrations/runtime_metrics/_index.md
+++ b/content/en/opentelemetry/integrations/runtime_metrics/_index.md
@@ -255,10 +255,7 @@ After setup is complete, you can view runtime metrics in:
 
 ## Data collected
 
-The following tables list the OpenTelemetry runtime metrics used in Datadog's out-of-the-box in-app experiences. Each row maps an OpenTelemetry metric to the equivalent Datadog metric name, along with a description and any attribute conditions Datadog uses to identify the correct data point:
-
-- **Transform**: shown when both the OpenTelemetry metric and the Datadog metric require attribute filters to uniquely identify the data point.
-- **Filter**: shown when only the OpenTelemetry metric requires an attribute filter.
+The following tables list the OpenTelemetry runtime metrics collected for Datadog's out-of-the-box in-app experiences, along with a description and any attribute conditions (**Filter**) that Datadog uses to identify the correct data point.
 
 For Collector processor configuration required to make these metrics compatible with Datadog, see the [Collector configuration](#2-configure-your-application) instructions above.
 

--- a/content/en/opentelemetry/integrations/spark_metrics.md
+++ b/content/en/opentelemetry/integrations/spark_metrics.md
@@ -27,7 +27,7 @@ See the [Apache Spark receiver documentation][1] for detailed configuration opti
 
 {{< mapping-table resource="apachespark.csv">}}
 
-See [OpenTelemetry Metrics Mapping][2] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][2].
 
 ## Further reading
 

--- a/content/en/opentelemetry/integrations/sqlserver_metrics.md
+++ b/content/en/opentelemetry/integrations/sqlserver_metrics.md
@@ -157,7 +157,7 @@ If you configured the file log receiver, add a logs pipeline:
 
 {{< mapping-table resource="sqlserver.csv">}}
 
-See [OpenTelemetry Metrics Mapping][4] for more information.
+For the full mapping between OpenTelemetry and Datadog metric names, see [OpenTelemetry Metrics Mapping][4].
 
 ## Further reading
 

--- a/content/en/opentelemetry/mapping/metrics_mapping.md
+++ b/content/en/opentelemetry/mapping/metrics_mapping.md
@@ -15,7 +15,7 @@ disable_sidebar: true
 
 ## Overview
 
-Datadog products and visualizations are built on metrics and tags that follow specific naming patterns. Therefore, Datadog maps incoming OpenTelemetry metrics to the appropriate Datadog metric format. This mapping process may create additional metrics, but these do not affect Datadog billing.
+Datadog products and visualizations are built on metrics and tags that follow specific naming patterns. Datadog automatically maps incoming OpenTelemetry metrics to the appropriate Datadog metric format. You don't need to configure these mappings yourself. This mapping process may create additional metrics, but these do not affect Datadog billing.
 
 <div class="alert alert-info"><strong>Want to unify OpenTelemetry and Datadog metrics in your queries?</strong> Learn how to <a href="/metrics/open_telemetry/query_metrics">query across Datadog and OpenTelemetry metrics</a> from the Metrics Query Editor.</div>
 


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?

Content follow up to WEB-8985

Follow-up content changes after Stefon's table simplification (removing Datadog metric name, Transform, and mapping columns from OTel integration pages). Updates the surrounding text to match the new tables:

- **runtime_metrics**: Removes stale "Transform" column description and updates the Data Collected intro text
- **host_metrics, docker_metrics**: Updates table intro text that referenced Datadog metric names and transform math
- **12 integration pages**: Replaces vague "See Metrics Mapping for more information" with descriptive text about what the mapping page contains
- **metrics_mapping**: Adds "automatically maps" messaging so users know they don't need to configure mappings themselves

### Merge instructions

Merge readiness:
- [ ] Ready for merge

### Additional notes